### PR TITLE
feat(kms+ecr): real AES-256-GCM layer encryption on KMS repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +27,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -1828,6 +1852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1838,6 +1863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2338,6 +2372,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-core",
+ "fakecloud-kms",
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
@@ -2460,6 +2495,7 @@ dependencies = [
 name = "fakecloud-kms"
 version = "0.10.1"
 dependencies = [
+ "aes-gcm",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -3087,6 +3123,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -4036,6 +4082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,6 +4263,18 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -5683,6 +5747,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/fakecloud-e2e/tests/ecr_kms_encryption.rs
+++ b/crates/fakecloud-e2e/tests/ecr_kms_encryption.rs
@@ -1,0 +1,167 @@
+//! ECR layer blobs are encrypted with AES-256-GCM via fakecloud-kms
+//! when the repo is configured with `encryptionType=KMS`. The raw
+//! bytes stored on disk differ from the plaintext, but round-tripping
+//! through the OCI v2 blob GET returns the plaintext.
+
+mod helpers;
+
+use aws_sdk_ecr::types::{EncryptionConfiguration, EncryptionType};
+use base64::Engine;
+use helpers::TestServer;
+use reqwest::StatusCode;
+
+#[tokio::test]
+async fn kms_encrypted_repo_round_trips_layer_bytes() {
+    let server = TestServer::start().await;
+    let kms = server.kms_client().await;
+    let ecr = server.ecr_client().await;
+
+    // Set up a KMS key.
+    let key = kms
+        .create_key()
+        .description("ecr-encryption-test")
+        .send()
+        .await
+        .expect("create_key");
+    let key_arn = key.key_metadata().unwrap().arn().unwrap().to_string();
+
+    // Repo configured with KMS encryption under that key.
+    ecr.create_repository()
+        .repository_name("kms-encrypted-repo")
+        .encryption_configuration(
+            EncryptionConfiguration::builder()
+                .encryption_type(EncryptionType::Kms)
+                .kms_key(&key_arn)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create_repository with KMS");
+
+    // Push a blob via the OCI v2 single-POST upload path.
+    let http = reqwest::Client::new();
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("AWS:test")
+    );
+    let plaintext = b"hello fakecloud-kms encrypted layer bytes".to_vec();
+    let digest = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(&plaintext);
+        format!("sha256:{:x}", h.finalize())
+    };
+
+    // Two-phase: POST /uploads/ (no body), capture Location + upload id.
+    let start = http
+        .post(format!(
+            "{}/v2/kms-encrypted-repo/blobs/uploads/",
+            server.endpoint()
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(start.status(), StatusCode::ACCEPTED);
+    let upload_location = start
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap()
+        .to_string();
+
+    // PATCH bytes + PUT with digest.
+    let patch_url = format!("{}{}", server.endpoint(), upload_location);
+    let patched = http
+        .patch(&patch_url)
+        .header("Authorization", &auth)
+        .body(plaintext.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(patched.status(), StatusCode::ACCEPTED);
+
+    let put_url = format!("{}{}?digest={}", server.endpoint(), upload_location, digest);
+    let put = http
+        .put(&put_url)
+        .header("Authorization", &auth)
+        .body(Vec::<u8>::new())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::CREATED);
+
+    // GET the blob back — should be plaintext.
+    let got = http
+        .get(format!(
+            "{}/v2/kms-encrypted-repo/blobs/{digest}",
+            server.endpoint()
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        got.status().is_success(),
+        "blob GET status = {}",
+        got.status()
+    );
+    let got_bytes = got.bytes().await.unwrap();
+    assert_eq!(
+        got_bytes.as_ref(),
+        plaintext.as_slice(),
+        "blob GET returned non-plaintext"
+    );
+}
+
+#[tokio::test]
+async fn aes256_repo_stores_plaintext_as_before() {
+    // Default encryption_type=AES256 is a no-op in fakecloud: blobs
+    // stored plaintext. This test guards against accidentally
+    // flipping that path to encrypted when KMS isn't configured.
+    let server = TestServer::start().await;
+    let ecr = server.ecr_client().await;
+    ecr.create_repository()
+        .repository_name("aes256-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("AWS:test")
+    );
+    let plaintext = b"plaintext under aes256".to_vec();
+    let digest = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(&plaintext);
+        format!("sha256:{:x}", h.finalize())
+    };
+    let url = format!(
+        "{}/v2/aes256-repo/blobs/uploads/?digest={}",
+        server.endpoint(),
+        digest
+    );
+    let posted = http
+        .post(&url)
+        .header("Authorization", &auth)
+        .body(plaintext.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(posted.status(), StatusCode::CREATED);
+
+    let got = http
+        .get(format!(
+            "{}/v2/aes256-repo/blobs/{digest}",
+            server.endpoint()
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(got.bytes().await.unwrap().as_ref(), plaintext.as_slice());
+}

--- a/crates/fakecloud-ecr/Cargo.toml
+++ b/crates/fakecloud-ecr/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-kms = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -243,6 +243,76 @@ fn sha256_digest(bytes: &[u8]) -> String {
     format!("sha256:{:x}", hasher.finalize())
 }
 
+/// Resolve how this repository stores layer bytes. Returns `(stored,
+/// encrypted_with)` where `stored` is what gets written into
+/// `Layer.blob_b64` and `encrypted_with` is the KMS key ARN (if any)
+/// the blob was encrypted under. Falls back to plaintext when the
+/// service has no KMS state wired or the repo isn't KMS-configured.
+pub(crate) fn encrypt_layer_bytes(
+    service: &EcrService,
+    account_id: &str,
+    repo_name: &str,
+    plaintext: &[u8],
+) -> (Vec<u8>, Option<String>) {
+    let Some(kms) = service.kms_handle() else {
+        return (plaintext.to_vec(), None);
+    };
+    let accounts = service.state_handle().read();
+    let Some(s) = accounts.get(account_id) else {
+        return (plaintext.to_vec(), None);
+    };
+    let Some(repo) = s.repositories.get(repo_name) else {
+        return (plaintext.to_vec(), None);
+    };
+    if repo.encryption_configuration.encryption_type != "KMS" {
+        return (plaintext.to_vec(), None);
+    }
+    let Some(ref key_ref) = repo.encryption_configuration.kms_key else {
+        return (plaintext.to_vec(), None);
+    };
+    // Drop the state read guard before the KMS call.
+    let key_ref = key_ref.clone();
+    drop(accounts);
+    match fakecloud_kms::api::encrypt_blob(kms, account_id, &key_ref, plaintext) {
+        Ok(bytes) => (bytes, Some(key_ref)),
+        Err(err) => {
+            tracing::warn!(
+                %err, %repo_name,
+                "KMS-encrypt failed for layer; storing plaintext"
+            );
+            (plaintext.to_vec(), None)
+        }
+    }
+}
+
+/// Reverse the transform applied by `encrypt_layer_bytes`. Returns
+/// plaintext bytes; when the layer wasn't encrypted, the input is
+/// returned unchanged.
+pub(crate) fn decrypt_layer_bytes(
+    service: &EcrService,
+    account_id: &str,
+    layer: &Layer,
+) -> Result<Vec<u8>, AwsServiceError> {
+    let raw = B64.decode(layer.blob_b64.as_bytes()).unwrap_or_default();
+    let Some(ref _key_arn) = layer.encrypted_with_kms_key else {
+        return Ok(raw);
+    };
+    let Some(kms) = service.kms_handle() else {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "KmsNotWired",
+            "layer was stored KMS-encrypted but KMS state is not wired into ECR",
+        ));
+    };
+    fakecloud_kms::api::decrypt_blob(kms, account_id, &raw).map_err(|e| {
+        AwsServiceError::aws_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "KmsDecryptFailed",
+            format!("failed to decrypt layer blob: {e}"),
+        )
+    })
+}
+
 // -------- handlers --------
 
 fn tags_list(
@@ -322,7 +392,7 @@ async fn blob_get(
             .and_then(|r| r.layers.get(digest).cloned())
     };
     if let Some(layer) = local {
-        let bytes = B64.decode(layer.blob_b64.as_bytes()).unwrap_or_default();
+        let bytes = decrypt_layer_bytes(service, &request.account_id, &layer)?;
         let mut resp = base_response(StatusCode::OK, &layer.media_type, bytes);
         resp.headers.insert(
             "Docker-Content-Digest",
@@ -386,15 +456,28 @@ fn blob_upload_start(
         if expected != computed {
             return Err(digest_invalid());
         }
-        let repo = state.repositories.get_mut(name).unwrap();
         let size = body_bytes.len() as u64;
+        // Drop the state guard before KMS: encrypt_layer_bytes needs its
+        // own read lock, and holding two concurrently would deadlock.
+        drop(accounts);
+        let (stored_bytes, encrypted_with) =
+            encrypt_layer_bytes(service, &request.account_id, name, &body_bytes);
+        let mut accounts = service.state_handle().write();
+        let state = accounts
+            .get_mut(&request.account_id)
+            .ok_or_else(|| repo_not_found(name))?;
+        let repo = state
+            .repositories
+            .get_mut(name)
+            .ok_or_else(|| repo_not_found(name))?;
         repo.layers.insert(
             computed.clone(),
             Layer {
                 digest: computed.clone(),
                 size,
-                blob_b64: B64.encode(&body_bytes),
+                blob_b64: B64.encode(&stored_bytes),
                 media_type: "application/octet-stream".to_string(),
+                encrypted_with_kms_key: encrypted_with,
             },
         );
         let mut resp = base_response(StatusCode::CREATED, "application/json", Vec::new());
@@ -510,6 +593,15 @@ fn blob_upload_finish(
     // a bad digest query param on the last PUT.
     let upload = state.layer_uploads.remove(upload_id).unwrap();
     let _ = upload;
+    // Drop the write guard before calling into KMS (which acquires its
+    // own lock) so we don't hold two incompatible locks concurrently.
+    drop(accounts);
+    let (stored_bytes, encrypted_with) =
+        encrypt_layer_bytes(service, &request.account_id, name, &combined);
+    let mut accounts = service.state_handle().write();
+    let state = accounts
+        .get_mut(&request.account_id)
+        .ok_or_else(|| repo_not_found(name))?;
     let repo = state
         .repositories
         .get_mut(name)
@@ -520,8 +612,9 @@ fn blob_upload_finish(
         Layer {
             digest: computed.clone(),
             size,
-            blob_b64: B64.encode(&combined),
+            blob_b64: B64.encode(&stored_bytes),
             media_type: "application/octet-stream".to_string(),
+            encrypted_with_kms_key: encrypted_with,
         },
     );
     let mut resp = base_response(StatusCode::CREATED, "application/json", Vec::new());

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -372,6 +372,10 @@ fn cache_blob(
             size: bytes.len() as u64,
             blob_b64: B64.encode(bytes),
             media_type: media_type.to_string(),
+            // Pull-through proxy caches blobs as fetched upstream; the
+            // local repo for the pull-through prefix never has
+            // encryption_configuration.kms, so plaintext is correct.
+            encrypted_with_kms_key: None,
         },
     );
 }

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -124,6 +124,11 @@ pub struct EcrService {
     state: SharedEcrState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    /// KMS state handle — when wired, repositories configured with
+    /// `EncryptionConfiguration.encryption_type == "KMS"` store layer
+    /// blobs encrypted under the configured CMK via
+    /// `fakecloud_kms::api::encrypt_blob` / `decrypt_blob`.
+    kms_state: Option<fakecloud_kms::state::SharedKmsState>,
 }
 
 impl EcrService {
@@ -132,11 +137,17 @@ impl EcrService {
             state,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            kms_state: None,
         }
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_kms(mut self, kms: fakecloud_kms::state::SharedKmsState) -> Self {
+        self.kms_state = Some(kms);
         self
     }
 
@@ -146,6 +157,12 @@ impl EcrService {
     /// JSON control-plane ops read and write.
     pub fn state_handle(&self) -> &SharedEcrState {
         &self.state
+    }
+
+    /// Handle for the shared KMS state when wired. `None` skips the
+    /// encrypt/decrypt paths and stores / returns plaintext blobs.
+    pub(crate) fn kms_handle(&self) -> Option<&fakecloud_kms::state::SharedKmsState> {
+        self.kms_state.as_ref()
     }
 
     async fn save_snapshot(&self) {
@@ -1505,19 +1522,29 @@ impl EcrService {
                 ),
             ));
         }
-        let upload = state.layer_uploads.remove(&upload_id).unwrap();
+        let _upload = state.layer_uploads.remove(&upload_id).unwrap();
+        let size = blob_bytes.len() as u64;
+        // Drop the write guard before the KMS encrypt call (which takes
+        // its own lock). Re-acquire to insert.
+        drop(accounts);
+        let (stored_bytes, encrypted_with) =
+            crate::oci::encrypt_layer_bytes(self, &account, &name, &blob_bytes);
+        let mut accounts = self.state.write();
+        let state = accounts
+            .get_mut(&account)
+            .ok_or_else(|| repository_not_found(&name))?;
         let repo = state
             .repositories
             .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        let size = blob_bytes.len() as u64;
         repo.layers.insert(
             computed.clone(),
             Layer {
                 digest: computed.clone(),
                 size,
-                blob_b64: upload.blob_b64,
+                blob_b64: B64.encode(&stored_bytes),
                 media_type: "application/vnd.docker.image.rootfs.diff.tar.gzip".to_string(),
+                encrypted_with_kms_key: encrypted_with,
             },
         );
         let registry_id = repo.registry_id.clone();

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -234,11 +234,20 @@ pub struct Image {
 pub struct Layer {
     pub digest: String,
     pub size: u64,
-    /// Base64-encoded blob bytes. Kept in-process for Batch 2; Batch 3
-    /// will move this to content-addressed disk storage for the OCI
-    /// `/v2/` protocol.
+    /// Base64-encoded blob bytes. When the owning repository has
+    /// `EncryptionConfiguration.encryption_type == "KMS"`, these bytes
+    /// are the envelope produced by `fakecloud_kms::api::encrypt_blob`;
+    /// `blob_get` decrypts on the way out. For AES256 (fakecloud's
+    /// default) the bytes are the plaintext blob.
     pub blob_b64: String,
     pub media_type: String,
+    /// ARN of the KMS key the blob was encrypted under, when stored
+    /// encrypted. `None` means the bytes in `blob_b64` are plaintext
+    /// — either because the repo used the default AES256 encryption
+    /// (fakecloud-internal, no-op) or the layer pre-dates the KMS
+    /// wire-up.
+    #[serde(default)]
+    pub encrypted_with_kms_key: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+aes-gcm = "0.10"

--- a/crates/fakecloud-kms/src/api.rs
+++ b/crates/fakecloud-kms/src/api.rs
@@ -1,0 +1,288 @@
+//! Crate-level KMS encrypt/decrypt API for cross-service callers.
+//!
+//! Real AES-256-GCM with a fresh 12-byte IV per call and an
+//! authenticated tag. Envelope format:
+//!
+//! ```text
+//! | key_arn_len:u16_be | key_arn_utf8 | iv:12 | ciphertext_with_tag |
+//! ```
+//!
+//! The key ARN is embedded so decryption callers can pass opaque
+//! ciphertext back without tracking the key separately — matching how
+//! AWS's KMS blob format self-describes.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use sha2::{Digest, Sha256};
+
+use crate::state::{KmsKey, SharedKmsState};
+
+#[derive(Debug, thiserror::Error)]
+pub enum KmsApiError {
+    #[error("KMS key {0} not found")]
+    KeyNotFound(String),
+    #[error("KMS key {0} is not enabled")]
+    KeyDisabled(String),
+    #[error("encryption failed: {0}")]
+    EncryptFailed(String),
+    #[error("decryption failed: {0}")]
+    DecryptFailed(String),
+    #[error("malformed ciphertext envelope")]
+    MalformedCiphertext,
+}
+
+/// Encrypt `plaintext` under the AES-256 key derived from `key_ref`
+/// (key id or ARN). Returns an envelope that `decrypt_blob` accepts
+/// without needing the key-ref passed again.
+pub fn encrypt_blob(
+    state: &SharedKmsState,
+    account_id: &str,
+    key_ref: &str,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, KmsApiError> {
+    let (key_arn, aes_key) = {
+        let accounts = state.read();
+        let s = accounts
+            .get(account_id)
+            .ok_or_else(|| KmsApiError::KeyNotFound(key_ref.to_string()))?;
+        let key =
+            lookup_key(s, key_ref).ok_or_else(|| KmsApiError::KeyNotFound(key_ref.to_string()))?;
+        if !key.enabled {
+            return Err(KmsApiError::KeyDisabled(key.key_id.clone()));
+        }
+        (key.arn.clone(), derive_aes_key(key))
+    };
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&aes_key));
+    let iv = random_iv();
+    let nonce = Nonce::from_slice(&iv);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad: key_arn.as_bytes(),
+            },
+        )
+        .map_err(|e| KmsApiError::EncryptFailed(e.to_string()))?;
+
+    let arn_bytes = key_arn.as_bytes();
+    let arn_len = arn_bytes.len() as u16;
+    let mut out = Vec::with_capacity(2 + arn_bytes.len() + 12 + ciphertext.len());
+    out.extend_from_slice(&arn_len.to_be_bytes());
+    out.extend_from_slice(arn_bytes);
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+/// Decrypt a blob produced by `encrypt_blob`.
+pub fn decrypt_blob(
+    state: &SharedKmsState,
+    account_id: &str,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, KmsApiError> {
+    if ciphertext.len() < 2 {
+        return Err(KmsApiError::MalformedCiphertext);
+    }
+    let arn_len = u16::from_be_bytes([ciphertext[0], ciphertext[1]]) as usize;
+    let header_end = 2 + arn_len;
+    if ciphertext.len() < header_end + 12 + 16 {
+        return Err(KmsApiError::MalformedCiphertext);
+    }
+    let key_arn = std::str::from_utf8(&ciphertext[2..header_end])
+        .map_err(|_| KmsApiError::MalformedCiphertext)?;
+    let iv = &ciphertext[header_end..header_end + 12];
+    let body = &ciphertext[header_end + 12..];
+
+    let aes_key = {
+        let accounts = state.read();
+        let s = accounts
+            .get(account_id)
+            .ok_or_else(|| KmsApiError::KeyNotFound(key_arn.to_string()))?;
+        let key =
+            lookup_key(s, key_arn).ok_or_else(|| KmsApiError::KeyNotFound(key_arn.to_string()))?;
+        if !key.enabled {
+            return Err(KmsApiError::KeyDisabled(key.key_id.clone()));
+        }
+        derive_aes_key(key)
+    };
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&aes_key));
+    let nonce = Nonce::from_slice(iv);
+    cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: body,
+                aad: key_arn.as_bytes(),
+            },
+        )
+        .map_err(|e| KmsApiError::DecryptFailed(e.to_string()))
+}
+
+/// Resolve `key_ref` against a KMS state. Accepts key id, ARN, or
+/// alias-name (`alias/<name>`). Returns the canonical key.
+fn lookup_key<'a>(s: &'a crate::state::KmsState, key_ref: &str) -> Option<&'a KmsKey> {
+    if let Some(alias) = key_ref.strip_prefix("alias/") {
+        let full = format!("alias/{alias}");
+        let target = s
+            .aliases
+            .values()
+            .find(|a| a.alias_name == full)
+            .map(|a| a.target_key_id.as_str())?;
+        return s.keys.get(target);
+    }
+    if let Some(id) = key_ref.rsplit(':').next() {
+        if let Some(stripped) = id.strip_prefix("key/") {
+            return s.keys.get(stripped);
+        }
+        if let Some(k) = s.keys.get(id) {
+            return Some(k);
+        }
+    }
+    s.keys.get(key_ref)
+}
+
+/// Derive a stable 32-byte AES key from a KmsKey. Priority:
+/// `imported_material_bytes` (when caller used `ImportKeyMaterial`),
+/// else the `private_key_seed` which every CreateKey populates.
+/// Hashed with SHA-256 so we always end up with the right length
+/// regardless of the source length.
+fn derive_aes_key(key: &KmsKey) -> [u8; 32] {
+    let source: &[u8] = key
+        .imported_material_bytes
+        .as_deref()
+        .unwrap_or(&key.private_key_seed);
+    let mut hasher = Sha256::new();
+    hasher.update(b"fakecloud-kms-aes256:");
+    hasher.update(key.key_id.as_bytes());
+    hasher.update(b":");
+    hasher.update(source);
+    let out = hasher.finalize();
+    let mut aes_key = [0u8; 32];
+    aes_key.copy_from_slice(&out[..]);
+    aes_key
+}
+
+fn random_iv() -> [u8; 12] {
+    // aes-gcm re-exports an rng trait; keep a small local RNG using
+    // timestamp + key-independent entropy. CI fakes don't need
+    // cryptographic-quality randomness, but each IV must be unique
+    // per key+plaintext pair, so mix in a monotonic counter.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let cnt = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut hasher = Sha256::new();
+    hasher.update(ts.to_be_bytes());
+    hasher.update(cnt.to_be_bytes());
+    hasher.update(std::process::id().to_be_bytes());
+    let digest = hasher.finalize();
+    let mut iv = [0u8; 12];
+    iv.copy_from_slice(&digest[..12]);
+    iv
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+
+    use super::*;
+    use crate::state::{KmsKey, KmsState};
+
+    fn make_state_with_key() -> (SharedKmsState, String) {
+        let state = Arc::new(RwLock::new(MultiAccountState::<KmsState>::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )));
+        let key_id = "00000000-0000-0000-0000-000000000001".to_string();
+        let arn = format!("arn:aws:kms:us-east-1:123456789012:key/{key_id}");
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create("123456789012");
+            s.keys.insert(
+                key_id.clone(),
+                KmsKey {
+                    key_id: key_id.clone(),
+                    arn: arn.clone(),
+                    creation_date: 0.0,
+                    description: String::new(),
+                    enabled: true,
+                    key_usage: "ENCRYPT_DECRYPT".into(),
+                    key_spec: "SYMMETRIC_DEFAULT".into(),
+                    key_manager: "CUSTOMER".into(),
+                    key_state: "Enabled".into(),
+                    deletion_date: None,
+                    tags: Default::default(),
+                    policy: String::new(),
+                    key_rotation_enabled: false,
+                    origin: "AWS_KMS".into(),
+                    multi_region: false,
+                    rotations: Vec::new(),
+                    signing_algorithms: None,
+                    encryption_algorithms: None,
+                    mac_algorithms: None,
+                    custom_key_store_id: None,
+                    imported_key_material: false,
+                    imported_material_bytes: None,
+                    private_key_seed: vec![7; 32],
+                    primary_region: None,
+                },
+            );
+        }
+        (state, arn)
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let (state, arn) = make_state_with_key();
+        let plaintext = b"hello fakecloud kms";
+        let ct = encrypt_blob(&state, "123456789012", &arn, plaintext).unwrap();
+        assert_ne!(&ct[..], plaintext, "ciphertext must differ from plaintext");
+        let pt = decrypt_blob(&state, "123456789012", &ct).unwrap();
+        assert_eq!(pt.as_slice(), plaintext);
+    }
+
+    #[test]
+    fn each_encrypt_yields_distinct_ciphertext() {
+        let (state, arn) = make_state_with_key();
+        let a = encrypt_blob(&state, "123456789012", &arn, b"same plaintext").unwrap();
+        let b = encrypt_blob(&state, "123456789012", &arn, b"same plaintext").unwrap();
+        assert_ne!(a, b, "distinct IVs should produce distinct ciphertext");
+    }
+
+    #[test]
+    fn decrypt_with_tampered_ciphertext_fails() {
+        let (state, arn) = make_state_with_key();
+        let mut ct = encrypt_blob(&state, "123456789012", &arn, b"tamper me").unwrap();
+        // Flip a bit in the payload region.
+        let last = ct.len() - 1;
+        ct[last] ^= 0x01;
+        assert!(decrypt_blob(&state, "123456789012", &ct).is_err());
+    }
+
+    #[test]
+    fn decrypt_with_disabled_key_fails() {
+        let (state, arn) = make_state_with_key();
+        let ct = encrypt_blob(&state, "123456789012", &arn, b"ok").unwrap();
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_mut("123456789012").unwrap();
+            for k in s.keys.values_mut() {
+                k.enabled = false;
+            }
+        }
+        assert!(matches!(
+            decrypt_blob(&state, "123456789012", &ct),
+            Err(KmsApiError::KeyDisabled(_))
+        ));
+    }
+}

