### PR TITLE
content(seo): 4 Bedrock landing pages

### DIFF
--- a/website/content/bedrock-emulator.md
+++ b/website/content/bedrock-emulator.md
@@ -1,0 +1,132 @@
++++
+title = "Bedrock emulator"
+description = "Bedrock emulator for tests: 111 operations, real wire protocol, fault injection, configurable responses. Deterministic, offline, free. Not a mock library, not a real LLM."
+template = "page.html"
++++
+
+Need a Bedrock emulator? Use [fakecloud](https://github.com/faiscadev/fakecloud). Not a mock library. Not a real LLM. A real server that speaks the Bedrock wire protocol and returns exactly what you tell it to.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point any AWS SDK at `http://localhost:4566`. That's the setup.
+
+## Why emulator, not mock, not Ollama
+
+Three categories of tools, three different jobs:
+
+- **Mock library** (moto, aws-sdk-client-mock) — replaces the AWS SDK internals with stubs. Never hits HTTP. Your code isn't tested against anything that looks like Bedrock — it's tested against a fake object matching the SDK interface. If you assemble the request wrong, the mock doesn't care.
+- **Real LLM locally** (Ollama, LM Studio) — real inference on your CPU. Slow. Non-deterministic. GBs of weights. Your tests can't assert on output because every run returns different text. A CI runner takes 8 minutes to boot the model. LocalStack's "Ultimate"-tier Bedrock does this.
+- **Emulator** (fakecloud) — real HTTP server on port 4566. Speaks Bedrock's JSON wire protocol. Your AWS SDK sends real requests. You control the response per prompt. Deterministic. Millisecond latency. No GBs of weights.
+
+Tests want the third one. You're testing your code, not whether the model happens to understand the prompt today.
+
+## What fakecloud Bedrock does
+
+**111 operations across the full Bedrock surface**, not just the runtime:
+
+- **Runtime**: `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` — EventStream binary encoded, same as real AWS.
+- **Guardrails**: full CRUD + versioning + apply + content evaluation. Test your guardrail config locally before deploying.
+- **Custom models**: `CreateModelCustomizationJob`, `GetCustomModel`, `ListCustomModels`, deletion, versioning.
+- **Model import**: `CreateModelImportJob` for bring-your-own weights flow.
+- **Inference profiles**, **provisioned throughput**, **model copy jobs**, **async invoke + batch inference via S3**.
+- **Prompt management**: prompts + prompt routers with versioning.
+- **Foundation model agreements**: the `PutUseCaseForModelAccess` / `CreateFoundationModelAgreement` access approval flow.
+- **Automated reasoning policies**, **evaluation jobs**, **marketplace**, **resource policies**, **logging configuration**.
+
+What it does NOT do: actual inference. Response content is whatever you configured. That's the point — deterministic tests.
+
+## Configurable responses per prompt
+
+```ts
+import { FakeCloud } from "fakecloud";
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const fc = new FakeCloud();
+
+beforeEach(() => fc.reset());
+
+test("spam classifier routes to review on borderline score", async () => {
+  await fc.bedrock.setResponseRule({
+    whenPromptContains: "classify spam",
+    respond: {
+      completion: JSON.stringify({ label: "borderline", confidence: 0.62 }),
+    },
+  });
+
+  const rt = new BedrockRuntimeClient({ endpoint: "http://localhost:4566" });
+  const out = await classifyEmail(rt, "buy now!!");
+
+  expect(out.routedTo).toBe("human-review");
+});
+```
+
+## Fault injection
+
+```ts
+await fc.bedrock.injectFault({
+  operation: "InvokeModel",
+  error: "ThrottlingException",
+  count: 2,
+});
+
+// your code retries with backoff; third call succeeds
+const out = await yourClassifier(rt, "buy now!!");
+expect(fc.bedrock.getCallHistory()).toHaveLength(3);
+```
+
+Real retry code paths get exercised. No more "we'll test the retry logic later."
+
+## Guardrails, locally
+
+```python
+import boto3
+bedrock = boto3.client('bedrock', endpoint_url='http://localhost:4566',
+    aws_access_key_id='test', aws_secret_access_key='test', region_name='us-east-1')
+
+g = bedrock.create_guardrail(
+    name='no-pii',
+    contentPolicyConfig={
+        'filtersConfig': [
+            {'type': 'HATE', 'inputStrength': 'HIGH', 'outputStrength': 'HIGH'},
+        ],
+    },
+    sensitiveInformationPolicyConfig={
+        'piiEntitiesConfig': [{'type': 'EMAIL', 'action': 'BLOCK'}],
+    },
+    blockedInputMessaging='Blocked.',
+    blockedOutputsMessaging='Blocked.',
+)
+
+# your app flows
+rt = boto3.client('bedrock-runtime', endpoint_url='http://localhost:4566',
+    aws_access_key_id='test', aws_secret_access_key='test', region_name='us-east-1')
+rt.apply_guardrail(guardrailIdentifier=g['guardrailId'],
+                   guardrailVersion='DRAFT', source='INPUT',
+                   content=[{'text': {'text': 'contact me at bob@example.com'}}])
+```
+
+`ApplyGuardrail` runs real content evaluation. PII action `BLOCK` returns the blocked message. Test your guardrail policy without AWS.
+
+## Comparison
+
+| Tool | Wire protocol | Deterministic | Guardrails | Fine-tuning jobs | Async batch | Price |
+|---|---|---|---|---|---|---|
+| **fakecloud** | Real | Yes | Yes | Yes (control plane) | Yes | Free, AGPL-3.0 |
+| Real Bedrock | Real | No | Yes | Yes | Yes | $$$ per token |
+| LocalStack Ultimate (Ollama) | Real | No (Ollama inference) | No | No | Partial | Paid Ultimate tier |
+| Ollama standalone | Different (OpenAI-ish) | No | No | No | No | Free, but doesn't speak Bedrock |
+| Mock library (moto, etc.) | N/A (no HTTP) | Yes | Stubbed | Stubbed | Stubbed | Free |
+
+## Links
+
+- **Install**: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Deep dive**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)
+- **LLM Guardrails**: [Testing LLM guardrails locally](/blog/llm-guardrails/)
+- **Related**: [Fake AWS server for tests](/fake-aws-server/), [Test Lambda locally](/test-lambda-locally/)

