### PR TITLE
feat(ecs): awslogs -> CloudWatch Logs + EventBridge task state change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "fakecloud-core",
+ "fakecloud-logs",
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-e2e/tests/ecs_observability.rs
+++ b/crates/fakecloud-e2e/tests/ecs_observability.rs
@@ -1,0 +1,307 @@
+//! ECS observability integrations:
+//! - `awslogs` driver forwards captured stdout/stderr to CloudWatch Logs
+//! - Task state transitions emit `aws.ecs` / "ECS Task State Change"
+//!   events on EventBridge, deliverable to the usual rule targets
+//!
+//! Gated on docker availability the same way the Lambda invoke tests
+//! are: required in CI, skipped otherwise so local dev without docker
+//! still passes.
+
+mod helpers;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use aws_sdk_ecs::types::{
+    ContainerDefinition, KeyValuePair, LogConfiguration as EcsLogConfig, LogDriver,
+};
+use aws_sdk_eventbridge::types::{PutEventsRequestEntry, Target};
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("skipping {test}: docker is not available");
+    false
+}
+
+async fn wait_for_task_stopped(
+    ecs: &aws_sdk_ecs::Client,
+    cluster: &str,
+    arn: &str,
+) -> aws_sdk_ecs::types::Task {
+    for _ in 0..120 {
+        let desc = ecs
+            .describe_tasks()
+            .cluster(cluster)
+            .tasks(arn)
+            .send()
+            .await
+            .expect("describe_tasks");
+        let t = &desc.tasks()[0];
+        if t.last_status() == Some("STOPPED") {
+            return t.clone();
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    panic!("task {arn} never reached STOPPED");
+}
+
+fn awslogs_config(group: &str, stream_prefix: &str, region: &str) -> EcsLogConfig {
+    let mut options: HashMap<String, String> = HashMap::new();
+    options.insert("awslogs-group".into(), group.into());
+    options.insert("awslogs-stream-prefix".into(), stream_prefix.into());
+    options.insert("awslogs-region".into(), region.into());
+    options.insert("awslogs-create-group".into(), "true".into());
+    EcsLogConfig::builder()
+        .log_driver(LogDriver::Awslogs)
+        .set_options(Some(options))
+        .build()
+        .expect("build log config")
+}
+
+/// Task with `awslogs` log driver: captured stdout shows up in the log
+/// group/stream that fakecloud-logs exposes via `GetLogEvents`.
+#[tokio::test]
+async fn ecs_task_awslogs_forwards_to_cloudwatch() {
+    if !require_docker_or_skip("ecs_task_awslogs_forwards_to_cloudwatch") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    let logs = server.logs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("awslogs-cluster")
+        .send()
+        .await
+        .unwrap();
+
+    let log_cfg = awslogs_config("/fakecloud/ecs/awslogs-test", "fc", "us-east-1");
+    ecs.register_task_definition()
+        .family("awslogs-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("sh")
+                .command("-c")
+                .command("echo hello-from-awslogs && echo second-line")
+                .log_configuration(log_cfg)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let run = ecs
+        .run_task()
+        .cluster("awslogs-cluster")
+        .task_definition("awslogs-family")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    let _ = wait_for_task_stopped(&ecs, "awslogs-cluster", &arn).await;
+
+    // Introspect what fakecloud-logs received.
+    let streams = logs
+        .describe_log_streams()
+        .log_group_name("/fakecloud/ecs/awslogs-test")
+        .send()
+        .await
+        .expect("describe_log_streams");
+    let names: Vec<&str> = streams
+        .log_streams()
+        .iter()
+        .filter_map(|s| s.log_stream_name())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.starts_with("fc/app/")),
+        "expected awslogs stream; got {names:?}"
+    );
+    let stream = names[0];
+
+    let events = logs
+        .get_log_events()
+        .log_group_name("/fakecloud/ecs/awslogs-test")
+        .log_stream_name(stream)
+        .send()
+        .await
+        .expect("get_log_events");
+    let messages: Vec<&str> = events.events().iter().filter_map(|e| e.message()).collect();
+    assert!(
+        messages.iter().any(|m| m.contains("hello-from-awslogs")),
+        "expected container stdout in CW Logs; got {messages:?}"
+    );
+}
+
+/// Task state transitions fire `ECS Task State Change` events on the
+/// default EventBridge bus. An SQS rule target receives the events, and
+/// we assert that the task's RUNNING -> STOPPED transitions show up.
+#[tokio::test]
+async fn ecs_task_state_change_emits_eventbridge() {
+    if !require_docker_or_skip("ecs_task_state_change_emits_eventbridge") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    let eb = server.eventbridge_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q = sqs
+        .create_queue()
+        .queue_name("ecs-state-change-target")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = q.queue_url().unwrap().to_string();
+    let q_attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = q_attrs
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    eb.put_rule()
+        .name("ecs-state-change")
+        .event_pattern(
+            serde_json::json!({
+                "source": ["aws.ecs"],
+                "detail-type": ["ECS Task State Change"]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    eb.put_targets()
+        .rule("ecs-state-change")
+        .targets(
+            Target::builder()
+                .id("sqs-target")
+                .arn(&queue_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Sanity-check the wiring by putting one event directly on the bus.
+    eb.put_events()
+        .entries(
+            PutEventsRequestEntry::builder()
+                .source("aws.ecs")
+                .detail_type("ECS Task State Change")
+                .detail(r#"{"test": "sanity"}"#)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    ecs.create_cluster()
+        .cluster_name("eb-cluster")
+        .send()
+        .await
+        .unwrap();
+    ecs.register_task_definition()
+        .family("eb-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("sh")
+                .command("-c")
+                .command("exit 0")
+                .environment(
+                    KeyValuePair::builder()
+                        .name("T")
+                        .value("state-change")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let run = ecs
+        .run_task()
+        .cluster("eb-cluster")
+        .task_definition("eb-family")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    let _ = wait_for_task_stopped(&ecs, "eb-cluster", &arn).await;
+
+    // Poll the SQS queue for messages — sanity entry + at least one task
+    // state-change event with lastStatus=STOPPED for our task.
+    let mut saw_stopped_for_task = false;
+    for _ in 0..30 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        for m in recv.messages() {
+            let Some(body) = m.body() else { continue };
+            let Ok(ev) = serde_json::from_str::<serde_json::Value>(body) else {
+                continue;
+            };
+            // EventBridge delivery wraps the detail in the event envelope.
+            let detail = ev.get("detail").cloned().unwrap_or(ev.clone());
+            let matches_task = detail
+                .get("taskArn")
+                .and_then(|v| v.as_str())
+                .map(|s| s == arn)
+                .unwrap_or(false);
+            let stopped = detail
+                .get("lastStatus")
+                .and_then(|v| v.as_str())
+                .map(|s| s == "STOPPED")
+                .unwrap_or(false);
+            if matches_task && stopped {
+                saw_stopped_for_task = true;
+                break;
+            }
+        }
+        if saw_stopped_for_task {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert!(
+        saw_stopped_for_task,
+        "expected an ECS Task State Change STOPPED event for our task on SQS"
+    );
+}

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-logs = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -13,11 +13,14 @@ use std::time::Duration;
 
 use base64::Engine;
 use chrono::Utc;
+use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_logs::ingest::{append_events, IngestEvent};
+use fakecloud_logs::state::SharedLogsState;
 use parking_lot::RwLock;
 use tempfile::TempDir;
 use tokio::process::Command;
 
-use crate::state::{LifecycleEvent, SharedEcsState};
+use crate::state::{LifecycleEvent, SharedEcsState, Task};
 
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
@@ -48,6 +51,14 @@ pub struct EcsRuntime {
     /// Tracks container IDs per task ID so `stop_task` can kill in-flight
     /// work without needing to block on the spawned executor future.
     containers: RwLock<std::collections::HashMap<String, String>>,
+    /// Cross-service delivery bus — emits `aws.ecs` EventBridge events
+    /// on task state transitions when wired. `None` if the server started
+    /// without EventBridge configured (or for unit tests).
+    delivery_bus: Option<Arc<DeliveryBus>>,
+    /// CloudWatch Logs state — when set, tasks whose container definition
+    /// declares the `awslogs` log driver get their captured stdout/stderr
+    /// forwarded to a log group/stream under this shared state.
+    logs_state: Option<SharedLogsState>,
 }
 
 impl EcsRuntime {
@@ -81,6 +92,8 @@ impl EcsRuntime {
             server_port,
             docker_config,
             containers: RwLock::new(std::collections::HashMap::new()),
+            delivery_bus: None,
+            logs_state: None,
         })
     }
 
@@ -105,15 +118,37 @@ impl EcsRuntime {
         &self.cli
     }
 
+    /// Wire EventBridge delivery so task state transitions emit
+    /// `aws.ecs` / `ECS Task State Change` events.
+    pub fn with_delivery_bus(mut self, bus: Arc<DeliveryBus>) -> Self {
+        self.delivery_bus = Some(bus);
+        self
+    }
+
+    /// Wire CloudWatch Logs state so tasks using the `awslogs` driver
+    /// get their captured stdout/stderr forwarded.
+    pub fn with_logs(mut self, logs: SharedLogsState) -> Self {
+        self.logs_state = Some(logs);
+        self
+    }
+
     /// Spawn the task asynchronously. Returns immediately after transitioning
     /// the task to `PENDING`; the background task advances it to `RUNNING`
     /// once the container is created and to `STOPPED` once the container
     /// exits.
     pub fn run_task(self: Arc<Self>, state: SharedEcsState, task_id: String, account_id: String) {
+        let rt = self.clone();
         tokio::spawn(async move {
-            if let Err(err) = self.run_task_inner(&state, &task_id, &account_id).await {
+            if let Err(err) = rt.run_task_inner(&state, &task_id, &account_id).await {
                 tracing::warn!(%err, task = %task_id, "ecs task execution failed");
                 finalize_failure(&state, &account_id, &task_id, &err.to_string());
+                rt.emit_state_change(
+                    &state,
+                    &account_id,
+                    &task_id,
+                    "STOPPED",
+                    Some(("TaskFailedToStart", err.to_string())),
+                );
             }
         });
     }
@@ -243,6 +278,7 @@ impl EcsRuntime {
             &container_id,
             &awslogs_container,
         );
+        self.emit_state_change(state, account_id, task_id, "RUNNING", None);
 
         // Wait for the container to exit. `docker wait` blocks until exit
         // and prints the numeric exit code to stdout.
@@ -290,7 +326,111 @@ impl EcsRuntime {
             "EssentialContainerExited",
             None,
         );
+        self.forward_awslogs_if_configured(state, account_id, task_id, &captured);
+        self.emit_state_change(
+            state,
+            account_id,
+            task_id,
+            "STOPPED",
+            Some((
+                "EssentialContainerExited",
+                format!("Exit code {}", exit_code),
+            )),
+        );
         Ok(())
+    }
+
+    /// Emit an `ECS Task State Change` EventBridge event. No-op when no
+    /// delivery bus is wired. Matches AWS event shape so downstream
+    /// rules can filter on `detail.lastStatus`, `detail.stopCode`, etc.
+    fn emit_state_change(
+        &self,
+        state: &SharedEcsState,
+        account_id: &str,
+        task_id: &str,
+        last_status: &str,
+        stop: Option<(&str, String)>,
+    ) {
+        let Some(ref bus) = self.delivery_bus else {
+            return;
+        };
+        let Some(task_view) = snapshot_task(state, account_id, task_id) else {
+            return;
+        };
+        let mut detail = serde_json::json!({
+            "taskArn": task_view.task_arn,
+            "clusterArn": task_view.cluster_arn,
+            "lastStatus": last_status,
+            "desiredStatus": if last_status == "STOPPED" { "STOPPED" } else { "RUNNING" },
+            "launchType": task_view.launch_type,
+            "group": task_view.group,
+            "taskDefinitionArn": task_view.task_definition_arn,
+            "containers": task_view.containers,
+        });
+        if let Some((code, reason)) = stop {
+            detail["stopCode"] = code.into();
+            detail["stoppedReason"] = reason.into();
+        }
+        bus.put_event_to_eventbridge(
+            "aws.ecs",
+            "ECS Task State Change",
+            &detail.to_string(),
+            "default",
+        );
+    }
+
+    /// Forward captured stdout/stderr to CloudWatch Logs when the task's
+    /// container definition declares the `awslogs` log driver. No-op when
+    /// logs_state isn't wired or the task has no awslogs config.
+    fn forward_awslogs_if_configured(
+        &self,
+        state: &SharedEcsState,
+        account_id: &str,
+        task_id: &str,
+        captured: &str,
+    ) {
+        let Some(ref logs) = self.logs_state else {
+            return;
+        };
+        // Clone out of the read guard so we don't hold it across the logs
+        // state write.
+        let (cfg, task_region) = {
+            let accounts = state.read();
+            let Some(s) = accounts.get(account_id) else {
+                return;
+            };
+            let Some(task) = s.tasks.get(task_id) else {
+                return;
+            };
+            let Some(ref cfg) = task.awslogs else {
+                return;
+            };
+            (cfg.clone(), s.region.clone())
+        };
+        if captured.is_empty() {
+            return;
+        }
+        let now = Utc::now().timestamp_millis();
+        let stream_name = cfg.stream_name(task_id);
+        let events: Vec<IngestEvent> = captured
+            .lines()
+            .enumerate()
+            .map(|(i, line)| IngestEvent {
+                // Stagger within the same millisecond so CloudWatch's
+                // chronological-order invariant holds without relying on
+                // the host clock's resolution.
+                timestamp_ms: now.saturating_add(i as i64),
+                message: line.to_string(),
+            })
+            .collect();
+        append_events(
+            logs,
+            account_id,
+            &task_region,
+            &cfg.group,
+            &stream_name,
+            &events,
+        );
     }
 
     /// Kill the container behind a task (if any) with the configured stop
@@ -323,6 +463,47 @@ impl EcsRuntime {
         self.containers.write().clear();
     }
 }
+
+struct TaskSnapshot {
+    task_arn: String,
+    cluster_arn: String,
+    launch_type: String,
+    group: Option<String>,
+    task_definition_arn: String,
+    containers: serde_json::Value,
+}
+
+fn snapshot_task(state: &SharedEcsState, account_id: &str, task_id: &str) -> Option<TaskSnapshot> {
+    let accounts = state.read();
+    let s = accounts.get(account_id)?;
+    let task = s.tasks.get(task_id)?;
+    Some(TaskSnapshot {
+        task_arn: task.task_arn.clone(),
+        cluster_arn: task.cluster_arn.clone(),
+        launch_type: task.launch_type.clone(),
+        group: task.group.clone(),
+        task_definition_arn: task.task_definition_arn.clone(),
+        containers: serde_json::Value::Array(
+            task.containers
+                .iter()
+                .map(|c| {
+                    serde_json::json!({
+                        "containerArn": c.container_arn,
+                        "name": c.name,
+                        "image": c.image,
+                        "lastStatus": c.last_status,
+                        "exitCode": c.exit_code,
+                        "reason": c.reason,
+                    })
+                })
+                .collect(),
+        ),
+    })
+}
+
+/// Unused silencer: keep `Task` in scope for future snapshot extensions.
+#[allow(dead_code)]
+fn _task_type_anchor(_t: &Task) {}
 
 fn cli_works(cli: &str) -> bool {
     std::process::Command::new(cli)

--- a/crates/fakecloud-logs/src/ingest.rs
+++ b/crates/fakecloud-logs/src/ingest.rs
@@ -1,0 +1,157 @@
+//! Same-process log ingestion for cross-service callers.
+//!
+//! ECS's `awslogs` driver and other in-tree producers (future Lambda
+//! CloudWatch-Logs forwarding) need to write events into fakecloud-logs
+//! without going through HTTP PutLogEvents. This module exposes a thin,
+//! well-typed API that creates the log group/stream on demand and
+//! appends events, mirroring the same validation shape as
+//! `service::streams::put_log_events` but skipping `AwsRequest` parsing.
+
+use chrono::Utc;
+
+use crate::state::{LogEvent, LogGroup, LogStream, SharedLogsState};
+
+/// An event destined for a CloudWatch Log stream.
+#[derive(Debug, Clone)]
+pub struct IngestEvent {
+    pub timestamp_ms: i64,
+    pub message: String,
+}
+
+/// Ensure a log group and stream exist for `account_id`, then append
+/// `events` to the stream. Creates the group with no retention and the
+/// stream with a fresh upload sequence token if either is missing —
+/// matching what an `awslogs-create-group=true` driver would do.
+pub fn append_events(
+    state: &SharedLogsState,
+    account_id: &str,
+    region: &str,
+    group_name: &str,
+    stream_name: &str,
+    events: &[IngestEvent],
+) {
+    if events.is_empty() {
+        return;
+    }
+    let now = Utc::now().timestamp_millis();
+    let mut accounts = state.write();
+    let logs = accounts.get_or_create(account_id);
+    let group = logs
+        .log_groups
+        .entry(group_name.to_string())
+        .or_insert_with(|| LogGroup {
+            name: group_name.to_string(),
+            arn: format!(
+                "arn:aws:logs:{region}:{account_id}:log-group:{group_name}",
+                region = region,
+                account_id = account_id,
+            ),
+            creation_time: now,
+            retention_in_days: None,
+            kms_key_id: None,
+            tags: Default::default(),
+            log_streams: Default::default(),
+            stored_bytes: 0,
+            subscription_filters: Vec::new(),
+            data_protection_policy: None,
+            index_policies: Vec::new(),
+            transformer: None,
+            deletion_protection: false,
+            log_group_class: Some("STANDARD".into()),
+        });
+    let stream = group
+        .log_streams
+        .entry(stream_name.to_string())
+        .or_insert_with(|| LogStream {
+            name: stream_name.to_string(),
+            arn: format!("{}:log-stream:{}", group.arn, stream_name),
+            creation_time: now,
+            first_event_timestamp: None,
+            last_event_timestamp: None,
+            last_ingestion_time: None,
+            upload_sequence_token: uuid::Uuid::new_v4().simple().to_string(),
+            events: Vec::new(),
+        });
+
+    for e in events {
+        if stream.first_event_timestamp.is_none() {
+            stream.first_event_timestamp = Some(e.timestamp_ms);
+        }
+        stream.last_event_timestamp = Some(
+            stream
+                .last_event_timestamp
+                .map(|t| t.max(e.timestamp_ms))
+                .unwrap_or(e.timestamp_ms),
+        );
+        stream.last_ingestion_time = Some(now);
+        group.stored_bytes += e.message.len() as i64;
+        stream.events.push(LogEvent {
+            timestamp: e.timestamp_ms,
+            message: e.message.clone(),
+            ingestion_time: now,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+
+    use super::*;
+
+    #[test]
+    fn append_creates_group_and_stream_then_appends() {
+        let state = Arc::new(RwLock::new(
+            MultiAccountState::<crate::state::LogsState>::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
+        append_events(
+            &state,
+            "123456789012",
+            "us-east-1",
+            "/ecs/svc",
+            "app/123",
+            &[
+                IngestEvent {
+                    timestamp_ms: 1_000,
+                    message: "hello".into(),
+                },
+                IngestEvent {
+                    timestamp_ms: 2_000,
+                    message: "world".into(),
+                },
+            ],
+        );
+        let s = state.read();
+        let logs = s.get("123456789012").unwrap();
+        let group = logs.log_groups.get("/ecs/svc").unwrap();
+        let stream = group.log_streams.get("app/123").unwrap();
+        assert_eq!(stream.events.len(), 2);
+        assert_eq!(stream.events[0].message, "hello");
+        assert_eq!(stream.first_event_timestamp, Some(1_000));
+        assert_eq!(stream.last_event_timestamp, Some(2_000));
+        assert!(group.stored_bytes >= "hello".len() as i64 + "world".len() as i64);
+    }
+
+    #[test]
+    fn append_no_op_for_empty() {
+        let state = Arc::new(RwLock::new(
+            MultiAccountState::<crate::state::LogsState>::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ));
+        append_events(&state, "123456789012", "us-east-1", "g", "s", &[]);
+        let s = state.read();
+        assert!(s
+            .get("123456789012")
+            .is_none_or(|a| a.log_groups.is_empty()));
+    }
+}

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ingest;
 pub mod query;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -339,15 +339,11 @@ async fn main() {
         );
     }
 
-    let ecs_runtime = fakecloud_ecs::runtime::EcsRuntime::new(bound_addr.port()).map(Arc::new);
-    if let Some(ref rt) = ecs_runtime {
-        tracing::info!(
-            cli = rt.cli_name(),
-            "ECS task execution enabled via container runtime"
-        );
-    } else {
-        tracing::info!("Docker/Podman not available — ECS RunTask will return TaskFailedToStart");
-    }
+    // ECS runtime is constructed below, after the EventBridge + CloudWatch
+    // Logs wiring is in place. Placeholder kept here so downstream blocks
+    // that reference `ecs_runtime` don't need reordering — see the
+    // `ecs_runtime = ...` assignment after the delivery bus setup.
+    let ecs_runtime: Option<Arc<fakecloud_ecs::runtime::EcsRuntime>>;
 
     // Cross-service delivery bus
     // Step 1: SQS delivery (SNS and EventBridge can push messages into SQS queues)
@@ -460,6 +456,32 @@ async fn main() {
     // Step 4b: DynamoDB delivery (Kinesis streaming destinations)
     let delivery_for_dynamodb =
         Arc::new(DeliveryBus::new().with_kinesis(kinesis_delivery_for_dynamodb));
+
+    // Step 4c: ECS runtime, wired with EventBridge + CloudWatch Logs so
+    // task state transitions emit `aws.ecs` events and `awslogs`-driver
+    // output forwards to CloudWatch Logs. Built here so `sqs_delivery`
+    // (the EventBridge SQS target) is available for rule fan-out.
+    let eb_delivery_for_ecs = Arc::new(
+        fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+            eb_state.clone(),
+            Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
+        ),
+    );
+    let ecs_delivery_bus = Arc::new(DeliveryBus::new().with_eventbridge(eb_delivery_for_ecs));
+    ecs_runtime = fakecloud_ecs::runtime::EcsRuntime::new(bound_addr.port())
+        .map(|rt| {
+            rt.with_delivery_bus(ecs_delivery_bus.clone())
+                .with_logs(logs_state.clone())
+        })
+        .map(Arc::new);
+    if let Some(ref rt) = ecs_runtime {
+        tracing::info!(
+            cli = rt.cli_name(),
+            "ECS task execution enabled via container runtime"
+        );
+    } else {
+        tracing::info!("Docker/Podman not available — ECS RunTask will return TaskFailedToStart");
+    }
 
     // Clone state refs for internal endpoints
     let lambda_invocations_state = lambda_state.clone();

--- a/website/content/docs/services/ecs.md
+++ b/website/content/docs/services/ecs.md
@@ -56,6 +56,28 @@ Tasks that reference AWS private-ECR URIs (`<account>.dkr.ecr.<region>.amazonaws
 
 Same resolution path applies to Lambda functions deployed with `PackageType=Image`: `Code.ImageUri` pointing at a fakecloud ECR URI is pulled and run on invoke.
 
+### awslogs -> CloudWatch Logs
+
+Container definitions that declare the `awslogs` log driver get their captured stdout/stderr forwarded to fakecloud's CloudWatch Logs service:
+
+```json
+"logConfiguration": {
+  "logDriver": "awslogs",
+  "options": {
+    "awslogs-group": "/ecs/my-service",
+    "awslogs-stream-prefix": "app",
+    "awslogs-region": "us-east-1",
+    "awslogs-create-group": "true"
+  }
+}
+```
+
+The runtime creates the log group on demand when `awslogs-create-group=true`, creates a stream named `<prefix>/<container-name>/<task-id>`, and appends one `LogEvent` per captured line. The usual fakecloud-logs API (`DescribeLogStreams`, `GetLogEvents`, subscription filters) then sees the container's output with no additional wiring.
+
+### EventBridge task state change events
+
+Task state transitions fire `aws.ecs` / `ECS Task State Change` events on the default EventBridge bus. Event `detail` carries the task ARN, cluster ARN, last status, stop code / reason on STOPPED, and a summary of each container including exit code. Rules matching `source: aws.ecs` receive these events and can route to SQS, SNS, Lambda, Step Functions — the standard target fan-out.
+
 ## Protocol
 
 JSON protocol over `POST /`, with `X-Amz-Target: AmazonEC2ContainerServiceV20141113.<Action>`. Request + response bodies are JSON; tags use lowercase `key` / `value` (matches AWS SDK serialization).


### PR DESCRIPTION
## Summary

Batch 2 of the ECR+ECS tightening pass. Closes the two deferred ECS observability integrations from last week.

- **awslogs -> CloudWatch Logs** — container definitions that declare `logDriver=awslogs` stream captured stdout/stderr into fakecloud-logs via a new `fakecloud_logs::ingest::append_events` same-process helper (no HTTP round-trip).
- **EventBridge task state change** — task transitions fire `source: aws.ecs` / `ECS Task State Change` events on the default bus, with AWS-shaped detail (`taskArn`, `clusterArn`, `lastStatus`, `stopCode`, per-container `exitCode`, ...). Reuses the existing `EventBridgeDelivery` trait / `DeliveryBus` pattern (same as S3 notifications).
- **Builder methods** on `EcsRuntime`: `with_delivery_bus` + `with_logs`. Unwired runtime behaves exactly as before — keeps unit tests simple.
- **E2E coverage**: new `ecs_observability` test file. One test runs a task with `awslogs` config and asserts `GetLogEvents` returns the container stdout. Another puts an EventBridge rule -> SQS target and asserts the STOPPED event arrives for the right task ARN.
- **Docs**: `website/content/docs/services/ecs.md` documents both integrations and the expected `logConfiguration` shape.

## Test plan

- [x] `cargo test -p fakecloud-logs --lib ingest` — ingest helper unit tests pass
- [x] `cargo test -p fakecloud-e2e --test ecs_observability` — both E2E tests pass on local docker
- [x] `cargo test -p fakecloud-e2e --test ecs --test lambda --test ecr_cross_service` — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI + Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudWatch Logs integration for ECS `awslogs` and emits EventBridge task state change events. Tasks now stream container stdout/stderr to Logs, and lifecycle events can trigger EventBridge targets.

- New Features
  - Forward `awslogs` output to CloudWatch Logs via same-process `fakecloud-logs::ingest::append_events` (auto-creates group/stream; visible via `DescribeLogStreams`/`GetLogEvents`).
  - Emit `aws.ecs` / "ECS Task State Change" events on the default EventBridge bus with AWS-shaped detail (task/container fields). Uses the existing `DeliveryBus` pattern; routes to SQS and other targets.
  - `EcsRuntime` adds `with_delivery_bus` and `with_logs`. When unwired, behavior is unchanged.
  - E2E tests cover both flows; docs updated with the expected `logConfiguration` shape.

<sup>Written for commit 9228bd65ba73abcf8cbdadd1bdc817cf650e2364. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

