### PR TITLE
content(blog): Bedrock batch 1 — three posts on tests, guardrails, LocalStack Ultimate

### DIFF
--- a/website/content/blog/bedrock-guardrails-local.md
+++ b/website/content/blog/bedrock-guardrails-local.md
@@ -1,0 +1,227 @@
++++
+title = "Testing Bedrock Guardrails without the AWS bill"
+date = 2026-04-22
+description = "Bedrock Guardrails evaluate content policies, PII filters, topic filters, and contextual grounding. Testing a guardrail setup against real AWS is slow and expensive. fakecloud runs the guardrail control plane and the ApplyGuardrail data plane locally, with real content evaluation."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Bedrock Guardrails are one of the better pieces of AWS infrastructure in the last year. You define a policy — filter out hate, block PII leakage, deny certain topics, enforce contextual grounding on RAG outputs — and either apply it to an entire model invocation via `guardrailIdentifier`, or call `ApplyGuardrail` directly on arbitrary text. Useful, sharp, limited-in-scope.
+
+The problem is testing. A serious guardrail config is an iterative thing — you tune filter strengths, add denied topics, tweak word filters, and test each change. Each test-cycle turn against real AWS costs tokens and time. And if the thing you're trying to guard against is LLM output, you're paying for the model call *and* the guardrail evaluation.
+
+fakecloud runs the full Bedrock Guardrails surface locally. `CreateGuardrail`, versioning, `UpdateGuardrail`, `DeleteGuardrail`, `ApplyGuardrail`, `ListGuardrails` — the whole thing. More interestingly, the data plane actually evaluates content. PII detection works. Content filters return sensible scores on real test text. You can write tests that verify your guardrail actually blocks what you think it blocks.
+
+## The shape of the problem
+
+The standard AWS recipe, cleaned up:
+
+```python
+import boto3
+
+bedrock = boto3.client('bedrock', region_name='us-east-1')
+
+g = bedrock.create_guardrail(
+    name='customer-facing-v1',
+    contentPolicyConfig={
+        'filtersConfig': [
+            {'type': 'HATE', 'inputStrength': 'HIGH', 'outputStrength': 'HIGH'},
+            {'type': 'VIOLENCE', 'inputStrength': 'HIGH', 'outputStrength': 'HIGH'},
+            {'type': 'SEXUAL', 'inputStrength': 'HIGH', 'outputStrength': 'HIGH'},
+            {'type': 'INSULTS', 'inputStrength': 'MEDIUM', 'outputStrength': 'MEDIUM'},
+        ],
+    },
+    sensitiveInformationPolicyConfig={
+        'piiEntitiesConfig': [
+            {'type': 'EMAIL', 'action': 'BLOCK'},
+            {'type': 'PHONE', 'action': 'BLOCK'},
+            {'type': 'CREDIT_DEBIT_CARD_NUMBER', 'action': 'BLOCK'},
+        ],
+    },
+    topicPolicyConfig={
+        'topicsConfig': [
+            {
+                'name': 'medical-advice',
+                'definition': 'Providing specific medical diagnoses or treatment recommendations',
+                'examples': ['What dose should I take?', 'Do I have cancer?'],
+                'type': 'DENY',
+            },
+        ],
+    },
+    blockedInputMessaging='Cannot process this input.',
+    blockedOutputsMessaging='Cannot respond to this.',
+)
+```
+
+Now you want to test: does an email containing `bob@example.com` trigger the EMAIL filter and return the blocked-input message? Does a prompt asking "what medication should I take for my headache" get denied via the medical-advice topic? Does the HATE filter catch slurs at HIGH strength?
+
+Against real AWS: each of those is an API call that costs a few cents, takes a second, and requires valid credentials. You'll do 50 of these across a tuning session. Repeated for each PR that touches guardrail config.
+
+## Against fakecloud
+
+Same code, different endpoint:
+
+```python
+import boto3
+
+bedrock = boto3.client('bedrock',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+# same create_guardrail call as above
+g = bedrock.create_guardrail(...)
+
+rt = boto3.client('bedrock-runtime',
+    endpoint_url='http://localhost:4566',
+    aws_access_key_id='test',
+    aws_secret_access_key='test',
+    region_name='us-east-1')
+
+resp = rt.apply_guardrail(
+    guardrailIdentifier=g['guardrailId'],
+    guardrailVersion='DRAFT',
+    source='INPUT',
+    content=[{'text': {'text': 'contact me at bob@example.com'}}],
+)
+
+assert resp['action'] == 'GUARDRAIL_INTERVENED'
+assert resp['outputs'][0]['text'] == 'Cannot process this input.'
+assert any(a['type'] == 'EMAIL' for a in resp['assessments'][0]['sensitiveInformationPolicy']['piiEntities'])
+```
+
+Real PII detection — the email is caught. Real blocked-input messaging returned. Assessments returned in the shape real AWS would return.
+
+No tokens. No AWS bill. No credentials. 30ms.
+
+## What's actually evaluated
+
+fakecloud's guardrail evaluator ships opinionated implementations of each policy type. Concrete checks you can rely on in tests:
+
+- **PII entities**: regex + context for email, phone (various formats), credit card (Luhn), SSN, IP, URL, name, address hints.
+- **Content filters**: keyword + pattern matching tuned for the common categories. HIGH strength catches more, LOW catches less — same directional behavior as real AWS.
+- **Topic filters**: pattern matching against the topic definition + examples you provided. Won't pass a Stanford NLI benchmark, but does what you need for testing: asserts the policy fires on obvious positives and passes obvious negatives.
+- **Word filters**: exact match + stemming.
+- **Regex filters**: the regex you supplied, as-is.
+
+It's shape-correct evaluation. For tests that verify "my guardrail config blocks what I intended," that's exactly what you need. If you want bulletproof production-grade content filtering, you're going to tune against real AWS or roll your own anyway — this gets you 95% of the iteration speed.
+
+## Versioning
+
+```python
+# publish a version
+v = bedrock.create_guardrail_version(
+    guardrailIdentifier=g['guardrailId'],
+    description='initial pinned version for prod',
+)
+
+# list versions
+versions = bedrock.list_guardrails(guardrailIdentifier=g['guardrailId'])
+
+# apply a specific version in production
+rt.apply_guardrail(
+    guardrailIdentifier=g['guardrailId'],
+    guardrailVersion=v['version'],  # '1'
+    source='INPUT',
+    content=[{'text': {'text': '...'}}],
+)
+```
+
+DRAFT is mutable. Numbered versions (1, 2, 3, ...) are immutable once created — same as real AWS. Your prod code should pin. Your dev iteration happens against DRAFT.
+
+## A realistic test suite
+
+```ts
+import { FakeCloud } from "fakecloud";
+import { BedrockRuntimeClient, ApplyGuardrailCommand } from "@aws-sdk/client-bedrock-runtime";
+import { BedrockClient, CreateGuardrailCommand } from "@aws-sdk/client-bedrock";
+
+const fc = new FakeCloud();
+const control = new BedrockClient({ endpoint: "http://localhost:4566" });
+const rt = new BedrockRuntimeClient({ endpoint: "http://localhost:4566" });
+
+let guardrailId: string;
+
+beforeAll(async () => {
+  const created = await control.send(new CreateGuardrailCommand({
+    name: "test-guardrail",
+    contentPolicyConfig: {
+      filtersConfig: [
+        { type: "HATE", inputStrength: "HIGH", outputStrength: "HIGH" },
+      ],
+    },
+    sensitiveInformationPolicyConfig: {
+      piiEntitiesConfig: [
+        { type: "EMAIL", action: "BLOCK" },
+        { type: "PHONE", action: "ANONYMIZE" },
+      ],
+    },
+    blockedInputMessaging: "Blocked.",
+    blockedOutputsMessaging: "Blocked.",
+  }));
+  guardrailId = created.guardrailId!;
+});
+
+beforeEach(() => fc.reset({ preserve: ["bedrock:guardrails"] }));
+
+test("blocks input containing email", async () => {
+  const resp = await rt.send(new ApplyGuardrailCommand({
+    guardrailIdentifier: guardrailId,
+    guardrailVersion: "DRAFT",
+    source: "INPUT",
+    content: [{ text: { text: "contact me at alice@example.com" } }],
+  }));
+
+  expect(resp.action).toBe("GUARDRAIL_INTERVENED");
+  expect(resp.outputs?.[0].text).toBe("Blocked.");
+});
+
+test("anonymizes phone in output", async () => {
+  const resp = await rt.send(new ApplyGuardrailCommand({
+    guardrailIdentifier: guardrailId,
+    guardrailVersion: "DRAFT",
+    source: "OUTPUT",
+    content: [{ text: { text: "call me at 555-123-4567 tomorrow" } }],
+  }));
+
+  expect(resp.action).toBe("GUARDRAIL_INTERVENED");
+  expect(resp.outputs?.[0].text).not.toContain("555-123-4567");
+});
+
+test("passes clean input through", async () => {
+  const resp = await rt.send(new ApplyGuardrailCommand({
+    guardrailIdentifier: guardrailId,
+    guardrailVersion: "DRAFT",
+    source: "INPUT",
+    content: [{ text: { text: "what's the weather in Paris?" } }],
+  }));
+
+  expect(resp.action).toBe("NONE");
+});
+```
+
+These run in milliseconds, are deterministic, and test the thing that matters — that your guardrail config enforces what you think it enforces.
+
+## Why this matters for agent systems
+
+Guardrails become critical when you're building tool-using agents. A tool call that leaks customer PII is a real incident; a model output that contains violence content is a real incident. You want those failure modes caught in CI, not in production.
+
+The pattern:
+
+1. Compose the guardrail config as code (Terraform / CDK) alongside your agent definition.
+2. In CI, deploy the guardrail to fakecloud, run a test matrix of adversarial inputs through your agent, assert that the guardrail fires (or doesn't fire) where expected.
+3. On merge to main, deploy the same config to real AWS.
+
+The first two steps cost nothing. The third is the one that actually consumes budget.
+
+This is the test loop real AWS makes nearly impossible — not because of technical obstacles, but because the cost-per-iteration is too high for the number of iterations you actually need.
+
+## Links
+
+- **Bedrock emulator** (landing): [/bedrock-emulator/](/bedrock-emulator/)
+- **Test Bedrock locally**: [/test-bedrock-locally/](/test-bedrock-locally/)
+- **Why not a real LLM in tests**: [/blog/bedrock-tests-real-llm/](/blog/bedrock-tests-real-llm/)
+- **Testing LLM guardrails** (broader view): [/blog/llm-guardrails/](/blog/llm-guardrails/)
+- **GitHub**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)

