### PR TITLE
feat(lambda): async destinations on InvocationType=Event

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda_destinations.rs
+++ b/crates/fakecloud-e2e/tests/lambda_destinations.rs
@@ -1,0 +1,268 @@
+//! Lambda async invocations route their result to the configured
+//! OnSuccess/OnFailure destination (SQS / SNS / EventBridge / Lambda).
+//! Test gates on Docker since real Lambda execution is required.
+
+mod helpers;
+
+use std::time::Duration;
+
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{
+    DestinationConfig as LambdaDestinationConfig, FunctionCode, InvocationType,
+    OnFailure as LambdaOnFailure, OnSuccess as LambdaOnSuccess, Runtime,
+};
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn build_python_handler_zip(body: &str) -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::FileOptions<'_, ()> =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("index.py", opts).unwrap();
+        zip.write_all(body.as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}
+
+#[tokio::test]
+async fn lambda_async_invoke_routes_on_success_to_sqs() {
+    if !docker_available() {
+        eprintln!("docker required for Lambda execution; skipping");
+        return;
+    }
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+    let iam = server.iam_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q = sqs
+        .create_queue()
+        .queue_name("destinations-success")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = q.queue_url().unwrap().to_string();
+    let queue_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    iam.create_role()
+        .role_name("dest-success-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+    let zip_bytes = build_python_handler_zip(
+        "def handler(event, context):\n    return {'ok': True, 'echo': event}\n",
+    );
+    lambda
+        .create_function()
+        .function_name("dest-success-fn")
+        .runtime(Runtime::Python311)
+        .role("arn:aws:iam::123456789012:role/dest-success-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(zip_bytes.into()).build())
+        .send()
+        .await
+        .unwrap();
+
+    lambda
+        .put_function_event_invoke_config()
+        .function_name("dest-success-fn")
+        .destination_config(
+            LambdaDestinationConfig::builder()
+                .on_success(LambdaOnSuccess::builder().destination(&queue_arn).build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    lambda
+        .invoke()
+        .function_name("dest-success-fn")
+        .invocation_type(InvocationType::Event)
+        .payload(Blob::new(br#"{"hello":"world"}"#.as_slice()))
+        .send()
+        .await
+        .unwrap();
+
+    // SQS receive — destination record should arrive shortly.
+    let mut saw = false;
+    for _ in 0..30 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        for m in recv.messages() {
+            let body = m.body().unwrap_or("");
+            let v: serde_json::Value = match serde_json::from_str(body) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if v["requestContext"]["condition"].as_str() == Some("Success")
+                && v["responsePayload"]["ok"].as_bool() == Some(true)
+            {
+                saw = true;
+            }
+        }
+        if saw {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        saw,
+        "expected OnSuccess destination record on SQS for async invoke"
+    );
+}
+
+#[tokio::test]
+async fn lambda_async_invoke_routes_on_failure_to_sns() {
+    if !docker_available() {
+        eprintln!("docker required for Lambda execution; skipping");
+        return;
+    }
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+    let iam = server.iam_client().await;
+    let sqs = server.sqs_client().await;
+    let sns = server.sns_client().await;
+
+    // SNS topic + SQS subscription so we can read what landed.
+    let topic = sns
+        .create_topic()
+        .name("dest-failure-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+    let q = sqs
+        .create_queue()
+        .queue_name("dest-failure-q")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = q.queue_url().unwrap().to_string();
+    let queue_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    iam.create_role()
+        .role_name("dest-failure-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+    let zip_bytes =
+        build_python_handler_zip("def handler(event, context):\n    raise Exception('boom')\n");
+    lambda
+        .create_function()
+        .function_name("dest-failure-fn")
+        .runtime(Runtime::Python311)
+        .role("arn:aws:iam::123456789012:role/dest-failure-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(zip_bytes.into()).build())
+        .send()
+        .await
+        .unwrap();
+    lambda
+        .put_function_event_invoke_config()
+        .function_name("dest-failure-fn")
+        .destination_config(
+            LambdaDestinationConfig::builder()
+                .on_failure(LambdaOnFailure::builder().destination(&topic_arn).build())
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    lambda
+        .invoke()
+        .function_name("dest-failure-fn")
+        .invocation_type(InvocationType::Event)
+        .payload(Blob::new(br#"{}"#.as_slice()))
+        .send()
+        .await
+        .unwrap();
+
+    let mut saw = false;
+    for _ in 0..30 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        for m in recv.messages() {
+            let body = m.body().unwrap_or("");
+            let env: serde_json::Value = match serde_json::from_str(body) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let inner_str = env.get("Message").and_then(|v| v.as_str()).unwrap_or("");
+            let inner: serde_json::Value =
+                serde_json::from_str(inner_str).unwrap_or(serde_json::Value::Null);
+            if inner["requestContext"]["condition"].as_str() == Some("RetriesExhausted") {
+                saw = true;
+            }
+        }
+        if saw {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        saw,
+        "expected OnFailure destination record on SNS for async invoke that errored"
+    );
+}

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -218,12 +218,12 @@ fn route_to_destination(
             let _ = bus.invoke_lambda(&dest, &payload).await;
         });
     } else if dest.contains(":events:") || dest.contains(":eventbridge:") {
-        bus.put_event_to_eventbridge(
-            "lambda",
-            "Lambda Function Invocation Result - Success",
-            &body,
-            "default",
-        );
+        let detail_type = if matches!(result, Ok(_)) {
+            "Lambda Function Invocation Result - Success"
+        } else {
+            "Lambda Function Invocation Result - Failure"
+        };
+        bus.put_event_to_eventbridge("lambda", detail_type, &body, "default");
     }
 }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -218,7 +218,7 @@ fn route_to_destination(
             let _ = bus.invoke_lambda(&dest, &payload).await;
         });
     } else if dest.contains(":events:") || dest.contains(":eventbridge:") {
-        let detail_type = if matches!(result, Ok(_)) {
+        let detail_type = if result.is_ok() {
             "Lambda Function Invocation Result - Success"
         } else {
             "Lambda Function Invocation Result - Failure"

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -138,11 +138,101 @@ impl CreateFunctionInput {
     }
 }
 
+/// AWS Lambda's InvocationType: synchronous, async (event), or dry-run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationType {
+    RequestResponse,
+    Event,
+    DryRun,
+}
+
+impl InvocationType {
+    pub fn from_header(value: Option<&str>) -> Self {
+        match value {
+            Some("Event") => Self::Event,
+            Some("DryRun") => Self::DryRun,
+            _ => Self::RequestResponse,
+        }
+    }
+}
+
+/// Route an async-invoke result to the configured OnSuccess / OnFailure
+/// destination. Destination is matched by ARN scheme: SQS, SNS, EventBridge,
+/// or another Lambda. Mirrors the AWS Lambda destinations record schema.
+fn route_to_destination(
+    bus: Arc<fakecloud_core::delivery::DeliveryBus>,
+    function_arn: &str,
+    request_payload: &[u8],
+    result: &Result<Vec<u8>, String>,
+    destination_config: Option<&serde_json::Value>,
+) {
+    let Some(cfg) = destination_config else {
+        return;
+    };
+    let (key, condition, response_value): (&str, &str, serde_json::Value) = match result {
+        Ok(bytes) => (
+            "OnSuccess",
+            "Success",
+            serde_json::from_slice(bytes).unwrap_or(serde_json::Value::Null),
+        ),
+        Err(err) => (
+            "OnFailure",
+            "RetriesExhausted",
+            serde_json::json!({ "errorMessage": err }),
+        ),
+    };
+    let Some(dest) = cfg
+        .get(key)
+        .and_then(|v| v.get("Destination"))
+        .and_then(|v| v.as_str())
+    else {
+        return;
+    };
+    let request_payload_v: serde_json::Value =
+        serde_json::from_slice(request_payload).unwrap_or(serde_json::Value::Null);
+    let record = serde_json::json!({
+        "version": "1.0",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "requestContext": {
+            "requestId": uuid::Uuid::new_v4().to_string(),
+            "functionArn": format!("{function_arn}:$LATEST"),
+            "condition": condition,
+            "approximateInvokeCount": 1,
+        },
+        "requestPayload": request_payload_v,
+        "responseContext": {
+            "statusCode": 200,
+            "executedVersion": "$LATEST",
+        },
+        "responsePayload": response_value,
+    });
+    let body = record.to_string();
+    if dest.contains(":sqs:") {
+        bus.send_to_sqs(dest, &body, &std::collections::HashMap::new());
+    } else if dest.contains(":sns:") {
+        bus.publish_to_sns(dest, &body, None);
+    } else if dest.contains(":lambda:") {
+        let dest = dest.to_string();
+        let payload = body.clone();
+        tokio::spawn(async move {
+            let _ = bus.invoke_lambda(&dest, &payload).await;
+        });
+    } else if dest.contains(":events:") || dest.contains(":eventbridge:") {
+        bus.put_event_to_eventbridge(
+            "lambda",
+            "Lambda Function Invocation Result - Success",
+            &body,
+            "default",
+        );
+    }
+}
+
 pub struct LambdaService {
     pub(crate) state: SharedLambdaState,
     runtime: Option<Arc<ContainerRuntime>>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    pub(crate) delivery_bus: Option<Arc<fakecloud_core::delivery::DeliveryBus>>,
 }
 
 impl LambdaService {
@@ -152,6 +242,7 @@ impl LambdaService {
             runtime: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            delivery_bus: None,
         }
     }
 
@@ -162,6 +253,11 @@ impl LambdaService {
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_delivery_bus(mut self, bus: Arc<fakecloud_core::delivery::DeliveryBus>) -> Self {
+        self.delivery_bus = Some(bus);
         self
     }
 
@@ -785,6 +881,7 @@ impl LambdaService {
         function_name: &str,
         payload: &[u8],
         account_id: &str,
+        invocation_type: InvocationType,
     ) -> Result<AwsResponse, AwsServiceError> {
         let func = {
             let accounts = self.state.read();
@@ -802,14 +899,6 @@ impl LambdaService {
             })?
         };
 
-        let runtime = self.runtime.as_ref().ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "ServiceException",
-                "Docker/Podman is required for Lambda execution but is not available",
-            )
-        })?;
-
         if func.code_zip.is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -818,24 +907,118 @@ impl LambdaService {
             ));
         }
 
-        match runtime.invoke(&func, payload).await {
-            Ok(response_bytes) => {
-                let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
+        if matches!(invocation_type, InvocationType::DryRun) {
+            let mut resp = AwsResponse::json(StatusCode::NO_CONTENT, "");
+            resp.headers.insert(
+                http::header::HeaderName::from_static("x-amz-executed-version"),
+                http::header::HeaderValue::from_static("$LATEST"),
+            );
+            return Ok(resp);
+        }
+
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "ServiceException",
+                "Docker/Podman is required for Lambda execution but is not available",
+            )
+        })?;
+
+        match invocation_type {
+            InvocationType::Event => {
+                // Fire-and-forget. AWS returns 202 with no body.
+                let runtime = runtime.clone();
+                let func_clone = func.clone();
+                let payload_vec = payload.to_vec();
+                let bus = self.delivery_bus.clone();
+                let destination_config = self.lookup_destination_config(&func, account_id);
+                let function_arn = func.function_arn.clone();
+                tokio::spawn(async move {
+                    let result = match runtime.invoke(&func_clone, &payload_vec).await {
+                        Ok(bytes) => {
+                            // Lambda runtime returns 200 even on uncaught
+                            // function errors; the body has errorMessage /
+                            // errorType. Treat that as failure for routing.
+                            let parsed: Option<serde_json::Value> =
+                                serde_json::from_slice(&bytes).ok();
+                            let is_error = parsed
+                                .as_ref()
+                                .and_then(|v| v.as_object())
+                                .map(|m| {
+                                    m.contains_key("errorMessage") || m.contains_key("errorType")
+                                })
+                                .unwrap_or(false);
+                            if is_error {
+                                let msg = parsed
+                                    .as_ref()
+                                    .and_then(|v| v.get("errorMessage"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("function error")
+                                    .to_string();
+                                Err(msg)
+                            } else {
+                                Ok(bytes)
+                            }
+                        }
+                        Err(e) => Err(e.to_string()),
+                    };
+                    if let Some(bus) = bus {
+                        route_to_destination(
+                            bus,
+                            &function_arn,
+                            &payload_vec,
+                            &result,
+                            destination_config.as_ref(),
+                        );
+                    }
+                });
+                let mut resp = AwsResponse::json(StatusCode::ACCEPTED, "");
                 resp.headers.insert(
                     http::header::HeaderName::from_static("x-amz-executed-version"),
                     http::header::HeaderValue::from_static("$LATEST"),
                 );
                 Ok(resp)
             }
-            Err(e) => {
-                tracing::error!(function = %function_name, error = %e, "Lambda invocation failed");
-                Err(AwsServiceError::aws_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "ServiceException",
-                    format!("Lambda execution failed: {e}"),
-                ))
+            InvocationType::RequestResponse | InvocationType::DryRun => {
+                match runtime.invoke(&func, payload).await {
+                    Ok(response_bytes) => {
+                        let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
+                        resp.headers.insert(
+                            http::header::HeaderName::from_static("x-amz-executed-version"),
+                            http::header::HeaderValue::from_static("$LATEST"),
+                        );
+                        Ok(resp)
+                    }
+                    Err(e) => {
+                        tracing::error!(function = %function_name, error = %e, "Lambda invocation failed");
+                        Err(AwsServiceError::aws_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "ServiceException",
+                            format!("Lambda execution failed: {e}"),
+                        ))
+                    }
+                }
             }
         }
+    }
+
+    /// Pull EventInvokeConfig.DestinationConfig for the function. The
+    /// stored key is `<function_name>:<qualifier>`; treat unqualified
+    /// invokes as the empty qualifier (matches `parse_qualifier` in
+    /// `extras.rs` when no `Qualifier` is supplied).
+    fn lookup_destination_config(
+        &self,
+        func: &crate::state::LambdaFunction,
+        account_id: &str,
+    ) -> Option<serde_json::Value> {
+        let accounts = self.state.read();
+        let state = accounts.get(account_id)?;
+        let key = format!("{}:$LATEST", func.function_name);
+        state
+            .event_invoke_configs
+            .get(&key)
+            .map(|cfg| cfg.destination_config.clone())
+            .filter(|v| !v.is_null() && !v.as_object().map(|o| o.is_empty()).unwrap_or(false))
     }
 
     fn publish_version(
@@ -1362,8 +1545,27 @@ impl AwsService for LambdaService {
             ),
             "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or(""), aid),
             "Invoke" => {
-                self.invoke(resource_name.as_deref().unwrap_or(""), &req.body, aid)
-                    .await
+                let invocation_type = InvocationType::from_header(
+                    req.headers
+                        .get("x-amz-invocation-type")
+                        .and_then(|v| v.to_str().ok()),
+                );
+                self.invoke(
+                    resource_name.as_deref().unwrap_or(""),
+                    &req.body,
+                    aid,
+                    invocation_type,
+                )
+                .await
+            }
+            "InvokeAsync" => {
+                self.invoke(
+                    resource_name.as_deref().unwrap_or(""),
+                    &req.body,
+                    aid,
+                    InvocationType::Event,
+                )
+                .await
             }
             "PublishVersion" => self.publish_version(resource_name.as_deref().unwrap_or(""), aid),
             "AddPermission" => self.add_permission(resource_name.as_deref().unwrap_or(""), &req),

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -432,7 +432,7 @@ async fn main() {
     let delivery_for_s3 = {
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
-            .with_sns(sns_delivery)
+            .with_sns(sns_delivery.clone())
             .with_eventbridge(eb_delivery_for_s3);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
@@ -841,6 +841,7 @@ async fn main() {
     let eb_state_for_sfn = eb_state.clone();
     let eb_state_for_scheduler = eb_state.clone();
     let eb_state_for_rds = eb_state.clone();
+    let eb_state_for_lambda = eb_state.clone();
     let mut scheduler = fakecloud_eventbridge::scheduler::Scheduler::new(eb_state, delivery_for_eb)
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
@@ -995,6 +996,27 @@ async fn main() {
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
     }
+    // Async-invoke destinations (OnSuccess/OnFailure) route to SQS / SNS /
+    // EventBridge / Lambda by ARN scheme.
+    let mut lambda_destinations_inner = DeliveryBus::new()
+        .with_sqs(sqs_delivery.clone())
+        .with_sns(sns_delivery.clone());
+    if let Some(ref ld) = lambda_delivery {
+        lambda_destinations_inner = lambda_destinations_inner.with_lambda(ld.clone());
+    }
+    let lambda_destinations_bus = Arc::new(
+        lambda_destinations_inner.with_eventbridge(Arc::new(
+            fakecloud_eventbridge::delivery::EventBridgeDeliveryImpl::new(
+                eb_state_for_lambda,
+                Arc::new(
+                    DeliveryBus::new()
+                        .with_sqs(sqs_delivery.clone())
+                        .with_sns(sns_delivery.clone()),
+                ),
+            ),
+        )),
+    );
+    lambda_service = lambda_service.with_delivery_bus(lambda_destinations_bus);
     let lambda_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -22,6 +22,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **DynamoDB Streams -> Lambda** — Event source mapping polls stream records and invokes.
 - **DynamoDB -> Kinesis** — Table changes stream to Kinesis Data Streams.
 - **CloudWatch Logs -> Lambda / Kinesis / SQS** — Subscription filters deliver log events.
+- **Lambda async destinations -> SQS / SNS / EventBridge / Lambda** — `InvocationType=Event` invocations route their result through `OnSuccess` / `OnFailure` using AWS's standard destinations record schema.
 
 **Identity and auth:**
 

--- a/website/content/docs/services/lambda.md
+++ b/website/content/docs/services/lambda.md
@@ -17,6 +17,8 @@ fakecloud implements **85 of 85** Lambda operations at 100% Smithy conformance. 
 - **Aliases and versions** — publish, point aliases at versions
 - **Concurrency controls** — reserved concurrency (recorded, not enforced)
 - **Warm container reuse** — subsequent invocations of the same function reuse the container
+- **Async invoke destinations** — `OnSuccess` / `OnFailure` routes the invocation result to SQS, SNS, EventBridge, or another Lambda by ARN scheme; record matches the AWS destinations schema (`requestContext`, `requestPayload`, `responseContext`, `responsePayload`)
+- **`InvocationType` honored** — `Event` returns 202 and runs in the background, `RequestResponse` blocks for the result, `DryRun` validates without executing
 
 ## Protocol
 


### PR DESCRIPTION
## Summary

Async Lambda invocations were a known PARTIAL: `EventInvokeConfig.DestinationConfig` was stored but never read, so OnSuccess/OnFailure destinations didn't fire. This wires it.

- ARN-scheme routing: SQS / SNS / EventBridge / Lambda destinations
- AWS-shaped record: `{version, timestamp, requestContext{requestId, functionArn, condition, approximateInvokeCount}, requestPayload, responseContext, responsePayload}`
- Detects runtime errors (200 + `errorMessage`/`errorType` body) and routes through OnFailure
- `InvocationType` honored: `Event` -> 202 + background, `RequestResponse` -> sync, `DryRun` -> 204
- `InvokeAsync` (legacy) reuses the new async path

## Test plan

- [x] E2E `lambda_async_invoke_routes_on_success_to_sqs` - SQS destination receives the success record (Docker-gated)
- [x] E2E `lambda_async_invoke_routes_on_failure_to_sns` - SNS destination receives the failure record from a function that raises
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] FilterCriteria, batchItemFailures, StartingPosition, ParallelizationFactor are tracked separately and will land in a follow-up PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Lambda async destinations for `InvocationType=Event` and honors `InvocationType` behavior. Results route to SQS, SNS, EventBridge, or Lambda with AWS’s standard destinations record.

- **New Features**
  - Activate `OnSuccess`/`OnFailure` routing by ARN scheme (SQS, SNS, EventBridge, Lambda).
  - Emit AWS-shaped destinations record: version, timestamp, requestContext, requestPayload, responseContext, responsePayload.
  - Treat runtime errors (200 with `errorMessage`/`errorType`) as failures for routing.
  - Honor `InvocationType`: `Event` → 202 + background execution, `RequestResponse` → sync, `DryRun` → 204; legacy `InvokeAsync` uses the async path.
  - Wire a delivery bus in the server for cross-service routing; add E2E tests (SQS success, SNS failure) and update docs.

- **Bug Fixes**
  - EventBridge destination detail-type now reflects Success or Failure correctly so rules can match both.
  - Simplified result checks using `is_ok()` (no behavior change).

<sup>Written for commit 6ca66d2cbab782b08f9016a487ff14240d8b98ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