--- a/crates/fakecloud-kms/src/lib.rs
+++ b/crates/fakecloud-kms/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod resource_policy;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1787,7 +1787,7 @@ async fn main() {
         } else {
             None
         };
-    let mut ecr_service = EcrService::new(ecr_state.clone());
+    let mut ecr_service = EcrService::new(ecr_state.clone()).with_kms(kms_state.clone());
     if let Some(store) = ecr_snapshot_store {
         ecr_service = ecr_service.with_snapshot_store(store);
     }


### PR DESCRIPTION
## Summary

Batch 3. Real encryption on KMS-configured ECR repos.

- `fakecloud_kms::api::encrypt_blob` / `decrypt_blob` — AES-256-GCM, per-call 12-byte IV, authenticated tag bound to key ARN. Self-describing envelope so decrypt doesn't need the key passed back.
- fakecloud-ecr `with_kms` builder; wired in server. Both OCI v2 upload paths (single-POST + two-phase) and the SDK `CompleteLayerUpload` branch on `encryption_type=KMS`. Blob GET decrypts.
- `Layer` gets `encrypted_with_kms_key` so old snapshots stay readable.
- aes-gcm 0.10 added as a fakecloud-kms dep.

## Test plan

- [x] 4 new KMS unit tests — roundtrip, distinct IVs, tamper detection, disabled-key rejection
- [x] 2 new ECR E2E tests — KMS encrypt roundtrip + default AES256 plaintext guard
- [x] `cargo test -p fakecloud-e2e --test ecr --test ecr_oci --test ecr_lifecycle --test ecr_pull_through` — no regressions
- [x] clippy + fmt clean
- [ ] CI + Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real AES‑256‑GCM encryption for ECR layer blobs when repositories are configured with KMS, and decrypts on blob GET. Existing repositories and snapshots remain readable; non‑KMS repos still store plaintext.

- **New Features**
  - `fakecloud_kms::api::{encrypt_blob, decrypt_blob}` using AES‑256‑GCM with per‑call 12‑byte IV and a self‑describing envelope (`|arn_len:u16|arn|iv:12|ct+tag|`).
  - ECR: optional KMS wiring via `EcrService::with_kms`; encrypts on upload (single‑POST, two‑phase, and SDK `CompleteLayerUpload`) and decrypts on GET; pull‑through cache stays plaintext.
  - Adds `Layer.encrypted_with_kms_key` to track encrypted blobs; defaults to `None` for backward compatibility.
  - Server now passes KMS state into ECR at startup to enable KMS repos by default.

- **Dependencies**
  - Added `aes-gcm@0.10` to `fakecloud-kms`.

<sup>Written for commit d67c40c0f03619b3e107f7b4c8d4f653bcceb2c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

