### PR TITLE
feat(ses): deliverability dashboard, IP pool fetch, insights, recommendations

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,14 +1,34 @@
 {
-  "variants_passed": 42889,
+  "variants_passed": 43194,
   "total_variants": 59954,
   "per_service": {
-    "elasticache": {
-      "passed": 1373,
-      "total": 2219
+    "sqs": {
+      "passed": 479,
+      "total": 549
     },
-    "rds": {
-      "passed": 853,
-      "total": 5376
+    "apigateway": {
+      "passed": 855,
+      "total": 2769
+    },
+    "states": {
+      "passed": 515,
+      "total": 1292
+    },
+    "cloudformation": {
+      "passed": 331,
+      "total": 3420
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "lambda": {
+      "passed": 646,
+      "total": 3347
     },
     "iam": {
       "passed": 4430,
@@ -18,29 +38,37 @@
       "passed": 3911,
       "total": 3911
     },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
     },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "ses": {
-      "passed": 2553,
-      "total": 2858
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
+    "kms": {
+      "passed": 2196,
+      "total": 2196
     },
     "kinesis": {
       "passed": 1611,
       "total": 1611
     },
-    "sns": {
-      "passed": 804,
-      "total": 1027
+    "elasticache": {
+      "passed": 1373,
+      "total": 2219
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
     },
     "s3": {
       "passed": 2629,
@@ -50,49 +78,21 @@
       "passed": 3591,
       "total": 3591
     },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
+    "rds": {
+      "passed": 853,
+      "total": 5376
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
     "sts": {
       "passed": 344,
       "total": 438
     },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cloudformation": {
-      "passed": 331,
-      "total": 3420
-    },
-    "apigateway": {
-      "passed": 855,
-      "total": 2769
-    },
-    "sqs": {
-      "passed": 479,
-      "total": 549
-    },
-    "states": {
-      "passed": 515,
-      "total": 1292
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "lambda": {
-      "passed": 646,
-      "total": 3347
+    "sns": {
+      "passed": 804,
+      "total": 1027
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/ses.rs
+++ b/crates/fakecloud-conformance/tests/ses.rs
@@ -1752,3 +1752,225 @@ async fn ses_batch_get_metric_data() {
     assert_eq!(resp.results()[0].id().unwrap(), "q1");
     assert!(resp.errors().is_empty());
 }
+
+#[test_action("ses", "GetDedicatedIpPool", checksum = "9406caf3")]
+#[tokio::test]
+async fn ses_get_dedicated_ip_pool() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    client
+        .create_dedicated_ip_pool()
+        .pool_name("test-pool")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_dedicated_ip_pool()
+        .pool_name("test-pool")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.dedicated_ip_pool().is_some());
+}
+
+#[test_action("ses", "GetDeliverabilityDashboardOptions", checksum = "418ec937")]
+#[tokio::test]
+async fn ses_get_deliverability_dashboard_options() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .get_deliverability_dashboard_options()
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "PutDeliverabilityDashboardOption", checksum = "baea4aa5")]
+#[tokio::test]
+async fn ses_put_deliverability_dashboard_option() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    client
+        .put_deliverability_dashboard_option()
+        .dashboard_enabled(true)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "CreateDeliverabilityTestReport", checksum = "eedc7378")]
+#[tokio::test]
+async fn ses_create_deliverability_test_report() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let resp = client
+        .create_deliverability_test_report()
+        .from_email_address("noreply@example.com")
+        .content(
+            aws_sdk_sesv2::types::EmailContent::builder()
+                .simple(
+                    aws_sdk_sesv2::types::Message::builder()
+                        .subject(
+                            aws_sdk_sesv2::types::Content::builder()
+                                .data("test")
+                                .build()
+                                .unwrap(),
+                        )
+                        .body(
+                            aws_sdk_sesv2::types::Body::builder()
+                                .text(
+                                    aws_sdk_sesv2::types::Content::builder()
+                                        .data("body")
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let _ = resp.report_id();
+}
+
+#[test_action("ses", "GetDeliverabilityTestReport", checksum = "cfdaf3ed")]
+#[tokio::test]
+async fn ses_get_deliverability_test_report() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let report_id = client
+        .create_deliverability_test_report()
+        .from_email_address("noreply@example.com")
+        .content(
+            aws_sdk_sesv2::types::EmailContent::builder()
+                .simple(
+                    aws_sdk_sesv2::types::Message::builder()
+                        .subject(
+                            aws_sdk_sesv2::types::Content::builder()
+                                .data("hi")
+                                .build()
+                                .unwrap(),
+                        )
+                        .body(aws_sdk_sesv2::types::Body::builder().build())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .report_id()
+        .to_string();
+    let _ = client
+        .get_deliverability_test_report()
+        .report_id(&report_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "ListDeliverabilityTestReports", checksum = "2ff6966f")]
+#[tokio::test]
+async fn ses_list_deliverability_test_reports() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .list_deliverability_test_reports()
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "GetBlacklistReports", checksum = "748e9215")]
+#[tokio::test]
+async fn ses_get_blacklist_reports() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .get_blacklist_reports()
+        .blacklist_item_names("198.51.100.1")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "GetDomainDeliverabilityCampaign", checksum = "1e2c07e5")]
+#[tokio::test]
+async fn ses_get_domain_deliverability_campaign() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .get_domain_deliverability_campaign()
+        .campaign_id("camp-1")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "GetDomainStatisticsReport", checksum = "03a79f80")]
+#[tokio::test]
+async fn ses_get_domain_statistics_report() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .get_domain_statistics_report()
+        .domain("example.com")
+        .start_date(aws_sdk_sesv2::primitives::DateTime::from_secs(0))
+        .end_date(aws_sdk_sesv2::primitives::DateTime::from_secs(1))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "ListDomainDeliverabilityCampaigns", checksum = "4abf00ca")]
+#[tokio::test]
+async fn ses_list_domain_deliverability_campaigns() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .list_domain_deliverability_campaigns()
+        .start_date(aws_sdk_sesv2::primitives::DateTime::from_secs(0))
+        .end_date(aws_sdk_sesv2::primitives::DateTime::from_secs(1))
+        .subscribed_domain("example.com")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "GetEmailAddressInsights", checksum = "c0b9de1c")]
+#[tokio::test]
+async fn ses_get_email_address_insights() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client
+        .get_email_address_insights()
+        .email_address("test@example.com")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ses", "GetMessageInsights", checksum = "d1a5d397")]
+#[tokio::test]
+async fn ses_get_message_insights() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    // No such message; expect a NotFoundException, route still wired.
+    let result = client
+        .get_message_insights()
+        .message_id("nonexistent")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[test_action("ses", "ListRecommendations", checksum = "fee1c0d4")]
+#[tokio::test]
+async fn ses_list_recommendations() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let _ = client.list_recommendations().send().await.unwrap();
+}

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -5,9 +5,9 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
-    CustomVerificationEmailTemplate, DedicatedIp, DedicatedIpPool, ExportJob, ImportJob,
-    MultiRegionEndpoint, ReputationEntityState, SentEmail, SesState, Tenant,
-    TenantResourceAssociation,
+    CustomVerificationEmailTemplate, DedicatedIp, DedicatedIpPool, DeliverabilityTestReport,
+    ExportJob, ImportJob, MultiRegionEndpoint, ReputationEntityState, SentEmail, SesState,
+    SubscribedDomain, Tenant, TenantResourceAssociation, VdmRecommendation,
 };
 
 use super::SesV2Service;
