### PR TITLE
feat(apigatewayv2): strip summary-only fields from Create/Update

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,14 +1,58 @@
 {
-  "variants_passed": 59737,
+  "variants_passed": 59832,
   "total_variants": 59954,
   "per_service": {
-    "sts": {
-      "passed": 438,
-      "total": 438
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "states": {
+      "passed": 1292,
+      "total": 1292
+    },
+    "apigateway": {
+      "passed": 2647,
+      "total": 2769
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "rds": {
+      "passed": 5376,
+      "total": 5376
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
     "sqs": {
       "passed": 549,
@@ -18,81 +62,37 @@
       "passed": 2108,
       "total": 2108
     },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
     },
     "bedrock-runtime": {
       "passed": 412,
       "total": 412
     },
-    "apigateway": {
-      "passed": 2552,
-      "total": 2769
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
     },
     "iam": {
       "passed": 5962,
       "total": 5962
     },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "elasticache": {
       "passed": 2219,
       "total": 2219
     },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
     "ses": {
       "passed": 2858,
       "total": 2858
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
+    "sts": {
+      "passed": 438,
+      "total": 438
     }
   }
 }

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1026,48 +1026,51 @@ impl ApiGatewayV2Service {
                         "arn:aws:apigateway:us-east-1::/portalproducts/{}/productpages/{}",
                         parent, id
                     ),
-                    "PageTitle": page_title,
+                    // Internal-only: the summary shape requires pageTitle
+                    // but Create/Update responses don't carry it. We
+                    // strip this before returning the response below.
+                    "_summary_pageTitle": page_title,
                     "LastModified": now,
                     "DisplayContent": dc,
                 })
             }
             "product_rest_endpoint_pages" => {
-                // EndpointDisplayContentResponse.Endpoint is a simple string
-                // (endpoint name / URL ref). If the caller sent a full
-                // Endpoint object at the root, store it separately and
-                // build a string ref for DisplayContent.Endpoint.
-                let endpoint_obj = input.get("Endpoint").cloned().unwrap_or_else(|| {
-                    json!({
-                        "ApiId": "",
-                        "StageName": "",
-                        "RouteKey": "ANY /",
-                    })
-                });
-                let mut dc = input
-                    .get("DisplayContent")
-                    .cloned()
-                    .unwrap_or_else(|| json!({}));
-                // Set a string endpoint label inside displayContent.
-                if dc
-                    .get("endpoint")
-                    .or_else(|| dc.get("Endpoint"))
-                    .and_then(|v| v.as_str())
-                    .is_none()
-                {
+                // EndpointDisplayContentResponse has only Body, Endpoint,
+                // OperationName. Input may carry EndpointDisplayContent
+                // (None, Overrides) shape — translate to the response
+                // shape rather than echoing the input.
+                let input_dc = input.get("DisplayContent").cloned().unwrap_or(json!({}));
+                let mut dc = json!({});
+                for (out_key, in_keys) in &[
+                    ("Endpoint", &["endpoint", "Endpoint"][..]),
+                    ("Body", &["body", "Body"][..]),
+                    ("OperationName", &["operationName", "OperationName"][..]),
+                ] {
+                    for in_key in *in_keys {
+                        if let Some(v) = input_dc.get(*in_key) {
+                            if !v.is_null() {
+                                dc[*out_key] = v.clone();
+                                break;
+                            }
+                        }
+                    }
+                }
+                if dc.get("Endpoint").and_then(|v| v.as_str()).is_none() {
                     dc["Endpoint"] = json!(id.clone());
                 }
                 let rei = input
                     .get("RestEndpointIdentifier")
                     .cloned()
                     .unwrap_or_else(|| json!({}));
-                let _ = endpoint_obj;
                 json!({
                     "ProductRestEndpointPageId": id,
                     "ProductRestEndpointPageArn": format!(
                         "arn:aws:apigateway:us-east-1::/portalproducts/{}/productrestendpointpages/{}",
                         parent, id
                     ),
-                    "Endpoint": id.clone(),
+                    // Internal-only: summary shape requires endpoint at
+                    // root but Create/Update responses don't carry it.
+                    "_summary_endpoint": id.clone(),
                     "Status": "AVAILABLE",
                     "LastModified": now,
                     "DisplayContent": dc,
@@ -1086,7 +1089,13 @@ impl ApiGatewayV2Service {
             _ => return Err(missing("Store")),
         };
         map.entry(parent).or_default().insert(id, entry.clone());
-        ok(entry)
+        // Strip summary-only fields that live in storage but aren't
+        // part of the Create/Update response shape.
+        let mut response = entry.clone();
+        if let Value::Object(ref mut obj) = response {
+            obj.retain(|k, _| !k.starts_with("_summary_"));
+        }
+        ok(response)
     }
 
     fn get_subresource(
@@ -1108,7 +1117,12 @@ impl ApiGatewayV2Service {
             map.get(parent)
                 .and_then(|m| m.get(id))
                 .cloned()
-                .map(ok)
+                .map(|mut v| {
+                    if let Value::Object(ref mut obj) = v {
+                        obj.retain(|k, _| !k.starts_with("_summary_"));
+                    }
+                    ok(v)
+                })
                 .unwrap_or_else(|| Err(not_found(store, id)))
         })
     }
@@ -1139,13 +1153,19 @@ impl ApiGatewayV2Service {
                             "product_pages" => json!({
                                 "ProductPageId": v.get("ProductPageId").cloned().unwrap_or(json!("")),
                                 "ProductPageArn": v.get("ProductPageArn").cloned().unwrap_or(json!("")),
-                                "PageTitle": v.get("PageTitle").cloned().unwrap_or(json!("")),
+                                "PageTitle": v.get("_summary_pageTitle")
+                                    .or_else(|| v.get("PageTitle"))
+                                    .cloned()
+                                    .unwrap_or(json!("")),
                                 "LastModified": v.get("LastModified").cloned().unwrap_or(json!("")),
                             }),
                             "product_rest_endpoint_pages" => json!({
                                 "ProductRestEndpointPageId": v.get("ProductRestEndpointPageId").cloned().unwrap_or(json!("")),
                                 "ProductRestEndpointPageArn": v.get("ProductRestEndpointPageArn").cloned().unwrap_or(json!("")),
-                                "Endpoint": v.get("Endpoint").cloned().unwrap_or(json!("")),
+                                "Endpoint": v.get("_summary_endpoint")
+                                    .or_else(|| v.get("Endpoint"))
+                                    .cloned()
+                                    .unwrap_or(json!("")),
                                 "Status": v.get("Status").cloned().unwrap_or(json!("AVAILABLE")),
                                 "TryItState": v.get("TryItState").cloned().unwrap_or(json!("DISABLED")),
                                 "LastModified": v.get("LastModified").cloned().unwrap_or(json!("")),


### PR DESCRIPTION
## Summary
- Product pages / rest endpoint pages store a `pageTitle` / `endpoint` string for the Smithy Summary shapes, but the Create/Update response shapes don't carry them. Stash them under `_summary_*` in storage and strip on response; `list_subresources` reads the stashed value.
- Translate incoming `EndpointDisplayContent` (None, Overrides) to the `EndpointDisplayContentResponse` (Body, Endpoint, OperationName) rather than echoing input.
- Lifts the `apigateway` probe baseline from 92.2% -> 95.6% and overall conformance from 99.6% -> 99.8%.

Stacked on top of #713. Merge that one first.

## Test plan
- `cargo test -p fakecloud-conformance --test apigatewayv2` (7 passing)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo run -p fakecloud-conformance -- audit` (PASS, 1702/1702)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns API Gateway v2 extras with Smithy response shapes for Create/Update/Get and List. Stashes summary-only fields in storage, strips them from responses, translates inputs to the correct outputs, adds required defaults, and lifts conformance (apigateway 92.2% → 95.6%, overall 99.6% → 99.8%).

- **Refactors**
  - Product pages and REST endpoint pages: stash `_summary_*` fields; strip on Create/Update/Get; List projects to Summary shapes (PageTitle/Endpoint).
  - Translate `EndpointDisplayContent` to `EndpointDisplayContentResponse` (Body, Endpoint, OperationName); default `Endpoint` to page id when missing.
  - Build `Portal`/`PortalProduct` responses from known Smithy fields; drop unknown inputs.
  - Add defaults/required fields: `IntegrationResponseKey`/`RouteResponseKey` → `$default`; include `DomainNameArn`, `ApiMappingSelectionExpression`, `RoutingMode`; add `RoutingRuleArn` and default `Priority`; include `MutualTlsAuthentication` only if set; rename ListRoutingRules wrapper to `RoutingRules`; include model `Description` only when provided.

<sup>Written for commit 4169b63c8999b2cd71f586faf940fcdc4543fd92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

