### PR TITLE
feat(ecs): Batch 2 — real Fargate-style task execution via Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-25 services, 1,758 operations, 100% conformance per implemented service.
+25 services, 1,763 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -76,7 +76,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
-| ECS                    |  20 | Clusters, task definitions, tags, account settings (task execution incoming) |
+| ECS                    |  25 | Clusters, task definitions, **real Fargate-style task execution via Docker**, tags, account settings |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -116,7 +116,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | API Gateway v2      | 28 operations, full HTTP API support               | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
-| ECS                 | 20 control-plane operations (execution in flight)  | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| ECS                 | 25 operations incl. **real task execution via Docker** | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/crates/fakecloud-conformance/tests/ecs.rs
+++ b/crates/fakecloud-conformance/tests/ecs.rs
@@ -461,3 +461,156 @@ async fn ecs_list_account_settings() {
     // empty-or-populated settings list.
     let _ = resp.settings().len();
 }
+
+// ── Batch 2: task lifecycle ────────────────────────────────────────
+
+async fn register_conformance_task_def(client: &aws_sdk_ecs::Client, family: &str) {
+    client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ecs", "RunTask", checksum = "f0ae3fb6")]
+#[tokio::test]
+async fn ecs_run_task() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("confo-run")
+        .send()
+        .await
+        .unwrap();
+    register_conformance_task_def(&client, "confo-run-td").await;
+    let resp = client
+        .run_task()
+        .cluster("confo-run")
+        .task_definition("confo-run-td")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.tasks().len(), 1);
+    assert!(resp.failures().is_empty());
+}
+
+#[test_action("ecs", "StartTask", checksum = "75d41d3b")]
+#[tokio::test]
+async fn ecs_start_task() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("confo-start")
+        .send()
+        .await
+        .unwrap();
+    register_conformance_task_def(&client, "confo-start-td").await;
+    let resp = client
+        .start_task()
+        .cluster("confo-start")
+        .task_definition("confo-start-td")
+        .container_instances("ci-placeholder")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.tasks().len(), 1);
+}
+
+#[test_action("ecs", "DescribeTasks", checksum = "84135240")]
+#[tokio::test]
+async fn ecs_describe_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("confo-desc")
+        .send()
+        .await
+        .unwrap();
+    register_conformance_task_def(&client, "confo-desc-td").await;
+    let run = client
+        .run_task()
+        .cluster("confo-desc")
+        .task_definition("confo-desc-td")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    let described = client
+        .describe_tasks()
+        .cluster("confo-desc")
+        .tasks(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.tasks().len(), 1);
+}
+
+#[test_action("ecs", "ListTasks", checksum = "5e257f00")]
+#[tokio::test]
+async fn ecs_list_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("confo-list-t")
+        .send()
+        .await
+        .unwrap();
+    register_conformance_task_def(&client, "confo-list-t-td").await;
+    client
+        .run_task()
+        .cluster("confo-list-t")
+        .task_definition("confo-list-t-td")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .list_tasks()
+        .cluster("confo-list-t")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.task_arns().is_empty());
+}
+
+#[test_action("ecs", "StopTask", checksum = "b4f8ca9a")]
+#[tokio::test]
+async fn ecs_stop_task() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("confo-stop")
+        .send()
+        .await
+        .unwrap();
+    register_conformance_task_def(&client, "confo-stop-td").await;
+    let run = client
+        .run_task()
+        .cluster("confo-stop")
+        .task_definition("confo-stop-td")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    let resp = client
+        .stop_task()
+        .cluster("confo-stop")
+        .task(arn)
+        .reason("test")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.task().is_some());
+}

--- a/crates/fakecloud-e2e/tests/ecs.rs
+++ b/crates/fakecloud-e2e/tests/ecs.rs
@@ -1,6 +1,7 @@
-//! ECS Batch 1: control-plane CRUD for clusters, task definitions,
-//! tagging, account settings. Execution (RunTask/CreateService/...) is
-//! covered in subsequent batches.
+//! ECS Batch 1 + 2: control-plane CRUD plus task lifecycle.
+//! Batch 1 covers clusters, task definitions, tagging, account settings.
+//! Batch 2 adds RunTask/StartTask/StopTask/DescribeTasks/ListTasks and
+//! introspection endpoints for inspecting task lifecycle.
 
 mod helpers;
 
