### PR TITLE
feat(ecr): pull-through cache real upstream proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/fakecloud-e2e/tests/ecr_pull_through.rs
+++ b/crates/fakecloud-e2e/tests/ecr_pull_through.rs
@@ -1,0 +1,111 @@
+//! ECR pull-through cache real proxy. Configures a rule pointing at
+//! `public.ecr.aws` (no-auth upstream), fetches a manifest through
+//! fakecloud's OCI v2, and asserts that the local repo is populated
+//! afterwards so the next pull hits local cache.
+
+mod helpers;
+
+use aws_sdk_ecr::types::PullThroughCacheRule;
+use helpers::TestServer;
+
+fn network_available() -> bool {
+    // Treat `FAKECLOUD_SKIP_NETWORK=1` as an opt-out for offline CI.
+    std::env::var("FAKECLOUD_SKIP_NETWORK").is_err()
+}
+
+#[tokio::test]
+async fn pull_through_proxies_manifest_from_public_ecr() {
+    if !network_available() {
+        eprintln!("skipping: FAKECLOUD_SKIP_NETWORK set");
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let ecr = server.ecr_client().await;
+
+    ecr.create_pull_through_cache_rule()
+        .ecr_repository_prefix("ecr-public")
+        .upstream_registry_url("https://public.ecr.aws")
+        .send()
+        .await
+        .expect("create_pull_through_cache_rule");
+
+    // Sanity: rule survives round-trip.
+    let rules = ecr
+        .describe_pull_through_cache_rules()
+        .send()
+        .await
+        .unwrap();
+    let matched: Vec<&PullThroughCacheRule> = rules
+        .pull_through_cache_rules()
+        .iter()
+        .filter(|r| r.ecr_repository_prefix() == Some("ecr-public"))
+        .collect();
+    assert_eq!(matched.len(), 1);
+
+    // Fetch a well-known small manifest (amazonlinux:latest index) via
+    // fakecloud's OCI v2. The path segment after `ecr-public/` is
+    // what proxies upstream — `amazonlinux/amazonlinux/manifests/...`
+    // goes to `https://public.ecr.aws/amazonlinux/amazonlinux/manifests/...`
+    let http = reqwest::Client::new();
+    let url = format!(
+        "{}/v2/ecr-public/amazonlinux/amazonlinux/manifests/latest",
+        server.endpoint()
+    );
+    let resp = http
+        .get(&url)
+        .header(
+            "Authorization",
+            format!("Basic {}", base64::engine::general_purpose::STANDARD.encode("AWS:test")),
+        )
+        .header(
+            "Accept",
+            "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json",
+        )
+        .send()
+        .await
+        .expect("fakecloud manifest GET");
+    assert!(
+        resp.status().is_success(),
+        "expected 2xx; got {}",
+        resp.status()
+    );
+    let digest = resp
+        .headers()
+        .get("docker-content-digest")
+        .and_then(|v| v.to_str().ok())
+        .expect("Docker-Content-Digest header")
+        .to_string();
+    assert!(digest.starts_with("sha256:"));
+
+    // Local repo should exist now, auto-created by the proxy.
+    let repos = ecr
+        .describe_repositories()
+        .repository_names("ecr-public/amazonlinux/amazonlinux")
+        .send()
+        .await
+        .expect("describe_repositories after proxy");
+    assert_eq!(
+        repos.repositories().len(),
+        1,
+        "pull-through proxy should have auto-created the local repo"
+    );
+
+    // Second request for the same manifest should hit the local cache —
+    // assert the stored image shows up through the AWS JSON API.
+    let images = ecr
+        .describe_images()
+        .repository_name("ecr-public/amazonlinux/amazonlinux")
+        .send()
+        .await
+        .expect("describe_images after proxy");
+    assert!(
+        images
+            .image_details()
+            .iter()
+            .any(|d| d.image_digest() == Some(&digest)),
+        "cached manifest digest missing from DescribeImages"
+    );
+}
+
+use base64::Engine;

--- a/crates/fakecloud-ecr/Cargo.toml
+++ b/crates/fakecloud-ecr/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }
+reqwest = { workspace = true }

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod oci;
+pub(crate) mod pull_through;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -25,7 +25,7 @@ use crate::state::{Image, Layer, LayerUpload};
 /// Classify an OCI v2 request by method + path. Returns `None` when
 /// the path is not a recognised OCI endpoint (the caller responds
 /// with 404 in that case).
