### PR TITLE
feat(ecs+ecr): account-setting ARN format + scan findings synthetic flag

### DIFF
--- a/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
+++ b/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
@@ -1,0 +1,82 @@
+//! ECR `DescribeImageScanFindings` returns `isSynthetic: true` so
+//! users introspecting scan results can tell fakecloud's stub scanner
+//! from real AWS Inspector output. Asserted via raw HTTP because
+//! aws-sdk-ecr drops unknown response fields during Smithy decode.
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn describe_image_scan_findings_is_flagged_synthetic() {
+    let server = TestServer::start().await;
+    let ecr = server.ecr_client().await;
+
+    ecr.create_repository()
+        .repository_name("synthetic-flag-repo")
+        .send()
+        .await
+        .unwrap();
+
+    // Push a minimal empty manifest via OCI v2 so there's an image to
+    // reference — `DescribeImageScanFindings` requires an existing
+    // imageId (digest or tag).
+    let http = reqwest::Client::new();
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("AWS:test")
+    );
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 0,
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "layers": []
+    });
+    let body = serde_json::to_vec(&manifest).unwrap();
+    http.put(format!(
+        "{}/v2/synthetic-flag-repo/manifests/v1",
+        server.endpoint()
+    ))
+    .header("Authorization", &auth)
+    .header(
+        "Content-Type",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+    .body(body)
+    .send()
+    .await
+    .unwrap()
+    .error_for_status()
+    .unwrap();
+
+    // Hit the AWS JSON surface via raw HTTP so the unknown
+    // `isSynthetic` key survives the response envelope.
+    let resp = http
+        .post(server.endpoint())
+        .header("X-Amz-Target", "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings")
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0000")
+        .body(
+            serde_json::json!({
+                "repositoryName": "synthetic-flag-repo",
+                "imageId": { "imageTag": "v1" }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "status = {}", resp.status());
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["imageScanFindings"]["isSynthetic"].as_bool(),
+        Some(true),
+        "expected isSynthetic=true; full body: {body}"
+    );
+}
+
+use base64::Engine;

--- a/crates/fakecloud-e2e/tests/ecs_account_settings_arn.rs
+++ b/crates/fakecloud-e2e/tests/ecs_account_settings_arn.rs
@@ -1,0 +1,162 @@
+//! ECS account-setting ARN format enforcement. Covers the
+//! `serviceLongArnFormat` / `taskLongArnFormat` /
+//! `containerInstanceLongArnFormat` flags which switch ECS between
+//! long-form (cluster segment included) and short-form ARNs.
+//!
+//! AWS has mandated long-form since Jan 2020 but the settings still
+//! exist for backward-compat. Tests that rely on short ARNs shouldn't
+//! be silently broken just because fakecloud ignored the setting.
+
+mod helpers;
+
+use aws_sdk_ecs::types::{ContainerDefinition, SettingName, SettingType};
+use helpers::TestServer;
+
+async fn register_noop_task_def(client: &aws_sdk_ecs::Client, family: &str) {
+    client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("true")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn task_long_arn_format_disabled_uses_short_arn() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.put_account_setting_default()
+        .name(SettingName::TaskLongArnFormat)
+        .value("disabled")
+        .send()
+        .await
+        .expect("put_account_setting_default");
+
+    ecs.create_cluster()
+        .cluster_name("short-arn-cluster")
+        .send()
+        .await
+        .unwrap();
+    register_noop_task_def(&ecs, "short-arn-family").await;
+
+    let run = ecs
+        .run_task()
+        .cluster("short-arn-cluster")
+        .task_definition("short-arn-family")
+        .send()
+        .await
+        .expect("run_task");
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    // Short form: `arn:aws:ecs:<region>:<acct>:task/<id>` — no cluster.
+    assert!(
+        arn.contains(":task/") && !arn.contains(":task/short-arn-cluster/"),
+        "expected short-form task ARN, got {arn}"
+    );
+    let tail = arn.rsplit(":task/").next().unwrap();
+    assert!(
+        !tail.contains('/'),
+        "short ARN tail should be a single id, got {tail}"
+    );
+}
+
+#[tokio::test]
+async fn service_long_arn_format_disabled_uses_short_arn() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.put_account_setting_default()
+        .name(SettingName::ServiceLongArnFormat)
+        .value("disabled")
+        .send()
+        .await
+        .unwrap();
+
+    ecs.create_cluster()
+        .cluster_name("svc-arn-cluster")
+        .send()
+        .await
+        .unwrap();
+    register_noop_task_def(&ecs, "svc-arn-family").await;
+
+    let created = ecs
+        .create_service()
+        .cluster("svc-arn-cluster")
+        .service_name("short-svc")
+        .task_definition("svc-arn-family")
+        .desired_count(0)
+        .send()
+        .await
+        .unwrap();
+    let arn = created
+        .service()
+        .unwrap()
+        .service_arn()
+        .unwrap()
+        .to_string();
+    assert!(
+        arn.contains(":service/short-svc") && !arn.contains(":service/svc-arn-cluster/"),
+        "expected short-form service ARN, got {arn}"
+    );
+}
+
+#[tokio::test]
+async fn long_format_is_the_default() {
+    // No account-setting touch — default long ARNs expected.
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    ecs.create_cluster()
+        .cluster_name("default-long")
+        .send()
+        .await
+        .unwrap();
+    register_noop_task_def(&ecs, "default-long-family").await;
+    let run = ecs
+        .run_task()
+        .cluster("default-long")
+        .task_definition("default-long-family")
+        .send()
+        .await
+        .unwrap();
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    assert!(
+        arn.contains(":task/default-long/"),
+        "expected long-form task ARN by default, got {arn}"
+    );
+}
+
+#[tokio::test]
+async fn account_setting_default_list_reflects_writes() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    ecs.put_account_setting_default()
+        .name(SettingName::TaskLongArnFormat)
+        .value("disabled")
+        .send()
+        .await
+        .unwrap();
+    let resp = ecs
+        .list_account_settings()
+        .effective_settings(true)
+        .send()
+        .await
+        .unwrap();
+    let found = resp
+        .settings()
+        .iter()
+        .find(|s| s.name() == Some(&SettingName::TaskLongArnFormat))
+        .expect("taskLongArnFormat in effective settings");
+    assert_eq!(found.value(), Some("disabled"));
+}
+
+// Silences clippy about unused import when this test module lives alone.
+#[allow(dead_code)]
+fn _setting_type_anchor(_t: SettingType) {}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1962,6 +1962,13 @@ impl EcrService {
                 "vulnerabilitySourceUpdatedAt": findings.vulnerability_source_updated_at.map(|t| t.timestamp()),
                 "findings": findings.findings,
                 "findingSeverityCounts": findings.finding_severity_counts,
+                // fakecloud-specific marker: these findings are synthetic
+                // and do not reflect real CVE data. AWS SDKs using Smithy
+                // codegen ignore unknown fields, so this is purely a
+                // signal for introspection callers and security-tooling
+                // integration tests that want to assert they're running
+                // against fakecloud rather than real Inspector output.
+                "isSynthetic": true,
             },
         })))
     }

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -2853,10 +2853,7 @@ impl EcsService {
             .map(|c| c.cluster_arn.clone())
             .unwrap_or_else(|| state.cluster_arn(&cluster_name));
         let uuid = uuid::Uuid::new_v4().to_string();
-        let ci_arn = format!(
-            "arn:aws:ecs:{}:{}:container-instance/{}/{}",
-            state.region, state.account_id, cluster_name, uuid
-        );
+        let ci_arn = state.container_instance_arn(&cluster_name, &uuid);
         let key = format!("{}/{}", cluster_name, uuid);
         let ci = ContainerInstance {
             container_instance_arn: ci_arn.clone(),

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -117,16 +117,76 @@ impl EcsState {
     }
 
     pub fn service_arn(&self, cluster_name: &str, service_name: &str) -> String {
-        format!(
-            "arn:aws:ecs:{}:{}:service/{}/{}",
-            self.region, self.account_id, cluster_name, service_name
-        )
+        if self.arn_format_disabled("serviceLongArnFormat") {
+            // Pre-Nov-2018 short form: no cluster segment.
+            format!(
+                "arn:aws:ecs:{}:{}:service/{}",
+                self.region, self.account_id, service_name
+            )
+        } else {
+            format!(
+                "arn:aws:ecs:{}:{}:service/{}/{}",
+                self.region, self.account_id, cluster_name, service_name
+            )
+        }
     }
 
     pub fn task_arn(&self, cluster_name: &str, task_id: &str) -> String {
-        format!(
-            "arn:aws:ecs:{}:{}:task/{}/{}",
-            self.region, self.account_id, cluster_name, task_id
+        if self.arn_format_disabled("taskLongArnFormat") {
+            format!(
+                "arn:aws:ecs:{}:{}:task/{}",
+                self.region, self.account_id, task_id
+            )
+        } else {
+            format!(
+                "arn:aws:ecs:{}:{}:task/{}/{}",
+                self.region, self.account_id, cluster_name, task_id
+            )
+        }
+    }
+
+    pub fn container_instance_arn(&self, cluster_name: &str, instance_id: &str) -> String {
+        if self.arn_format_disabled("containerInstanceLongArnFormat") {
+            format!(
+                "arn:aws:ecs:{}:{}:container-instance/{}",
+                self.region, self.account_id, instance_id
+            )
+        } else {
+            format!(
+                "arn:aws:ecs:{}:{}:container-instance/{}/{}",
+                self.region, self.account_id, cluster_name, instance_id
+            )
+        }
+    }
+
+    /// Resolve the effective value of an account setting. Principal
+    /// overrides win over account-level defaults, matching AWS's
+    /// PutAccountSetting / PutAccountSettingDefault layering. With no
+    /// `principal_arn` argument the caller gets the account default.
+    pub fn effective_account_setting(
+        &self,
+        name: &str,
+        principal_arn: Option<&str>,
+    ) -> Option<String> {
+        if let Some(arn) = principal_arn {
+            if let Some(p) = self.principal_account_settings.get(arn) {
+                if let Some(v) = p.get(name) {
+                    return Some(v.clone());
+                }
+            }
+        }
+        self.account_setting_defaults.get(name).cloned()
+    }
+
+    /// `true` when the given `*LongArnFormat` setting has been set to
+    /// `disabled`. The default (including unset) is long format —
+    /// matches AWS's current behaviour where long ARNs are mandatory
+    /// since Jan 2020 but the settings still flip for backward-compat.
+    fn arn_format_disabled(&self, setting_name: &str) -> bool {
+        matches!(
+            self.effective_account_setting(setting_name, None)
+                .as_deref(),
+            Some("disabled")
         )
     }
 
@@ -577,6 +637,70 @@ mod tests {
         assert_eq!(
             s.task_definition_arn("web", 3),
             "arn:aws:ecs:us-east-1:111122223333:task-definition/web:3"
+        );
+    }
+
+    #[test]
+    fn task_arn_long_format_default() {
+        let s = EcsState::new("111122223333", "us-east-1");
+        assert_eq!(
+            s.task_arn("prod", "abc123"),
+            "arn:aws:ecs:us-east-1:111122223333:task/prod/abc123"
+        );
+    }
+
+    #[test]
+    fn task_arn_short_when_disabled() {
+        let mut s = EcsState::new("111122223333", "us-east-1");
+        s.account_setting_defaults
+            .insert("taskLongArnFormat".into(), "disabled".into());
+        assert_eq!(
+            s.task_arn("prod", "abc123"),
+            "arn:aws:ecs:us-east-1:111122223333:task/abc123"
+        );
+    }
+
+    #[test]
+    fn service_arn_short_when_disabled() {
+        let mut s = EcsState::new("111122223333", "us-east-1");
+        s.account_setting_defaults
+            .insert("serviceLongArnFormat".into(), "disabled".into());
+        assert_eq!(
+            s.service_arn("prod", "web"),
+            "arn:aws:ecs:us-east-1:111122223333:service/web"
+        );
+    }
+
+    #[test]
+    fn container_instance_arn_short_when_disabled() {
+        let mut s = EcsState::new("111122223333", "us-east-1");
+        s.account_setting_defaults
+            .insert("containerInstanceLongArnFormat".into(), "disabled".into());
+        assert_eq!(
+            s.container_instance_arn("prod", "i-abc"),
+            "arn:aws:ecs:us-east-1:111122223333:container-instance/i-abc"
+        );
+    }
+
+    #[test]
+    fn principal_setting_overrides_default() {
+        let mut s = EcsState::new("111122223333", "us-east-1");
+        s.account_setting_defaults
+            .insert("taskLongArnFormat".into(), "disabled".into());
+        let principal = "arn:aws:iam::111122223333:user/alice".to_string();
+        let mut p = BTreeMap::new();
+        p.insert("taskLongArnFormat".into(), "enabled".into());
+        s.principal_account_settings.insert(principal.clone(), p);
+        assert_eq!(
+            s.effective_account_setting("taskLongArnFormat", Some(&principal))
+                .as_deref(),
+            Some("enabled")
+        );
+        // Without principal, default wins.
+        assert_eq!(
+            s.effective_account_setting("taskLongArnFormat", None)
+                .as_deref(),
+            Some("disabled")
         );
     }
 


### PR DESCRIPTION
## Summary

Batch 1 of the scoped-out tightening pass. Two small correctness fixes that had been silently no-opping since both services first landed.

- **ECS ARN format enforcement** — `serviceLongArnFormat` / `taskLongArnFormat` / `containerInstanceLongArnFormat` set to `disabled` now actually emits short-form ARNs. New `EcsState::effective_account_setting` helper resolves principal overrides over account defaults (matching AWS).
- **ECR `isSynthetic: true`** — `DescribeImageScanFindings` response now flags fakecloud's stub scanner output so introspection callers can tell it from real Inspector findings. AWS SDKs ignore unknown fields; no downstream impact.

## Test plan

- [x] 5 new unit tests in `fakecloud-ecs::state`
- [x] 4 new E2E tests in `ecs_account_settings_arn`
- [x] 1 new E2E test in `ecr_scan_synthetic_flag` (raw HTTP since Smithy decode drops unknown fields)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Existing ECS + ECR E2E suites — no regressions
- [ ] CI + Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces ECS ARN format account settings and flags ECR scan findings as synthetic to match AWS behavior and aid introspection.

- **Bug Fixes**
  - ECS: `serviceLongArnFormat`, `taskLongArnFormat`, and `containerInstanceLongArnFormat` now control ARN shape. When set to `disabled`, short-form ARNs are emitted; default is long-form. Added `EcsState::effective_account_setting` (principal overrides beat account defaults) and `EcsState::container_instance_arn(...)` to unify ARN generation.
  - ECR: `DescribeImageScanFindings` now includes `isSynthetic: true` inside `imageScanFindings` so tooling can spot fakecloud data. AWS SDKs ignore unknown fields, so no downstream impact.

<sup>Written for commit fcad2c69ba4b3f79a7e2f05b52d634ca9046cad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

