### PR TITLE
feat(sts): implement AssumeRoot, GetDelegatedAccessToken, GetWebIdentityToken

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,34 +1,26 @@
 {
-  "variants_passed": 42889,
+  "variants_passed": 42983,
   "total_variants": 59954,
   "per_service": {
-    "elasticache": {
-      "passed": 1373,
-      "total": 2219
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
     },
-    "rds": {
-      "passed": 853,
-      "total": 5376
+    "kms": {
+      "passed": 2196,
+      "total": 2196
     },
-    "iam": {
-      "passed": 4430,
-      "total": 5962
+    "lambda": {
+      "passed": 646,
+      "total": 3347
     },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
+    "states": {
+      "passed": 515,
+      "total": 1292
     },
     "scheduler": {
       "passed": 491,
       "total": 491
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "ses": {
-      "passed": 2553,
-      "total": 2858
     },
     "secretsmanager": {
       "passed": 852,
@@ -38,9 +30,29 @@
       "passed": 1611,
       "total": 1611
     },
-    "sns": {
-      "passed": 804,
-      "total": 1027
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "elasticache": {
+      "passed": 1373,
+      "total": 2219
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "iam": {
+      "passed": 4430,
+      "total": 5962
+    },
+    "apigateway": {
+      "passed": 855,
+      "total": 2769
     },
     "s3": {
       "passed": 2629,
@@ -50,49 +62,37 @@
       "passed": 3591,
       "total": 3591
     },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
+    "cloudformation": {
+      "passed": 331,
+      "total": 3420
+    },
+    "ses": {
+      "passed": 2553,
+      "total": 2858
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     },
     "ssm": {
       "passed": 5303,
       "total": 5303
     },
-    "sts": {
-      "passed": 344,
-      "total": 438
+    "sqs": {
+      "passed": 479,
+      "total": 549
     },
     "cognito-idp": {
       "passed": 4479,
       "total": 4479
     },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
+    "rds": {
+      "passed": 853,
+      "total": 5376
     },
-    "cloudformation": {
-      "passed": 331,
-      "total": 3420
-    },
-    "apigateway": {
-      "passed": 855,
-      "total": 2769
-    },
-    "sqs": {
-      "passed": 479,
-      "total": 549
-    },
-    "states": {
-      "passed": 515,
-      "total": 1292
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "lambda": {
-      "passed": 646,
-      "total": 3347
+    "sns": {
+      "passed": 804,
+      "total": 1027
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -110,3 +110,51 @@ async fn sts_decode_authorization_message() {
         .unwrap();
     assert!(result.decoded_message().is_some());
 }
+
+#[test_action("sts", "AssumeRoot", checksum = "ff632886")]
+#[tokio::test]
+async fn sts_assume_root() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .assume_root()
+        .target_principal("123456789012")
+        .task_policy_arn(
+            aws_sdk_sts::types::PolicyDescriptorType::builder()
+                .arn("arn:aws:iam::aws:policy/IAMAuditRootUserCredentials")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "GetDelegatedAccessToken", checksum = "93cb2870")]
+#[tokio::test]
+async fn sts_get_delegated_access_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_delegated_access_token()
+        .trade_in_token("opaque-token")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}
+
+#[test_action("sts", "GetWebIdentityToken", checksum = "9ea6bbde")]
+#[tokio::test]
+async fn sts_get_web_identity_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_web_identity_token()
+        .audience("https://example.com")
+        .signing_algorithm("RS256")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.web_identity_token().is_some());
+}

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -1669,4 +1669,185 @@ mod tests {
         let req = sts_request("GetFederationToken", vec![]);
         assert!(svc.get_federation_token(&req).is_err());
     }
+
+    // ── AssumeRoot ──
+
+    #[tokio::test]
+    async fn assume_root_with_account_id_succeeds() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "111122223333"),
+                (
+                    "TaskPolicyArn.arn",
+                    "arn:aws:iam::aws:policy/IAMAuditRootUserCredentials",
+                ),
+            ],
+        );
+        let resp = svc.assume_root(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("AccessKeyId"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn assume_root_with_arn_succeeds() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "arn:aws:iam::444455556666:root"),
+                (
+                    "TaskPolicyArn.arn",
+                    "arn:aws:iam::aws:policy/IAMAuditRootUserCredentials",
+                ),
+                ("DurationSeconds", "600"),
+                ("SourceIdentity", "alice"),
+            ],
+        );
+        let resp = svc.assume_root(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(
+            body.contains("<SourceIdentity>alice</SourceIdentity>"),
+            "{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_root_missing_task_policy_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request("AssumeRoot", vec![("TargetPrincipal", "111122223333")]);
+        let err = match svc.assume_root(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected err"),
+        };
+        assert!(err.to_string().contains("TaskPolicyArn"));
+    }
+
+    #[tokio::test]
+    async fn assume_root_invalid_principal_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "not-an-id"),
+                ("TaskPolicyArn.arn", "arn:aws:iam::aws:policy/X"),
+            ],
+        );
+        assert!(svc.assume_root(&req).is_err());
+    }
+
+    #[tokio::test]
+    async fn assume_root_duration_above_max_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "AssumeRoot",
+            vec![
+                ("TargetPrincipal", "111122223333"),
+                ("TaskPolicyArn.arn", "arn:aws:iam::aws:policy/X"),
+                ("DurationSeconds", "1800"),
+            ],
+        );
+        assert!(svc.assume_root(&req).is_err());
+    }
+
+    // ── GetDelegatedAccessToken ──
+
+    #[tokio::test]
+    async fn get_delegated_access_token_succeeds() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetDelegatedAccessToken",
+            vec![("TradeInToken", "any-non-empty-token")],
+        );
+        let resp = svc.get_delegated_access_token(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("AssumedPrincipal"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn get_delegated_access_token_missing_token_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request("GetDelegatedAccessToken", vec![]);
+        assert!(svc.get_delegated_access_token(&req).is_err());
+    }
+
+    // ── GetWebIdentityToken ──
+
+    #[tokio::test]
+    async fn get_web_identity_token_succeeds() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetWebIdentityToken",
+            vec![
+                ("Audience.member.1", "https://example.com"),
+                ("SigningAlgorithm", "RS256"),
+                ("DurationSeconds", "300"),
+            ],
+        );
+        let resp = svc.get_web_identity_token(&req).unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("WebIdentityToken"), "{body}");
+        // JWT structure: header.payload.signature (signature blank).
+        assert!(body.contains("."), "{body}");
+    }
+
+    #[tokio::test]
+    async fn get_web_identity_token_missing_audience_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request("GetWebIdentityToken", vec![("SigningAlgorithm", "RS256")]);
+        assert!(svc.get_web_identity_token(&req).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_web_identity_token_missing_signing_errors() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetWebIdentityToken",
+            vec![("Audience.member.1", "https://example.com")],
+        );
+        assert!(svc.get_web_identity_token(&req).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_web_identity_token_rejects_unknown_algorithm() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetWebIdentityToken",
+            vec![
+                ("Audience.member.1", "https://example.com"),
+                ("SigningAlgorithm", "HS256"),
+            ],
+        );
+        assert!(svc.get_web_identity_token(&req).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_web_identity_token_rejects_non_numeric_duration() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetWebIdentityToken",
+            vec![
+                ("Audience.member.1", "https://example.com"),
+                ("SigningAlgorithm", "RS256"),
+                ("DurationSeconds", "not-a-number"),
+            ],
+        );
+        assert!(svc.get_web_identity_token(&req).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_web_identity_token_rejects_out_of_range_duration() {
+        let (svc, _) = make_sts_service();
+        let req = sts_request(
+            "GetWebIdentityToken",
+            vec![
+                ("Audience.member.1", "https://example.com"),
+                ("SigningAlgorithm", "RS256"),
+                ("DurationSeconds", "10"),
+            ],
+        );
+        assert!(svc.get_web_identity_token(&req).is_err());
+    }
 }

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -95,6 +95,9 @@ fn is_mutating_action(action: &str) -> bool {
             | "AssumeRoleWithSAML"
             | "GetSessionToken"
             | "GetFederationToken"
+            | "AssumeRoot"
+            | "GetDelegatedAccessToken"
+            | "GetWebIdentityToken"
     )
 }
 
