### PR TITLE
feat(conformance): probe API Gateway v2 via Smithy model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 ## Why fakecloud
 
 - **Free, forever.** AGPL-3.0, no paid tier, no account, no token.
-- **100% conformance** per implemented service. Every operation validated against AWS's own Smithy models — 57,000+ generated test variants on every commit.
+- **100% conformance** per implemented service. Every operation validated against AWS's own Smithy models — 59,000+ generated test variants on every commit.
 - **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud. Catches waiter/field-presence/drift bugs that pure SDK tests miss.
 - **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, and 15+ more integrations actually execute end-to-end.
 - **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.

--- a/aws-models/apigatewayv2.json
+++ b/aws-models/apigatewayv2.json
@@ -1,0 +1,16057 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.apigatewayv2#ACMManaged": {
+      "type": "structure",
+      "members": {
+        "CertificateArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The certificate ARN.</p>",
+            "smithy.api#jsonName": "certificateArn",
+            "smithy.api#required": {}
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin3Max256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#jsonName": "domainName",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a domain name and certificate for a portal.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#AccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#jsonName": "message"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
+      }
+    },
+    "com.amazonaws.apigatewayv2#AccessLogSettings": {
+      "type": "structure",
+      "members": {
+        "DestinationArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the CloudWatch Logs log group to receive access logs.</p>",
+            "smithy.api#jsonName": "destinationArn"
+          }
+        },
+        "Format": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A single line format of the access logs of data, as specified by selected $context variables. The format must include at least $context.requestId.</p>",
+            "smithy.api#jsonName": "format"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Settings for logging access in a stage.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Api": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType",
+            "smithy.api#required": {}
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an API.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ApiGatewayV2": {
+      "type": "service",
+      "version": "2018-11-29",
+      "operations": [
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateApiMapping"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateAuthorizer"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateDeployment"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateDomainName"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateIntegration"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateIntegrationResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateModel"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreatePortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreatePortalProduct"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateProductPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateProductRestEndpointPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateRoute"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateRouteResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateRoutingRule"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateStage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#CreateVpcLink"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteAccessLogSettings"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteApiMapping"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteAuthorizer"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteCorsConfiguration"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteDeployment"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteDomainName"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteIntegration"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteIntegrationResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteModel"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeletePortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeletePortalProduct"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeletePortalProductSharingPolicy"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteProductPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteProductRestEndpointPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteRoute"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteRouteRequestParameter"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteRouteResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteRouteSettings"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteRoutingRule"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteStage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DeleteVpcLink"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#DisablePortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ExportApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetApiMapping"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetApiMappings"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetApis"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetAuthorizer"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetAuthorizers"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetDeployment"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetDeployments"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetDomainName"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetDomainNames"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetIntegration"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetIntegrationResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetIntegrationResponses"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetIntegrations"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetModel"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetModels"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetModelTemplate"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetPortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetPortalProduct"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicy"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetProductPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetProductRestEndpointPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetRoute"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetRouteResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetRouteResponses"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetRoutes"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetRoutingRule"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetStage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetStages"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetTags"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetVpcLink"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#GetVpcLinks"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ImportApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ListPortalProducts"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ListPortals"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ListProductPages"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ListProductRestEndpointPages"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ListRoutingRules"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#PreviewPortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#PublishPortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicy"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#PutRoutingRule"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ReimportApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ResetAuthorizersCache"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TagResource"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateApi"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateApiMapping"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateAuthorizer"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateDeployment"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateDomainName"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateIntegration"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateIntegrationResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateModel"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdatePortal"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdatePortalProduct"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateProductPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateRoute"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateRouteResponse"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateStage"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#UpdateVpcLink"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "ApiGatewayV2",
+          "arnNamespace": "apigateway",
+          "cloudFormationName": "ApiGatewayV2",
+          "cloudTrailEventSource": "apigatewayv2.amazonaws.com",
+          "endpointPrefix": "apigateway"
+        },
+        "aws.auth#sigv4": {
+          "name": "apigateway"
+        },
+        "aws.protocols#restJson1": {},
+        "smithy.api#auth": [
+          "aws.auth#sigv4"
+        ],
+        "smithy.api#documentation": "<p>Amazon API Gateway V2</p>",
+        "smithy.api#title": "AmazonApiGatewayV2",
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://apigateway-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://apigateway-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://apigateway.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://apigateway.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-northeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://apigateway.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ApiMapping": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId",
+            "smithy.api#required": {}
+          }
+        },
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#jsonName": "apiMappingId"
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping key.</p>",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an API mapping.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Arn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an Amazon Resource Name (ARN).</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Authorization": {
+      "type": "structure",
+      "members": {
+        "CognitoConfig": {
+          "target": "com.amazonaws.apigatewayv2#CognitoConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Cognito configuration.</p>",
+            "smithy.api#jsonName": "cognitoConfig"
+          }
+        },
+        "None": {
+          "target": "com.amazonaws.apigatewayv2#None",
+          "traits": {
+            "smithy.api#documentation": "<p>Provide no authorization for your portal. This makes your portal publicly accesible on the web.</p>",
+            "smithy.api#jsonName": "none"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an authorization configuration for a portal.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#AuthorizationScopes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#AuthorizationType": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "AWS_IAM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_IAM"
+          }
+        },
+        "CUSTOM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOM"
+          }
+        },
+        "JWT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JWT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The authorization type. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer. For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Authorizer": {
+      "type": "structure",
+      "members": {
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType"
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource"
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation expression does not apply to the REQUEST authorizer.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an authorizer.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#AuthorizerType": {
+      "type": "enum",
+      "members": {
+        "REQUEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUEST"
+          }
+        },
+        "JWT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JWT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#BadRequestException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the error encountered.</p>",
+            "smithy.api#jsonName": "message"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request is not valid, for example, the input is incomplete or incorrect. See the accompanying error message for details.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.apigatewayv2#CognitoConfig": {
+      "type": "structure",
+      "members": {
+        "AppClientId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The app client ID.</p>",
+            "smithy.api#jsonName": "appClientId",
+            "smithy.api#required": {}
+          }
+        },
+        "UserPoolArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The user pool ARN.</p>",
+            "smithy.api#jsonName": "userPoolArn",
+            "smithy.api#required": {}
+          }
+        },
+        "UserPoolDomain": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The user pool domain.</p>",
+            "smithy.api#jsonName": "userPoolDomain",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration for using Amazon Cognito user pools to control access to your portal.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the error encountered.</p>",
+            "smithy.api#jsonName": "message"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested operation would cause a conflict with the current state of a service resource associated with the request. Resolve the conflict before retrying this request. See the accompanying error message for details.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.apigatewayv2#ConnectionType": {
+      "type": "enum",
+      "members": {
+        "INTERNET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNET"
+          }
+        },
+        "VPC_LINK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VPC_LINK"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a connection type.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ContentHandlingStrategy": {
+      "type": "enum",
+      "members": {
+        "CONVERT_TO_BINARY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONVERT_TO_BINARY"
+          }
+        },
+        "CONVERT_TO_TEXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONVERT_TO_TEXT"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies how to handle response payload content type conversions. Supported only for WebSocket APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Cors": {
+      "type": "structure",
+      "members": {
+        "AllowCredentials": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether credentials are included in the CORS request. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "allowCredentials"
+          }
+        },
+        "AllowHeaders": {
+          "target": "com.amazonaws.apigatewayv2#CorsHeaderList",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a collection of allowed headers. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "allowHeaders"
+          }
+        },
+        "AllowMethods": {
+          "target": "com.amazonaws.apigatewayv2#CorsMethodList",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a collection of allowed HTTP methods. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "allowMethods"
+          }
+        },
+        "AllowOrigins": {
+          "target": "com.amazonaws.apigatewayv2#CorsOriginList",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a collection of allowed origins. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "allowOrigins"
+          }
+        },
+        "ExposeHeaders": {
+          "target": "com.amazonaws.apigatewayv2#CorsHeaderList",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a collection of exposed headers. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "exposeHeaders"
+          }
+        },
+        "MaxAge": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetweenMinus1And86400",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of seconds that the browser should cache preflight request results. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "maxAge"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a CORS configuration. Supported only for HTTP APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html\">Configuring CORS</a> for more information.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#CorsHeaderList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a collection of allowed headers. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#CorsMethodList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a collection of methods. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#CorsOriginList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a collection of origins. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Api resource.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApiMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateApiMappingRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateApiMappingResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an API mapping.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/domainnames/{DomainName}/apimappings",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApiMappingRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId",
+            "smithy.api#required": {}
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "The API mapping key.",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new ApiMapping resource to represent an API mapping.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApiMappingResponse": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#jsonName": "apiMappingId"
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping key.</p>",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html\">Configuring CORS</a> for more information.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. It specifies the credentials required for the integration, if any. For a Lambda integration, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null. Currently, this property is not used for HTTP integrations. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType",
+            "smithy.api#required": {}
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. If you don't specify a routeKey, a default route of $default is created. The $default route acts as a catch-all for any request made to your API, for a particular stage. The $default route key can't be modified. You can add routes after creating the API, and you can update the route keys of additional routes. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP_PROXY or AWS_PROXY, respectively. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Api resource to represent an API.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateApiResponse": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateAuthorizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateAuthorizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateAuthorizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Authorizer for an API.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/authorizers",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateAuthorizerRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType",
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. By default, a Lambda authorizer must return an IAM policy. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource",
+            "smithy.api#required": {}
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is not used.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Authorizer resource to represent an authorizer.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateAuthorizerResponse": {
+      "type": "structure",
+      "members": {
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType"
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource"
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation expression does not apply to the REQUEST authorizer.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a Deployment for an API.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/deployments",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment resource.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Stage resource for the Deployment resource to create.</p>",
+            "smithy.api#jsonName": "stageName"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Deployment resource to represent a deployment.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDeploymentResponse": {
+      "type": "structure",
+      "members": {
+        "AutoDeployed": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a deployment was automatically released.</p>",
+            "smithy.api#jsonName": "autoDeployed"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the Deployment resource was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the deployment.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "DeploymentStatus": {
+          "target": "com.amazonaws.apigatewayv2#DeploymentStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the deployment: PENDING, FAILED, or SUCCEEDED.</p>",
+            "smithy.api#jsonName": "deploymentStatus"
+          }
+        },
+        "DeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>May contain additional feedback on the status of an API deployment.</p>",
+            "smithy.api#jsonName": "deploymentStatusMessage"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDomainName": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateDomainNameRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateDomainNameResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a domain name.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/domainnames",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDomainNameRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#jsonName": "domainName",
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthenticationInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags associated with a domain name.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new DomainName resource to represent a domain name.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateDomainNameResponse": {
+      "type": "structure",
+      "members": {
+        "ApiMappingSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping selection expression.</p>",
+            "smithy.api#jsonName": "apiMappingSelectionExpression"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainName"
+          }
+        },
+        "DomainNameArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#jsonName": "domainNameArn"
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthentication",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags associated with a domain name.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateIntegrationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateIntegrationResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an Integration.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/integrations",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegrationRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the integration.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration. For HTTP API private integrations, use an HTTP_PROXY integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType",
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n               , where \n                  <replaceable>{location}</replaceable>\n                is querystring, path, or header; and \n                  <replaceable>{name}</replaceable>\n                must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to the backend. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt; where action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfigInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Integration resource to represent an integration.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegrationResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateIntegrationResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateIntegrationResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an IntegrationResponses.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegrationResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey",
+            "smithy.api#required": {}
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where {name} is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where {name} is a valid and unique response header name and {JSON-expression} is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new IntegrationResponse resource to represent an integration response.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegrationResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#jsonName": "integrationResponseId"
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expressions for the integration response.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateIntegrationResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an integration is managed by API Gateway. If you created an API using using quick create, the resulting integration is managed by API Gateway. You can update a managed integration, but you can't delete it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the description of an integration.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of an integration.</p>",
+            "smithy.api#jsonName": "integrationId"
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response selection expression for the integration. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-integration-response-selection-expressions\">Integration Response Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "integrationResponseSelectionExpression"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType"
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations, without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to backend integrations. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt;. The action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a Model for an API.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/models",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateModelRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Model.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateModelResponse": {
+      "type": "structure",
+      "members": {
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The model identifier.</p>",
+            "smithy.api#jsonName": "modelId"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreatePortalRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreatePortalResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a portal.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portals",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortalProduct": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreatePortalProductRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreatePortalProductResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new portal product.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portalproducts",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortalProductRequest": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the portal product.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the portal product as it appears in a published portal.</p>",
+            "smithy.api#jsonName": "displayName",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the post operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortalProductResponse": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the portal product.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The display name for the portal product.</p>",
+            "smithy.api#jsonName": "displayName"
+          }
+        },
+        "DisplayOrder": {
+          "target": "com.amazonaws.apigatewayv2#DisplayOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The visual ordering of the product pages and product REST endpoint pages in a published portal.</p>",
+            "smithy.api#jsonName": "displayOrder"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal product was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "PortalProductArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal product.</p>",
+            "smithy.api#jsonName": "portalProductArn"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#jsonName": "portalProductId"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortalRequest": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The authentication configuration for the portal.</p>",
+            "smithy.api#jsonName": "authorization",
+            "smithy.api#required": {}
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationRequest",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The domain configuration for the portal. Use a default domain provided by API Gateway or provide a fully-qualified domain name that you own.</p>",
+            "smithy.api#jsonName": "endpointConfiguration",
+            "smithy.api#required": {}
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns"
+          }
+        },
+        "LogoUri": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1092",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI for the portal logo image that is displayed in the portal header.</p>",
+            "smithy.api#jsonName": "logoUri"
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The content of the portal.</p>",
+            "smithy.api#jsonName": "portalContent",
+            "smithy.api#required": {}
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon CloudWatch RUM app monitor for the portal.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the post operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreatePortalResponse": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization for the portal. Supports Cognito-based user authentication or no authentication.</p>",
+            "smithy.api#jsonName": "authorization"
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The endpoint configuration.</p>",
+            "smithy.api#jsonName": "endpointConfiguration"
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal configuration was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "LastPublished": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last published.</p>",
+            "smithy.api#jsonName": "lastPublished"
+          }
+        },
+        "LastPublishedDescription": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A user-written description of the changes made in the last published version of the portal.</p>",
+            "smithy.api#jsonName": "lastPublishedDescription"
+          }
+        },
+        "PortalArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal.</p>",
+            "smithy.api#jsonName": "portalArn"
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The name, description, and theme for the portal.</p>",
+            "smithy.api#jsonName": "portalContent"
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#jsonName": "portalId"
+          }
+        },
+        "PublishStatus": {
+          "target": "com.amazonaws.apigatewayv2#PublishStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current publishing status of the portal.</p>",
+            "smithy.api#jsonName": "publishStatus"
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon CloudWatch RUM app monitor.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>Error information for failed portal operations. Contains details about any issues encountered during portal creation or publishing.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateProductPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateProductPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new product page for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portalproducts/{PortalProductId}/productpages",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductPageRequest": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContent",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The content of the product page.</p>",
+            "smithy.api#jsonName": "displayContent",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the post operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product page.</p>",
+            "smithy.api#jsonName": "productPageArn"
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product page identifier.</p>",
+            "smithy.api#jsonName": "productPageId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductRestEndpointPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateProductRestEndpointPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateProductRestEndpointPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a product REST endpoint page for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portalproducts/{PortalProductId}/productrestendpointpages",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductRestEndpointPageRequest": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#EndpointDisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RestEndpointIdentifier": {
+          "target": "com.amazonaws.apigatewayv2#RestEndpointIdentifier",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "restEndpointIdentifier",
+            "smithy.api#required": {}
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#documentation": "<p>The try it state of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "tryItState"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the post operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateProductRestEndpointPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#EndpointDisplayContentResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The display content.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product REST endpoint page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductRestEndpointPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageArn"
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint page identifier.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageId"
+          }
+        },
+        "RestEndpointIdentifier": {
+          "target": "com.amazonaws.apigatewayv2#RestEndpointIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "restEndpointIdentifier"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.apigatewayv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status.</p>",
+            "smithy.api#jsonName": "status"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#documentation": "<p>The try it state.</p>",
+            "smithy.api#jsonName": "tryItState"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRoute": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateRouteRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateRouteResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a Route for an API.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/routes",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRouteRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization scopes supported by this route.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey",
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Route resource to represent a route.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRouteResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateRouteResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateRouteResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a RouteResponse for a Route.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRouteResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The response models for the route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response parameters.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The route response key.</p>",
+            "smithy.api#jsonName": "routeResponseKey",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new RouteResponse resource to represent a route response.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRouteResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the model selection expression of a route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response models of a route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response parameters of a route response.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseId"
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the route response key of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseKey"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRouteResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a route is managed by API Gateway. If you created an API using quick create, the $default route is managed by API Gateway. You can't modify the $default route key.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for this route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#jsonName": "routeId"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRoutingRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateRoutingRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateRoutingRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a RoutingRule.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/domainnames/{DomainName}/routingrules",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRoutingRuleRequest": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents a routing rule action. The only supported action is invokeApi.</p>",
+            "smithy.api#jsonName": "actions",
+            "smithy.api#required": {}
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents a condition. Conditions can contain up to two matchHeaders conditions and one matchBasePaths conditions. API Gateway evaluates header conditions and base path conditions together. You can only use AND between header and base path conditions.</p>",
+            "smithy.api#jsonName": "conditions",
+            "smithy.api#required": {}
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name ID.</p>",
+            "smithy.api#httpQuery": "domainNameId"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "Represents the priority of the routing rule.",
+            "smithy.api#jsonName": "priority",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateRoutingRuleResponse": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a routing rule action. The only supported action is invokeApi.</p>",
+            "smithy.api#jsonName": "actions"
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a condition. Conditions can contain up to two matchHeaders conditions and one matchBasePaths conditions. API Gateway evaluates header conditions and base path conditions together. You can only use AND between header and base path conditions.</p>",
+            "smithy.api#jsonName": "conditions"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the priority of the routing rule.<p>",
+            "smithy.api#jsonName": "priority"
+          }
+        },
+        "RoutingRuleArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the domain name.<p>",
+            "smithy.api#jsonName": "routingRuleArn"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#jsonName": "routingRuleId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateStage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateStageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateStageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a Stage for an API.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/apis/{ApiId}/stages",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateStageRequest": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The deployment identifier of the API stage.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the API stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage, by routeKey.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the stage.</p>",
+            "smithy.api#jsonName": "stageName",
+            "smithy.api#required": {}
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Stage resource to represent a stage.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateStageResponse": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a stage is managed by API Gateway. If you created an API using quick create, the $default stage is managed by API Gateway. You can't modify the $default stage.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Deployment that the Stage is associated with. Can't be updated if autoDeploy is enabled.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "LastDeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the status of the last deployment of a stage. Supported only for stages with autoDeploy enabled.</p>",
+            "smithy.api#jsonName": "lastDeploymentStatusMessage"
+          }
+        },
+        "LastUpdatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was last updated.</p>",
+            "smithy.api#jsonName": "lastUpdatedDate"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage, by routeKey.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the stage.</p>",
+            "smithy.api#jsonName": "stageName"
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a stage resource. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateVpcLink": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#CreateVpcLinkRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#CreateVpcLinkResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a VPC link.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/vpclinks",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateVpcLinkRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.apigatewayv2#SecurityGroupIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>",
+            "smithy.api#jsonName": "securityGroupIds"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.apigatewayv2#SubnetIdList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>",
+            "smithy.api#jsonName": "subnetIds",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a VPC link</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CreateVpcLinkResponse": {
+      "type": "structure",
+      "members": {
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the VPC link was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.apigatewayv2#SecurityGroupIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>",
+            "smithy.api#jsonName": "securityGroupIds"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.apigatewayv2#SubnetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>",
+            "smithy.api#jsonName": "subnetIds"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the VPC link.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkId"
+          }
+        },
+        "VpcLinkStatus": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatus"
+          }
+        },
+        "VpcLinkStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A message summarizing the cause of the status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatusMessage"
+          }
+        },
+        "VpcLinkVersion": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkVersion"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#CustomColors": {
+      "type": "structure",
+      "members": {
+        "AccentColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the accent color.</p>",
+            "smithy.api#jsonName": "accentColor",
+            "smithy.api#required": {}
+          }
+        },
+        "BackgroundColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the background color.</p>",
+            "smithy.api#jsonName": "backgroundColor",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorValidationColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The errorValidationColor.</p>",
+            "smithy.api#jsonName": "errorValidationColor",
+            "smithy.api#required": {}
+          }
+        },
+        "HeaderColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the header color.</p>",
+            "smithy.api#jsonName": "headerColor",
+            "smithy.api#required": {}
+          }
+        },
+        "NavigationColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the navigation color.</p>",
+            "smithy.api#jsonName": "navigationColor",
+            "smithy.api#required": {}
+          }
+        },
+        "TextColor": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max16",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the text color.</p>",
+            "smithy.api#jsonName": "textColor",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents custom colors for a published portal.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteAccessLogSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteAccessLogSettingsRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the AccessLogSettings for a Stage. To disable access logging for a Stage, delete its AccessLogSettings.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}/accesslogsettings",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteAccessLogSettingsRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteApiRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Api resource.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteApiMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteApiMappingRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an API mapping.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteApiMappingRequest": {
+      "type": "structure",
+      "members": {
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteAuthorizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteAuthorizerRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Authorizer.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/authorizers/{AuthorizerId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteAuthorizerRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteCorsConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteCorsConfigurationRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a CORS configuration.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/cors",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteCorsConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteDeploymentRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Deployment.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/deployments/{DeploymentId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The deployment ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteDomainName": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteDomainNameRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a domain name.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/domainnames/{DomainName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteDomainNameRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteIntegration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteIntegrationRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Integration.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteIntegrationRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteIntegrationResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteIntegrationResponseRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an IntegrationResponses.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteIntegrationResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteModelRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Model.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/models/{ModelId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteModelRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The model ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeletePortalRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a portal.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portals/{PortalId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortalProduct": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeletePortalProductRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a portal product.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portalproducts/{PortalProductId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortalProductRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortalProductSharingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeletePortalProductSharingPolicyRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the sharing policy for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portalproducts/{PortalProductId}/sharingpolicy",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortalProductSharingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeletePortalRequest": {
+      "type": "structure",
+      "members": {
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteProductPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteProductPageRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a product page of a portal product.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portalproducts/{PortalProductId}/productpages/{ProductPageId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteProductPageRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteProductRestEndpointPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteProductRestEndpointPageRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a product REST endpoint page.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portalproducts/{PortalProductId}/productrestendpointpages/{ProductRestEndpointPageId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteProductRestEndpointPageRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRoute": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteRouteRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Route.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteRequestParameter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteRouteRequestParameterRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a route request parameter. Supported only for WebSocket APIs.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/requestparameters/{RequestParameterKey}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteRequestParameterRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RequestParameterKey": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route request parameter key.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteRouteResponseRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a RouteResponse.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteRouteSettingsRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the RouteSettings for a stage.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}/routesettings/{RouteKey}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRouteSettingsRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route key.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRoutingRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteRoutingRuleRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a routing rule.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/domainnames/{DomainName}/routingrules/{RoutingRuleId}",
+          "code": 204
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteRoutingRuleRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name ID.</p>",
+            "smithy.api#httpQuery": "domainNameId"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteStage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteStageRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Stage.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteStageRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteVpcLink": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DeleteVpcLinkRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#DeleteVpcLinkResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a VPC link.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/vpclinks/{VpcLinkId}",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteVpcLinkRequest": {
+      "type": "structure",
+      "members": {
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeleteVpcLinkResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#Deployment": {
+      "type": "structure",
+      "members": {
+        "AutoDeployed": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a deployment was automatically released.</p>",
+            "smithy.api#jsonName": "autoDeployed"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the Deployment resource was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the deployment.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "DeploymentStatus": {
+          "target": "com.amazonaws.apigatewayv2#DeploymentStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the deployment: PENDING, FAILED, or SUCCEEDED.</p>",
+            "smithy.api#jsonName": "deploymentStatus"
+          }
+        },
+        "DeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>May contain additional feedback on the status of an API deployment.</p>",
+            "smithy.api#jsonName": "deploymentStatusMessage"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An immutable representation of an API that can be called by users. A Deployment must be associated with a Stage for it to be callable over the internet.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DeploymentStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "DEPLOYED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEPLOYED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a deployment status.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DisablePortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#DisablePortalRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the publication of a portal portal.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/portals/{PortalId}/publish",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#DisablePortalRequest": {
+      "type": "structure",
+      "members": {
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#DisplayContent": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max32768",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The body.</p>",
+            "smithy.api#jsonName": "body",
+            "smithy.api#required": {}
+          }
+        },
+        "Title": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The title.</p>",
+            "smithy.api#jsonName": "title",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The content of the product page.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DisplayContentOverrides": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max32768",
+          "traits": {
+            "smithy.api#documentation": "<p>By default, this is the documentation of your REST API from API Gateway. You can provide custom documentation to override this value.</p>",
+            "smithy.api#jsonName": "body"
+          }
+        },
+        "Endpoint": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL for your REST API. By default, API Gateway uses the default execute API endpoint. You can provide a custom domain to override this value.</p>",
+            "smithy.api#jsonName": "endpoint"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains any values that override the default configuration generated from API Gateway.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DisplayOrder": {
+      "type": "structure",
+      "members": {
+        "Contents": {
+          "target": "com.amazonaws.apigatewayv2#__listOfSection",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a list of sections which include section name and list of product REST endpoints for a product.</p>",
+            "smithy.api#jsonName": "contents"
+          }
+        },
+        "OverviewPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the overview page.</p>",
+            "smithy.api#jsonName": "overviewPageArn"
+          }
+        },
+        "ProductPageArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The product page ARNs.</p>",
+            "smithy.api#jsonName": "productPageArns"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The display order.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DomainName": {
+      "type": "structure",
+      "members": {
+        "ApiMappingSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping selection expression.</p>",
+            "smithy.api#jsonName": "apiMappingSelectionExpression"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainName",
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#jsonName": "domainNameArn"
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthentication",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags associated with a domain name.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a domain name.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DomainNameConfiguration": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayDomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>A domain name for the API.</p>",
+            "smithy.api#jsonName": "apiGatewayDomainName"
+          }
+        },
+        "CertificateArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>An AWS-managed certificate that will be used by the edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>",
+            "smithy.api#jsonName": "certificateArn"
+          }
+        },
+        "CertificateName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The user-friendly name of the certificate that will be used by the edge-optimized endpoint for this domain name.</p>",
+            "smithy.api#jsonName": "certificateName"
+          }
+        },
+        "CertificateUploadDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the certificate that was used by edge-optimized endpoint for this domain name was uploaded.</p>",
+            "smithy.api#jsonName": "certificateUploadDate"
+          }
+        },
+        "DomainNameStatus": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the domain name migration. The valid values are AVAILABLE, UPDATING, PENDING_CERTIFICATE_REIMPORT, and PENDING_OWNERSHIP_VERIFICATION. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.</p>",
+            "smithy.api#jsonName": "domainNameStatus"
+          }
+        },
+        "DomainNameStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional text message containing detailed information about status of the domain name migration.</p>",
+            "smithy.api#jsonName": "domainNameStatusMessage"
+          }
+        },
+        "EndpointType": {
+          "target": "com.amazonaws.apigatewayv2#EndpointType",
+          "traits": {
+            "smithy.api#documentation": "<p>The endpoint type.</p>",
+            "smithy.api#jsonName": "endpointType"
+          }
+        },
+        "HostedZoneId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Route 53 Hosted Zone ID of the endpoint.</p>",
+            "smithy.api#jsonName": "hostedZoneId"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the domain name. Use ipv4 to allow only IPv4 addresses to invoke your domain name, or use dualstack to allow both IPv4 and IPv6 addresses to invoke your domain name.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "SecurityPolicy": {
+          "target": "com.amazonaws.apigatewayv2#SecurityPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The Transport Layer Security (TLS) version of the security policy for this domain name. The valid values are TLS_1_0 and TLS_1_2.</p>",
+            "smithy.api#jsonName": "securityPolicy"
+          }
+        },
+        "OwnershipVerificationCertificateArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the public certificate issued by ACM to validate ownership of your custom domain. Only required when configuring mutual TLS and using an ACM imported or private CA certificate ARN as the regionalCertificateArn</p>",
+            "smithy.api#jsonName": "ownershipVerificationCertificateArn"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The domain name configuration.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DomainNameConfigurations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#DomainNameConfiguration"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The domain name configurations.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#DomainNameStatus": {
+      "type": "enum",
+      "members": {
+        "AVAILABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVAILABLE"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "PENDING_CERTIFICATE_REIMPORT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING_CERTIFICATE_REIMPORT"
+          }
+        },
+        "PENDING_OWNERSHIP_VERIFICATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING_OWNERSHIP_VERIFICATION"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the domain name migration. The valid values are AVAILABLE, UPDATING, PENDING_CERTIFICATE_REIMPORT, and PENDING_OWNERSHIP_VERIFICATION. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#EndpointConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "AcmManaged": {
+          "target": "com.amazonaws.apigatewayv2#ACMManaged",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a domain name and certificate for a portal.</p>",
+            "smithy.api#jsonName": "acmManaged"
+          }
+        },
+        "None": {
+          "target": "com.amazonaws.apigatewayv2#None",
+          "traits": {
+            "smithy.api#documentation": "<p>Use the default portal domain name that is generated and managed by API Gateway.</p>",
+            "smithy.api#jsonName": "none"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an endpoint configuration.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#EndpointConfigurationResponse": {
+      "type": "structure",
+      "members": {
+        "CertificateArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the ACM certificate.</p>",
+            "smithy.api#jsonName": "certificateArn"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin3Max256",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#jsonName": "domainName"
+          }
+        },
+        "PortalDefaultDomainName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin3Max256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The portal default domain name. This domain name is generated and managed by API Gateway.</p>",
+            "smithy.api#jsonName": "portalDefaultDomainName",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalDomainHostedZoneId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max64",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The portal domain hosted zone identifier.</p>",
+            "smithy.api#jsonName": "portalDomainHostedZoneId",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an endpoint configuration.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#EndpointDisplayContent": {
+      "type": "structure",
+      "members": {
+        "None": {
+          "target": "com.amazonaws.apigatewayv2#None",
+          "traits": {
+            "smithy.api#documentation": "<p>If your product REST endpoint contains no overrides, the none object is returned.</p>",
+            "smithy.api#jsonName": "none"
+          }
+        },
+        "Overrides": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContentOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>The overrides for endpoint display content.</p>",
+            "smithy.api#jsonName": "overrides"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the endpoint display content.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#EndpointDisplayContentResponse": {
+      "type": "structure",
+      "members": {
+        "Body": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max32768",
+          "traits": {
+            "smithy.api#documentation": "<p>The API documentation.</p>",
+            "smithy.api#jsonName": "body"
+          }
+        },
+        "Endpoint": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max1024",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The URL to invoke your REST API.</p>",
+            "smithy.api#jsonName": "endpoint",
+            "smithy.api#required": {}
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The product REST endpoint page.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#EndpointType": {
+      "type": "enum",
+      "members": {
+        "REGIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REGIONAL"
+          }
+        },
+        "EDGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EDGE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an endpoint type.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ExportApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ExportApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ExportApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/exports/{Specification}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ExportApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ExportVersion": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the API Gateway export algorithm. API Gateway uses the latest version by default. Currently, the only supported version is 1.0.</p>",
+            "smithy.api#httpQuery": "exportVersion"
+          }
+        },
+        "IncludeExtensions": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to include <a href=\"https://docs.aws.amazon.com//apigateway/latest/developerguide/api-gateway-swagger-extensions.html\">API Gateway extensions</a> in the exported API definition. API Gateway extensions are included by default.</p>",
+            "smithy.api#httpQuery": "includeExtensions"
+          }
+        },
+        "OutputType": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The output type of the exported definition file. Valid values are JSON and YAML.</p>",
+            "smithy.api#httpQuery": "outputType",
+            "smithy.api#required": {}
+          }
+        },
+        "Specification": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the API specification to use. OAS30, for OpenAPI 3.0, is the only supported value.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API stage to export. If you don't specify this property, a representation of the latest API configuration is exported.</p>",
+            "smithy.api#httpQuery": "stageName"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ExportApiResponse": {
+      "type": "structure",
+      "members": {
+        "body": {
+          "target": "com.amazonaws.apigatewayv2#ExportedApi",
+          "traits": {
+            "smithy.api#httpPayload": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ExportedApi": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an exported definition of an API in a particular output format, for example, YAML. The API is serialized to the requested specification, for example, OpenAPI 3.0.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets an Api resource.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetApiMappingRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetApiMappingResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets an API mapping.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMappingRequest": {
+      "type": "structure",
+      "members": {
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMappingResponse": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#jsonName": "apiMappingId"
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping key.</p>",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMappings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetApiMappingsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetApiMappingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets API mappings.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames/{DomainName}/apimappings",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMappingsRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiMappingsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfApiMapping",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApiResponse": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetApisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetApisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a collection of Api resources.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApisRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetApisResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfApi",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetAuthorizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetAuthorizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets an Authorizer.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/authorizers/{AuthorizerId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizerRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizerResponse": {
+      "type": "structure",
+      "members": {
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType"
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource"
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation expression does not apply to the REQUEST authorizer.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizers": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetAuthorizersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetAuthorizersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Authorizers for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/authorizers",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizersRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetAuthorizersResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfAuthorizer",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a Deployment.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/deployments/{DeploymentId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The deployment ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeploymentResponse": {
+      "type": "structure",
+      "members": {
+        "AutoDeployed": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a deployment was automatically released.</p>",
+            "smithy.api#jsonName": "autoDeployed"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the Deployment resource was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the deployment.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "DeploymentStatus": {
+          "target": "com.amazonaws.apigatewayv2#DeploymentStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the deployment: PENDING, FAILED, or SUCCEEDED.</p>",
+            "smithy.api#jsonName": "deploymentStatus"
+          }
+        },
+        "DeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>May contain additional feedback on the status of an API deployment.</p>",
+            "smithy.api#jsonName": "deploymentStatusMessage"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeployments": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetDeploymentsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetDeploymentsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Deployments for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/deployments",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeploymentsRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDeploymentsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfDeployment",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainName": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetDomainNameRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetDomainNameResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a domain name.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames/{DomainName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainNameRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainNameResponse": {
+      "type": "structure",
+      "members": {
+        "ApiMappingSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping selection expression.</p>",
+            "smithy.api#jsonName": "apiMappingSelectionExpression"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainName"
+          }
+        },
+        "DomainNameArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainNameArn"
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthentication",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags associated with a domain name.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainNames": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetDomainNamesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetDomainNamesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the domain names for an AWS account.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainNamesRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetDomainNamesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfDomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets an Integration.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets an IntegrationResponses.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#jsonName": "integrationResponseId"
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expressions for the integration response.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationResponsesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationResponsesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the IntegrationResponses for an Integration.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponsesRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResponsesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfIntegrationResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an integration is managed by API Gateway. If you created an API using using quick create, the resulting integration is managed by API Gateway. You can update a managed integration, but you can't delete it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the description of an integration.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of an integration.</p>",
+            "smithy.api#jsonName": "integrationId"
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response selection expression for the integration. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-integration-response-selection-expressions\">Integration Response Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "integrationResponseSelectionExpression"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType"
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations, without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to backend integrations. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt;. The action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetIntegrationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Integrations for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/integrations",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationsRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetIntegrationsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfIntegration",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a Model.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/models/{ModelId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The model ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelResponse": {
+      "type": "structure",
+      "members": {
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The model identifier.</p>",
+            "smithy.api#jsonName": "modelId"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelTemplate": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetModelTemplateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetModelTemplateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a model template.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/models/{ModelId}/template",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelTemplateRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The model ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelTemplateResponse": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The template value.</p>",
+            "smithy.api#jsonName": "value"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetModelsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetModelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Models for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/models",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelsRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetModelsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfModel",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a portal.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portals/{PortalId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProduct": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalProductRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalProductResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a portal product.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProductRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceOwnerAccountId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The account ID of the resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwnerAccountId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProductResponse": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of a portal product.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The display name.</p>",
+            "smithy.api#jsonName": "displayName"
+          }
+        },
+        "DisplayOrder": {
+          "target": "com.amazonaws.apigatewayv2#DisplayOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The display order.</p>",
+            "smithy.api#jsonName": "displayOrder"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal product was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "PortalProductArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal product.</p>",
+            "smithy.api#jsonName": "portalProductArn"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#jsonName": "portalProductId"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the sharing policy for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}/sharingpolicy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalProductSharingPolicyResponse": {
+      "type": "structure",
+      "members": {
+        "PolicyDocument": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max307200",
+          "traits": {
+            "smithy.api#documentation": "<p>The product sharing policy.</p>",
+            "smithy.api#jsonName": "policyDocument"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#jsonName": "portalProductId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalRequest": {
+      "type": "structure",
+      "members": {
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetPortalResponse": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization for the portal.</p>",
+            "smithy.api#jsonName": "authorization"
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The endpoint configuration.</p>",
+            "smithy.api#jsonName": "endpointConfiguration"
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "LastPublished": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last published.</p>",
+            "smithy.api#jsonName": "lastPublished"
+          }
+        },
+        "LastPublishedDescription": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The publish description used when the portal was last published.</p>",
+            "smithy.api#jsonName": "lastPublishedDescription"
+          }
+        },
+        "PortalArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal.</p>",
+            "smithy.api#jsonName": "portalArn"
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the content that is visible to portal consumers including the themes, display names, and description.</p>",
+            "smithy.api#jsonName": "portalContent"
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#jsonName": "portalId"
+          }
+        },
+        "Preview": {
+          "target": "com.amazonaws.apigatewayv2#Preview",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the preview endpoint and the any possible error messages during preview generation.</p>",
+            "smithy.api#jsonName": "preview"
+          }
+        },
+        "PublishStatus": {
+          "target": "com.amazonaws.apigatewayv2#PublishStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The publish status of a portal.</p>",
+            "smithy.api#jsonName": "publishStatus"
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The CloudWatch RUM app monitor name.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetProductPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetProductPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a product page of a portal product.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}/productpages/{ProductPageId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductPageRequest": {
+      "type": "structure",
+      "members": {
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceOwnerAccountId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The account ID of the resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwnerAccountId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product page.</p>",
+            "smithy.api#jsonName": "productPageArn"
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product page identifier.</p>",
+            "smithy.api#jsonName": "productPageId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductRestEndpointPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetProductRestEndpointPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetProductRestEndpointPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a product REST endpoint page.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}/productrestendpointpages/{ProductRestEndpointPageId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductRestEndpointPageRequest": {
+      "type": "structure",
+      "members": {
+        "IncludeRawDisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The query parameter to include raw display content.</p>",
+            "smithy.api#httpQuery": "includeRawDisplayContent"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceOwnerAccountId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The account ID of the resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwnerAccountId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetProductRestEndpointPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#EndpointDisplayContentResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product REST endpoint page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductRestEndpointPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageArn"
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint page identifier.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageId"
+          }
+        },
+        "RawDisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The raw display content of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "rawDisplayContent"
+          }
+        },
+        "RestEndpointIdentifier": {
+          "target": "com.amazonaws.apigatewayv2#RestEndpointIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "restEndpointIdentifier"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.apigatewayv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "status"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#documentation": "<p>The try it state.</p>",
+            "smithy.api#jsonName": "tryItState"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoute": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a Route.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a RouteResponse.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the model selection expression of a route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response models of a route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response parameters of a route response.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseId"
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the route response key of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseKey"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteResponsesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetRouteResponsesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the RouteResponses for a Route.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponsesRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResponsesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRouteResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRouteResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a route is managed by API Gateway. If you created an API using quick create, the $default route is managed by API Gateway. You can't modify the $default route key.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for this route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#jsonName": "routeId"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetRoutesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetRoutesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Routes for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/routes",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutesRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoute",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutingRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetRoutingRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetRoutingRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a routing rule.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames/{DomainName}/routingrules/{RoutingRuleId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutingRuleRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name ID.</p>",
+            "smithy.api#httpQuery": "domainNameId"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetRoutingRuleResponse": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#documentation": "<p>The resulting action based on matching a routing rules condition. Only InvokeApi is supported.</p>",
+            "smithy.api#jsonName": "actions"
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditions of the routing rule.</p>",
+            "smithy.api#jsonName": "conditions"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The order in which API Gateway evaluates a rule. Priority is evaluated from the lowest value to the highest value.</p>",
+            "smithy.api#jsonName": "priority"
+          }
+        },
+        "RoutingRuleArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ARN.</p>",
+            "smithy.api#jsonName": "routingRuleArn"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#jsonName": "routingRuleId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetStageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetStageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a Stage.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStageRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStageResponse": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a stage is managed by API Gateway. If you created an API using quick create, the $default stage is managed by API Gateway. You can't modify the $default stage.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Deployment that the Stage is associated with. Can't be updated if autoDeploy is enabled.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "LastDeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the status of the last deployment of a stage. Supported only for stages with autoDeploy enabled.</p>",
+            "smithy.api#jsonName": "lastDeploymentStatusMessage"
+          }
+        },
+        "LastUpdatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was last updated.</p>",
+            "smithy.api#jsonName": "lastUpdatedDate"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage, by routeKey.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the stage.</p>",
+            "smithy.api#jsonName": "stageName"
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a stage resource. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStages": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetStagesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetStagesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the Stages for an API.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/apis/{ApiId}/stages",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStagesRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetStagesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfStage",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetTags": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetTagsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetTagsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a collection of Tag resources.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/tags/{ResourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetTagsRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource ARN for the tag.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetTagsResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLink": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetVpcLinkRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetVpcLinkResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a VPC link.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/vpclinks/{VpcLinkId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLinkRequest": {
+      "type": "structure",
+      "members": {
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLinkResponse": {
+      "type": "structure",
+      "members": {
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the VPC link was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.apigatewayv2#SecurityGroupIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>",
+            "smithy.api#jsonName": "securityGroupIds"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.apigatewayv2#SubnetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>",
+            "smithy.api#jsonName": "subnetIds"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the VPC link.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkId"
+          }
+        },
+        "VpcLinkStatus": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatus"
+          }
+        },
+        "VpcLinkStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A message summarizing the cause of the status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatusMessage"
+          }
+        },
+        "VpcLinkVersion": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkVersion"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLinks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#GetVpcLinksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#GetVpcLinksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a collection of VPC links.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/vpclinks",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLinksRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#GetVpcLinksResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfVpcLink",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of VPC links.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#Id": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The identifier.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IdentifierParts": {
+      "type": "structure",
+      "members": {
+        "Method": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max20",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The method of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "method",
+            "smithy.api#required": {}
+          }
+        },
+        "Path": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max4096",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The path of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "path",
+            "smithy.api#required": {}
+          }
+        },
+        "RestApiId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max50",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The REST API ID of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "restApiId",
+            "smithy.api#required": {}
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The stage of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "stage",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The identifier parts of a product REST endpoint.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IdentitySourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The identity source for which authorization is requested. For the REQUEST authorizer, this is required when authorization caching is enabled. The value is a comma-separated string of one or more mapping expressions of the specified request parameters. For example, if an Auth header, a Name query string parameter are defined as identity sources, this value is $method.request.header.Auth, $method.request.querystring.Name. These parameters will be used to derive the authorization caching key and to perform runtime validation of the REQUEST authorizer by verifying all of the identity-related request parameters are present, not null and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function, otherwise, it returns a 401 Unauthorized response without calling the Lambda function. The valid value is a string of comma-separated mapping expressions of the specified request parameters. When the authorization caching is not enabled, this property is optional.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ImportApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ImportApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ImportApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Imports an API.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/apis",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ImportApiRequest": {
+      "type": "structure",
+      "members": {
+        "Basepath": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how to interpret the base path of the API during import. Valid values are ignore, prepend, and split. The default value is ignore. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-import-api-basePath.html\">Set the OpenAPI basePath Property</a>. Supported only for HTTP APIs.</p>",
+            "smithy.api#httpQuery": "basepath"
+          }
+        },
+        "Body": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The OpenAPI definition. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "body",
+            "smithy.api#required": {}
+          }
+        },
+        "FailOnWarnings": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to rollback the API creation when a warning is encountered. By default, API creation continues if a warning is encountered.</p>",
+            "smithy.api#httpQuery": "failOnWarnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ImportApiResponse": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#documentation": "<p>An integer with a value between [0-3600].</p>",
+        "smithy.api#range": {
+          "min": 0,
+          "max": 3600
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#documentation": "<p>An integer with a value between [50-30000].</p>",
+        "smithy.api#range": {
+          "min": 50,
+          "max": 30000
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegerWithLengthBetweenMinus1And86400": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#documentation": "<p>An integer with a value between -1 and 86400. Supported only for HTTP APIs.</p>",
+        "smithy.api#range": {
+          "min": -1,
+          "max": 86400
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#Integration": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an integration is managed by API Gateway. If you created an API using using quick create, the resulting integration is managed by API Gateway. You can update a managed integration, but you can't delete it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the description of an integration.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of an integration.</p>",
+            "smithy.api#jsonName": "integrationId"
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response selection expression for the integration. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-integration-response-selection-expressions\">Integration Response Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "integrationResponseSelectionExpression"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType"
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations, without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to backend integrations. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt;. The action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an integration.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegrationParameters": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to the backend. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt; where action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegrationResponse": {
+      "type": "structure",
+      "members": {
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#jsonName": "integrationResponseId"
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey",
+            "smithy.api#required": {}
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expressions for the integration response.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an integration response.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IntegrationType": {
+      "type": "enum",
+      "members": {
+        "AWS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS"
+          }
+        },
+        "HTTP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HTTP"
+          }
+        },
+        "MOCK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MOCK"
+          }
+        },
+        "HTTP_PROXY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HTTP_PROXY"
+          }
+        },
+        "AWS_PROXY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_PROXY"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an API method integration type.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#IpAddressType": {
+      "type": "enum",
+      "members": {
+        "ipv4": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ipv4"
+          }
+        },
+        "dualstack": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "dualstack"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The IP address types that can invoke your API or domain name.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#JWTConfiguration": {
+      "type": "structure",
+      "members": {
+        "Audience": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the intended recipients of the JWT. A valid JWT must provide an aud that matches at least one entry in this list. See <a href=\"https://tools.ietf.org/html/rfc7519#section-4.1.3\">RFC 7519</a>. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "audience"
+          }
+        },
+        "Issuer": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The base domain of the identity provider that issues JSON Web Tokens. For example, an Amazon Cognito user pool has the following format: https://cognito-idp.<replaceable>{region}</replaceable>.amazonaws.com/<replaceable>{userPoolId}</replaceable>\n               . Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "issuer"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortalProducts": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ListPortalProductsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ListPortalProductsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists portal products.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortalProductsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        },
+        "ResourceOwner": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwner"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortalProductsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfPortalProductSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortals": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ListPortalsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ListPortalsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists portals.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portals",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortalsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListPortalsResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfPortalSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductPages": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ListProductPagesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ListProductPagesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the product pages for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}/productpages",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductPagesRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceOwnerAccountId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The account ID of the resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwnerAccountId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductPagesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfProductPageSummaryNoBody",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductRestEndpointPages": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ListProductRestEndpointPagesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ListProductRestEndpointPagesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the product REST endpoint pages of a portal product.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/portalproducts/{PortalProductId}/productrestendpointpages",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductRestEndpointPagesRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceOwnerAccountId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The account ID of the resource owner of the portal product.</p>",
+            "smithy.api#httpQuery": "resourceOwnerAccountId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListProductRestEndpointPagesResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.apigatewayv2#__listOfProductRestEndpointPageSummaryNoBody",
+          "traits": {
+            "smithy.api#documentation": "<p>The elements from this collection.</p>",
+            "smithy.api#jsonName": "items"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#jsonName": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListRoutingRules": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ListRoutingRulesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ListRoutingRulesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists routing rules.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/v2/domainnames/{DomainName}/routingrules",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "RoutingRules",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListRoutingRulesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name ID.</p>",
+            "smithy.api#httpQuery": "domainNameId"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.apigatewayv2#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of elements to be returned for this resource.</p>",
+            "smithy.api#httpQuery": "maxResults"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+            "smithy.api#httpQuery": "nextToken"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ListRoutingRulesResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.apigatewayv2#NextToken",
+          "traits": {
+            "smithy.api#jsonName": "nextToken"
+          }
+        },
+        "RoutingRules": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRule",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rules.<p>",
+            "smithy.api#jsonName": "routingRules"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#LoggingLevel": {
+      "type": "enum",
+      "members": {
+        "ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ERROR"
+          }
+        },
+        "INFO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INFO"
+          }
+        },
+        "OFF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OFF"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The logging level.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#Model": {
+      "type": "structure",
+      "members": {
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The model identifier.</p>",
+            "smithy.api#jsonName": "modelId"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a data model for an API. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html\">Create Models and Mapping Templates for Request and Response Mappings</a>.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#MutualTlsAuthentication": {
+      "type": "structure",
+      "members": {
+        "TruststoreUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, s3://<replaceable>bucket-name</replaceable>/<replaceable>key-name</replaceable>. The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version. To update the truststore, you must have permissions to access the S3 object.</p>",
+            "smithy.api#jsonName": "truststoreUri"
+          }
+        },
+        "TruststoreVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the S3 object that contains your truststore. To specify a version, you must have versioning enabled for the S3 bucket.</p>",
+            "smithy.api#jsonName": "truststoreVersion"
+          }
+        },
+        "TruststoreWarnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of warnings that API Gateway returns while processing your truststore. Invalid certificates produce warnings. Mutual TLS is still enabled, but some clients might not be able to access your API. To resolve warnings, upload a new truststore to S3, and then update you domain name to use the new version.</p>",
+            "smithy.api#jsonName": "truststoreWarnings"
+          }
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#MutualTlsAuthenticationInput": {
+      "type": "structure",
+      "members": {
+        "TruststoreUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, s3://<replaceable>bucket-name</replaceable>/<replaceable>key-name</replaceable>. The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version. To update the truststore, you must have permissions to access the S3 object.</p>",
+            "smithy.api#jsonName": "truststoreUri"
+          }
+        },
+        "TruststoreVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the S3 object that contains your truststore. To specify a version, you must have versioning enabled for the S3 bucket.</p>",
+            "smithy.api#jsonName": "truststoreVersion"
+          }
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#NextToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#None": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>The none option.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#NotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the error encountered.</p>",
+            "smithy.api#jsonName": "message"
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type.</p>",
+            "smithy.api#jsonName": "resourceType"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource specified in the request was not found. See the message field for more information.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.apigatewayv2#ParameterConstraints": {
+      "type": "structure",
+      "members": {
+        "Required": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether or not the parameter is required.</p>",
+            "smithy.api#jsonName": "required"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Validation constraints imposed on parameters of a request (path, query string, headers).</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PassthroughBehavior": {
+      "type": "enum",
+      "members": {
+        "WHEN_NO_MATCH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WHEN_NO_MATCH"
+          }
+        },
+        "NEVER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEVER"
+          }
+        },
+        "WHEN_NO_TEMPLATES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WHEN_NO_TEMPLATES"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents passthrough behavior for an integration response. Supported only for WebSocket APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PortalContent": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the portal.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin3Max255",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The display name for the portal.</p>",
+            "smithy.api#jsonName": "displayName",
+            "smithy.api#required": {}
+          }
+        },
+        "Theme": {
+          "target": "com.amazonaws.apigatewayv2#PortalTheme",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The theme for the portal.</p>",
+            "smithy.api#jsonName": "theme",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the content that is visible to portal consumers including the themes, display names, and description.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PortalProductSummary": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The description.</p>",
+            "smithy.api#jsonName": "description",
+            "smithy.api#required": {}
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The display name of a portal product.</p>",
+            "smithy.api#jsonName": "displayName",
+            "smithy.api#required": {}
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The timestamp when the portal product was last modified.</p>",
+            "smithy.api#jsonName": "lastModified",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalProductArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARN of a portal product.</p>",
+            "smithy.api#jsonName": "portalProductArn",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#jsonName": "portalProductId",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a portal product.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PortalSummary": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The authorization of the portal.</p>",
+            "smithy.api#jsonName": "authorization",
+            "smithy.api#required": {}
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationResponse",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The endpoint configuration of the portal.</p>",
+            "smithy.api#jsonName": "endpointConfiguration",
+            "smithy.api#required": {}
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns",
+            "smithy.api#required": {}
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The timestamp when the portal was last modified.</p>",
+            "smithy.api#jsonName": "lastModified",
+            "smithy.api#required": {}
+          }
+        },
+        "LastPublished": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last published.</p>",
+            "smithy.api#jsonName": "lastPublished"
+          }
+        },
+        "LastPublishedDescription": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the portal the last time it was published.</p>",
+            "smithy.api#jsonName": "lastPublishedDescription"
+          }
+        },
+        "PortalArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARN of the portal.</p>",
+            "smithy.api#jsonName": "portalArn",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Contains the content that is visible to portal consumers including the themes, display names, and description.</p>",
+            "smithy.api#jsonName": "portalContent",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#jsonName": "portalId",
+            "smithy.api#required": {}
+          }
+        },
+        "Preview": {
+          "target": "com.amazonaws.apigatewayv2#Preview",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the preview endpoint and the any possible error messages during preview generation.</p>",
+            "smithy.api#jsonName": "preview"
+          }
+        },
+        "PublishStatus": {
+          "target": "com.amazonaws.apigatewayv2#PublishStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The publish status.</p>",
+            "smithy.api#jsonName": "publishStatus"
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The CloudWatch RUM app monitor name.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a portal summary.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PortalTheme": {
+      "type": "structure",
+      "members": {
+        "CustomColors": {
+          "target": "com.amazonaws.apigatewayv2#CustomColors",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Defines custom color values.</p>",
+            "smithy.api#jsonName": "customColors",
+            "smithy.api#required": {}
+          }
+        },
+        "LogoLastUploaded": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the logo was last uploaded.</p>",
+            "smithy.api#jsonName": "logoLastUploaded"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines the theme for a portal.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Preview": {
+      "type": "structure",
+      "members": {
+        "PreviewStatus": {
+          "target": "com.amazonaws.apigatewayv2#PreviewStatus",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The status of the preview.</p>",
+            "smithy.api#jsonName": "previewStatus",
+            "smithy.api#required": {}
+          }
+        },
+        "PreviewUrl": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URL of the preview.</p>",
+            "smithy.api#jsonName": "previewUrl"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the preview status and preview URL.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PreviewPortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#PreviewPortalRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#PreviewPortalResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a portal preview.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portals/{PortalId}/preview",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#PreviewPortalRequest": {
+      "type": "structure",
+      "members": {
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PreviewPortalResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PreviewStatus": {
+      "type": "enum",
+      "members": {
+        "PREVIEW_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PREVIEW_IN_PROGRESS"
+          }
+        },
+        "PREVIEW_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PREVIEW_FAILED"
+          }
+        },
+        "PREVIEW_READY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PREVIEW_READY"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the preview status.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ProductPageSummaryNoBody": {
+      "type": "structure",
+      "members": {
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The timestamp when the product page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified",
+            "smithy.api#required": {}
+          }
+        },
+        "PageTitle": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The page title.</p>",
+            "smithy.api#jsonName": "pageTitle",
+            "smithy.api#required": {}
+          }
+        },
+        "ProductPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARN of the product page.</p>",
+            "smithy.api#jsonName": "productPageArn",
+            "smithy.api#required": {}
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The product page identifier.</p>",
+            "smithy.api#jsonName": "productPageId",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a product page summary without listing any page content.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ProductRestEndpointPageSummaryNoBody": {
+      "type": "structure",
+      "members": {
+        "Endpoint": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max1024",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The endpoint of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "endpoint",
+            "smithy.api#required": {}
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The timestamp when the product REST endpoint page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified",
+            "smithy.api#required": {}
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name of the product REST endpoint.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "ProductRestEndpointPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARN of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageArn",
+            "smithy.api#required": {}
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The product REST endpoint page identifier.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageId",
+            "smithy.api#required": {}
+          }
+        },
+        "RestEndpointIdentifier": {
+          "target": "com.amazonaws.apigatewayv2#RestEndpointIdentifier",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "restEndpointIdentifier",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.apigatewayv2#Status",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The status.</p>",
+            "smithy.api#jsonName": "status",
+            "smithy.api#required": {}
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The try it state of a product REST endpoint page.</p>",
+            "smithy.api#jsonName": "tryItState",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of a product REST endpoint page, without providing the page content.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#ProtocolType": {
+      "type": "enum",
+      "members": {
+        "WEBSOCKET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WEBSOCKET"
+          }
+        },
+        "HTTP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HTTP"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Represents a protocol type."
+      }
+    },
+    "com.amazonaws.apigatewayv2#PublishPortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#PublishPortalRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#PublishPortalResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Publishes a portal.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/portals/{PortalId}/publish",
+          "code": 202
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#PublishPortalRequest": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the portal. When the portal is published, this description becomes the last published description.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the post operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PublishPortalResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PublishStatus": {
+      "type": "enum",
+      "members": {
+        "PUBLISHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUBLISHED"
+          }
+        },
+        "PUBLISH_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUBLISH_IN_PROGRESS"
+          }
+        },
+        "PUBLISH_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUBLISH_FAILED"
+          }
+        },
+        "DISABLE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLE_IN_PROGRESS"
+          }
+        },
+        "DISABLE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLE_FAILED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a publish status.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the sharing policy for a portal product.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/portalproducts/{PortalProductId}/sharingpolicy",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "PolicyDocument": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max307200",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The product sharing policy.</p>",
+            "smithy.api#jsonName": "policyDocument",
+            "smithy.api#required": {}
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the put operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutPortalProductSharingPolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutRoutingRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#PutRoutingRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#PutRoutingRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a routing rule.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/domainnames/{DomainName}/routingrules/{RoutingRuleId}",
+          "code": 200
+        },
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutRoutingRuleRequest": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The routing rule action.</p>",
+            "smithy.api#jsonName": "actions",
+            "smithy.api#required": {}
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The routing rule condition.</p>",
+            "smithy.api#jsonName": "conditions",
+            "smithy.api#required": {}
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name ID.</p>",
+            "smithy.api#httpQuery": "domainNameId"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The routing rule priority.</p>",
+            "smithy.api#jsonName": "priority",
+            "smithy.api#required": {}
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#PutRoutingRuleResponse": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule action.</p>",
+            "smithy.api#jsonName": "actions"
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#documentation": "<p>The conditions of the routing rule.</p>",
+            "smithy.api#jsonName": "conditions"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule priority.</p>",
+            "smithy.api#jsonName": "priority"
+          }
+        },
+        "RoutingRuleArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ARN.</p>",
+            "smithy.api#jsonName": "routingRuleArn"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#jsonName": "routingRuleId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ReimportApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ReimportApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#ReimportApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Puts an Api resource.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/v2/apis/{ApiId}",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ReimportApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Basepath": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how to interpret the base path of the API during import. Valid values are ignore, prepend, and split. The default value is ignore. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-import-api-basePath.html\">Set the OpenAPI basePath Property</a>. Supported only for HTTP APIs.</p>",
+            "smithy.api#httpQuery": "basepath"
+          }
+        },
+        "Body": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The OpenAPI definition. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "body",
+            "smithy.api#required": {}
+          }
+        },
+        "FailOnWarnings": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to rollback the API creation when a warning is encountered. By default, API creation continues if a warning is encountered.</p>",
+            "smithy.api#httpQuery": "failOnWarnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ReimportApiResponse": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ResetAuthorizersCache": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#ResetAuthorizersCacheRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Resets all authorizer cache entries on a stage. Supported only for HTTP APIs.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}/cache/authorizers",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#ResetAuthorizersCacheRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can contain only alphanumeric characters, hyphens, and underscores, or be $default. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#ResponseParameters": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#IntegrationParameters"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RestEndpointIdentifier": {
+      "type": "structure",
+      "members": {
+        "IdentifierParts": {
+          "target": "com.amazonaws.apigatewayv2#IdentifierParts",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier parts of the REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "identifierParts"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The REST API endpoint identifier.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Route": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a route is managed by API Gateway. If you created an API using quick create, the $default route is managed by API Gateway. You can't modify the $default route key.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for this route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#jsonName": "routeId"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey",
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a route.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RouteModels": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The route models.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RouteParameters": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#ParameterConstraints"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The route parameters.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RouteResponse": {
+      "type": "structure",
+      "members": {
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the model selection expression of a route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response models of a route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response parameters of a route response.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseId"
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Represents the route response key of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseKey",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a route response.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RouteSettings": {
+      "type": "structure",
+      "members": {
+        "DataTraceEnabled": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether (true) or not (false) data trace logging is enabled for this route. This property affects the log entries pushed to Amazon CloudWatch Logs. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "dataTraceEnabled"
+          }
+        },
+        "DetailedMetricsEnabled": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether detailed metrics are enabled.</p>",
+            "smithy.api#jsonName": "detailedMetricsEnabled"
+          }
+        },
+        "LoggingLevel": {
+          "target": "com.amazonaws.apigatewayv2#LoggingLevel",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the logging level for this route: INFO, ERROR, or OFF. This property affects the log entries pushed to Amazon CloudWatch Logs. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "loggingLevel"
+          }
+        },
+        "ThrottlingBurstLimit": {
+          "target": "com.amazonaws.apigatewayv2#__integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the throttling burst limit.</p>",
+            "smithy.api#jsonName": "throttlingBurstLimit"
+          }
+        },
+        "ThrottlingRateLimit": {
+          "target": "com.amazonaws.apigatewayv2#__double",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the throttling rate limit.</p>",
+            "smithy.api#jsonName": "throttlingRateLimit"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a collection of route settings.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RouteSettingsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#RouteSettings"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The route settings map.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingMode": {
+      "type": "enum",
+      "members": {
+        "API_MAPPING_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "API_MAPPING_ONLY"
+          }
+        },
+        "ROUTING_RULE_ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROUTING_RULE_ONLY"
+          }
+        },
+        "ROUTING_RULE_THEN_API_MAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROUTING_RULE_THEN_API_MAPPING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRule": {
+      "type": "structure",
+      "members": {
+        "Actions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule action.</p>",
+            "smithy.api#jsonName": "actions"
+          }
+        },
+        "Conditions": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule condition.</p>",
+            "smithy.api#jsonName": "conditions"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRulePriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule priority.</p>",
+            "smithy.api#jsonName": "priority"
+          }
+        },
+        "RoutingRuleArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ARN.</p>",
+            "smithy.api#jsonName": "routingRuleArn"
+          }
+        },
+        "RoutingRuleId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing rule ID.</p>",
+            "smithy.api#jsonName": "routingRuleId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a routing rule.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleAction": {
+      "type": "structure",
+      "members": {
+        "InvokeApi": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRuleActionInvokeApi",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#jsonName": "invokeApi",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The routing rule action.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleActionInvokeApi": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#jsonName": "apiId",
+            "smithy.api#required": {}
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#jsonName": "stage",
+            "smithy.api#required": {}
+          }
+        },
+        "StripBasePath": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>The strip base path setting.</p>",
+            "smithy.api#jsonName": "stripBasePath"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an InvokeApi action.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleCondition": {
+      "type": "structure",
+      "members": {
+        "MatchBasePaths": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRuleMatchBasePaths",
+          "traits": {
+            "smithy.api#documentation": "<p>The base path to be matched.</p>",
+            "smithy.api#jsonName": "matchBasePaths"
+          }
+        },
+        "MatchHeaders": {
+          "target": "com.amazonaws.apigatewayv2#RoutingRuleMatchHeaders",
+          "traits": {
+            "smithy.api#documentation": "<p>The headers to be matched.</p>",
+            "smithy.api#jsonName": "matchHeaders"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a routing rule condition.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleMatchBasePaths": {
+      "type": "structure",
+      "members": {
+        "AnyOf": {
+          "target": "com.amazonaws.apigatewayv2#__listOfSelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "The string of the case sensitive base path to be matched.",
+            "smithy.api#jsonName": "anyOf",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a MatchBasePaths condition.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleMatchHeaderValue": {
+      "type": "structure",
+      "members": {
+        "Header": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#jsonName": "header",
+            "smithy.api#required": {}
+          }
+        },
+        "ValueGlob": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#jsonName": "valueGlob",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a MatchHeaderValue.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRuleMatchHeaders": {
+      "type": "structure",
+      "members": {
+        "AnyOf": {
+          "target": "com.amazonaws.apigatewayv2#__listOfRoutingRuleMatchHeaderValue",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The header name and header value glob to be matched. The matchHeaders condition is matched if any of the header name and header value globs are matched.</p>",
+            "smithy.api#jsonName": "anyOf",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a MatchHeaders condition.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#RoutingRulePriority": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#documentation": "<p>The routing rule priority.</p>",
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000000
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#Section": {
+      "type": "structure",
+      "members": {
+        "ProductRestEndpointPageArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ARNs of the product REST endpoint pages in a portal product.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageArns",
+            "smithy.api#required": {}
+          }
+        },
+        "SectionName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The section name.</p>",
+            "smithy.api#jsonName": "sectionName",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the section name and list of product REST endpoints for a product.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#SecurityGroupIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#SecurityPolicy": {
+      "type": "enum",
+      "members": {
+        "TLS_1_0": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TLS_1_0"
+          }
+        },
+        "TLS_1_2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TLS_1_2"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Transport Layer Security (TLS) version of the security policy for this domain name. The valid values are TLS_1_0 and TLS_1_2.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#SelectionExpression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>An expression used to extract information at runtime. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">Selection Expressions</a> for more information.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#SelectionKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>After evaluating a selection expression, the result is compared against one or more selection keys to find a matching key. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">Selection Expressions</a> for a list of expressions and each expression's associated selection key type.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Stage": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a stage is managed by API Gateway. If you created an API using quick create, the $default stage is managed by API Gateway. You can't modify the $default stage.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Deployment that the Stage is associated with. Can't be updated if autoDeploy is enabled.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "LastDeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the status of the last deployment of a stage. Supported only for stages with autoDeploy enabled.</p>",
+            "smithy.api#jsonName": "lastDeploymentStatusMessage"
+          }
+        },
+        "LastUpdatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was last updated.</p>",
+            "smithy.api#jsonName": "lastUpdatedDate"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage, by routeKey.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the stage.</p>",
+            "smithy.api#jsonName": "stageName",
+            "smithy.api#required": {}
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a stage resource. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an API stage.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StageVariablesMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And2048"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The stage variable map.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#Status": {
+      "type": "enum",
+      "members": {
+        "AVAILABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVAILABLE"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StatusException": {
+      "type": "structure",
+      "members": {
+        "Exception": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max256",
+          "traits": {
+            "smithy.api#documentation": "<p>The exception.</p>",
+            "smithy.api#jsonName": "exception"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message.</p>",
+            "smithy.api#jsonName": "message"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a StatusException.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [0-1024].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween0And2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [0-2048].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [0-32768].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [1-1024].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [1-128].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1600": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [0-1600].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [1-256].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [1-512].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string with a length between [1-64].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#SubnetIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Tag resource to represent a tag.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/v2/tags/{ResourceArn}",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource ARN for the tag.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Tag resource to represent a tag.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#Tags": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1600"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a collection of tags associated with the resource.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#TemplateMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      },
+      "value": {
+        "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A mapping of identifier keys to templates. The value is an actual template script. The key is typically a SelectionKey which is chosen based on evaluating a selection expression.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#TlsConfig": {
+      "type": "structure",
+      "members": {
+        "ServerNameToVerify": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#documentation": "<p>If you specify a server name, API Gateway uses it to verify the hostname on the integration's certificate. The server name is also included in the TLS handshake to support Server Name Indication (SNI) or virtual hosting.</p>",
+            "smithy.api#jsonName": "serverNameToVerify"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#TlsConfigInput": {
+      "type": "structure",
+      "members": {
+        "ServerNameToVerify": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#documentation": "<p>If you specify a server name, API Gateway uses it to verify the hostname on the integration's certificate. The server name is also included in the TLS handshake to support Server Name Indication (SNI) or virtual hosting.</p>",
+            "smithy.api#jsonName": "serverNameToVerify"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "LimitType": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit type.</p>",
+            "smithy.api#jsonName": "limitType"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the error encountered.</p>",
+            "smithy.api#jsonName": "message"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A limit has been exceeded. See the accompanying error message for details.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.apigatewayv2#TryItState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the try it state for a product REST endpoint page.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UntagResourceRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Tag.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/v2/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource ARN for the tag.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Tag keys to delete</p>",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApi": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateApiRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateApiResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Api resource.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApiMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateApiMappingRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateApiMappingResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>The API mapping.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApiMappingRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId",
+            "smithy.api#required": {}
+          }
+        },
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping key.</p>",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an ApiMapping.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApiMappingResponse": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiMappingId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping identifier.</p>",
+            "smithy.api#jsonName": "apiMappingId"
+          }
+        },
+        "ApiMappingKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping key.</p>",
+            "smithy.api#jsonName": "apiMappingKey"
+          }
+        },
+        "Stage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The API stage.</p>",
+            "smithy.api#jsonName": "stage"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApiRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. It specifies the credentials required for the integration, if any. For a Lambda integration, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, don't specify this parameter. Currently, this property is not used for HTTP integrations. If provided, this value replaces the credentials associated with the quick create integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke your API or domain name.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. If not specified, the route created using quick create is kept. Otherwise, this value replaces the route key of the quick create route. Additional routes may still be added after the API is updated. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>This property is part of quick create. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP_PROXY or AWS_PROXY, respectively. The value provided updates the integration URI and integration type. You can update a quick-created target, but you can't remove it from an API. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Api.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateApiResponse": {
+      "type": "structure",
+      "members": {
+        "ApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+            "smithy.api#jsonName": "apiEndpoint"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API is managed by API Gateway. You can't update or delete a managed API by using API Gateway. A managed API can be deleted only through the tooling or service that created it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The API ID.</p>",
+            "smithy.api#jsonName": "apiId"
+          }
+        },
+        "ApiKeySelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "apiKeySelectionExpression"
+          }
+        },
+        "CorsConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#Cors",
+          "traits": {
+            "smithy.api#documentation": "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "corsConfiguration"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the API was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the API.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisableSchemaValidation": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "disableSchemaValidation"
+          }
+        },
+        "DisableExecuteApiEndpoint": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint.</p>",
+            "smithy.api#jsonName": "disableExecuteApiEndpoint"
+          }
+        },
+        "ImportInfo": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "importInfo"
+          }
+        },
+        "IpAddressType": {
+          "target": "com.amazonaws.apigatewayv2#IpAddressType",
+          "traits": {
+            "smithy.api#documentation": "<p>The IP address types that can invoke the API.</p>",
+            "smithy.api#jsonName": "ipAddressType"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the API.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "ProtocolType": {
+          "target": "com.amazonaws.apigatewayv2#ProtocolType",
+          "traits": {
+            "smithy.api#documentation": "<p>The API protocol.</p>",
+            "smithy.api#jsonName": "protocolType"
+          }
+        },
+        "RouteSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeSelectionExpression"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags associated with the API.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>A version identifier for the API.</p>",
+            "smithy.api#jsonName": "version"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+            "smithy.api#jsonName": "warnings"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateAuthorizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateAuthorizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateAuthorizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Authorizer.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/authorizers/{AuthorizerId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateAuthorizerRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType"
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. By default, a Lambda authorizer must return an IAM policy. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource"
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter is not used.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Authorizer.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateAuthorizerResponse": {
+      "type": "structure",
+      "members": {
+        "AuthorizerCredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, don't specify this parameter. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerCredentialsArn"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer identifier.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "AuthorizerPayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers. Supported values are 1.0 and 2.0. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "authorizerPayloadFormatVersion"
+          }
+        },
+        "AuthorizerResultTtlInSeconds": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween0And3600",
+          "traits": {
+            "smithy.api#documentation": "<p>The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Supported only for HTTP API Lambda authorizers.</p>",
+            "smithy.api#jsonName": "authorizerResultTtlInSeconds"
+          }
+        },
+        "AuthorizerType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer type. Specify REQUEST for a Lambda function using incoming request parameters. Specify JWT to use JSON Web Tokens (supported only for HTTP APIs).</p>",
+            "smithy.api#jsonName": "authorizerType"
+          }
+        },
+        "AuthorizerUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+            "smithy.api#jsonName": "authorizerUri"
+          }
+        },
+        "EnableSimpleResponses": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy. Supported only for HTTP APIs. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a></p>",
+            "smithy.api#jsonName": "enableSimpleResponses"
+          }
+        },
+        "IdentitySource": {
+          "target": "com.amazonaws.apigatewayv2#IdentitySourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. The identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name for WebSocket APIs. For HTTP APIs, use selection expressions prefixed with $, for example, $request.header.Auth, $request.querystring.Name. These parameters are used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function. For HTTP APIs, identity sources are also used as the cache key when caching is enabled. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html\">Working with AWS Lambda authorizers for HTTP APIs</a>.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example $request.header.Authorization.</p>",
+            "smithy.api#jsonName": "identitySource"
+          }
+        },
+        "IdentityValidationExpression": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The validation expression does not apply to the REQUEST authorizer.</p>",
+            "smithy.api#jsonName": "identityValidationExpression"
+          }
+        },
+        "JwtConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#JWTConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "jwtConfiguration"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateDeploymentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateDeploymentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Deployment.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/deployments/{DeploymentId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The deployment ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment resource.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Deployment.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDeploymentResponse": {
+      "type": "structure",
+      "members": {
+        "AutoDeployed": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a deployment was automatically released.</p>",
+            "smithy.api#jsonName": "autoDeployed"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the Deployment resource was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the deployment.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "DeploymentStatus": {
+          "target": "com.amazonaws.apigatewayv2#DeploymentStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the deployment: PENDING, FAILED, or SUCCEEDED.</p>",
+            "smithy.api#jsonName": "deploymentStatus"
+          }
+        },
+        "DeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>May contain additional feedback on the status of an API deployment.</p>",
+            "smithy.api#jsonName": "deploymentStatusMessage"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the deployment.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDomainName": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateDomainNameRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateDomainNameResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a domain name.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/domainnames/{DomainName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDomainNameRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthenticationInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a DomainName.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateDomainNameResponse": {
+      "type": "structure",
+      "members": {
+        "ApiMappingSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The API mapping selection expression.</p>",
+            "smithy.api#jsonName": "apiMappingSelectionExpression"
+          }
+        },
+        "DomainName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And512",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainName"
+          }
+        },
+        "DomainNameArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the DomainName resource.</p>",
+            "smithy.api#jsonName": "domainNameArn"
+          }
+        },
+        "DomainNameConfigurations": {
+          "target": "com.amazonaws.apigatewayv2#DomainNameConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain name configurations.</p>",
+            "smithy.api#jsonName": "domainNameConfigurations"
+          }
+        },
+        "MutualTlsAuthentication": {
+          "target": "com.amazonaws.apigatewayv2#MutualTlsAuthentication",
+          "traits": {
+            "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name.</p>",
+            "smithy.api#jsonName": "mutualTlsAuthentication"
+          }
+        },
+        "RoutingMode": {
+          "target": "com.amazonaws.apigatewayv2#RoutingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The routing mode.</p>",
+            "smithy.api#jsonName": "routingMode"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags associated with a domain name.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateIntegrationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateIntegrationResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Integration.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegrationRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the integration</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration. For HTTP API private integrations, use an HTTP_PROXY integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType"
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations, without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to the backend. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt; where action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfigInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Integration.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegrationResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateIntegrationResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateIntegrationResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an IntegrationResponses.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegrationResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.<replaceable>{name}</replaceable>\n               , where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.<replaceable>{name}</replaceable>\n                or integration.response.body.<replaceable>{JSON-expression}</replaceable>\n               , where \n                  <replaceable>{name}</replaceable>\n                is a valid and unique response header name and \n                  <replaceable>{JSON-expression}</replaceable>\n                is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an IntegrationResponses.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegrationResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "IntegrationResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response ID.</p>",
+            "smithy.api#jsonName": "integrationResponseId"
+          }
+        },
+        "IntegrationResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response key.</p>",
+            "smithy.api#jsonName": "integrationResponseKey"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "ResponseTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+            "smithy.api#jsonName": "responseTemplates"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expressions for the integration response.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateIntegrationResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an integration is managed by API Gateway. If you created an API using using quick create, the resulting integration is managed by API Gateway. You can update a managed integration, but you can't delete it.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ConnectionId": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "connectionId"
+          }
+        },
+        "ConnectionType": {
+          "target": "com.amazonaws.apigatewayv2#ConnectionType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+            "smithy.api#jsonName": "connectionType"
+          }
+        },
+        "ContentHandlingStrategy": {
+          "target": "com.amazonaws.apigatewayv2#ContentHandlingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+            "smithy.api#jsonName": "contentHandlingStrategy"
+          }
+        },
+        "CredentialsArn": {
+          "target": "com.amazonaws.apigatewayv2#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+            "smithy.api#jsonName": "credentialsArn"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the description of an integration.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "IntegrationId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of an integration.</p>",
+            "smithy.api#jsonName": "integrationId"
+          }
+        },
+        "IntegrationMethod": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>",
+            "smithy.api#jsonName": "integrationMethod"
+          }
+        },
+        "IntegrationResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration response selection expression for the integration. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-integration-response-selection-expressions\">Integration Response Selection Expressions</a>.</p>",
+            "smithy.api#jsonName": "integrationResponseSelectionExpression"
+          }
+        },
+        "IntegrationSubtype": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP API AWS_PROXY integrations. Specifies the AWS service action to invoke. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html\">Integration subtype reference</a>.</p>",
+            "smithy.api#jsonName": "integrationSubtype"
+          }
+        },
+        "IntegrationType": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with a Lambda function or other AWS service action. This integration is also referred to as a Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "integrationType"
+          }
+        },
+        "IntegrationUri": {
+          "target": "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048",
+          "traits": {
+            "smithy.api#documentation": "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+            "smithy.api#jsonName": "integrationUri"
+          }
+        },
+        "PassthroughBehavior": {
+          "target": "com.amazonaws.apigatewayv2#PassthroughBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+            "smithy.api#jsonName": "passthroughBehavior"
+          }
+        },
+        "PayloadFormatVersion": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs. Supported values for Lambda proxy integrations are 1.0 and 2.0. For all other integrations, 1.0 is the only supported value. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html\">Working with AWS Lambda proxy integrations for HTTP APIs</a>.</p>",
+            "smithy.api#jsonName": "payloadFormatVersion"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#IntegrationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n          , where \n            <replaceable>{location}</replaceable>\n           is querystring, path, or header; and \n            <replaceable>{name}</replaceable>\n           must be a valid and unique method request parameter name.</p> <p>For HTTP API integrations with a specified integrationSubtype, request parameters are a key-value map specifying parameters that are passed to AWS_PROXY integrations. You can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html\">Working with AWS service integrations for HTTP APIs</a>.</p> <p>For HTTP API integrations, without a specified integrationSubtype request parameters are a key-value map specifying how to transform HTTP requests before sending them to backend integrations. The key should follow the pattern &lt;action&gt;:&lt;header|querystring|path&gt;.&lt;location&gt;. The action can be append, overwrite or remove. For values, you can provide static values, or map request data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RequestTemplates": {
+          "target": "com.amazonaws.apigatewayv2#TemplateMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestTemplates"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#ResponseParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Supported only for HTTP APIs. You use response parameters to transform the HTTP response from a backend integration before returning the response to clients. Specify a key-value map from a selection key to response parameters. The selection key must be a valid HTTP status code within the range of 200-599. Response parameters are a key-value map. The key must match pattern &lt;action&gt;:&lt;header&gt;.&lt;location&gt; or overwrite.statuscode. The action can be append, overwrite or remove. The value can be a static value, or map to response data, stage variables, or context variables that are evaluated at runtime. To learn more, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html\">Transforming API requests and responses</a>.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "TemplateSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The template selection expression for the integration. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "templateSelectionExpression"
+          }
+        },
+        "TimeoutInMillis": {
+          "target": "com.amazonaws.apigatewayv2#IntegerWithLengthBetween50And30000",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+            "smithy.api#jsonName": "timeoutInMillis"
+          }
+        },
+        "TlsConfig": {
+          "target": "com.amazonaws.apigatewayv2#TlsConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+            "smithy.api#jsonName": "tlsConfig"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Model.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/models/{ModelId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateModelRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The model ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the model.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Model.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateModelResponse": {
+      "type": "structure",
+      "members": {
+        "ContentType": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And256",
+          "traits": {
+            "smithy.api#documentation": "<p>The content-type for the model, for example, \"application/json\".</p>",
+            "smithy.api#jsonName": "contentType"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the model.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "ModelId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The model identifier.</p>",
+            "smithy.api#jsonName": "modelId"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And32K",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+            "smithy.api#jsonName": "schema"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortal": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdatePortalRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdatePortalResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a portal.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/portals/{PortalId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortalProduct": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdatePortalProductRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdatePortalProductResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the portal product.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/portalproducts/{PortalProductId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortalProductRequest": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The displayName.</p>",
+            "smithy.api#jsonName": "displayName"
+          }
+        },
+        "DisplayOrder": {
+          "target": "com.amazonaws.apigatewayv2#DisplayOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The display order.</p>",
+            "smithy.api#jsonName": "displayOrder"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the patch operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortalProductResponse": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the portal product.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "DisplayName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin1Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The display name of a portal product.</p>",
+            "smithy.api#jsonName": "displayName"
+          }
+        },
+        "DisplayOrder": {
+          "target": "com.amazonaws.apigatewayv2#DisplayOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The display order that the portal products will appear in a portal.</p>",
+            "smithy.api#jsonName": "displayOrder"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal product was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "PortalProductArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal product.</p>",
+            "smithy.api#jsonName": "portalProductArn"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#jsonName": "portalProductId"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortalRequest": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization of the portal.</p>",
+            "smithy.api#jsonName": "authorization"
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationRequest",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents an endpoint configuration.</p>",
+            "smithy.api#jsonName": "endpointConfiguration"
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns"
+          }
+        },
+        "LogoUri": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1092",
+          "traits": {
+            "smithy.api#documentation": "<p>The logo URI.</p>",
+            "smithy.api#jsonName": "logoUri"
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the content that is visible to portal consumers including the themes, display names, and description.</p>",
+            "smithy.api#jsonName": "portalContent"
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The CloudWatch RUM app monitor name.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the patch operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdatePortalResponse": {
+      "type": "structure",
+      "members": {
+        "Authorization": {
+          "target": "com.amazonaws.apigatewayv2#Authorization",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization for the portal.</p>",
+            "smithy.api#jsonName": "authorization"
+          }
+        },
+        "EndpointConfiguration": {
+          "target": "com.amazonaws.apigatewayv2#EndpointConfigurationResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The endpoint configuration.</p>",
+            "smithy.api#jsonName": "endpointConfiguration"
+          }
+        },
+        "IncludedPortalProductArns": {
+          "target": "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs of the portal products included in the portal.</p>",
+            "smithy.api#jsonName": "includedPortalProductArns"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "LastPublished": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the portal was last published.</p>",
+            "smithy.api#jsonName": "lastPublished"
+          }
+        },
+        "LastPublishedDescription": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description associated with the last time the portal was published.</p>",
+            "smithy.api#jsonName": "lastPublishedDescription"
+          }
+        },
+        "PortalArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the portal.</p>",
+            "smithy.api#jsonName": "portalArn"
+          }
+        },
+        "PortalContent": {
+          "target": "com.amazonaws.apigatewayv2#PortalContent",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the content that is visible to portal consumers including the themes, display names, and description.</p>",
+            "smithy.api#jsonName": "portalContent"
+          }
+        },
+        "PortalId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal identifier.</p>",
+            "smithy.api#jsonName": "portalId"
+          }
+        },
+        "Preview": {
+          "target": "com.amazonaws.apigatewayv2#Preview",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the preview endpoint and the any possible error messages during preview generation.</p>",
+            "smithy.api#jsonName": "preview"
+          }
+        },
+        "PublishStatus": {
+          "target": "com.amazonaws.apigatewayv2#PublishStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The publishStatus.</p>",
+            "smithy.api#jsonName": "publishStatus"
+          }
+        },
+        "RumAppMonitorName": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin0Max255",
+          "traits": {
+            "smithy.api#documentation": "<p>The CloudWatch RUM app monitor name.</p>",
+            "smithy.api#jsonName": "rumAppMonitorName"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateProductPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateProductPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a product page of a portal product.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/portalproducts/{PortalProductId}/productpages/{ProductPageId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductPageRequest": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the patch operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#DisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product page.</p>",
+            "smithy.api#jsonName": "productPageArn"
+          }
+        },
+        "ProductPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product page identifier.</p>",
+            "smithy.api#jsonName": "productPageId"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a product REST endpoint page.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/portalproducts/{PortalProductId}/productrestendpointpages/{ProductRestEndpointPageId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPageRequest": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#EndpointDisplayContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The display content.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "PortalProductId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The portal product identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#documentation": "<p>The try it state of a product REST endpoint page.</p>",
+            "smithy.api#jsonName": "tryItState"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request body for the patch operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateProductRestEndpointPageResponse": {
+      "type": "structure",
+      "members": {
+        "DisplayContent": {
+          "target": "com.amazonaws.apigatewayv2#EndpointDisplayContentResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "displayContent"
+          }
+        },
+        "LastModified": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the product REST endpoint page was last modified.</p>",
+            "smithy.api#jsonName": "lastModified"
+          }
+        },
+        "ProductRestEndpointPageArn": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the product REST endpoint page.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageArn"
+          }
+        },
+        "ProductRestEndpointPageId": {
+          "target": "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09",
+          "traits": {
+            "smithy.api#documentation": "<p>The product REST endpoint page identifier.</p>",
+            "smithy.api#jsonName": "productRestEndpointPageId"
+          }
+        },
+        "RestEndpointIdentifier": {
+          "target": "com.amazonaws.apigatewayv2#RestEndpointIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The REST endpoint identifier.</p>",
+            "smithy.api#jsonName": "restEndpointIdentifier"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.apigatewayv2#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status.</p>",
+            "smithy.api#jsonName": "status"
+          }
+        },
+        "StatusException": {
+          "target": "com.amazonaws.apigatewayv2#StatusException",
+          "traits": {
+            "smithy.api#documentation": "<p>The status exception information.</p>",
+            "smithy.api#jsonName": "statusException"
+          }
+        },
+        "TryItState": {
+          "target": "com.amazonaws.apigatewayv2#TryItState",
+          "traits": {
+            "smithy.api#documentation": "<p>The try it state of a product REST endpoint page.</p>",
+            "smithy.api#jsonName": "tryItState"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRoute": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateRouteRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateRouteResult"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Route.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRouteRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization scopes supported by this route.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Route.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRouteResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateRouteResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateRouteResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a RouteResponse.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRouteResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The response models for the route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response parameters.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response ID.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response key.</p>",
+            "smithy.api#jsonName": "routeResponseKey"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a RouteResponse.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRouteResponseResponse": {
+      "type": "structure",
+      "members": {
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the model selection expression of a route response. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "ResponseModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response models of a route response.</p>",
+            "smithy.api#jsonName": "responseModels"
+          }
+        },
+        "ResponseParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the response parameters of a route response.</p>",
+            "smithy.api#jsonName": "responseParameters"
+          }
+        },
+        "RouteResponseId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the identifier of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseId"
+          }
+        },
+        "RouteResponseKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents the route response key of a route response.</p>",
+            "smithy.api#jsonName": "routeResponseKey"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateRouteResult": {
+      "type": "structure",
+      "members": {
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a route is managed by API Gateway. If you created an API using quick create, the $default route is managed by API Gateway. You can't modify the $default route key.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "ApiKeyRequired": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether an API key is required for this route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "apiKeyRequired"
+          }
+        },
+        "AuthorizationScopes": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationScopes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+            "smithy.api#jsonName": "authorizationScopes"
+          }
+        },
+        "AuthorizationType": {
+          "target": "com.amazonaws.apigatewayv2#AuthorizationType",
+          "traits": {
+            "smithy.api#documentation": "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, JWT for using JSON Web Tokens, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer.</p>",
+            "smithy.api#jsonName": "authorizationType"
+          }
+        },
+        "AuthorizerId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+            "smithy.api#jsonName": "authorizerId"
+          }
+        },
+        "ModelSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "modelSelectionExpression"
+          }
+        },
+        "OperationName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And64",
+          "traits": {
+            "smithy.api#documentation": "<p>The operation name for the route.</p>",
+            "smithy.api#jsonName": "operationName"
+          }
+        },
+        "RequestModels": {
+          "target": "com.amazonaws.apigatewayv2#RouteModels",
+          "traits": {
+            "smithy.api#documentation": "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestModels"
+          }
+        },
+        "RequestParameters": {
+          "target": "com.amazonaws.apigatewayv2#RouteParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "requestParameters"
+          }
+        },
+        "RouteId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The route ID.</p>",
+            "smithy.api#jsonName": "routeId"
+          }
+        },
+        "RouteKey": {
+          "target": "com.amazonaws.apigatewayv2#SelectionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The route key for the route.</p>",
+            "smithy.api#jsonName": "routeKey"
+          }
+        },
+        "RouteResponseSelectionExpression": {
+          "target": "com.amazonaws.apigatewayv2#SelectionExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "routeResponseSelectionExpression"
+          }
+        },
+        "Target": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The target for the route.</p>",
+            "smithy.api#jsonName": "target"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateStage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateStageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateStageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Stage.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/apis/{ApiId}/stages/{StageName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateStageRequest": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The API identifier.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>The default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The deployment identifier for the API stage. Can't be updated if autoDeploy is enabled.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the API stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The stage name. Stage names can contain only alphanumeric characters, hyphens, and underscores, or be $default. Maximum length is 128 characters.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a Stage.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateStageResponse": {
+      "type": "structure",
+      "members": {
+        "AccessLogSettings": {
+          "target": "com.amazonaws.apigatewayv2#AccessLogSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>",
+            "smithy.api#jsonName": "accessLogSettings"
+          }
+        },
+        "ApiGatewayManaged": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether a stage is managed by API Gateway. If you created an API using quick create, the $default stage is managed by API Gateway. You can't modify the $default stage.</p>",
+            "smithy.api#jsonName": "apiGatewayManaged"
+          }
+        },
+        "AutoDeploy": {
+          "target": "com.amazonaws.apigatewayv2#__boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+            "smithy.api#jsonName": "autoDeploy"
+          }
+        },
+        "ClientCertificateId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+            "smithy.api#jsonName": "clientCertificateId"
+          }
+        },
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "DefaultRouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Default route settings for the stage.</p>",
+            "smithy.api#jsonName": "defaultRouteSettings"
+          }
+        },
+        "DeploymentId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Deployment that the Stage is associated with. Can't be updated if autoDeploy is enabled.</p>",
+            "smithy.api#jsonName": "deploymentId"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the stage.</p>",
+            "smithy.api#jsonName": "description"
+          }
+        },
+        "LastDeploymentStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the status of the last deployment of a stage. Supported only for stages with autoDeploy enabled.</p>",
+            "smithy.api#jsonName": "lastDeploymentStatusMessage"
+          }
+        },
+        "LastUpdatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the stage was last updated.</p>",
+            "smithy.api#jsonName": "lastUpdatedDate"
+          }
+        },
+        "RouteSettings": {
+          "target": "com.amazonaws.apigatewayv2#RouteSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Route settings for the stage, by routeKey.</p>",
+            "smithy.api#jsonName": "routeSettings"
+          }
+        },
+        "StageName": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the stage.</p>",
+            "smithy.api#jsonName": "stageName"
+          }
+        },
+        "StageVariables": {
+          "target": "com.amazonaws.apigatewayv2#StageVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that defines the stage variables for a stage resource. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+            "smithy.api#jsonName": "stageVariables"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateVpcLink": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.apigatewayv2#UpdateVpcLinkRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.apigatewayv2#UpdateVpcLinkResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.apigatewayv2#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#NotFoundException"
+        },
+        {
+          "target": "com.amazonaws.apigatewayv2#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a VPC link.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/v2/vpclinks/{VpcLinkId}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateVpcLinkRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#__string",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a VPC link.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UpdateVpcLinkResponse": {
+      "type": "structure",
+      "members": {
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the VPC link was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name"
+          }
+        },
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.apigatewayv2#SecurityGroupIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>",
+            "smithy.api#jsonName": "securityGroupIds"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.apigatewayv2#SubnetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>",
+            "smithy.api#jsonName": "subnetIds"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the VPC link.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkId"
+          }
+        },
+        "VpcLinkStatus": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatus"
+          }
+        },
+        "VpcLinkStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A message summarizing the cause of the status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatusMessage"
+          }
+        },
+        "VpcLinkVersion": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkVersion"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.apigatewayv2#UriWithLengthBetween1And2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#documentation": "<p>A string representation of a URI with a length between [1-2048].</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#VpcLink": {
+      "type": "structure",
+      "members": {
+        "CreatedDate": {
+          "target": "com.amazonaws.apigatewayv2#__timestampIso8601",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the VPC link was created.</p>",
+            "smithy.api#jsonName": "createdDate"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween1And128",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the VPC link.</p>",
+            "smithy.api#jsonName": "name",
+            "smithy.api#required": {}
+          }
+        },
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.apigatewayv2#SecurityGroupIdList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of security group IDs for the VPC link.</p>",
+            "smithy.api#jsonName": "securityGroupIds",
+            "smithy.api#required": {}
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.apigatewayv2#SubnetIdList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of subnet IDs to include in the VPC link.</p>",
+            "smithy.api#jsonName": "subnetIds",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.apigatewayv2#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the VPC link.</p>",
+            "smithy.api#jsonName": "tags"
+          }
+        },
+        "VpcLinkId": {
+          "target": "com.amazonaws.apigatewayv2#Id",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkId",
+            "smithy.api#required": {}
+          }
+        },
+        "VpcLinkStatus": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatus"
+          }
+        },
+        "VpcLinkStatusMessage": {
+          "target": "com.amazonaws.apigatewayv2#StringWithLengthBetween0And1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A message summarizing the cause of the status of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkStatusMessage"
+          }
+        },
+        "VpcLinkVersion": {
+          "target": "com.amazonaws.apigatewayv2#VpcLinkVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the VPC link.</p>",
+            "smithy.api#jsonName": "vpcLinkVersion"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a VPC link.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#VpcLinkStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "AVAILABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVAILABLE"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "INACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INACTIVE"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the VPC link.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#VpcLinkVersion": {
+      "type": "enum",
+      "members": {
+        "V2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "V2"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The version of the VPC link.</p>"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.apigatewayv2#__double": {
+      "type": "double"
+    },
+    "com.amazonaws.apigatewayv2#__integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.apigatewayv2#__listOfApi": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Api"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfApiMapping": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#ApiMapping"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfAuthorizer": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Authorizer"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfDeployment": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Deployment"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfDomainName": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#DomainName"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfIntegration": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Integration"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfIntegrationResponse": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#IntegrationResponse"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfModel": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Model"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfPortalProductSummary": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#PortalProductSummary"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfPortalSummary": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#PortalSummary"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfProductPageSummaryNoBody": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#ProductPageSummaryNoBody"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfProductRestEndpointPageSummaryNoBody": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#ProductRestEndpointPageSummaryNoBody"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRoute": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Route"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRouteResponse": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#RouteResponse"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRoutingRule": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#RoutingRule"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRoutingRuleAction": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#RoutingRuleAction"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRoutingRuleCondition": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#RoutingRuleCondition"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfRoutingRuleMatchHeaderValue": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#RoutingRuleMatchHeaderValue"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfSection": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Section"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfSelectionKey": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#SelectionKey"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfStage": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#Stage"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOfVpcLink": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#VpcLink"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOf__string": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__string"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__listOf__stringMin20Max2048": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.apigatewayv2#__stringMin20Max2048"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__string": {
+      "type": "string"
+    },
+    "com.amazonaws.apigatewayv2#__stringMin0Max1024": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin0Max1092": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1092
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin0Max255": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin10Max2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 10,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin10Max30PatternAZ09": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 10,
+          "max": 30
+        },
+        "smithy.api#pattern": "^[a-z0-9]+$"
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max1024": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max128": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max16": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 16
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max20": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max255": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max307200": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 307200
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max32768": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32768
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max4096": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4096
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max50": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin1Max64": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin20Max2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin3Max255": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__stringMin3Max256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.apigatewayv2#__timestampIso8601": {
+      "type": "timestamp",
+      "traits": {
+        "smithy.api#timestampFormat": "date-time"
+      }
+    }
+  }
+}

