### PR TITLE
feat(ecr): Batch 2 — image + layer ops, content-addressed blob storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Local AWS cloud emulator. Part of the faisca project family.
 ## Product Context
 
 - FakeCloud is a local AWS emulator focused on high-fidelity behavior and AWS-compatible responses.
-- Current project state from prior work: 24 services, with SES, Cognito User Pools, Docker-backed Lambda execution, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock (111 ops), Bedrock Runtime, and ECR (Batch 1: repositories + tags + policies; image ops and OCI push/pull land in follow-up batches) already shipped.
+- Current project state from prior work: 24 services, with SES, Cognito User Pools, Docker-backed Lambda execution, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock (111 ops), Bedrock Runtime, and ECR (Batches 1-2: repositories + tags + policies + images + layers with content-addressed blob storage; OCI v2 Distribution push/pull lands in Batch 3) already shipped.
 - The broader roadmap prioritizes services that LocalStack keeps behind paid tiers, especially ECS, ELB/ALB, CloudFront, CloudWatch Metrics, and EC2.
 - Introspection SDKs (Rust, Python, TypeScript, Go, PHP, Java) are already built and maintained for the `/_fakecloud/*` endpoints.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-24 services, 1,691 operations, 100% conformance per implemented service.
+24 services, 1,701 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -75,7 +75,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | API Gateway v2         |  28 | HTTP APIs, Lambda proxy, JWT/Lambda authorizers, CORS                  |
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
-| ECR                    |  11 | Repositories, tags, policies; image + OCI push/pull in follow-ups      |
+| ECR                    |  21 | Repositories, images, layers, tags, policies; OCI push/pull next       |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -114,7 +114,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | ElastiCache         | 75 operations, Redis and Valkey via Docker         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | API Gateway v2      | 28 operations, full HTTP API support               | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
-| ECR                 | 11 control-plane ops so far, full push/pull next   | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| ECR                 | 21 ops (repos + images + layers), OCI push/pull next | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,74 +1,58 @@
 {
-  "variants_passed": 60285,
+  "variants_passed": 60621,
   "total_variants": 61743,
   "per_service": {
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
-    },
-    "scheduler": {
-      "passed": 491,
-      "total": 491
-    },
-    "apigateway": {
-      "passed": 2769,
-      "total": 2769
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
     },
     "kms": {
       "passed": 2196,
       "total": 2196
     },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
-    },
-    "ecr": {
-      "passed": 331,
-      "total": 1789
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
     },
     "sqs": {
       "passed": 549,
       "total": 549
     },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
+    "events": {
+      "passed": 2108,
+      "total": 2108
     },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
     },
     "iam": {
       "passed": 5962,
       "total": 5962
+    },
+    "dynamodb": {
+      "passed": 2123,
+      "total": 2123
+    },
+    "apigateway": {
+      "passed": 2769,
+      "total": 2769
+    },
+    "scheduler": {
+      "passed": 491,
+      "total": 491
+    },
+    "elasticache": {
+      "passed": 2219,
+      "total": 2219
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 852
     },
     "ssm": {
       "passed": 5303,
@@ -78,25 +62,41 @@
       "passed": 1292,
       "total": 1292
     },
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
+    },
     "lambda": {
       "passed": 3347,
       "total": 3347
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
     },
     "sts": {
       "passed": 438,
       "total": 438
     },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