@@ -115,6 +118,9 @@ impl AwsService for StsService {
             "GetFederationToken" => self.get_federation_token(&req),
             "GetAccessKeyInfo" => self.get_access_key_info(&req),
             "DecodeAuthorizationMessage" => self.decode_authorization_message(&req),
+            "AssumeRoot" => self.assume_root(&req),
+            "GetDelegatedAccessToken" => self.get_delegated_access_token(&req),
+            "GetWebIdentityToken" => self.get_web_identity_token(&req),
             _ => Err(AwsServiceError::action_not_implemented("sts", &req.action)),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
@@ -138,6 +144,9 @@ impl AwsService for StsService {
             "GetFederationToken",
             "GetAccessKeyInfo",
             "DecodeAuthorizationMessage",
+            "AssumeRoot",
+            "GetDelegatedAccessToken",
+            "GetWebIdentityToken",
         ]
     }
 
@@ -163,12 +172,20 @@ impl AwsService for StsService {
             "GetFederationToken" => "GetFederationToken",
             "GetAccessKeyInfo" => "GetAccessKeyInfo",
             "DecodeAuthorizationMessage" => "DecodeAuthorizationMessage",
+            "AssumeRoot" => "AssumeRoot",
+            "GetDelegatedAccessToken" => "GetDelegatedAccessToken",
+            "GetWebIdentityToken" => "GetWebIdentityToken",
             _ => return None,
         };
         let resource = match action {
             "AssumeRole" | "AssumeRoleWithWebIdentity" | "AssumeRoleWithSAML" => request
                 .query_params
                 .get("RoleArn")
+                .cloned()
+                .unwrap_or_else(|| "*".to_string()),
+            "AssumeRoot" => request
+                .query_params
+                .get("TargetPrincipal")
                 .cloned()
                 .unwrap_or_else(|| "*".to_string()),
             _ => "*".to_string(),
@@ -717,7 +734,7 @@ impl StsService {
         let state = accounts.get_or_create(&req.account_id);
         let (principal_arn, user_id, account_id) =
             if let Some(akid) = extract_access_key(req).as_deref() {
-                if let Some(lookup) = state.credential_secret(akid) {
+                if let Some(lookup) = state.credential_secret_readonly(akid) {
                     (lookup.principal_arn, lookup.user_id, lookup.account_id)
                 } else {
                     (
@@ -903,6 +920,271 @@ impl StsService {
         let xml = xml_responses::get_access_key_info_response(&account_id, &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
+
+    /// AssumeRoot: returns short-lived privileged credentials scoped to a
+    /// member-account root principal. Caller must be from the management
+    /// account; we mint and persist credentials so subsequent calls under
+    /// them resolve to the target account's root identity.
+    fn assume_root(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let target_principal = req.query_params.get("TargetPrincipal").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                "The request must contain the parameter TargetPrincipal",
+            )
+        })?;
+        let task_policy_arn = req
+            .query_params
+            .get("TaskPolicyArn.arn")
+            .or_else(|| req.query_params.get("TaskPolicyArn"))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MissingParameter",
+                    "The request must contain the parameter TaskPolicyArn",
+                )
+            })?;
+        validate_string_length("taskPolicyArn", task_policy_arn, 20, 2048)?;
+
+        if let Some(ds) = req.query_params.get("DurationSeconds") {
+            let v = ds.parse::<i64>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!(
+                        "Value '{}' at 'durationSeconds' failed to satisfy constraint: \
+                         Member must be a valid integer",
+                        ds
+                    ),
+                )
+            })?;
+            validate_range_i64("durationSeconds", v, 0, 900)?;
+        }
+
+        // Target principal can be an ARN (arn:aws:iam::123:root) or a 12-digit
+        // account id; normalize to (account_id, principal_arn).
+        let partition = partition_for_region(&req.region);
+        let (target_account, target_arn) = if target_principal.starts_with("arn:") {
+            let acct = extract_account_from_arn(target_principal).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    "TargetPrincipal ARN is malformed",
+                )
+            })?;
+            (acct, target_principal.to_string())
+        } else if target_principal.len() == 12
+            && target_principal.chars().all(|c| c.is_ascii_digit())
+        {
+            (
+                target_principal.to_string(),
+                format!("arn:{}:iam::{}:root", partition, target_principal),
+            )
+        } else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "TargetPrincipal must be a member account ID or root ARN",
+            ));
+        };
+
+        let expiration_at = compute_expiration_at(req, 900)?;
+        let expiration = format_expiration(expiration_at);
+        let creds = StsCredentials::generate();
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&target_account);
+        state.credential_identities.insert(
+            creds.access_key_id.clone(),
+            CredentialIdentity {
+                arn: target_arn.clone(),
+                user_id: target_account.clone(),
+                account_id: target_account.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: target_arn.clone(),
+                user_id: target_account.clone(),
+                account_id: target_account.clone(),
+                expiration: expiration_at,
+                session_policies: Vec::new(),
+            },
+        );
+
+        let source_identity = req.query_params.get("SourceIdentity").map(|s| s.as_str());
+        let xml = xml_responses::assume_root_response(
+            &creds,
+            &expiration,
+            source_identity,
+            &req.request_id,
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
+    /// GetDelegatedAccessToken: trades an opaque token for short-lived
+    /// credentials bound to the caller's principal. We accept any non-empty
+    /// trade-in token (the emulator does not issue verifiable trade-in tokens
+    /// upstream), mint fresh STS credentials, and tie them to the caller's
+    /// access key (or account root when unauthenticated).
+    fn get_delegated_access_token(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let trade_in = req.query_params.get("TradeInToken").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                "The request must contain the parameter TradeInToken",
+            )
+        })?;
+        validate_string_length("tradeInToken", trade_in, 1, 4096)?;
+
+        let partition = partition_for_region(&req.region);
+        let expiration_at = compute_expiration_at(req, DEFAULT_SESSION_TOKEN_DURATION)?;
+        let expiration = format_expiration(expiration_at);
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let (assumed_principal, user_id, account_id) =
+            if let Some(akid) = extract_access_key(req).as_deref() {
+                if let Some(lookup) = state.credential_secret_readonly(akid) {
+                    (lookup.principal_arn, lookup.user_id, lookup.account_id)
+                } else {
+                    (
+                        format!("arn:{}:iam::{}:root", partition, state.account_id),
+                        state.account_id.clone(),
+                        state.account_id.clone(),
+                    )
+                }
+            } else {
+                (
+                    format!("arn:{}:iam::{}:root", partition, state.account_id),
+                    state.account_id.clone(),
+                    state.account_id.clone(),
+                )
+            };
+
+        let creds = StsCredentials::generate();
+        state.credential_identities.insert(
+            creds.access_key_id.clone(),
+            CredentialIdentity {
+                arn: assumed_principal.clone(),
+                user_id: user_id.clone(),
+                account_id: account_id.clone(),
+            },
+        );
+        state.sts_temp_credentials.insert(
+            creds.access_key_id.clone(),
+            StsTempCredential {
+                access_key_id: creds.access_key_id.clone(),
+                secret_access_key: creds.secret_access_key.clone(),
+                session_token: creds.session_token.clone(),
+                principal_arn: assumed_principal.clone(),
+                user_id,
+                account_id,
+                expiration: expiration_at,
+                session_policies: Vec::new(),
+            },
+        );
+
+        let xml = xml_responses::get_delegated_access_token_response(
+            &creds,
+            &expiration,
+            &assumed_principal,
+            &req.request_id,
+        );
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+
+    /// GetWebIdentityToken: issues a signed JWT representing the caller. We
+    /// produce an unsigned JWT (alg "none"-style) since the emulator has no
+    /// signing key material; the structure matches AWS so client decoders
+    /// see standard JWT claims.
+    fn get_web_identity_token(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // Audience.member.N (Query protocol). Required.
+        let mut audiences: Vec<String> = Vec::new();
+        for i in 1..=12 {
+            let key = format!("Audience.member.{i}");
+            match req.query_params.get(&key) {
+                Some(a) => audiences.push(a.clone()),
+                None => break,
+            }
+        }
+        if audiences.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                "The request must contain the parameter Audience",
+            ));
+        }
+
+        let signing = req.query_params.get("SigningAlgorithm").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                "The request must contain the parameter SigningAlgorithm",
+            )
+        })?;
+        if signing != "RS256" && signing != "ES384" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "SigningAlgorithm must be one of RS256, ES384",
+            ));
+        }
+
+        let duration = req
+            .query_params
+            .get("DurationSeconds")
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(300);
+        if !(60..=3600).contains(&duration) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationError",
+                "durationSeconds must be between 60 and 3600",
+            ));
+        }
+
+        let partition = partition_for_region(&req.region);
+        let accounts = self.state.read();
+        let empty = IamState::new(&req.account_id);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let subject = if let Some(akid) = extract_access_key(req).as_deref() {
+            state
+                .credential_secret_readonly(akid)
+                .map(|l| l.principal_arn)
+                .unwrap_or_else(|| format!("arn:{}:iam::{}:root", partition, state.account_id))
+        } else {
+            format!("arn:{}:iam::{}:root", partition, state.account_id)
+        };
+
+        let now = chrono::Utc::now().timestamp();
+        let exp = now + duration;
+        let header = base64_url(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = serde_json::json!({
+            "iss": format!("https://sts.{}.amazonaws.com", req.region),
+            "sub": subject,
+            "aud": audiences,
+            "iat": now,
+            "exp": exp,
+        });
+        let payload_b64 = base64_url(payload.to_string().as_bytes());
+        let token = format!("{}.{}.", header, payload_b64);
+        let expiration =
+            format_expiration(chrono::Utc::now() + chrono::Duration::seconds(duration));
+
+        let xml =
+            xml_responses::get_web_identity_token_response(&token, &expiration, &req.request_id);
+        Ok(AwsResponse::xml(StatusCode::OK, xml))
+    }
+}
+
+fn base64_url(input: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(input)
 }
 
 /// Extract account ID from an ARN like `arn:aws:iam::123456789012:role/name`.

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -97,7 +97,6 @@ fn is_mutating_action(action: &str) -> bool {
             | "GetFederationToken"
             | "AssumeRoot"
             | "GetDelegatedAccessToken"
-            | "GetWebIdentityToken"
     )
 }
 
