### PR TITLE
feat(ecr): real cosign signature verification (keyed ECDSA-P256)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
  "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring",
  "sha2 0.10.9",
@@ -1314,6 +1314,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1841,8 +1847,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1935,6 +1943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2000,10 +2020,24 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2018,16 +2052,36 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
- "der",
+ "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array",
+ "group 0.13.0",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2354,6 +2408,7 @@ dependencies = [
  "fakecloud-sdk",
  "fakecloud-testkit",
  "flate2",
+ "p256 0.13.2",
  "reqwest",
  "serde_json",
  "sha2 0.10.9",
@@ -2375,6 +2430,7 @@ dependencies = [
  "fakecloud-kms",
  "fakecloud-persistence",
  "http 1.4.0",
+ "p256 0.13.2",
  "parking_lot",
  "reqwest",
  "serde",
@@ -2893,6 +2949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3148,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3147,7 +3214,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -4143,8 +4221,20 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -4189,6 +4279,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4254,8 +4353,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4337,6 +4446,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -4675,6 +4793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,10 +5051,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -5117,6 +5259,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,7 +5325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -52,3 +52,4 @@ fakecloud-sdk = { path = "../fakecloud-sdk" }
 fakecloud-testkit = { path = "../fakecloud-testkit", features = ["sdk-clients"] }
 tempfile = { workspace = true }
 sha2 = { workspace = true }
+p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }

--- a/crates/fakecloud-e2e/tests/ecr_cosign_verify.rs
+++ b/crates/fakecloud-e2e/tests/ecr_cosign_verify.rs
@@ -1,0 +1,350 @@
+//! ECR cosign signature verification end-to-end: push an image, push
+//! a cosign companion `.sig` manifest, configure a trusted public
+//! key, and assert `DescribeImageSigningStatus` reports SIGNED.
+
+mod helpers;
+
+use base64::Engine;
+use helpers::TestServer;
+use p256::ecdsa::signature::Signer;
+use p256::ecdsa::{Signature, SigningKey};
+use p256::pkcs8::EncodePublicKey;
+use reqwest::StatusCode;
+
+fn auth_header() -> String {
+    format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("AWS:test")
+    )
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("sha256:{:x}", h.finalize())
+}
+
+/// Push `bytes` as a generic blob via OCI v2 single-POST upload.
+async fn push_blob(http: &reqwest::Client, endpoint: &str, repo: &str, bytes: &[u8]) -> String {
+    let digest = sha256(bytes);
+    let url = format!(
+        "{endpoint}/v2/{repo}/blobs/uploads/?digest={digest}",
+        endpoint = endpoint,
+        repo = repo,
+        digest = digest,
+    );
+    let r = http
+        .post(&url)
+        .header("Authorization", auth_header())
+        .body(bytes.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::CREATED,
+        "blob push failed: {}",
+        r.status()
+    );
+    digest
+}
+
+async fn push_manifest(
+    http: &reqwest::Client,
+    endpoint: &str,
+    repo: &str,
+    reference: &str,
+    manifest: &serde_json::Value,
+) -> String {
+    let body = serde_json::to_vec(manifest).unwrap();
+    let r = http
+        .put(format!(
+            "{endpoint}/v2/{repo}/manifests/{reference}",
+            endpoint = endpoint,
+            repo = repo,
+            reference = reference,
+        ))
+        .header("Authorization", auth_header())
+        .header(
+            "Content-Type",
+            "application/vnd.docker.distribution.manifest.v2+json",
+        )
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::CREATED);
+    r.headers()
+        .get("docker-content-digest")
+        .and_then(|v| v.to_str().ok())
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn cosign_signed_image_reports_signed() {
+    let server = TestServer::start().await;
+    let ecr = server.ecr_client().await;
+    ecr.create_repository()
+        .repository_name("cosign-test")
+        .send()
+        .await
+        .unwrap();
+
+    // Push a minimal empty image (no layers) so we have something to sign.
+    let http = reqwest::Client::new();
+    let config_blob = br#"{}"#.to_vec();
+    let config_digest = push_blob(&http, server.endpoint(), "cosign-test", &config_blob).await;
+    let image_manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": config_blob.len(),
+            "digest": config_digest
+        },
+        "layers": []
+    });
+    let image_digest = push_manifest(
+        &http,
+        server.endpoint(),
+        "cosign-test",
+        "v1",
+        &image_manifest,
+    )
+    .await;
+    let image_hex = image_digest.strip_prefix("sha256:").unwrap();
+
+    // Build cosign simple-signing payload that names the signed image.
+    let payload = serde_json::json!({
+        "critical": {
+            "identity": {"docker-reference": "fakecloud.local/cosign-test"},
+            "image": {"docker-manifest-digest": image_digest},
+            "type": "cosign container image signature"
+        },
+        "optional": {}
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+
+    // Deterministic keypair so the public PEM is stable across runs.
+    let sk_bytes = [9u8; 32];
+    let sk = SigningKey::from_bytes((&sk_bytes).into()).unwrap();
+    let vk_pem = sk
+        .verifying_key()
+        .to_public_key_pem(Default::default())
+        .unwrap();
+    let sig: Signature = sk.sign(&payload_bytes);
+    let sig_der_b64 = base64::engine::general_purpose::STANDARD.encode(sig.to_der());
+
+    // Push the payload as a blob and the cosign manifest tagged `.sig`.
+    let payload_digest = push_blob(&http, server.endpoint(), "cosign-test", &payload_bytes).await;
+    let sig_manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 2,
+            "digest": config_digest
+        },
+        "layers": [{
+            "mediaType": "application/vnd.dev.cosign.simplesigning.v1+json",
+            "size": payload_bytes.len(),
+            "digest": payload_digest,
+            "annotations": {
+                "dev.cosignproject.cosign/signature": sig_der_b64
+            }
+        }]
+    });
+    let sig_tag = format!("sha256-{image_hex}.sig");
+    push_manifest(
+        &http,
+        server.endpoint(),
+        "cosign-test",
+        &sig_tag,
+        &sig_manifest,
+    )
+    .await;
+
+    // Without a trusted key configured yet, status should be UNVERIFIED.
+    let resp = ecr
+        .describe_image_signing_status()
+        .repository_name("cosign-test")
+        .image_id(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("describe_image_signing_status pre-config");
+    // Raw HTTP to read signingStatus — unknown SDK fields get dropped.
+    let raw: serde_json::Value = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.DescribeImageSigningStatus",
+        )
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0")
+        .body(
+            serde_json::json!({
+                "repositoryName": "cosign-test",
+                "imageId": {"imageTag": "v1"}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        raw["signingStatus"].as_str(),
+        Some("UNVERIFIED"),
+        "expected UNVERIFIED pre-config; raw={raw}"
+    );
+    let _ = resp;
+
+    // Configure the trusted key.
+    reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.PutSigningConfiguration",
+        )
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0")
+        .body(
+            serde_json::json!({
+                "signingConfiguration": {
+                    "rules": [{
+                        "trustedKeys": [{
+                            "keyId": "test-key",
+                            "pem": vk_pem,
+                            "algorithm": "ECDSA-P256",
+                        }]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Re-describe — should now be SIGNED + valid.
+    let raw: serde_json::Value = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.DescribeImageSigningStatus",
+        )
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0")
+        .body(
+            serde_json::json!({
+                "repositoryName": "cosign-test",
+                "imageId": {"imageTag": "v1"}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        raw["signingStatus"].as_str(),
+        Some("SIGNED"),
+        "expected SIGNED post-config; raw={raw}"
+    );
+    assert_eq!(raw["imageSignatures"][0]["valid"].as_bool(), Some(true));
+    assert_eq!(
+        raw["imageSignatures"][0]["keyId"].as_str(),
+        Some("test-key")
+    );
+}
+
+#[tokio::test]
+async fn unsigned_image_reports_unsigned() {
+    let server = TestServer::start().await;
+    let ecr = server.ecr_client().await;
+    ecr.create_repository()
+        .repository_name("unsigned-repo")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 0,
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "layers": []
+    });
+    push_manifest(&http, server.endpoint(), "unsigned-repo", "v1", &manifest).await;
+
+    let raw: serde_json::Value = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.DescribeImageSigningStatus",
+        )
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0")
+        .body(
+            serde_json::json!({
+                "repositoryName": "unsigned-repo",
+                "imageId": {"imageTag": "v1"}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(raw["signingStatus"].as_str(), Some("UNSIGNED"));
+    assert_eq!(raw["imageSignatures"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn put_signing_configuration_rejects_bad_pem() {
+    let server = TestServer::start().await;
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.PutSigningConfiguration",
+        )
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0")
+        .body(
+            serde_json::json!({
+                "signingConfiguration": {
+                    "rules": [{
+                        "trustedKeys": [{
+                            "keyId": "bad",
+                            "pem": "not-a-pem",
+                            "algorithm": "ECDSA-P256"
+                        }]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/fakecloud-ecr/Cargo.toml
+++ b/crates/fakecloud-ecr/Cargo.toml
@@ -24,3 +24,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }
 reqwest = { workspace = true }
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pem", "pkcs8", "std"] }

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod oci;
 pub(crate) mod pull_through;
 pub mod service;
+pub mod signing;
 pub mod state;

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -2721,6 +2721,7 @@ impl EcrService {
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        use crate::signing::TrustedKey;
         use crate::state::SigningConfiguration;
         let body = request.json_body();
         let cfg = body
@@ -2731,11 +2732,59 @@ impl EcrService {
             .and_then(|v| v.as_array())
             .cloned()
             .unwrap_or_default();
+
+        // Extract trusted keys from the rules. AWS's real signing-config
+        // schema is nested; we accept the minimal fakecloud-friendly
+        // shape `{trustedKeys: [{keyId, pem, algorithm}]}` per rule.
+        // Rules that don't carry recognised keys are still
+        // round-trippable via the raw `rules` passthrough.
+        let mut trusted_keys: Vec<TrustedKey> = Vec::new();
+        for rule in &rules {
+            let keys = match rule.get("trustedKeys").and_then(|v| v.as_array()) {
+                Some(k) => k,
+                None => continue,
+            };
+            for k in keys {
+                let key_id = k
+                    .get("keyId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let pem = match k.get("pem").and_then(|v| v.as_str()) {
+                    Some(p) => p.to_string(),
+                    None => continue,
+                };
+                let algorithm = k
+                    .get("algorithm")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("ECDSA-P256")
+                    .to_string();
+                // Validate the PEM up front so bad rules fail
+                // PutSigningConfiguration rather than silently skipping
+                // verification at describe time.
+                if <p256::ecdsa::VerifyingKey as p256::pkcs8::DecodePublicKey>::from_public_key_pem(
+                    &pem,
+                )
+                .is_err()
+                {
+                    return Err(invalid_parameter(format!(
+                        "trusted key {key_id} is not a valid ECDSA-P256 PEM-encoded public key"
+                    )));
+                }
+                trusted_keys.push(TrustedKey {
+                    key_id,
+                    pem,
+                    algorithm,
+                });
+            }
+        }
+
         let account = target_account_id(request, &body);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
         state.signing_configuration = Some(SigningConfiguration {
             rules: rules.clone(),
+            trusted_keys,
         });
         Ok(AwsResponse::ok_json(json!({
             "signingConfiguration": {"rules": rules},
@@ -2773,15 +2822,156 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        if resolve_image_digest(repo, &image_id).is_none() {
-            return Err(image_not_found(&name, &image_id));
+        let image_digest = resolve_image_digest(repo, &image_id)
+            .ok_or_else(|| image_not_found(&name, &image_id))?;
+
+        let trusted_keys: &[crate::signing::TrustedKey] = state
+            .signing_configuration
+            .as_ref()
+            .map(|c| c.trusted_keys.as_slice())
+            .unwrap_or(&[]);
+
+        // Locate the cosign companion signature tag
+        // (`sha256-<hex>.sig`) in the same repo. Absent -> UNSIGNED.
+        let sig_tag = match crate::signing::companion_sig_tag(&image_digest) {
+            Some(t) => t,
+            None => {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "UNSIGNED",
+                })));
+            }
+        };
+        let sig_manifest_digest = match repo.image_tags.get(&sig_tag) {
+            Some(d) => d,
+            None => {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "UNSIGNED",
+                })));
+            }
+        };
+        let sig_image = match repo.images.get(sig_manifest_digest) {
+            Some(i) => i,
+            None => {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "UNSIGNED",
+                })));
+            }
+        };
+
+        let manifest_json: Value = match serde_json::from_str(&sig_image.image_manifest) {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "INVALID_SIGNATURE",
+                })));
+            }
+        };
+        let (layer_digest, signature_b64) =
+            match crate::signing::extract_signature_annotation(&manifest_json) {
+                Some(x) => x,
+                None => {
+                    return Ok(AwsResponse::ok_json(json!({
+                        "registryId": repo.registry_id,
+                        "repositoryName": name,
+                        "imageId": image_id,
+                        "imageSignatures": [],
+                        "signingStatus": "UNSIGNED",
+                    })));
+                }
+            };
+
+        // Fetch the payload (signed bytes = simple-signing JSON blob).
+        let payload_bytes: Vec<u8> = match repo.layers.get(&layer_digest) {
+            Some(layer) => base64::Engine::decode(
+                &base64::engine::general_purpose::STANDARD,
+                layer.blob_b64.as_bytes(),
+            )
+            .unwrap_or_default(),
+            None => {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "UNSIGNED",
+                })));
+            }
+        };
+
+        // The payload must name the signed image — catches copy-paste
+        // of one image's signature onto another.
+        if let Some(named) = crate::signing::referenced_image_digest(&payload_bytes) {
+            if named != image_digest {
+                return Ok(AwsResponse::ok_json(json!({
+                    "registryId": repo.registry_id,
+                    "repositoryName": name,
+                    "imageId": image_id,
+                    "imageSignatures": [],
+                    "signingStatus": "INVALID_SIGNATURE",
+                    "statusReason": "signature payload references a different image digest",
+                })));
+            }
         }
-        Ok(AwsResponse::ok_json(json!({
+
+        // Verify against each trusted key until one matches.
+        let mut matched: Option<&crate::signing::TrustedKey> = None;
+        for key in trusted_keys {
+            if crate::signing::verify_cosign_signature(&key.pem, &payload_bytes, &signature_b64)
+                .is_ok()
+            {
+                matched = Some(key);
+                break;
+            }
+        }
+
+        let mut response = json!({
             "registryId": repo.registry_id,
             "repositoryName": name,
             "imageId": image_id,
-            "imageSignatures": [],
-        })))
+        });
+        if let Some(key) = matched {
+            response["imageSignatures"] = json!([{
+                "signatureFormat": "COSIGN",
+                "keyId": key.key_id,
+                "algorithm": key.algorithm,
+                "valid": true,
+            }]);
+            response["signingStatus"] = json!("SIGNED");
+        } else if trusted_keys.is_empty() {
+            // A valid-looking signature exists but no trusted keys are
+            // configured to verify against — surface the signature but
+            // mark it UNVERIFIED so the caller knows to configure keys.
+            response["imageSignatures"] = json!([{
+                "signatureFormat": "COSIGN",
+                "valid": false,
+                "statusReason": "no trusted keys configured"
+            }]);
+            response["signingStatus"] = json!("UNVERIFIED");
+        } else {
+            response["imageSignatures"] = json!([{
+                "signatureFormat": "COSIGN",
+                "valid": false,
+                "statusReason": "signature did not match any trusted key"
+            }]);
+            response["signingStatus"] = json!("INVALID_SIGNATURE");
+        }
+        Ok(AwsResponse::ok_json(response))
     }
 
     fn register_pull_time_update_exclusion(

--- a/crates/fakecloud-ecr/src/signing.rs
+++ b/crates/fakecloud-ecr/src/signing.rs
@@ -1,0 +1,178 @@
+//! Real OCI image signature verification via cosign (keyed mode).
+//!
+//! Cosign stores signatures as a companion manifest tagged
+//! `sha256-<image-digest>.sig`. That manifest has one layer with
+//! `mediaType: application/vnd.dev.cosign.simplesigning.v1+json`
+//! whose blob is a JSON "simple-signing payload" that names the
+//! signed image. The cosign signature (ECDSA) is attached as an
+//! annotation on the layer descriptor with key
+//! `dev.cosignproject.cosign/signature`, and the signed bytes are
+//! the layer blob itself.
+//!
+//! This module supports the common case: ECDSA-P256 keys encoded as
+//! PEM (PKCS8 SubjectPublicKeyInfo). No sigstore transparency log,
+//! no keyless / Fulcio / Rekor — that's scoped out until fakecloud
+//! grows a Rekor shim.
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use p256::ecdsa::signature::Verifier;
+use p256::ecdsa::{Signature, VerifyingKey};
+use p256::pkcs8::DecodePublicKey;
+use serde::{Deserialize, Serialize};
+
+/// Companion tag convention: `sha256-<hex>.sig` sits in the same repo
+/// as the signed image and points at a cosign simple-signing manifest.
+pub fn companion_sig_tag(image_digest: &str) -> Option<String> {
+    image_digest
+        .strip_prefix("sha256:")
+        .map(|hex| format!("sha256-{hex}.sig"))
+}
+
+/// Structured form of a trusted public key. Stored inside
+/// `SigningConfiguration.trusted_keys` so `PutSigningConfiguration`
+/// validates PEMs up front and `DescribeImageSigningStatus` doesn't
+/// re-parse on every call.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TrustedKey {
+    pub key_id: String,
+    pub pem: String,
+    /// Cosmetic label for the key-usage algorithm. Only ECDSA-P256 is
+    /// supported for verification today; other values are stored
+    /// round-trippably but won't match a signature.
+    pub algorithm: String,
+}
+
+#[derive(Debug)]
+pub enum VerifyError {
+    InvalidPemKey,
+    SignatureDecode,
+    SignatureVerify,
+}
+
+/// Verify `signature_b64` (base64 DER ECDSA signature) over `payload`
+/// using `key_pem` (PEM-wrapped PKCS8 SubjectPublicKeyInfo for
+/// ECDSA-P256). Matches cosign's default verification flow.
+pub fn verify_cosign_signature(
+    key_pem: &str,
+    payload: &[u8],
+    signature_b64: &str,
+) -> Result<(), VerifyError> {
+    let verifying_key =
+        VerifyingKey::from_public_key_pem(key_pem).map_err(|_| VerifyError::InvalidPemKey)?;
+    let sig_bytes = B64
+        .decode(signature_b64.trim().as_bytes())
+        .map_err(|_| VerifyError::SignatureDecode)?;
+    let sig = Signature::from_der(&sig_bytes).map_err(|_| VerifyError::SignatureDecode)?;
+    verifying_key
+        .verify(payload, &sig)
+        .map_err(|_| VerifyError::SignatureVerify)
+}
+
+/// Walk the layers of a cosign signature manifest and pull the
+/// `dev.cosignproject.cosign/signature` annotation plus the layer
+/// digest. Returns the layer whose blob is the simple-signing
+/// payload.
+pub fn extract_signature_annotation(manifest_json: &serde_json::Value) -> Option<(String, String)> {
+    let layer = manifest_json.get("layers")?.as_array()?.first()?;
+    let digest = layer.get("digest")?.as_str()?.to_string();
+    let sig = layer
+        .get("annotations")?
+        .as_object()?
+        .get("dev.cosignproject.cosign/signature")?
+        .as_str()?
+        .to_string();
+    Some((digest, sig))
+}
+
+/// Parse cosign's simple-signing payload and pull the referenced
+/// image manifest digest. Used to verify the signed payload names
+/// the image we're checking.
+pub fn referenced_image_digest(payload_bytes: &[u8]) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_slice(payload_bytes).ok()?;
+    v.get("critical")?
+        .get("image")?
+        .get("docker-manifest-digest")?
+        .as_str()
+        .map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::signature::Signer;
+    use p256::ecdsa::SigningKey;
+    use p256::pkcs8::EncodePublicKey;
+
+    fn keypair_pem() -> (SigningKey, String) {
+        // Deterministic P-256 key — fakecloud doesn't need real
+        // entropy for unit tests.
+        let bytes = [7u8; 32];
+        let sk = SigningKey::from_bytes((&bytes).into()).unwrap();
+        let pem = sk
+            .verifying_key()
+            .to_public_key_pem(Default::default())
+            .unwrap();
+        (sk, pem)
+    }
+
+    #[test]
+    fn verify_roundtrip() {
+        let (sk, pem) = keypair_pem();
+        let payload = br#"{"critical":{"image":{"docker-manifest-digest":"sha256:abc"}}}"#;
+        let sig: Signature = sk.sign(payload);
+        let sig_b64 = B64.encode(sig.to_der());
+        verify_cosign_signature(&pem, payload, &sig_b64).unwrap();
+    }
+
+    #[test]
+    fn wrong_payload_fails() {
+        let (sk, pem) = keypair_pem();
+        let payload = b"original";
+        let sig: Signature = sk.sign(payload);
+        let sig_b64 = B64.encode(sig.to_der());
+        assert!(matches!(
+            verify_cosign_signature(&pem, b"tampered", &sig_b64),
+            Err(VerifyError::SignatureVerify)
+        ));
+    }
+
+    #[test]
+    fn malformed_pem_rejected() {
+        assert!(matches!(
+            verify_cosign_signature("not a pem", b"payload", "ignored"),
+            Err(VerifyError::InvalidPemKey)
+        ));
+    }
+
+    #[test]
+    fn companion_tag_shape() {
+        assert_eq!(
+            companion_sig_tag("sha256:abc123"),
+            Some("sha256-abc123.sig".to_string())
+        );
+        assert_eq!(companion_sig_tag("bare-tag"), None);
+    }
+
+    #[test]
+    fn extracts_layer_annotation() {
+        let m = serde_json::json!({
+            "layers": [{
+                "digest": "sha256:deadbeef",
+                "annotations": {
+                    "dev.cosignproject.cosign/signature": "sig-b64"
+                }
+            }]
+        });
+        assert_eq!(
+            extract_signature_annotation(&m),
+            Some(("sha256:deadbeef".into(), "sig-b64".into()))
+        );
+    }
+
+    #[test]
+    fn parses_payload_referenced_digest() {
+        let p = br#"{"critical":{"image":{"docker-manifest-digest":"sha256:target"}}}"#;
+        assert_eq!(referenced_image_digest(p).as_deref(), Some("sha256:target"));
+    }
+}

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -216,7 +216,16 @@ pub struct RepositoryCreationTemplate {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SigningConfiguration {
+    /// Raw rule payload from `PutSigningConfiguration`. Round-trippable
+    /// via `GetSigningConfiguration` even when a rule specifies a
+    /// key algorithm we can't verify against.
     pub rules: Vec<Value>,
+    /// PEM-parsed public keys that `DescribeImageSigningStatus` will
+    /// use to verify companion cosign signatures. Populated lazily
+    /// from `rules` at `PutSigningConfiguration` time; unrecognised
+    /// rule shapes just leave this empty.
+    #[serde(default)]
+    pub trusted_keys: Vec<crate::signing::TrustedKey>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Batch 4. Real signature verification on `DescribeImageSigningStatus`.

- `signing` module parses PEM public keys, verifies DER ECDSA-P256 signatures against cosign simple-signing payloads.
- `SigningConfiguration.trusted_keys` stored alongside raw `rules` passthrough. PEMs validated at put time.
- `DescribeImageSigningStatus` walks the `sha256-<digest>.sig` companion manifest, parses the annotation, verifies against trusted keys.
- Response carries new `signingStatus: SIGNED | UNSIGNED | UNVERIFIED | INVALID_SIGNATURE` + populated `imageSignatures` array.
- p256 0.13 added as ECR dep. No Rekor / keyless / Notation — scoped out.

## Test plan

- [x] 6 signing unit tests
- [x] 3 E2E tests — signed flow, unsigned flow, bad-PEM rejection
- [x] ECR regression suites — no regressions
- [x] clippy + fmt clean
- [ ] CI + Cubic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add real cosign signature verification to ECR. DescribeImageSigningStatus now validates ECDSA-P256 signatures from the companion `.sig` manifest against trusted keys and returns SIGNED, UNSIGNED, UNVERIFIED, or INVALID_SIGNATURE.

- **New Features**
  - New `signing` module: parses PEM PKCS8 P-256 public keys, verifies DER ECDSA signatures, extracts cosign annotation, and checks the payload references the image digest.
  - `SigningConfiguration` now stores `trusted_keys` parsed from raw `rules`; PEMs are validated on PutSigningConfiguration.
  - DescribeImageSigningStatus reads `sha256-<hex>.sig`, loads the simple-signing payload, verifies against trusted keys, and fills `imageSignatures` (format COSIGN).
  - Out of scope: Rekor, keyless/Fulcio, Notation.
  - Tests: 6 unit + 3 E2E (signed flow, unsigned flow, bad-PEM rejection).

- **Dependencies**
  - Add `p256` 0.13 (features: `ecdsa`, `pem`, `pkcs8`) to `fakecloud-ecr` and e2e.

<sup>Written for commit 4ef005cfafb1e7131f84d69dfe59025722b24ebf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