-    "elasticache": {
-      "passed": 2219,
-      "total": 2219
+    "ecr": {
+      "passed": 667,
+      "total": 1789
+    },
+    "logs": {
+      "passed": 3911,
+      "total": 3911
+    },
+    "rds": {
+      "passed": 5376,
+      "total": 5376
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
+    },
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/ecr.rs
+++ b/crates/fakecloud-conformance/tests/ecr.rs
@@ -177,6 +177,315 @@ async fn ecr_delete_repository_policy() {
         .unwrap();
 }
 
+#[test_action("ecr", "PutImage", checksum = "6e4bc561")]
+#[tokio::test]
+async fn ecr_put_image() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-putimg")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .put_image()
+        .repository_name("confo-putimg")
+        .image_manifest(r#"{"schemaVersion":2}"#)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.image().is_some());
+}
+
+#[test_action("ecr", "BatchGetImage", checksum = "753d3e24")]
+#[tokio::test]
+async fn ecr_batch_get_image() {
+    use aws_sdk_ecr::types::ImageIdentifier;
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-batchget")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_image()
+        .repository_name("confo-batchget")
+        .image_manifest(r#"{"a":1}"#)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .batch_get_image()
+        .repository_name("confo-batchget")
+        .image_ids(ImageIdentifier::builder().image_tag("v1").build())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.images().len(), 1);
+}
+
+#[test_action("ecr", "BatchDeleteImage", checksum = "523e89b9")]
+#[tokio::test]
+async fn ecr_batch_delete_image() {
+    use aws_sdk_ecr::types::ImageIdentifier;
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-batchdel")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_image()
+        .repository_name("confo-batchdel")
+        .image_manifest(r#"{"a":1}"#)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    client
+        .batch_delete_image()
+        .repository_name("confo-batchdel")
+        .image_ids(ImageIdentifier::builder().image_tag("v1").build())
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ecr", "BatchCheckLayerAvailability", checksum = "eb040870")]
+#[tokio::test]
+async fn ecr_batch_check_layer_availability() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-checklayer")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .batch_check_layer_availability()
+        .repository_name("confo-checklayer")
+        .layer_digests("sha256:deadbeef")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.failures().is_empty());
+}
+
+#[test_action("ecr", "DescribeImages", checksum = "822fc635")]
+#[tokio::test]
+async fn ecr_describe_images() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-descrimg")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_image()
+        .repository_name("confo-descrimg")
+        .image_manifest(r#"{"a":1}"#)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_images()
+        .repository_name("confo-descrimg")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.image_details().len(), 1);
+}
+
+#[test_action("ecr", "ListImages", checksum = "f082164b")]
+#[tokio::test]
+async fn ecr_list_images() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-listimg")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_image()
+        .repository_name("confo-listimg")
+        .image_manifest(r#"{"a":1}"#)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .list_images()
+        .repository_name("confo-listimg")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.image_ids().len(), 1);
+}
+
+#[test_action("ecr", "GetDownloadUrlForLayer", checksum = "5d5dfa91")]
+#[tokio::test]
+async fn ecr_get_download_url_for_layer() {
+    use aws_sdk_ecr::primitives::Blob;
+    use sha2::{Digest, Sha256};
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-dlurl")
+        .send()
+        .await
+        .unwrap();
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("confo-dlurl")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+    let blob = b"x".to_vec();
+    let digest = {
+        let mut h = Sha256::new();
+        h.update(&blob);
+        format!("sha256:{:x}", h.finalize())
+    };
+    client
+        .upload_layer_part()
+        .repository_name("confo-dlurl")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte(0)
+        .layer_part_blob(Blob::new(blob))
+        .send()
+        .await
+        .unwrap();
+    client
+        .complete_layer_upload()
+        .repository_name("confo-dlurl")
+        .upload_id(&upload_id)
+        .layer_digests(&digest)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get_download_url_for_layer()
+        .repository_name("confo-dlurl")
+        .layer_digest(&digest)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.download_url().unwrap().contains(&digest));
+}
+
+#[test_action("ecr", "InitiateLayerUpload", checksum = "f7d9ee29")]
+#[tokio::test]
+async fn ecr_initiate_layer_upload() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-initup")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .initiate_layer_upload()
+        .repository_name("confo-initup")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.upload_id().is_some());
+}
+
+#[test_action("ecr", "UploadLayerPart", checksum = "5312a154")]
+#[tokio::test]
+async fn ecr_upload_layer_part() {
+    use aws_sdk_ecr::primitives::Blob;
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-uppart")
+        .send()
+        .await
+        .unwrap();
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("confo-uppart")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+    client
+        .upload_layer_part()
+        .repository_name("confo-uppart")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte(2)
+        .layer_part_blob(Blob::new(vec![1u8, 2, 3]))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ecr", "CompleteLayerUpload", checksum = "06e7311e")]
+#[tokio::test]
+async fn ecr_complete_layer_upload() {
+    use aws_sdk_ecr::primitives::Blob;
+    use sha2::{Digest, Sha256};
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("confo-complete")
+        .send()
+        .await
+        .unwrap();
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("confo-complete")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+    let blob = vec![1u8, 2, 3];
+    let digest = {
+        let mut h = Sha256::new();
+        h.update(&blob);
+        format!("sha256:{:x}", h.finalize())
+    };
+    client
+        .upload_layer_part()
+        .repository_name("confo-complete")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte(2)
+        .layer_part_blob(Blob::new(blob))
+        .send()
+        .await
+        .unwrap();
+    client
+        .complete_layer_upload()
+        .repository_name("confo-complete")
+        .upload_id(&upload_id)
+        .layer_digests(&digest)
+        .send()
+        .await
+        .unwrap();
+}
+
 #[test_action("ecr", "TagResource", checksum = "866cf7cc")]
 #[tokio::test]
 async fn ecr_tag_resource() {

--- a/crates/fakecloud-e2e/tests/ecr_images.rs
+++ b/crates/fakecloud-e2e/tests/ecr_images.rs
@@ -92,6 +92,81 @@ async fn layer_upload_round_trip() {
 }
 
 #[tokio::test]
+async fn complete_layer_upload_retry_after_bad_digest() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("retry-repo")
+        .send()
+        .await
+        .unwrap();
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("retry-repo")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+    let blob = b"retry-bytes".to_vec();
+    let real_digest = sha256_digest(&blob);
+    client
+        .upload_layer_part()
+        .repository_name("retry-repo")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte((blob.len() as i64) - 1)
+        .layer_part_blob(Blob::new(blob))
+        .send()
+        .await
+        .unwrap();
+    // First complete with wrong digest — must fail WITHOUT dropping upload state.
+    client
+        .complete_layer_upload()
+        .repository_name("retry-repo")
+        .upload_id(&upload_id)
+        .layer_digests("sha256:deadbeef")
+        .send()
+        .await
+        .expect_err("wrong digest fails");
+    // Retry with the real digest using the same upload id.
+    client
+        .complete_layer_upload()
+        .repository_name("retry-repo")
+        .upload_id(&upload_id)
+        .layer_digests(&real_digest)
+        .send()
+        .await
+        .expect("retry with correct digest should succeed");
+}
+
+#[tokio::test]
+async fn put_image_rejects_mismatched_supplied_digest() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("digest-check-repo")
+        .send()
+        .await
+        .unwrap();
+    let err = client
+        .put_image()
+        .repository_name("digest-check-repo")
+        .image_manifest(r#"{"x":1}"#)
+        .image_digest("sha256:deadbeef")
+        .send()
+        .await
+        .expect_err("mismatched digest should fail");
+    assert!(
+        format!("{err:?}").contains("ImageDigestDoesNotMatch"),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
 async fn upload_layer_part_digest_mismatch_is_rejected() {
     let server = TestServer::start().await;
     let client = server.ecr_client().await;

--- a/crates/fakecloud-e2e/tests/ecr_images.rs
+++ b/crates/fakecloud-e2e/tests/ecr_images.rs
@@ -1,0 +1,356 @@
+//! ECR Batch 2: image + layer operations end-to-end.
+
+mod helpers;
+
+use aws_sdk_ecr::primitives::Blob;
+use helpers::TestServer;
+use sha2::{Digest, Sha256};
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+#[tokio::test]
+async fn layer_upload_round_trip() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("layers-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("layers-repo")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+    assert!(init.part_size().unwrap_or(0) >= 1);
+
+    let blob = b"hello-fakecloud-ecr-layer".to_vec();
+    let expected_digest = sha256_digest(&blob);
+
+    let part = client
+        .upload_layer_part()
+        .repository_name("layers-repo")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte((blob.len() as i64) - 1)
+        .layer_part_blob(Blob::new(blob.clone()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(part.last_byte_received(), Some((blob.len() as i64) - 1),);
+
+    let complete = client
+        .complete_layer_upload()
+        .repository_name("layers-repo")
+        .upload_id(&upload_id)
+        .layer_digests(&expected_digest)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(complete.layer_digest(), Some(expected_digest.as_str()));
+
+    let avail = client
+        .batch_check_layer_availability()
+        .repository_name("layers-repo")
+        .layer_digests(&expected_digest)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(avail.layers().len(), 1);
+    assert_eq!(
+        avail.layers()[0].layer_digest(),
+        Some(expected_digest.as_str())
+    );
+    assert_eq!(
+        avail.layers()[0].layer_availability().unwrap().as_str(),
+        "AVAILABLE"
+    );
+
+    // Download URL should reference the /v2 path even though Batch 3 hasn't landed.
+    let dl = client
+        .get_download_url_for_layer()
+        .repository_name("layers-repo")
+        .layer_digest(&expected_digest)
+        .send()
+        .await
+        .unwrap();
+    let url = dl.download_url().unwrap();
+    assert!(
+        url.contains("/v2/layers-repo/blobs/"),
+        "unexpected url: {url}"
+    );
+    assert!(url.contains(&expected_digest));
+}
+
+#[tokio::test]
+async fn upload_layer_part_digest_mismatch_is_rejected() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("bad-digest-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let init = client
+        .initiate_layer_upload()
+        .repository_name("bad-digest-repo")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = init.upload_id().unwrap().to_string();
+
+    let blob = b"real-bytes".to_vec();
+    client
+        .upload_layer_part()
+        .repository_name("bad-digest-repo")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte((blob.len() as i64) - 1)
+        .layer_part_blob(Blob::new(blob))
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .complete_layer_upload()
+        .repository_name("bad-digest-repo")
+        .upload_id(&upload_id)
+        .layer_digests("sha256:deadbeef")
+        .send()
+        .await
+        .expect_err("mismatched digest should fail");
+    assert!(
+        format!("{err:?}").contains("LayerDigestMismatch"),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn put_image_and_describe() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("image-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let manifest = r#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":7023,"digest":"sha256:dummy"},"layers":[]}"#;
+    let put = client
+        .put_image()
+        .repository_name("image-repo")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let image = put.image().unwrap();
+    assert_eq!(image.repository_name(), Some("image-repo"));
+    assert_eq!(image.image_id().and_then(|id| id.image_tag()), Some("v1"),);
+    let digest = image
+        .image_id()
+        .and_then(|id| id.image_digest())
+        .unwrap()
+        .to_string();
+    assert_eq!(digest, sha256_digest(manifest.as_bytes()));
+
+    // Re-put with a new tag pointing at the same digest.
+    client
+        .put_image()
+        .repository_name("image-repo")
+        .image_manifest(manifest)
+        .image_tag("latest")
+        .send()
+        .await
+        .unwrap();
+
+    let list = client
+        .list_images()
+        .repository_name("image-repo")
+        .send()
+        .await
+        .unwrap();
+    let tags: Vec<String> = list
+        .image_ids()
+        .iter()
+        .filter_map(|id| id.image_tag().map(|s| s.to_string()))
+        .collect();
+    assert!(tags.contains(&"v1".to_string()));
+    assert!(tags.contains(&"latest".to_string()));
+
+    let desc = client
+        .describe_images()
+        .repository_name("image-repo")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desc.image_details().len(), 1);
+    let details = &desc.image_details()[0];
+    assert_eq!(details.image_digest(), Some(digest.as_str()));
+    let detail_tags = details.image_tags();
+    assert!(detail_tags.iter().any(|t| t == "v1"));
+    assert!(detail_tags.iter().any(|t| t == "latest"));
+}
+
+#[tokio::test]
+async fn batch_get_image_by_tag_and_digest() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("batch-get-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let manifest = r#"{"schemaVersion":2,"layers":[]}"#;
+    let put = client
+        .put_image()
+        .repository_name("batch-get-repo")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let digest = put
+        .image()
+        .and_then(|i| i.image_id())
+        .and_then(|id| id.image_digest())
+        .unwrap()
+        .to_string();
+
+    use aws_sdk_ecr::types::ImageIdentifier;
+    let by_tag = ImageIdentifier::builder().image_tag("v1").build();
+    let by_digest = ImageIdentifier::builder().image_digest(&digest).build();
+
+    let got = client
+        .batch_get_image()
+        .repository_name("batch-get-repo")
+        .image_ids(by_tag)
+        .image_ids(by_digest)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.images().len(), 2);
+    assert!(got.failures().is_empty());
+}
+
+#[tokio::test]
+async fn batch_delete_image_by_tag_keeps_image_until_last_tag() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("del-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let manifest = r#"{"schemaVersion":2}"#;
+    client
+        .put_image()
+        .repository_name("del-repo")
+        .image_manifest(manifest)
+        .image_tag("a")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_image()
+        .repository_name("del-repo")
+        .image_manifest(manifest)
+        .image_tag("b")
+        .send()
+        .await
+        .unwrap();
+
+    use aws_sdk_ecr::types::ImageIdentifier;
+    // Delete tag "a" — image should still be reachable via tag "b".
+    client
+        .batch_delete_image()
+        .repository_name("del-repo")
+        .image_ids(ImageIdentifier::builder().image_tag("a").build())
+        .send()
+        .await
+        .unwrap();
+
+    let still_there = client
+        .describe_images()
+        .repository_name("del-repo")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(still_there.image_details().len(), 1);
+    let tags: Vec<&str> = still_there.image_details()[0]
+        .image_tags()
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    assert_eq!(tags, vec!["b"]);
+
+    // Delete tag "b" too — image should be gone.
+    client
+        .batch_delete_image()
+        .repository_name("del-repo")
+        .image_ids(ImageIdentifier::builder().image_tag("b").build())
+        .send()
+        .await
+        .unwrap();
+    let empty = client
+        .describe_images()
+        .repository_name("del-repo")
+        .send()
+        .await
+        .unwrap();
+    assert!(empty.image_details().is_empty());
+}
+
+#[tokio::test]
+async fn immutable_tag_blocks_reassignment() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    use aws_sdk_ecr::types::ImageTagMutability;
+    client
+        .create_repository()
+        .repository_name("immut-repo")
+        .image_tag_mutability(ImageTagMutability::Immutable)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_image()
+        .repository_name("immut-repo")
+        .image_manifest(r#"{"a":1}"#)
+        .image_tag("pinned")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .put_image()
+        .repository_name("immut-repo")
+        .image_manifest(r#"{"a":2}"#)
+        .image_tag("pinned")
+        .send()
+        .await
+        .expect_err("immutable tag rewrite should fail");
+    assert!(format!("{err:?}").contains("ImageAlreadyExists"), "{err:?}");
+}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -788,6 +788,17 @@ impl EcrService {
         let account = target_account_id(request, &body);
 
         let computed_digest = sha256_digest(manifest.as_bytes());
+        if let Some(ref supplied) = supplied_digest {
+            if supplied != &computed_digest {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ImageDigestDoesNotMatchException",
+                    format!(
+                        "The imageDigest '{supplied}' does not match the digest of the uploaded manifest ('{computed_digest}')."
+                    ),
+                ));
+            }
+        }
         let digest = supplied_digest.unwrap_or_else(|| computed_digest.clone());
 
         let mut accounts = self.state.write();
@@ -1292,12 +1303,14 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        // Peek, validate, then commit — so a digest mismatch lets the
+        // caller retry CompleteLayerUpload with the correct digest
+        // instead of having to re-upload the entire blob.
         let upload = state
             .layer_uploads
-            .remove(&upload_id)
+            .get(&upload_id)
             .ok_or_else(|| upload_not_found(&upload_id))?;
         if upload.repository_name != name {
-            state.layer_uploads.insert(upload_id.clone(), upload);
             return Err(upload_not_found(&upload_id));
         }
         let blob_bytes = B64.decode(upload.blob_b64.as_bytes()).unwrap_or_default();
@@ -1312,6 +1325,7 @@ impl EcrService {
                 ),
             ));
         }
+        let upload = state.layer_uploads.remove(&upload_id).unwrap();
         let repo = state
             .repositories
             .get_mut(&name)

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1,16 +1,21 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex as AsyncMutex;
+use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    EcrSnapshot, EncryptionConfiguration, ImageScanningConfiguration, Repository, SharedEcrState,
-    ECR_SNAPSHOT_SCHEMA_VERSION,
+    EcrSnapshot, EncryptionConfiguration, Image, ImageScanningConfiguration, Layer, LayerUpload,
+    Repository, SharedEcrState, ECR_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED_ACTIONS: &[&str] = &[
@@ -25,6 +30,16 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "TagResource",
     "UntagResource",
     "ListTagsForResource",
+    "PutImage",
+    "BatchGetImage",
+    "BatchDeleteImage",
+    "BatchCheckLayerAvailability",
+    "DescribeImages",
+    "ListImages",
+    "GetDownloadUrlForLayer",
+    "InitiateLayerUpload",
+    "UploadLayerPart",
+    "CompleteLayerUpload",
 ];
 
 /// Actions that mutate persisted state. Only these trigger a snapshot save.
@@ -39,6 +54,11 @@ fn is_mutating(action: &str) -> bool {
             | "DeleteRepositoryPolicy"
             | "TagResource"
             | "UntagResource"
+            | "PutImage"
+            | "BatchDeleteImage"
+            | "InitiateLayerUpload"
+            | "UploadLayerPart"
+            | "CompleteLayerUpload"
     )
 }
 
