### PR TITLE
content(blog): sharpen title of LocalStack Ultimate Bedrock post

### DIFF
--- a/website/content/blog/localstack-ultimate-bedrock.md
+++ b/website/content/blog/localstack-ultimate-bedrock.md
@@ -1,5 +1,5 @@
 +++
-title = "LocalStack Ultimate for Bedrock: 4 operations, Ollama-backed, top-tier pricing"
+title = "LocalStack Ultimate covers 4 Bedrock ops. Here's why that's the wrong bet for tests."
 date = 2026-04-22
 description = "LocalStack supports Bedrock only on their Ultimate plan, and only four operations, all backed by Ollama. Here's what that gets you, what it doesn't, and why fakecloud's approach is different."
 


### PR DESCRIPTION
## Summary

- Old title: `LocalStack Ultimate for Bedrock: 4 operations, Ollama-backed, top-tier pricing`
- New title: `LocalStack Ultimate covers 4 Bedrock ops. Here's why that's the wrong bet for tests.`

Old title read like ad copy for LocalStack (listed features, no critique). New title flags the critique in the hook itself — dev scanning HN/Dev.to sees the frame immediately.

Post shipped today (~2h ago); minimal SEO cost to retitle now.

## Test plan

- [x] Zola builds
- [x] Slug unchanged (`/blog/localstack-ultimate-bedrock/`)
- [x] Canonical URL unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retitled the blog post to sharpen the hook and make the critique clear: "LocalStack Ultimate for Bedrock: 4 operations, Ollama-backed, top-tier pricing" → "LocalStack Ultimate covers 4 Bedrock ops. Here's why that's the wrong bet for tests."
Slug `/blog/localstack-ultimate-bedrock/` and canonical URL unchanged.

<sup>Written for commit 1cf1a1b6a8454e3f15fad59b9b8dd2241ec3f3da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

