### PR TITLE
refactor(seo): rename /mock-*/ landings to /*-emulator/

### DIFF
--- a/website/content/cognito-emulator.md
+++ b/website/content/cognito-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock Cognito for tests"
-description = "Mock AWS Cognito User Pools locally for integration tests with fakecloud. 122 operations, full auth flows (USER_PASSWORD_AUTH, USER_SRP_AUTH, CUSTOM_AUTH), MFA, identity providers, triggers."
+title = "Cognito emulator for tests"
+description = "Run AWS Cognito User Pools locally for integration tests with fakecloud. 122 operations, full auth flows (USER_PASSWORD_AUTH, USER_SRP_AUTH, CUSTOM_AUTH), MFA, identity providers, triggers."
 template = "page.html"
 +++
 
-Need to mock AWS Cognito for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need a Cognito emulator for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the Cognito wire protocol.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash

--- a/website/content/dynamodb-emulator.md
+++ b/website/content/dynamodb-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock DynamoDB for tests"
-description = "Mock DynamoDB locally for integration tests with fakecloud. 57 operations, transactions, PartiQL, streams, global tables. Any language, no Docker required, free."
+title = "DynamoDB emulator for tests"
+description = "Run DynamoDB locally for integration tests with fakecloud. 57 operations, transactions, PartiQL, streams, global tables. Any language, no Docker required, free."
 template = "page.html"
 +++
 
-Need to mock DynamoDB for tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need a DynamoDB emulator for tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the DynamoDB wire protocol.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash

--- a/website/content/kms-emulator.md
+++ b/website/content/kms-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock KMS for tests"
-description = "Mock AWS KMS locally for integration tests with fakecloud. 53 KMS operations, real ECDH, encryption/decryption, aliases, grants, key import, multi-region keys. Any AWS SDK, free."
+title = "KMS emulator for tests"
+description = "Run AWS KMS locally for integration tests with fakecloud. 53 KMS operations, real ECDH, encryption/decryption, aliases, grants, key import, multi-region keys. Any AWS SDK, free."
 template = "page.html"
 +++
 
-Need to mock AWS KMS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need a KMS emulator for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the KMS wire protocol with real crypto.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash

--- a/website/content/local-s3-for-tests.md
+++ b/website/content/local-s3-for-tests.md
@@ -141,4 +141,4 @@ If you need S3 + cross-service wiring (S3 -> SNS/SQS/Lambda actually fires), pic
 - **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
 - **S3 docs:** [fakecloud.dev/docs/services](/docs/services/)
-- **Related:** [Fake AWS server for tests](/fake-aws-server/), [Mock DynamoDB for tests](/mock-dynamodb/), [Test Lambda locally](/test-lambda-locally/)
+- **Related:** [Fake AWS server for tests](/fake-aws-server/), [DynamoDB emulator](/dynamodb-emulator/), [Test Lambda locally](/test-lambda-locally/)

--- a/website/content/ses-emulator.md
+++ b/website/content/ses-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock SES for tests"
-description = "Mock AWS SES locally for integration tests with fakecloud. 110 SES operations, v2 send + templates + DKIM, real receipt rule execution for inbound email. Free, no account required."
+title = "SES emulator for tests"
+description = "Run AWS SES locally for integration tests with fakecloud. 110 SES operations, v2 send + templates + DKIM, real receipt rule execution for inbound email. Free, no account required."
 template = "page.html"
 +++
 
-Need to mock AWS SES for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need a SES emulator for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the SES wire protocol.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash

--- a/website/content/sns-emulator.md
+++ b/website/content/sns-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock SNS for tests"
-description = "Mock SNS locally for integration tests with fakecloud. 42 SNS operations, fan-out to SQS/Lambda/HTTP, filter policies, real cross-service delivery. Any AWS SDK, free, no account required."
+title = "SNS emulator for tests"
+description = "Run SNS locally for integration tests with fakecloud. 42 SNS operations, fan-out to SQS/Lambda/HTTP, filter policies, real cross-service delivery. Any AWS SDK, free, no account required."
 template = "page.html"
 +++
 
-Need to mock SNS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need an SNS emulator for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the SNS wire protocol.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
@@ -117,11 +117,11 @@ SDKs for TypeScript, Python, Go, PHP, Java, Rust.
 |---|---|---|---|---|
 | fakecloud | Any | Yes | Yes (real code runs) | Yes |
 | LocalStack Community | Any (auth required post-paywall) | Yes | Yes | Yes |
-| Moto (mock_sns) | Python only | Yes | Stubbed | Partial |
+| Moto (`mock_sns`) | Python only | Yes | Stubbed | Partial |
 | aws-sdk-client-mock | Node only | Stubbed | N/A | Stubbed |
 
 ## Links
 
 - **Install:** `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
 - **Repo:** [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
-- **Related:** [Mock SQS for tests](/mock-sqs/), [Test Lambda locally](/test-lambda-locally/), [Fake AWS server for tests](/fake-aws-server/)
+- **Related:** [SQS emulator](/sqs-emulator/), [Test Lambda locally](/test-lambda-locally/), [Fake AWS server for tests](/fake-aws-server/)

--- a/website/content/sqs-emulator.md
+++ b/website/content/sqs-emulator.md
@@ -1,10 +1,10 @@
 +++
-title = "Mock SQS for tests"
-description = "Mock SQS locally for integration tests with fakecloud. 23 SQS operations, FIFO, DLQs, long polling, real Lambda event source mappings. Any AWS SDK, free."
+title = "SQS emulator for tests"
+description = "Run SQS locally for integration tests with fakecloud. 23 SQS operations, FIFO, DLQs, long polling, real Lambda event source mappings. Any AWS SDK, free."
 template = "page.html"
 +++
 
-Need to mock SQS for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud).
+Need an SQS emulator for integration tests? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library — a real server that speaks the SQS wire protocol.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
@@ -141,7 +141,7 @@ SDKs available in TypeScript, Python, Go, PHP, Java, Rust.
 |---|---|---|---|---|---|
 | fakecloud | Any | Yes | Yes | Yes (real code runs) | Yes |
 | ElasticMQ | Any | Yes | Yes | No (no Lambda service) | N/A |
-| Moto (mock_sqs) | Python only | Yes | Yes | Stubbed | Stubbed |
+| Moto (`mock_sqs`) | Python only | Yes | Yes | Stubbed | Stubbed |
 | LocalStack Community | Any | Yes | Yes | Yes (post-paywall auth required) | Yes (paywall) |
 | aws-sdk-client-mock | Node only | Stubbed | Stubbed | N/A | N/A |
 

--- a/website/content/vs/dynamodb-local.md
+++ b/website/content/vs/dynamodb-local.md
@@ -54,4 +54,4 @@ If you already test against DynamoDB Local and need nothing more, no reason to s
 
 - [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
 - [DynamoDB Local docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
-- [Mock DynamoDB for tests](/mock-dynamodb/)
+- [DynamoDB emulator](/dynamodb-emulator/)

--- a/website/content/vs/elasticmq.md
+++ b/website/content/vs/elasticmq.md
@@ -52,4 +52,4 @@ Both implement the SQS wire protocol.
 
 - [fakecloud GitHub](https://github.com/faiscadev/fakecloud)
 - [ElasticMQ GitHub](https://github.com/softwaremill/elasticmq)
-- [Mock SQS for tests](/mock-sqs/)
+- [SQS emulator](/sqs-emulator/)


### PR DESCRIPTION
## Summary

- fakecloud is an emulator (real AWS wire-protocol server), not a mock library. "Mock" framing reinforces the wrong mental model and puts us in the same bucket as moto / aws-sdk-client-mock.
- Rename 6 landing pages: /mock-{cognito,dynamodb,kms,ses,sns,sqs}/ → /{cognito,dynamodb,kms,ses,sns,sqs}-emulator/
- Each landing now opens with "Not a mock library — a real server that speaks the X wire protocol."
- Fix cross-links in local-s3-for-tests.md, vs/dynamodb-local.md, vs/elasticmq.md.

## Why no redirects

Pages shipped earlier today. Nothing external links them, nothing indexed. Clean rename is simplest.

## Test plan

- [x] `zola build` succeeds, 81 pages generated, 6 /*-emulator/ slugs present
- [x] No internal links point to /mock-*/ anywhere in repo
- [x] Competitor mentions ("Moto's mock_sqs", "aws-sdk-client-mock") preserved as legitimate naming

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed website landings from /mock-*/ to /*-emulator/ to reflect that fakecloud is an emulator (real AWS wire protocol) and improve SEO clarity. Updated page copy and cross-links; no redirects needed as pages are new.

- **Refactors**
  - Renamed: /mock-{cognito,dynamodb,kms,ses,sns,sqs}/ → /{cognito,dynamodb,kms,ses,sns,sqs}-emulator/
  - Updated titles/descriptions and openers to say “Not a mock library — a real server that speaks the X wire protocol.”
  - Fixed links in local-s3-for-tests.md, vs/dynamodb-local.md, vs/elasticmq.md; preserved competitor names like Moto (`mock_sqs`) and `aws-sdk-client-mock`.

<sup>Written for commit 1f2d0944ebad510758e52fd03b9a690139ce5570. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