@@ -105,6 +125,16 @@ impl AwsService for EcrService {
             "TagResource" => self.tag_resource(&request),
             "UntagResource" => self.untag_resource(&request),
             "ListTagsForResource" => self.list_tags_for_resource(&request),
+            "PutImage" => self.put_image(&request),
+            "BatchGetImage" => self.batch_get_image(&request),
+            "BatchDeleteImage" => self.batch_delete_image(&request),
+            "BatchCheckLayerAvailability" => self.batch_check_layer_availability(&request),
+            "DescribeImages" => self.describe_images(&request),
+            "ListImages" => self.list_images(&request),
+            "GetDownloadUrlForLayer" => self.get_download_url_for_layer(&request),
+            "InitiateLayerUpload" => self.initiate_layer_upload(&request),
+            "UploadLayerPart" => self.upload_layer_part(&request),
+            "CompleteLayerUpload" => self.complete_layer_upload(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 self.service_name(),
                 &request.action,
@@ -643,6 +673,666 @@ impl EcrService {
             .map(|(k, v)| json!({ "Key": k, "Value": v }))
             .collect();
         Ok(AwsResponse::ok_json(json!({ "tags": tags })))
+    }
+}
+
+// -------- image + layer helpers --------
+
+fn image_not_found(repo: &str, id: &Value) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ImageNotFoundException",
+        format!("The image with imageId {{{id}}} does not exist within the repository with name '{repo}'"),
+    )
+}
+
+fn layer_not_found(digest: &str, repo: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "LayersNotFoundException",
+        format!(
+            "The layers with layerDigests '[{digest}]' do not exist in the repository with name '{repo}'"
+        ),
+    )
+}
+
+fn upload_not_found(upload_id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "UploadNotFoundException",
+        format!("The upload '{upload_id}' does not exist."),
+    )
+}
+
+fn image_already_exists(repo: &str, tag: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ImageAlreadyExistsException",
+        format!(
+            "Image with tag '{tag}' in repository '{repo}' already exists with a different digest and tag mutability is set to IMMUTABLE."
+        ),
+    )
+}
+
+fn invalid_layer(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidLayerException", message)
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn image_id_for(image: &Image, tag: Option<&str>) -> Value {
+    let mut id = json!({ "imageDigest": image.image_digest });
+    if let Some(t) = tag {
+        id["imageTag"] = json!(t);
+    }
+    id
+}
+
+fn image_to_details(repo: &Repository, image: &Image, registry_id: &str) -> Value {
+    // All tags pointing at this digest.
+    let tags: Vec<&str> = repo
+        .image_tags
+        .iter()
+        .filter(|(_, d)| d.as_str() == image.image_digest)
+        .map(|(t, _)| t.as_str())
+        .collect();
+    let mut out = json!({
+        "registryId": registry_id,
+        "repositoryName": repo.repository_name,
+        "imageDigest": image.image_digest,
+        "imageTags": tags,
+        "imageSizeInBytes": image.image_size_in_bytes,
+        "imagePushedAt": image.image_pushed_at.timestamp(),
+        "imageManifestMediaType": image.image_manifest_media_type,
+    });
+    if let Some(a) = &image.artifact_media_type {
+        out["artifactMediaType"] = json!(a);
+    }
+    if let Some(t) = image.last_recorded_pull_time {
+        out["lastRecordedPullTime"] = json!(t.timestamp());
+    }
+    out
+}
+
+/// Resolve `imageId` into a stored digest for this repo. Accepts either
+/// `{imageDigest}` or `{imageTag}` (or both — digest wins when both set).
+fn resolve_image_digest(repo: &Repository, image_id: &Value) -> Option<String> {
+    if let Some(d) = image_id.get("imageDigest").and_then(|v| v.as_str()) {
+        if repo.images.contains_key(d) {
+            return Some(d.to_string());
+        }
+        return None;
+    }
+    if let Some(tag) = image_id.get("imageTag").and_then(|v| v.as_str()) {
+        return repo.image_tags.get(tag).cloned();
+    }
+    None
+}
+
+// -------- image + layer operations --------
+
+impl EcrService {
+    fn put_image(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let manifest = req_str(&body, "imageManifest")?.to_string();
+        let manifest_media_type = opt_str(&body, "imageManifestMediaType")
+            .unwrap_or("application/vnd.docker.distribution.manifest.v2+json")
+            .to_string();
+        let supplied_tag = opt_str(&body, "imageTag").map(|s| s.to_string());
+        let supplied_digest = opt_str(&body, "imageDigest").map(|s| s.to_string());
+        let account = target_account_id(request, &body);
+
+        let computed_digest = sha256_digest(manifest.as_bytes());
+        let digest = supplied_digest.unwrap_or_else(|| computed_digest.clone());
+
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get_mut(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+
+        // Immutable tag guard: if a tag is supplied, it already maps to
+        // a different digest, and the repo is IMMUTABLE, reject.
+        if let Some(ref tag) = supplied_tag {
+            if let Some(existing) = repo.image_tags.get(tag) {
+                if existing != &digest && repo.image_tag_mutability == "IMMUTABLE" {
+                    return Err(image_already_exists(&name, tag));
+                }
+            }
+        }
+
+        let image_entry = repo.images.entry(digest.clone()).or_insert_with(|| Image {
+            image_digest: digest.clone(),
+            image_manifest: manifest.clone(),
+            image_manifest_media_type: manifest_media_type.clone(),
+            artifact_media_type: None,
+            image_size_in_bytes: manifest.len() as u64,
+            image_pushed_at: Utc::now(),
+            last_recorded_pull_time: None,
+        });
+        // If the caller re-pushes an existing digest with a new manifest
+        // payload (shouldn't happen under sha256 addressing but tolerate
+        // it), keep the latest manifest.
+        image_entry.image_manifest = manifest;
+        image_entry.image_manifest_media_type = manifest_media_type.clone();
+
+        if let Some(tag) = supplied_tag.clone() {
+            repo.image_tags.insert(tag, digest.clone());
+        }
+
+        let snapshot = repo.images.get(&digest).cloned().unwrap();
+        let tag_ref = supplied_tag.as_deref();
+        Ok(AwsResponse::ok_json(json!({
+            "image": {
+                "registryId": repo.registry_id,
+                "repositoryName": name,
+                "imageId": image_id_for(&snapshot, tag_ref),
+                "imageManifest": snapshot.image_manifest,
+                "imageManifestMediaType": snapshot.image_manifest_media_type,
+            }
+        })))
+    }
+
+    fn batch_get_image(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let ids = body
+            .get("imageIds")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let account = target_account_id(request, &body);
+        let accounts = self.state.read();
+        let state = accounts
+            .get(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+
+        let mut images: Vec<Value> = Vec::new();
+        let mut failures: Vec<Value> = Vec::new();
+        for id in &ids {
+            match resolve_image_digest(repo, id) {
+                Some(digest) => {
+                    let img = repo.images.get(&digest).unwrap();
+                    let tag = id.get("imageTag").and_then(|v| v.as_str());
+                    images.push(json!({
+                        "registryId": repo.registry_id,
+                        "repositoryName": name,
+                        "imageId": image_id_for(img, tag),
+                        "imageManifest": img.image_manifest,
+                        "imageManifestMediaType": img.image_manifest_media_type,
+                    }));
+                }
+                None => failures.push(json!({
+                    "imageId": id,
+                    "failureCode": "ImageNotFound",
+                    "failureReason": "Requested image not found",
+                })),
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "images": images,
+            "failures": failures,
+        })))
+    }
+
+    fn batch_delete_image(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let ids = body
+            .get("imageIds")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let account = target_account_id(request, &body);
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get_mut(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+
+        let mut deleted: Vec<Value> = Vec::new();
+        let mut failures: Vec<Value> = Vec::new();
+        for id in &ids {
+            if let Some(tag) = id.get("imageTag").and_then(|v| v.as_str()) {
+                // Delete by tag: remove only the tag, image stays if
+                // other tags still reference the digest.
+                if let Some(digest) = repo.image_tags.remove(tag) {
+                    deleted.push(json!({ "imageDigest": digest, "imageTag": tag }));
+                    let still_tagged = repo.image_tags.values().any(|d| *d == digest);
+                    if !still_tagged {
+                        repo.images.remove(&digest);
+                    }
+                    continue;
+                }
+                failures.push(json!({
+                    "imageId": id,
+                    "failureCode": "ImageNotFound",
+                    "failureReason": "Requested image not found",
+                }));
+            } else if let Some(digest) = id.get("imageDigest").and_then(|v| v.as_str()) {
+                if repo.images.remove(digest).is_some() {
+                    repo.image_tags.retain(|_, d| d != digest);
+                    deleted.push(json!({ "imageDigest": digest }));
+                    continue;
+                }
+                failures.push(json!({
+                    "imageId": id,
+                    "failureCode": "ImageNotFound",
+                    "failureReason": "Requested image not found",
+                }));
+            } else {
+                failures.push(json!({
+                    "imageId": id,
+                    "failureCode": "InvalidImageTag",
+                    "failureReason": "Either imageDigest or imageTag must be supplied",
+                }));
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "imageIds": deleted,
+            "failures": failures,
+        })))
+    }
+
+    fn batch_check_layer_availability(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let digests: Vec<String> = body
+            .get("layerDigests")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if digests.is_empty() {
+            return Err(invalid_parameter(
+                "At least one layerDigest must be supplied to BatchCheckLayerAvailability",
+            ));
+        }
+        let account = target_account_id(request, &body);
+        let accounts = self.state.read();
+        let state = accounts
+            .get(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let mut layers: Vec<Value> = Vec::new();
+        let mut failures: Vec<Value> = Vec::new();
+        for digest in &digests {
+            match repo.layers.get(digest) {
+                Some(layer) => layers.push(json!({
+                    "layerDigest": layer.digest,
+                    "layerAvailability": "AVAILABLE",
+                    "layerSize": layer.size,
+                    "mediaType": layer.media_type,
+                })),
+                None => failures.push(json!({
+                    "layerDigest": digest,
+                    "failureCode": "MissingLayerDigest",
+                    "failureReason": "Layer not found in repository",
+                })),
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "layers": layers,
+            "failures": failures,
+        })))
+    }
+
+    fn describe_images(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        const DEFAULT_PAGE_SIZE: usize = 100;
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let ids = body
+            .get("imageIds")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let max_results = match body.get("maxResults").and_then(|v| v.as_i64()) {
+            Some(n) => {
+                if !(1..=1000).contains(&n) {
+                    return Err(invalid_parameter(format!(
+                        "Value '{n}' at 'maxResults' failed to satisfy constraint: \
+                         Member must have value between 1 and 1000",
+                    )));
+                }
+                n as usize
+            }
+            None => DEFAULT_PAGE_SIZE,
+        };
+        let offset = match body.get("nextToken").and_then(|v| v.as_str()) {
+            Some(raw) => raw.parse::<usize>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidContinuationTokenException",
+                    "The specified continuation token is not valid.",
+                )
+            })?,
+            None => 0,
+        };
+        let account = target_account_id(request, &body);
+        let accounts = self.state.read();
+        let state = accounts
+            .get(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+
+        let mut details: Vec<Value> = Vec::new();
+        let mut next_token: Option<String> = None;
+        if ids.is_empty() {
+            let all: Vec<&Image> = repo.images.values().collect();
+            let start = offset.min(all.len());
+            let end = (start + max_results).min(all.len());
+            for img in &all[start..end] {
+                details.push(image_to_details(repo, img, &repo.registry_id));
+            }
+            if end < all.len() {
+                next_token = Some(end.to_string());
+            }
+        } else {
+            for id in &ids {
+                let digest =
+                    resolve_image_digest(repo, id).ok_or_else(|| image_not_found(&name, id))?;
+                let img = repo.images.get(&digest).unwrap();
+                details.push(image_to_details(repo, img, &repo.registry_id));
+            }
+        }
+        let mut response = json!({ "imageDetails": details });
+        if let Some(token) = next_token {
+            response["nextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    fn list_images(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        const DEFAULT_PAGE_SIZE: usize = 100;
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let filter_tag_status = body
+            .get("filter")
+            .and_then(|v| v.get("tagStatus"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let max_results = match body.get("maxResults").and_then(|v| v.as_i64()) {
+            Some(n) => {
+                if !(1..=1000).contains(&n) {
+                    return Err(invalid_parameter(format!(
+                        "Value '{n}' at 'maxResults' failed to satisfy constraint: \
+                         Member must have value between 1 and 1000",
+                    )));
+                }
+                n as usize
+            }
+            None => DEFAULT_PAGE_SIZE,
+        };
+        let offset = match body.get("nextToken").and_then(|v| v.as_str()) {
+            Some(raw) => raw.parse::<usize>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidContinuationTokenException",
+                    "The specified continuation token is not valid.",
+                )
+            })?,
+            None => 0,
+        };
+        let account = target_account_id(request, &body);
+        let accounts = self.state.read();
+        let state = accounts
+            .get(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+
+        // Enumerate once per (digest, tag-or-untagged) combination.
+        let mut all: Vec<(String, Option<String>)> = Vec::new();
+        for (tag, digest) in &repo.image_tags {
+            all.push((digest.clone(), Some(tag.clone())));
+        }
+        let tagged_digests: std::collections::HashSet<&String> = repo.image_tags.values().collect();
+        for digest in repo.images.keys() {
+            if !tagged_digests.contains(digest) {
+                all.push((digest.clone(), None));
+            }
+        }
+        // Apply filter.
+        all.retain(|(_, tag)| match filter_tag_status.as_deref() {
+            Some("TAGGED") => tag.is_some(),
+            Some("UNTAGGED") => tag.is_none(),
+            _ => true,
+        });
+        all.sort();
+
+        let start = offset.min(all.len());
+        let end = (start + max_results).min(all.len());
+        let ids: Vec<Value> = all[start..end]
+            .iter()
+            .map(|(d, t)| {
+                let mut v = json!({ "imageDigest": d });
+                if let Some(tag) = t {
+                    v["imageTag"] = json!(tag);
+                }
+                v
+            })
+            .collect();
+        let mut response = json!({ "imageIds": ids });
+        if end < all.len() {
+            response["nextToken"] = json!(end.to_string());
+        }
+        Ok(AwsResponse::ok_json(response))
+    }
+
+    fn get_download_url_for_layer(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let digest = req_str(&body, "layerDigest")?.to_string();
+        let account = target_account_id(request, &body);
+        let accounts = self.state.read();
+        let state = accounts
+            .get(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        if !repo.layers.contains_key(&digest) {
+            return Err(layer_not_found(&digest, &name));
+        }
+        // Batch 3 will host `/v2/<name>/blobs/<digest>` — return that
+        // path as a relative URL so callers that trust the endpoint
+        // they're already talking to can resolve it.
+        let endpoint = accounts.endpoint();
+        let url = format!(
+            "{}/v2/{}/blobs/{}",
+            endpoint.trim_end_matches('/'),
+            name,
+            digest
+        );
+        Ok(AwsResponse::ok_json(json!({
+            "downloadUrl": url,
+            "layerDigest": digest,
+        })))
+    }
+
+    fn initiate_layer_upload(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let account = target_account_id(request, &body);
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        if !state.repositories.contains_key(&name) {
+            return Err(repository_not_found(&name));
+        }
+        let upload_id = Uuid::new_v4().to_string();
+        state.layer_uploads.insert(
+            upload_id.clone(),
+            LayerUpload {
+                upload_id: upload_id.clone(),
+                repository_name: name,
+                created_at: Utc::now(),
+                blob_b64: String::new(),
+                last_byte_received: 0,
+            },
+        );
+        Ok(AwsResponse::ok_json(json!({
+            "uploadId": upload_id,
+            // Matches the real AWS default of 10 MiB.
+            "partSize": 10_485_760u64,
+        })))
+    }
+
+    fn upload_layer_part(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let upload_id = req_str(&body, "uploadId")?.to_string();
+        let first_byte = body
+            .get("partFirstByte")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| invalid_parameter("Missing partFirstByte"))?;
+        let last_byte = body
+            .get("partLastByte")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| invalid_parameter("Missing partLastByte"))?;
+        let part_blob_b64 = req_str(&body, "layerPartBlob")?.to_string();
+        let part_bytes = B64
+            .decode(part_blob_b64.as_bytes())
+            .map_err(|_| invalid_layer("layerPartBlob is not valid base64"))?;
+        let account = target_account_id(request, &body);
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let upload = state
+            .layer_uploads
+            .get_mut(&upload_id)
+            .ok_or_else(|| upload_not_found(&upload_id))?;
+        if upload.repository_name != name {
+            return Err(upload_not_found(&upload_id));
+        }
+        if first_byte != upload.last_byte_received {
+            return Err(invalid_layer(format!(
+                "Layer part upload out of order: expected partFirstByte {} got {}",
+                upload.last_byte_received, first_byte,
+            )));
+        }
+        let expected_len = last_byte
+            .checked_sub(first_byte)
+            .and_then(|d| d.checked_add(1))
+            .ok_or_else(|| invalid_layer("partLastByte < partFirstByte"))?;
+        if part_bytes.len() as u64 != expected_len {
+            return Err(invalid_layer(format!(
+                "Layer part size mismatch: bytes {} doesn't match range [{first_byte}, {last_byte}]",
+                part_bytes.len()
+            )));
+        }
+        let existing = B64.decode(upload.blob_b64.as_bytes()).unwrap_or_default();
+        let mut combined = existing;
+        combined.extend_from_slice(&part_bytes);
+        upload.blob_b64 = B64.encode(&combined);
+        upload.last_byte_received = last_byte + 1;
+        Ok(AwsResponse::ok_json(json!({
+            "registryId": state.registry_id(),
+            "repositoryName": name,
+            "uploadId": upload_id,
+            "lastByteReceived": last_byte,
+        })))
+    }
+
+    fn complete_layer_upload(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let name = req_str(&body, "repositoryName")?.to_string();
+        let upload_id = req_str(&body, "uploadId")?.to_string();
+        let digests: Vec<String> = body
+            .get("layerDigests")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if digests.is_empty() {
+            return Err(invalid_parameter(
+                "At least one layerDigest must be supplied to CompleteLayerUpload",
+            ));
+        }
+        let account = target_account_id(request, &body);
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let upload = state
+            .layer_uploads
+            .remove(&upload_id)
+            .ok_or_else(|| upload_not_found(&upload_id))?;
+        if upload.repository_name != name {
+            state.layer_uploads.insert(upload_id.clone(), upload);
+            return Err(upload_not_found(&upload_id));
+        }
+        let blob_bytes = B64.decode(upload.blob_b64.as_bytes()).unwrap_or_default();
+        let computed = sha256_digest(&blob_bytes);
+        if !digests.iter().any(|d| d == &computed) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "LayerDigestMismatchException",
+                format!(
+                    "The layer digest from the client ({}) does not match the digest of the received bytes ({computed})",
+                    digests.join(",")
+                ),
+            ));
+        }
+        let repo = state
+            .repositories
+            .get_mut(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        let size = blob_bytes.len() as u64;
+        repo.layers.insert(
+            computed.clone(),
+            Layer {
+                digest: computed.clone(),
+                size,
+                blob_b64: upload.blob_b64,
+                media_type: "application/vnd.docker.image.rootfs.diff.tar.gzip".to_string(),
+            },
+        );
+        let registry_id = repo.registry_id.clone();
+        Ok(AwsResponse::ok_json(json!({
+            "registryId": registry_id,
+            "repositoryName": name,
+            "uploadId": upload_id,
+            "layerDigest": computed,
+        })))
     }
 }
 

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -13,7 +13,7 @@ impl fakecloud_core::multi_account::AccountState for EcrState {
     }
 }
 
