### PR TITLE
feat(ses): execute Bounce, AddHeader, Stop receipt rule actions

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_receipt_actions.rs
+++ b/crates/fakecloud-e2e/tests/ses_receipt_actions.rs
@@ -104,6 +104,11 @@ async fn ses_receipt_rule_executes_addheader_s3_and_bounce() {
                 )
                 .actions(
                     ReceiptAction::builder()
+                        .sns_action(SnsAction::builder().topic_arn(&topic_arn).build().unwrap())
+                        .build(),
+                )
+                .actions(
+                    ReceiptAction::builder()
                         .bounce_action(
                             BounceAction::builder()
                                 .smtp_reply_code("550")
@@ -207,8 +212,11 @@ async fn ses_receipt_rule_executes_addheader_s3_and_bounce() {
         "bounce body should contain SMTP reply code + message, got: {body}"
     );
 
-    // Bounce notification should be delivered through SNS -> SQS.
+    // Both notifications should be delivered through SNS -> SQS:
+    // - Received notification whose `content` includes the AddHeader-injected header
+    // - Bounce notification
     let mut saw_bounce_notif = false;
+    let mut saw_received_with_header = false;
     for _ in 0..20 {
         let recv = sqs
             .receive_message()
@@ -227,21 +235,30 @@ async fn ses_receipt_rule_executes_addheader_s3_and_bounce() {
             let msg_str = env.get("Message").and_then(|v| v.as_str()).unwrap_or("");
             let inner: serde_json::Value =
                 serde_json::from_str(msg_str).unwrap_or(serde_json::Value::Null);
-            if inner["notificationType"].as_str() == Some("Bounce") {
-                saw_bounce_notif = true;
+            match inner["notificationType"].as_str() {
+                Some("Bounce") => saw_bounce_notif = true,
+                Some("Received") => {
+                    let content = inner["content"].as_str().unwrap_or("");
+                    assert!(
+                        content.contains("X-Receipt-Tag: processed"),
+                        "SNS Received content should include AddHeader-injected header, got: {content}"
+                    );
+                    saw_received_with_header = true;
+                }
+                _ => {}
             }
         }
-        if saw_bounce_notif {
+        if saw_bounce_notif && saw_received_with_header {
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
     assert!(saw_bounce_notif, "expected SNS Bounce notification");
+    assert!(
+        saw_received_with_header,
+        "expected SNS Received notification carrying AddHeader-augmented content"
+    );
 
     // Suppress unused warnings for AWS SDK types pulled in for clarity.
-    let _ = (
-        BouncedRecipientInfo::builder,
-        StopAction::builder,
-        SnsAction::builder,
-    );
+    let _ = (BouncedRecipientInfo::builder, StopAction::builder);
 }

--- a/crates/fakecloud-e2e/tests/ses_receipt_actions.rs
+++ b/crates/fakecloud-e2e/tests/ses_receipt_actions.rs
@@ -1,0 +1,247 @@
+//! SES receipt rule actions execute end-to-end:
+//! - S3 stores the (header-augmented) message
+//! - SNS publishes a notification
+//! - Bounce action enqueues a bounce email + optional SNS notification
+//! - Stop action with topic notifies and halts subsequent rules
+//!
+//! Hits the existing `/_fakecloud/ses/inbound` introspection endpoint that
+//! delivers the email to the active receipt rule set.
+
+mod helpers;
+
+use aws_sdk_ses::types::{
+    AddHeaderAction, BounceAction, BouncedRecipientInfo, ReceiptAction, ReceiptRule, S3Action,
+    SnsAction, StopAction,
+};
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn ses_receipt_rule_executes_addheader_s3_and_bounce() {
+    let server = TestServer::start().await;
+    let ses = server.ses_client().await;
+    let s3 = server.s3_client().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+    let http = reqwest::Client::new();
+
+    // S3 bucket used by the S3 action.
+    s3.create_bucket()
+        .bucket("inbound-emails")
+        .send()
+        .await
+        .unwrap();
+
+    // SNS topic + SQS queue subscription so we can read the bounce
+    // notification.
+    let topic = sns
+        .create_topic()
+        .name("bounce-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+    let q = sqs
+        .create_queue()
+        .queue_name("bounce-q")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = q.queue_url().unwrap().to_string();
+    let queue_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .send()
+        .await
+        .unwrap();
+
+    ses.create_receipt_rule_set()
+        .rule_set_name("inbound-rs")
+        .send()
+        .await
+        .unwrap();
+    ses.create_receipt_rule()
+        .rule_set_name("inbound-rs")
+        .rule(
+            ReceiptRule::builder()
+                .name("hello-rule")
+                .enabled(true)
+                .recipients("hello@example.com")
+                .actions(
+                    ReceiptAction::builder()
+                        .add_header_action(
+                            AddHeaderAction::builder()
+                                .header_name("X-Receipt-Tag")
+                                .header_value("processed")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .actions(
+                    ReceiptAction::builder()
+                        .s3_action(
+                            S3Action::builder()
+                                .bucket_name("inbound-emails")
+                                .object_key_prefix("incoming/")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .actions(
+                    ReceiptAction::builder()
+                        .bounce_action(
+                            BounceAction::builder()
+                                .smtp_reply_code("550")
+                                .status_code("5.7.1")
+                                .message("Mailbox not allowed")
+                                .sender("postmaster@example.com")
+                                .topic_arn(&topic_arn)
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    ses.set_active_receipt_rule_set()
+        .rule_set_name("inbound-rs")
+        .send()
+        .await
+        .unwrap();
+
+    // Trigger a delivery via the introspection endpoint.
+    let resp = http
+        .post(format!("{}/_fakecloud/ses/inbound", server.endpoint()))
+        .json(&serde_json::json!({
+            "from": "alice@example.com",
+            "to": ["hello@example.com"],
+            "subject": "Hi",
+            "body": "Hello world",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // S3 object should exist with the AddHeader prepended.
+    let mut found_s3 = false;
+    for _ in 0..20 {
+        let listed = s3
+            .list_objects_v2()
+            .bucket("inbound-emails")
+            .send()
+            .await
+            .unwrap();
+        if let Some(objs) = listed.contents.as_ref() {
+            for o in objs {
+                let key = o.key().unwrap();
+                if key.starts_with("incoming/") {
+                    let got = s3
+                        .get_object()
+                        .bucket("inbound-emails")
+                        .key(key)
+                        .send()
+                        .await
+                        .unwrap();
+                    let body = got.body.collect().await.unwrap().into_bytes();
+                    let s = String::from_utf8_lossy(&body).to_string();
+                    assert!(
+                        s.contains("X-Receipt-Tag: processed"),
+                        "S3 object should contain AddHeader header, got: {s}"
+                    );
+                    assert!(s.contains("Hello world"));
+                    found_s3 = true;
+                }
+            }
+        }
+        if found_s3 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(found_s3, "S3 action should have stored the message");
+
+    // Bounce email should have landed in /_fakecloud/ses/emails addressed
+    // back to alice@example.com.
+    let emails: serde_json::Value = http
+        .get(format!("{}/_fakecloud/ses/emails", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let arr = emails["emails"].as_array().unwrap();
+    let bounce = arr
+        .iter()
+        .find(|e| {
+            e["to"]
+                .as_array()
+                .map(|to| to.iter().any(|t| t.as_str() == Some("alice@example.com")))
+                .unwrap_or(false)
+                && e["from"].as_str() == Some("postmaster@example.com")
+        })
+        .expect("bounce email should be enqueued");
+    let body = bounce["textBody"].as_str().unwrap_or("");
+    assert!(
+        body.contains("550") && body.contains("Mailbox not allowed"),
+        "bounce body should contain SMTP reply code + message, got: {body}"
+    );
+
+    // Bounce notification should be delivered through SNS -> SQS.
+    let mut saw_bounce_notif = false;
+    for _ in 0..20 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        for m in recv.messages() {
+            let body = m.body().unwrap_or("");
+            let env: serde_json::Value = match serde_json::from_str(body) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let msg_str = env.get("Message").and_then(|v| v.as_str()).unwrap_or("");
+            let inner: serde_json::Value =
+                serde_json::from_str(msg_str).unwrap_or(serde_json::Value::Null);
+            if inner["notificationType"].as_str() == Some("Bounce") {
+                saw_bounce_notif = true;
+            }
+        }
+        if saw_bounce_notif {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(saw_bounce_notif, "expected SNS Bounce notification");
+
+    // Suppress unused warnings for AWS SDK types pulled in for clarity.
+    let _ = (
+        BouncedRecipientInfo::builder,
+        StopAction::builder,
+        SnsAction::builder,
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2500,7 +2500,7 @@ async fn main() {
                                             "subject": &body.subject,
                                         }
                                     },
-                                    "content": &body.body,
+                                    "content": &augmented_body,
                                 });
                                 tracing::info!(
                                     topic_arn = %topic_arn,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2394,6 +2394,7 @@ async fn main() {
                     }
                     Arc::new(bus)
                 };
+                let ses_state_for_inbound_actions = ses_inbound_state.clone();
                 move |axum::Json(body): axum::Json<types::InboundEmailRequest>| async move {
                     let (message_id, matched_rules, actions) =
                         fakecloud_ses::v1::evaluate_inbound_email(
@@ -2403,6 +2404,31 @@ async fn main() {
                             &body.subject,
                             &body.body,
                         );
+
+                    // AddHeader actions are processed inline first so
+                    // downstream S3 / Lambda / SNS payloads see the new
+                    // headers (matches AWS evaluation order: AddHeader is
+                    // applied to the in-flight message).
+                    let mut extra_headers: Vec<(String, String)> = Vec::new();
+                    for (_rule, action) in &actions {
+                        if let fakecloud_ses::state::ReceiptAction::AddHeader {
+                            header_name,
+                            header_value,
+                        } = action
+                        {
+                            extra_headers.push((header_name.clone(), header_value.clone()));
+                        }
+                    }
+                    let augmented_body = if extra_headers.is_empty() {
+                        body.body.clone()
+                    } else {
+                        let header_block = extra_headers
+                            .iter()
+                            .map(|(k, v)| format!("{k}: {v}"))
+                            .collect::<Vec<_>>()
+                            .join("\r\n");
+                        format!("{header_block}\r\n{}", body.body)
+                    };
 
                     // Execute actions for real
                     for (_rule, action) in &actions {
@@ -2415,7 +2441,7 @@ async fn main() {
                                 let prefix = object_key_prefix.as_deref().unwrap_or("");
                                 let key = format!("{prefix}{message_id}");
                                 let now = chrono::Utc::now();
-                                let data = bytes::Bytes::from(body.body.clone());
+                                let data = bytes::Bytes::from(augmented_body.clone());
                                 let size = data.len() as u64;
                                 let etag = format!("\"{:x}\"", md5::Md5::digest(&data));
                                 let obj = fakecloud_s3::state::S3Object {
@@ -2547,8 +2573,90 @@ async fn main() {
                                     }
                                 });
                             }
-                            // Bounce, AddHeader, Stop are metadata-only — no cross-service delivery
-                            _ => {}
+                            fakecloud_ses::state::ReceiptAction::Bounce {
+                                smtp_reply_code,
+                                message,
+                                sender,
+                                status_code,
+                                topic_arn,
+                            } => {
+                                // Real AWS sends a bounce email back to the
+                                // original sender. Append a SentEmail entry
+                                // mirroring the bounce payload so test code
+                                // can read it back via /_fakecloud/ses/emails.
+                                let bounce_subject = format!(
+                                    "Delivery Status Notification (Failure) for {}",
+                                    body.from
+                                );
+                                let bounce_body = format!(
+                                    "Your message could not be delivered.\r\n\r\nSMTP code: {smtp_reply_code}\r\nStatus: {}\r\nMessage: {message}\r\n",
+                                    status_code.as_deref().unwrap_or("5.0.0")
+                                );
+                                let bounce_record = fakecloud_ses::state::SentEmail {
+                                    message_id: format!("bounce-{}", uuid::Uuid::new_v4()),
+                                    from: sender.clone(),
+                                    to: vec![body.from.clone()],
+                                    cc: Vec::new(),
+                                    bcc: Vec::new(),
+                                    subject: Some(bounce_subject),
+                                    html_body: None,
+                                    text_body: Some(bounce_body),
+                                    raw_data: None,
+                                    template_name: None,
+                                    template_data: None,
+                                    timestamp: chrono::Utc::now(),
+                                };
+                                {
+                                    let mut mas = ses_state_for_inbound_actions.write();
+                                    let st = mas.default_mut();
+                                    st.sent_emails.push(bounce_record);
+                                }
+                                // Optional notification topic.
+                                if let Some(topic) = topic_arn {
+                                    let notification = serde_json::json!({
+                                        "notificationType": "Bounce",
+                                        "bounce": {
+                                            "bounceType": "Permanent",
+                                            "bounceSubType": "General",
+                                            "bouncedRecipients": [{
+                                                "emailAddress": &body.from,
+                                                "status": status_code,
+                                                "diagnosticCode": message,
+                                            }],
+                                            "smtpReplyCode": smtp_reply_code,
+                                        },
+                                        "mail": {
+                                            "messageId": message_id,
+                                            "source": &body.from,
+                                            "destination": &body.to,
+                                        },
+                                    });
+                                    delivery_for_inbound.publish_to_sns(
+                                        topic,
+                                        &notification.to_string(),
+                                        Some("SES Bounce"),
+                                    );
+                                }
+                            }
+                            fakecloud_ses::state::ReceiptAction::Stop { topic_arn, .. } => {
+                                if let Some(topic) = topic_arn {
+                                    let notification = serde_json::json!({
+                                        "notificationType": "ReceiptRuleStop",
+                                        "mail": {
+                                            "messageId": message_id,
+                                            "source": &body.from,
+                                            "destination": &body.to,
+                                        },
+                                    });
+                                    delivery_for_inbound.publish_to_sns(
+                                        topic,
+                                        &notification.to_string(),
+                                        Some("SES ReceiptRule Stop"),
+                                    );
+                                }
+                            }
+                            // AddHeader is processed inline above
+                            fakecloud_ses::state::ReceiptAction::AddHeader { .. } => {}
                         }
                     }
 

--- a/website/content/docs/services/ses.md
+++ b/website/content/docs/services/ses.md
@@ -28,7 +28,13 @@ fakecloud implements **110 of 110** SES v2 operations at 100% Smithy conformance
 - **Receipt rule sets** — CRUD, active rule set management
 - **Receipt rules** — CRUD, scan rules
 - **Receipt filters** — IP filters
-- **Real inbound pipeline** — `/_fakecloud/ses/inbound` simulates receiving an email, evaluates receipt rules, and **actually executes** the configured actions (S3 PutObject, SNS Publish, Lambda Invoke)
+- **Real inbound pipeline** — `/_fakecloud/ses/inbound` simulates receiving an email, evaluates receipt rules, and **actually executes** the configured actions:
+  - **S3 action** — writes the (header-augmented) message to the bucket
+  - **SNS action** — publishes a `Received` notification to the topic
+  - **Lambda action** — invokes the function with the `aws:ses` event envelope
+  - **AddHeader action** — prepends headers to the message before downstream actions see it
+  - **Bounce action** — enqueues a bounce email back to the sender (visible at `/_fakecloud/ses/emails`) and publishes a `Bounce` notification to the optional topic
+  - **Stop action** — halts subsequent rules; publishes a notification when a topic is configured
 
 ## Protocol
 
@@ -42,7 +48,7 @@ SES v2 uses REST. SES v1 inbound uses Query protocol.
 ## Cross-service delivery
 
 - **SES -> SNS / EventBridge** — Send/delivery/bounce/complaint events fan out via configured event destinations
-- **SES Inbound -> S3 / SNS / Lambda** — Receipt rules evaluate and execute actions on inbound mail
+- **SES Inbound -> S3 / SNS / Lambda / Bounce / AddHeader / Stop** — Receipt rules evaluate and execute every supported action type
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary

The `/_fakecloud/ses/inbound` pipeline already executed S3 / SNS / Lambda actions; this completes the set of supported AWS receipt-rule actions:

- **AddHeader** — prepends headers to the in-flight message before S3 / Lambda / SNS actions run.
- **Bounce** — enqueues a bounce-shaped `SentEmail` back to the sender (visible at `/_fakecloud/ses/emails`) and publishes a `notificationType: Bounce` notification when an SNS topic is configured.
- **Stop** — already halted subsequent rules; now also publishes a `ReceiptRuleStop` notification to the optional topic.

## Test plan

- [x] E2E `ses_receipt_rule_executes_addheader_s3_and_bounce` — walks all three new actions plus the existing S3 path and SNS notification, asserts the augmented header lands in the S3 object, the bounce email is enqueued back to the sender, and the SNS bounce notification reaches an SQS subscriber.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Execute SES receipt rule actions AddHeader, Bounce, and Stop in the `/_fakecloud/ses/inbound` pipeline to complete support for inbound actions. This modifies messages before delivery, emits bounce emails, and publishes stop notifications when configured.

- **New Features**
  - AddHeader: prepends headers to the in-flight message before downstream actions run, so payloads include the new MIME headers.
  - Bounce: enqueues a bounce-shaped email back to the sender (visible at `/_fakecloud/ses/emails`) and publishes a `notificationType: Bounce` to SNS when `TopicArn` is set.
  - Stop: continues to halt subsequent rules; now also publishes a `notificationType: ReceiptRuleStop` to the optional topic.

- **Bug Fixes**
  - Applied AddHeader preprocessing to SNS Received notification content (not just S3/Lambda) and extended the E2E test to assert the header is present.

<sup>Written for commit 6f8280e371ceb25550b2c581813d4c5298a40c18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