--- a/website/content/fake-bedrock.md
+++ b/website/content/fake-bedrock.md
@@ -1,0 +1,115 @@
++++
+title = "Fake Bedrock"
+description = "fake Bedrock server for local dev and tests. Real wire protocol, fake responses you control. 111 operations, deterministic, free. Not a mock library, not a real LLM."
+template = "page.html"
++++
+
+Need a fake Bedrock? Use [fakecloud](https://github.com/faiscadev/fakecloud). Real HTTP server that speaks the Bedrock wire protocol and returns whatever you tell it to. 111 operations, deterministic, free.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point any AWS SDK at `http://localhost:4566`.
+
+## What "fake" means here
+
+**Fake** is not **mock**. A mock replaces the SDK internals with stub functions. A fake is a real running service that happens to return fake (configured) responses. The difference matters:
+
+- A mock fails to catch bugs in how your code assembles HTTP requests. It never sent a request.
+- A fake catches those bugs. Your code made a real HTTP call. The request body was parsed by a real JSON parser. The response traveled back through the real SDK response parser.
+
+fakecloud is a fake AWS — a complete server on port 4566 that speaks 23 AWS services' wire protocols. Your code thinks it's talking to real AWS.
+
+And it is, as far as the protocol is concerned. The part that's fake is the response content — which is exactly the part you want to control in tests.
+
+## Fake Bedrock, not fake LLM
+
+fakecloud's Bedrock is deliberately not backed by a real model (no Ollama, no local Claude). Here's why:
+
+- Real LLMs are non-deterministic. Tests need determinism.
+- Real LLMs are slow. Tests need milliseconds.
+- Real LLMs are GBs. Tests need zero external dependencies.
+- Real LLMs test the model. Tests need to test *your code*.
+
+So Bedrock in fakecloud returns what you configure. That's the whole product:
+
+```ts
+await fc.bedrock.setResponseRule({
+  whenPromptContains: "summarize",
+  respond: { completion: "- one\n- two\n- three" },
+});
+```
+
+Now `InvokeModel` with a prompt containing "summarize" returns exactly that. Every time. In milliseconds.
+
+## 111 operations
+
+The control plane is real. Create guardrails, customization jobs, imported models, inference profiles, provisioned throughput — all the Bedrock shape your infrastructure code deals with:
+
+```python
+import boto3
+bedrock = boto3.client('bedrock',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test', aws_secret_access_key='test', region_name='us-east-1')
+
+# guardrail crud
+g = bedrock.create_guardrail(
+    name='safety-v1',
+    contentPolicyConfig={'filtersConfig': [
+        {'type': 'SEXUAL', 'inputStrength': 'HIGH', 'outputStrength': 'HIGH'},
+    ]},
+    blockedInputMessaging='blocked',
+    blockedOutputsMessaging='blocked',
+)
+
+v = bedrock.create_guardrail_version(guardrailIdentifier=g['guardrailId'])
+bedrock.list_guardrails()
+
+# customization job (fine-tuning flow shape)
+bedrock.create_model_customization_job(
+    jobName='my-ft-job',
+    customModelName='my-claude-ft',
+    roleArn='arn:aws:iam::000000000000:role/bedrock',
+    baseModelIdentifier='anthropic.claude-3-haiku-20240307-v1:0',
+    trainingDataConfig={'s3Uri': 's3://fakecloud-demo/train.jsonl'},
+    outputDataConfig={'s3Uri': 's3://fakecloud-demo/output/'},
+    hyperParameters={'epochCount': '1'},
+)
+```
+
+Terraform, CloudFormation, and CDK that deploy Bedrock infra can all target fakecloud.
+
+## Fault injection
+
+```ts
+await fc.bedrock.injectFault({
+  operation: "Converse",
+  error: "ValidationException",
+  messageSubstring: "The model returned the following errors: too many messages",
+});
+
+// your code catches ValidationException, falls back to single-turn mode
+const result = await resilientConverse(rt, longConversation);
+expect(result.mode).toBe("single-turn-fallback");
+```
+
+Assert your code handles every Bedrock error code you read in the docs. No more "I'll test that path later."
+
+## Comparison
+
+| Tool | Type | Wire protocol | Deterministic | Cost |
+|---|---|---|---|---|
+| **fakecloud** | Emulator (fake server) | Real | Yes | Free |
+| Real Bedrock | Cloud service | Real | No | $$$ per token |
+| Ollama / LM Studio | Real local LLM | Different | No | CPU+RAM |
+| LocalStack Ultimate | Emulator with Ollama | Real | No (Ollama) | Paid Ultimate tier |
+| Moto / aws-sdk-client-mock | Mock library | None (no HTTP) | Yes | Free, but misses HTTP bugs |
+
+## Links
+
+- **Install**: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Tutorial**: [How to test Bedrock code locally](/blog/bedrock-local-testing/)
+- **Related**: [Bedrock emulator](/bedrock-emulator/), [Test Bedrock locally](/test-bedrock-locally/), [Fake AWS server](/fake-aws-server/)

--- a/website/content/localstack-bedrock-alternative.md
+++ b/website/content/localstack-bedrock-alternative.md
@@ -1,0 +1,102 @@
++++
+title = "LocalStack Bedrock alternative"
+description = "Free, open-source alternative to LocalStack Ultimate-tier Bedrock. 111 operations, full control plane, deterministic responses for tests. Not backed by Ollama. AGPL-3.0."
+template = "page.html"
++++
+
+Looking for a free, open-source alternative to LocalStack's Ultimate-tier Bedrock? Use [fakecloud](https://github.com/faiscadev/fakecloud). 111 Bedrock operations, full control plane, deterministic responses, free.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point any AWS SDK at `http://localhost:4566`. Same setup as LocalStack.
+
+## How LocalStack Bedrock compares
+
+As of April 2026, per [docs.localstack.cloud/aws/services/bedrock](https://docs.localstack.cloud/aws/services/bedrock/):
+
+| | LocalStack Bedrock | fakecloud Bedrock |
+|---|---|---|
+| **Tier** | Ultimate (top paid plan) | Free, AGPL-3.0 |
+| **Operations** | 4: `InvokeModel`, `Converse`, `ListFoundationModels`, `CreateModelInvocationJob` | 111 across runtime + full control plane |
+| **Backend** | Ollama (real local LLM) | Configurable responses per prompt rule |
+| **Determinism** | No — real inference, different output each run | Yes — returns exactly what you configured |
+| **Speed** | 1-30s per call (Ollama CPU inference) | Milliseconds |
+| **Disk** | GBs (Ollama model weights) | ~19 MB binary |
+| **Guardrails** | Not supported | Full CRUD + versioning + `ApplyGuardrail` content evaluation |
+| **Custom models** | Not supported | `CreateModelCustomizationJob`, imported models, model copy jobs |
+| **Async invoke / batch** | Partial (CreateModelInvocationJob only) | Full flow, S3-backed |
+| **Prompt management** | Not supported | Prompts + prompt routers |
+| **Fault injection** | No | Yes (`ThrottlingException`, `ValidationException`, etc. on demand) |
+| **Call history introspection** | No | `/_fakecloud/bedrock/calls` endpoint |
+| **GPU required** | Usually | No |
+| **Persistence** | "Not supported" | Yes (built-in state management) |
+
+If you came to LocalStack Bedrock for testing, fakecloud covers every test case better. If you came for real local inference: that's Ollama's job, not ours — [Ollama](https://ollama.com) runs standalone.
+
+## Migration from LocalStack
+
+**Env vars:** the same ones work. fakecloud accepts `AWS_ENDPOINT_URL`, dummy credentials, any region.
+
+```sh
+# before (LocalStack)
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+localstack start
+
+# after (fakecloud)
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+fakecloud
+```
+
+**Model IDs:** LocalStack's `ollama.<id>` convention does not exist here. Use real Bedrock model IDs (`anthropic.claude-3-haiku-20240307-v1:0`, `amazon.nova-lite-v1:0`, `meta.llama3-8b-instruct-v1:0`, etc.). fakecloud accepts them and returns whatever response rule you configured.
+
+**Response config:** LocalStack's `BEDROCK_PREWARM` and `DEFAULT_BEDROCK_MODEL` go away. Replace with explicit per-test fixtures:
+
+```ts
+import { FakeCloud } from "fakecloud";
+const fc = new FakeCloud();
+
+await fc.bedrock.setResponseRule({
+  whenPromptContains: "summarize",
+  respond: { completion: "deterministic summary" },
+});
+```
+
+**Tests that depend on real inference output**: these were never good tests on LocalStack either (Ollama's Llama ≠ Claude). Rewrite assertions to check that *your code* handled the response shape correctly, not that the model "got the right answer."
+
+## What fakecloud Bedrock actually runs
+
+Full operation surface across 27 modules:
+
+- **Runtime**: `InvokeModel`, `InvokeModelWithResponseStream` (binary EventStream), `Converse`, `ConverseStream`
+- **Guardrails**: `CreateGuardrail`, `GetGuardrail`, `UpdateGuardrail`, `DeleteGuardrail`, `CreateGuardrailVersion`, `ListGuardrails`, `ApplyGuardrail` (with real PII detection, content filters, topic filters)
+- **Customization**: `CreateModelCustomizationJob`, `GetModelCustomizationJob`, `StopModelCustomizationJob`, `ListModelCustomizationJobs`, custom model CRUD
+- **Custom model deployments**
+- **Model import**: `CreateModelImportJob`, imported model lifecycle
+- **Inference profiles** (cross-region routing config)
+- **Provisioned throughput**
+- **Model copy jobs** (cross-region model replication)
+- **Async invoke**: `StartAsyncInvoke`, `GetAsyncInvoke`, `ListAsyncInvokes`
+- **Invocation jobs** (batch via S3)
+- **Prompt management**: prompts, prompt versions, prompt routers
+- **Foundation model agreements**: access approval flow
+- **Automated reasoning policies + workflows**
+- **Evaluation jobs**
+- **Marketplace**
+- **Resource policies**
+- **Logging configuration**
+
+## Links
+
+- **Install**: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Deep dive**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)
+- **Related**: [Bedrock emulator](/bedrock-emulator/), [Test Bedrock locally](/test-bedrock-locally/), [LocalStack alternative (all services)](/localstack-alternative/)

--- a/website/content/test-bedrock-locally.md
+++ b/website/content/test-bedrock-locally.md
@@ -1,0 +1,153 @@
++++
+title = "Test Bedrock locally"
+description = "Test code that calls AWS Bedrock, locally and deterministically. Configurable responses per prompt, fault injection for retry logic, call-history assertions. Free, no account, no GPU."
+template = "page.html"
++++
+
+Want to test code that calls Bedrock, without spending real tokens or hitting a real LLM? Use [fakecloud](https://github.com/faiscadev/fakecloud). Real Bedrock-wire-protocol server. Deterministic responses. Millisecond latency. Free.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash
+fakecloud
+```
+
+Point any AWS SDK at `http://localhost:4566`.
+
+## Why you don't want a real LLM in tests
+
+Tests exist to prove your code is correct. A real LLM — including Ollama-backed local inference — makes that job harder, not easier:
+
+1. **Non-deterministic.** Same prompt, different output every run. Even at `temperature=0`, attention-kernel non-determinism and tokenizer drift break snapshot tests. You end up asserting `output.length > 0`, which passes even if the model returned "cabbage."
+2. **Slow.** Ollama on CPU = seconds per call. 100 tests × 5s = 8 minutes. Your TDD loop dies. CI times out.
+3. **Resource-heavy.** GB-scale model weights. CI runners balloon, `docker pull` drags, laptops OOM.
+4. **Tests the wrong thing.** A real LLM tests whether the model understood your prompt. Your tests should cover whether *your code* handles Bedrock's response shape, retries correctly on throttling, builds the request body right. Those are different concerns.
+5. **Flaky.** Rate limits if real AWS. GPU-less OOM if local. Cold-start delays everywhere.
+
+What your tests actually need:
+
+- Deterministic response per input
+- Fault injection (throttle, validation error, timeout)
+- Call history ("did my code send the right prompt?")
+- Millisecond latency
+- Zero external dependencies
+
+fakecloud gives exactly this.
+
+## Configurable responses
+
+```ts
+import { FakeCloud } from "fakecloud";
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const fc = new FakeCloud();
+const rt = new BedrockRuntimeClient({ endpoint: "http://localhost:4566" });
+
+beforeEach(() => fc.reset());
+
+test("summarizer returns 3-bullet format", async () => {
+  await fc.bedrock.setResponseRule({
+    whenPromptContains: "summarize",
+    respond: {
+      completion: "- bullet one\n- bullet two\n- bullet three",
+    },
+  });
+
+  const out = await summarize(rt, "long text here");
+
+  expect(out.bullets).toHaveLength(3);
+});
+
+test("classifier returns spam vs ham", async () => {
+  await fc.bedrock.setResponseRule({
+    whenPromptContains: "classify",
+    respond: { completion: JSON.stringify({ label: "spam" }) },
+  });
+
+  expect(await classify(rt, "buy now!!")).toBe("spam");
+});
+```
+
+Same test file, different fixtures per branch of your code.
+
+## Fault injection for retry logic
+
+```python
+import boto3
+from fakecloud import FakeCloud
+
+fc = FakeCloud()
+rt = boto3.client('bedrock-runtime', endpoint_url='http://localhost:4566',
+    aws_access_key_id='test', aws_secret_access_key='test', region_name='us-east-1')
+
+fc.bedrock.inject_fault(
+    operation='InvokeModel',
+    error='ThrottlingException',
+    count=2,
+)
+
+# your code retries with exponential backoff; third call succeeds
+result = resilient_classify(rt, "some text")
+
+history = fc.bedrock.get_call_history()
+assert len(history) == 3  # two throttles, one success
+assert history[0].error == 'ThrottlingException'
+assert history[2].error is None
+```
+
+Your retry path — the thing that breaks in production if you didn't write it right — now gets exercised in every test run.
+
+## Call-history assertions
+
+```ts
+await myAgent.run({ task: "research fakecloud" });
+
+const calls = await fc.bedrock.getCallHistory();
+expect(calls).toHaveLength(3);                    // agent made exactly 3 model calls
+expect(calls[0].modelId).toBe("anthropic.claude-3-haiku-20240307-v1:0");
+expect(calls[0].messages[0].content).toContain("research");
+expect(calls[2].messages).toHaveLength(5);        // 3-turn conversation
+```
+
+Assert on what your code *sent*, not just what it received.
+
+## Streaming
+
+Bedrock returns binary EventStream frames for streaming endpoints. fakecloud encodes them correctly — your streaming consumer sees real chunks:
+
+```ts
+await fc.bedrock.setResponseRule({
+  operation: "InvokeModelWithResponseStream",
+  chunks: ["Once ", "upon ", "a ", "time"],
+});
+
+const stream = await rt.send(new InvokeModelWithResponseStreamCommand({
+  modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+  body: JSON.stringify({ messages: [{ role: "user", content: "story" }] }),
+}));
+
+const chunks = [];
+for await (const evt of stream.body!) {
+  chunks.push(decodeChunk(evt));
+}
+expect(chunks).toEqual(["Once ", "upon ", "a ", "time"]);
+```
+
+## Comparison
+
+| | Deterministic | Fault injection | Call history | Speed | Cost | AWS bill |
+|---|---|---|---|---|---|---|
+| **fakecloud** | Yes | Yes | Yes | ms | Free | None |
+| Real Bedrock | No | Hard (rate-limit abuse) | No | 100-2000ms | $$$ | Real |
+| Ollama / local LLM | No | No | No | 1-30s | CPU + RAM | None |
+| LocalStack Ultimate | No (Ollama backed) | Limited | No | 1-30s | Paid Ultimate tier | None |
+| Mock library | Yes | Yes | Yes | ms | Free | None, but doesn't test HTTP path |
+
+## Links
+
+- **Install**: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **Repo**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Full tutorial**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)
+- **Related**: [Bedrock emulator](/bedrock-emulator/), [LocalStack Bedrock alternative](/localstack-bedrock-alternative/), [Testing LLM guardrails](/blog/llm-guardrails/)


### PR DESCRIPTION
## Summary

Bedrock is fakecloud's biggest differentiator vs LocalStack — 111 ops (full control plane) vs LocalStack Ultimate's 4 ops (Ollama-backed). Four new landings targeting distinct query buckets with a shared positioning: **fakecloud is an emulator with configurable responses, not a mock, not a real LLM.**

- `/bedrock-emulator/` — primary technical SEO slug
- `/test-bedrock-locally/` — task-intent upstream query
- `/fake-bedrock/` — brand voice, explains "fake != mock"
- `/localstack-bedrock-alternative/` — migration query with LocalStack Ultimate comparison

## Positioning

Three categories of tools, three jobs:
- Mock library (moto, aws-sdk-client-mock) — stubs the SDK, never hits HTTP
- Real local LLM (Ollama, LM Studio) — real inference, slow + non-deterministic
- Emulator (fakecloud) — real HTTP, real wire protocol, configured responses

Tests want the third. Your tests cover *your code*, not whether the model understood the prompt today.

## Test plan

- [x] `zola build` succeeds, 85 pages (up from 81), 4 Bedrock slugs present
- [x] Cross-links to existing blog `/blog/bedrock-local-testing/` intact
- [x] Code samples use real Bedrock model IDs; no false claims of inference
- [x] LocalStack comparison cites source (docs.localstack.cloud/aws/services/bedrock)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four Bedrock landing pages to improve technical SEO and clarify our positioning: fakecloud is a Bedrock emulator with configurable responses, not a mock and not a real LLM. These pages target key queries and link to the Bedrock testing blog for depth.

- New Features
  - /bedrock-emulator/ — primary technical SEO page; emulator vs mock vs local LLM.
  - /test-bedrock-locally/ — how to test deterministically with configurable responses, fault injection, and streaming.
  - /fake-bedrock/ — explains “fake != mock” and highlights full control-plane coverage (111 ops).
  - /localstack-bedrock-alternative/ — comparison to LocalStack Ultimate and simple migration guidance.
  - Cross-links between pages and to /blog/bedrock-local-testing/.

<sup>Written for commit a5cd40f4074d0054c458897829473c2ebdcd6e60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