--- a/website/content/blog/bedrock-tests-real-llm.md
+++ b/website/content/blog/bedrock-tests-real-llm.md
@@ -1,0 +1,162 @@
++++
+title = "Why your Bedrock tests shouldn't call a real LLM (not even a local one)"
+date = 2026-04-22
+description = "Every AI-team engineer eventually asks: should my Bedrock tests hit a real model? Even a local one like Ollama? Short answer: no. Here's what tests actually need, and what happens when you try to use real inference instead."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Every team building on Bedrock eventually asks the same question: for tests, should we call a real model? If the cost of real Bedrock is the concern, can we run Ollama locally and point our SDK at that?
+
+The answer is no — but the reason is worth spelling out, because it shapes how you should think about tests for any LLM-calling code.
+
+## What a test is for
+
+A test asserts that *your code* behaves correctly under a given input. Not that a model behaves correctly. Not that an API is up. Just that the code you wrote, given a response from its upstream, does the thing you expected.
+
+The upstream, for Bedrock code, is `InvokeModel` or `Converse`. Your code sends a prompt, gets a response, and does something with it: parses JSON, branches on a label, stores it in a DB, passes it to another tool call, retries on throttling, falls back on a cheaper model. Every one of those behaviors is yours to test.
+
+The model's behavior is AWS's problem.
+
+## What goes wrong with real models in tests
+
+Once you try to use real inference — whether it's actual Bedrock or a local Ollama — four things break, in roughly ascending order of annoyance:
+
+### 1. Non-determinism
+
+Real models return different text on every call. Temperature = 0 doesn't save you: there's non-determinism in attention kernel implementations across GPU/CPU backends, in tokenizer versions, in batching behavior. Anthropic's own docs say "don't rely on deterministic outputs."
+
+What this means for tests:
+
+```ts
+// hope this passes
+expect(output).toBe("Classification: spam");
+```
+
+On run 1 the model returned `"Classification: spam"`. On run 2 it returned `"The email is spam."`. Both correct. Your test fails.
+
+The usual fix is to assert loosely:
+
+```ts
+expect(output.toLowerCase()).toContain("spam");
+```
+
+This passes even if the model returns `"This is not spam"`. Your test is now worthless.
+
+People end up using LLM-as-judge ("ask Claude if this response is approximately correct"). That's a research paper, not a CI pipeline.
+
+### 2. Speed
+
+Real Bedrock: 100-2000ms per call. Ollama on a developer laptop: 1-30s per call. Ollama on a CI runner without a GPU: 5-60s per call.
+
+A test suite with 50 tests hitting the model at 5s each is 4 minutes. Ten times that and your developers stop running tests locally. CI times out. The TDD loop dies. The whole point of unit tests — fast feedback — is gone.
+
+### 3. Resource overhead
+
+Ollama-sized models are 3-70 GB on disk. `docker pull` on a CI runner taking 3 GB of layer cache makes your pipeline brittle. A laptop without a GPU starts thrashing memory and swapping. You now need an infrastructure project just to make tests runnable, which is the opposite of "tests should be easy to run."
+
+### 4. You're testing the wrong thing
+
+Even if determinism, speed, and memory weren't problems, the thing you'd be testing is whether the model handles the prompt correctly. That's AWS's problem. Your code could be catastrophically broken — build requests wrong, parse responses wrong, handle errors wrong — and if the model happens to hallucinate a passable answer, your test passes.
+
+Conversely, if the model has a bad day (bad weights snapshot, a silent version bump), your tests fail even though your code is fine. You spend an hour bisecting the CI failure only to discover Claude got 3% worse at following instructions last Tuesday.
+
+This inverts cause and effect. Tests should tell you about your code. They shouldn't be a regression suite against a foundation model.
+
+## What tests actually need
+
+1. **Deterministic output.** Given the same input, same output. Every time.
+2. **Configurable responses.** Different tests want the model to return different things. You want to control that explicitly.
+3. **Fault injection.** Your retry logic needs to be exercised. Your fallback-model logic needs to be exercised. Your rate-limit handler needs to be exercised. You can't wait for real throttling to happen.
+4. **Call history.** Did my code send the right prompt? Did it set the right temperature? Did it include the right system message? Right tool definitions? Those are assertions about *your code*.
+5. **Sub-millisecond latency.** Tests should fly.
+6. **No external dependencies.** CI should work offline.
+
+A real LLM gives you none of those. A mock library (moto, `@aws-sdk-client-mock`) gives you 1, 2, and 4, but misses the HTTP path entirely — your code's request-assembly bugs go untested.
+
+The thing that gives you all six is a [Bedrock emulator](/bedrock-emulator/): a real HTTP server speaking Bedrock's wire protocol, with configurable responses and fault injection. That's what fakecloud is.
+
+## What this looks like in practice
+
+You write a test. You configure fakecloud to return a specific response when it sees a specific prompt. Your code runs. It sends a real HTTP request to `localhost:4566`. The request is parsed by a real JSON parser, routed through a real request validator, and responded to with your fixture. Your code parses the response, does its thing, and you assert on the outcome.
+
+```ts
+import { FakeCloud } from "fakecloud";
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const fc = new FakeCloud();
+const rt = new BedrockRuntimeClient({ endpoint: "http://localhost:4566" });
+
+beforeEach(() => fc.reset());
+
+test("spam classifier marks borderline scores for human review", async () => {
+  await fc.bedrock.setResponseRule({
+    whenPromptContains: "classify spam",
+    respond: {
+      completion: JSON.stringify({ label: "borderline", confidence: 0.62 }),
+    },
+  });
+
+  const { routedTo } = await classifyEmail(rt, "buy now!!");
+
+  expect(routedTo).toBe("human-review");
+});
+
+test("classifier retries on throttling with backoff", async () => {
+  await fc.bedrock.injectFault({
+    operation: "InvokeModel",
+    error: "ThrottlingException",
+    count: 2,
+  });
+  await fc.bedrock.setResponseRule({
+    whenPromptContains: "classify spam",
+    respond: { completion: JSON.stringify({ label: "spam" }) },
+  });
+
+  const { routedTo } = await classifyEmail(rt, "buy now!!");
+
+  expect(routedTo).toBe("spam-folder");
+  expect((await fc.bedrock.getCallHistory()).length).toBe(3);
+});
+```
+
+Both tests run in 30ms. Both are deterministic. Both test your code, not the model.
+
+## But I want *some* tests that hit real Bedrock
+
+Good instinct. Keep those separate.
+
+Put them in a suite gated behind an env var (`RUN_REAL_BEDROCK_TESTS=1`). Run them once per release, not once per PR. They'll catch:
+
+- Major AWS API shape changes
+- Model version bumps that alter response format
+- IAM permission changes
+
+That's a fundamentally different job from "did my PR break my code." Mixing them produces a test suite that's flaky, slow, expensive, and hides real regressions under model noise.
+
+The unit/integration suite, which is 99% of your runs, should hit fakecloud. The real-bedrock suite, which is a few dozen targeted tests, runs weekly. This is the same pattern every team that tests against cloud APIs converges on — you just have to name it.
+
+## A word on Ollama
+
+Ollama is great. It's not a Bedrock emulator. It speaks its own HTTP protocol (roughly OpenAI-compatible), runs real models, and is the right tool for developer-time exploratory prompting.
+
+LocalStack's Ultimate tier wraps Ollama in a Bedrock-shaped response — you get real inference on the local machine through the Bedrock SDK. Interesting product. Wrong tool for tests.
+
+If you want to prototype a prompt, run Ollama directly. If you want to test the code that calls Bedrock with that prompt, use an emulator.
+
+## Closing
+
+The "tests should use a real LLM" instinct comes from a reasonable place — a fear that mocks lie, that configured responses can drift from reality, that you'll ship a bug because your tests were checking something different than production. That fear is real, and the answer is a real server (an emulator) that speaks the real wire protocol. What you don't need is real inference.
+
+Your tests are about your code. The model is not your code.
+
+## Links
+
+- **Bedrock emulator** (landing): [/bedrock-emulator/](/bedrock-emulator/)
+- **Tutorial with running code**: [How to test Bedrock code locally, for free, deterministically](/blog/bedrock-local-testing/)
+- **LocalStack alternative for Bedrock**: [/localstack-bedrock-alternative/](/localstack-bedrock-alternative/)
+- **GitHub**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)

