### PR TITLE
feat(apigatewayv2): align path routing + JSON case with Smithy model

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,26 +1,26 @@
 {
-  "variants_passed": 58712,
+  "variants_passed": 59486,
   "total_variants": 59954,
   "per_service": {
-    "apigateway": {
-      "passed": 1527,
-      "total": 2769
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
     },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     },
     "kms": {
       "passed": 2196,
       "total": 2196
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
     },
     "elasticache": {
       "passed": 2219,
@@ -30,21 +30,37 @@
       "passed": 412,
       "total": 412
     },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "states": {
+      "passed": 1292,
+      "total": 1292
     },
     "rds": {
       "passed": 5376,
       "total": 5376
     },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
+    "apigateway": {
+      "passed": 2301,
+      "total": 2769
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "events": {
+      "passed": 2108,
+      "total": 2108
     },
     "dynamodb": {
       "passed": 2123,
@@ -54,45 +70,29 @@
       "passed": 3620,
       "total": 3620
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
     },
     "sts": {
       "passed": 438,
       "total": 438
     },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
     },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     }
   }
 }

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -11,12 +11,68 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::service::ApiGatewayV2Service;
 use crate::state::ApiGatewayV2State;
 
+/// Lowercase the first letter of a key — Smithy's `@jsonName` default for
+/// apigatewayv2 shapes (e.g. `ApiId` -> `apiId`).
+fn lower_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Walk a `Value` and lowercase the first character of every object key
+/// (recursive). Handlers emit fields in Pascal-case for legibility but
+/// the apigatewayv2 Smithy model serializes them as camel-case.
+fn to_camel(v: Value) -> Value {
+    match v {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, val) in map {
+                out.insert(lower_first(&k), to_camel(val));
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(to_camel).collect()),
+        other => other,
+    }
+}
+
+/// Parse the request body as JSON. Keep incoming case-as-is; handlers
+/// read fields in Pascal-case for legibility, but SDK clients send
+/// camel-case per Smithy — so we also merge a Pascal-case copy.
 fn body(req: &AwsRequest) -> Value {
-    serde_json::from_slice(&req.body).unwrap_or_else(|_| Value::Object(Default::default()))
+    let raw: Value =
+        serde_json::from_slice(&req.body).unwrap_or_else(|_| Value::Object(Default::default()));
+    // Augment with Pascal-first duplicates so handlers can read either
+    // incoming case without needing to know which the caller used.
+    match raw {
+        Value::Object(map) => {
+            let mut merged = serde_json::Map::new();
+            for (k, v) in map {
+                // Insert Pascal-case view for handlers that look up e.g. `body["ApiId"]`
+                let mut chars = k.chars();
+                let pascal = match chars.next() {
+                    Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+                    None => String::new(),
+                };
+                // If pascal differs from the original key, add both
+                if pascal != k {
+                    merged.insert(pascal, v.clone());
+                }
+                merged.insert(k, v);
+            }
+            Value::Object(merged)
+        }
+        other => other,
+    }
 }
 
 fn ok(body: Value) -> Result<AwsResponse, AwsServiceError> {
-    Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
+    Ok(AwsResponse::json(
+        StatusCode::OK,
+        to_camel(body).to_string(),
+    ))
 }
 
 fn empty_ok() -> Result<AwsResponse, AwsServiceError> {
@@ -259,14 +315,13 @@ impl ApiGatewayV2Service {
             "GetRouteResponses" => self.list_subresponses(api_id, resource_id, false, &region, aid),
             "DeleteRouteResponse" => self.delete_subresponse(req, api_id, resource_id, false),
 
-            // ── Routing rules ──
-            "CreateRoutingRule" | "PutRoutingRule" => {
-                let body = body(req);
-                let domain = body["DomainName"]
-                    .as_str()
+            // ── Routing rules (nested under /v2/domainnames/{name}) ──
+            "CreateRoutingRule" => {
+                let domain = resource_id
                     .ok_or_else(|| missing("DomainName"))?
                     .to_string();
-                let id = resource_id.map(String::from).unwrap_or_else(rand_id);
+                let body = body(req);
+                let id = rand_id();
                 let entry = json!({
                     "RoutingRuleId": id,
                     "DomainName": domain,
@@ -282,32 +337,60 @@ impl ApiGatewayV2Service {
                     .insert(id.clone(), entry.clone());
                 ok(entry)
             }
+            "PutRoutingRule" => {
+                let domain = resource_id
+                    .ok_or_else(|| missing("DomainName"))?
+                    .to_string();
+                let id = api_id.ok_or_else(|| missing("RoutingRuleId"))?.to_string();
+                let body = body(req);
+                let entry = json!({
+                    "RoutingRuleId": id,
+                    "DomainName": domain,
+                    "Conditions": body.get("Conditions").cloned().unwrap_or(json!([])),
+                    "Actions": body.get("Actions").cloned().unwrap_or(json!([])),
+                });
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                state
+                    .routing_rules
+                    .entry(domain)
+                    .or_default()
+                    .insert(id, entry.clone());
+                ok(entry)
+            }
             "GetRoutingRule" => {
-                let id = resource_id.ok_or_else(|| missing("RoutingRuleId"))?;
+                let domain = resource_id.ok_or_else(|| missing("DomainName"))?;
+                let id = api_id.ok_or_else(|| missing("RoutingRuleId"))?;
                 self.read_state(aid, &region, |state| {
                     state
                         .routing_rules
-                        .values()
-                        .find_map(|m| m.get(id))
+                        .get(domain)
+                        .and_then(|m| m.get(id))
                         .cloned()
                         .map(ok)
                         .unwrap_or_else(|| Err(not_found("RoutingRule", id)))
                 })
             }
-            "ListRoutingRules" => self.read_state(aid, &region, |state| {
-                let items: Vec<&Value> = state
-                    .routing_rules
-                    .values()
-                    .flat_map(|m| m.values())
-                    .collect();
-                ok(json!({"Items": items}))
-            }),
+            "ListRoutingRules" => {
+                let domain = resource_id.ok_or_else(|| missing("DomainName"))?;
+                self.read_state(aid, &region, |state| {
+                    let items: Vec<Value> = state
+                        .routing_rules
+                        .get(domain)
+                        .map(|m| m.values().cloned().collect())
+                        .unwrap_or_default();
+                    ok(json!({"Items": items}))
+                })
+            }
             "DeleteRoutingRule" => {
-                let id = resource_id.ok_or_else(|| missing("RoutingRuleId"))?;
+                let domain = resource_id
+                    .ok_or_else(|| missing("DomainName"))?
+                    .to_string();
+                let id = api_id.ok_or_else(|| missing("RoutingRuleId"))?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                for map in state.routing_rules.values_mut() {
-                    map.remove(id);
+                if let Some(m) = state.routing_rules.get_mut(&domain) {
+                    m.remove(&id);
                 }
                 no_content()
             }
@@ -1023,18 +1106,18 @@ mod tests {
         run(
             &s,
             "CreateRoutingRule",
-            r#"{"DomainName":"d"}"#,
-            &["v2", "routingrules"],
+            r#"{}"#,
+            &["v2", "domainnames", "d", "routingrules"],
             None,
-            None,
+            Some("d"),
         );
         run(
             &s,
             "ListRoutingRules",
             "",
-            &["v2", "routingrules"],
+            &["v2", "domainnames", "d", "routingrules"],
             None,
-            None,
+            Some("d"),
         );
         run(
             &s,

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -230,6 +230,13 @@ impl ApiGatewayV2Service {
                 (&Method::GET, 5, Some("apimappings")) => Some(("GetApiMapping", sub, res)),
                 (&Method::PATCH, 5, Some("apimappings")) => Some(("UpdateApiMapping", sub, res)),
                 (&Method::DELETE, 5, Some("apimappings")) => Some(("DeleteApiMapping", sub, res)),
+                // Routing rules are nested under a domain name per the Smithy
+                // model (/v2/domainnames/{DomainName}/routingrules[/...]).
+                (&Method::POST, 4, Some("routingrules")) => Some(("CreateRoutingRule", None, res)),
+                (&Method::GET, 4, Some("routingrules")) => Some(("ListRoutingRules", None, res)),
+                (&Method::GET, 5, Some("routingrules")) => Some(("GetRoutingRule", sub, res)),
+                (&Method::PUT, 5, Some("routingrules")) => Some(("PutRoutingRule", sub, res)),
+                (&Method::DELETE, 5, Some("routingrules")) => Some(("DeleteRoutingRule", sub, res)),
                 _ => None,
             };
         }
@@ -241,17 +248,6 @@ impl ApiGatewayV2Service {
                 (&Method::GET, 3) => Some(("GetVpcLink", None, res)),
                 (&Method::PATCH, 3) => Some(("UpdateVpcLink", None, res)),
                 (&Method::DELETE, 3) => Some(("DeleteVpcLink", None, res)),
-                _ => None,
-            };
-        }
-
-        if second == Some("routingrules") {
-            return match (m, segs.len()) {
-                (&Method::POST, 2) => Some(("CreateRoutingRule", None, None)),
-                (&Method::GET, 2) => Some(("ListRoutingRules", None, None)),
-                (&Method::GET, 3) => Some(("GetRoutingRule", None, res)),
-                (&Method::PUT, 3) => Some(("PutRoutingRule", None, res)),
-                (&Method::DELETE, 3) => Some(("DeleteRoutingRule", None, res)),
                 _ => None,
             };
         }
@@ -274,7 +270,10 @@ impl ApiGatewayV2Service {
                 (&Method::GET, 3, _) => Some(("GetPortal", None, res)),
                 (&Method::PATCH, 3, _) => Some(("UpdatePortal", None, res)),
                 (&Method::DELETE, 3, _) => Some(("DeletePortal", None, res)),
-                (&Method::POST, 4, Some("disable")) => Some(("DisablePortal", None, res)),
+                // Smithy: DisablePortal is DELETE /v2/portals/{id}/publish
+                // (it "unpublishes" the portal). PublishPortal is POST of the
+                // same path.
+                (&Method::DELETE, 4, Some("publish")) => Some(("DisablePortal", None, res)),
                 (&Method::POST, 4, Some("preview")) => Some(("PreviewPortal", None, res)),
                 (&Method::POST, 4, Some("publish")) => Some(("PublishPortal", None, res)),
                 _ => None,
@@ -288,33 +287,33 @@ impl ApiGatewayV2Service {
                 (&Method::GET, 3, _) => Some(("GetPortalProduct", None, res)),
                 (&Method::PATCH, 3, _) => Some(("UpdatePortalProduct", None, res)),
                 (&Method::DELETE, 3, _) => Some(("DeletePortalProduct", None, res)),
-                (&Method::PUT, 4, Some("sharing-policy")) => {
+                (&Method::PUT, 4, Some("sharingpolicy")) => {
                     Some(("PutPortalProductSharingPolicy", None, res))
                 }
-                (&Method::GET, 4, Some("sharing-policy")) => {
+                (&Method::GET, 4, Some("sharingpolicy")) => {
                     Some(("GetPortalProductSharingPolicy", None, res))
                 }
-                (&Method::DELETE, 4, Some("sharing-policy")) => {
+                (&Method::DELETE, 4, Some("sharingpolicy")) => {
                     Some(("DeletePortalProductSharingPolicy", None, res))
                 }
-                (&Method::POST, 4, Some("pages")) => Some(("CreateProductPage", None, res)),
-                (&Method::GET, 4, Some("pages")) => Some(("ListProductPages", None, res)),
-                (&Method::GET, 5, Some("pages")) => Some(("GetProductPage", sub, res)),
-                (&Method::PATCH, 5, Some("pages")) => Some(("UpdateProductPage", sub, res)),
-                (&Method::DELETE, 5, Some("pages")) => Some(("DeleteProductPage", sub, res)),
-                (&Method::POST, 4, Some("rest-endpoint-pages")) => {
+                (&Method::POST, 4, Some("productpages")) => Some(("CreateProductPage", None, res)),
+                (&Method::GET, 4, Some("productpages")) => Some(("ListProductPages", None, res)),
+                (&Method::GET, 5, Some("productpages")) => Some(("GetProductPage", sub, res)),
+                (&Method::PATCH, 5, Some("productpages")) => Some(("UpdateProductPage", sub, res)),
+                (&Method::DELETE, 5, Some("productpages")) => Some(("DeleteProductPage", sub, res)),
+                (&Method::POST, 4, Some("productrestendpointpages")) => {
                     Some(("CreateProductRestEndpointPage", None, res))
                 }
-                (&Method::GET, 4, Some("rest-endpoint-pages")) => {
+                (&Method::GET, 4, Some("productrestendpointpages")) => {
                     Some(("ListProductRestEndpointPages", None, res))
                 }
-                (&Method::GET, 5, Some("rest-endpoint-pages")) => {
+                (&Method::GET, 5, Some("productrestendpointpages")) => {
                     Some(("GetProductRestEndpointPage", sub, res))
                 }
-                (&Method::PATCH, 5, Some("rest-endpoint-pages")) => {
+                (&Method::PATCH, 5, Some("productrestendpointpages")) => {
                     Some(("UpdateProductRestEndpointPage", sub, res))
                 }
-                (&Method::DELETE, 5, Some("rest-endpoint-pages")) => {
+                (&Method::DELETE, 5, Some("productrestendpointpages")) => {
                     Some(("DeleteProductRestEndpointPage", sub, res))
                 }
                 _ => None,

--- a/crates/fakecloud-conformance/tests/apigatewayv2.rs
+++ b/crates/fakecloud-conformance/tests/apigatewayv2.rs
@@ -480,7 +480,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let mapping_id = body["ApiMappingId"].as_str().unwrap().to_string();
+    let mapping_id = body["apiMappingId"].as_str().unwrap().to_string();
     let resp = apigw_request(
         &server,
         reqwest::Method::GET,
@@ -531,7 +531,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let vpc_id = body["VpcLinkId"].as_str().unwrap().to_string();
+    let vpc_id = body["vpcLinkId"].as_str().unwrap().to_string();
     apigw_request(&server, reqwest::Method::GET, "/v2/vpclinks", "").await;
     apigw_request(
         &server,
@@ -555,35 +555,48 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
 
-    // Routing rules.
-    let resp = apigw_request(
+    // Routing rules (nested under a domain name per Smithy).
+    apigw_request(
         &server,
         reqwest::Method::POST,
-        "/v2/routingrules",
+        "/v2/domainnames",
         r#"{"DomainName":"example.com"}"#,
     )
     .await;
+    let resp = apigw_request(
+        &server,
+        reqwest::Method::POST,
+        "/v2/domainnames/example.com/routingrules",
+        r#"{}"#,
+    )
+    .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let rule_id = body["RoutingRuleId"].as_str().unwrap().to_string();
-    apigw_request(&server, reqwest::Method::GET, "/v2/routingrules", "").await;
+    let rule_id = body["routingRuleId"].as_str().unwrap().to_string();
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/routingrules/{rule_id}"),
+        "/v2/domainnames/example.com/routingrules",
+        "",
+    )
+    .await;
+    apigw_request(
+        &server,
+        reqwest::Method::GET,
+        &format!("/v2/domainnames/example.com/routingrules/{rule_id}"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::PUT,
-        &format!("/v2/routingrules/{rule_id}"),
-        r#"{"DomainName":"example.com"}"#,
+        &format!("/v2/domainnames/example.com/routingrules/{rule_id}"),
+        r#"{}"#,
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::DELETE,
-        &format!("/v2/routingrules/{rule_id}"),
+        &format!("/v2/domainnames/example.com/routingrules/{rule_id}"),
         "",
     )
     .await;
@@ -620,7 +633,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let model_id = body["ModelId"].as_str().unwrap().to_string();
+    let model_id = body["modelId"].as_str().unwrap().to_string();
     apigw_request(
         &server,
         reqwest::Method::GET,
@@ -668,7 +681,7 @@ async fn apigwv2_closure_routes_exist() {
     let body: serde_json::Value = resp.json().await.unwrap();
     let integ_id = body["integrationId"]
         .as_str()
-        .or_else(|| body["IntegrationId"].as_str())
+        .or_else(|| body["integrationId"].as_str())
         .unwrap()
         .to_string();
     let resp = apigw_request(
@@ -679,7 +692,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let ir_id = body["IntegrationResponseId"].as_str().unwrap().to_string();
+    let ir_id = body["integrationResponseId"].as_str().unwrap().to_string();
     apigw_request(
         &server,
         reqwest::Method::GET,
@@ -720,7 +733,7 @@ async fn apigwv2_closure_routes_exist() {
     let body: serde_json::Value = resp.json().await.unwrap();
     let route_id = body["routeId"]
         .as_str()
-        .or_else(|| body["RouteId"].as_str())
+        .or_else(|| body["routeId"].as_str())
         .unwrap()
         .to_string();
     let resp = apigw_request(
@@ -731,7 +744,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let rr_id = body["RouteResponseId"]
+    let rr_id = body["routeResponseId"]
         .as_str()
         .unwrap_or("rr1")
         .to_string();
@@ -820,7 +833,7 @@ async fn apigwv2_closure_routes_exist() {
     let body: serde_json::Value = dep_resp.json().await.unwrap();
     let dep_id = body["deploymentId"]
         .as_str()
-        .or_else(|| body["DeploymentId"].as_str())
+        .or_else(|| body["deploymentId"].as_str())
         .unwrap_or("dep1")
         .to_string();
     apigw_request(
@@ -870,7 +883,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let portal_id = body["PortalId"].as_str().unwrap().to_string();
+    let portal_id = body["portalId"].as_str().unwrap().to_string();
     apigw_request(&server, reqwest::Method::GET, "/v2/portals", "").await;
     apigw_request(
         &server,
@@ -888,8 +901,8 @@ async fn apigwv2_closure_routes_exist() {
     .await;
     apigw_request(
         &server,
-        reqwest::Method::POST,
-        &format!("/v2/portals/{portal_id}/disable"),
+        reqwest::Method::DELETE,
+        &format!("/v2/portals/{portal_id}/publish"),
         "",
     )
     .await;
@@ -923,7 +936,7 @@ async fn apigwv2_closure_routes_exist() {
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let pp_id = body["PortalProductId"].as_str().unwrap().to_string();
+    let pp_id = body["portalProductId"].as_str().unwrap().to_string();
     apigw_request(&server, reqwest::Method::GET, "/v2/portalproducts", "").await;
     apigw_request(
         &server,
@@ -942,21 +955,21 @@ async fn apigwv2_closure_routes_exist() {
     apigw_request(
         &server,
         reqwest::Method::PUT,
-        &format!("/v2/portalproducts/{pp_id}/sharing-policy"),
+        &format!("/v2/portalproducts/{pp_id}/sharingpolicy"),
         r#"{}"#,
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/portalproducts/{pp_id}/sharing-policy"),
+        &format!("/v2/portalproducts/{pp_id}/sharingpolicy"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::DELETE,
-        &format!("/v2/portalproducts/{pp_id}/sharing-policy"),
+        &format!("/v2/portalproducts/{pp_id}/sharingpolicy"),
         "",
     )
     .await;
@@ -964,37 +977,37 @@ async fn apigwv2_closure_routes_exist() {
     let resp = apigw_request(
         &server,
         reqwest::Method::POST,
-        &format!("/v2/portalproducts/{pp_id}/pages"),
+        &format!("/v2/portalproducts/{pp_id}/productpages"),
         r#"{"Name":"p"}"#,
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let page_id = body["Id"].as_str().unwrap().to_string();
+    let page_id = body["id"].as_str().unwrap().to_string();
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/portalproducts/{pp_id}/pages"),
+        &format!("/v2/portalproducts/{pp_id}/productpages"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/portalproducts/{pp_id}/pages/{page_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productpages/{page_id}"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::PATCH,
-        &format!("/v2/portalproducts/{pp_id}/pages/{page_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productpages/{page_id}"),
         r#"{}"#,
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::DELETE,
-        &format!("/v2/portalproducts/{pp_id}/pages/{page_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productpages/{page_id}"),
         "",
     )
     .await;
@@ -1002,37 +1015,37 @@ async fn apigwv2_closure_routes_exist() {
     let resp = apigw_request(
         &server,
         reqwest::Method::POST,
-        &format!("/v2/portalproducts/{pp_id}/rest-endpoint-pages"),
+        &format!("/v2/portalproducts/{pp_id}/productrestendpointpages"),
         r#"{"Name":"p"}"#,
     )
     .await;
     let body: serde_json::Value = resp.json().await.unwrap();
-    let rep_id = body["Id"].as_str().unwrap().to_string();
+    let rep_id = body["id"].as_str().unwrap().to_string();
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/portalproducts/{pp_id}/rest-endpoint-pages"),
+        &format!("/v2/portalproducts/{pp_id}/productrestendpointpages"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::GET,
-        &format!("/v2/portalproducts/{pp_id}/rest-endpoint-pages/{rep_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productrestendpointpages/{rep_id}"),
         "",
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::PATCH,
-        &format!("/v2/portalproducts/{pp_id}/rest-endpoint-pages/{rep_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productrestendpointpages/{rep_id}"),
         r#"{}"#,
     )
     .await;
     apigw_request(
         &server,
         reqwest::Method::DELETE,
-        &format!("/v2/portalproducts/{pp_id}/rest-endpoint-pages/{rep_id}"),
+        &format!("/v2/portalproducts/{pp_id}/productrestendpointpages/{rep_id}"),
         "",
     )
     .await;


### PR DESCRIPTION
## Summary
- Reroute apigatewayv2 paths to match the Smithy model (routing rules nest under `/v2/domainnames/{name}/routingrules`, sharing policies are `/sharingpolicy`, portal product pages are `/productpages` and `/productrestendpointpages`, DisablePortal is `DELETE /v2/portals/{id}/publish`).
- Smithy serializes apigatewayv2 fields in camel-case (`apiId`, `lastModified`, …). Extras handlers emit Pascal-case; add a `to_camel` walker on every response and a body reader that merges Pascal-case duplicates of incoming camel-case fields, so handlers can stay Pascal-case-friendly.
- Bumps baseline `apigateway` probe coverage from 76.1% -> 83.1% and overall variants from 98.9% -> 99.2%.

## Test plan
- `cargo test -p fakecloud-conformance --test apigatewayv2` (7 passing)
- `cargo run -p fakecloud-conformance -- audit` (PASS, 1702/1702)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `fakecloud-apigatewayv2` path routing and camelCase JSON with the Smithy model to match AWS and boost conformance coverage.

- **Migration**
  - Routing rules now nest under `/v2/domainnames/{DomainName}/routingrules` (create/list/get/put/delete).
  - Portal product sharing policy path is `/sharingpolicy` (no hyphen).
  - Portal product pages paths are `/productpages` and `/productrestendpointpages` (no hyphens).
  - DisablePortal is `DELETE /v2/portals/{id}/publish` (not `POST /disable`).
  - Responses are camelCase; request bodies accept camelCase and PascalCase (handlers remain Pascal-case-friendly).  
  - Conformance: apigateway 76.1% → 83.1%; overall 98.9% → 99.2% (`fakecloud-conformance`).

<sup>Written for commit 530d9b6152e68ebfa856ae11d54742f7de57d29b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

