### PR TITLE
feat(ecs): Batch 3 — services with rolling deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-25 services, 1,763 operations, 100% conformance per implemented service.
+25 services, 1,769 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -76,7 +76,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
-| ECS                    |  25 | Clusters, task definitions, **real Fargate-style task execution via Docker**, tags, account settings |
+| ECS                    |  31 | Clusters, task definitions, **real Fargate-style task execution**, services with rolling deployments |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -116,7 +116,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | API Gateway v2      | 28 operations, full HTTP API support               | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
-| ECS                 | 25 operations incl. **real task execution via Docker** | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| ECS                 | 31 operations incl. **services with rolling deployments + real task execution** | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/crates/fakecloud-conformance/tests/ecs.rs
+++ b/crates/fakecloud-conformance/tests/ecs.rs
@@ -614,3 +614,157 @@ async fn ecs_stop_task() {
         .unwrap();
     assert!(resp.task().is_some());
 }
+
+// ── Batch 3: services ──────────────────────────────────────────────
+
+async fn bootstrap_service_fixtures(client: &aws_sdk_ecs::Client, cluster: &str, family: &str) {
+    client
+        .create_cluster()
+        .cluster_name(cluster)
+        .send()
+        .await
+        .unwrap();
+    client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("ecs", "CreateService", checksum = "15a6dbd5")]
+#[tokio::test]
+async fn ecs_create_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "confo-svc", "confo-svc-td").await;
+    let resp = client
+        .create_service()
+        .cluster("confo-svc")
+        .service_name("svc-a")
+        .task_definition("confo-svc-td")
+        .desired_count(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.service().unwrap().service_name(), Some("svc-a"));
+}
+
+#[test_action("ecs", "DescribeServices", checksum = "ca07d4ee")]
+#[tokio::test]
+async fn ecs_describe_services() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "confo-svc-desc", "confo-svc-desc-td").await;
+    client
+        .create_service()
+        .cluster("confo-svc-desc")
+        .service_name("svc-d")
+        .task_definition("confo-svc-desc-td")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_services()
+        .cluster("confo-svc-desc")
+        .services("svc-d")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.services().len(), 1);
+}
+
+#[test_action("ecs", "ListServices", checksum = "4bc85a42")]
+#[tokio::test]
+async fn ecs_list_services() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "confo-svc-list", "confo-svc-list-td").await;
+    client
+        .create_service()
+        .cluster("confo-svc-list")
+        .service_name("svc-l")
+        .task_definition("confo-svc-list-td")
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .list_services()
+        .cluster("confo-svc-list")
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.service_arns().is_empty());
+}
+
+#[test_action("ecs", "ListServicesByNamespace", checksum = "13f69425")]
+#[tokio::test]
+async fn ecs_list_services_by_namespace() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    let resp = client
+        .list_services_by_namespace()
+        .namespace("arn:aws:servicediscovery:us-east-1:111122223333:namespace/ns-1")
+        .send()
+        .await
+        .unwrap();
+    let _ = resp.service_arns().len();
+}
+
+#[test_action("ecs", "UpdateService", checksum = "c1482ff6")]
+#[tokio::test]
+async fn ecs_update_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "confo-svc-up", "confo-svc-up-td").await;
+    client
+        .create_service()
+        .cluster("confo-svc-up")
+        .service_name("svc-u")
+        .task_definition("confo-svc-up-td")
+        .desired_count(1)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .update_service()
+        .cluster("confo-svc-up")
+        .service("svc-u")
+        .desired_count(2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.service().unwrap().desired_count(), 2);
+}
+
+#[test_action("ecs", "DeleteService", checksum = "d4f5fbe7")]
+#[tokio::test]
+async fn ecs_delete_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "confo-svc-del", "confo-svc-del-td").await;
+    client
+        .create_service()
+        .cluster("confo-svc-del")
+        .service_name("svc-del")
+        .task_definition("confo-svc-del-td")
+        .desired_count(0)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .delete_service()
+        .cluster("confo-svc-del")
+        .service("svc-del")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service().is_some());
+}

--- a/crates/fakecloud-e2e/tests/ecs.rs
+++ b/crates/fakecloud-e2e/tests/ecs.rs
@@ -606,3 +606,244 @@ async fn introspection_tasks_endpoint_lists_ecs_state() {
     let ev = events.get("events").and_then(|v| v.as_array()).unwrap();
     assert!(!ev.is_empty());
 }