--- a/website/content/blog/localstack-ultimate-bedrock.md
+++ b/website/content/blog/localstack-ultimate-bedrock.md
@@ -1,0 +1,126 @@
++++
+title = "LocalStack Ultimate for Bedrock: 4 operations, Ollama-backed, top-tier pricing"
+date = 2026-04-22
+description = "LocalStack supports Bedrock only on their Ultimate plan, and only four operations, all backed by Ollama. Here's what that gets you, what it doesn't, and why fakecloud's approach is different."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+If you've been looking for a local Bedrock emulator and landed on LocalStack's documentation, you've seen this: Bedrock is available, but only on the Ultimate plan, and only four operations are supported. Those four operations are backed by [Ollama](https://ollama.com), the local-LLM runtime.
+
+This is a real product decision, not an accident. It's worth understanding what it gets you, what it doesn't, and why fakecloud took a very different approach.
+
+## What LocalStack Ultimate gives you for Bedrock
+
+Per [docs.localstack.cloud/aws/services/bedrock](https://docs.localstack.cloud/aws/services/bedrock/), as of April 2026:
+
+- **Tier**: Ultimate plan only. This is the top paid tier.
+- **Operations**: `InvokeModel`, `Converse`, `ListFoundationModels`, `CreateModelInvocationJob`. Four, total.
+- **Backend**: Ollama, called via its HTTP API.
+- **Models**: whatever Ollama supports — Llama, Mistral, Phi, etc. You call them via `ollama.<model-id>` strings through the Bedrock SDK.
+- **Limitations per the docs**: only text models, no GPU, no persistence, and responsiveness issues on Docker Desktop due to storage/memory constraints.
+
+That's the whole product. The "Bedrock" you're calling in your code is a LocalStack process forwarding your request to Ollama, which runs a model like Llama 3 on your CPU or GPU, and returns the response in a Bedrock-shaped envelope.
+
+## What that actually means at the test bench
+
+Let's be concrete. You're writing tests for code that calls `anthropic.claude-3-haiku-20240307-v1:0` (Haiku). You point your SDK at LocalStack Ultimate's Bedrock. What happens:
+
+1. Haiku doesn't exist locally. You have to set `DEFAULT_BEDROCK_MODEL=ollama.llama3.2` (or whichever Ollama model you have installed).
+2. Your code's `modelId: "anthropic.claude-3-haiku-20240307-v1:0"` string gets routed to Llama 3.2.
+3. Your prompt, which was tuned for Claude, runs through Llama, which interprets it differently.
+4. The response comes back. Llama's output goes through Bedrock's response envelope shape.
+5. Your code parses the envelope, extracts the text, and... what?
+
+If your code is doing structured extraction (return JSON matching schema X), Llama and Claude don't produce identical JSON even at temperature 0. If your code is doing classification, they disagree on edge cases. If your code is doing agent work with tool use, they have different tool-use protocols entirely (Claude's tool-use format differs from Llama's function-calling format).
+
+You are not testing your Claude code. You are testing whether your Claude code happens to also work against Llama when shimmed through a Bedrock envelope.
+
+## The slowness problem
+
+Ollama on CPU: 1-30 seconds per call depending on model and prompt length.
+
+Ollama on GPU (if you have one): 100ms-3s per call.
+
+Bedrock on real AWS: 100-2000ms per call.
+
+The "local" Bedrock is often slower than the cloud one. And you get non-determinism either way.
+
+The LocalStack docs explicitly mention `BEDROCK_PREWARM` to reduce startup delays, which is an acknowledgment of the pain — you're essentially waiting for Ollama to load a multi-GB model into memory before your test suite can start. CI runners without `--shm-size` tuning routinely OOM during this.
+
+## The four operations
+
+`InvokeModel` and `Converse` are the data plane — the calls your application makes at runtime. That's the part Ollama can back.
+
+`ListFoundationModels` returns which models exist.
+
+`CreateModelInvocationJob` starts an async batch job against S3 input. This is partial support (based on what the docs describe) — it's the only control-plane operation covered.
+
+What's not covered: 
+- Guardrails
+- Custom models / customization jobs  
+- Model import
+- Inference profiles
+- Provisioned throughput
+- Model copy jobs
+- Prompt management
+- Foundation model agreements
+- Resource policies
+- Logging configuration
+- Evaluation jobs
+- Marketplace
+- Automated reasoning
+
+If your test code touches anything in that list — and any serious Bedrock integration touches several of them — LocalStack Ultimate's Bedrock emulation doesn't help.
+
+## What fakecloud does differently
+
+fakecloud covers 111 Bedrock operations. The data plane (InvokeModel, Converse, streaming variants) is not backed by a real LLM — it returns exactly the responses you configure, per-prompt rule.
+
+This is the deliberate opposite of LocalStack Ultimate's choice:
+
+| | LocalStack Ultimate Bedrock | fakecloud Bedrock |
+|---|---|---|
+| Pricing | Top-tier paid plan | Free, AGPL-3.0 |
+| Data plane | Ollama (real local LLM) | Configurable responses per prompt rule |
+| Determinism | No | Yes |
+| Speed | 1-30s per call | Milliseconds |
+| Guardrails | Not supported | Full CRUD + real content evaluation |
+| Custom models | Not supported | Full control plane |
+| Async batch | Partial | Full flow |
+| Prompt management | Not supported | Prompts + prompt routers |
+| GPU required | Usually | No |
+| Persistence | "Not supported" (from docs) | Yes |
+
+## Why Ollama is the wrong backing for a Bedrock emulator
+
+The word "emulator" and the word "Bedrock" together set an expectation: I can run a simulation of Bedrock locally. People reach for that when they want to test their Bedrock-calling code.
+
+Testing code that calls an LLM API and testing an LLM are different problems. The first wants determinism, speed, fault injection, and call-history introspection. The second wants a real model.
+
+LocalStack's Ultimate Bedrock chose the second. That decision makes sense if your goal is "let me prototype against a Bedrock SDK without burning tokens." It's the wrong decision if your goal is "let me have fast, deterministic integration tests of my production Bedrock code."
+
+fakecloud picked the first job and optimized hard for it. If you want real inference locally, run Ollama directly — it's free, open source, and does that job excellently. If you want deterministic Bedrock behavior in your test suite, you want an emulator with configured responses.
+
+## When to pay for LocalStack Ultimate anyway
+
+There are reasons to pay for LocalStack Ultimate that aren't about Bedrock. Their core strength is deep coverage of the long tail of AWS services — things like ACM, Certificate Manager, Backup, Config, etc. If you rely on those in your infrastructure and you want a local mirror of them, paying for Ultimate may be worth it.
+
+If the Bedrock emulation is the reason you were about to open a procurement ticket for Ultimate, though, stop. Bedrock-on-Ollama isn't going to solve your test problem. What will solve it is an emulator built for tests — which you can get for free.
+
+## What to do next
+
+If you're currently testing against real Bedrock, start with [how to test Bedrock code locally](/blog/bedrock-local-testing/) — walks through the full pattern end to end.
+
+If you're on LocalStack Ultimate and Bedrock was the draw, look at [the migration comparison](/localstack-bedrock-alternative/).
+
+If you want to understand why "just use Ollama" doesn't work as a test strategy, [here's a longer version of the argument](/blog/bedrock-tests-real-llm/).
+
+## Links
+
+- **Install fakecloud**: `curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash`
+- **LocalStack Bedrock docs (cited)**: [docs.localstack.cloud/aws/services/bedrock](https://docs.localstack.cloud/aws/services/bedrock/)
+- **Bedrock emulator landing**: [/bedrock-emulator/](/bedrock-emulator/)
+- **Migration landing**: [/localstack-bedrock-alternative/](/localstack-bedrock-alternative/)
+- **GitHub**: [github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)


### PR DESCRIPTION
## Summary

Three blog posts landing the positioning we'll be driving traffic toward via Google Ads + awesome-list PRs:

- **`/blog/bedrock-tests-real-llm/`** — the essay. "Your tests are about your code. The model is not your code." Makes the case that real LLMs (Ollama or otherwise) break all six things tests actually need.
- **`/blog/bedrock-guardrails-local/`** — feature deep-dive. Concrete PII/content/topic/word/regex filter coverage. Full runnable test suite with `ApplyGuardrail`. Agent-system failure-mode framing.
- **`/blog/localstack-ultimate-bedrock/`** — direct comparison post. Honest about when LocalStack Ultimate makes sense (long-tail service coverage) and when it doesn't (Bedrock for tests). Cites [docs.localstack.cloud/aws/services/bedrock](https://docs.localstack.cloud/aws/services/bedrock/).

All three cross-link to the landings shipped in #693 and the existing `/blog/bedrock-local-testing/` + `/blog/llm-guardrails/` posts.

## Test plan

- [x] `zola build` succeeds (84 pages, up from 81 + 3 new landings)
- [x] No external link-check regressions beyond the pre-existing GitHub-anchor ones
- [x] Cross-link network forms a coherent graph: landings → posts → landings, no dead ends
- [x] LocalStack comparison uses real numbers cited to docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three Bedrock-focused blog posts to anchor our testing and guardrails positioning and support ads landing pages. Covers why not to use real LLMs in tests, how to test Guardrails locally with `ApplyGuardrail`, and when LocalStack Ultimate makes sense.

- **New Features**
  - /blog/bedrock-tests-real-llm/: Why tests shouldn’t hit real models (even Ollama); use a Bedrock emulator for determinism, fault injection, and call history.
  - /blog/bedrock-guardrails-local/: How to test Guardrails locally with `ApplyGuardrail`; concrete PII/content/topic/word/regex coverage and versioning; runnable examples.
  - /blog/localstack-ultimate-bedrock/: Compares LocalStack Ultimate’s 4-op, Ollama-backed Bedrock support; when it’s useful vs. when a Bedrock emulator is better for tests.

<sup>Written for commit d7669b9bbaed708bf9b114de99093b00f1866761. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