--- a/aws-models/service-map.json
+++ b/aws-models/service-map.json
@@ -86,5 +86,9 @@
   "scheduler": {
     "repo_dir": "scheduler",
     "service_name": "scheduler"
+  },
+  "apigatewayv2": {
+    "repo_dir": "apigatewayv2",
+    "service_name": "apigateway"
   }
 }

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,14 +1,42 @@
 {
-  "variants_passed": 57185,
-  "total_variants": 57185,
+  "variants_passed": 59954,
+  "total_variants": 59954,
   "per_service": {
-    "elasticache": {
-      "passed": 2219,
-      "total": 2219
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
     "dynamodb": {
       "passed": 2123,
       "total": 2123
+    },
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "states": {
+      "passed": 1292,
+      "total": 1292
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "events": {
       "passed": 2108,
@@ -18,6 +46,34 @@
       "passed": 3347,
       "total": 3347
     },
+    "apigateway": {
+      "passed": 2769,
+      "total": 2769
+    },
+    "scheduler": {
+      "passed": 491,
+      "total": 491
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "elasticache": {
+      "passed": 2219,
+      "total": 2219
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
     "rds": {
       "passed": 5376,
       "total": 5376
@@ -26,69 +82,17 @@
       "passed": 2196,
       "total": 2196
     },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
-    },
     "iam": {
       "passed": 5962,
       "total": 5962
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
     },
     "kinesis": {
       "passed": 1611,
       "total": 1611
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
     "s3": {
       "passed": 3620,
       "total": 3620
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
-    },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
     }
   }
 }

--- a/crates/fakecloud-conformance/README.md
+++ b/crates/fakecloud-conformance/README.md
@@ -29,7 +29,7 @@ For every operation, [`generators/`](./src/generators/) produces test variants u
 | **Model examples** (`examples.rs`) | The `@examples` trait from the Smithy model itself — AWS's own canonical inputs and outputs | Divergence from AWS's documented examples |
 | **Negative** (`negative.rs`) | Missing required fields, out-of-range values, invalid enums, wrong types | Validation gaps, silent-pass bugs, 500s that should be 400s |
 
-A single operation typically produces anywhere from a dozen to several hundred variants. Across the 22 services currently wired into the harness the baseline is **57,185 / 57,185 variants passing (100%)** — see [`conformance-baseline.json`](../../conformance-baseline.json) for the per-service breakdown. The 23rd service fakecloud ships (API Gateway v2) is not yet probed here; it is being brought into the harness batch-by-batch as its 103 operations are implemented.
+A single operation typically produces anywhere from a dozen to several hundred variants. Across all 23 services the baseline is **59,954 / 59,954 variants passing (100%)** — see [`conformance-baseline.json`](../../conformance-baseline.json) for the per-service breakdown.
 
 ### 3. Send and capture
 

--- a/crates/fakecloud-conformance/src/audit.rs
+++ b/crates/fakecloud-conformance/src/audit.rs
@@ -90,6 +90,15 @@ fn service_source_files(project_root: &Path) -> Vec<AuditMapping> {
             &["service.rs"],
             &["bedrock", "bedrock-runtime"],
         ),
+        // fakecloud's APIGWv2 crate reports `service_name() = "apigateway"`,
+        // which matches the Smithy service-map entry, but handwritten conformance
+        // tests tag `apigatewayv2` to stay consistent with the AWS SDK crate.
+        (
+            "apigateway",
+            "apigatewayv2",
+            &["service.rs"],
+            &["apigateway", "apigatewayv2"],
+        ),
     ];
 
     mappings

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -92,6 +92,11 @@ pub fn service_protocol(service_name: &str) -> Protocol {
         },
         "s3" => Protocol::Rest,
         "lambda" => Protocol::Rest,
+        // `service_name` in `service-map.json` for API Gateway v2 is
+        // `apigateway` — matches the `service_name()` reported by
+        // fakecloud's `ApiGatewayV2Service`. restJson1 wire format; no
+        // hardcoded op table, relies on the generic `@http`-driven builder.
+        "apigateway" => Protocol::Rest,
         _ => Protocol::Query,
     }
 }

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -207,7 +207,11 @@ fn validate_shape(
                     });
                 }
                 for (key, val) in obj {
-                    if let Some(member) = members.iter().find(|m| m.name == *key) {
+                    let member = members.iter().find(|m| {
+                        let member_key = m.traits.json_name.as_deref().unwrap_or(&m.name);
+                        member_key == key.as_str()
+                    });
+                    if let Some(member) = member {
                         let child_path = format!("{}.{}", path, key);
                         validate_shape(
                             model,
@@ -314,19 +318,35 @@ fn validate_structure(
         }
     };
 
+    // Per-member key: `@jsonName` trait on the member (or its target shape)
+    // wins; otherwise the member's own name. AWS restJson1 services commonly
+    // override with camelCase (e.g. `Items` -> `items`).
+    let member_key = |m: &crate::smithy::Member| -> String {
+        if let Some(name) = &m.traits.json_name {
+            return name.clone();
+        }
+        if let Some(shape) = model.shapes.get(&m.target) {
+            if let Some(name) = &shape.traits.json_name {
+                return name.clone();
+            }
+        }
+        m.name.clone()
+    };
+
     // Check required fields are present
     for member in members {
-        if member.required && !obj.contains_key(&member.name) {
+        let key = member_key(member);
+        if member.required && !obj.contains_key(&key) {
             violations.push(ShapeViolation::MissingField {
                 path: path.to_string(),
-                field: member.name.clone(),
+                field: key,
             });
         }
     }
 
     // Validate present fields
     for (key, val) in obj {
-        if let Some(member) = members.iter().find(|m| m.name == *key) {
+        if let Some(member) = members.iter().find(|m| member_key(m) == *key) {
             let child_path = format!("{}.{}", path, key);
             validate_shape(
                 model,

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -743,4 +743,93 @@ mod tests {
         );
         assert!(violations.is_empty());
     }
+
+    /// Build a model where the output member has a `@jsonName` override
+    /// (`Items` -> `items`), matching the restJson1 pattern used by
+    /// API Gateway v2 and most AWS REST services.
+    fn json_name_model() -> ServiceModel {
+        let mut shapes = HashMap::new();
+
+        let items_traits = ShapeTraits {
+            json_name: Some("items".to_string()),
+            ..ShapeTraits::default()
+        };
+
+        shapes.insert(
+            "test#GetApisOutput".to_string(),
+            Shape {
+                shape_id: "test#GetApisOutput".to_string(),
+                shape_type: ShapeType::Structure {
+                    members: vec![Member {
+                        name: "Items".to_string(),
+                        target: "test#ApiList".to_string(),
+                        required: false,
+                        traits: items_traits,
+                    }],
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+
+        shapes.insert(
+            "test#ApiList".to_string(),
+            Shape {
+                shape_id: "test#ApiList".to_string(),
+                shape_type: ShapeType::List {
+                    member_target: "smithy.api#String".to_string(),
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+
+        ServiceModel {
+            service_name: "test".to_string(),
+            operations: Vec::new(),
+            shapes,
+        }
+    }
+
+    #[test]
+    fn json_name_override_accepts_lowercase_key() {
+        let model = json_name_model();
+        // Response uses the @jsonName ("items"), not the Smithy PascalCase
+        // member name ("Items"). Must validate cleanly.
+        let body = r#"{"items": ["a", "b"]}"#;
+        let violations = validate_response(
+            &model,
+            "test#GetApisOutput",
+            body,
+            Protocol::Json {
+                target_prefix: "Test",
+            },
+        );
+        assert!(
+            violations.is_empty(),
+            "expected no violations, got {:?}",
+            violations
+        );
+    }
+
+    #[test]
+    fn json_name_override_rejects_pascal_key() {
+        let model = json_name_model();
+        // Member has @jsonName("items"), so a response using the PascalCase
+        // Smithy name is NOT a valid restJson1 payload — flag it.
+        let body = r#"{"Items": ["a"]}"#;
+        let violations = validate_response(
+            &model,
+            "test#GetApisOutput",
+            body,
+            Protocol::Json {
+                target_prefix: "Test",
+            },
+        );
+        assert!(
+            violations.iter().any(
+                |v| matches!(v, ShapeViolation::UnexpectedField { field, .. } if field == "Items")
+            ),
+            "expected an UnexpectedField(Items) violation, got {:?}",
+            violations
+        );
+    }
 }

--- a/crates/fakecloud-conformance/src/smithy.rs
+++ b/crates/fakecloud-conformance/src/smithy.rs
@@ -115,6 +115,10 @@ pub struct ShapeTraits {
     pub http_header: Option<String>,
     /// `smithy.api#httpPayload` — member is sent as the raw request/response body.
     pub http_payload: bool,
+    /// `smithy.api#jsonName("name")` — override the key used when serializing
+    /// this member in JSON bodies. AWS restJson1 services use this to map
+    /// camelCase/kebab-case JSON keys to PascalCase Smithy member names.
+    pub json_name: Option<String>,
 }
 
 /// An example from `smithy.api#examples` trait on operations.
@@ -502,6 +506,10 @@ fn parse_traits(raw: Option<&serde_json::Map<String, Value>>) -> ShapeTraits {
 
     if raw.contains_key("smithy.api#httpPayload") {
         traits.http_payload = true;
+    }
+
+    if let Some(name) = raw.get("smithy.api#jsonName").and_then(|v| v.as_str()) {
+        traits.json_name = Some(name.to_string());
     }
 
     if let Some(default) = raw.get("smithy.api#default") {

--- a/crates/fakecloud-conformance/tests/apigatewayv2.rs
+++ b/crates/fakecloud-conformance/tests/apigatewayv2.rs
@@ -1,0 +1,319 @@
+mod helpers;
+
+use aws_sdk_apigatewayv2::types::{AuthorizerType, IntegrationType, ProtocolType};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+#[test_action("apigatewayv2", "CreateApi", checksum = "9a3b68c2")]
+#[test_action("apigatewayv2", "GetApi", checksum = "6e24d0aa")]
+#[test_action("apigatewayv2", "GetApis", checksum = "a8aed2d1")]
+#[test_action("apigatewayv2", "UpdateApi", checksum = "c0fcd25b")]
+#[test_action("apigatewayv2", "DeleteApi", checksum = "959314b8")]
+#[tokio::test]
+async fn apigatewayv2_api_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+
+    let created = client
+        .create_api()
+        .name("conf-api")
+        .protocol_type(ProtocolType::Http)
+        .description("original")
+        .send()
+        .await
+        .unwrap();
+    let api_id = created.api_id().unwrap().to_string();
+
+    let got = client.get_api().api_id(&api_id).send().await.unwrap();
+    assert_eq!(got.name(), Some("conf-api"));
+
+    let list = client.get_apis().send().await.unwrap();
+    assert!(list.items().iter().any(|a| a.api_id() == Some(&api_id)));
+
+    client
+        .update_api()
+        .api_id(&api_id)
+        .description("updated")
+        .send()
+        .await
+        .unwrap();
+
+    client.delete_api().api_id(api_id).send().await.unwrap();
+}
+
+async fn create_api(client: &aws_sdk_apigatewayv2::Client, name: &str) -> String {
+    client
+        .create_api()
+        .name(name)
+        .protocol_type(ProtocolType::Http)
+        .send()
+        .await
+        .unwrap()
+        .api_id()
+        .unwrap()
+        .to_string()
+}
+
+#[test_action("apigatewayv2", "CreateRoute", checksum = "a838460b")]
+#[test_action("apigatewayv2", "GetRoute", checksum = "0c7a355a")]
+#[test_action("apigatewayv2", "GetRoutes", checksum = "22479c59")]
+#[test_action("apigatewayv2", "UpdateRoute", checksum = "165a43c2")]
+#[test_action("apigatewayv2", "DeleteRoute", checksum = "e7c19a5c")]
+#[tokio::test]
+async fn apigatewayv2_route_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+    let api_id = create_api(&client, "conf-routes").await;
+
+    let route = client
+        .create_route()
+        .api_id(&api_id)
+        .route_key("GET /hello")
+        .send()
+        .await
+        .unwrap();
+    let route_id = route.route_id().unwrap().to_string();
+
+    let got = client
+        .get_route()
+        .api_id(&api_id)
+        .route_id(&route_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.route_key(), Some("GET /hello"));
+
+    let list = client.get_routes().api_id(&api_id).send().await.unwrap();
+    assert!(list.items().iter().any(|r| r.route_id() == Some(&route_id)));
+
+    client
+        .update_route()
+        .api_id(&api_id)
+        .route_id(&route_id)
+        .route_key("POST /hello")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_route()
+        .api_id(&api_id)
+        .route_id(route_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("apigatewayv2", "CreateIntegration", checksum = "5df9afa0")]
+#[test_action("apigatewayv2", "GetIntegration", checksum = "c64b20b5")]
+#[test_action("apigatewayv2", "GetIntegrations", checksum = "a03f870e")]
+#[test_action("apigatewayv2", "UpdateIntegration", checksum = "67a390d2")]
+#[test_action("apigatewayv2", "DeleteIntegration", checksum = "3d7cf5a3")]
+#[tokio::test]
+async fn apigatewayv2_integration_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+    let api_id = create_api(&client, "conf-integrations").await;
+
+    let integration = client
+        .create_integration()
+        .api_id(&api_id)
+        .integration_type(IntegrationType::HttpProxy)
+        .integration_uri("https://example.com/upstream")
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id().unwrap().to_string();
+
+    let got = client
+        .get_integration()
+        .api_id(&api_id)
+        .integration_id(&integration_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.integration_uri(), Some("https://example.com/upstream"));
+
+    let list = client
+        .get_integrations()
+        .api_id(&api_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(list
+        .items()
+        .iter()
+        .any(|i| i.integration_id() == Some(&integration_id)));
+
+    client
+        .update_integration()
+        .api_id(&api_id)
+        .integration_id(&integration_id)
+        .integration_uri("https://example.com/updated")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_integration()
+        .api_id(&api_id)
+        .integration_id(integration_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("apigatewayv2", "CreateStage", checksum = "3f012a6b")]
+#[test_action("apigatewayv2", "GetStage", checksum = "ea4e5f71")]
+#[test_action("apigatewayv2", "GetStages", checksum = "a48f1731")]
+#[test_action("apigatewayv2", "UpdateStage", checksum = "5c70fd1e")]
+#[test_action("apigatewayv2", "DeleteStage", checksum = "d9ec4d37")]
+#[tokio::test]
+async fn apigatewayv2_stage_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+    let api_id = create_api(&client, "conf-stages").await;
+
+    client
+        .create_stage()
+        .api_id(&api_id)
+        .stage_name("conf-stage")
+        .description("original")
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_stage()
+        .api_id(&api_id)
+        .stage_name("conf-stage")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.stage_name(), Some("conf-stage"));
+
+    let list = client.get_stages().api_id(&api_id).send().await.unwrap();
+    assert!(!list.items().is_empty());
+
+    client
+        .update_stage()
+        .api_id(&api_id)
+        .stage_name("conf-stage")
+        .description("updated")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_stage()
+        .api_id(&api_id)
+        .stage_name("conf-stage")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("apigatewayv2", "CreateDeployment", checksum = "58848759")]
+#[test_action("apigatewayv2", "GetDeployment", checksum = "b5d245b0")]
+#[test_action("apigatewayv2", "GetDeployments", checksum = "7e2975cf")]
+#[tokio::test]
+async fn apigatewayv2_deployment_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+    let api_id = create_api(&client, "conf-deployments").await;
+
+    let dep = client
+        .create_deployment()
+        .api_id(&api_id)
+        .description("initial rollout")
+        .send()
+        .await
+        .unwrap();
+    let deployment_id = dep.deployment_id().unwrap().to_string();
+
+    let got = client
+        .get_deployment()
+        .api_id(&api_id)
+        .deployment_id(&deployment_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.deployment_id(), Some(deployment_id.as_str()));
+
+    let list = client
+        .get_deployments()
+        .api_id(&api_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(list
+        .items()
+        .iter()
+        .any(|d| d.deployment_id() == Some(&deployment_id)));
+}
+
+#[test_action("apigatewayv2", "CreateAuthorizer", checksum = "6ef46e28")]
+#[test_action("apigatewayv2", "GetAuthorizer", checksum = "7eedcf26")]
+#[test_action("apigatewayv2", "GetAuthorizers", checksum = "49cf9fe9")]
+#[test_action("apigatewayv2", "UpdateAuthorizer", checksum = "63b0c0bc")]
+#[test_action("apigatewayv2", "DeleteAuthorizer", checksum = "42e93a7e")]
+#[tokio::test]
+async fn apigatewayv2_authorizer_lifecycle() {
+    let server = TestServer::start().await;
+    let client = server.apigatewayv2_client().await;
+    let api_id = create_api(&client, "conf-auth").await;
+
+    let auth = client
+        .create_authorizer()
+        .api_id(&api_id)
+        .name("conf-authorizer")
+        .authorizer_type(AuthorizerType::Jwt)
+        .identity_source("$request.header.Authorization")
+        .jwt_configuration(
+            aws_sdk_apigatewayv2::types::JwtConfiguration::builder()
+                .issuer("https://example.com/.well-known/openid-configuration")
+                .audience("test-audience")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let authorizer_id = auth.authorizer_id().unwrap().to_string();
+
+    let got = client
+        .get_authorizer()
+        .api_id(&api_id)
+        .authorizer_id(&authorizer_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.name(), Some("conf-authorizer"));
+
+    let list = client
+        .get_authorizers()
+        .api_id(&api_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(list
+        .items()
+        .iter()
+        .any(|a| a.authorizer_id() == Some(&authorizer_id)));
+
+    client
+        .update_authorizer()
+        .api_id(&api_id)
+        .authorizer_id(&authorizer_id)
+        .name("conf-authorizer-updated")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .delete_authorizer()
+        .api_id(&api_id)
+        .authorizer_id(authorizer_id)
+        .send()
+        .await
+        .unwrap();
+}

--- a/scripts/update-aws-models.sh
+++ b/scripts/update-aws-models.sh
@@ -37,6 +37,12 @@ SERVICES=(
     "sesv2:sesv2"
     "cognito-identity-provider:cognito-identity-provider"
     "rds:rds"
+    "elasticache:elasticache"
+    "sfn:sfn"
+    "bedrock:bedrock"
+    "bedrock-runtime:bedrock-runtime"
+    "scheduler:scheduler"
+    "apigatewayv2:apigatewayv2"
 )
 
 # Sparse checkout only the models we need

--- a/website/content/docs/about/conformance.md
+++ b/website/content/docs/about/conformance.md
@@ -35,7 +35,7 @@ Every response is validated against the operation's Smithy output shape. Missing
 
 ## Current coverage
 
-57,000+ generated test variants, covering every operation in every service currently wired into the harness. 22 services at 100% conformance. The 23rd service fakecloud ships (API Gateway v2) is being brought into the harness incrementally as its 103 operations are implemented; in the meantime it is covered by handwritten SDK tests.
+59,000+ generated test variants across all 23 services, at 100% conformance.
 
 See the harness and methodology at [`crates/fakecloud-conformance/`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-conformance).
 

--- a/website/content/docs/about/what-it-is.md
+++ b/website/content/docs/about/what-it-is.md
@@ -6,7 +6,7 @@ weight = 3
 
 ## What fakecloud is
 
-A free, open-source local AWS emulator for integration testing and local development. For every service it implements, the goal is 100% behavioral parity with real AWS — measured by a schema-driven [conformance harness](/docs/about/conformance/) that runs 57,000+ generated test variants against official AWS Smithy models on every commit.
+A free, open-source local AWS emulator for integration testing and local development. For every service it implements, the goal is 100% behavioral parity with real AWS — measured by a schema-driven [conformance harness](/docs/about/conformance/) that runs 59,000+ generated test variants against official AWS Smithy models on every commit.
 
 The point is to let you run your application code against something that behaves like AWS, without burning an AWS account or hitting rate limits. Your tests exercise real SDK code paths end-to-end. Your CI pipeline runs fast and free.
 

--- a/website/content/fake-aws-server.md
+++ b/website/content/fake-aws-server.md
@@ -16,7 +16,7 @@ Listens on `http://localhost:4566`. Any AWS SDK in any language points at it and
 ## What "fake AWS server" means here
 
 - **Real HTTP server**, not an in-process mock. Your Go / Java / Kotlin / Node / Rust / PHP / Python code uses the regular AWS SDK with `endpoint_url` set to `http://localhost:4566`.
-- **Speaks the AWS wire protocol** at 100% conformance per implemented service. 23 services, 1,680 operations, validated against AWS's own Smithy models on every commit (57,000+ generated test variants).
+- **Speaks the AWS wire protocol** at 100% conformance per implemented service. 23 services, 1,680 operations, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
 - **Real execution** for stateful services: Lambda runs your function code in Docker containers across 13 runtimes, RDS runs real PostgreSQL/MySQL/MariaDB, ElastiCache runs real Redis/Valkey.
 - **Real cross-service wiring**: S3 -> Lambda, SQS -> Lambda, SNS fan-out, EventBridge -> Step Functions, and 15+ more integrations execute end-to-end, not as stubs.
 - **Free, open-source, AGPL-3.0.** No account, no auth token, no paid tier.

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -24,7 +24,7 @@ This is why fakecloud runs real Lambda code in real runtime containers, runs rea
 ## What fakecloud gives you
 
 - **23 AWS services.** S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
-- **1,680 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (57,000+ generated test variants).
+- **1,680 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
 - **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud, catching waiter and field-presence drift that pure SDK tests miss.
 - **Real Lambda execution.** 13 runtimes in Docker containers. Not a mock, not a stub. Node, Python, Java, Go, .NET, Ruby, custom runtimes.
 - **Real stateful services.** RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey. Your Lambda talking to RDS is talking to a real Postgres.
@@ -111,7 +111,7 @@ Yes. Single binary, ~19 MB, ~500ms startup. Common patterns: install-and-run as 
 
 **What does "100% conformance" mean?**
 
-For every operation exposed by AWS's Smithy model, fakecloud accepts every documented input shape and returns the documented output shape, with every field AWS returns. Validated on every commit against 57,000+ generated test variants, plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites. This applies to every service listed above.
+For every operation exposed by AWS's Smithy model, fakecloud accepts every documented input shape and returns the documented output shape, with every field AWS returns. Validated on every commit against 59,000+ generated test variants, plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites. This applies to every service listed above.
 
 **What's fakecloud's coverage goal?**
 

--- a/website/content/mock-dynamodb.md
+++ b/website/content/mock-dynamodb.md
@@ -16,7 +16,7 @@ Point your AWS SDK at `http://localhost:4566`. That's the whole setup.
 ## Why fakecloud for DynamoDB
 
 - **57 DynamoDB operations** at 100% conformance — tables, items, transactions (`TransactWriteItems`, `TransactGetItems`), PartiQL (`ExecuteStatement`, `BatchExecuteStatement`), backups, global tables, streams, secondary indexes.
-- **Validated against AWS's own Smithy models** on every commit (57,000+ generated test variants).
+- **Validated against AWS's own Smithy models** on every commit (59,000+ generated test variants).
 - **Any AWS SDK in any language.** Real HTTP server on port 4566 — Python boto3, Node aws-sdk, Go aws-sdk-go-v2, Java, Kotlin, Rust, PHP all work identically.
 - **No account, no auth token, no paid tier.** AGPL-3.0.
 - **No Docker required** for DynamoDB (binary runs the storage engine in-process). Fastest local DynamoDB you can run.

--- a/website/content/vs/floci.md
+++ b/website/content/vs/floci.md
@@ -16,7 +16,7 @@ Both are free, open-source, local AWS emulators. Real HTTP server speaking the A
 
 **floci's approach** (check their site for the current details — the project publishes performance claims like startup time, memory, and SDK-test pass rate): a free LocalStack replacement. Verify their numbers against the version you'd actually run.
 
-**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. A service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today. Built around real Lambda execution (13 runtimes in Docker), real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), real cross-service wiring, and validation on every commit against AWS's own Smithy models (57,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. A service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today. Built around real Lambda execution (13 runtimes in Docker), real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), real cross-service wiring, and validation on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
 
 Breadth-first and depth-first are both valid tradeoffs. Pick by whether your tests need real downstream execution and cross-service flows, or surface-level plausibility across more services.
 
@@ -37,7 +37,7 @@ Run your actual test suite against both. Numbers published on landing pages are 
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |
 | Cross-service wiring | S3 -> Lambda, SNS fan-out, EventBridge -> Step Functions, SES inbound -> S3/SNS/Lambda, 15+ more fire end-to-end |
-| Conformance methodology | Smithy-validated, 57k+ test variants per commit |
+| Conformance methodology | Smithy-validated, 59k+ test variants per commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
 | Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
 | Multi-account, SCPs, ABAC | Yes |

--- a/website/content/vs/ministack.md
+++ b/website/content/vs/ministack.md
@@ -16,7 +16,7 @@ Free, open-source, local AWS emulation. Real HTTP server speaking the AWS wire p
 
 **MiniStack's approach** (check their repo for current details — it's moving fast): positions as a free LocalStack replacement. Evaluate their service coverage and architecture directly against your test suite.
 
-**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land one at a time; a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today; more progressively. Built around real Lambda execution, real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), and real cross-service wiring, validated on every commit against AWS's own Smithy models (57,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land one at a time; a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 23 services shipped today; more progressively. Built around real Lambda execution, real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), and real cross-service wiring, validated on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
 
 These are philosophies, not rankings. Breadth-first and depth-first are different tradeoffs. A team whose tests lean lightly on many services will prefer breadth. A team whose tests exercise real cross-service flows or need real code execution will prefer depth.
 
@@ -39,7 +39,7 @@ These are philosophies, not rankings. Breadth-first and depth-first are differen
 | Lambda execution | Real, 13 runtimes in Docker |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |
-| Conformance methodology | Smithy-validated, 57k+ test variants on every commit |
+| Conformance methodology | Smithy-validated, 59k+ test variants on every commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
 | Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |
 | License | AGPL-3.0 |

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -101,7 +101,7 @@
       <div class="feature">
         <div class="label">Tested</div>
         <h3>Conformance tested</h3>
-        <p>100% conformance across all 1,680 implemented API operations, backed by 57,000+ Smithy-model-generated test variants plus end-to-end tests against the official AWS SDKs.</p>
+        <p>100% conformance across all 1,680 implemented API operations, backed by 59,000+ Smithy-model-generated test variants plus end-to-end tests against the official AWS SDKs.</p>
       </div>
       <div class="feature">
         <div class="label">Real behavior</div>


### PR DESCRIPTION
## Summary

Batch 2 of the APIGWv2 conformance initiative. Wires the 23rd service fakecloud ships (API Gateway v2) into the Smithy harness, completing **23/23** coverage at 100% conformance across **59,954** generated variants.

- `aws-models/apigatewayv2.json` — upstream Smithy model, 103 operations, restJson1.
- `aws-models/service-map.json` — new `apigatewayv2` entry mapping `service_name: "apigateway"` (fakecloud's internal dispatch key, shared with v1 legacy code paths).
- `scripts/update-aws-models.sh` — catch up the pull list with the companion models already committed (elasticache, sfn, bedrock, bedrock-runtime, scheduler) plus apigatewayv2.
- `probe.rs` — `"apigateway" => Protocol::Rest`. Routing uses the generic `@http`-driven REST builder from Batch 1; no hand-maintained op table for this service.
- `audit.rs` — new `AuditMapping` entry covering the 28 currently-implemented APIGWv2 actions; accepts both `apigateway` and `apigatewayv2` test tags.

### Ancillary fix: `@jsonName` trait

APIGWv2 output shapes (and every restJson1 service) annotate members with `smithy.api#jsonName("lowercaseName")`. fakecloud returns the lowercase JSON keys correctly, but `shape_validator.rs` was comparing response keys against the Smithy PascalCase member name, flagging every `GetApisResponse.items` (etc.) as an unexpected field. Fix:

- `ShapeTraits::json_name` parsed from `smithy.api#jsonName`.
- `shape_validator::validate_structure` + union branch look up members by `json_name.unwrap_or(name)`.

Without this, `GetApis` (and any other restJson response with `@jsonName` overrides) reported 24/24 shape mismatches.

### Tests

- `crates/fakecloud-conformance/tests/apigatewayv2.rs` — new file. `#[test_action("apigatewayv2", <Action>)]` annotations on lifecycle tests covering all 28 currently-implemented APIGWv2 actions (Api/Route/Integration/Stage/Deployment lifecycles + Authorizer CRUD). Mirrors the pattern used in `rds.rs` / `kinesis.rs`.

### Baseline

- 57,185/57,185 (22 services) -> 59,954/59,954 (23 services), 100% everywhere.
- README + website: 57,000+ -> 59,000+ generated variants.

## Test plan

- [x] `cargo test -p fakecloud-conformance --lib probe::` — 14/14 generic REST tests pass
- [x] `cargo test -p fakecloud-conformance --lib smithy::` — 2 @http tests still pass
- [x] `cargo run -p fakecloud-conformance -- audit` — PASS, all 1173 implemented actions covered
- [x] `cargo run -p fakecloud-conformance -- check` — no regressions vs refreshed baseline
- [x] `cargo nextest run -P ci -p fakecloud-conformance --tests` — 782/782 pass locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired API Gateway v2 into the Smithy conformance harness, bringing coverage to 23/23 services with 59,954/59,954 variants passing. Fixed and covered `@jsonName` handling in the shape validator for restJson1 outputs.

- **New Features**
  - Added model `aws-models/apigatewayv2.json` and `aws-models/service-map.json` entry mapping `apigatewayv2` to `service_name: "apigateway"`.
  - Probed via generic REST path: `crates/fakecloud-conformance/src/probe.rs` adds `"apigateway" => Protocol::Rest"`.
  - Conformance audit mapping for 28 actions; accepts `apigateway` and `apigatewayv2` tags.
  - Tests: APIGWv2 lifecycles/authorizers (`crates/fakecloud-conformance/tests/apigatewayv2.rs`) and unit tests for the `@jsonName` validator path.
  - Baseline/docs refreshed to 59,954/59,954; `scripts/update-aws-models.sh` now pulls `apigatewayv2` and companions.

- **Bug Fixes**
  - Parse and use `smithy.api#jsonName` when validating structures/unions and required fields (`crates/fakecloud-conformance/src/smithy.rs`, `shape_validator.rs`); removes false positives on restJson1 outputs (e.g., `GetApisResponse.items`).

<sup>Written for commit f06816423c95177d41747c2cf9ecf70ff30d0e99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