-pub(crate) fn dispatch(
+pub(crate) async fn dispatch(
     service: &EcrService,
     request: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -67,8 +67,8 @@ pub(crate) fn dispatch(
     let parts: Vec<&str> = action_segs.iter().map(|s| s.as_str()).collect();
     match (method, parts.as_slice()) {
         (&Method::GET, ["tags", "list"]) => tags_list(service, request, &repo_name),
-        (&Method::HEAD, ["blobs", digest]) => blob_head(service, request, &repo_name, digest),
-        (&Method::GET, ["blobs", digest]) => blob_get(service, request, &repo_name, digest),
+        (&Method::HEAD, ["blobs", digest]) => blob_head(service, request, &repo_name, digest).await,
+        (&Method::GET, ["blobs", digest]) => blob_get(service, request, &repo_name, digest).await,
         (&Method::DELETE, ["blobs", digest]) => blob_delete(service, request, &repo_name, digest),
         (&Method::POST, ["blobs", "uploads"]) | (&Method::POST, ["blobs", "uploads", ""]) => {
             blob_upload_start(service, request, &repo_name)
@@ -83,10 +83,10 @@ pub(crate) fn dispatch(
             blob_upload_cancel(service, request, &repo_name, upload_id)
         }
         (&Method::HEAD, ["manifests", reference]) => {
-            manifest_head(service, request, &repo_name, reference)
+            manifest_head(service, request, &repo_name, reference).await
         }
         (&Method::GET, ["manifests", reference]) => {
-            manifest_get(service, request, &repo_name, reference)
+            manifest_get(service, request, &repo_name, reference).await
         }
         (&Method::PUT, ["manifests", reference]) => {
             manifest_put(service, request, &repo_name, reference)
@@ -268,59 +268,75 @@ fn tags_list(
     ))
 }
 
-fn blob_head(
+async fn blob_head(
     service: &EcrService,
     request: &AwsRequest,
     name: &str,
     digest: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let accounts = service.state_handle().read();
-    let state = accounts
-        .get(&request.account_id)
-        .ok_or_else(|| repo_not_found(name))?;
-    let repo = state
-        .repositories
-        .get(name)
-        .ok_or_else(|| repo_not_found(name))?;
-    let layer = repo
-        .layers
-        .get(digest)
-        .ok_or_else(|| blob_not_found(name, digest))?;
-    let mut resp = base_response(StatusCode::OK, "application/octet-stream", Vec::new());
-    resp.headers.insert(
-        "Docker-Content-Digest",
-        HeaderValue::from_str(digest).unwrap(),
-    );
-    resp.headers
-        .insert("Content-Length", HeaderValue::from(layer.size));
-    Ok(resp)
+    // Fast path: blob already in local state.
+    let local = {
+        let accounts = service.state_handle().read();
+        accounts
+            .get(&request.account_id)
+            .and_then(|s| s.repositories.get(name))
+            .and_then(|r| r.layers.get(digest).cloned())
+    };
+    if let Some(layer) = local {
+        let mut resp = base_response(StatusCode::OK, "application/octet-stream", Vec::new());
+        resp.headers.insert(
+            "Docker-Content-Digest",
+            HeaderValue::from_str(digest).unwrap(),
+        );
+        resp.headers
+            .insert("Content-Length", HeaderValue::from(layer.size));
+        return Ok(resp);
+    }
+    // Cache miss: try pull-through, which (on success) also caches.
+    if let Some(outcome) =
+        crate::pull_through::proxy_blob(service, &request.account_id, name, digest).await
+    {
+        let proxied = outcome?;
+        let mut resp = crate::pull_through::blob_response(&proxied, digest);
+        resp.body = fakecloud_core::service::ResponseBody::Bytes(bytes::Bytes::new());
+        resp.headers.insert(
+            "Content-Length",
+            HeaderValue::from(proxied.bytes.len() as u64),
+        );
+        return Ok(resp);
+    }
+    Err(blob_not_found(name, digest))
 }
 
-fn blob_get(
+async fn blob_get(
     service: &EcrService,
     request: &AwsRequest,
     name: &str,
     digest: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let accounts = service.state_handle().read();
-    let state = accounts
-        .get(&request.account_id)
-        .ok_or_else(|| repo_not_found(name))?;
-    let repo = state
-        .repositories
-        .get(name)
-        .ok_or_else(|| repo_not_found(name))?;
-    let layer = repo
-        .layers
-        .get(digest)
-        .ok_or_else(|| blob_not_found(name, digest))?;
-    let bytes = B64.decode(layer.blob_b64.as_bytes()).unwrap_or_default();
-    let mut resp = base_response(StatusCode::OK, &layer.media_type, bytes);
-    resp.headers.insert(
-        "Docker-Content-Digest",
-        HeaderValue::from_str(digest).unwrap(),
-    );
-    Ok(resp)
+    let local = {
+        let accounts = service.state_handle().read();
+        accounts
+            .get(&request.account_id)
+            .and_then(|s| s.repositories.get(name))
+            .and_then(|r| r.layers.get(digest).cloned())
+    };
+    if let Some(layer) = local {
+        let bytes = B64.decode(layer.blob_b64.as_bytes()).unwrap_or_default();
+        let mut resp = base_response(StatusCode::OK, &layer.media_type, bytes);
+        resp.headers.insert(
+            "Docker-Content-Digest",
+            HeaderValue::from_str(digest).unwrap(),
+        );
+        return Ok(resp);
+    }
+    if let Some(outcome) =
+        crate::pull_through::proxy_blob(service, &request.account_id, name, digest).await
+    {
+        let proxied = outcome?;
+        return Ok(crate::pull_through::blob_response(&proxied, digest));
+    }
+    Err(blob_not_found(name, digest))
 }
 
 fn blob_delete(
@@ -549,62 +565,92 @@ fn blob_upload_cancel(
     ))
 }
 
-fn manifest_head(
+async fn manifest_head(
     service: &EcrService,
     request: &AwsRequest,
     name: &str,
     reference: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let accounts = service.state_handle().read();
-    let state = accounts
-        .get(&request.account_id)
-        .ok_or_else(|| repo_not_found(name))?;
-    let repo = state
-        .repositories
-        .get(name)
-        .ok_or_else(|| repo_not_found(name))?;
-    let digest =
-        resolve_reference(repo, reference).ok_or_else(|| manifest_not_found(name, reference))?;
-    let image = repo.images.get(&digest).unwrap();
-    let mut resp = base_response(StatusCode::OK, &image.image_manifest_media_type, Vec::new());
-    resp.headers.insert(
-        "Docker-Content-Digest",
-        HeaderValue::from_str(&digest).unwrap(),
-    );
-    resp.headers.insert(
-        "Content-Length",
-        HeaderValue::from(image.image_manifest.len() as u64),
-    );
-    Ok(resp)
+    let local = {
+        let accounts = service.state_handle().read();
+        accounts
+            .get(&request.account_id)
+            .and_then(|s| s.repositories.get(name))
+            .and_then(|repo| {
+                resolve_reference(repo, reference).and_then(|digest| {
+                    repo.images.get(&digest).map(|img| {
+                        (
+                            digest,
+                            img.image_manifest_media_type.clone(),
+                            img.image_manifest.len() as u64,
+                        )
+                    })
+                })
+            })
+    };
+    if let Some((digest, media_type, size)) = local {
+        let mut resp = base_response(StatusCode::OK, &media_type, Vec::new());
+        resp.headers.insert(
+            "Docker-Content-Digest",
+            HeaderValue::from_str(&digest).unwrap(),
+        );
+        resp.headers
+            .insert("Content-Length", HeaderValue::from(size));
+        return Ok(resp);
+    }
+    if let Some(outcome) =
+        crate::pull_through::proxy_manifest(service, &request.account_id, name, reference).await
+    {
+        let proxied = outcome?;
+        let mut resp = crate::pull_through::manifest_response(&proxied);
+        resp.headers.insert(
+            "Content-Length",
+            HeaderValue::from(proxied.bytes.len() as u64),
+        );
+        resp.body = fakecloud_core::service::ResponseBody::Bytes(bytes::Bytes::new());
+        return Ok(resp);
+    }
+    Err(manifest_not_found(name, reference))
 }
 
-fn manifest_get(
+async fn manifest_get(
     service: &EcrService,
     request: &AwsRequest,
     name: &str,
     reference: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let accounts = service.state_handle().read();
-    let state = accounts
-        .get(&request.account_id)
-        .ok_or_else(|| repo_not_found(name))?;
-    let repo = state
-        .repositories
-        .get(name)
-        .ok_or_else(|| repo_not_found(name))?;
-    let digest =
-        resolve_reference(repo, reference).ok_or_else(|| manifest_not_found(name, reference))?;
-    let image = repo.images.get(&digest).unwrap();
-    let mut resp = base_response(
-        StatusCode::OK,
-        &image.image_manifest_media_type,
-        image.image_manifest.as_bytes().to_vec(),
-    );
-    resp.headers.insert(
-        "Docker-Content-Digest",
-        HeaderValue::from_str(&digest).unwrap(),
-    );
-    Ok(resp)
+    let local = {
+        let accounts = service.state_handle().read();
+        accounts
+            .get(&request.account_id)
+            .and_then(|s| s.repositories.get(name))
+            .and_then(|repo| {
+                resolve_reference(repo, reference).and_then(|digest| {
+                    repo.images.get(&digest).map(|img| {
+                        (
+                            digest,
+                            img.image_manifest_media_type.clone(),
+                            img.image_manifest.as_bytes().to_vec(),
+                        )
+                    })
+                })
+            })
+    };
+    if let Some((digest, media_type, body)) = local {
+        let mut resp = base_response(StatusCode::OK, &media_type, body);
+        resp.headers.insert(
+            "Docker-Content-Digest",
+            HeaderValue::from_str(&digest).unwrap(),
+        );
+        return Ok(resp);
+    }
+    if let Some(outcome) =
+        crate::pull_through::proxy_manifest(service, &request.account_id, name, reference).await
+    {
+        let proxied = outcome?;
+        return Ok(crate::pull_through::manifest_response(&proxied));
+    }
+    Err(manifest_not_found(name, reference))
 }
 
 fn manifest_put(

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -1,0 +1,460 @@
+//! ECR pull-through cache: on OCI v2 cache miss, proxy manifest / blob
+//! GETs to the upstream registry configured via `CreatePullThroughCacheRule`,
+//! stream the response through, and cache the result into fakecloud's
+//! content-addressed blob store so subsequent pulls hit local.
+//!
+//! AWS supports a fixed set of upstreams (public.ecr.aws, registry.k8s.io,
+//! docker.io, quay.io, ghcr.io); fakecloud is upstream-agnostic and
+//! accepts any `upstreamRegistryUrl` the rule stores. Bearer-token
+//! handshake is implemented per the OCI Distribution spec so Docker Hub
+//! / Quay / ghcr work out of the box, not just `public.ecr.aws`.
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use bytes::Bytes;
+use chrono::Utc;
+use http::{HeaderMap, HeaderValue, StatusCode};
+use sha2::{Digest, Sha256};
+
+use fakecloud_core::service::{AwsResponse, AwsServiceError, ResponseBody};
+
+use crate::service::EcrService;
+use crate::state::{Image, Layer, PullThroughCacheRule};
+
+/// Result of a successful pull-through proxy call.
+pub(crate) struct ProxiedManifest {
+    pub bytes: Vec<u8>,
+    pub media_type: String,
+    pub digest: String,
+}
+
+pub(crate) struct ProxiedBlob {
+    pub bytes: Vec<u8>,
+    pub media_type: String,
+}
+
+/// Find the pull-through rule whose `ecr_repository_prefix` matches
+/// the start of `repo_name`. Returns the matching rule plus the repo
+/// path upstream (`repo_name` with the prefix stripped).
+fn match_rule<'a>(
+    rules: &'a [PullThroughCacheRule],
+    repo_name: &str,
+) -> Option<(&'a PullThroughCacheRule, String)> {
+    rules.iter().find_map(|r| {
+        let prefix = format!("{}/", r.ecr_repository_prefix);
+        repo_name
+            .strip_prefix(&prefix)
+            .map(|tail| (r, tail.to_string()))
+    })
+}
+
+/// Collect the configured pull-through rules for this account. Returns
+/// an owned Vec so the caller doesn't hold the state read guard across
+/// the network call.
+fn rules_for_account(service: &EcrService, account_id: &str) -> Vec<PullThroughCacheRule> {
+    let accounts = service.state_handle().read();
+    accounts
+        .get(account_id)
+        .map(|s| s.pull_through_cache_rules.values().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Issue an upstream GET for `<registry>/v2/<path>`. Handles the
+/// two-phase bearer-token flow: on 401 with `WWW-Authenticate: Bearer
+/// realm=...,service=...[,scope=...]`, fetch a token from the realm
+/// and retry with `Authorization: Bearer <token>`. No fallback for
+/// Basic challenges since none of the supported upstreams use them.
+async fn fetch_upstream(
+    registry_url: &str,
+    path: &str,
+    accept: &[&str],
+) -> Result<reqwest::Response, String> {
+    let url = format!(
+        "{}/v2/{}",
+        registry_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
+    let client = reqwest::Client::builder()
+        .user_agent("fakecloud-ecr/pull-through")
+        .build()
+        .map_err(|e| format!("reqwest build: {e}"))?;
+
+    let mut req = client.get(&url);
+    for a in accept {
+        req = req.header("Accept", *a);
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("upstream GET {url}: {e}"))?;
+
+    if resp.status() != StatusCode::UNAUTHORIZED {
+        return Ok(resp);
+    }
+
+    let Some(token) = exchange_bearer_token(&client, resp.headers()).await? else {
+        return Err(format!(
+            "upstream {url} returned 401 with no recognised WWW-Authenticate challenge"
+        ));
+    };
+
+    let mut req = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"));
+    for a in accept {
+        req = req.header("Accept", *a);
+    }
+    req.send()
+        .await
+        .map_err(|e| format!("upstream retry GET {url}: {e}"))
+}
+
+/// Parse `WWW-Authenticate: Bearer realm=...,service=...,scope=...`
+/// and hit the realm to get an anonymous token. Returns None when the
+/// challenge isn't Bearer.
+async fn exchange_bearer_token(
+    client: &reqwest::Client,
+    headers: &reqwest::header::HeaderMap,
+) -> Result<Option<String>, String> {
+    let Some(challenge) = headers
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())
+    else {
+        return Ok(None);
+    };
+    let Some(params) = challenge.strip_prefix("Bearer ") else {
+        return Ok(None);
+    };
+    let mut realm = None;
+    let mut service = None;
+    let mut scope = None;
+    for part in params.split(',') {
+        let part = part.trim();
+        let (key, value) = match part.split_once('=') {
+            Some((k, v)) => (k.trim(), v.trim().trim_matches('"')),
+            None => continue,
+        };
+        match key {
+            "realm" => realm = Some(value.to_string()),
+            "service" => service = Some(value.to_string()),
+            "scope" => scope = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    let Some(realm) = realm else {
+        return Ok(None);
+    };
+
+    let mut url = realm;
+    let mut sep = if url.contains('?') { '&' } else { '?' };
+    if let Some(s) = service.as_deref() {
+        url.push(sep);
+        url.push_str("service=");
+        url.push_str(&url_encode(s));
+        sep = '&';
+    }
+    if let Some(s) = scope.as_deref() {
+        url.push(sep);
+        url.push_str("scope=");
+        url.push_str(&url_encode(s));
+    }
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("bearer token realm GET: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("bearer token realm non-2xx: {e}"))?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("bearer token JSON parse: {e}"))?;
+    // Registries emit the token under either `token` or `access_token`.
+    let token = json
+        .get("token")
+        .or_else(|| json.get("access_token"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "bearer token response missing `token` field".to_string())?
+        .to_string();
+    Ok(Some(token))
+}
+
+/// Proxy a manifest GET. On success, persist the manifest + auto-create
+/// the local `Repository` so subsequent requests hit local.
+pub(crate) async fn proxy_manifest(
+    service: &EcrService,
+    account_id: &str,
+    repo_name: &str,
+    reference: &str,
+) -> Option<Result<ProxiedManifest, AwsServiceError>> {
+    let rules = rules_for_account(service, account_id);
+    let (rule, upstream_path) = match_rule(&rules, repo_name)?;
+    let accept = &[
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+    ];
+    let resp = match fetch_upstream(
+        &rule.upstream_registry_url,
+        &format!("{upstream_path}/manifests/{reference}"),
+        accept,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return Some(Err(proxy_error(repo_name, &e))),
+    };
+    if resp.status() == StatusCode::NOT_FOUND {
+        return Some(Err(upstream_not_found(repo_name, reference)));
+    }
+    if !resp.status().is_success() {
+        return Some(Err(proxy_error(
+            repo_name,
+            &format!("upstream manifest status {}", resp.status()),
+        )));
+    }
+    let media_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/vnd.docker.distribution.manifest.v2+json")
+        .to_string();
+    let bytes = match resp.bytes().await {
+        Ok(b) => b.to_vec(),
+        Err(e) => return Some(Err(proxy_error(repo_name, &e.to_string()))),
+    };
+    let digest = sha256_digest(&bytes);
+    cache_manifest(
+        service,
+        account_id,
+        repo_name,
+        reference,
+        &bytes,
+        &media_type,
+        &digest,
+    );
+    Some(Ok(ProxiedManifest {
+        bytes,
+        media_type,
+        digest,
+    }))
+}
+
+/// Proxy a blob GET. Caches the returned bytes keyed by digest so
+/// future requests skip the upstream entirely.
+pub(crate) async fn proxy_blob(
+    service: &EcrService,
+    account_id: &str,
+    repo_name: &str,
+    digest: &str,
+) -> Option<Result<ProxiedBlob, AwsServiceError>> {
+    let rules = rules_for_account(service, account_id);
+    let (rule, upstream_path) = match_rule(&rules, repo_name)?;
+    let accept = &["application/octet-stream"];
+    let resp = match fetch_upstream(
+        &rule.upstream_registry_url,
+        &format!("{upstream_path}/blobs/{digest}"),
+        accept,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return Some(Err(proxy_error(repo_name, &e))),
+    };
+    if resp.status() == StatusCode::NOT_FOUND {
+        return Some(Err(blob_not_found(repo_name, digest)));
+    }
+    if !resp.status().is_success() {
+        return Some(Err(proxy_error(
+            repo_name,
+            &format!("upstream blob status {}", resp.status()),
+        )));
+    }
+    let media_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let bytes = match resp.bytes().await {
+        Ok(b) => b.to_vec(),
+        Err(e) => return Some(Err(proxy_error(repo_name, &e.to_string()))),
+    };
+    cache_blob(service, account_id, repo_name, digest, &bytes, &media_type);
+    Some(Ok(ProxiedBlob { bytes, media_type }))
+}
+
+fn cache_manifest(
+    service: &EcrService,
+    account_id: &str,
+    repo_name: &str,
+    reference: &str,
+    bytes: &[u8],
+    media_type: &str,
+    digest: &str,
+) {
+    let mut accounts = service.state_handle().write();
+    let state = accounts.get_or_create(account_id);
+    let account_id = state.account_id.clone();
+    let region = state.region.clone();
+    let repo = state
+        .repositories
+        .entry(repo_name.to_string())
+        .or_insert_with(|| {
+            let arn = format!(
+                "arn:aws:ecr:{region}:{account_id}:repository/{repo_name}",
+                region = region,
+                account_id = account_id,
+                repo_name = repo_name,
+            );
+            crate::state::Repository::new(
+                repo_name,
+                arn,
+                &account_id,
+                "http://pull-through.fakecloud.internal",
+            )
+        });
+    repo.images.insert(
+        digest.to_string(),
+        Image {
+            image_digest: digest.to_string(),
+            image_manifest: String::from_utf8_lossy(bytes).to_string(),
+            image_manifest_media_type: media_type.to_string(),
+            artifact_media_type: None,
+            image_size_in_bytes: bytes.len() as u64,
+            image_pushed_at: Utc::now(),
+            last_recorded_pull_time: Some(Utc::now()),
+        },
+    );
+    // A reference can be a tag (alphanumeric) or a digest. Only store
+    // the tag mapping; digest refs don't need one since images are
+    // keyed by digest already.
+    if !reference.starts_with("sha256:") {
+        repo.image_tags
+            .insert(reference.to_string(), digest.to_string());
+    }
+}
+
+fn cache_blob(
+    service: &EcrService,
+    account_id: &str,
+    repo_name: &str,
+    digest: &str,
+    bytes: &[u8],
+    media_type: &str,
+) {
+    let mut accounts = service.state_handle().write();
+    let state = accounts.get_or_create(account_id);
+    let account_id = state.account_id.clone();
+    let region = state.region.clone();
+    let repo = state
+        .repositories
+        .entry(repo_name.to_string())
+        .or_insert_with(|| {
+            let arn = format!(
+                "arn:aws:ecr:{region}:{account_id}:repository/{repo_name}",
+                region = region,
+                account_id = account_id,
+                repo_name = repo_name,
+            );
+            crate::state::Repository::new(
+                repo_name,
+                arn,
+                &account_id,
+                "http://pull-through.fakecloud.internal",
+            )
+        });
+    repo.layers.insert(
+        digest.to_string(),
+        Layer {
+            digest: digest.to_string(),
+            size: bytes.len() as u64,
+            blob_b64: B64.encode(bytes),
+            media_type: media_type.to_string(),
+        },
+    );
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+/// Minimal percent-encoder for bearer-token query params. Encodes
+/// anything outside `[A-Za-z0-9._~-]` (the RFC 3986 unreserved set).
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        match *b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'~' | b'-' => {
+                out.push(*b as char);
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+fn upstream_not_found(repo: &str, reference: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        "MANIFEST_UNKNOWN",
+        format!("manifest {reference} not found upstream of pull-through repo {repo}"),
+    )
+}
+
+fn blob_not_found(repo: &str, digest: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        "BLOB_UNKNOWN",
+        format!("blob {digest} not found upstream of pull-through repo {repo}"),
+    )
+}
+
+fn proxy_error(repo: &str, detail: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_GATEWAY,
+        "PROXY_ERROR",
+        format!("pull-through proxy failed for repo {repo}: {detail}"),
+    )
+}
+
+/// Build an AwsResponse that mirrors the local OCI handlers'
+/// `base_response` shape, with `Docker-Content-Digest` set.
+pub(crate) fn manifest_response(proxied: &ProxiedManifest) -> AwsResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Docker-Distribution-Api-Version",
+        HeaderValue::from_static("registry/2.0"),
+    );
+    headers.insert(
+        "Docker-Content-Digest",
+        HeaderValue::from_str(&proxied.digest).unwrap(),
+    );
+    AwsResponse {
+        status: StatusCode::OK,
+        content_type: proxied.media_type.clone(),
+        body: ResponseBody::Bytes(Bytes::from(proxied.bytes.clone())),
+        headers,
+    }
+}
+
+pub(crate) fn blob_response(proxied: &ProxiedBlob, digest: &str) -> AwsResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Docker-Distribution-Api-Version",
+        HeaderValue::from_static("registry/2.0"),
+    );
+    headers.insert(
+        "Docker-Content-Digest",
+        HeaderValue::from_str(digest).unwrap(),
+    );
+    AwsResponse {
+        status: StatusCode::OK,
+        content_type: proxied.media_type.clone(),
+        body: ResponseBody::Bytes(Bytes::from(proxied.bytes.clone())),
+        headers,
+    }
+}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -188,7 +188,7 @@ impl AwsService for EcrService {
             .map(|s| s == "v2")
             .unwrap_or(false)
         {
-            let result = crate::oci::dispatch(self, &request);
+            let result = crate::oci::dispatch(self, &request).await;
             let mutates_oci = matches!(
                 request.method,
                 http::Method::POST | http::Method::PUT | http::Method::PATCH | http::Method::DELETE


### PR DESCRIPTION
## Summary

Batch 2. Real upstream proxying on pull-through cache miss.

- OCI v2 `manifest`/`blob` GET+HEAD fall through to `pull_through::proxy_*` when the repo isn't local.
- Matches configured `CreatePullThroughCacheRule`s by prefix; strips prefix, issues upstream GET.
- Bearer-token handshake for Docker Hub / Quay / ghcr.io; public.ecr.aws works direct.
- Cache-fills blob + manifest into the existing content-addressed store so subsequent pulls skip the network. Local `Repository` auto-created on first successful proxy.
- `oci::dispatch` is now async to support the upstream HTTP call.

## Test plan

- [x] `cargo test -p fakecloud-e2e --test ecr_pull_through` — full loop against public.ecr.aws
- [x] `cargo test -p fakecloud-e2e --test ecr --test ecr_oci --test ecr_images --test ecr_persistence --test ecr_lifecycle` — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI + Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables real pull‑through caching by proxying OCI v2 manifest/blob GET and HEAD requests to the configured upstream on cache miss, then caching results locally for future pulls. Supports bearer-token auth for Docker Hub, Quay, and ghcr.io; `public.ecr.aws` works without auth.

- **New Features**
  - Prefix-matched `CreatePullThroughCacheRule` routes; strips the prefix and proxies upstream for manifest/blob GET/HEAD with proper Accept negotiation.
  - New `pull_through` module; `oci::dispatch` is now async and falls through on cache miss from `manifest_*`/`blob_*`.
  - Auto-creates the local repository and caches manifests/blobs in the existing content-addressed store to avoid repeat network calls; upstream 404 maps to standard OCI errors, other failures return 502.
  - Adds an E2E test against `public.ecr.aws` (skippable via `FAKECLOUD_SKIP_NETWORK=1`); bearer-token handshake implemented for Docker Hub, Quay, and ghcr.io.

- **Dependencies**
  - Add `reqwest`.

<sup>Written for commit 88856eeee624ff9b06e0dd4959a83d959a088cbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