-pub const ECR_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const ECR_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 /// Top-level persisted ECR snapshot. The shape mirrors the convention
 /// used by other multi-account services (Kinesis, ElastiCache) so the
@@ -42,6 +42,10 @@ pub struct EcrState {
     /// Account setting flags keyed by setting name (e.g.,
     /// `BASIC_SCAN_TYPE_VERSION`, `REGISTRY_POLICY_SCOPE`).
     pub account_settings: HashMap<String, String>,
+    /// Layer upload state machine keyed by `uploadId`. Each entry is
+    /// tied to a specific repository.
+    #[serde(default)]
+    pub layer_uploads: BTreeMap<String, LayerUpload>,
 }
 
 impl EcrState {
@@ -54,6 +58,7 @@ impl EcrState {
             registry_scanning_configuration: RegistryScanningConfiguration::default(),
             replication_configuration: None,
             account_settings: HashMap::new(),
+            layer_uploads: BTreeMap::new(),
         }
     }
 
@@ -63,6 +68,7 @@ impl EcrState {
         self.registry_scanning_configuration = RegistryScanningConfiguration::default();
         self.replication_configuration = None;
         self.account_settings.clear();
+        self.layer_uploads.clear();
     }
 
     pub fn repository_arn(&self, repository_name: &str) -> String {
@@ -93,6 +99,19 @@ pub struct Repository {
     pub policy: Option<String>,
     /// Repository-level lifecycle policy document JSON.
     pub lifecycle_policy: Option<String>,
+    /// Stored images keyed by manifest digest (sha256). One image can
+    /// have many tags (via `image_tags`).
+    #[serde(default)]
+    pub images: BTreeMap<String, Image>,
+    /// Tag name -> image digest. Multiple tags can point to the same
+    /// digest.
+    #[serde(default)]
+    pub image_tags: BTreeMap<String, String>,
+    /// Content-addressed layer blobs keyed by their sha256 digest
+    /// (e.g. `sha256:deadbeef…`). Stored as base64 to keep JSON
+    /// snapshots portable.
+    #[serde(default)]
+    pub layers: BTreeMap<String, Layer>,
 }
 
 impl Repository {
@@ -120,8 +139,44 @@ impl Repository {
             tags: BTreeMap::new(),
             policy: None,
             lifecycle_policy: None,
+            images: BTreeMap::new(),
+            image_tags: BTreeMap::new(),
+            layers: BTreeMap::new(),
         }
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Image {
+    pub image_digest: String,
+    pub image_manifest: String,
+    pub image_manifest_media_type: String,
+    pub artifact_media_type: Option<String>,
+    pub image_size_in_bytes: u64,
+    pub image_pushed_at: DateTime<Utc>,
+    pub last_recorded_pull_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Layer {
+    pub digest: String,
+    pub size: u64,
+    /// Base64-encoded blob bytes. Kept in-process for Batch 2; Batch 3
+    /// will move this to content-addressed disk storage for the OCI
+    /// `/v2/` protocol.
+    pub blob_b64: String,
+    pub media_type: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LayerUpload {
+    pub upload_id: String,
+    pub repository_name: String,
+    pub created_at: DateTime<Utc>,
+    /// Accumulated blob bytes (base64). Each `UploadLayerPart` call
+    /// appends to this and updates `last_byte_received`.
+    pub blob_b64: String,
+    pub last_byte_received: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Batch 2 of 4 in the ECR buildout, building on #717.
- Ships 10 ops: `PutImage`, `BatchGetImage`, `BatchDeleteImage`, `BatchCheckLayerAvailability`, `DescribeImages`, `ListImages`, `GetDownloadUrlForLayer`, `InitiateLayerUpload`, `UploadLayerPart`, `CompleteLayerUpload`.
- Adds the content-addressed sha256 blob storage that Batch 3's OCI v2 Distribution protocol (the thing that makes real `docker push` / `docker pull` work) will expose over HTTP.
- 21/58 ECR operations now implemented, **all 21 at 100% variant coverage**.
- Baseline bumped: 60,621 / 61,743 variants passing (98.2%). No regressions on the 23 pre-existing services.

## Key behaviours

- **Layer upload state machine.** `InitiateLayerUpload` returns a UUID + 10 MiB partSize (matching AWS). `UploadLayerPart` requires contiguous byte ranges and part-size consistency, bumping `last_byte_received`. `CompleteLayerUpload` recomputes the sha256 of the received bytes and rejects mismatched digests with `LayerDigestMismatchException`.
- **Tag mutability.** `PutImage` on an `IMMUTABLE` repo returns `ImageAlreadyExistsException` when a tag already points at a different digest; `MUTABLE` repos allow tag reassignment.
- **BatchDeleteImage semantics.** Deleting by tag removes only the tag when other tags still reference the digest; deleting by digest or removing the last tag removes the underlying image.
- **Pagination.** `DescribeImages` / `ListImages` use AWS's documented default page size of 100, enforce `maxResults` 1..=1000, and return `InvalidContinuationTokenException` on garbage `nextToken` input.
- **Persistence.** Snapshot schema v1 -> v2, with every new field `serde(default)` so v1 snapshots load cleanly. All mutating ops trigger a snapshot save.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-e2e --test ecr --test ecr_persistence --test ecr_images` — 13 passing
- [x] `cargo test -p fakecloud-conformance --test ecr` — 21 passing
- [x] `cargo run -p fakecloud-conformance --release -- run --services ecr` — 21/58 ops implemented, all 100%
- [x] `cargo run -p fakecloud-conformance --release -- check` — no regressions on other services

## Follow-up

- Batch 3: OCI v2 Distribution HTTP endpoints (`/v2/...`) + `GetAuthorizationToken` + Basic-Auth — the differentiator that makes `docker push` work against `localhost:4566`.
- Batch 4: lifecycle + scanning + registry + CloudFormation/Lambda integration + website landing + marketing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ECR image and layer operations with content‑addressed sha256 blob storage. Enables full image management via the JSON control plane and sets up OCI v2 push/pull next.

- **New Features**
  - Implemented: PutImage, BatchGetImage, BatchDeleteImage, BatchCheckLayerAvailability, DescribeImages, ListImages, GetDownloadUrlForLayer, InitiateLayerUpload, UploadLayerPart, CompleteLayerUpload.
  - Layer upload state machine: Initiate returns UUID + 10 MiB partSize; UploadLayerPart enforces contiguous ranges; CompleteLayerUpload validates digest before finalizing so mismatches return LayerDigestMismatchException without dropping upload state (retryable).
  - PutImage: computes manifest digest; if a supplied imageDigest mismatches, returns ImageDigestDoesNotMatchException. Tag rules: IMMUTABLE repos block tag reassignment (ImageAlreadyExistsException); MUTABLE repos allow it.
  - Delete behavior: deleting by tag removes only the tag; deleting by digest or the last tag removes the image.
  - Pagination: default 100 items; maxResults 1..=1000; invalid nextToken → InvalidContinuationTokenException.
  - Blob storage: per‑repo, sha256‑addressed layers; GetDownloadUrlForLayer returns `/v2/<repo>/blobs/<digest>` URL.
  - Persistence: snapshot schema v2 with serde defaults (v1 snapshots still load); all mutating ops save snapshots.
  - Conformance: 21/58 ECR ops at 100% variant coverage; baseline 60,621/61,743 (98.2%); no regressions.

<sup>Written for commit cc6b6b1c19757a103a695b70cb6e7db0a3925a4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

