### PR TITLE
feat(conformance): strict route detection via SUPPORTED list

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,98 +1,98 @@
 {
-  "variants_passed": 59954,
+  "variants_passed": 42889,
   "total_variants": 59954,
   "per_service": {
-    "sns": {
-      "passed": 1027,
-      "total": 1027
+    "elasticache": {
+      "passed": 1373,
+      "total": 2219
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "rds": {
+      "passed": 853,
+      "total": 5376
     },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
+    "iam": {
+      "passed": 4430,
+      "total": 5962
     },
     "logs": {
       "passed": 3911,
       "total": 3911
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
     "events": {
       "passed": 2108,
       "total": 2108
     },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "apigateway": {
-      "passed": 2769,
-      "total": 2769
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
+    "ses": {
+      "passed": 2553,
+      "total": 2858
     },
     "secretsmanager": {
       "passed": 852,
       "total": 852
     },
-    "elasticache": {
-      "passed": 2219,
-      "total": 2219
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "sns": {
+      "passed": 804,
+      "total": 1027
+    },
+    "s3": {
+      "passed": 2629,
+      "total": 3620
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
     },
     "bedrock-runtime": {
       "passed": 412,
       "total": 412
     },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "sts": {
-      "passed": 438,
+      "passed": 344,
       "total": 438
     },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "cloudformation": {
+      "passed": 331,
+      "total": 3420
+    },
+    "apigateway": {
+      "passed": 855,
+      "total": 2769
+    },
+    "sqs": {
+      "passed": 479,
+      "total": 549
+    },
+    "states": {
+      "passed": 515,
+      "total": 1292
     },
     "kms": {
       "passed": 2196,
       "total": 2196
     },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "lambda": {
+      "passed": 646,
+      "total": 3347
     }
   }
 }

--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -180,6 +180,30 @@ fn run_probes(
         .build()
         .expect("Failed to create HTTP client");
 
+    // Cross-reference Smithy operations against fakecloud's own
+    // `fn supported_actions()` lists. Operations not in a service's SUPPORTED
+    // set are classified as NotImplemented without sending a probe. This
+    // prevents fakecloud's grab-bag of unrouted-path responses
+    // (NotFoundException, UnknownOperationException, execute-api stage errors,
+    // generic-handler stubs, etc.) from being counted as "routed successes"
+    // under the lenient 2xx-4xx = Pass rule.
+    //
+    // The SUPPORTED list is fakecloud's own source of truth for "we implement
+    // this action." Treating it as authoritative gives honest per-service
+    // coverage numbers and surfaces real feature gaps — the same numbers the
+    // Level-2 audit uses. If a service routes actions without listing them
+    // in SUPPORTED (a known under-reporting pattern in some older services),
+    // the right fix is to update SUPPORTED, not to paper over in the probe.
+    let project_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..");
+    let implemented_actions = fakecloud_conformance::audit::scan_implemented_actions(&project_root)
+        .unwrap_or_else(|e| {
+            eprintln!("Warning: failed to scan implemented actions: {e}");
+            HashMap::new()
+        });
+    let implemented_tags = fakecloud_conformance::audit::audit_service_tags(&project_root);
+
     let mut all_results: HashMap<String, HashMap<String, Vec<probe::ProbeResult>>> = HashMap::new();
     let mut total_ops_per_service: HashMap<String, usize> = HashMap::new();
 
@@ -200,9 +224,58 @@ fn run_probes(
 
         let mut service_results: HashMap<String, Vec<probe::ProbeResult>> = HashMap::new();
 
+        // Union SUPPORTED lists across every audit mapping whose tag list
+        // includes this Smithy service_name. Covers shared-crate services
+        // (bedrock + bedrock-runtime share one SUPPORTED list across two
+        // Smithy service keys).
+        let supported_for_service: Option<Vec<String>> = {
+            let mut combined: Vec<String> = Vec::new();
+            let mut any = false;
+            for (audit_key, tags) in &implemented_tags {
+                if tags.iter().any(|t| t == service_name) {
+                    if let Some(list) = implemented_actions.get(audit_key) {
+                        combined.extend(list.iter().cloned());
+                        any = true;
+                    }
+                }
+            }
+            if any {
+                combined.sort();
+                combined.dedup();
+                Some(combined)
+            } else {
+                // Smithy service not yet in audit mapping — preserve the
+                // legacy probe-and-classify behavior so nothing regresses.
+                None
+            }
+        };
+
         for op in &model.operations {
             let overrides = HashMap::new();
             let variants = generators::generate_all_variants(model, &op.name, &overrides);
+
+            // If fakecloud's SUPPORTED list is known and this op isn't in it,
+            // short-circuit every variant to NotImplemented. Saves the
+            // network round-trip and, more importantly, gives an honest
+            // per-service coverage number.
+            if let Some(supported) = supported_for_service.as_ref() {
+                if !supported.iter().any(|s| s == &op.name) {
+                    let results: Vec<probe::ProbeResult> = variants
+                        .iter()
+                        .map(|v| probe::ProbeResult {
+                            variant_name: v.name.clone(),
+                            status: probe::ProbeStatus::NotImplemented,
+                            http_status: 0,
+                            response_body: String::new(),
+                            duration_ms: 0,
+                        })
+                        .collect();
+                    let total = results.len();
+                    eprintln!("  SKIP {} (0/{})", op.name, total);
+                    service_results.insert(op.name.clone(), results);
+                    continue;
+                }
+            }
 
             // Get output shape for shape validation
             let output_shape_id = op.output_shape.as_deref();

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -1533,4 +1533,43 @@ mod tests {
         let (_, url, _, _) = build_http_request_from_model(&op, &model, &input).unwrap();
         assert_eq!(url, "/foo/a%20b%23c");
     }
+
+    #[test]
+    fn classify_unknown_path_is_not_implemented() {
+        // API Gateway v2 emits `Unknown path: ...` when resolve_action
+        // can't match a URL. Must classify as NotImplemented, not Pass.
+        let body = r#"{"__type":"NotFoundException","message":"Unknown path: /v2/domainnames"}"#;
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        assert_eq!(result.status, ProbeStatus::NotImplemented);
+    }
+
+    #[test]
+    fn classify_unknown_operation_is_not_implemented() {
+        // Lambda emits `UnknownOperationException` for URLs its
+        // resolve_action doesn't recognize.
+        let body = r#"{"__type":"UnknownOperationException","message":"Unknown operation: /foo"}"#;
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        assert_eq!(result.status, ProbeStatus::NotImplemented);
+    }
+
+    #[test]
+    fn classify_action_not_implemented_string() {
+        // `ActionNotImplemented` error maps to the substring "not implemented"
+        // in the response body.
+        let body =
+            r#"{"__type":"InvalidAction","message":"action Foo not implemented for service bar"}"#;
+        let result = classify_response("v1", 501, body, &Expectation::Success, 0);
+        assert_eq!(result.status, ProbeStatus::NotImplemented);
+    }
+
+    #[test]
+    fn classify_legit_resource_not_found_is_pass() {
+        // AWS-shaped `ResourceNotFoundException` for a synthetic id is a
+        // legitimate response from an implemented handler; must not be
+        // confused with NotImplemented.
+        let body =
+            r#"{"__type":"ResourceNotFoundException","message":"Function not found: test-fn"}"#;
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        assert_eq!(result.status, ProbeStatus::Pass);
+    }
 }

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -1042,10 +1042,34 @@ fn classify_response(
     expectation: &Expectation,
     duration_ms: u64,
 ) -> ProbeResult {
+    // Classify as NotImplemented when fakecloud signals "we did not find a
+    // handler for this action" — as opposed to AWS-shaped errors that mean
+    // "handler found, rejected synthetic input" (e.g. ValidationException,
+    // ResourceNotFoundException for a non-existent resource id).
+    //
+    // The error-body patterns below cover every way fakecloud services
+    // today express an unrouted action:
+    //   - `not implemented` / `NotImplemented` — `ActionNotImplemented`
+    //     emitted by the generic service dispatcher.
+    //   - `UnknownAction` / `InvalidAction` — Query-protocol services
+    //     for unknown `Action=…` form params.
+    //   - `UnknownOperationException` — Lambda for unrouted URL paths.
+    //   - `Unknown path:` — API Gateway v2, EventBridge Scheduler, and
+    //     a few other REST-routed services return this string in the
+    //     error body when `resolve_action` yields None.
+    //   - `Unknown operation:` — also emitted by some Query services.
+    //
+    // Important: these substrings must NOT appear in legitimate AWS-shaped
+    // error responses for implemented actions. `NotFoundException` alone is
+    // not listed here because it's also what implemented handlers return
+    // for a missing resource id.
     let is_not_implemented = body.contains("not implemented")
         || body.contains("NotImplemented")
         || body.contains("UnknownAction")
-        || body.contains("InvalidAction");
+        || body.contains("InvalidAction")
+        || body.contains("UnknownOperationException")
+        || body.contains("Unknown path:")
+        || body.contains("Unknown operation:");
 
     if is_not_implemented {
         return ProbeResult {


### PR DESCRIPTION
## Summary

The lenient \`2xx-4xx = Pass\` rule in the conformance classifier was hiding real implementation gaps: fakecloud's various "I didn't route this" responses (generic NotFoundException, APIGWv2's execute-api fallback, Lambda's UnknownOperationException, etc.) all looked like successful AWS-shaped errors from the probe's point of view. Result: conformance reported 100% per service while several services ship only a fraction of their Smithy op surface.

This PR cross-references every Smithy operation against the service's own \`fn supported_actions()\` list (the same source-of-truth used by the Level-2 audit) and classifies out-of-list ops as NotImplemented without even sending a probe. No service implementations change — the classifier just stops lying.

### Honest baseline

\`\`\`
total: 42,889 / 59,954 (71.5%)

100% services (11): bedrock, bedrock-runtime, cognito-idp, dynamodb,
                    events, kinesis, kms, logs, scheduler,
                    secretsmanager, ssm
partial services (12):
  apigateway       28 / 103  (27%)
  cloudformation    8 /  90  ( 9%)
  elasticache      44 /  75  (59%)
  iam             130 / 176  (74%)
  lambda           13 /  85  (15%)
  rds              23 / 163  (14%)
  s3               74 / 107  (69%)
  ses              97 / 110  (88%)
  sns              34 /  42  (81%)
  sqs              20 /  23  (87%)
  states           14 /  37  (38%)
  sts               8 /  11  (73%)
\`\`\`

### Additional belt-and-suspenders

Added \`UnknownOperationException\`, \`Unknown path:\`, and \`Unknown operation:\` to the NotImplemented response-body patterns in \`classify_response\` so any Smithy service not yet wired into audit still degrades gracefully.

## Test plan

- [x] \`cargo test -p fakecloud-conformance --lib\` — 44/44 pass
- [x] \`cargo run -p fakecloud-conformance -- check\` — baseline green at new honest numbers
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`

Follow-up work (not in this PR) is closing the 529-op gap across the 12 partial services. Handed off to a separate agent session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make conformance strict by checking each Smithy operation against the service’s `supported_actions()` list, so unrouted paths no longer count as passes. Added unit tests for the new NotImplemented patterns; honest coverage is now 42,889/59,954 (71.5%) with no service code changes.

- **New Features**
  - Cross-reference operations with each service’s `supported_actions()`; out-of-list ops are `NotImplemented` without a probe.
  - Union SUPPORTED lists via audit tags for shared crates (e.g., bedrock and bedrock-runtime).
  - Broaden `classify_response` patterns to treat `UnknownOperationException`, `Unknown path:`, and `Unknown operation:` as `NotImplemented`.
  - Add unit tests for these patterns and a negative case to keep `ResourceNotFoundException` classified as Pass.

<sup>Written for commit d47e3d929f84d6e1df339cbb0b4d10f97d8a8da7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

