### PR TITLE
fix(ecs): honor containerDefinition.entryPoint in docker run

### DIFF
--- a/crates/fakecloud-e2e/tests/ecr_cross_service.rs
+++ b/crates/fakecloud-e2e/tests/ecr_cross_service.rs
@@ -97,6 +97,34 @@ async fn run_docker(args: &[&str]) {
     }
 }
 
+/// `docker pull` against `public.ecr.aws` is rate-limited per IP
+/// (1 req/sec anonymous). Shared CI runner IPs hit `toomanyrequests`
+/// often enough that a single attempt is flaky. Retry with exponential
+/// backoff so a transient rate-limit doesn't fail the whole suite.
+async fn run_docker_pull_with_retry(image: &str) {
+    let mut last_err = String::new();
+    for attempt in 0..6 {
+        if attempt > 0 {
+            let delay = 5u64 * (1u64 << (attempt - 1)).min(8);
+            tokio::time::sleep(Duration::from_secs(delay)).await;
+        }
+        let out = Command::new("docker")
+            .args(["pull", "--quiet", image])
+            .output()
+            .await
+            .expect("spawn docker");
+        if out.status.success() {
+            return;
+        }
+        last_err = String::from_utf8_lossy(&out.stderr).to_string();
+        if !last_err.contains("toomanyrequests") && !last_err.contains("Rate exceeded") {
+            // Hard failure that retries won't fix.
+            panic!("docker pull {image} failed: stderr={last_err}");
+        }
+    }
+    panic!("docker pull {image} rate-limited after 6 attempts: stderr={last_err}");
+}
+
 /// Seed fakecloud ECR with a minimal alpine image under `repo:tag`.
 /// Returns the AWS-style ECR URI that consumers (ECS/Lambda) will
 /// reference.
@@ -105,7 +133,7 @@ async fn seed_image(endpoint: &str, repo: &str, tag: &str) -> String {
     let local_uri = format!("127.0.0.1:{port}/{repo}:{tag}");
     let aws_uri = format!("{AWS_ACCOUNT}.dkr.ecr.{AWS_REGION}.amazonaws.com/{repo}:{tag}");
 
-    run_docker(&["pull", "--quiet", SEED_IMAGE]).await;
+    run_docker_pull_with_retry(SEED_IMAGE).await;
     run_docker(&["tag", SEED_IMAGE, &local_uri]).await;
 
     // Write a docker config.json with Basic auth for our registry port.

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -183,7 +183,7 @@ impl EcsRuntime {
         task_id: &str,
         account_id: &str,
     ) -> Result<(), RuntimeError> {
-        let (image, mut env, command, awslogs_container, secrets_refs, has_task_role) = {
+        let (image, mut env, entry_point, command, awslogs_container, secrets_refs, has_task_role) = {
             let accounts = state.read();
             let s = accounts
                 .get(account_id)
@@ -211,6 +211,16 @@ impl EcsRuntime {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let str_array = |key: &str| -> Vec<String> {
+                def.as_ref()
+                    .and_then(|d| d.get(key).and_then(|v| v.as_array()).cloned())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            };
             (
                 container.image.clone(),
                 def.as_ref()
@@ -225,14 +235,8 @@ impl EcsRuntime {
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default(),
-                def.as_ref()
-                    .and_then(|d| d.get("command").and_then(|v| v.as_array()).cloned())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default(),
+                str_array("entryPoint"),
+                str_array("command"),
                 container.name.clone(),
                 secrets,
                 task.task_role_arn.is_some(),
@@ -329,7 +333,18 @@ impl EcsRuntime {
                 .replace("https://localhost:", "https://host.docker.internal:");
             cmd.arg("-e").arg(format!("{}={}", k, transformed));
         }
+        // `containerDefinition.entryPoint` overrides the image's ENTRYPOINT.
+        // Docker CLI's `--entrypoint` only takes a single executable; any
+        // additional entryPoint elements are appended as positional args
+        // before the user-supplied `command[]`, which matches how docker
+        // composes ENTRYPOINT + CMD at exec time.
+        if let Some(first) = entry_point.first() {
+            cmd.args(["--entrypoint", first]);
+        }
         cmd.arg(&run_image);
+        for arg in entry_point.iter().skip(1) {
+            cmd.arg(arg);
+        }
         for arg in &command {
             cmd.arg(arg);
         }


### PR DESCRIPTION
## Summary

- ECS runtime read `command[]` but silently dropped `entryPoint[]`. `docker run <image> <command...>` exec'd the first arg (typically `-c`) as the program — empty stdout, exit 0.
- `ecr_push_then_ecs_run_task_pulls_image` has been red on every E2E run since PR #726 because of this. The test sets `entry_point("/bin/sh")` and `command("-c")` / `command("echo from-ecr ...")`; without `--entrypoint` the container produces no logs and the `from-ecr` assertion fails.
- Fix: read `entryPoint` from the container definition and forward it via docker `--entrypoint <first>` plus any remaining elements as positional args before `command[]`. Matches docker's ENTRYPOINT + CMD composition.

## Test plan

- [x] `cargo check -p fakecloud-ecs`
- [x] `cargo clippy -p fakecloud-ecs --all-targets`
- [x] `cargo fmt --check -p fakecloud-ecs`
- [ ] CI E2E general-1 (the partition that runs `ecr_cross_service`) goes green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `containerDefinition.entryPoint` when running ECS tasks by passing the first element to `docker run` as `--entrypoint` and inserting remaining elements before `command[]`. Restores Docker ENTRYPOINT+CMD behavior (e.g., `/bin/sh -c ...`), fixes `ecr_push_then_ecs_run_task_pulls_image`, and adds exponential-backoff retries to the seed `docker pull` to avoid public ECR rate limits.

<sup>Written for commit 62f5bd4fee6e146f4e06bfd46b58d9526ce52831. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