@@ -1135,11 +1134,21 @@ impl StsService {
             ));
         }
 
-        let duration = req
-            .query_params
-            .get("DurationSeconds")
-            .and_then(|s| s.parse::<i64>().ok())
-            .unwrap_or(300);
+        let duration = if let Some(ds) = req.query_params.get("DurationSeconds") {
+            ds.parse::<i64>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationError",
+                    format!(
+                        "Value '{}' at 'durationSeconds' failed to satisfy constraint: \
+                         Member must be a valid integer",
+                        ds
+                    ),
+                )
+            })?
+        } else {
+            300
+        };
         if !(60..=3600).contains(&duration) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -788,6 +788,83 @@ pub fn get_federation_token_response(
     )
 }
 
+pub fn assume_root_response(
+    creds: &StsCredentials,
+    expiration: &str,
+    source_identity: Option<&str>,
+    request_id: &str,
+) -> String {
+    let access_key_id = creds.access_key_id.as_str();
+    let secret_access_key = creds.secret_access_key.as_str();
+    let session_token = creds.session_token.as_str();
+    let source_identity_section = match source_identity {
+        Some(s) => format!("\n    <SourceIdentity>{}</SourceIdentity>", xml_escape(s)),
+        None => String::new(),
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRootResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRootResult>
+    <Credentials>
+      <AccessKeyId>{access_key_id}</AccessKeyId>
+      <SecretAccessKey>{secret_access_key}</SecretAccessKey>
+      <SessionToken>{session_token}</SessionToken>
+      <Expiration>{expiration}</Expiration>
+    </Credentials>{source_identity_section}
+  </AssumeRootResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</AssumeRootResponse>"#,
+    )
+}
+
+pub fn get_delegated_access_token_response(
+    creds: &StsCredentials,
+    expiration: &str,
+    assumed_principal: &str,
+    request_id: &str,
+) -> String {
+    let access_key_id = creds.access_key_id.as_str();
+    let secret_access_key = creds.secret_access_key.as_str();
+    let session_token = creds.session_token.as_str();
+    let assumed_principal = xml_escape(assumed_principal);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<GetDelegatedAccessTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetDelegatedAccessTokenResult>
+    <Credentials>
+      <AccessKeyId>{access_key_id}</AccessKeyId>
+      <SecretAccessKey>{secret_access_key}</SecretAccessKey>
+      <SessionToken>{session_token}</SessionToken>
+      <Expiration>{expiration}</Expiration>
+    </Credentials>
+    <PackedPolicySize>0</PackedPolicySize>
+    <AssumedPrincipal>{assumed_principal}</AssumedPrincipal>
+  </GetDelegatedAccessTokenResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</GetDelegatedAccessTokenResponse>"#,
+    )
+}
+
+pub fn get_web_identity_token_response(token: &str, expiration: &str, request_id: &str) -> String {
+    let token = xml_escape(token);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<GetWebIdentityTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetWebIdentityTokenResult>
+    <WebIdentityToken>{token}</WebIdentityToken>
+    <Expiration>{expiration}</Expiration>
+  </GetWebIdentityTokenResult>
+  <ResponseMetadata>
+    <RequestId>{request_id}</RequestId>
+  </ResponseMetadata>
+</GetWebIdentityTokenResponse>"#,
+    )
+}
+
 pub fn decode_authorization_message_response(decoded_message: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- `AssumeRoot` mints short-lived (<=900s) member-account-root credentials, persists them in the IAM state so subsequent SigV4 lookups resolve to the new principal.
- `GetDelegatedAccessToken` trades any non-empty `TradeInToken` for fresh STS credentials tied to the caller (or account root when unauthenticated).
- `GetWebIdentityToken` returns an unsigned JWT (`iss`/`sub`/`aud`/`iat`/`exp` claims) so client decoders see standard structure; `SigningAlgorithm` validated against `RS256`/`ES384`.
- STS conformance: 8/11 -> 11/11 (100%); workspace baseline +94 passing variants.

## Test plan
- [x] `cargo test -p fakecloud-conformance --test sts` -> 11 pass
- [x] `cargo run -p fakecloud-conformance -- run --services sts` -> 11/11 OK
- [x] `cargo run -p fakecloud-conformance -- audit` / `check` -> PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three STS actions—AssumeRoot, GetDelegatedAccessToken, and GetWebIdentityToken—to mint short‑lived credentials and issue a web identity token. Completes STS conformance (11/11, 438/438), updates the conformance baseline, and adds unit tests for happy paths and validation errors.

- **New Features**
  - AssumeRoot: mints ≤900s credentials for a member account’s root; persists in IAM; validates TaskPolicyArn and DurationSeconds.
  - GetDelegatedAccessToken: trades a non-empty TradeInToken for temporary credentials bound to the caller (or account root if unauthenticated).
  - GetWebIdentityToken: returns an unsigned JWT with iss/sub/aud/iat/exp; validates SigningAlgorithm (RS256/ES384) and DurationSeconds (60–3600).

- **Bug Fixes**
  - Treat GetWebIdentityToken as read-only to avoid unnecessary snapshot writes.
  - Parse DurationSeconds strictly and return ValidationError on non-numeric input.

<sup>Written for commit b59a43cac73d65964c1683f25d89b1764890c8e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

