### PR TITLE
chore(conformance): refresh baseline after 529-op batch merges

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,50 +1,14 @@
 {
-  "variants_passed": 58712,
+  "variants_passed": 59293,
   "total_variants": 59954,
   "per_service": {
-    "apigateway": {
-      "passed": 1527,
-      "total": 2769
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
     "elasticache": {
       "passed": 2219,
       "total": 2219
-    },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
     },
     "dynamodb": {
       "passed": 2123,
@@ -58,25 +22,65 @@
       "passed": 1027,
       "total": 1027
     },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
     "sqs": {
       "passed": 549,
       "total": 549
     },
-    "states": {
-      "passed": 1292,
-      "total": 1292
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "sts": {
       "passed": 438,
       "total": 438
     },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "states": {
+      "passed": 1292,
+      "total": 1292
+    },
+    "apigateway": {
+      "passed": 2108,
+      "total": 2769
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
     "cloudformation": {
       "passed": 3420,
       "total": 3420
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     },
     "cognito-idp": {
       "passed": 4479,
@@ -86,13 +90,9 @@
       "passed": 852,
       "total": 852
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
+    "rds": {
+      "passed": 5376,
+      "total": 5376
     }
   }
 }


### PR DESCRIPTION
## Summary
- Final baseline refresh after merging all 12 conformance batches (PRs #697–#706 plus the RDS PR).
- 22/23 services now report 100% conformance in `conformance-baseline.json`.
- Only `apigateway` (v1 REST) remains below 100% at 76.1%; `apigatewayv2` is 100%. v1 REST is a separate service, out of scope for this batch set.

## Test plan
- `cargo run -p fakecloud-conformance -- audit` → PASS (1702/1702)
- 59293/59954 variants passing (98.9%)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `conformance-baseline.json` after merging the 529-op conformance batches, updating totals and per-service results. Passing variants are now 59,293/59,954 (98.9%); 22/23 services are at 100%, with only `apigateway` (v1 REST) at 76.1% and `apigatewayv2` at 100% (out of scope).

<sup>Written for commit 3fddaa5a8e48fb9b4fc3fcabddfe6ec9499e8f5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

