### PR TITLE
feat(apigatewayv2): close conformance gap to 100%

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,43 +1,7 @@
 {
-  "variants_passed": 59832,
+  "variants_passed": 59954,
   "total_variants": 59954,
   "per_service": {
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
-    },
-    "apigateway": {
-      "passed": 2647,
-      "total": 2769
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
     "rds": {
       "passed": 5376,
       "total": 5376
@@ -46,53 +10,89 @@
       "passed": 3420,
       "total": 3420
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
     },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     },
     "cognito-idp": {
       "passed": 4479,
       "total": 4479
     },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "apigateway": {
+      "passed": 2769,
+      "total": 2769
     },
     "elasticache": {
       "passed": 2219,
       "total": 2219
     },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "scheduler": {
+      "passed": 491,
+      "total": 491
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
     },
     "sts": {
       "passed": 438,
       "total": 438
+    },
+    "states": {
+      "passed": 1292,
+      "total": 1292
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
     }
   }
 }

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,14 +1,58 @@
 {
-  "variants_passed": 59737,
+  "variants_passed": 59832,
   "total_variants": 59954,
   "per_service": {
-    "sts": {
-      "passed": 438,
-      "total": 438
+    "logs": {
+      "passed": 3911,
+      "total": 3911
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "states": {
+      "passed": 1292,
+      "total": 1292
+    },
+    "apigateway": {
+      "passed": 2647,
+      "total": 2769
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "rds": {
+      "passed": 5376,
+      "total": 5376
+    },
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "scheduler": {
+      "passed": 491,
+      "total": 491
     },
     "sqs": {
       "passed": 549,
@@ -18,81 +62,37 @@
       "passed": 2108,
       "total": 2108
     },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "states": {
-      "passed": 1292,
-      "total": 1292
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
     },
     "bedrock-runtime": {
       "passed": 412,
       "total": 412
     },
-    "apigateway": {
-      "passed": 2552,
-      "total": 2769
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
     },
     "iam": {
       "passed": 5962,
       "total": 5962
     },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
     },
     "elasticache": {
       "passed": 2219,
       "total": 2219
     },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
     "ses": {
       "passed": 2858,
       "total": 2858
     },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
+    "sts": {
+      "passed": 438,
+      "total": 438
     }
   }
 }

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1026,48 +1026,51 @@ impl ApiGatewayV2Service {
                         "arn:aws:apigateway:us-east-1::/portalproducts/{}/productpages/{}",
                         parent, id
                     ),
-                    "PageTitle": page_title,
+                    // Internal-only: the summary shape requires pageTitle
+                    // but Create/Update responses don't carry it. We
+                    // strip this before returning the response below.
+                    "_summary_pageTitle": page_title,
                     "LastModified": now,
                     "DisplayContent": dc,
                 })
             }
             "product_rest_endpoint_pages" => {
-                // EndpointDisplayContentResponse.Endpoint is a simple string
-                // (endpoint name / URL ref). If the caller sent a full
-                // Endpoint object at the root, store it separately and
-                // build a string ref for DisplayContent.Endpoint.
-                let endpoint_obj = input.get("Endpoint").cloned().unwrap_or_else(|| {
-                    json!({
-                        "ApiId": "",
-                        "StageName": "",
-                        "RouteKey": "ANY /",
-                    })
-                });
-                let mut dc = input
-                    .get("DisplayContent")
-                    .cloned()
-                    .unwrap_or_else(|| json!({}));
-                // Set a string endpoint label inside displayContent.
-                if dc
-                    .get("endpoint")
-                    .or_else(|| dc.get("Endpoint"))
-                    .and_then(|v| v.as_str())
-                    .is_none()
-                {
+                // EndpointDisplayContentResponse has only Body, Endpoint,
+                // OperationName. Input may carry EndpointDisplayContent
+                // (None, Overrides) shape — translate to the response
+                // shape rather than echoing the input.
+                let input_dc = input.get("DisplayContent").cloned().unwrap_or(json!({}));
+                let mut dc = json!({});
+                for (out_key, in_keys) in &[
+                    ("Endpoint", &["endpoint", "Endpoint"][..]),
+                    ("Body", &["body", "Body"][..]),
+                    ("OperationName", &["operationName", "OperationName"][..]),
+                ] {
+                    for in_key in *in_keys {
+                        if let Some(v) = input_dc.get(*in_key) {
+                            if !v.is_null() {
+                                dc[*out_key] = v.clone();
+                                break;
+                            }
+                        }
+                    }
+                }
+                if dc.get("Endpoint").and_then(|v| v.as_str()).is_none() {
                     dc["Endpoint"] = json!(id.clone());
                 }
                 let rei = input
                     .get("RestEndpointIdentifier")
                     .cloned()
                     .unwrap_or_else(|| json!({}));
-                let _ = endpoint_obj;
                 json!({
                     "ProductRestEndpointPageId": id,
                     "ProductRestEndpointPageArn": format!(
                         "arn:aws:apigateway:us-east-1::/portalproducts/{}/productrestendpointpages/{}",
                         parent, id
                     ),
-                    "Endpoint": id.clone(),
+                    // Internal-only: summary shape requires endpoint at
+                    // root but Create/Update responses don't carry it.
+                    "_summary_endpoint": id.clone(),
                     "Status": "AVAILABLE",
                     "LastModified": now,
                     "DisplayContent": dc,
@@ -1086,7 +1089,13 @@ impl ApiGatewayV2Service {
             _ => return Err(missing("Store")),
         };
         map.entry(parent).or_default().insert(id, entry.clone());
-        ok(entry)
+        // Strip summary-only fields that live in storage but aren't
+        // part of the Create/Update response shape.
+        let mut response = entry.clone();
+        if let Value::Object(ref mut obj) = response {
+            obj.retain(|k, _| !k.starts_with("_summary_"));
+        }
+        ok(response)
     }
 
     fn get_subresource(
@@ -1108,7 +1117,12 @@ impl ApiGatewayV2Service {
             map.get(parent)
                 .and_then(|m| m.get(id))
                 .cloned()
-                .map(ok)
+                .map(|mut v| {
+                    if let Value::Object(ref mut obj) = v {
+                        obj.retain(|k, _| !k.starts_with("_summary_"));
+                    }
+                    ok(v)
+                })
                 .unwrap_or_else(|| Err(not_found(store, id)))
         })
     }
@@ -1139,13 +1153,19 @@ impl ApiGatewayV2Service {
                             "product_pages" => json!({
                                 "ProductPageId": v.get("ProductPageId").cloned().unwrap_or(json!("")),
                                 "ProductPageArn": v.get("ProductPageArn").cloned().unwrap_or(json!("")),
-                                "PageTitle": v.get("PageTitle").cloned().unwrap_or(json!("")),
+                                "PageTitle": v.get("_summary_pageTitle")
+                                    .or_else(|| v.get("PageTitle"))
+                                    .cloned()
+                                    .unwrap_or(json!("")),
                                 "LastModified": v.get("LastModified").cloned().unwrap_or(json!("")),
                             }),
                             "product_rest_endpoint_pages" => json!({
                                 "ProductRestEndpointPageId": v.get("ProductRestEndpointPageId").cloned().unwrap_or(json!("")),
                                 "ProductRestEndpointPageArn": v.get("ProductRestEndpointPageArn").cloned().unwrap_or(json!("")),
-                                "Endpoint": v.get("Endpoint").cloned().unwrap_or(json!("")),
+                                "Endpoint": v.get("_summary_endpoint")
+                                    .or_else(|| v.get("Endpoint"))
+                                    .cloned()
+                                    .unwrap_or(json!("")),
                                 "Status": v.get("Status").cloned().unwrap_or(json!("AVAILABLE")),
                                 "TryItState": v.get("TryItState").cloned().unwrap_or(json!("DISABLED")),
                                 "LastModified": v.get("LastModified").cloned().unwrap_or(json!("")),

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -91,6 +91,168 @@ fn missing(name: &str) -> AwsServiceError {
     )
 }
 
+/// Extract a required string body field. Accepts either Pascal-case
+/// (handler-style) or camel-case (Smithy wire). Errors with a 400
+/// `BadRequestException` naming the field when absent or empty.
+fn req_str<'a>(body: &'a Value, name: &str) -> Result<&'a str, AwsServiceError> {
+    let v = body.get(name).or_else(|| {
+        // Fallback to camel-case first-letter lookup.
+        let mut chars = name.chars();
+        let lowered = match chars.next() {
+            Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+            None => String::new(),
+        };
+        body.get(&lowered)
+    });
+    match v.and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => Ok(s),
+        _ => Err(missing(name)),
+    }
+}
+
+/// Extract a required array body field. Errors with a 400 when absent
+/// or not an array.
+fn req_array<'a>(body: &'a Value, name: &str) -> Result<&'a Vec<Value>, AwsServiceError> {
+    let v = body.get(name).or_else(|| {
+        let mut chars = name.chars();
+        let lowered = match chars.next() {
+            Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+            None => String::new(),
+        };
+        body.get(&lowered)
+    });
+    match v.and_then(|v| v.as_array()) {
+        Some(a) => Ok(a),
+        _ => Err(missing(name)),
+    }
+}
+
+/// Extract a required object body field.
+fn req_object<'a>(
+    body: &'a Value,
+    name: &str,
+) -> Result<&'a serde_json::Map<String, Value>, AwsServiceError> {
+    let v = body.get(name).or_else(|| {
+        let mut chars = name.chars();
+        let lowered = match chars.next() {
+            Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+            None => String::new(),
+        };
+        body.get(&lowered)
+    });
+    match v.and_then(|v| v.as_object()) {
+        Some(o) => Ok(o),
+        _ => Err(missing(name)),
+    }
+}
+
+fn bad_request(field: &str, reason: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "BadRequestException",
+        format!("{field}: {reason}"),
+    )
+}
+
+/// Look up a body field in either Pascal- or camel-case.
+fn body_get<'a>(body: &'a Value, name: &str) -> Option<&'a Value> {
+    body.get(name).or_else(|| {
+        let mut chars = name.chars();
+        let lowered = match chars.next() {
+            Some(c) => c.to_ascii_lowercase().to_string() + chars.as_str(),
+            None => String::new(),
+        };
+        body.get(lowered)
+    })
+}
+
+/// Enforce the Smithy `@length` trait (inclusive min/max) on an optional
+/// string body field.
+fn check_length(
+    body: &Value,
+    name: &str,
+    min: Option<u64>,
+    max: Option<u64>,
+) -> Result<(), AwsServiceError> {
+    if let Some(s) = body_get(body, name).and_then(|v| v.as_str()) {
+        let len = s.chars().count() as u64;
+        if let Some(m) = min {
+            if len < m {
+                return Err(bad_request(name, &format!("length below min {m}")));
+            }
+        }
+        if let Some(m) = max {
+            if len > m {
+                return Err(bad_request(name, &format!("length above max {m}")));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Enforce the Smithy `@range` trait on an optional integer body field.
+fn check_range(
+    body: &Value,
+    name: &str,
+    min: Option<i64>,
+    max: Option<i64>,
+) -> Result<(), AwsServiceError> {
+    if let Some(n) = body_get(body, name).and_then(|v| v.as_i64()) {
+        if let Some(m) = min {
+            if n < m {
+                return Err(bad_request(name, &format!("value below min {m}")));
+            }
+        }
+        if let Some(m) = max {
+            if n > m {
+                return Err(bad_request(name, &format!("value above max {m}")));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Enforce a closed set of enum values on an optional string body field.
+fn check_enum(body: &Value, name: &str, allowed: &[&str]) -> Result<(), AwsServiceError> {
+    if let Some(s) = body_get(body, name).and_then(|v| v.as_str()) {
+        if !allowed.contains(&s) {
+            return Err(bad_request(name, "invalid enum value"));
+        }
+    }
+    Ok(())
+}
+
+/// Require a non-empty path-derived resource id. Empty ids come from
+/// probe variants that omit a `{param}` from the URI (rendering e.g.
+/// `/v2/tags/` or `/v2/portals/`); treat them as missing rather than
+/// silently succeeding.
+#[allow(dead_code)]
+fn non_empty<'a>(s: Option<&'a str>, name: &str) -> Result<&'a str, AwsServiceError> {
+    match s {
+        Some(v) if !v.is_empty() => Ok(v),
+        _ => Err(missing(name)),
+    }
+}
+
+/// An id segment is "valid" iff it's non-empty and not a literal
+/// placeholder (`{Name}` or URL-encoded `%7BName%7D`). Probe variants
+/// that omit a required label leave the template token behind; treating
+/// such paths as missing lets required-field validation fire instead of
+/// silently operating on a placeholder string.
+pub(crate) fn valid_path_id(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.starts_with('{') && s.ends_with('}') {
+        return false;
+    }
+    if (s.starts_with("%7B") || s.starts_with("%7b")) && (s.ends_with("%7D") || s.ends_with("%7d"))
+    {
+        return false;
+    }
+    true
+}
+
 fn not_found(entity: &str, id: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::NOT_FOUND,
@@ -121,14 +283,27 @@ impl ApiGatewayV2Service {
         let region = self.region_for(aid);
         let segs = &req.path_segments;
 
+        // Normalize invalid path-derived ids to None so handlers that
+        // `ok_or_else(missing)` on a required id reject the request
+        // instead of silently operating on a placeholder. See
+        // `valid_path_id` for the rules.
+        let api_id = api_id.filter(|s| valid_path_id(s));
+        let resource_id = resource_id.filter(|s| valid_path_id(s));
+
         match action {
             // ── Domain names + API mappings ──
             "CreateDomainName" => {
                 let body = body(req);
-                let name = body["DomainName"]
-                    .as_str()
-                    .ok_or_else(|| missing("DomainName"))?
-                    .to_string();
+                check_enum(
+                    &body,
+                    "RoutingMode",
+                    &[
+                        "API_MAPPING_ONLY",
+                        "ROUTING_RULE_ONLY",
+                        "ROUTING_RULE_THEN_API_MAPPING",
+                    ],
+                )?;
+                let name = req_str(&body, "DomainName")?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 let mut entry = json!({
@@ -182,19 +357,23 @@ impl ApiGatewayV2Service {
                 let name = resource_id.ok_or_else(|| missing("DomainName"))?;
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                state.domain_names.remove(name);
+                if state.domain_names.remove(name).is_none() {
+                    return Err(not_found("DomainName", name));
+                }
                 state.api_mappings.remove(name);
                 no_content()
             }
             "CreateApiMapping" => {
                 let domain = resource_id.ok_or_else(|| missing("DomainName"))?;
                 let body = body(req);
+                let api = req_str(&body, "ApiId")?.to_string();
+                let stage = req_str(&body, "Stage")?.to_string();
                 let mapping_id = rand_id();
                 let entry = json!({
                     "ApiMappingId": mapping_id,
                     "ApiMappingKey": body["ApiMappingKey"].as_str().unwrap_or(""),
-                    "ApiId": body["ApiId"].as_str().unwrap_or(""),
-                    "Stage": body["Stage"].as_str().unwrap_or(""),
+                    "ApiId": api,
+                    "Stage": stage,
                 });
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
@@ -233,6 +412,9 @@ impl ApiGatewayV2Service {
                 let domain = resource_id.ok_or_else(|| missing("DomainName"))?;
                 let mapping = api_id.ok_or_else(|| missing("ApiMappingId"))?.to_string();
                 let body = body(req);
+                // Per Smithy: UpdateApiMappingRequest.@required = ApiId,
+                // ApiMappingId, DomainName.
+                let new_api = req_str(&body, "ApiId")?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 let map = state
@@ -242,6 +424,7 @@ impl ApiGatewayV2Service {
                 let entry = map
                     .get_mut(&mapping)
                     .ok_or_else(|| not_found("ApiMapping", &mapping))?;
+                entry["ApiId"] = json!(new_api);
                 if let Some(k) = body["ApiMappingKey"].as_str() {
                     entry["ApiMappingKey"] = json!(k);
                 }
@@ -255,8 +438,13 @@ impl ApiGatewayV2Service {
                 let mapping = api_id.ok_or_else(|| missing("ApiMappingId"))?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                if let Some(map) = state.api_mappings.get_mut(domain) {
-                    map.remove(&mapping);
+                let removed = state
+                    .api_mappings
+                    .get_mut(domain)
+                    .and_then(|m| m.remove(&mapping))
+                    .is_some();
+                if !removed {
+                    return Err(not_found("ApiMapping", &mapping));
                 }
                 no_content()
             }
@@ -293,22 +481,39 @@ impl ApiGatewayV2Service {
                 let model = resource_id.ok_or_else(|| missing("ModelId"))?;
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                if let Some(m) = state.models.get_mut(api) {
-                    m.remove(model);
+                let removed = state
+                    .models
+                    .get_mut(api)
+                    .and_then(|m| m.remove(model))
+                    .is_some();
+                if !removed {
+                    return Err(not_found("Model", model));
                 }
                 no_content()
             }
-            "GetModelTemplate" => ok(json!({"Value": "{}"})),
+            "GetModelTemplate" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("ModelId"))?;
+                ok(json!({"Value": "{}"}))
+            }
 
             // ── Integration responses ──
-            "CreateIntegrationResponse" => self.put_subresponse(
-                req,
-                api_id,
-                resource_id,
-                /* is_integration */ true,
-                /* create */ true,
-            ),
+            "CreateIntegrationResponse" => {
+                let b = body(req);
+                check_enum(
+                    &b,
+                    "ContentHandlingStrategy",
+                    &["CONVERT_TO_BINARY", "CONVERT_TO_TEXT"],
+                )?;
+                self.put_subresponse(req, api_id, resource_id, true, true)
+            }
             "UpdateIntegrationResponse" => {
+                let b = body(req);
+                check_enum(
+                    &b,
+                    "ContentHandlingStrategy",
+                    &["CONVERT_TO_BINARY", "CONVERT_TO_TEXT"],
+                )?;
                 self.put_subresponse(req, api_id, resource_id, true, false)
             }
             "GetIntegrationResponse" => self.get_subresponse(req, api_id, resource_id, true),
@@ -330,6 +535,14 @@ impl ApiGatewayV2Service {
                     .ok_or_else(|| missing("DomainName"))?
                     .to_string();
                 let body = body(req);
+                let actions = req_array(&body, "Actions")?.clone();
+                let conditions = req_array(&body, "Conditions")?.clone();
+                check_range(&body, "Priority", Some(1), Some(1_000_000))?;
+                let priority = body
+                    .get("Priority")
+                    .or_else(|| body.get("priority"))
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| missing("Priority"))?;
                 let id = rand_id();
                 let entry = json!({
                     "RoutingRuleId": id,
@@ -337,9 +550,9 @@ impl ApiGatewayV2Service {
                         "arn:aws:apigateway:us-east-1::/domainnames/{}/routingrules/{}",
                         domain, id
                     ),
-                    "Priority": body.get("Priority").cloned().unwrap_or(json!(1)),
-                    "Conditions": body.get("Conditions").cloned().unwrap_or(json!([])),
-                    "Actions": body.get("Actions").cloned().unwrap_or(json!([])),
+                    "Priority": priority,
+                    "Conditions": conditions,
+                    "Actions": actions,
                 });
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
@@ -356,15 +569,23 @@ impl ApiGatewayV2Service {
                     .to_string();
                 let id = api_id.ok_or_else(|| missing("RoutingRuleId"))?.to_string();
                 let body = body(req);
+                let actions = req_array(&body, "Actions")?.clone();
+                let conditions = req_array(&body, "Conditions")?.clone();
+                check_range(&body, "Priority", Some(1), Some(1_000_000))?;
+                let priority = body
+                    .get("Priority")
+                    .or_else(|| body.get("priority"))
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| missing("Priority"))?;
                 let entry = json!({
                     "RoutingRuleId": id,
                     "RoutingRuleArn": format!(
                         "arn:aws:apigateway:us-east-1::/domainnames/{}/routingrules/{}",
                         domain, id
                     ),
-                    "Priority": body.get("Priority").cloned().unwrap_or(json!(1)),
-                    "Conditions": body.get("Conditions").cloned().unwrap_or(json!([])),
-                    "Actions": body.get("Actions").cloned().unwrap_or(json!([])),
+                    "Priority": priority,
+                    "Conditions": conditions,
+                    "Actions": actions,
                 });
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
@@ -390,6 +611,19 @@ impl ApiGatewayV2Service {
             }
             "ListRoutingRules" => {
                 let domain = resource_id.ok_or_else(|| missing("DomainName"))?;
+                // MaxResults is @range(min:1,max:100) per Smithy.
+                if let Some(mr_str) = req
+                    .query_params
+                    .iter()
+                    .find(|(k, _)| *k == "maxResults")
+                    .map(|(_, v)| v.as_str())
+                {
+                    if let Ok(n) = mr_str.parse::<i64>() {
+                        if !(1..=100).contains(&n) {
+                            return Err(bad_request("MaxResults", "value out of range [1,100]"));
+                        }
+                    }
+                }
                 self.read_state(aid, &region, |state| {
                     let rules: Vec<Value> = state
                         .routing_rules
@@ -406,8 +640,13 @@ impl ApiGatewayV2Service {
                 let id = api_id.ok_or_else(|| missing("RoutingRuleId"))?.to_string();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                if let Some(m) = state.routing_rules.get_mut(&domain) {
-                    m.remove(&id);
+                let removed = state
+                    .routing_rules
+                    .get_mut(&domain)
+                    .and_then(|m| m.remove(&id))
+                    .is_some();
+                if !removed {
+                    return Err(not_found("RoutingRule", &id));
                 }
                 no_content()
             }
@@ -415,11 +654,13 @@ impl ApiGatewayV2Service {
             // ── VPC links ──
             "CreateVpcLink" => {
                 let body = body(req);
+                let name = req_str(&body, "Name")?.to_string();
+                let subnet_ids = req_array(&body, "SubnetIds")?.clone();
                 let id = rand_id();
                 let entry = json!({
                     "VpcLinkId": id,
-                    "Name": body["Name"].as_str().unwrap_or(""),
-                    "SubnetIds": body.get("SubnetIds").cloned().unwrap_or(json!([])),
+                    "Name": name,
+                    "SubnetIds": subnet_ids,
                     "SecurityGroupIds": body.get("SecurityGroupIds").cloned().unwrap_or(json!([])),
                     "VpcLinkStatus": "AVAILABLE",
                 });
@@ -461,7 +702,9 @@ impl ApiGatewayV2Service {
                 let id = resource_id.ok_or_else(|| missing("VpcLinkId"))?;
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                state.vpc_links.remove(id);
+                if state.vpc_links.remove(id).is_none() {
+                    return Err(not_found("VpcLink", id));
+                }
                 no_content()
             }
 
@@ -471,20 +714,28 @@ impl ApiGatewayV2Service {
                     .ok_or_else(|| missing("ResourceArn"))?
                     .to_string();
                 let body = body(req);
+                let tags_in = req_object(&body, "Tags")?.clone();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 let tags = state.tags.entry(arn).or_default();
-                if let Some(map) = body["Tags"].as_object() {
-                    for (k, v) in map {
-                        if let Some(s) = v.as_str() {
-                            tags.insert(k.clone(), s.to_string());
-                        }
+                for (k, v) in &tags_in {
+                    if let Some(s) = v.as_str() {
+                        tags.insert(k.clone(), s.to_string());
                     }
                 }
                 no_content()
             }
             "UntagResource" => {
                 let arn = resource_id.ok_or_else(|| missing("ResourceArn"))?;
+                // TagKeys is a required @httpQuery param per Smithy — the
+                // SDK renders each entry as `tagKeys={key}`.
+                let has_tag_keys = req
+                    .query_params
+                    .iter()
+                    .any(|(k, _)| k == "tagKeys" || k.starts_with("tagKeys"));
+                if !has_tag_keys {
+                    return Err(missing("TagKeys"));
+                }
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 if let Some(tags) = state.tags.get_mut(arn) {
@@ -505,19 +756,51 @@ impl ApiGatewayV2Service {
             }
 
             // ── Portals + portal products + product pages ──
-            "CreatePortal" | "UpdatePortal" => self.put_keyed(
-                req,
-                resource_id,
-                "PortalId",
-                /* store */ "portals",
-                aid,
-            ),
+            "CreatePortal" => {
+                // Per Smithy, CreatePortalRequest.@required = Authorization,
+                // EndpointConfiguration, PortalContent. Validate before
+                // delegating to put_keyed.
+                let b = body(req);
+                req_object(&b, "Authorization")?;
+                req_object(&b, "EndpointConfiguration")?;
+                req_object(&b, "PortalContent")?;
+                check_length(&b, "LogoUri", None, Some(1092))?;
+                check_length(&b, "RumAppMonitorName", None, Some(255))?;
+                self.put_keyed(req, resource_id, "PortalId", "portals", aid)
+            }
+            "UpdatePortal" => {
+                resource_id.ok_or_else(|| missing("PortalId"))?;
+                let b = body(req);
+                check_length(&b, "LogoUri", None, Some(1092))?;
+                check_length(&b, "RumAppMonitorName", None, Some(255))?;
+                self.put_keyed(req, resource_id, "PortalId", "portals", aid)
+            }
             "GetPortal" => self.get_keyed(resource_id, "portals", aid, &region),
             "ListPortals" => self.list_keyed("portals", aid, &region),
             "DeletePortal" => self.delete_keyed(resource_id, "portals", aid),
-            "DisablePortal" | "PreviewPortal" | "PublishPortal" => empty_ok(),
+            "DisablePortal" | "PreviewPortal" => {
+                resource_id.ok_or_else(|| missing("PortalId"))?;
+                empty_ok()
+            }
+            "PublishPortal" => {
+                resource_id.ok_or_else(|| missing("PortalId"))?;
+                let b = body(req);
+                check_length(&b, "Description", None, Some(1024))?;
+                empty_ok()
+            }
 
-            "CreatePortalProduct" | "UpdatePortalProduct" => {
+            "CreatePortalProduct" => {
+                let b = body(req);
+                req_str(&b, "DisplayName")?;
+                check_length(&b, "DisplayName", Some(1), Some(255))?;
+                check_length(&b, "Description", None, Some(1024))?;
+                self.put_keyed(req, resource_id, "PortalProductId", "portal_products", aid)
+            }
+            "UpdatePortalProduct" => {
+                resource_id.ok_or_else(|| missing("PortalProductId"))?;
+                let b = body(req);
+                check_length(&b, "DisplayName", Some(1), Some(255))?;
+                check_length(&b, "Description", None, Some(1024))?;
                 self.put_keyed(req, resource_id, "PortalProductId", "portal_products", aid)
             }
             "GetPortalProduct" => self.get_keyed(resource_id, "portal_products", aid, &region),
@@ -527,6 +810,7 @@ impl ApiGatewayV2Service {
             "PutPortalProductSharingPolicy" => {
                 let id = resource_id.ok_or_else(|| missing("PortalProductId"))?;
                 let body = body(req);
+                req_str(&body, "PolicyDocument")?;
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 state
@@ -549,17 +833,37 @@ impl ApiGatewayV2Service {
                 let id = resource_id.ok_or_else(|| missing("PortalProductId"))?;
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
-                state.portal_product_sharing_policies.remove(id);
+                if state.portal_product_sharing_policies.remove(id).is_none() {
+                    return Err(not_found("PortalProductSharingPolicy", id));
+                }
                 no_content()
             }
 
-            "CreateProductPage" | "UpdateProductPage" => self.put_subresource(
-                req,
-                resource_id,
-                segs.get(4).map(|s| s.to_string()),
-                "product_pages",
-                aid,
-            ),
+            "CreateProductPage" => {
+                let b = body(req);
+                req_object(&b, "DisplayContent")?;
+                self.put_subresource(
+                    req,
+                    resource_id,
+                    segs.get(4).map(|s| s.to_string()),
+                    "product_pages",
+                    aid,
+                )
+            }
+            "UpdateProductPage" => {
+                resource_id.ok_or_else(|| missing("PortalProductId"))?;
+                let page_id = segs.get(4).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(page_id) {
+                    return Err(missing("ProductPageId"));
+                }
+                self.put_subresource(
+                    req,
+                    resource_id,
+                    Some(page_id.to_string()),
+                    "product_pages",
+                    aid,
+                )
+            }
             "GetProductPage" => self.get_subresource(
                 resource_id,
                 segs.get(4).map(|s| s.as_str()),
@@ -576,14 +880,34 @@ impl ApiGatewayV2Service {
                 "product_pages",
                 aid,
             ),
-            "CreateProductRestEndpointPage" | "UpdateProductRestEndpointPage" => self
-                .put_subresource(
+            "CreateProductRestEndpointPage" => {
+                let b = body(req);
+                req_object(&b, "RestEndpointIdentifier")?;
+                check_enum(&b, "TryItState", &["ENABLED", "DISABLED"])?;
+                self.put_subresource(
                     req,
                     resource_id,
                     segs.get(4).map(|s| s.to_string()),
                     "product_rest_endpoint_pages",
                     aid,
-                ),
+                )
+            }
+            "UpdateProductRestEndpointPage" => {
+                resource_id.ok_or_else(|| missing("PortalProductId"))?;
+                let page_id = segs.get(4).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(page_id) {
+                    return Err(missing("ProductRestEndpointPageId"));
+                }
+                let b = body(req);
+                check_enum(&b, "TryItState", &["ENABLED", "DISABLED"])?;
+                self.put_subresource(
+                    req,
+                    resource_id,
+                    Some(page_id.to_string()),
+                    "product_rest_endpoint_pages",
+                    aid,
+                )
+            }
             "GetProductRestEndpointPage" => self.get_subresource(
                 resource_id,
                 segs.get(4).map(|s| s.as_str()),
@@ -603,6 +927,8 @@ impl ApiGatewayV2Service {
 
             // ── Import / Export ──
             "ImportApi" => {
+                let body = body(req);
+                req_str(&body, "Body")?;
                 let api_id = format!("imported-{}", rand_id());
                 ok(json!({
                     "ApiId": api_id,
@@ -610,20 +936,77 @@ impl ApiGatewayV2Service {
                     "ProtocolType": "HTTP",
                 }))
             }
-            "ReimportApi" => ok(json!({"ApiId": api_id.unwrap_or_default(), "Name": "reimported"})),
-            "ExportApi" => ok(json!({"body": "openapi: 3.0.1\n"})),
+            "ReimportApi" => {
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let body = body(req);
+                req_str(&body, "Body")?;
+                ok(json!({"ApiId": api, "Name": "reimported"}))
+            }
+            "ExportApi" => {
+                let _api = api_id.ok_or_else(|| missing("ApiId"))?;
+                // Specification is an httpLabel (segs[4]) — already filtered
+                // to None for empty/placeholder path ids, so resource_id=None
+                // here means the caller omitted it.
+                let _spec = resource_id.ok_or_else(|| missing("Specification"))?;
+                let output_type = req
+                    .query_params
+                    .iter()
+                    .find(|(k, _)| *k == "outputType")
+                    .map(|(_, v)| v.as_str());
+                if output_type.is_none() {
+                    return Err(missing("OutputType"));
+                }
+                ok(json!({"body": "openapi: 3.0.1\n"}))
+            }
 
             // ── Cleanup ops ──
-            "DeleteCorsConfiguration"
-            | "DeleteAccessLogSettings"
-            | "DeleteRouteRequestParameter"
-            | "DeleteRouteSettings"
-            | "DeleteDeployment" => no_content(),
-            "UpdateDeployment" => ok(json!({
-                "DeploymentId": resource_id.unwrap_or_default(),
-                "DeploymentStatus": "DEPLOYED",
-            })),
-            "ResetAuthorizersCache" => no_content(),
+            "DeleteCorsConfiguration" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                no_content()
+            }
+            "DeleteAccessLogSettings" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("StageName"))?;
+                no_content()
+            }
+            "DeleteRouteRequestParameter" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("RouteId"))?;
+                // RequestParameterKey is segs[6]; enforce non-empty too.
+                let key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(key) {
+                    return Err(missing("RequestParameterKey"));
+                }
+                no_content()
+            }
+            "DeleteRouteSettings" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("StageName"))?;
+                let key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(key) {
+                    return Err(missing("RouteKey"));
+                }
+                no_content()
+            }
+            "DeleteDeployment" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("DeploymentId"))?;
+                no_content()
+            }
+            "UpdateDeployment" => {
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let dep = resource_id.ok_or_else(|| missing("DeploymentId"))?;
+                let _ = api;
+                ok(json!({
+                    "DeploymentId": dep,
+                    "DeploymentStatus": "DEPLOYED",
+                }))
+            }
+            "ResetAuthorizersCache" => {
+                api_id.ok_or_else(|| missing("ApiId"))?;
+                resource_id.ok_or_else(|| missing("StageName"))?;
+                no_content()
+            }
 
             _ => Err(AwsServiceError::action_not_implemented(
                 "apigateway",
@@ -640,6 +1023,11 @@ impl ApiGatewayV2Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let api = api_id.ok_or_else(|| missing("ApiId"))?.to_string();
         let body = body(req);
+        // CreateModelRequest.@required = ApiId, Name, Schema.
+        if is_create {
+            req_str(&body, "Name")?;
+            req_str(&body, "Schema")?;
+        }
         let id = if is_create {
             rand_id()
         } else {
@@ -683,6 +1071,17 @@ impl ApiGatewayV2Service {
                 missing("RouteId")
             }
         })?;
+        let entry = body(req);
+        // On Create, the response-key is required per Smithy (members
+        // IntegrationResponseKey / RouteResponseKey).
+        if is_create {
+            let key_name = if is_integration {
+                "IntegrationResponseKey"
+            } else {
+                "RouteResponseKey"
+            };
+            req_str(&entry, key_name)?;
+        }
         let id = if is_create {
             rand_id()
         } else {
@@ -691,7 +1090,6 @@ impl ApiGatewayV2Service {
                 .map(|s| s.to_string())
                 .ok_or_else(|| missing("ResponseId"))?
         };
-        let entry = body(req);
         let key = format!("{parent}/{id}");
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -811,8 +1209,9 @@ impl ApiGatewayV2Service {
         } else {
             &mut state.route_responses
         };
-        if let Some(map) = store.get_mut(&api) {
-            map.remove(&key);
+        let removed = store.get_mut(&api).and_then(|m| m.remove(&key)).is_some();
+        if !removed {
+            return Err(not_found("Response", &id));
         }
         no_content()
     }
@@ -977,7 +1376,9 @@ impl ApiGatewayV2Service {
             "portal_products" => &mut state.portal_products,
             _ => return Err(missing("Store")),
         };
-        map.remove(id);
+        if map.remove(id).is_none() {
+            return Err(not_found(store, id));
+        }
         no_content()
     }
 
@@ -1196,8 +1597,9 @@ impl ApiGatewayV2Service {
             "product_rest_endpoint_pages" => &mut state.product_rest_endpoint_pages,
             _ => return Err(missing("Store")),
         };
-        if let Some(m) = map.get_mut(parent) {
-            m.remove(id);
+        let removed = map.get_mut(parent).and_then(|m| m.remove(id)).is_some();
+        if !removed {
+            return Err(not_found(store, id));
         }
         no_content()
     }
@@ -1243,13 +1645,26 @@ mod tests {
     }
 
     fn req(action: &str, body: &str, segs: &[&str]) -> AwsRequest {
+        req_with_query(action, body, segs, &[])
+    }
+
+    fn req_with_query(
+        action: &str,
+        body: &str,
+        segs: &[&str],
+        query: &[(&str, &str)],
+    ) -> AwsRequest {
+        let mut qp = HashMap::new();
+        for (k, v) in query {
+            qp.insert((*k).to_string(), (*v).to_string());
+        }
         AwsRequest {
             service: "apigatewayv2".to_string(),
             method: Method::POST,
             raw_path: format!("/{}", segs.join("/")),
             raw_query: String::new(),
             path_segments: segs.iter().map(|s| s.to_string()).collect(),
-            query_params: HashMap::new(),
+            query_params: qp,
             headers: http::HeaderMap::new(),
             body: bytes::Bytes::from(body.to_string()),
             account_id: "000000000000".to_string(),
@@ -1347,7 +1762,7 @@ mod tests {
         run(
             &s,
             "CreateVpcLink",
-            r#"{"Name":"l"}"#,
+            r#"{"Name":"l","SubnetIds":["s-1"]}"#,
             &["v2", "vpclinks"],
             None,
             None,
@@ -1356,7 +1771,7 @@ mod tests {
         run(
             &s,
             "CreateRoutingRule",
-            r#"{}"#,
+            r#"{"Actions":[],"Conditions":[],"Priority":1}"#,
             &["v2", "domainnames", "d", "routingrules"],
             None,
             Some("d"),
@@ -1378,18 +1793,22 @@ mod tests {
             Some("arn"),
         );
         run(&s, "GetTags", "", &["v2", "tags", "arn"], None, Some("arn"));
-        run(
-            &s,
-            "UntagResource",
-            "",
-            &["v2", "tags", "arn"],
-            None,
-            Some("arn"),
-        );
+        {
+            // Seed a tag then untag via query params to match the Smithy
+            // @httpQuery("tagKeys") binding.
+            let r = req_with_query(
+                "UntagResource",
+                "",
+                &["v2", "tags", "arn"],
+                &[("tagKeys", "k")],
+            );
+            s.handle_extra_action("UntagResource", &r, None, Some("arn"))
+                .expect("UntagResource");
+        }
         run(
             &s,
             "CreatePortal",
-            r#"{"Name":"p"}"#,
+            r#"{"Authorization":{},"EndpointConfiguration":{},"PortalContent":{}}"#,
             &["v2", "portals"],
             None,
             Some("p"),
@@ -1430,7 +1849,7 @@ mod tests {
         run(
             &s,
             "CreatePortalProduct",
-            r#"{"Name":"pp"}"#,
+            r#"{"DisplayName":"pp"}"#,
             &["v2", "portalproducts"],
             None,
             Some("pp"),
@@ -1454,7 +1873,7 @@ mod tests {
         run(
             &s,
             "PutPortalProductSharingPolicy",
-            "{}",
+            r#"{"PolicyDocument":"{}"}"#,
             &["v2", "portalproducts", "pp", "sharing-policy"],
             None,
             Some("pp"),
@@ -1481,7 +1900,7 @@ mod tests {
     fn models_and_responses() {
         ok(
             "CreateModel",
-            r#"{"Name":"m"}"#,
+            r#"{"Name":"m","Schema":"{}"}"#,
             &["v2", "apis", "a1", "models"],
             Some("a1"),
             None,
@@ -1560,13 +1979,18 @@ mod tests {
             Some("a1"),
             None,
         );
-        ok(
-            "ExportApi",
-            "",
-            &["v2", "apis", "a1", "exports", "OAS30"],
-            Some("a1"),
-            None,
-        );
+        {
+            // ExportApi requires @httpQuery("outputType") + path Specification.
+            let s = svc();
+            let r = req_with_query(
+                "ExportApi",
+                "",
+                &["v2", "apis", "a1", "exports", "OAS30"],
+                &[("outputType", "JSON")],
+            );
+            s.handle_extra_action("ExportApi", &r, Some("a1"), Some("OAS30"))
+                .expect("ExportApi");
+        }
         ok(
             "DeleteCorsConfiguration",
             "",

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -482,6 +482,11 @@ impl ApiGatewayV2Service {
                 format!("Unknown path: {}", req.raw_path),
             )
         })?;
+        // Normalize invalid path-derived ids to None so handlers that
+        // require an id reject the request instead of silently
+        // operating on a placeholder. See extras::valid_path_id.
+        let api_id = api_id.filter(|s| crate::extras::valid_path_id(s));
+        let resource_id = resource_id.filter(|s| crate::extras::valid_path_id(s));
         let mutates = action.starts_with("Create")
             || action.starts_with("Update")
             || action.starts_with("Delete")


### PR DESCRIPTION
## Summary
- apigatewayv2 conformance now at **2769/2769 = 100.0%** (overall 59954/59954 = 100.00%)
- Enforces Smithy @required, @length, @range, and @enum constraints on apigwv2 management handlers so every `negative_*` probe variant returns a 4xx instead of silently succeeding
- New helpers: `req_str` / `req_array` / `req_object` for required body fields, `check_length` / `check_range` / `check_enum` for constraint traits, `valid_path_id` for placeholder/URL-encoded `{Name}` detection
- Update* handlers now require their own path id explicitly so `put_keyed` and `put_subresource` can't fabricate a new entity when the caller omits the label

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test -p fakecloud-apigatewayv2 --lib` (83 passed)
- [x] `fakecloud-conformance run --services apigateway` — 2769/2769
- [x] `fakecloud-conformance run` full sweep — 59954/59954 = 100%
- [x] Baseline updated: `conformance-baseline.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Smithy validation and path-id checks for API Gateway v2 management APIs so invalid requests return 4xx. This brings apigatewayv2 conformance to 100% (2769/2769) and overall to 100% (59954/59954).

- New Features
  - Added validation helpers (`req_str`, `req_array`, `req_object`, `check_length`, `check_range`, `check_enum`) and `valid_path_id`. Update operations now require their path id to prevent accidental creates.
  - Normalized empty or placeholder path labels (e.g., `{Name}`, `%7BName%7D`) to “missing”, so handlers reject omitted labels with a 400.

- Bug Fixes
  - Enforced Smithy-required fields and constraints across operations (e.g., DomainName routing mode, ContentHandlingStrategy, RoutingRule Priority and ListRoutingRules MaxResults, portal/product field lengths, TryItState, response-key required on create).
  - Required explicit ids/params where missing before: GetModelTemplate needs ApiId/ModelId; Import/Reimport need Body; ExportApi needs Specification + `outputType`; UntagResource needs `tagKeys`; CreateVpcLink needs Name + SubnetIds.
  - Delete operations now return 404 when the resource does not exist; adjusted product page and REST endpoint page responses to strip internal summary-only fields from Create/Update responses.

<sup>Written for commit 51a749c6e01f6950e59a9a38b0f432821cf78f22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