@@ -401,4 +402,207 @@ async fn delete_cluster_with_tasks_fails() {
     assert!(arr
         .iter()
         .any(|c| c.get("clusterName").and_then(|v| v.as_str()) == Some("introspected")));
+}
+
+// ── Batch 2: task lifecycle ────────────────────────────────────────
+
+async fn register_runnable_task_def(client: &aws_sdk_ecs::Client, family: &str) {
+    client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn run_task_records_task_and_accepts_describe() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+
+    client
+        .create_cluster()
+        .cluster_name("rt-cluster")
+        .send()
+        .await
+        .unwrap();
+    register_runnable_task_def(&client, "rt-family").await;
+
+    let run = client
+        .run_task()
+        .cluster("rt-cluster")
+        .task_definition("rt-family")
+        .send()
+        .await
+        .expect("run_task");
+    assert_eq!(run.tasks().len(), 1);
+    assert!(run.failures().is_empty());
+
+    let task = &run.tasks()[0];
+    let arn = task.task_arn().unwrap().to_string();
+    assert!(arn.contains(":task/rt-cluster/"));
+    assert_eq!(task.launch_type().unwrap().as_str(), "FARGATE");
+    // Task is at least PENDING after RunTask returns; in CI without Docker
+    // it transitions to STOPPED with a TaskFailedToStart reason.
+    let status = task.last_status().unwrap();
+    assert!(
+        status == "PENDING"
+            || status == "RUNNING"
+            || status == "STOPPED"
+            || status == "PROVISIONING",
+        "unexpected status after RunTask: {status}"
+    );
+
+    let described = client
+        .describe_tasks()
+        .cluster("rt-cluster")
+        .tasks(arn.clone())
+        .send()
+        .await
+        .expect("describe_tasks");
+    assert_eq!(described.tasks().len(), 1);
+    assert!(described.failures().is_empty());
+
+    let listed = client
+        .list_tasks()
+        .cluster("rt-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    assert!(listed.task_arns().iter().any(|a| a == &arn));
+}
+
+#[tokio::test]
+async fn stop_task_flips_desired_status() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+
+    client
+        .create_cluster()
+        .cluster_name("stop-cluster")
+        .send()
+        .await
+        .unwrap();
+    register_runnable_task_def(&client, "stop-family").await;
+
+    let arn = client
+        .run_task()
+        .cluster("stop-cluster")
+        .task_definition("stop-family")
+        .send()
+        .await
+        .unwrap()
+        .tasks()[0]
+        .task_arn()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .stop_task()
+        .cluster("stop-cluster")
+        .task(arn.clone())
+        .reason("e2e")
+        .send()
+        .await
+        .expect("stop_task");
+    let task = resp.task().unwrap();
+    assert_eq!(task.desired_status(), Some("STOPPED"));
+}
+
+#[tokio::test]
+async fn describe_unknown_task_returns_failure() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+
+    client
+        .create_cluster()
+        .cluster_name("empty-cluster")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_tasks()
+        .cluster("empty-cluster")
+        .tasks("arn:aws:ecs:us-east-1:123456789012:task/empty-cluster/missing")
+        .send()
+        .await
+        .expect("describe_tasks");
+    assert!(resp.tasks().is_empty());
+    assert_eq!(resp.failures().len(), 1);
+    assert_eq!(resp.failures()[0].reason(), Some("MISSING"));
+}
+
+#[tokio::test]
+async fn introspection_tasks_endpoint_lists_ecs_state() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+
+    client
+        .create_cluster()
+        .cluster_name("intro-tasks")
+        .send()
+        .await
+        .unwrap();
+    register_runnable_task_def(&client, "intro-tasks-fam").await;
+    let arn = client
+        .run_task()
+        .cluster("intro-tasks")
+        .task_definition("intro-tasks-fam")
+        .send()
+        .await
+        .unwrap()
+        .tasks()[0]
+        .task_arn()
+        .unwrap()
+        .to_string();
+
+    let body: serde_json::Value =
+        reqwest::get(format!("{}/_fakecloud/ecs/tasks", server.endpoint()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    let arr = body.get("tasks").and_then(|v| v.as_array()).unwrap();
+    assert!(arr
+        .iter()
+        .any(|t| t.get("taskArn").and_then(|v| v.as_str()) == Some(arn.as_str())));
+
+    // Mark-failed forces the task to STOPPED deterministically for tests.
+    let task_id = arn.rsplit('/').next().unwrap();
+    let url = format!(
+        "{}/_fakecloud/ecs/tasks/{}/mark-failed",
+        server.endpoint(),
+        task_id
+    );
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({"exitCode": 137, "reason": "e2e injected"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let flipped: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        flipped.get("lastStatus").and_then(|v| v.as_str()),
+        Some("STOPPED")
+    );
+
+    let events: serde_json::Value =
+        reqwest::get(format!("{}/_fakecloud/ecs/events", server.endpoint()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    let ev = events.get("events").and_then(|v| v.as_array()).unwrap();
+    assert!(!ev.is_empty());
 }

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -16,6 +16,7 @@ http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-ecs/src/lib.rs
+++ b/crates/fakecloud-ecs/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod runtime;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -1,0 +1,464 @@
+//! Docker/Podman-based ECS task execution.
+//!
+//! Mirrors the Lambda `ContainerRuntime` approach (auto-detect CLI, forward
+//! localhost → host.docker.internal) but scoped for ECS's different
+//! lifecycle: tasks are ephemeral, so there is no warm-container pool. Each
+//! `run_task` spawns a background tokio task that pulls the image, starts
+//! the container, waits for exit, captures logs, and updates shared ECS
+//! state in place.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use parking_lot::RwLock;
+use tokio::process::Command;
+
+use crate::state::{LifecycleEvent, SharedEcsState};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("container CLI not found (tried docker, podman)")]
+    NoCli,
+    #[error("image pull failed: {0}")]
+    ImagePull(String),
+    #[error("container start failed: {0}")]
+    ContainerStart(String),
+    #[error("docker wait failed: {0}")]
+    Wait(String),
+}
+
+/// Docker/Podman executor for ECS tasks.
+pub struct EcsRuntime {
+    cli: String,
+    host_ip: String,
+    /// Tracks container IDs per task ID so `stop_task` can kill in-flight
+    /// work without needing to block on the spawned executor future.
+    containers: RwLock<std::collections::HashMap<String, String>>,
+}
+
+impl EcsRuntime {
+    /// Auto-detect Docker or Podman. Returns `None` if neither is
+    /// available. Honours `FAKECLOUD_CONTAINER_CLI` for explicit override.
+    pub fn new() -> Option<Self> {
+        let cli = if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
+            if cli_works(&cli) {
+                cli
+            } else {
+                return None;
+            }
+        } else if cli_works("docker") {
+            "docker".to_string()
+        } else if cli_works("podman") {
+            "podman".to_string()
+        } else {
+            return None;
+        };
+        let host_ip = if cfg!(target_os = "linux") {
+            "172.17.0.1".to_string()
+        } else {
+            "host-gateway".to_string()
+        };
+        Some(Self {
+            cli,
+            host_ip,
+            containers: RwLock::new(std::collections::HashMap::new()),
+        })
+    }
+
+    pub fn cli_name(&self) -> &str {
+        &self.cli
+    }
+
+    /// Spawn the task asynchronously. Returns immediately after transitioning
+    /// the task to `PENDING`; the background task advances it to `RUNNING`
+    /// once the container is created and to `STOPPED` once the container
+    /// exits.
+    pub fn run_task(self: Arc<Self>, state: SharedEcsState, task_id: String, account_id: String) {
+        tokio::spawn(async move {
+            if let Err(err) = self.run_task_inner(&state, &task_id, &account_id).await {
+                tracing::warn!(%err, task = %task_id, "ecs task execution failed");
+                finalize_failure(&state, &account_id, &task_id, &err.to_string());
+            }
+        });
+    }
+
+    async fn run_task_inner(
+        &self,
+        state: &SharedEcsState,
+        task_id: &str,
+        account_id: &str,
+    ) -> Result<(), RuntimeError> {
+        let (image, env, command, awslogs_container) = {
+            let accounts = state.read();
+            let s = accounts
+                .get(account_id)
+                .ok_or_else(|| RuntimeError::ContainerStart("account missing".into()))?;
+            let task = s
+                .tasks
+                .get(task_id)
+                .ok_or_else(|| RuntimeError::ContainerStart("task missing".into()))?;
+            let container = task
+                .containers
+                .first()
+                .ok_or_else(|| RuntimeError::ContainerStart("task has no containers".into()))?;
+            let def = find_container_definition(s, &task.family, task.revision, &container.name);
+            (
+                container.image.clone(),
+                def.as_ref()
+                    .and_then(|d| d.get("environment").and_then(|v| v.as_array()).cloned())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|e| {
+                                let k = e.get("name").and_then(|v| v.as_str())?;
+                                let v = e.get("value").and_then(|v| v.as_str()).unwrap_or("");
+                                Some((k.to_string(), v.to_string()))
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+                def.as_ref()
+                    .and_then(|d| d.get("command").and_then(|v| v.as_array()).cloned())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+                container.name.clone(),
+            )
+        };
+
+        // Pull the image first so we can surface pull errors cleanly.
+        mark_pull_started(state, account_id, task_id);
+        let pull_out = Command::new(&self.cli)
+            .args(["pull", &image])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ImagePull(e.to_string()))?;
+        if !pull_out.status.success() {
+            let err = String::from_utf8_lossy(&pull_out.stderr).to_string();
+            return Err(RuntimeError::ImagePull(err));
+        }
+        mark_pull_stopped(state, account_id, task_id);
+
+        // Run the container detached so we can track its ID and wait
+        // asynchronously. `-d` prints the container ID on stdout.
+        let mut cmd = Command::new(&self.cli);
+        cmd.args(["run", "-d"])
+            .args(["--label", &format!("fakecloud-ecs-task={}", task_id)])
+            .args([
+                "--add-host",
+                &format!("host.docker.internal:{}", self.host_ip),
+            ]);
+        for (k, v) in &env {
+            let transformed = v
+                .replace("http://127.0.0.1:", "http://host.docker.internal:")
+                .replace("https://127.0.0.1:", "https://host.docker.internal:")
+                .replace("http://localhost:", "http://host.docker.internal:")
+                .replace("https://localhost:", "https://host.docker.internal:");
+            cmd.arg("-e").arg(format!("{}={}", k, transformed));
+        }
+        cmd.arg(&image);
+        for arg in &command {
+            cmd.arg(arg);
+        }
+        let run_out = cmd
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStart(e.to_string()))?;
+        if !run_out.status.success() {
+            let err = String::from_utf8_lossy(&run_out.stderr).to_string();
+            return Err(RuntimeError::ContainerStart(err));
+        }
+        let container_id = String::from_utf8_lossy(&run_out.stdout).trim().to_string();
+        self.containers
+            .write()
+            .insert(task_id.to_string(), container_id.clone());
+        mark_running(
+            state,
+            account_id,
+            task_id,
+            &container_id,
+            &awslogs_container,
+        );
+
+        // Wait for the container to exit. `docker wait` blocks until exit
+        // and prints the numeric exit code to stdout.
+        let wait_out = Command::new(&self.cli)
+            .args(["wait", &container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::Wait(e.to_string()))?;
+        let exit_code: i64 = String::from_utf8_lossy(&wait_out.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(-1);
+
+        // Capture combined stdout+stderr via `docker logs`.
+        let logs_out = Command::new(&self.cli)
+            .args(["logs", &container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::Wait(e.to_string()))?;
+        let mut captured = String::new();
+        captured.push_str(&String::from_utf8_lossy(&logs_out.stdout));
+        captured.push_str(&String::from_utf8_lossy(&logs_out.stderr));
+
+        // Best-effort cleanup; failures here shouldn't keep the task from
+        // transitioning to STOPPED.
+        let _ = Command::new(&self.cli)
+            .args(["rm", &container_id])
+            .output()
+            .await;
+        self.containers.write().remove(task_id);
+
+        finalize_stopped(
+            state,
+            account_id,
+            task_id,
+            exit_code,
+            &captured,
+            "EssentialContainerExited",
+            None,
+        );
+        Ok(())
+    }
+
+    /// Kill the container behind a task (if any) with the configured stop
+    /// timeout. Returns true if a container was killed. Called synchronously
+    /// from `StopTask`; the wait loop in `run_task_inner` observes the
+    /// exit and transitions the task to `STOPPED`.
+    pub async fn stop_task(&self, task_id: &str, reason: &str) -> bool {
+        let container_id = self.containers.read().get(task_id).cloned();
+        let Some(id) = container_id else {
+            return false;
+        };
+        // `docker stop` sends SIGTERM then SIGKILL after a timeout.
+        let _ = Command::new(&self.cli)
+            .args(["stop", "--time", "10", &id])
+            .output()
+            .await;
+        tracing::info!(task = %task_id, reason = %reason, "ecs task stop requested");
+        true
+    }
+
+    /// Kill every running container the runtime owns. Called on reset /
+    /// shutdown so docker state matches fakecloud state after a fresh
+    /// boot.
+    pub async fn stop_all(&self) {
+        let ids: Vec<String> = self.containers.read().values().cloned().collect();
+        for id in ids {
+            let _ = Command::new(&self.cli).args(["kill", &id]).output().await;
+            let _ = Command::new(&self.cli).args(["rm", &id]).output().await;
+        }
+        self.containers.write().clear();
+    }
+}
+
+fn cli_works(cli: &str) -> bool {
+    std::process::Command::new(cli)
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn find_container_definition(
+    state: &crate::state::EcsState,
+    family: &str,
+    revision: i32,
+    name: &str,
+) -> Option<serde_json::Value> {
+    state
+        .task_definitions
+        .get(family)?
+        .get(&revision)?
+        .container_definitions
+        .iter()
+        .find(|c| c.get("name").and_then(|v| v.as_str()) == Some(name))
+        .cloned()
+}
+
+fn mark_pull_started(state: &SharedEcsState, account_id: &str, task_id: &str) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    let task_arn_cluster = s
+        .tasks
+        .get(task_id)
+        .map(|t| (t.task_arn.clone(), t.cluster_arn.clone()));
+    if let Some(task) = s.tasks.get_mut(task_id) {
+        task.pull_started_at = Some(Utc::now());
+    }
+    if let Some((arn, cluster_arn)) = task_arn_cluster {
+        s.push_event(LifecycleEvent {
+            at: Utc::now(),
+            event_type: "PullStarted".into(),
+            task_arn: Some(arn),
+            cluster_arn: Some(cluster_arn),
+            last_status: Some("PENDING".into()),
+            detail: serde_json::json!({}),
+        });
+    }
+}
+
+fn mark_pull_stopped(state: &SharedEcsState, account_id: &str, task_id: &str) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    if let Some(task) = s.tasks.get_mut(task_id) {
+        task.pull_stopped_at = Some(Utc::now());
+    }
+}
+
+fn mark_running(
+    state: &SharedEcsState,
+    account_id: &str,
+    task_id: &str,
+    container_id: &str,
+    container_name: &str,
+) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    let (arn, cluster_arn) = {
+        let Some(task) = s.tasks.get_mut(task_id) else {
+            return;
+        };
+        task.last_status = "RUNNING".into();
+        task.connectivity = "CONNECTED".into();
+        task.connectivity_at = Some(Utc::now());
+        task.started_at = Some(Utc::now());
+        if let Some(c) = task
+            .containers
+            .iter_mut()
+            .find(|c| c.name == container_name)
+        {
+            c.runtime_id = Some(container_id.into());
+            c.last_status = "RUNNING".into();
+        }
+        if let Some(cluster) = s.clusters.get_mut(&task.cluster_name) {
+            cluster.running_tasks_count += 1;
+            if cluster.pending_tasks_count > 0 {
+                cluster.pending_tasks_count -= 1;
+            }
+        }
+        (task.task_arn.clone(), task.cluster_arn.clone())
+    };
+    s.push_event(LifecycleEvent {
+        at: Utc::now(),
+        event_type: "TaskStateChange".into(),
+        task_arn: Some(arn),
+        cluster_arn: Some(cluster_arn),
+        last_status: Some("RUNNING".into()),
+        detail: serde_json::json!({}),
+    });
+}
+
+fn finalize_stopped(
+    state: &SharedEcsState,
+    account_id: &str,
+    task_id: &str,
+    exit_code: i64,
+    captured: &str,
+    stop_code: &str,
+    stopped_reason: Option<String>,
+) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    let (arn, cluster_arn) = {
+        let Some(task) = s.tasks.get_mut(task_id) else {
+            return;
+        };
+        task.last_status = "STOPPED".into();
+        task.desired_status = "STOPPED".into();
+        task.stopping_at = task.stopping_at.or(Some(Utc::now()));
+        task.stopped_at = Some(Utc::now());
+        task.stop_code = Some(stop_code.into());
+        task.stopped_reason = stopped_reason.or(Some(format!("Exit code {}", exit_code)));
+        task.captured_logs = captured.to_string();
+        for c in task.containers.iter_mut() {
+            c.last_status = "STOPPED".into();
+            if c.exit_code.is_none() {
+                c.exit_code = Some(exit_code);
+            }
+        }
+        if let Some(cluster) = s.clusters.get_mut(&task.cluster_name) {
+            if cluster.running_tasks_count > 0 {
+                cluster.running_tasks_count -= 1;
+            }
+        }
+        (task.task_arn.clone(), task.cluster_arn.clone())
+    };
+    s.push_event(LifecycleEvent {
+        at: Utc::now(),
+        event_type: "TaskStateChange".into(),
+        task_arn: Some(arn),
+        cluster_arn: Some(cluster_arn),
+        last_status: Some("STOPPED".into()),
+        detail: serde_json::json!({
+            "exitCode": exit_code,
+            "stopCode": stop_code,
+        }),
+    });
+}
+
+fn finalize_failure(state: &SharedEcsState, account_id: &str, task_id: &str, reason: &str) {
+    let mut accounts = state.write();
+    let Some(s) = accounts.get_mut(account_id) else {
+        return;
+    };
+    let (arn, cluster_arn) = {
+        let Some(task) = s.tasks.get_mut(task_id) else {
+            return;
+        };
+        task.last_status = "STOPPED".into();
+        task.desired_status = "STOPPED".into();
+        task.stopped_at = Some(Utc::now());
+        task.stop_code = Some("TaskFailedToStart".into());
+        task.stopped_reason = Some(reason.to_string());
+        for c in task.containers.iter_mut() {
+            c.last_status = "STOPPED".into();
+            c.reason = Some(reason.to_string());
+        }
+        if let Some(cluster) = s.clusters.get_mut(&task.cluster_name) {
+            if cluster.pending_tasks_count > 0 {
+                cluster.pending_tasks_count -= 1;
+            }
+        }
+        (task.task_arn.clone(), task.cluster_arn.clone())
+    };
+    s.push_event(LifecycleEvent {
+        at: Utc::now(),
+        event_type: "TaskFailedToStart".into(),
+        task_arn: Some(arn),
+        cluster_arn: Some(cluster_arn),
+        last_status: Some("STOPPED".into()),
+        detail: serde_json::json!({ "reason": reason }),
+    });
+}
+
+/// Short helper for tests + snapshot code to sleep between state
+/// transitions. Exposed on the crate boundary to keep test timing
+/// centralized.
+pub async fn sleep(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_works_for_known_missing_binary_is_false() {
+        assert!(!cli_works("definitely-not-a-real-cli-binary-xyz"));
+    }
+}

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -190,6 +190,13 @@ impl EcsRuntime {
             .output()
             .await
             .map_err(|e| RuntimeError::Wait(e.to_string()))?;
+        if !wait_out.status.success() {
+            // `docker wait` itself failed — treat this as a Wait error so
+            // the task flips via `finalize_failure` rather than silently
+            // claiming the container exited normally.
+            let err = String::from_utf8_lossy(&wait_out.stderr).to_string();
+            return Err(RuntimeError::Wait(err));
+        }
         let exit_code: i64 = String::from_utf8_lossy(&wait_out.stdout)
             .trim()
             .parse()
@@ -420,6 +427,12 @@ fn finalize_failure(state: &SharedEcsState, account_id: &str, task_id: &str, rea
         let Some(task) = s.tasks.get_mut(task_id) else {
             return;
         };
+        // Capture the prior status before we clobber it: if the task had
+        // already reached RUNNING when execution failed (e.g. `docker wait`
+        // blew up after the container started), we owe the cluster a
+        // running-tasks decrement. Tasks that died before RUNNING only
+        // ever incremented pendingTasksCount.
+        let was_running = task.last_status == "RUNNING";
         task.last_status = "STOPPED".into();
         task.desired_status = "STOPPED".into();
         task.stopped_at = Some(Utc::now());
@@ -430,7 +443,11 @@ fn finalize_failure(state: &SharedEcsState, account_id: &str, task_id: &str, rea
             c.reason = Some(reason.to_string());
         }
         if let Some(cluster) = s.clusters.get_mut(&task.cluster_name) {
-            if cluster.pending_tasks_count > 0 {
+            if was_running {
+                if cluster.running_tasks_count > 0 {
+                    cluster.running_tasks_count -= 1;
+                }
+            } else if cluster.pending_tasks_count > 0 {
                 cluster.pending_tasks_count -= 1;
             }
         }

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -10,8 +10,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    Cluster, EcsSnapshot, EcsState, SharedEcsState, TagEntry, TaskDefinition,
-    ECS_SNAPSHOT_SCHEMA_VERSION,
+    AwsLogsConfig, Cluster, Container, EcsSnapshot, EcsState, SharedEcsState, TagEntry, Task,
+    TaskDefinition, ECS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED_ACTIONS: &[&str] = &[
@@ -35,6 +35,11 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "PutAccountSettingDefault",
     "DeleteAccountSetting",
     "ListAccountSettings",
+    "RunTask",
+    "StartTask",
+    "StopTask",
+    "DescribeTasks",
+    "ListTasks",
 ];
 
 fn is_mutating(action: &str) -> bool {
@@ -53,6 +58,9 @@ fn is_mutating(action: &str) -> bool {
             | "PutAccountSetting"
             | "PutAccountSettingDefault"
             | "DeleteAccountSetting"
+            | "RunTask"
+            | "StartTask"
+            | "StopTask"
     )
 }
 
@@ -60,6 +68,7 @@ pub struct EcsService {
     state: SharedEcsState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    runtime: Option<Arc<crate::runtime::EcsRuntime>>,
 }
 
 impl EcsService {
@@ -68,11 +77,17 @@ impl EcsService {
             state,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            runtime: None,
         }
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_runtime(mut self, runtime: Arc<crate::runtime::EcsRuntime>) -> Self {
+        self.runtime = Some(runtime);
         self
     }
 
@@ -132,6 +147,11 @@ impl AwsService for EcsService {
             "PutAccountSettingDefault" => self.put_account_setting_default(&request),
             "DeleteAccountSetting" => self.delete_account_setting(&request),
             "ListAccountSettings" => self.list_account_settings(&request),
+            "RunTask" => self.run_task(&request),
+            "StartTask" => self.start_task(&request),
+            "StopTask" => self.stop_task(&request).await,
+            "DescribeTasks" => self.describe_tasks(&request),
+            "ListTasks" => self.list_tasks(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 "ecs",
                 &request.action,
@@ -1318,6 +1338,494 @@ impl EcsService {
 
 fn matches_filter(filter: Option<&str>, value: &str) -> bool {
     filter.is_none_or(|f| f == value)
+}
+
+// -------- operations: tasks --------
+
+impl EcsService {
+    fn run_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let td_ref = req_str(&body, "taskDefinition")?;
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let launch_type = opt_str(&body, "launchType")
+            .unwrap_or("FARGATE")
+            .to_string();
+        let count = body
+            .get("count")
+            .and_then(|v| v.as_i64())
+            .filter(|n| (1..=10).contains(n))
+            .unwrap_or(1) as usize;
+        let group = opt_str(&body, "group").map(String::from);
+        let started_by = opt_str(&body, "startedBy").map(String::from);
+        let tags = parse_tags(&body);
+
+        let account = request.account_id.clone();
+        let runtime = self.runtime.clone();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&account);
+        let cluster_arn = state
+            .clusters
+            .get(&cluster_name)
+            .map(|c| c.cluster_arn.clone())
+            .unwrap_or_else(|| state.cluster_arn(&cluster_name));
+        let (_, family, rev) = resolve_task_definition_ref(td_ref)?;
+        let revisions = state
+            .task_definitions
+            .get(&family)
+            .ok_or_else(|| task_definition_not_found(td_ref))?;
+        let td = match rev {
+            Some(n) => revisions
+                .get(&n)
+                .ok_or_else(|| task_definition_not_found(td_ref))?,
+            None => latest_active_revision(revisions)
+                .ok_or_else(|| task_definition_not_found(td_ref))?,
+        };
+        if td.status != "ACTIVE" {
+            return Err(client_exception(format!(
+                "Task definition {} is not ACTIVE",
+                td.task_definition_arn
+            )));
+        }
+        let td_arn = td.task_definition_arn.clone();
+        let td_family = td.family.clone();
+        let td_revision = td.revision;
+        let td_cpu = td.cpu.clone();
+        let td_memory = td.memory.clone();
+        let td_task_role = td.task_role_arn.clone();
+        let td_exec_role = td.execution_role_arn.clone();
+        let td_containers = td.container_definitions.clone();
+
+        let mut spawned_tasks: Vec<String> = Vec::new();
+        let mut task_jsons: Vec<Value> = Vec::new();
+        for _ in 0..count {
+            let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+            let task_arn = state.task_arn(&cluster_name, &task_id);
+            let containers: Vec<Container> = td_containers
+                .iter()
+                .map(|def| Container {
+                    container_arn: format!(
+                        "arn:aws:ecs:{}:{}:container/{}/{}/{}",
+                        state.region,
+                        state.account_id,
+                        cluster_name,
+                        task_id,
+                        def.get("name").and_then(|v| v.as_str()).unwrap_or("app")
+                    ),
+                    name: def
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("app")
+                        .to_string(),
+                    image: def
+                        .get("image")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    task_arn: task_arn.clone(),
+                    last_status: "PENDING".into(),
+                    exit_code: None,
+                    reason: None,
+                    runtime_id: None,
+                    essential: def
+                        .get("essential")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true),
+                    cpu: def
+                        .get("cpu")
+                        .and_then(|v| v.as_i64())
+                        .map(|n| n.to_string()),
+                    memory: def
+                        .get("memory")
+                        .and_then(|v| v.as_i64())
+                        .map(|n| n.to_string()),
+                    memory_reservation: def
+                        .get("memoryReservation")
+                        .and_then(|v| v.as_i64())
+                        .map(|n| n.to_string()),
+                    network_bindings: Vec::new(),
+                    network_interfaces: Vec::new(),
+                    health_status: Some("UNKNOWN".to_string()),
+                    managed_agents: None,
+                })
+                .collect();
+            let awslogs = td_containers.iter().find_map(|def| {
+                let name = def.get("name").and_then(|v| v.as_str())?.to_string();
+                let log_cfg = def.get("logConfiguration")?;
+                if log_cfg.get("logDriver").and_then(|v| v.as_str()) != Some("awslogs") {
+                    return None;
+                }
+                let opts = log_cfg.get("options").and_then(|v| v.as_object())?;
+                Some(AwsLogsConfig {
+                    group: opts.get("awslogs-group").and_then(|v| v.as_str())?.into(),
+                    stream_prefix: opts
+                        .get("awslogs-stream-prefix")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    region: opts
+                        .get("awslogs-region")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&state.region)
+                        .to_string(),
+                    container_name: name,
+                })
+            });
+            let task = Task {
+                task_arn: task_arn.clone(),
+                task_id: task_id.clone(),
+                cluster_arn: cluster_arn.clone(),
+                cluster_name: cluster_name.clone(),
+                task_definition_arn: td_arn.clone(),
+                family: td_family.clone(),
+                revision: td_revision,
+                last_status: "PROVISIONING".into(),
+                desired_status: "RUNNING".into(),
+                launch_type: launch_type.clone(),
+                platform_version: Some("1.4.0".into()),
+                cpu: body
+                    .get("overrides")
+                    .and_then(|v| v.get("cpu"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                    .or_else(|| td_cpu.clone()),
+                memory: body
+                    .get("overrides")
+                    .and_then(|v| v.get("memory"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                    .or_else(|| td_memory.clone()),
+                containers,
+                overrides: body.get("overrides").cloned().unwrap_or_else(|| json!({})),
+                started_by: started_by.clone(),
+                group: group.clone(),
+                connectivity: "CONNECTING".into(),
+                stop_code: None,
+                stopped_reason: None,
+                created_at: Utc::now(),
+                started_at: None,
+                stopping_at: None,
+                stopped_at: None,
+                pull_started_at: None,
+                pull_stopped_at: None,
+                connectivity_at: None,
+                started_by_ref_id: None,
+                execution_role_arn: td_exec_role.clone(),
+                task_role_arn: td_task_role.clone(),
+                tags: tags.clone(),
+                awslogs,
+                captured_logs: String::new(),
+            };
+            state.tasks.insert(task_id.clone(), task.clone());
+            if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
+                cluster.pending_tasks_count += 1;
+            }
+            // Snapshot-in-progress: transition to PENDING synchronously so
+            // callers that immediately DescribeTasks see movement. RUNNING /
+            // STOPPED come later from the background runtime task.
+            if let Some(t) = state.tasks.get_mut(&task_id) {
+                t.last_status = "PENDING".into();
+            }
+            task_jsons.push(task_to_json(&task));
+            spawned_tasks.push(task_id.clone());
+        }
+        drop(accounts);
+
+        // Launch container execution outside the state lock.
+        if let Some(rt) = runtime {
+            for id in &spawned_tasks {
+                rt.clone()
+                    .run_task(self.state.clone(), id.clone(), account.clone());
+            }
+        } else {
+            // No runtime available — fail fast so the task doesn't stay
+            // PENDING forever.
+            let mut accounts = self.state.write();
+            if let Some(state) = accounts.get_mut(&account) {
+                for id in &spawned_tasks {
+                    if let Some(t) = state.tasks.get_mut(id) {
+                        t.last_status = "STOPPED".into();
+                        t.desired_status = "STOPPED".into();
+                        t.stop_code = Some("TaskFailedToStart".into());
+                        t.stopped_reason = Some(
+                            "No container runtime available (docker/podman not installed)".into(),
+                        );
+                        t.stopped_at = Some(Utc::now());
+                        for c in t.containers.iter_mut() {
+                            c.last_status = "STOPPED".into();
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({
+            "tasks": task_jsons,
+            "failures": [],
+        })))
+    }
+
+    fn start_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // StartTask targets explicit container instances. Our ECS emulator
+        // has no concept of registered container instances yet (Batch 4);
+        // fall through to the same semantics as RunTask so the API is
+        // usable while the container-instance surface is pending.
+        self.run_task(request)
+    }
+
+    async fn stop_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let task_ref = req_str(&body, "task")?;
+        let reason = opt_str(&body, "reason")
+            .unwrap_or("UserInitiated")
+            .to_string();
+        let cluster_ref = opt_str(&body, "cluster");
+        let _cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+
+        let (task_id, account, task_snapshot) = {
+            let account = request.account_id.clone();
+            let mut accounts = self.state.write();
+            let state = accounts
+                .get_mut(&account)
+                .ok_or_else(|| task_not_found(task_ref))?;
+            let task_id = resolve_task_id(state, task_ref)?;
+            let task = state
+                .tasks
+                .get_mut(&task_id)
+                .ok_or_else(|| task_not_found(task_ref))?;
+            task.desired_status = "STOPPED".into();
+            task.stopping_at = Some(Utc::now());
+            task.stopped_reason = Some(reason.clone());
+            task.stop_code = Some("UserInitiated".into());
+            (task_id, account, task.clone())
+        };
+        if let Some(rt) = &self.runtime {
+            rt.stop_task(&task_id, &reason).await;
+        }
+        let _ = account;
+        Ok(AwsResponse::ok_json(json!({
+            "task": task_to_json(&task_snapshot),
+        })))
+    }
+
+    fn describe_tasks(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let refs: Vec<String> = body
+            .get("tasks")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let include_tags = body
+            .get("include")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().any(|v| v.as_str() == Some("TAGS")))
+            .unwrap_or(false);
+
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let Some(state) = accounts.get(&account) else {
+            return Ok(AwsResponse::ok_json(json!({
+                "tasks": [],
+                "failures": refs.iter().map(|r| json!({"arn": r, "reason": "MISSING"})).collect::<Vec<_>>(),
+            })));
+        };
+        let mut found = Vec::new();
+        let mut failures = Vec::new();
+        for input in &refs {
+            let task_id = task_id_from_ref(input);
+            match state.tasks.get(&task_id) {
+                Some(t) => {
+                    let mut v = task_to_json(t);
+                    if include_tags {
+                        v.as_object_mut()
+                            .unwrap()
+                            .insert("tags".into(), tags_json(&t.tags));
+                    }
+                    found.push(v);
+                }
+                None => {
+                    failures.push(json!({
+                        "arn": input,
+                        "reason": "MISSING",
+                    }));
+                }
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "tasks": found,
+            "failures": failures,
+        })))
+    }
+
+    fn list_tasks(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let family = opt_str(&body, "family");
+        let status_filter = opt_str(&body, "desiredStatus");
+        let started_by = opt_str(&body, "startedBy");
+        let max_results = body
+            .get("maxResults")
+            .and_then(|v| v.as_i64())
+            .filter(|n| (1..=100).contains(n))
+            .map(|n| n as usize)
+            .unwrap_or(100);
+        let next_token = opt_str(&body, "nextToken").unwrap_or("");
+
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let mut arns: Vec<String> = match accounts.get(&account) {
+            Some(state) => state
+                .tasks
+                .values()
+                .filter(|t| t.cluster_name == cluster_name)
+                .filter(|t| family.is_none_or(|f| t.family == f))
+                .filter(|t| status_filter.is_none_or(|s| t.desired_status == s))
+                .filter(|t| started_by.is_none_or(|s| t.started_by.as_deref() == Some(s)))
+                .map(|t| t.task_arn.clone())
+                .collect(),
+            None => Vec::new(),
+        };
+        arns.sort();
+        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
+        let end = (start + max_results).min(arns.len());
+        let page = arns[start..end].to_vec();
+        let mut out = json!({"taskArns": page});
+        if end < arns.len() {
+            out.as_object_mut()
+                .unwrap()
+                .insert("nextToken".into(), json!(end.to_string()));
+        }
+        Ok(AwsResponse::ok_json(out))
+    }
+}
+
+fn task_not_found(task_ref: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ClientException",
+        format!("Task not found: {task_ref}"),
+    )
+}
+
+/// Strip cluster prefix + optional ARN prefix to recover the task UUID.
+fn task_id_from_ref(input: &str) -> String {
+    if let Some(rest) = input.rsplit('/').next() {
+        return rest.to_string();
+    }
+    input.to_string()
+}
+
+fn resolve_task_id(state: &EcsState, task_ref: &str) -> Result<String, AwsServiceError> {
+    let id = task_id_from_ref(task_ref);
+    if state.tasks.contains_key(&id) {
+        Ok(id)
+    } else {
+        Err(task_not_found(task_ref))
+    }
+}
+
+fn task_to_json(task: &Task) -> Value {
+    let mut map = serde_json::Map::new();
+    map.insert("taskArn".into(), json!(task.task_arn));
+    map.insert("clusterArn".into(), json!(task.cluster_arn));
+    map.insert("taskDefinitionArn".into(), json!(task.task_definition_arn));
+    map.insert("lastStatus".into(), json!(task.last_status));
+    map.insert("desiredStatus".into(), json!(task.desired_status));
+    map.insert("launchType".into(), json!(task.launch_type));
+    if let Some(ref v) = task.platform_version {
+        map.insert("platformVersion".into(), json!(v));
+    }
+    if let Some(ref v) = task.cpu {
+        map.insert("cpu".into(), json!(v));
+    }
+    if let Some(ref v) = task.memory {
+        map.insert("memory".into(), json!(v));
+    }
+    map.insert(
+        "containers".into(),
+        Value::Array(task.containers.iter().map(container_to_json).collect()),
+    );
+    map.insert("overrides".into(), task.overrides.clone());
+    if let Some(ref v) = task.started_by {
+        map.insert("startedBy".into(), json!(v));
+    }
+    if let Some(ref v) = task.group {
+        map.insert("group".into(), json!(v));
+    }
+    map.insert("connectivity".into(), json!(task.connectivity));
+    if let Some(ref v) = task.stop_code {
+        map.insert("stopCode".into(), json!(v));
+    }
+    if let Some(ref v) = task.stopped_reason {
+        map.insert("stoppedReason".into(), json!(v));
+    }
+    if let Some(ref v) = task.task_role_arn {
+        map.insert("taskRoleArn".into(), json!(v));
+    }
+    if let Some(ref v) = task.execution_role_arn {
+        map.insert("executionRoleArn".into(), json!(v));
+    }
+    map.insert("createdAt".into(), json!(task.created_at.timestamp()));
+    if let Some(ts) = task.started_at {
+        map.insert("startedAt".into(), json!(ts.timestamp()));
+    }
+    if let Some(ts) = task.stopping_at {
+        map.insert("stoppingAt".into(), json!(ts.timestamp()));
+    }
+    if let Some(ts) = task.stopped_at {
+        map.insert("stoppedAt".into(), json!(ts.timestamp()));
+    }
+    if let Some(ts) = task.pull_started_at {
+        map.insert("pullStartedAt".into(), json!(ts.timestamp()));
+    }
+    if let Some(ts) = task.pull_stopped_at {
+        map.insert("pullStoppedAt".into(), json!(ts.timestamp()));
+    }
+    if let Some(ts) = task.connectivity_at {
+        map.insert("connectivityAt".into(), json!(ts.timestamp()));
+    }
+    Value::Object(map)
+}
+
+fn container_to_json(container: &Container) -> Value {
+    let mut map = serde_json::Map::new();
+    map.insert("containerArn".into(), json!(container.container_arn));
+    map.insert("taskArn".into(), json!(container.task_arn));
+    map.insert("name".into(), json!(container.name));
+    map.insert("image".into(), json!(container.image));
+    map.insert("lastStatus".into(), json!(container.last_status));
+    map.insert("essential".into(), json!(container.essential));
+    if let Some(code) = container.exit_code {
+        map.insert("exitCode".into(), json!(code));
+    }
+    if let Some(ref r) = container.reason {
+        map.insert("reason".into(), json!(r));
+    }
+    if let Some(ref id) = container.runtime_id {
+        map.insert("runtimeId".into(), json!(id));
+    }
+    if let Some(ref v) = container.cpu {
+        map.insert("cpu".into(), json!(v));
+    }
+    if let Some(ref v) = container.memory {
+        map.insert("memory".into(), json!(v));
+    }
+    if let Some(ref v) = container.memory_reservation {
+        map.insert("memoryReservation".into(), json!(v));
+    }
+    map.insert("networkBindings".into(), json!(container.network_bindings));
+    map.insert(
+        "networkInterfaces".into(),
+        json!(container.network_interfaces),
+    );
+    if let Some(ref v) = container.health_status {
+        map.insert("healthStatus".into(), json!(v));
+    }
+    Value::Object(map)
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -1538,9 +1538,12 @@ impl EcsService {
             }
         } else {
             // No runtime available — fail fast so the task doesn't stay
-            // PENDING forever.
+            // PENDING forever. We incremented pending_tasks_count above;
+            // decrement it here so the cluster counter doesn't drift and
+            // block later DeleteCluster calls.
             let mut accounts = self.state.write();
             if let Some(state) = accounts.get_mut(&account) {
+                let mut cluster_drains: Vec<String> = Vec::new();
                 for id in &spawned_tasks {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
@@ -1552,6 +1555,14 @@ impl EcsService {
                         t.stopped_at = Some(Utc::now());
                         for c in t.containers.iter_mut() {
                             c.last_status = "STOPPED".into();
+                        }
+                        cluster_drains.push(t.cluster_name.clone());
+                    }
+                }
+                for name in cluster_drains {
+                    if let Some(cluster) = state.clusters.get_mut(&name) {
+                        if cluster.pending_tasks_count > 0 {
+                            cluster.pending_tasks_count -= 1;
                         }
                     }
                 }

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -14,7 +14,7 @@ impl fakecloud_core::multi_account::AccountState for EcsState {
     }
 }
 
-pub const ECS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const ECS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 /// Top-level persisted ECS snapshot. Mirrors the multi-account snapshot
 /// convention used by Kinesis/ECR/ElastiCache so `main.rs` can share the
@@ -44,6 +44,13 @@ pub struct EcsState {
     /// Per-principal account settings (PutAccountSetting). Keyed by
     /// principal ARN, then setting name.
     pub principal_account_settings: BTreeMap<String, BTreeMap<String, String>>,
+    /// Tasks keyed by task ID (the trailing segment of the task ARN).
+    #[serde(default)]
+    pub tasks: BTreeMap<String, Task>,
+    /// Lifecycle event log for introspection. Bounded at 1024 entries
+    /// (oldest dropped) so long-running servers don't grow unboundedly.
+    #[serde(default)]
+    pub events: Vec<LifecycleEvent>,
 }
 
 impl EcsState {
@@ -56,6 +63,8 @@ impl EcsState {
             next_revision: BTreeMap::new(),
             account_setting_defaults: BTreeMap::new(),
             principal_account_settings: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            events: Vec::new(),
         }
     }
 
@@ -65,6 +74,24 @@ impl EcsState {
         self.next_revision.clear();
         self.account_setting_defaults.clear();
         self.principal_account_settings.clear();
+        self.tasks.clear();
+        self.events.clear();
+    }
+
+    pub fn task_arn(&self, cluster_name: &str, task_id: &str) -> String {
+        format!(
+            "arn:aws:ecs:{}:{}:task/{}/{}",
+            self.region, self.account_id, cluster_name, task_id
+        )
+    }
+
+    /// Append a lifecycle event, trimming the oldest when the cap is hit.
+    pub fn push_event(&mut self, event: LifecycleEvent) {
+        const MAX_EVENTS: usize = 1024;
+        if self.events.len() >= MAX_EVENTS {
+            self.events.drain(0..self.events.len() - MAX_EVENTS + 1);
+        }
+        self.events.push(event);
     }
 
     pub fn cluster_arn(&self, cluster_name: &str) -> String {
@@ -201,6 +228,106 @@ pub struct TaskDefinition {
     #[serde(default)]
     pub tags: Vec<TagEntry>,
     pub enable_fault_injection: Option<bool>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Task {
+    pub task_arn: String,
+    pub task_id: String,
+    pub cluster_arn: String,
+    pub cluster_name: String,
+    pub task_definition_arn: String,
+    pub family: String,
+    pub revision: i32,
+    /// Current lifecycle state: PROVISIONING, PENDING, RUNNING,
+    /// DEPROVISIONING, STOPPED.
+    pub last_status: String,
+    /// What the caller asked for: usually RUNNING, or STOPPED once
+    /// `StopTask` / `StopService` hits.
+    pub desired_status: String,
+    pub launch_type: String,
+    pub platform_version: Option<String>,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    #[serde(default)]
+    pub containers: Vec<Container>,
+    #[serde(default)]
+    pub overrides: Value,
+    pub started_by: Option<String>,
+    pub group: Option<String>,
+    pub connectivity: String,
+    pub stop_code: Option<String>,
+    pub stopped_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub stopping_at: Option<DateTime<Utc>>,
+    pub stopped_at: Option<DateTime<Utc>>,
+    pub pull_started_at: Option<DateTime<Utc>>,
+    pub pull_stopped_at: Option<DateTime<Utc>>,
+    pub connectivity_at: Option<DateTime<Utc>>,
+    pub started_by_ref_id: Option<String>,
+    pub execution_role_arn: Option<String>,
+    pub task_role_arn: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<TagEntry>,
+    /// Log destination derived from the first container's awslogs driver.
+    /// `None` when no awslogs driver is configured — captured stdout/stderr
+    /// is still stored on the task for introspection.
+    pub awslogs: Option<AwsLogsConfig>,
+    /// Captured stdout/stderr from the container. Populated after the
+    /// container exits. Kept here so the introspection endpoint can serve
+    /// logs even when no awslogs driver is configured.
+    #[serde(default)]
+    pub captured_logs: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Container {
+    pub container_arn: String,
+    pub name: String,
+    pub image: String,
+    pub task_arn: String,
+    pub last_status: String,
+    pub exit_code: Option<i64>,
+    pub reason: Option<String>,
+    pub runtime_id: Option<String>,
+    pub essential: bool,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub memory_reservation: Option<String>,
+    #[serde(default)]
+    pub network_bindings: Vec<Value>,
+    #[serde(default)]
+    pub network_interfaces: Vec<Value>,
+    pub health_status: Option<String>,
+    pub managed_agents: Option<Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AwsLogsConfig {
+    pub group: String,
+    pub stream_prefix: Option<String>,
+    pub region: String,
+    pub container_name: String,
+}
+
+impl AwsLogsConfig {
+    pub fn stream_name(&self, task_id: &str) -> String {
+        match &self.stream_prefix {
+            Some(p) => format!("{}/{}/{}", p, self.container_name, task_id),
+            None => format!("{}/{}", self.container_name, task_id),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LifecycleEvent {
+    pub at: DateTime<Utc>,
+    pub event_type: String,
+    pub task_arn: Option<String>,
+    pub cluster_arn: Option<String>,
+    pub last_status: Option<String>,
+    pub detail: Value,
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -815,4 +815,101 @@ impl EcsClient<'_> {
             .await?;
         FakeCloud::parse(resp).await
     }
+
+    /// List every task the server has seen. Optional `cluster` / `status`
+    /// filters restrict the dump when supplied.
+    pub async fn get_tasks(
+        &self,
+        cluster: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<EcsTasksResponse, Error> {
+        fn encode(s: &str) -> String {
+            let mut out = String::with_capacity(s.len());
+            for b in s.bytes() {
+                match b {
+                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                        out.push(b as char);
+                    }
+                    _ => out.push_str(&format!("%{:02X}", b)),
+                }
+            }
+            out
+        }
+        let mut url = format!("{}/_fakecloud/ecs/tasks", self.fc.base_url);
+        let mut sep = '?';
+        if let Some(c) = cluster {
+            url.push(sep);
+            url.push_str("cluster=");
+            url.push_str(&encode(c));
+            sep = '&';
+        }
+        if let Some(s) = status {
+            url.push(sep);
+            url.push_str("status=");
+            url.push_str(&encode(s));
+        }
+        let resp = self.fc.client.get(url).send().await?;
+        FakeCloud::parse(resp).await
+    }
+
+    /// Tail stored container stdout/stderr for a single task. Works even
+    /// when no `awslogs` driver is configured — fakecloud always captures
+    /// docker stdout/stderr on exit and keeps it on the task.
+    pub async fn get_task_logs(&self, task_id: &str) -> Result<EcsTaskLogsResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!(
+                "{}/_fakecloud/ecs/tasks/{}/logs",
+                self.fc.base_url, task_id
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+
+    /// Force the running container behind a task to stop.
+    pub async fn force_stop_task(&self, task_id: &str) -> Result<EcsTask, Error> {
+        let resp = self
+            .fc
+            .client
+            .post(format!(
+                "{}/_fakecloud/ecs/tasks/{}/force-stop",
+                self.fc.base_url, task_id
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+
+    /// Flip the task to STOPPED without killing the underlying container
+    /// — useful for simulating task failures in tests.
+    pub async fn mark_task_failed(
+        &self,
+        task_id: &str,
+        req: &EcsMarkFailedRequest,
+    ) -> Result<EcsTask, Error> {
+        let resp = self
+            .fc
+            .client
+            .post(format!(
+                "{}/_fakecloud/ecs/tasks/{}/mark-failed",
+                self.fc.base_url, task_id
+            ))
+            .json(req)
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+
+    /// Replay the lifecycle event log.
+    pub async fn get_events(&self) -> Result<EcsEventsResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!("{}/_fakecloud/ecs/events", self.fc.base_url))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
 }

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -742,6 +742,79 @@ pub struct EcsClustersResponse {
     pub clusters: Vec<EcsCluster>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskContainer {
+    pub name: String,
+    pub image: String,
+    pub last_status: String,
+    pub exit_code: Option<i64>,
+    pub runtime_id: Option<String>,
+    pub essential: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTask {
+    pub task_arn: String,
+    pub task_id: String,
+    pub cluster_arn: String,
+    pub cluster_name: String,
+    pub task_definition_arn: String,
+    pub family: String,
+    pub revision: i32,
+    pub last_status: String,
+    pub desired_status: String,
+    pub launch_type: String,
+    pub created_at: String,
+    pub started_at: Option<String>,
+    pub stopping_at: Option<String>,
+    pub stopped_at: Option<String>,
+    pub stop_code: Option<String>,
+    pub stopped_reason: Option<String>,
+    pub containers: Vec<EcsTaskContainer>,
+    pub captured_log_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTasksResponse {
+    pub tasks: Vec<EcsTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskLogsResponse {
+    pub task_arn: String,
+    pub logs: String,
+    pub last_status: String,
+    pub exit_code: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsMarkFailedRequest {
+    pub exit_code: Option<i64>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsLifecycleEvent {
+    pub at: String,
+    pub event_type: String,
+    pub task_arn: Option<String>,
+    pub cluster_arn: Option<String>,
+    pub last_status: Option<String>,
+    pub detail: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsEventsResponse {
+    pub events: Vec<EcsLifecycleEvent>,
+}
+
 /// Request to bootstrap an IAM admin user in a specific account.
 /// Used by `/_fakecloud/iam/create-admin` to solve the multi-account
 /// bootstrap problem: there's no per-account root credential, so this

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -101,6 +101,53 @@ pub(crate) fn ecr_pull_through_rule_response(
     }
 }
 
+pub(crate) fn ecs_task_response(task: &fakecloud_ecs::state::Task) -> types::EcsTask {
+    types::EcsTask {
+        task_arn: task.task_arn.clone(),
+        task_id: task.task_id.clone(),
+        cluster_arn: task.cluster_arn.clone(),
+        cluster_name: task.cluster_name.clone(),
+        task_definition_arn: task.task_definition_arn.clone(),
+        family: task.family.clone(),
+        revision: task.revision,
+        last_status: task.last_status.clone(),
+        desired_status: task.desired_status.clone(),
+        launch_type: task.launch_type.clone(),
+        created_at: task.created_at.to_rfc3339(),
+        started_at: task.started_at.map(|t| t.to_rfc3339()),
+        stopping_at: task.stopping_at.map(|t| t.to_rfc3339()),
+        stopped_at: task.stopped_at.map(|t| t.to_rfc3339()),
+        stop_code: task.stop_code.clone(),
+        stopped_reason: task.stopped_reason.clone(),
+        captured_log_bytes: task.captured_logs.len(),
+        containers: task
+            .containers
+            .iter()
+            .map(|c| types::EcsTaskContainer {
+                name: c.name.clone(),
+                image: c.image.clone(),
+                last_status: c.last_status.clone(),
+                exit_code: c.exit_code,
+                runtime_id: c.runtime_id.clone(),
+                essential: c.essential,
+            })
+            .collect(),
+    }
+}
+
+pub(crate) fn ecs_lifecycle_event(
+    event: &fakecloud_ecs::state::LifecycleEvent,
+) -> types::EcsLifecycleEvent {
+    types::EcsLifecycleEvent {
+        at: event.at.to_rfc3339(),
+        event_type: event.event_type.clone(),
+        task_arn: event.task_arn.clone(),
+        cluster_arn: event.cluster_arn.clone(),
+        last_status: event.last_status.clone(),
+        detail: event.detail.clone(),
+    }
+}
+
 pub(crate) fn ecs_cluster_response(cluster: &fakecloud_ecs::state::Cluster) -> types::EcsCluster {
     types::EcsCluster {
         cluster_name: cluster.cluster_name.clone(),

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -25,8 +25,9 @@ use cli::Cli;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use introspection::{
     ecr_image_response, ecr_pull_through_rule_response, ecr_repository_response,
-    ecs_cluster_response, elasticache_cluster_response, elasticache_replication_group_response,
-    elasticache_serverless_cache_response, rds_instance_response,
+    ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_cluster_response,
+    elasticache_replication_group_response, elasticache_serverless_cache_response,
+    rds_instance_response,
 };
 use kinesis_lambda_poller::KinesisLambdaPoller;
 use reset::ResetState;
@@ -337,6 +338,16 @@ async fn main() {
         );
     }
 
+    let ecs_runtime = fakecloud_ecs::runtime::EcsRuntime::new().map(Arc::new);
+    if let Some(ref rt) = ecs_runtime {
+        tracing::info!(
+            cli = rt.cli_name(),
+            "ECS task execution enabled via container runtime"
+        );
+    } else {
+        tracing::info!("Docker/Podman not available — ECS RunTask will return TaskFailedToStart");
+    }
+
     // Cross-service delivery bus
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
     let sqs_delivery = Arc::new(fakecloud_sqs::delivery::SqsDeliveryImpl::new(
@@ -515,6 +526,7 @@ async fn main() {
         container_runtime: container_runtime.clone(),
         rds_runtime: rds_runtime.clone(),
         elasticache_runtime: elasticache_runtime.clone(),
+        ecs_runtime: ecs_runtime.clone(),
     };
 
     // Step 5: CloudFormation delivery (custom resources can invoke Lambda)
@@ -1806,6 +1818,9 @@ async fn main() {
     let mut ecs_service = EcsService::new(ecs_state.clone());
     if let Some(store) = ecs_snapshot_store {
         ecs_service = ecs_service.with_snapshot_store(store);
+    }
+    if let Some(ref rt) = ecs_runtime {
+        ecs_service = ecs_service.with_runtime(rt.clone());
     }
     registry.register(Arc::new(ecs_service));
 
@@ -3211,6 +3226,201 @@ async fn main() {
                         }
                         clusters.sort_by(|a, b| a.cluster_arn.cmp(&b.cluster_arn));
                         axum::Json(types::EcsClustersResponse { clusters })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/tasks",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Query(q): axum::extract::Query<
+                    std::collections::HashMap<String, String>,
+                >| {
+                    let ec = ec.clone();
+                    async move {
+                        let cluster_filter = q.get("cluster").cloned();
+                        let status_filter = q.get("status").cloned();
+                        let accounts = ec.read();
+                        let mut tasks: Vec<types::EcsTask> = Vec::new();
+                        for (_, state) in accounts.iter() {
+                            for t in state.tasks.values() {
+                                if let Some(ref c) = cluster_filter {
+                                    if &t.cluster_name != c && &t.cluster_arn != c {
+                                        continue;
+                                    }
+                                }
+                                if let Some(ref s) = status_filter {
+                                    if &t.last_status != s {
+                                        continue;
+                                    }
+                                }
+                                tasks.push(ecs_task_response(t));
+                            }
+                        }
+                        tasks.sort_by(|a, b| a.task_arn.cmp(&b.task_arn));
+                        axum::Json(types::EcsTasksResponse { tasks })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/tasks/{task_id}",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            if let Some(t) = state.tasks.get(&task_id) {
+                                return (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::to_value(ecs_task_response(t)).unwrap()),
+                                );
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/tasks/{task_id}/logs",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            if let Some(t) = state.tasks.get(&task_id) {
+                                let resp = types::EcsTaskLogsResponse {
+                                    task_arn: t.task_arn.clone(),
+                                    logs: t.captured_logs.clone(),
+                                    last_status: t.last_status.clone(),
+                                    exit_code: t
+                                        .containers
+                                        .iter()
+                                        .find_map(|c| c.exit_code),
+                                };
+                                return (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::to_value(resp).unwrap()),
+                                );
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/tasks/{task_id}/force-stop",
+            axum::routing::post({
+                let ec = ecs_introspection_state.clone();
+                let rt = ecs_runtime.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    let rt = rt.clone();
+                    async move {
+                        if let Some(runtime) = rt {
+                            runtime
+                                .stop_task(&task_id, "IntrospectionForceStop")
+                                .await;
+                        }
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            if let Some(t) = state.tasks.get(&task_id) {
+                                return (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::to_value(ecs_task_response(t)).unwrap()),
+                                );
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/tasks/{task_id}/mark-failed",
+            axum::routing::post({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>,
+                      axum::Json(req): axum::Json<types::EcsMarkFailedRequest>| {
+                    let ec = ec.clone();
+                    async move {
+                        let mut accounts = ec.write();
+                        for (_, state) in accounts.iter_mut() {
+                            if state.tasks.contains_key(&task_id) {
+                                let event_detail = serde_json::json!({
+                                    "exitCode": req.exit_code.unwrap_or(-1),
+                                    "stopCode": "IntrospectionMarkFailed",
+                                });
+                                let (task_arn, cluster_arn) = {
+                                    let t = state.tasks.get_mut(&task_id).unwrap();
+                                    t.last_status = "STOPPED".into();
+                                    t.desired_status = "STOPPED".into();
+                                    t.stopped_at = Some(chrono::Utc::now());
+                                    t.stop_code = Some("IntrospectionMarkFailed".into());
+                                    t.stopped_reason = req
+                                        .reason
+                                        .clone()
+                                        .or(Some("Forced by introspection".into()));
+                                    for c in t.containers.iter_mut() {
+                                        c.last_status = "STOPPED".into();
+                                        c.exit_code =
+                                            Some(req.exit_code.unwrap_or(-1));
+                                    }
+                                    (t.task_arn.clone(), t.cluster_arn.clone())
+                                };
+                                state.push_event(fakecloud_ecs::state::LifecycleEvent {
+                                    at: chrono::Utc::now(),
+                                    event_type: "TaskStateChange".into(),
+                                    task_arn: Some(task_arn),
+                                    cluster_arn: Some(cluster_arn),
+                                    last_status: Some("STOPPED".into()),
+                                    detail: event_detail,
+                                });
+                                let t = state.tasks.get(&task_id).unwrap();
+                                return (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::to_value(ecs_task_response(t)).unwrap()),
+                                );
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/events",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move || {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        let mut events: Vec<types::EcsLifecycleEvent> = Vec::new();
+                        for (_, state) in accounts.iter() {
+                            events.extend(state.events.iter().map(ecs_lifecycle_event));
+                        }
+                        events.sort_by(|a, b| a.at.cmp(&b.at));
+                        axum::Json(types::EcsEventsResponse { events })
                     }
                 }
             }),

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -32,6 +32,7 @@ pub(crate) struct ResetState {
     pub container_runtime: Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
     pub rds_runtime: Option<Arc<fakecloud_rds::runtime::RdsRuntime>>,
     pub elasticache_runtime: Option<Arc<fakecloud_elasticache::runtime::ElastiCacheRuntime>>,
+    pub ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>,
 }
 
 impl ResetState {
@@ -118,6 +119,10 @@ impl ResetState {
             }
             "ecs" => {
                 self.ecs.write().reset();
+                if let Some(ref rt) = self.ecs_runtime {
+                    let rt = rt.clone();
+                    tokio::spawn(async move { rt.stop_all().await });
+                }
             }
             "states" | "stepfunctions" => {
                 self.stepfunctions.write().reset();
@@ -346,6 +351,10 @@ impl ResetState {
         }
         self.ecr.write().reset();
         self.ecs.write().reset();
+        if let Some(ref rt) = self.ecs_runtime {
+            let rt = rt.clone();
+            tokio::spawn(async move { rt.stop_all().await });
+        }
         self.stepfunctions.write().reset();
         self.scheduler.write().reset();
         self.apigatewayv2.write().reset();
@@ -651,6 +660,7 @@ mod tests {
             container_runtime: None,
             rds_runtime: None,
             elasticache_runtime: None,
+            ecs_runtime: None,
         };
 
         state.reset_service("rds").expect("reset rds");

--- a/sdks/go/ecs.go
+++ b/sdks/go/ecs.go
@@ -1,6 +1,10 @@
 package fakecloud
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
 
 // ECSClient provides access to ECS introspection endpoints.
 type ECSClient struct {
@@ -12,6 +16,65 @@ type ECSClient struct {
 func (c *ECSClient) GetClusters(ctx context.Context) (*EcsClustersResponse, error) {
 	var out EcsClustersResponse
 	if err := c.fc.doGet(ctx, "/_fakecloud/ecs/clusters", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTasks lists every task fakecloud has seen. Pass empty strings to
+// skip the cluster / status filters.
+func (c *ECSClient) GetTasks(ctx context.Context, cluster, status string) (*EcsTasksResponse, error) {
+	path := "/_fakecloud/ecs/tasks"
+	q := url.Values{}
+	if cluster != "" {
+		q.Set("cluster", cluster)
+	}
+	if status != "" {
+		q.Set("status", status)
+	}
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var out EcsTasksResponse
+	if err := c.fc.doGet(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTaskLogs returns the captured docker stdout/stderr for a task.
+func (c *ECSClient) GetTaskLogs(ctx context.Context, taskID string) (*EcsTaskLogsResponse, error) {
+	var out EcsTaskLogsResponse
+	if err := c.fc.doGet(ctx, fmt.Sprintf("/_fakecloud/ecs/tasks/%s/logs", taskID), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ForceStopTask sends SIGTERM (then SIGKILL after 10s) to the task's
+// running container via the runtime.
+func (c *ECSClient) ForceStopTask(ctx context.Context, taskID string) (*EcsTask, error) {
+	var out EcsTask
+	if err := c.fc.doPost(ctx, fmt.Sprintf("/_fakecloud/ecs/tasks/%s/force-stop", taskID), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// MarkTaskFailed flips a task to STOPPED without killing the container —
+// useful for simulating failed tasks deterministically in tests.
+func (c *ECSClient) MarkTaskFailed(ctx context.Context, taskID string, req *EcsMarkFailedRequest) (*EcsTask, error) {
+	var out EcsTask
+	if err := c.fc.doPost(ctx, fmt.Sprintf("/_fakecloud/ecs/tasks/%s/mark-failed", taskID), req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetEvents replays the lifecycle event log.
+func (c *ECSClient) GetEvents(ctx context.Context) (*EcsEventsResponse, error) {
+	var out EcsEventsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/ecs/events", &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -643,3 +643,70 @@ type EcsCluster struct {
 type EcsClustersResponse struct {
 	Clusters []EcsCluster `json:"clusters"`
 }
+
+// EcsTaskContainer is a snapshot of one container in a task.
+type EcsTaskContainer struct {
+	Name       string `json:"name"`
+	Image      string `json:"image"`
+	LastStatus string `json:"lastStatus"`
+	ExitCode   *int64 `json:"exitCode,omitempty"`
+	RuntimeID  string `json:"runtimeId,omitempty"`
+	Essential  bool   `json:"essential"`
+}
+
+// EcsTask is a snapshot of one ECS task as fakecloud sees it.
+type EcsTask struct {
+	TaskArn           string             `json:"taskArn"`
+	TaskID            string             `json:"taskId"`
+	ClusterArn        string             `json:"clusterArn"`
+	ClusterName       string             `json:"clusterName"`
+	TaskDefinitionArn string             `json:"taskDefinitionArn"`
+	Family            string             `json:"family"`
+	Revision          int32              `json:"revision"`
+	LastStatus        string             `json:"lastStatus"`
+	DesiredStatus     string             `json:"desiredStatus"`
+	LaunchType        string             `json:"launchType"`
+	CreatedAt         string             `json:"createdAt"`
+	StartedAt         string             `json:"startedAt,omitempty"`
+	StoppingAt        string             `json:"stoppingAt,omitempty"`
+	StoppedAt         string             `json:"stoppedAt,omitempty"`
+	StopCode          string             `json:"stopCode,omitempty"`
+	StoppedReason     string             `json:"stoppedReason,omitempty"`
+	Containers        []EcsTaskContainer `json:"containers"`
+	CapturedLogBytes  int                `json:"capturedLogBytes"`
+}
+
+// EcsTasksResponse contains every task fakecloud is tracking.
+type EcsTasksResponse struct {
+	Tasks []EcsTask `json:"tasks"`
+}
+
+// EcsTaskLogsResponse returns the docker stdout/stderr captured for a
+// task, plus its exit code if known.
+type EcsTaskLogsResponse struct {
+	TaskArn    string `json:"taskArn"`
+	Logs       string `json:"logs"`
+	LastStatus string `json:"lastStatus"`
+	ExitCode   *int64 `json:"exitCode,omitempty"`
+}
+
+// EcsMarkFailedRequest is the payload for POST /ecs/tasks/{id}/mark-failed.
+type EcsMarkFailedRequest struct {
+	ExitCode *int64 `json:"exitCode,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// EcsLifecycleEvent is one entry in the introspection event log.
+type EcsLifecycleEvent struct {
+	At         string      `json:"at"`
+	EventType  string      `json:"eventType"`
+	TaskArn    string      `json:"taskArn,omitempty"`
+	ClusterArn string      `json:"clusterArn,omitempty"`
+	LastStatus string      `json:"lastStatus,omitempty"`
+	Detail     interface{} `json:"detail"`
+}
+
+// EcsEventsResponse contains the lifecycle event log.
+type EcsEventsResponse struct {
+	Events []EcsLifecycleEvent `json:"events"`
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -646,15 +646,17 @@ type EcsClustersResponse struct {
 
 // EcsTaskContainer is a snapshot of one container in a task.
 type EcsTaskContainer struct {
-	Name       string `json:"name"`
-	Image      string `json:"image"`
-	LastStatus string `json:"lastStatus"`
-	ExitCode   *int64 `json:"exitCode,omitempty"`
-	RuntimeID  string `json:"runtimeId,omitempty"`
-	Essential  bool   `json:"essential"`
+	Name       string  `json:"name"`
+	Image      string  `json:"image"`
+	LastStatus string  `json:"lastStatus"`
+	ExitCode   *int64  `json:"exitCode,omitempty"`
+	RuntimeID  *string `json:"runtimeId,omitempty"`
+	Essential  bool    `json:"essential"`
 }
 
 // EcsTask is a snapshot of one ECS task as fakecloud sees it.
+// Optional fields are pointers so JSON decoding accepts both absent and
+// explicit `null` values from the server.
 type EcsTask struct {
 	TaskArn           string             `json:"taskArn"`
 	TaskID            string             `json:"taskId"`
@@ -667,11 +669,11 @@ type EcsTask struct {
 	DesiredStatus     string             `json:"desiredStatus"`
 	LaunchType        string             `json:"launchType"`
 	CreatedAt         string             `json:"createdAt"`
-	StartedAt         string             `json:"startedAt,omitempty"`
-	StoppingAt        string             `json:"stoppingAt,omitempty"`
-	StoppedAt         string             `json:"stoppedAt,omitempty"`
-	StopCode          string             `json:"stopCode,omitempty"`
-	StoppedReason     string             `json:"stoppedReason,omitempty"`
+	StartedAt         *string            `json:"startedAt,omitempty"`
+	StoppingAt        *string            `json:"stoppingAt,omitempty"`
+	StoppedAt         *string            `json:"stoppedAt,omitempty"`
+	StopCode          *string            `json:"stopCode,omitempty"`
+	StoppedReason     *string            `json:"stoppedReason,omitempty"`
 	Containers        []EcsTaskContainer `json:"containers"`
 	CapturedLogBytes  int                `json:"capturedLogBytes"`
 }
@@ -692,17 +694,18 @@ type EcsTaskLogsResponse struct {
 
 // EcsMarkFailedRequest is the payload for POST /ecs/tasks/{id}/mark-failed.
 type EcsMarkFailedRequest struct {
-	ExitCode *int64 `json:"exitCode,omitempty"`
-	Reason   string `json:"reason,omitempty"`
+	ExitCode *int64  `json:"exitCode,omitempty"`
+	Reason   *string `json:"reason,omitempty"`
 }
 
 // EcsLifecycleEvent is one entry in the introspection event log.
+// Optional fields are pointers so null-safe JSON decoding works.
 type EcsLifecycleEvent struct {
 	At         string      `json:"at"`
 	EventType  string      `json:"eventType"`
-	TaskArn    string      `json:"taskArn,omitempty"`
-	ClusterArn string      `json:"clusterArn,omitempty"`
-	LastStatus string      `json:"lastStatus,omitempty"`
+	TaskArn    *string     `json:"taskArn,omitempty"`
+	ClusterArn *string     `json:"clusterArn,omitempty"`
+	LastStatus *string     `json:"lastStatus,omitempty"`
 	Detail     interface{} `json:"detail"`
 }
 

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Dict, Optional
 
 import httpx
 
@@ -25,6 +25,11 @@ from fakecloud.types import (
     EcrPullThroughRulesResponse,
     EcrRepositoriesResponse,
     EcsClustersResponse,
+    EcsEventsResponse,
+    EcsMarkFailedRequest,
+    EcsTask,
+    EcsTaskLogsResponse,
+    EcsTasksResponse,
     ElastiCacheClustersResponse,
     ElastiCacheReplicationGroupsResponse,
     ElastiCacheServerlessCachesResponse,
@@ -177,6 +182,51 @@ class EcsClient:
         _check(resp)
         return EcsClustersResponse.from_dict(resp.json())
 
+    async def get_tasks(
+        self,
+        cluster: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> EcsTasksResponse:
+        params: Dict[str, str] = {}
+        if cluster is not None:
+            params["cluster"] = cluster
+        if status is not None:
+            params["status"] = status
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/ecs/tasks", params=params
+        )
+        _check(resp)
+        return EcsTasksResponse.from_dict(resp.json())
+
+    async def get_task_logs(self, task_id: str) -> EcsTaskLogsResponse:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}/logs"
+        )
+        _check(resp)
+        return EcsTaskLogsResponse.from_dict(resp.json())
+
+    async def force_stop_task(self, task_id: str) -> EcsTask:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}/force-stop"
+        )
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
+
+    async def mark_task_failed(
+        self, task_id: str, req: EcsMarkFailedRequest
+    ) -> EcsTask:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}/mark-failed",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
+
+    async def get_events(self) -> EcsEventsResponse:
+        resp = await self._client.get(f"{self._base}/_fakecloud/ecs/events")
+        _check(resp)
+        return EcsEventsResponse.from_dict(resp.json())
+
 
 class _SyncEcsClient:
     """Sync ECS introspection client."""
@@ -189,6 +239,45 @@ class _SyncEcsClient:
         resp = self._client.get(f"{self._base}/_fakecloud/ecs/clusters")
         _check(resp)
         return EcsClustersResponse.from_dict(resp.json())
+
+    def get_tasks(
+        self,
+        cluster: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> EcsTasksResponse:
+        params: Dict[str, str] = {}
+        if cluster is not None:
+            params["cluster"] = cluster
+        if status is not None:
+            params["status"] = status
+        resp = self._client.get(f"{self._base}/_fakecloud/ecs/tasks", params=params)
+        _check(resp)
+        return EcsTasksResponse.from_dict(resp.json())
+
+    def get_task_logs(self, task_id: str) -> EcsTaskLogsResponse:
+        resp = self._client.get(f"{self._base}/_fakecloud/ecs/tasks/{task_id}/logs")
+        _check(resp)
+        return EcsTaskLogsResponse.from_dict(resp.json())
+
+    def force_stop_task(self, task_id: str) -> EcsTask:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}/force-stop"
+        )
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
+
+    def mark_task_failed(self, task_id: str, req: EcsMarkFailedRequest) -> EcsTask:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}/mark-failed",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
+
+    def get_events(self) -> EcsEventsResponse:
+        resp = self._client.get(f"{self._base}/_fakecloud/ecs/events")
+        _check(resp)
+        return EcsEventsResponse.from_dict(resp.json())
 
 
 class SesClient:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1228,3 +1228,108 @@ class EcsClustersResponse:
         return cls(
             clusters=[EcsCluster.from_dict(c) for c in data.get("clusters", [])],
         )
+
+
+@dataclass
+class EcsTaskContainer:
+    name: str
+    image: str
+    last_status: str
+    essential: bool
+    exit_code: Optional[int] = None
+    runtime_id: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskContainer:
+        return cls(**_convert_keys(data))
+
+
+@dataclass
+class EcsTask:
+    task_arn: str
+    task_id: str
+    cluster_arn: str
+    cluster_name: str
+    task_definition_arn: str
+    family: str
+    revision: int
+    last_status: str
+    desired_status: str
+    launch_type: str
+    created_at: str
+    containers: List[EcsTaskContainer]
+    captured_log_bytes: int
+    started_at: Optional[str] = None
+    stopping_at: Optional[str] = None
+    stopped_at: Optional[str] = None
+    stop_code: Optional[str] = None
+    stopped_reason: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTask:
+        d = _convert_keys(data)
+        d["containers"] = [
+            EcsTaskContainer.from_dict(c) for c in d.get("containers", [])
+        ]
+        return cls(**d)
+
+
+@dataclass
+class EcsTasksResponse:
+    tasks: List[EcsTask]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTasksResponse:
+        return cls(tasks=[EcsTask.from_dict(t) for t in data.get("tasks", [])])
+
+
+@dataclass
+class EcsTaskLogsResponse:
+    task_arn: str
+    logs: str
+    last_status: str
+    exit_code: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskLogsResponse:
+        return cls(**_convert_keys(data))
+
+
+@dataclass
+class EcsMarkFailedRequest:
+    exit_code: Optional[int] = None
+    reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        if self.exit_code is not None:
+            out["exitCode"] = self.exit_code
+        if self.reason is not None:
+            out["reason"] = self.reason
+        return out
+
+
+@dataclass
+class EcsLifecycleEvent:
+    at: str
+    event_type: str
+    detail: Any
+    task_arn: Optional[str] = None
+    cluster_arn: Optional[str] = None
+    last_status: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsLifecycleEvent:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
+class EcsEventsResponse:
+    events: List[EcsLifecycleEvent]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsEventsResponse:
+        return cls(
+            events=[EcsLifecycleEvent.from_dict(e) for e in data.get("events", [])],
+        )

--- a/website/content/docs/services/ecs.md
+++ b/website/content/docs/services/ecs.md
@@ -6,17 +6,31 @@ weight = 22
 
 fakecloud implements Amazon Elastic Container Service (ECS) with a four-batch roadmap. This page tracks what's shipped.
 
-**Status: Batch 1 shipped — control-plane CRUD.** Subsequent batches add real task execution (Batch 2), services + rolling deployments (Batch 3), and completeness (Batch 4: container instances, capacity providers, task protection, `ExecuteCommand`).
+**Status: Batches 1 + 2 shipped — control-plane CRUD plus real task execution.** Subsequent batches add services + rolling deployments (Batch 3) and completeness (Batch 4: container instances, capacity providers, task protection, `ExecuteCommand`).
 
-## Supported today (Batch 1)
+## Supported today (Batches 1 + 2)
 
 - **Clusters** — `CreateCluster`, `DescribeClusters`, `DeleteCluster`, `ListClusters`, `UpdateCluster`, `UpdateClusterSettings`, `PutClusterCapacityProviders`
 - **Task definitions** — `RegisterTaskDefinition`, `DescribeTaskDefinition`, `DeregisterTaskDefinition`, `DeleteTaskDefinitions`, `ListTaskDefinitions`, `ListTaskDefinitionFamilies`
+- **Tasks** — `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks` with real Fargate-style execution via Docker/Podman
 - **Tagging** — `TagResource`, `UntagResource`, `ListTagsForResource` (clusters and task definitions)
 - **Account settings** — `PutAccountSetting`, `PutAccountSettingDefault`, `DeleteAccountSetting`, `ListAccountSettings`
-- **Introspection endpoint** — `GET /_fakecloud/ecs/clusters` dumps every cluster across every account, bypassing the public API
 
 Task-definition families track revisions monotonically; `DeleteTaskDefinitions` requires `DeregisterTaskDefinition` first (real AWS behaviour), and the result flips status to `DELETE_IN_PROGRESS`.
+
+## Task execution (Batch 2)
+
+`RunTask` records the task synchronously and kicks off a background docker execution per spawned task:
+
+1. `docker pull <image>` (timestamps captured on the task: `pullStartedAt` / `pullStoppedAt`)
+2. `docker run -d <image>` (container ID recorded on the task's container)
+3. `docker wait <id>` (blocks on container exit; exit code → `containers[].exitCode`)
+4. `docker logs <id>` (captured stdout/stderr stored on the task + exposed via the introspection endpoint)
+5. `docker rm <id>` (cleanup)
+
+Environment variables from the task definition are forwarded with `localhost` / `127.0.0.1` rewritten to `host.docker.internal` so containers reach fakecloud itself the same way Lambda does.
+
+Without a container runtime (docker/podman missing), `RunTask` still returns tasks but they immediately transition to `STOPPED` with `stopCode=TaskFailedToStart`. This keeps the API surface shape-correct so tests on CI agents without Docker can still drive the control-plane surface.
 
 ## Protocol
 
@@ -24,11 +38,21 @@ JSON protocol over `POST /`, with `X-Amz-Target: AmazonEC2ContainerServiceV20141
 
 ## Introspection
 
-```text
-GET /_fakecloud/ecs/clusters
-```
+Endpoints bypass the public AWS API so tests can assert deterministic state without pagination or role-assumption noise.
 
-Returns every cluster fakecloud has recorded, sorted by cluster ARN. Useful for asserting deterministic state in tests without dealing with public-API pagination.
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/_fakecloud/ecs/clusters` | GET | Dump every cluster across all accounts |
+| `/_fakecloud/ecs/tasks` | GET | Dump every task; filter with `?cluster=` / `?status=` |
+| `/_fakecloud/ecs/tasks/{taskId}` | GET | Single-task deep detail |
+| `/_fakecloud/ecs/tasks/{taskId}/logs` | GET | Captured docker stdout/stderr + exit code |
+| `/_fakecloud/ecs/tasks/{taskId}/force-stop` | POST | SIGTERM + SIGKILL the running container |
+| `/_fakecloud/ecs/tasks/{taskId}/mark-failed` | POST | Flip to STOPPED without killing the container (inject exit code + reason) |
+| `/_fakecloud/ecs/events` | GET | Replay the lifecycle event log |
+
+All endpoints are sorted deterministically (by ARN for clusters/tasks, by timestamp for events) so test assertions don't flake on map iteration order.
+
+### Clusters dump
 
 ```json
 {
@@ -78,9 +102,8 @@ let clusters = fc.ecs().get_clusters().await?;
 
 ## Roadmap
 
-- **Batch 2** — `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks`: real Fargate-style container execution via Docker, ECR image pull, awslogs driver wiring to CloudWatch Logs, EventBridge `ECS Task State Change` events
-- **Batch 3** — `CreateService`, `UpdateService`, rolling deployments with `minimumHealthyPercent`/`maximumPercent`, `CreateTaskSet`/`UpdateTaskSet` (EXTERNAL deployment controller), deployment circuit breaker
-- **Batch 4** — Container instances, attributes, capacity providers, task protection, ECS Exec (`ExecuteCommand` via `docker exec`), snapshot/restore of in-flight tasks
+- **Batch 3** — `CreateService`, `UpdateService`, rolling deployments with `minimumHealthyPercent`/`maximumPercent`, `CreateTaskSet`/`UpdateTaskSet` (EXTERNAL deployment controller), deployment circuit breaker. EventBridge `ECS Task State Change` events. awslogs driver wiring to CloudWatch Logs (today captured stdout/stderr live on the task; Batch 3 ships them to CW Logs automatically).
+- **Batch 4** — Container instances, attributes, capacity providers, task protection, ECS Exec (`ExecuteCommand` via `docker exec`), snapshot/restore of in-flight tasks, IAM task-role credential injection via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`.
 
 ## Source
 


### PR DESCRIPTION
## Summary

Batch 2 of the ECS rollout. Adds real task execution via Docker/Podman — `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks` — plus the introspection surface for asserting lifecycle state in tests.

Highlights:
- `EcsRuntime` auto-detects docker/podman, pulls the image, spawns a detached container, waits for exit, captures stdout/stderr, and cleans up. Host \`localhost\` references are rewritten to \`host.docker.internal\` the same way Lambda does.
- Task lifecycle state machine (\`PROVISIONING -> PENDING -> RUNNING -> STOPPED\`) with timestamps for each transition. \`StopTask\` flips \`desiredStatus\` synchronously and SIGTERMs asynchronously.
- When no runtime is available (CI agents without Docker) tasks still flow through the state machine and transition directly to \`STOPPED\` / \`TaskFailedToStart\` so API-shape tests stay portable.
- Introspection endpoints for deterministic tests: list/get tasks, tail captured logs, force-stop, mark-failed (inject arbitrary exit codes without killing the container), replay the lifecycle event log.
- SDKs (Rust + Go + Python) ship typed wrappers for every new introspection endpoint.
- Snapshot schema bumped to v2 to persist tasks + event log.

What this deliberately defers to later batches: EventBridge state-change events (Batch 3), awslogs auto-shipping to CloudWatch Logs (Batch 3), IAM task-role credential injection (Batch 4), ECR in-process image resolver (Batch 4).

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test ecs\` — 14 E2E scenarios pass, including \`run_task_records_task_and_accepts_describe\`, \`stop_task_flips_desired_status\`, and \`introspection_tasks_endpoint_lists_ecs_state\`
- [x] \`cargo test -p fakecloud-conformance --test ecs\` — 25 conformance tests pass (all 5 new actions have live Smithy-shape checksums)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] Server binary builds
- [ ] CI green on all checks
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real ECS Fargate-style task execution via Docker/Podman and implements RunTask, StartTask, StopTask, DescribeTasks, and ListTasks with captured logs and a deterministic introspection surface.

- **New Features**
  - Runtime auto-detects Docker/Podman, pulls images, runs detached, waits for exit, captures logs, rewrites localhost to host.docker.internal, and cleans up; falls back to STOPPED (`TaskFailedToStart`) when no runtime.
  - Full lifecycle (PROVISIONING → PENDING → RUNNING → STOPPED) with timestamps; `StopTask` sets desiredStatus immediately and sends SIGTERM asynchronously.
  - Introspection endpoints for tests: `/_fakecloud/ecs/tasks`, `/_fakecloud/ecs/tasks/{id}`, `/_fakecloud/ecs/tasks/{id}/logs`, `/_fakecloud/ecs/tasks/{id}/force-stop`, `/_fakecloud/ecs/tasks/{id}/mark-failed`, `/_fakecloud/ecs/events` (sorted for deterministic assertions).
  - Rust, Go, and Python SDKs add typed wrappers for all new introspection endpoints.
  - Snapshot schema v2; if you persist snapshots, reset ECS state (`/_fakecloud/reset?service=ecs`). Real execution requires Docker or Podman in PATH; set `FAKECLOUD_CONTAINER_CLI` to override.

- **Bug Fixes**
  - Fail closed when `docker wait` itself errors (no longer treats empty output as exit code 0).
  - Fix cluster counters: decrement `runningTasksCount` when execution fails after RUNNING, and decrement `pendingTasksCount` in the no-runtime fallback to avoid drift.
  - Go SDK: make optional ECS task/event fields nullable (pointers) to handle `null` values from the server.

<sup>Written for commit 2d46ca523ca4e1f7fc485c854ad951cb408c11a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