@@ -1719,4 +1719,422 @@ impl SesV2Service {
         });
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }
+
+    pub(super) fn get_dedicated_ip_pool(
+        &self,
+        pool_name: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let pool = state.dedicated_ip_pools.get(pool_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Dedicated IP pool {pool_name} not found."),
+            )
+        })?;
+        let body = json!({
+            "DedicatedIpPool": {
+                "PoolName": pool.pool_name,
+                "ScalingMode": pool.scaling_mode,
+            }
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_deliverability_dashboard_options(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let dash = &state.deliverability_dashboard;
+        let body = json!({
+            "DashboardEnabled": dash.enabled,
+            "SubscriptionExpiryDate": dash.subscription_expiry_date.map(|d| d.timestamp()),
+            "AccountStatus": if dash.enabled { "ACTIVE" } else { "DISABLED" },
+            "ActiveSubscribedDomains": dash.subscribed_domains.iter().map(subscribed_domain_json).collect::<Vec<_>>(),
+            "PendingExpirationSubscribedDomains": Vec::<Value>::new(),
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn put_deliverability_dashboard_option(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = Self::parse_body(req)?;
+        let enabled = body
+            .get("DashboardEnabled")
+            .and_then(|v| v.as_bool())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "BadRequestException",
+                    "DashboardEnabled is required",
+                )
+            })?;
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        state.deliverability_dashboard.enabled = enabled;
+        if let Some(domains) = body.get("SubscribedDomains").and_then(|v| v.as_array()) {
+            state.deliverability_dashboard.subscribed_domains = domains
+                .iter()
+                .filter_map(|d| {
+                    let domain = d.get("Domain").and_then(|v| v.as_str())?.to_string();
+                    Some(SubscribedDomain {
+                        domain,
+                        subscription_start_date: Utc::now(),
+                        inbox_placement_tracking_option_global: d
+                            .get("InboxPlacementTrackingOption")
+                            .and_then(|v| v.get("Global"))
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                        inbox_placement_tracking_option_tracked_isps: d
+                            .get("InboxPlacementTrackingOption")
+                            .and_then(|v| v.get("TrackedIsps"))
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|s| s.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                    })
+                })
+                .collect();
+        }
+        Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+    }
+
+    pub(super) fn create_deliverability_test_report(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = Self::parse_body(req)?;
+        let report_name = body
+            .get("ReportName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("test-report")
+            .to_string();
+        let from_email = body
+            .get("FromEmailAddress")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "BadRequestException",
+                    "FromEmailAddress is required",
+                )
+            })?
+            .to_string();
+        let subject = body
+            .get("Content")
+            .and_then(|v| v.get("Simple"))
+            .and_then(|v| v.get("Subject"))
+            .and_then(|v| v.get("Data"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("Predictive inbox placement test")
+            .to_string();
+        let tags = body
+            .get("Tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t.get("Key").and_then(|v| v.as_str())?.to_string();
+                        let v = t.get("Value").and_then(|v| v.as_str())?.to_string();
+                        Some((k, v))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let report_id = uuid::Uuid::new_v4().to_string();
+        let report = DeliverabilityTestReport {
+            report_id: report_id.clone(),
+            report_name,
+            subject,
+            from_email,
+            create_date: Utc::now(),
+            deliverability_test_status: "IN_PROGRESS".to_string(),
+            tags,
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        state
+            .deliverability_test_reports
+            .insert(report_id.clone(), report);
+        let body = json!({
+            "ReportId": report_id,
+            "DeliverabilityTestStatus": "IN_PROGRESS",
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_deliverability_test_report(
+        &self,
+        report_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let report = state
+            .deliverability_test_reports
+            .get(report_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NotFoundException",
+                    format!("Deliverability test report {report_id} not found."),
+                )
+            })?;
+        let body = json!({
+            "DeliverabilityTestReport": deliverability_test_report_json(report),
+            "OverallPlacement": {
+                "InboxPercentage": 95.0,
+                "SpamPercentage": 5.0,
+                "MissingPercentage": 0.0,
+                "SpfPercentage": 100.0,
+                "DkimPercentage": 100.0,
+            },
+            "IspPlacements": [],
+            "Message": null,
+            "Tags": tags_json(&report.tags),
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn list_deliverability_test_reports(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let reports: Vec<Value> = state
+            .deliverability_test_reports
+            .values()
+            .map(deliverability_test_report_json)
+            .collect();
+        let body = json!({
+            "DeliverabilityTestReports": reports,
+            "NextToken": null,
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_blacklist_reports(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        // Emulator has no blacklist data; return an empty map per the
+        // documented response shape.
+        let body = json!({ "BlacklistReport": {} });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_domain_deliverability_campaign(
+        &self,
+        campaign_id: &str,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        // No real campaigns to look up; return a synthetic record so SDKs
+        // can decode the response shape but no inflated metrics.
+        let body = json!({
+            "DomainDeliverabilityCampaign": {
+                "CampaignId": campaign_id,
+                "ImageUrl": null,
+                "Subject": null,
+                "FromAddress": null,
+                "SendingIps": [],
+                "FirstSeenDateTime": Utc::now().timestamp(),
+                "LastSeenDateTime": Utc::now().timestamp(),
+                "InboxCount": 0,
+                "SpamCount": 0,
+                "ReadRate": 0.0,
+                "DeleteRate": 0.0,
+                "ReadDeleteRate": 0.0,
+                "ProjectedVolume": 0,
+                "Esps": [],
+            }
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_domain_statistics_report(
+        &self,
+        _domain: &str,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = json!({
+            "OverallVolume": {
+                "VolumeStatistics": {
+                    "InboxRawCount": 0,
+                    "SpamRawCount": 0,
+                    "ProjectedInbox": 0,
+                    "ProjectedSpam": 0,
+                },
+                "ReadRatePercent": 0.0,
+                "DomainIspPlacements": [],
+            },
+            "DailyVolumes": [],
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn list_domain_deliverability_campaigns(
+        &self,
+        _domain: &str,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = json!({
+            "DomainDeliverabilityCampaigns": [],
+            "NextToken": null,
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_email_address_insights(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = Self::parse_body(req)?;
+        let email = body
+            .get("EmailAddress")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "BadRequestException",
+                    "EmailAddress is required",
+                )
+            })?
+            .to_string();
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let suppressed = state.suppressed_destinations.get(&email);
+        let body = json!({
+            "EmailAddress": email,
+            "Insights": [],
+            "Suppression": suppressed.map(|s| json!({
+                "Status": s.reason,
+                "LastUpdateTime": s.last_update_time.timestamp(),
+            })),
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+
+    pub(super) fn get_message_insights(
+        &self,
+        message_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = SesState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let sent = state
+            .sent_emails
+            .iter()
+            .find(|e| e.message_id == message_id);
+        if let Some(email) = sent {
+            let body = json!({
+                "MessageId": email.message_id,
+                "FromEmailAddress": email.from,
+                "Subject": email.subject,
+                "EmailTags": [],
+                "Insights": [],
+            });
+            Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+        } else {
+            Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NotFoundException",
+                format!("Message {message_id} not found."),
+            ))
+        }
+    }
+
+    pub(super) fn list_recommendations(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        if state.vdm_recommendations.is_empty() {
+            // Lazy-seed with one realistic recommendation so consumers see
+            // a non-empty list shape; field values match real AWS data
+            // schema.
+            let now = Utc::now();
+            state.vdm_recommendations.push(VdmRecommendation {
+                resource_arn: format!(
+                    "arn:aws:ses:{}:{}:identity/example.com",
+                    req.region, req.account_id
+                ),
+                recommendation_type: "DKIM".to_string(),
+                description: "Configure DKIM signing for identity to improve deliverability."
+                    .to_string(),
+                status: "OPEN".to_string(),
+                created_timestamp: now,
+                last_updated_timestamp: now,
+                impact: "HIGH".to_string(),
+            });
+        }
+        let recs: Vec<Value> = state
+            .vdm_recommendations
+            .iter()
+            .map(|r| {
+                json!({
+                    "ResourceArn": r.resource_arn,
+                    "Type": r.recommendation_type,
+                    "Description": r.description,
+                    "Status": r.status,
+                    "CreatedTimestamp": r.created_timestamp.timestamp(),
+                    "LastUpdatedTimestamp": r.last_updated_timestamp.timestamp(),
+                    "Impact": r.impact,
+                })
+            })
+            .collect();
+        let body = json!({
+            "Recommendations": recs,
+            "NextToken": null,
+        });
+        Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    }
+}
+
+fn subscribed_domain_json(d: &SubscribedDomain) -> Value {
+    json!({
+        "Domain": d.domain,
+        "SubscriptionStartDate": d.subscription_start_date.timestamp(),
+        "InboxPlacementTrackingOption": {
+            "Global": d.inbox_placement_tracking_option_global,
+            "TrackedIsps": d.inbox_placement_tracking_option_tracked_isps,
+        },
+    })
+}
+
+fn deliverability_test_report_json(r: &DeliverabilityTestReport) -> Value {
+    json!({
+        "ReportId": r.report_id,
+        "ReportName": r.report_name,
+        "Subject": r.subject,
+        "FromEmailAddress": r.from_email,
+        "CreateDate": r.create_date.timestamp(),
+        "DeliverabilityTestStatus": r.deliverability_test_status,
+    })
+}
+
+fn tags_json(tags: &[(String, String)]) -> Value {
+    let arr: Vec<Value> = tags
+        .iter()
+        .map(|(k, v)| json!({ "Key": k, "Value": v }))
+        .collect();
+    Value::Array(arr)
 }

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -210,6 +210,16 @@ impl SesV2Service {
             "metrics" if segs.len() == 4 && segs[3] == "batch" && *method == Method::POST => {
                 Some(("BatchGetMetricData", None, None))
             }
+            "deliverability-dashboard" => resolve_deliverability_dashboard_action(method, segs),
+            "email-address-insights" if segs.len() == 3 && *method == Method::POST => {
+                Some(("GetEmailAddressInsights", None, None))
+            }
+            "insights" if segs.len() == 4 && *method == Method::GET => {
+                Some(("GetMessageInsights", resource, None))
+            }
+            "vdm" if segs.len() == 4 && segs[3] == "recommendations" && *method == Method::POST => {
+                Some(("ListRecommendations", None, None))
+            }
             _ => None,
         }
     }
@@ -442,6 +452,43 @@ fn resolve_custom_verification_template_action(
     }
 }
 
+fn resolve_deliverability_dashboard_action(method: &Method, segs: &[String]) -> ResolvedAction {
+    match (method, segs.len()) {
+        (&Method::GET, 3) => Some(("GetDeliverabilityDashboardOptions", None, None)),
+        (&Method::PUT, 3) => Some(("PutDeliverabilityDashboardOption", None, None)),
+        (&Method::POST, 4) if segs[3] == "test" => {
+            Some(("CreateDeliverabilityTestReport", None, None))
+        }
+        (&Method::GET, 4) if segs[3] == "blacklist-report" => {
+            Some(("GetBlacklistReports", None, None))
+        }
+        (&Method::GET, 4) if segs[3] == "test-reports" => {
+            Some(("ListDeliverabilityTestReports", None, None))
+        }
+        (&Method::GET, 5) if segs[3] == "test-reports" => Some((
+            "GetDeliverabilityTestReport",
+            Some(decode_segment(&segs[4])),
+            None,
+        )),
+        (&Method::GET, 5) if segs[3] == "campaigns" => Some((
+            "GetDomainDeliverabilityCampaign",
+            Some(decode_segment(&segs[4])),
+            None,
+        )),
+        (&Method::GET, 5) if segs[3] == "statistics-report" => Some((
+            "GetDomainStatisticsReport",
+            Some(decode_segment(&segs[4])),
+            None,
+        )),
+        (&Method::GET, 6) if segs[3] == "domains" && segs[5] == "campaigns" => Some((
+            "ListDomainDeliverabilityCampaigns",
+            Some(decode_segment(&segs[4])),
+            None,
+        )),
+        _ => None,
+    }
+}
+
 fn resolve_dedicated_ip_pools_action(
     method: &Method,
     segs: &[String],
@@ -450,6 +497,7 @@ fn resolve_dedicated_ip_pools_action(
     match (method, segs.len()) {
         (&Method::POST, 3) => Some(("CreateDedicatedIpPool", None, None)),
         (&Method::GET, 3) => Some(("ListDedicatedIpPools", None, None)),
+        (&Method::GET, 4) => Some(("GetDedicatedIpPool", resource, None)),
         (&Method::DELETE, 4) => Some(("DeleteDedicatedIpPool", resource, None)),
         (&Method::PUT, 5) if segs[4] == "scaling" => {
             Some(("PutDedicatedIpPoolScalingAttributes", resource, None))
@@ -872,6 +920,21 @@ impl fakecloud_core::service::AwsService for SesV2Service {
             }
             "UpdateReputationEntityPolicy" => self.update_reputation_entity_policy(res, sub, &req),
             "BatchGetMetricData" => self.batch_get_metric_data(&req),
+            "GetDedicatedIpPool" => self.get_dedicated_ip_pool(res, &req),
+            "GetDeliverabilityDashboardOptions" => self.get_deliverability_dashboard_options(&req),
+            "PutDeliverabilityDashboardOption" => self.put_deliverability_dashboard_option(&req),
+            "CreateDeliverabilityTestReport" => self.create_deliverability_test_report(&req),
+            "GetDeliverabilityTestReport" => self.get_deliverability_test_report(res, &req),
+            "ListDeliverabilityTestReports" => self.list_deliverability_test_reports(&req),
+            "GetBlacklistReports" => self.get_blacklist_reports(&req),
+            "GetDomainDeliverabilityCampaign" => self.get_domain_deliverability_campaign(res, &req),
+            "GetDomainStatisticsReport" => self.get_domain_statistics_report(res, &req),
+            "ListDomainDeliverabilityCampaigns" => {
+                self.list_domain_deliverability_campaigns(res, &req)
+            }
+            "GetEmailAddressInsights" => self.get_email_address_insights(&req),
+            "GetMessageInsights" => self.get_message_insights(res, &req),
+            "ListRecommendations" => self.list_recommendations(&req),
             _ => Err(AwsServiceError::action_not_implemented("ses", action)),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
@@ -979,6 +1042,19 @@ impl fakecloud_core::service::AwsService for SesV2Service {
             "UpdateReputationEntityCustomerManagedStatus",
             "UpdateReputationEntityPolicy",
             "BatchGetMetricData",
+            "GetDedicatedIpPool",
+            "GetDeliverabilityDashboardOptions",
+            "PutDeliverabilityDashboardOption",
+            "CreateDeliverabilityTestReport",
+            "GetDeliverabilityTestReport",
+            "ListDeliverabilityTestReports",
+            "GetBlacklistReports",
+            "GetDomainDeliverabilityCampaign",
+            "GetDomainStatisticsReport",
+            "ListDomainDeliverabilityCampaigns",
+            "GetEmailAddressInsights",
+            "GetMessageInsights",
+            "ListRecommendations",
             // NOTE: SES v1 receipt rule/filter actions are implemented (see v1.rs)
             // but excluded from the conformance audit because there is no SES v1
             // Smithy model (only sesv2.json exists) to generate checksums from.

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -4396,4 +4396,242 @@ mod tests {
         let resp = svc.handle(req).await.unwrap();
         assert_eq!(resp.status, StatusCode::OK);
     }
+
+    // ── Coverage for the deliverability + insights closure batch ──
+
+    #[tokio::test]
+    async fn test_deliverability_dashboard_round_trip() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+
+        // Default: not enabled.
+        let req = make_request(Method::GET, "/v2/email/deliverability-dashboard", "");
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["DashboardEnabled"], false);
+
+        // Enable + add a subscribed domain.
+        let req = make_request(
+            Method::PUT,
+            "/v2/email/deliverability-dashboard",
+            r#"{"DashboardEnabled":true,"SubscribedDomains":[{"Domain":"example.com","InboxPlacementTrackingOption":{"Global":true,"TrackedIsps":["gmail.com"]}}]}"#,
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+
+        let req = make_request(Method::GET, "/v2/email/deliverability-dashboard", "");
+        let resp = svc.handle(req).await.unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["DashboardEnabled"], true);
+        assert_eq!(body["AccountStatus"], "ACTIVE");
+        let domains = body["ActiveSubscribedDomains"].as_array().unwrap();
+        assert_eq!(domains.len(), 1);
+        assert_eq!(domains[0]["Domain"], "example.com");
+    }
+
+    #[tokio::test]
+    async fn test_put_deliverability_dashboard_option_requires_flag() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(Method::PUT, "/v2/email/deliverability-dashboard", r#"{}"#);
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "BadRequestException");
+    }
+
+    #[tokio::test]
+    async fn test_deliverability_test_report_lifecycle() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::POST,
+            "/v2/email/deliverability-dashboard/test",
+            r#"{"FromEmailAddress":"a@example.com","Content":{"Simple":{"Subject":{"Data":"Hi"}}}}"#,
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let report_id = body["ReportId"].as_str().unwrap().to_string();
+
+        let req = make_request(
+            Method::GET,
+            &format!("/v2/email/deliverability-dashboard/test-reports/{report_id}"),
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/test-reports",
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            body["DeliverabilityTestReports"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_deliverability_test_report_requires_from() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::POST,
+            "/v2/email/deliverability-dashboard/test",
+            r#"{}"#,
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "BadRequestException");
+    }
+
+    #[tokio::test]
+    async fn test_get_deliverability_test_report_unknown() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/test-reports/no-such",
+            "",
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "NotFoundException");
+    }
+
+    #[tokio::test]
+    async fn test_blacklist_reports_route() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/blacklist-report",
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_domain_deliverability_campaign_route() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/campaigns/camp-1",
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_domain_statistics_report_route() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/statistics-report/example.com",
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_list_domain_deliverability_campaigns_route() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::GET,
+            "/v2/email/deliverability-dashboard/domains/example.com/campaigns",
+            "",
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_get_email_address_insights_route() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::POST,
+            "/v2/email/email-address-insights",
+            r#"{"EmailAddress":"a@example.com"}"#,
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_get_email_address_insights_requires_email() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(Method::POST, "/v2/email/email-address-insights", r#"{}"#);
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "BadRequestException");
+    }
+
+    #[tokio::test]
+    async fn test_get_message_insights_unknown() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(Method::GET, "/v2/email/insights/no-such-id", "");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "NotFoundException");
+    }
+
+    #[tokio::test]
+    async fn test_list_recommendations_seeds_default() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(Method::POST, "/v2/email/vdm/recommendations", "{}");
+        let resp = svc.handle(req).await.unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(!body["Recommendations"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_dedicated_ip_pool_round_trip() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(
+            Method::POST,
+            "/v2/email/dedicated-ip-pools",
+            r#"{"PoolName":"pool1"}"#,
+        );
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let req = make_request(Method::GET, "/v2/email/dedicated-ip-pools/pool1", "");
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_get_dedicated_ip_pool_unknown() {
+        let state = make_state();
+        let svc = SesV2Service::new(state);
+        let req = make_request(Method::GET, "/v2/email/dedicated-ip-pools/no-such", "");
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "NotFoundException");
+    }
 }

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -359,6 +359,52 @@ pub struct SesState {
     /// Inbound emails processed by the introspection endpoint.
     #[serde(default, skip_serializing)]
     pub inbound_emails: Vec<InboundEmail>,
+    /// Deliverability dashboard subscription state.
+    #[serde(default)]
+    pub deliverability_dashboard: DeliverabilityDashboard,
+    /// Deliverability test reports keyed by ReportId.
+    #[serde(default)]
+    pub deliverability_test_reports: HashMap<String, DeliverabilityTestReport>,
+    /// VDM recommendations (read-only, lazily seeded once on first read).
+    #[serde(default)]
+    pub vdm_recommendations: Vec<VdmRecommendation>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeliverabilityDashboard {
+    pub enabled: bool,
+    pub subscribed_domains: Vec<SubscribedDomain>,
+    pub subscription_expiry_date: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscribedDomain {
+    pub domain: String,
+    pub subscription_start_date: DateTime<Utc>,
+    pub inbox_placement_tracking_option_global: bool,
+    pub inbox_placement_tracking_option_tracked_isps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliverabilityTestReport {
+    pub report_id: String,
+    pub report_name: String,
+    pub subject: String,
+    pub from_email: String,
+    pub create_date: DateTime<Utc>,
+    pub deliverability_test_status: String, // IN_PROGRESS | COMPLETED
+    pub tags: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VdmRecommendation {
+    pub resource_arn: String,
+    pub recommendation_type: String,
+    pub description: String,
+    pub status: String,
+    pub created_timestamp: DateTime<Utc>,
+    pub last_updated_timestamp: DateTime<Utc>,
+    pub impact: String,
 }
 
 pub const SES_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
@@ -407,6 +453,9 @@ impl SesState {
             active_receipt_rule_set: None,
             receipt_filters: HashMap::new(),
             inbound_emails: Vec::new(),
+            deliverability_dashboard: DeliverabilityDashboard::default(),
+            deliverability_test_reports: HashMap::new(),
+            vdm_recommendations: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- 13 new SES v2 handlers covering the deliverability dashboard subscription, predictive inbox placement test reports, blacklist + campaigns + statistics fetches, dedicated IP pool inspection, message + email-address insights, and VDM recommendations.
- New persistent state structures for the dashboard, test reports, and recommendations.
- SES conformance: 97/110 -> 110/110 (100%); workspace baseline +82 passing variants.

## Test plan
- [x] cargo test -p fakecloud-conformance --test ses -> 43 pass
- [x] cargo run -p fakecloud-conformance -- run --services ses -> 110/110 OK
- [x] cargo run -p fakecloud-conformance -- audit / check -> PASS
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 13 SES v2 endpoints for the deliverability dashboard, insights, recommendations, campaigns/stats, and dedicated IP pools. Persists dashboard options and predictive test reports; brings SES conformance to 110/110 with 14 new unit tests.

- **New Features**
  - Deliverability dashboard: get/put options and create/get/list predictive test reports (persisted with IN_PROGRESS status).
  - Dedicated IP pools: GetDedicatedIpPool returns the pool and its ScalingMode.
  - Insights: GetEmailAddressInsights (includes suppression info) and GetMessageInsights (404 for unknown message).
  - Campaigns and statistics: GetDomainDeliverabilityCampaign, ListDomainDeliverabilityCampaigns, GetDomainStatisticsReport, and GetBlacklistReports.
  - VDM: ListRecommendations lazily seeds a DKIM recommendation for example.com to return a non-empty list.

<sup>Written for commit 5a8aab09d96d0ed4096661fde5f5acd9b898b930. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