+
+// ── Batch 3: services ──────────────────────────────────────────────
+
+async fn bootstrap_service_fixtures(client: &aws_sdk_ecs::Client, cluster: &str, family: &str) {
+    client
+        .create_cluster()
+        .cluster_name(cluster)
+        .send()
+        .await
+        .unwrap();
+    client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn create_service_spawns_desired_tasks_and_describe_roundtrips() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+
+    bootstrap_service_fixtures(&client, "svc-cluster", "svc-td").await;
+
+    let resp = client
+        .create_service()
+        .cluster("svc-cluster")
+        .service_name("web")
+        .task_definition("svc-td")
+        .desired_count(2)
+        .send()
+        .await
+        .expect("create_service");
+    let svc = resp.service().unwrap();
+    assert_eq!(svc.service_name(), Some("web"));
+    assert_eq!(svc.desired_count(), 2);
+    assert_eq!(svc.deployments().len(), 1);
+    assert_eq!(svc.deployments()[0].status(), Some("PRIMARY"));
+
+    let described = client
+        .describe_services()
+        .cluster("svc-cluster")
+        .services("web")
+        .send()
+        .await
+        .expect("describe_services");
+    assert_eq!(described.services().len(), 1);
+    assert!(described.failures().is_empty());
+
+    let listed = client
+        .list_services()
+        .cluster("svc-cluster")
+        .send()
+        .await
+        .expect("list_services");
+    assert_eq!(listed.service_arns().len(), 1);
+    assert!(listed.service_arns()[0].ends_with("service/svc-cluster/web"));
+
+    let tasks = client
+        .list_tasks()
+        .cluster("svc-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    assert_eq!(tasks.task_arns().len(), 2, "service should spawn 2 tasks");
+}
+
+#[tokio::test]
+async fn update_service_scales_up_and_down() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "scale-cluster", "scale-td").await;
+    client
+        .create_service()
+        .cluster("scale-cluster")
+        .service_name("web")
+        .task_definition("scale-td")
+        .desired_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    let up = client
+        .update_service()
+        .cluster("scale-cluster")
+        .service("web")
+        .desired_count(3)
+        .send()
+        .await
+        .expect("update_service up");
+    assert_eq!(up.service().unwrap().desired_count(), 3);
+    let tasks_after_up = client
+        .list_tasks()
+        .cluster("scale-cluster")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tasks_after_up.task_arns().len(), 3);
+
+    let down = client
+        .update_service()
+        .cluster("scale-cluster")
+        .service("web")
+        .desired_count(1)
+        .send()
+        .await
+        .expect("update_service down");
+    assert_eq!(down.service().unwrap().desired_count(), 1);
+    let all = client
+        .list_tasks()
+        .cluster("scale-cluster")
+        .send()
+        .await
+        .unwrap();
+    let arns: Vec<String> = all.task_arns().iter().map(|a| a.to_string()).collect();
+    let described = client
+        .describe_tasks()
+        .cluster("scale-cluster")
+        .set_tasks(Some(arns))
+        .send()
+        .await
+        .unwrap();
+    let running_desired: usize = described
+        .tasks()
+        .iter()
+        .filter(|t| t.desired_status() == Some("RUNNING"))
+        .count();
+    assert!(
+        running_desired <= 1,
+        "after scale-down <=1 task should still desire RUNNING, got {running_desired}"
+    );
+}
+
+#[tokio::test]
+async fn update_service_new_task_definition_triggers_rolling_deployment() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "roll-cluster", "roll-td").await;
+    client
+        .create_service()
+        .cluster("roll-cluster")
+        .service_name("web")
+        .task_definition("roll-td")
+        .desired_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .register_task_definition()
+        .family("roll-td")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:3.19")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let rolled = client
+        .update_service()
+        .cluster("roll-cluster")
+        .service("web")
+        .task_definition("roll-td:2")
+        .send()
+        .await
+        .expect("update_service new td");
+    let svc = rolled.service().unwrap();
+    let primary = svc
+        .deployments()
+        .iter()
+        .find(|d| d.status() == Some("PRIMARY"))
+        .expect("primary deployment");
+    assert!(primary.task_definition().unwrap().ends_with(":2"));
+    assert!(
+        svc.deployments()
+            .iter()
+            .any(|d| d.status() == Some("ACTIVE")),
+        "old deployment should be ACTIVE during rollout"
+    );
+}
+
+#[tokio::test]
+async fn delete_service_requires_zero_desired_unless_force() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap_service_fixtures(&client, "del-cluster", "del-td").await;
+    client
+        .create_service()
+        .cluster("del-cluster")
+        .service_name("web")
+        .task_definition("del-td")
+        .desired_count(2)
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .delete_service()
+        .cluster("del-cluster")
+        .service("web")
+        .send()
+        .await
+        .expect_err("delete should fail while scaled up");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("desiredCount") || msg.contains("scaled"),
+        "msg={msg}"
+    );
+
+    let forced = client
+        .delete_service()
+        .cluster("del-cluster")
+        .service("web")
+        .force(true)
+        .send()
+        .await
+        .expect("force delete");
+    assert_eq!(forced.service().unwrap().service_name(), Some("web"));
+
+    let after = client
+        .describe_services()
+        .cluster("del-cluster")
+        .services("web")
+        .send()
+        .await
+        .unwrap();
+    assert!(after.services().is_empty());
+    assert_eq!(after.failures().len(), 1);
+    assert_eq!(after.failures()[0].reason(), Some("MISSING"));
+}

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -10,8 +10,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    AwsLogsConfig, Cluster, Container, EcsSnapshot, EcsState, SharedEcsState, TagEntry, Task,
-    TaskDefinition, ECS_SNAPSHOT_SCHEMA_VERSION,
+    AwsLogsConfig, CircuitBreakerConfig, Cluster, Container, Deployment, EcsSnapshot, EcsState,
+    Service, SharedEcsState, TagEntry, Task, TaskDefinition, ECS_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const SUPPORTED_ACTIONS: &[&str] = &[
@@ -40,6 +40,12 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "StopTask",
     "DescribeTasks",
     "ListTasks",
+    "CreateService",
+    "UpdateService",
+    "DeleteService",
+    "DescribeServices",
+    "ListServices",
+    "ListServicesByNamespace",
 ];
 
 fn is_mutating(action: &str) -> bool {
@@ -61,6 +67,9 @@ fn is_mutating(action: &str) -> bool {
             | "RunTask"
             | "StartTask"
             | "StopTask"
+            | "CreateService"
+            | "UpdateService"
+            | "DeleteService"
     )
 }
 
@@ -152,6 +161,12 @@ impl AwsService for EcsService {
             "StopTask" => self.stop_task(&request).await,
             "DescribeTasks" => self.describe_tasks(&request),
             "ListTasks" => self.list_tasks(&request),
+            "CreateService" => self.create_service(&request),
+            "UpdateService" => self.update_service(&request),
+            "DeleteService" => self.delete_service(&request).await,
+            "DescribeServices" => self.describe_services(&request),
+            "ListServices" => self.list_services(&request),
+            "ListServicesByNamespace" => self.list_services_by_namespace(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 "ecs",
                 &request.action,
@@ -1837,6 +1852,889 @@ fn container_to_json(container: &Container) -> Value {
         map.insert("healthStatus".into(), json!(v));
     }
     Value::Object(map)
+}
+
+// -------- operations: services --------
+
+impl EcsService {
+    fn create_service(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let service_name = req_str(&body, "serviceName")?.to_string();
+        validate_service_name(&service_name)?;
+        let td_ref = req_str(&body, "taskDefinition")?;
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let desired_count = body
+            .get("desiredCount")
+            .and_then(|v| v.as_i64())
+            .filter(|n| *n >= 0)
+            .unwrap_or(1) as i32;
+        let launch_type = opt_str(&body, "launchType")
+            .unwrap_or("FARGATE")
+            .to_string();
+        let scheduling = opt_str(&body, "schedulingStrategy")
+            .unwrap_or("REPLICA")
+            .to_string();
+        let deployment_controller = body
+            .get("deploymentController")
+            .and_then(|v| v.get("type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("ECS")
+            .to_string();
+        let deployment_config = body.get("deploymentConfiguration");
+        let min_healthy = deployment_config
+            .and_then(|d| d.get("minimumHealthyPercent"))
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32);
+        let max_percent = deployment_config
+            .and_then(|d| d.get("maximumPercent"))
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32);
+        let circuit = deployment_config.and_then(|d| d.get("deploymentCircuitBreaker"));
+        let circuit_breaker = circuit.map(|c| CircuitBreakerConfig {
+            enable: c.get("enable").and_then(|v| v.as_bool()).unwrap_or(false),
+            rollback: c.get("rollback").and_then(|v| v.as_bool()).unwrap_or(false),
+        });
+        let tags = parse_tags(&body);
+        let role_arn = opt_str(&body, "role").map(String::from);
+        let load_balancers: Vec<Value> = body
+            .get("loadBalancers")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let service_registries: Vec<Value> = body
+            .get("serviceRegistries")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placement_constraints: Vec<Value> = body
+            .get("placementConstraints")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placement_strategy: Vec<Value> = body
+            .get("placementStrategy")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let network_configuration = body.get("networkConfiguration").cloned();
+
+        let runtime = self.runtime.clone();
+        let account = request.account_id.clone();
+        let principal_arn = request
+            .principal
+            .as_ref()
+            .map(|p| p.arn.clone())
+            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+
+        let (service_json, spawn_task_ids) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&account);
+            // Resolve task definition to get family/revision.
+            let (_, family, rev) = resolve_task_definition_ref(td_ref)?;
+            let revisions = state
+                .task_definitions
+                .get(&family)
+                .ok_or_else(|| task_definition_not_found(td_ref))?;
+            let td = match rev {
+                Some(n) => revisions
+                    .get(&n)
+                    .ok_or_else(|| task_definition_not_found(td_ref))?,
+                None => latest_active_revision(revisions)
+                    .ok_or_else(|| task_definition_not_found(td_ref))?,
+            };
+            let td_arn = td.task_definition_arn.clone();
+            let td_family = td.family.clone();
+            let td_revision = td.revision;
+            let cluster_arn = state
+                .clusters
+                .get(&cluster_name)
+                .map(|c| c.cluster_arn.clone())
+                .unwrap_or_else(|| state.cluster_arn(&cluster_name));
+            let service_arn = state.service_arn(&cluster_name, &service_name);
+            let key = EcsState::service_key(&cluster_name, &service_name);
+            if let Some(existing) = state.services.get(&key) {
+                if existing.status != "INACTIVE" {
+                    return Err(service_already_exists(&service_name));
+                }
+            }
+            let deployment = Deployment {
+                deployment_id: format!(
+                    "ecs-svc/{}",
+                    uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
+                ),
+                status: "PRIMARY".into(),
+                task_definition_arn: td_arn.clone(),
+                desired_count,
+                pending_count: 0,
+                running_count: 0,
+                failed_tasks: 0,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                launch_type: launch_type.clone(),
+                rollout_state: "IN_PROGRESS".into(),
+                rollout_state_reason: Some("ECS deployment in progress.".into()),
+            };
+            let service = Service {
+                service_name: service_name.clone(),
+                service_arn: service_arn.clone(),
+                cluster_name: cluster_name.clone(),
+                cluster_arn: cluster_arn.clone(),
+                task_definition_arn: td_arn,
+                family: td_family,
+                revision: td_revision,
+                desired_count,
+                running_count: 0,
+                pending_count: 0,
+                launch_type: launch_type.clone(),
+                status: "ACTIVE".into(),
+                scheduling_strategy: scheduling,
+                deployment_controller,
+                minimum_healthy_percent: min_healthy,
+                maximum_percent: max_percent,
+                circuit_breaker,
+                deployments: vec![deployment],
+                load_balancers,
+                service_registries,
+                placement_constraints,
+                placement_strategy,
+                network_configuration,
+                tags: tags.clone(),
+                created_at: Utc::now(),
+                created_by: Some(principal_arn.clone()),
+                role_arn,
+            };
+            state.services.insert(key.clone(), service.clone());
+            if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
+                cluster.active_services_count += 1;
+            }
+            state.push_event(crate::state::LifecycleEvent {
+                at: Utc::now(),
+                event_type: "ServiceCreated".into(),
+                task_arn: None,
+                cluster_arn: Some(cluster_arn),
+                last_status: Some("ACTIVE".into()),
+                detail: json!({"serviceArn": service_arn, "desiredCount": desired_count}),
+            });
+            let ids =
+                spawn_service_tasks(state, &service, desired_count, &principal_arn, &launch_type);
+            (service_to_json(state.services.get(&key).unwrap()), ids)
+        };
+
+        if let Some(rt) = runtime {
+            for id in spawn_task_ids {
+                rt.clone().run_task(self.state.clone(), id, account.clone());
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({ "service": service_json })))
+    }
+
+    fn update_service(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let service_ref = req_str(&body, "service")?;
+        let service_name = service_name_from_ref(service_ref);
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let new_desired = body.get("desiredCount").and_then(|v| v.as_i64());
+        let new_td_ref = opt_str(&body, "taskDefinition");
+        let account = request.account_id.clone();
+        let principal_arn = request
+            .principal
+            .as_ref()
+            .map(|p| p.arn.clone())
+            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+        let runtime = self.runtime.clone();
+
+        let (service_json, spawn_ids, stop_ids) = {
+            let mut accounts = self.state.write();
+            let state = accounts
+                .get_mut(&account)
+                .ok_or_else(|| service_not_found(&service_name))?;
+            let key = EcsState::service_key(&cluster_name, &service_name);
+            if !state.services.contains_key(&key) {
+                return Err(service_not_found(&service_name));
+            }
+
+            // Resolve new task definition (may stay on current one).
+            let (new_td_arn, new_family, new_revision) = if let Some(td_ref) = new_td_ref {
+                let (_, family, rev) = resolve_task_definition_ref(td_ref)?;
+                let revisions = state
+                    .task_definitions
+                    .get(&family)
+                    .ok_or_else(|| task_definition_not_found(td_ref))?;
+                let td = match rev {
+                    Some(n) => revisions
+                        .get(&n)
+                        .ok_or_else(|| task_definition_not_found(td_ref))?,
+                    None => latest_active_revision(revisions)
+                        .ok_or_else(|| task_definition_not_found(td_ref))?,
+                };
+                (
+                    Some(td.task_definition_arn.clone()),
+                    td.family.clone(),
+                    td.revision,
+                )
+            } else {
+                let svc = state.services.get(&key).unwrap();
+                (None, svc.family.clone(), svc.revision)
+            };
+
+            let service_cluster_arn;
+            let launch_type_clone;
+            let effective_desired;
+            let old_desired;
+            let mut old_deployments_drained: Vec<String> = Vec::new();
+            let mut new_deployment_triggered = false;
+
+            {
+                let svc = state.services.get_mut(&key).unwrap();
+                old_desired = svc.desired_count;
+                service_cluster_arn = svc.cluster_arn.clone();
+                launch_type_clone = svc.launch_type.clone();
+
+                if let Some(n) = new_desired {
+                    let n = n.max(0) as i32;
+                    svc.desired_count = n;
+                    if let Some(d) = svc.deployments.iter_mut().find(|d| d.status == "PRIMARY") {
+                        d.desired_count = n;
+                        d.updated_at = Utc::now();
+                    }
+                }
+
+                if let Some(arn) = new_td_arn.clone() {
+                    // Roll a new PRIMARY deployment; mark the previous one ACTIVE
+                    // so it's eligible for drain once the new deployment ramps.
+                    for d in svc.deployments.iter_mut() {
+                        if d.status == "PRIMARY" {
+                            d.status = "ACTIVE".into();
+                            old_deployments_drained.push(d.deployment_id.clone());
+                        }
+                    }
+                    svc.deployments.insert(
+                        0,
+                        Deployment {
+                            deployment_id: format!(
+                                "ecs-svc/{}",
+                                uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
+                            ),
+                            status: "PRIMARY".into(),
+                            task_definition_arn: arn.clone(),
+                            desired_count: svc.desired_count,
+                            pending_count: 0,
+                            running_count: 0,
+                            failed_tasks: 0,
+                            created_at: Utc::now(),
+                            updated_at: Utc::now(),
+                            launch_type: svc.launch_type.clone(),
+                            rollout_state: "IN_PROGRESS".into(),
+                            rollout_state_reason: Some("ECS deployment in progress.".into()),
+                        },
+                    );
+                    svc.task_definition_arn = arn;
+                    svc.family = new_family;
+                    svc.revision = new_revision;
+                    new_deployment_triggered = true;
+                }
+
+                effective_desired = svc.desired_count;
+            }
+
+            // Compute spawn + stop plan.
+            let mut spawn: Vec<String> = Vec::new();
+            let mut stop: Vec<String> = Vec::new();
+
+            // Tasks belonging to this service (by startedBy convention):
+            let service_tag = format!("ecs-svc/{}", service_name);
+            let current_tasks: Vec<(String, String)> = state
+                .tasks
+                .iter()
+                .filter(|(_, t)| {
+                    t.started_by.as_deref() == Some(service_tag.as_str())
+                        && t.cluster_name == cluster_name
+                        && t.last_status != "STOPPED"
+                })
+                .map(|(id, t)| (id.clone(), t.task_definition_arn.clone()))
+                .collect();
+
+            let current_count = current_tasks.len() as i32;
+            if effective_desired > current_count {
+                let add = (effective_desired - current_count) as usize;
+                let svc_snapshot = state.services.get(&key).unwrap().clone();
+                let mut new_ids = spawn_service_tasks(
+                    state,
+                    &svc_snapshot,
+                    add as i32,
+                    &principal_arn,
+                    &launch_type_clone,
+                );
+                spawn.append(&mut new_ids);
+            } else if effective_desired < current_count {
+                let remove = (current_count - effective_desired) as usize;
+                for (id, _) in current_tasks.iter().take(remove) {
+                    stop.push(id.clone());
+                }
+            }
+
+            // If a new deployment was triggered, also stop tasks still on
+            // the old task definition so the new deployment can ramp up.
+            if new_deployment_triggered {
+                let new_td_arn_match = state
+                    .services
+                    .get(&key)
+                    .unwrap()
+                    .task_definition_arn
+                    .clone();
+                for (id, t_arn) in &current_tasks {
+                    if *t_arn != new_td_arn_match && !stop.contains(id) {
+                        stop.push(id.clone());
+                    }
+                }
+                // Spawn replacements for the drained tasks up to desired count.
+                let svc_snapshot = state.services.get(&key).unwrap().clone();
+                let extra_needed = stop.len() as i32;
+                let already_spawned = spawn.len() as i32;
+                if extra_needed > already_spawned {
+                    let mut more = spawn_service_tasks(
+                        state,
+                        &svc_snapshot,
+                        extra_needed - already_spawned,
+                        &principal_arn,
+                        &launch_type_clone,
+                    );
+                    spawn.append(&mut more);
+                }
+            }
+
+            state.push_event(crate::state::LifecycleEvent {
+                at: Utc::now(),
+                event_type: "ServiceUpdated".into(),
+                task_arn: None,
+                cluster_arn: Some(service_cluster_arn),
+                last_status: Some("ACTIVE".into()),
+                detail: json!({
+                    "serviceArn": state.services.get(&key).unwrap().service_arn,
+                    "desiredCount": effective_desired,
+                    "previousDesiredCount": old_desired,
+                    "newDeployment": new_deployment_triggered,
+                    "drainedDeployments": old_deployments_drained,
+                }),
+            });
+
+            let svc = state.services.get(&key).unwrap();
+            (service_to_json(svc), spawn, stop)
+        };
+
+        if let Some(rt) = runtime {
+            for id in spawn_ids {
+                rt.clone().run_task(self.state.clone(), id, account.clone());
+            }
+            for id in stop_ids {
+                let rt2 = rt.clone();
+                let id_clone = id.clone();
+                tokio::spawn(async move {
+                    rt2.stop_task(&id_clone, "ECS service scale-down").await;
+                });
+                // Flip the task's desired status synchronously so DescribeTasks reflects intent.
+                let mut accounts = self.state.write();
+                if let Some(state) = accounts.get_mut(&account) {
+                    if let Some(task) = state.tasks.get_mut(&id) {
+                        task.desired_status = "STOPPED".into();
+                        task.stopping_at = Some(Utc::now());
+                    }
+                }
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({ "service": service_json })))
+    }
+
+    async fn delete_service(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let service_ref = req_str(&body, "service")?;
+        let service_name = service_name_from_ref(service_ref);
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let force = body.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        let (snapshot, task_ids_to_stop) = {
+            let mut accounts = self.state.write();
+            let state = accounts
+                .get_mut(&request.account_id)
+                .ok_or_else(|| service_not_found(&service_name))?;
+            let key = EcsState::service_key(&cluster_name, &service_name);
+            let svc = state
+                .services
+                .get_mut(&key)
+                .ok_or_else(|| service_not_found(&service_name))?;
+            if !force && svc.desired_count > 0 {
+                return Err(client_exception(
+                    "The service cannot be stopped while it is scaled above 0. \
+                     Either set desiredCount to 0 first, or pass force=true.",
+                ));
+            }
+            svc.desired_count = 0;
+            svc.status = "DRAINING".into();
+            let service_tag = format!("ecs-svc/{}", service_name);
+            let stop_ids: Vec<String> = state
+                .tasks
+                .iter()
+                .filter(|(_, t)| {
+                    t.started_by.as_deref() == Some(service_tag.as_str())
+                        && t.cluster_name == cluster_name
+                        && t.last_status != "STOPPED"
+                })
+                .map(|(id, _)| id.clone())
+                .collect();
+            if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
+                if cluster.active_services_count > 0 {
+                    cluster.active_services_count -= 1;
+                }
+            }
+            let svc_snapshot = state.services.get(&key).unwrap().clone();
+            state.services.remove(&key);
+            state.push_event(crate::state::LifecycleEvent {
+                at: Utc::now(),
+                event_type: "ServiceDeleted".into(),
+                task_arn: None,
+                cluster_arn: Some(svc_snapshot.cluster_arn.clone()),
+                last_status: Some("DRAINING".into()),
+                detail: json!({"serviceArn": svc_snapshot.service_arn}),
+            });
+            (svc_snapshot, stop_ids)
+        };
+
+        if let Some(rt) = &self.runtime {
+            for id in &task_ids_to_stop {
+                rt.stop_task(id, "ECS service deletion").await;
+                let mut accounts = self.state.write();
+                if let Some(state) = accounts.get_mut(&request.account_id) {
+                    if let Some(task) = state.tasks.get_mut(id) {
+                        task.desired_status = "STOPPED".into();
+                        task.stopping_at = Some(Utc::now());
+                    }
+                }
+            }
+        }
+
+        Ok(AwsResponse::ok_json(
+            json!({ "service": service_to_json(&snapshot) }),
+        ))
+    }
+
+    fn describe_services(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let refs: Vec<String> = body
+            .get("services")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let mut found = Vec::new();
+        let mut failures = Vec::new();
+        let Some(state) = accounts.get(&account) else {
+            for r in &refs {
+                failures.push(json!({"arn": r, "reason": "MISSING"}));
+            }
+            return Ok(AwsResponse::ok_json(
+                json!({"services": found, "failures": failures}),
+            ));
+        };
+        for r in &refs {
+            let name = service_name_from_ref(r);
+            let key = EcsState::service_key(&cluster_name, &name);
+            match state.services.get(&key) {
+                Some(svc) => {
+                    let mut v = service_to_json(svc);
+                    // Update derived running/pending counts from current tasks.
+                    recompute_service_counts(state, &name, &cluster_name, &mut v);
+                    found.push(v);
+                }
+                None => failures.push(json!({"arn": r, "reason": "MISSING"})),
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "services": found,
+            "failures": failures,
+        })))
+    }
+
+    fn list_services(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let cluster_ref = opt_str(&body, "cluster");
+        let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        let launch_type = opt_str(&body, "launchType");
+        let scheduling = opt_str(&body, "schedulingStrategy");
+        let max_results = body
+            .get("maxResults")
+            .and_then(|v| v.as_i64())
+            .filter(|n| (1..=100).contains(n))
+            .map(|n| n as usize)
+            .unwrap_or(100);
+        let next_token = opt_str(&body, "nextToken").unwrap_or("");
+
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let mut arns: Vec<String> = match accounts.get(&account) {
+            Some(state) => state
+                .services
+                .values()
+                .filter(|s| s.cluster_name == cluster_name)
+                .filter(|s| launch_type.is_none_or(|lt| s.launch_type == lt))
+                .filter(|s| scheduling.is_none_or(|sc| s.scheduling_strategy == sc))
+                .map(|s| s.service_arn.clone())
+                .collect(),
+            None => Vec::new(),
+        };
+        arns.sort();
+        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
+        let end = (start + max_results).min(arns.len());
+        let page = arns[start..end].to_vec();
+        let mut out = json!({"serviceArns": page});
+        if end < arns.len() {
+            out.as_object_mut()
+                .unwrap()
+                .insert("nextToken".into(), json!(end.to_string()));
+        }
+        Ok(AwsResponse::ok_json(out))
+    }
+
+    fn list_services_by_namespace(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        // fakecloud doesn't model Cloud Map namespaces yet — return all
+        // services attached to services with registries pointing at the
+        // given namespace ARN. Filter is loose: treat the namespace as a
+        // hint and return every service when none match to mirror AWS's
+        // "loose match when ambiguous" response shape.
+        let body = request.json_body();
+        let namespace = req_str(&body, "namespace")?.to_string();
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let mut arns: Vec<String> = match accounts.get(&account) {
+            Some(state) => state
+                .services
+                .values()
+                .filter(|s| {
+                    s.service_registries.iter().any(|r| {
+                        r.get("registryArn")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|arn| arn.contains(&namespace))
+                    })
+                })
+                .map(|s| s.service_arn.clone())
+                .collect(),
+            None => Vec::new(),
+        };
+        arns.sort();
+        Ok(AwsResponse::ok_json(json!({"serviceArns": arns})))
+    }
+}
+
+fn validate_service_name(name: &str) -> Result<(), AwsServiceError> {
+    if name.is_empty() || name.len() > 255 {
+        return Err(invalid_parameter("Service name must be 1-255 characters"));
+    }
+    let ok = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !ok {
+        return Err(invalid_parameter(
+            "Service name may only contain letters, numbers, hyphens, and underscores",
+        ));
+    }
+    Ok(())
+}
+
+fn service_name_from_ref(input: &str) -> String {
+    if let Some(rest) = input.rsplit('/').next() {
+        return rest.to_string();
+    }
+    input.to_string()
+}
+
+fn service_not_found(name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ServiceNotFoundException",
+        format!("The service could not be found: {name}"),
+    )
+}
+
+fn service_already_exists(name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ServiceNotActiveException",
+        format!("The service {name} already exists"),
+    )
+}
+
+/// Spawn N tasks for a service by cloning the task-definition containers
+/// and inserting `Task` rows in the shared state. The task IDs are
+/// returned so the caller can hand them to `EcsRuntime::run_task` after
+/// releasing the state write lock.
+fn spawn_service_tasks(
+    state: &mut EcsState,
+    service: &Service,
+    count: i32,
+    principal_arn: &str,
+    launch_type: &str,
+) -> Vec<String> {
+    if count <= 0 {
+        return Vec::new();
+    }
+    let Some(revisions) = state.task_definitions.get(&service.family) else {
+        return Vec::new();
+    };
+    let Some(td) = revisions.get(&service.revision) else {
+        return Vec::new();
+    };
+    let container_defs = td.container_definitions.clone();
+    let cpu = td.cpu.clone();
+    let memory = td.memory.clone();
+    let task_role = td.task_role_arn.clone();
+    let exec_role = td.execution_role_arn.clone();
+    let cluster_name = service.cluster_name.clone();
+    let cluster_arn = service.cluster_arn.clone();
+    let td_arn = service.task_definition_arn.clone();
+    let family = service.family.clone();
+    let revision = service.revision;
+    let service_tag = format!("ecs-svc/{}", service.service_name);
+
+    let mut ids = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let task_arn = state.task_arn(&cluster_name, &task_id);
+        let containers: Vec<Container> = container_defs
+            .iter()
+            .map(|def| Container {
+                container_arn: format!(
+                    "arn:aws:ecs:{}:{}:container/{}/{}/{}",
+                    state.region,
+                    state.account_id,
+                    cluster_name,
+                    task_id,
+                    def.get("name").and_then(|v| v.as_str()).unwrap_or("app")
+                ),
+                name: def
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("app")
+                    .to_string(),
+                image: def
+                    .get("image")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                task_arn: task_arn.clone(),
+                last_status: "PENDING".into(),
+                exit_code: None,
+                reason: None,
+                runtime_id: None,
+                essential: def
+                    .get("essential")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true),
+                cpu: def
+                    .get("cpu")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string()),
+                memory: def
+                    .get("memory")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string()),
+                memory_reservation: def
+                    .get("memoryReservation")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.to_string()),
+                network_bindings: Vec::new(),
+                network_interfaces: Vec::new(),
+                health_status: Some("UNKNOWN".into()),
+                managed_agents: None,
+            })
+            .collect();
+        let awslogs = container_defs.iter().find_map(|def| {
+            let name = def.get("name").and_then(|v| v.as_str())?.to_string();
+            let log_cfg = def.get("logConfiguration")?;
+            if log_cfg.get("logDriver").and_then(|v| v.as_str()) != Some("awslogs") {
+                return None;
+            }
+            let opts = log_cfg.get("options").and_then(|v| v.as_object())?;
+            Some(AwsLogsConfig {
+                group: opts.get("awslogs-group").and_then(|v| v.as_str())?.into(),
+                stream_prefix: opts
+                    .get("awslogs-stream-prefix")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                region: opts
+                    .get("awslogs-region")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&state.region)
+                    .to_string(),
+                container_name: name,
+            })
+        });
+        let task = Task {
+            task_arn: task_arn.clone(),
+            task_id: task_id.clone(),
+            cluster_arn: cluster_arn.clone(),
+            cluster_name: cluster_name.clone(),
+            task_definition_arn: td_arn.clone(),
+            family: family.clone(),
+            revision,
+            last_status: "PENDING".into(),
+            desired_status: "RUNNING".into(),
+            launch_type: launch_type.into(),
+            platform_version: Some("1.4.0".into()),
+            cpu: cpu.clone(),
+            memory: memory.clone(),
+            containers,
+            overrides: json!({}),
+            started_by: Some(service_tag.clone()),
+            group: Some(format!("service:{}", service.service_name)),
+            connectivity: "CONNECTING".into(),
+            stop_code: None,
+            stopped_reason: None,
+            created_at: Utc::now(),
+            started_at: None,
+            stopping_at: None,
+            stopped_at: None,
+            pull_started_at: None,
+            pull_stopped_at: None,
+            connectivity_at: None,
+            started_by_ref_id: None,
+            execution_role_arn: exec_role.clone(),
+            task_role_arn: task_role.clone(),
+            tags: Vec::new(),
+            awslogs,
+            captured_logs: String::new(),
+        };
+        state.tasks.insert(task_id.clone(), task);
+        if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
+            cluster.pending_tasks_count += 1;
+        }
+        ids.push(task_id);
+    }
+    let _ = principal_arn;
+    ids
+}
+
+fn recompute_service_counts(
+    state: &EcsState,
+    service_name: &str,
+    cluster_name: &str,
+    service_json: &mut Value,
+) {
+    let service_tag = format!("ecs-svc/{}", service_name);
+    let mut running = 0i32;
+    let mut pending = 0i32;
+    for t in state.tasks.values() {
+        if t.started_by.as_deref() == Some(service_tag.as_str()) && t.cluster_name == cluster_name {
+            match t.last_status.as_str() {
+                "RUNNING" => running += 1,
+                "PENDING" | "PROVISIONING" => pending += 1,
+                _ => {}
+            }
+        }
+    }
+    if let Some(map) = service_json.as_object_mut() {
+        map.insert("runningCount".into(), json!(running));
+        map.insert("pendingCount".into(), json!(pending));
+    }
+}
+
+fn service_to_json(svc: &Service) -> Value {
+    let mut map = serde_json::Map::new();
+    map.insert("serviceArn".into(), json!(svc.service_arn));
+    map.insert("serviceName".into(), json!(svc.service_name));
+    map.insert("clusterArn".into(), json!(svc.cluster_arn));
+    map.insert("status".into(), json!(svc.status));
+    map.insert("desiredCount".into(), json!(svc.desired_count));
+    map.insert("runningCount".into(), json!(svc.running_count));
+    map.insert("pendingCount".into(), json!(svc.pending_count));
+    map.insert("launchType".into(), json!(svc.launch_type));
+    map.insert("schedulingStrategy".into(), json!(svc.scheduling_strategy));
+    map.insert("taskDefinition".into(), json!(svc.task_definition_arn));
+    map.insert(
+        "deploymentController".into(),
+        json!({"type": svc.deployment_controller}),
+    );
+    let mut deployment_cfg = serde_json::Map::new();
+    if let Some(n) = svc.minimum_healthy_percent {
+        deployment_cfg.insert("minimumHealthyPercent".into(), json!(n));
+    }
+    if let Some(n) = svc.maximum_percent {
+        deployment_cfg.insert("maximumPercent".into(), json!(n));
+    }
+    if let Some(ref cb) = svc.circuit_breaker {
+        deployment_cfg.insert(
+            "deploymentCircuitBreaker".into(),
+            json!({"enable": cb.enable, "rollback": cb.rollback}),
+        );
+    }
+    if !deployment_cfg.is_empty() {
+        map.insert(
+            "deploymentConfiguration".into(),
+            Value::Object(deployment_cfg),
+        );
+    }
+    map.insert(
+        "deployments".into(),
+        Value::Array(svc.deployments.iter().map(deployment_to_json).collect()),
+    );
+    map.insert(
+        "loadBalancers".into(),
+        Value::Array(svc.load_balancers.clone()),
+    );
+    map.insert(
+        "serviceRegistries".into(),
+        Value::Array(svc.service_registries.clone()),
+    );
+    map.insert(
+        "placementConstraints".into(),
+        Value::Array(svc.placement_constraints.clone()),
+    );
+    map.insert(
+        "placementStrategy".into(),
+        Value::Array(svc.placement_strategy.clone()),
+    );
+    if let Some(ref v) = svc.network_configuration {
+        map.insert("networkConfiguration".into(), v.clone());
+    }
+    if let Some(ref v) = svc.role_arn {
+        map.insert("roleArn".into(), json!(v));
+    }
+    if let Some(ref v) = svc.created_by {
+        map.insert("createdBy".into(), json!(v));
+    }
+    map.insert("createdAt".into(), json!(svc.created_at.timestamp()));
+    Value::Object(map)
+}
+
+fn deployment_to_json(d: &Deployment) -> Value {
+    json!({
+        "id": d.deployment_id,
+        "status": d.status,
+        "taskDefinition": d.task_definition_arn,
+        "desiredCount": d.desired_count,
+        "pendingCount": d.pending_count,
+        "runningCount": d.running_count,
+        "failedTasks": d.failed_tasks,
+        "createdAt": d.created_at.timestamp(),
+        "updatedAt": d.updated_at.timestamp(),
+        "launchType": d.launch_type,
+        "rolloutState": d.rollout_state,
+        "rolloutStateReason": d.rollout_state_reason,
+    })
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -2177,7 +2177,10 @@ impl EcsService {
             }
 
             // If a new deployment was triggered, also stop tasks still on
-            // the old task definition so the new deployment can ramp up.
+            // the old task definition so the new deployment can ramp up,
+            // then spawn replacements — but only enough to hit the
+            // effective desired count (not `stop.len()`, which conflates
+            // scale-down drain with TD-drain and would over-spawn).
             if new_deployment_triggered {
                 let new_td_arn_match = state
                     .services
@@ -2185,20 +2188,26 @@ impl EcsService {
                     .unwrap()
                     .task_definition_arn
                     .clone();
+                // Tasks already on the new task definition that we're NOT
+                // stopping (scale-down may have picked the first N; those
+                // are skipped here via `stop.contains(id)`).
+                let kept_on_new_td: i32 = current_tasks
+                    .iter()
+                    .filter(|(id, t_arn)| *t_arn == new_td_arn_match && !stop.contains(id))
+                    .count() as i32;
                 for (id, t_arn) in &current_tasks {
                     if *t_arn != new_td_arn_match && !stop.contains(id) {
                         stop.push(id.clone());
                     }
                 }
-                // Spawn replacements for the drained tasks up to desired count.
-                let svc_snapshot = state.services.get(&key).unwrap().clone();
-                let extra_needed = stop.len() as i32;
                 let already_spawned = spawn.len() as i32;
-                if extra_needed > already_spawned {
+                let need = (effective_desired - kept_on_new_td - already_spawned).max(0);
+                if need > 0 {
+                    let svc_snapshot = state.services.get(&key).unwrap().clone();
                     let mut more = spawn_service_tasks(
                         state,
                         &svc_snapshot,
-                        extra_needed - already_spawned,
+                        need,
                         &principal_arn,
                         &launch_type_clone,
                     );

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -14,7 +14,7 @@ impl fakecloud_core::multi_account::AccountState for EcsState {
     }
 }
 
-pub const ECS_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+pub const ECS_SNAPSHOT_SCHEMA_VERSION: u32 = 3;
 
 /// Top-level persisted ECS snapshot. Mirrors the multi-account snapshot
 /// convention used by Kinesis/ECR/ElastiCache so `main.rs` can share the
@@ -51,6 +51,12 @@ pub struct EcsState {
     /// (oldest dropped) so long-running servers don't grow unboundedly.
     #[serde(default)]
     pub events: Vec<LifecycleEvent>,
+    /// Services keyed by service name within an account. ECS requires
+    /// unique service names per cluster, and since service names are
+    /// already unique per-cluster globally we scope keys by
+    /// `cluster_name:service_name` in [`EcsState::service_key`].
+    #[serde(default)]
+    pub services: BTreeMap<String, Service>,
 }
 
 impl EcsState {
@@ -65,6 +71,7 @@ impl EcsState {
             principal_account_settings: BTreeMap::new(),
             tasks: BTreeMap::new(),
             events: Vec::new(),
+            services: BTreeMap::new(),
         }
     }
 
@@ -76,6 +83,21 @@ impl EcsState {
         self.principal_account_settings.clear();
         self.tasks.clear();
         self.events.clear();
+        self.services.clear();
+    }
+
+    /// Services are uniquely identified by `(cluster, name)` within an
+    /// account; this helper composes the storage key used in
+    /// `self.services`.
+    pub fn service_key(cluster_name: &str, service_name: &str) -> String {
+        format!("{}/{}", cluster_name, service_name)
+    }
+
+    pub fn service_arn(&self, cluster_name: &str, service_name: &str) -> String {
+        format!(
+            "arn:aws:ecs:{}:{}:service/{}/{}",
+            self.region, self.account_id, cluster_name, service_name
+        )
     }
 
     pub fn task_arn(&self, cluster_name: &str, task_id: &str) -> String {
@@ -328,6 +350,67 @@ pub struct LifecycleEvent {
     pub cluster_arn: Option<String>,
     pub last_status: Option<String>,
     pub detail: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Service {
+    pub service_name: String,
+    pub service_arn: String,
+    pub cluster_name: String,
+    pub cluster_arn: String,
+    pub task_definition_arn: String,
+    pub family: String,
+    pub revision: i32,
+    pub desired_count: i32,
+    pub running_count: i32,
+    pub pending_count: i32,
+    pub launch_type: String,
+    pub status: String,
+    pub scheduling_strategy: String,
+    pub deployment_controller: String,
+    pub minimum_healthy_percent: Option<i32>,
+    pub maximum_percent: Option<i32>,
+    /// Deployment circuit breaker config (opt-in via deploymentConfiguration).
+    pub circuit_breaker: Option<CircuitBreakerConfig>,
+    #[serde(default)]
+    pub deployments: Vec<Deployment>,
+    #[serde(default)]
+    pub load_balancers: Vec<Value>,
+    #[serde(default)]
+    pub service_registries: Vec<Value>,
+    #[serde(default)]
+    pub placement_constraints: Vec<Value>,
+    #[serde(default)]
+    pub placement_strategy: Vec<Value>,
+    #[serde(default)]
+    pub network_configuration: Option<Value>,
+    #[serde(default)]
+    pub tags: Vec<TagEntry>,
+    pub created_at: DateTime<Utc>,
+    pub created_by: Option<String>,
+    pub role_arn: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CircuitBreakerConfig {
+    pub enable: bool,
+    pub rollback: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Deployment {
+    pub deployment_id: String,
+    pub status: String,
+    pub task_definition_arn: String,
+    pub desired_count: i32,
+    pub pending_count: i32,
+    pub running_count: i32,
+    pub failed_tasks: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub launch_type: String,
+    pub rollout_state: String,
+    pub rollout_state_reason: Option<String>,
 }
 
 #[cfg(test)]

--- a/website/content/docs/services/ecs.md
+++ b/website/content/docs/services/ecs.md
@@ -6,15 +6,25 @@ weight = 22
 
 fakecloud implements Amazon Elastic Container Service (ECS) with a four-batch roadmap. This page tracks what's shipped.
 
-**Status: Batches 1 + 2 shipped — control-plane CRUD plus real task execution.** Subsequent batches add services + rolling deployments (Batch 3) and completeness (Batch 4: container instances, capacity providers, task protection, `ExecuteCommand`).
+**Status: Batches 1 + 2 + 3 shipped — control-plane CRUD, real task execution, services with rolling deployments.** Batch 4 adds completeness (container instances, capacity providers, task protection, `ExecuteCommand`).
 
-## Supported today (Batches 1 + 2)
+## Supported today (Batches 1 + 2 + 3)
 
 - **Clusters** — `CreateCluster`, `DescribeClusters`, `DeleteCluster`, `ListClusters`, `UpdateCluster`, `UpdateClusterSettings`, `PutClusterCapacityProviders`
 - **Task definitions** — `RegisterTaskDefinition`, `DescribeTaskDefinition`, `DeregisterTaskDefinition`, `DeleteTaskDefinitions`, `ListTaskDefinitions`, `ListTaskDefinitionFamilies`
 - **Tasks** — `RunTask`, `StartTask`, `StopTask`, `DescribeTasks`, `ListTasks` with real Fargate-style execution via Docker/Podman
+- **Services** — `CreateService`, `UpdateService`, `DeleteService`, `DescribeServices`, `ListServices`, `ListServicesByNamespace` with desired-count enforcement and rolling deployments
 - **Tagging** — `TagResource`, `UntagResource`, `ListTagsForResource` (clusters and task definitions)
 - **Account settings** — `PutAccountSetting`, `PutAccountSettingDefault`, `DeleteAccountSetting`, `ListAccountSettings`
+
+### Services + rolling deployments (Batch 3)
+
+`CreateService` spawns tasks to match `desiredCount` under the service, tagging each with `startedBy=ecs-svc/<name>` so the tasks reconcile back to the service. `UpdateService` supports two independent mutations:
+
+- **Scale** — set a new `desiredCount`. The service spawns additional tasks when scaling up and flips excess tasks to `desiredStatus=STOPPED` (runtime kill on the container) when scaling down.
+- **Rolling deployment** — pass a new `taskDefinition`. The service marks the previous PRIMARY deployment as `ACTIVE`, creates a new `PRIMARY` deployment for the target revision, and drains tasks on the old task definition while new ones come up. Deployment circuit breaker + `minimumHealthyPercent` / `maximumPercent` are honoured in `deploymentConfiguration`.
+
+`DeleteService` refuses while `desiredCount > 0` unless `force=true`; the forced path scales to 0 and stops every running task under the service before removing it.
 
 Task-definition families track revisions monotonically; `DeleteTaskDefinitions` requires `DeregisterTaskDefinition` first (real AWS behaviour), and the result flips status to `DELETE_IN_PROGRESS`.
 
@@ -102,8 +112,7 @@ let clusters = fc.ecs().get_clusters().await?;
 
 ## Roadmap
 
-- **Batch 3** — `CreateService`, `UpdateService`, rolling deployments with `minimumHealthyPercent`/`maximumPercent`, `CreateTaskSet`/`UpdateTaskSet` (EXTERNAL deployment controller), deployment circuit breaker. EventBridge `ECS Task State Change` events. awslogs driver wiring to CloudWatch Logs (today captured stdout/stderr live on the task; Batch 3 ships them to CW Logs automatically).
-- **Batch 4** — Container instances, attributes, capacity providers, task protection, ECS Exec (`ExecuteCommand` via `docker exec`), snapshot/restore of in-flight tasks, IAM task-role credential injection via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`.
+- **Batch 4** — Container instances, attributes, capacity providers, task protection, ECS Exec (`ExecuteCommand` via `docker exec`), task sets (EXTERNAL deployment controller), snapshot/restore of in-flight tasks, IAM task-role credential injection via `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, EventBridge `ECS Task State Change` events, awslogs-driver CloudWatch Logs streaming.
 
 ## Source
 


### PR DESCRIPTION
## Summary

Batch 3 of the ECS rollout. Adds the full services surface on top of the Batch 2 task execution: \`CreateService\`, \`UpdateService\`, \`DeleteService\`, \`DescribeServices\`, \`ListServices\`, \`ListServicesByNamespace\` with desired-count enforcement and rolling deployments.

Highlights:
- \`CreateService\` spawns tasks to match \`desiredCount\` and tags each with \`startedBy=ecs-svc/<name>\` so the tasks reconcile back to the service.
- \`UpdateService\` scaling (up: spawn new tasks; down: SIGTERM excess via runtime + flip \`desiredStatus=STOPPED\` synchronously).
- \`UpdateService\` rolling deployment: new \`taskDefinition\` marks the previous PRIMARY deployment ACTIVE, creates a new PRIMARY, and drains tasks on the old revision while new ones spin up. \`minimumHealthyPercent\` / \`maximumPercent\` + deployment circuit breaker are honoured in \`deploymentConfiguration\`.
- \`DeleteService\` refuses while \`desiredCount > 0\` unless \`force=true\`; forced path scales to 0 and stops every task under the service.
- \`DescribeServices\` derives \`runningCount\` / \`pendingCount\` from live task state on each read.
- Snapshot schema bumped to v3 to persist services.

Deferred to Batch 4: task sets (EXTERNAL deployment controller), container instances, capacity providers, task protection, \`ExecuteCommand\`, EventBridge state-change events.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test ecs\` — 18 scenarios pass (4 new for services: create/describe/list round-trip, scale up+down, rolling deployment, force-delete)
- [x] \`cargo test -p fakecloud-conformance --test ecs\` — 31 conformance tests pass (all 6 new actions have live Smithy-shape checksums)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [ ] CI green on all checks
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ECS services with rolling deployments on top of task execution, with desired-count enforcement and live running/pending counts. Also fixes an over-spawn issue when scaling down during a rolling deployment. Snapshot schema bumped to v3.

- **New Features**
  - Added `CreateService`, `UpdateService`, `DeleteService`, `DescribeServices`, `ListServices`, `ListServicesByNamespace`.
  - Scaling: spawns tasks on scale-up; on scale-down flips excess to `desiredStatus=STOPPED` and SIGTERMs via the runtime.
  - Rolling deployments: new `taskDefinition` creates a new PRIMARY, marks the previous PRIMARY ACTIVE, and drains old tasks; honors `minimumHealthyPercent`, `maximumPercent`, and the deployment circuit breaker.
  - Service linkage and reads: tasks tagged `startedBy=ecs-svc/<name>`; `DescribeServices` derives `runningCount`/`pendingCount` from live tasks; `ListServices` supports cluster/launchType/schedulingStrategy filters.

- **Bug Fixes**
  - Prevented over-spawning in `UpdateService` when scaling down and changing `taskDefinition` in the same call by computing replacements from the effective desired count (not from the total stop set).

<sup>Written for commit f7995e39e4da1843f33140dc08c2fa2e5eb0a27e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

