### PR TITLE
feat(iam): PassRole trust-policy enforcement on Lambda + ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | EventBridge Scheduler  |  12 | at/rate/cron, SQS targets, DLQ routing, one-shot self-delete           |
 | Lambda                 |  85 | Real code execution in Docker, 13 runtimes, event source mappings      |
 | DynamoDB               |  57 | Transactions, PartiQL, backups, global tables, streams                 |
-| IAM                    | 176 | Users, roles, policies, groups, instance profiles, OIDC/SAML           |
+| IAM                    | 176 | Users, roles, policies, groups, OIDC/SAML, **PassRole trust enforcement** |
 | STS                    |  11 | AssumeRole, session tokens, federation                                 |
 | SSM                    | 146 | Parameters, documents, commands, maintenance, patch baselines          |
 | Secrets Manager        |  23 | Versioning, rotation via Lambda, replication                           |

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -413,6 +413,62 @@ pub trait ResourcePolicyProvider: Send + Sync {
     fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String>;
 }
 
+/// Failure mode for IAM PassRole trust-policy validation.
+///
+/// Exists in `fakecloud-core` so service crates (Lambda, ECS, …) can
+/// surface a wire-shaped error without taking a dependency on
+/// `fakecloud-iam`. The server crate wires the concrete validator that
+/// reads the IAM state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassRoleError {
+    /// No role with this ARN exists in the IAM state.
+    RoleNotFound(String),
+    /// Role exists but its `AssumeRolePolicyDocument` does not allow the
+    /// service principal to call `sts:AssumeRole`. Real AWS returns
+    /// `InvalidParameterValueException` in this shape.
+    TrustPolicyDenies {
+        role_arn: String,
+        service_principal: String,
+    },
+    /// Role's `AssumeRolePolicyDocument` could not be parsed as JSON.
+    InvalidTrustPolicy(String),
+}
+
+impl std::fmt::Display for PassRoleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RoleNotFound(arn) => write!(f, "role not found: {arn}"),
+            Self::TrustPolicyDenies {
+                role_arn,
+                service_principal,
+            } => write!(
+                f,
+                "Role's trust policy does not allow {service_principal} to assume the role: {role_arn}"
+            ),
+            Self::InvalidTrustPolicy(arn) => {
+                write!(f, "invalid trust policy on role {arn}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PassRoleError {}
+
+/// Validator that checks whether a role can be passed to a given
+/// service. Used by Lambda / ECS / EC2 etc. to reject `CreateFunction`,
+/// `RegisterTaskDefinition`, etc. when the supplied role's trust policy
+/// doesn't allow the service principal — matching the `iam:PassRole`
+/// trust-side behavior real AWS enforces unconditionally (separate from
+/// identity-policy `iam:PassRole`, which sits behind the IAM evaluator).
+pub trait RoleTrustValidator: Send + Sync {
+    fn validate(
+        &self,
+        account_id: &str,
+        role_arn: &str,
+        service_principal: &str,
+    ) -> Result<(), PassRoleError>;
+}
+
 /// Composite [`ResourcePolicyProvider`] that delegates to a list of
 /// sub-providers in order, returning the first `Some` hit.
 ///

--- a/crates/fakecloud-e2e/tests/iam_pass_role.rs
+++ b/crates/fakecloud-e2e/tests/iam_pass_role.rs
@@ -1,0 +1,190 @@
+//! IAM PassRole trust-policy enforcement across services that accept a
+//! role ARN (Lambda CreateFunction, ECS RegisterTaskDefinition / RunTask).
+//!
+//! AWS validates two things when a service is given a role:
+//!   1. caller has `iam:PassRole` on the role (identity-policy half),
+//!   2. role's `AssumeRolePolicyDocument` allows the service principal
+//!      (trust-policy half).
+//!
+//! These tests cover the trust-policy half — the service-side check
+//! that real AWS enforces unconditionally regardless of the caller's
+//! identity policy.
+
+mod helpers;
+
+use aws_sdk_ecs::types::ContainerDefinition;
+use helpers::TestServer;
+
+const LAMBDA_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+const ECS_TASKS_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+const EC2_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ec2.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+async fn create_role(iam: &aws_sdk_iam::Client, name: &str, trust: &str) -> String {
+    iam.create_role()
+        .role_name(name)
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap()
+        .role()
+        .unwrap()
+        .arn()
+        .to_string()
+}
+
+#[tokio::test]
+async fn lambda_create_function_rejects_role_without_lambda_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let lambda = server.lambda_client().await;
+
+    let bad_role = create_role(&iam, "ec2-only-role", EC2_TRUST).await;
+
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    let err = lambda
+        .create_function()
+        .function_name("rejects-bad-role")
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role(bad_role.clone())
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err(
+            "CreateFunction should fail when role's trust policy excludes lambda.amazonaws.com",
+        );
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("trust policy")
+            || msg.contains("InvalidParameterValueException")
+            || msg.contains("lambda.amazonaws.com"),
+        "expected PassRole trust-policy rejection, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn lambda_create_function_accepts_role_with_lambda_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let lambda = server.lambda_client().await;
+
+    let good_role = create_role(&iam, "lambda-exec", LAMBDA_TRUST).await;
+
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    let resp = lambda
+        .create_function()
+        .function_name("trust-policy-ok")
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role(good_role)
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("CreateFunction should succeed when role trusts lambda.amazonaws.com");
+    assert_eq!(resp.function_name(), Some("trust-policy-ok"));
+}
+
+#[tokio::test]
+async fn ecs_register_task_definition_rejects_role_without_ecs_tasks_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let ecs = server.ecs_client().await;
+
+    let bad_role = create_role(&iam, "lambda-only-role", LAMBDA_TRUST).await;
+
+    let cd = ContainerDefinition::builder()
+        .name("app")
+        .image("public.ecr.aws/docker/library/alpine:3.19")
+        .build();
+
+    let err = ecs
+        .register_task_definition()
+        .family("rejects-bad-task-role")
+        .container_definitions(cd)
+        .task_role_arn(bad_role.clone())
+        .send()
+        .await
+        .expect_err("RegisterTaskDefinition should fail when taskRoleArn doesn't trust ecs-tasks.amazonaws.com");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("trust policy")
+            || msg.contains("InvalidParameterException")
+            || msg.contains("ecs-tasks.amazonaws.com"),
+        "expected PassRole trust-policy rejection, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ecs_register_task_definition_accepts_role_with_ecs_tasks_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let ecs = server.ecs_client().await;
+
+    let good_role = create_role(&iam, "ecs-task", ECS_TASKS_TRUST).await;
+    let exec_role = create_role(&iam, "ecs-exec", ECS_TASKS_TRUST).await;
+
+    let cd = ContainerDefinition::builder()
+        .name("app")
+        .image("public.ecr.aws/docker/library/alpine:3.19")
+        .build();
+
+    let resp = ecs
+        .register_task_definition()
+        .family("good-roles")
+        .container_definitions(cd)
+        .task_role_arn(good_role)
+        .execution_role_arn(exec_role)
+        .send()
+        .await
+        .expect("RegisterTaskDefinition should accept ecs-tasks.amazonaws.com-trusting roles");
+    assert_eq!(resp.task_definition().unwrap().family(), Some("good-roles"));
+}
+
+/// Smallest possible zip with a single empty file. Lambda CreateFunction
+/// won't actually invoke the function in this test — we only need the
+/// service to accept the upload and complete the create.
+fn minimal_zip() -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+        zip.start_file("index.sh", opts).unwrap();
+        zip.write_all(b"#!/bin/sh\necho hi\n").unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -126,6 +126,7 @@ pub struct EcsService {
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
     runtime: Option<Arc<crate::runtime::EcsRuntime>>,
+    role_trust_validator: Option<Arc<dyn fakecloud_core::auth::RoleTrustValidator>>,
 }
 
 impl EcsService {
@@ -135,6 +136,7 @@ impl EcsService {
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             runtime: None,
+            role_trust_validator: None,
         }
     }
 
@@ -146,6 +148,28 @@ impl EcsService {
     pub fn with_runtime(mut self, runtime: Arc<crate::runtime::EcsRuntime>) -> Self {
         self.runtime = Some(runtime);
         self
+    }
+
+    pub fn with_role_trust_validator(
+        mut self,
+        validator: Arc<dyn fakecloud_core::auth::RoleTrustValidator>,
+    ) -> Self {
+        self.role_trust_validator = Some(validator);
+        self
+    }
+
+    fn check_pass_role(&self, account_id: &str, role_arn: &str) -> Result<(), AwsServiceError> {
+        let Some(ref validator) = self.role_trust_validator else {
+            return Ok(());
+        };
+        if let Err(err) = validator.validate(account_id, role_arn, "ecs-tasks.amazonaws.com") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                err.to_string(),
+            ));
+        }
+        Ok(())
     }
 
     pub fn state_handle(&self) -> &SharedEcsState {
@@ -831,6 +855,16 @@ impl EcsService {
                 ));
             }
         }
+        // PassRole trust check on the task + execution roles. Real AWS
+        // rejects RegisterTaskDefinition when the role's trust policy
+        // doesn't list `ecs-tasks.amazonaws.com`.
+        if let Some(role_arn) = opt_str(&body, "taskRoleArn") {
+            self.check_pass_role(&request.account_id, role_arn)?;
+        }
+        if let Some(role_arn) = opt_str(&body, "executionRoleArn") {
+            self.check_pass_role(&request.account_id, role_arn)?;
+        }
+
         let tags = parse_tags(&body);
         let requires_compatibilities: Vec<String> = body
             .get("requiresCompatibilities")
@@ -1451,6 +1485,20 @@ impl EcsService {
         let group = opt_str(&body, "group").map(String::from);
         let started_by = opt_str(&body, "startedBy").map(String::from);
         let tags = parse_tags(&body);
+
+        // PassRole trust check on any role overrides supplied via the
+        // overrides.taskRoleArn / overrides.executionRoleArn fields.
+        // The base task definition was already checked at Register time,
+        // but RunTask can override either role and AWS re-validates the
+        // trust policy on every call.
+        if let Some(overrides) = body.get("overrides") {
+            if let Some(role_arn) = opt_str(overrides, "taskRoleArn") {
+                self.check_pass_role(&request.account_id, role_arn)?;
+            }
+            if let Some(role_arn) = opt_str(overrides, "executionRoleArn") {
+                self.check_pass_role(&request.account_id, role_arn)?;
+            }
+        }
 
         let account = request.account_id.clone();
         let runtime = self.runtime.clone();

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -2,6 +2,7 @@ pub mod condition;
 pub mod credential_resolver;
 pub mod evaluator;
 pub mod iam_service;
+pub mod pass_role;
 pub mod persistence;
 pub mod policy_evaluator;
 pub mod policy_validation;

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -47,25 +47,37 @@ fn role_name_from_arn(role_arn: &str) -> Option<&str> {
 }
 
 impl RoleTrustValidator for IamRoleTrustValidator {
+    /// Validate a role's trust policy against a service principal.
+    ///
+    /// fakecloud is intentionally permissive when the role is not
+    /// present in IAM state: real AWS requires the role to exist, but
+    /// long-standing fakecloud tests pass arbitrary role ARNs without
+    /// creating IAM roles first. To keep that test culture working we
+    /// only reject when the role *does* exist *and* its trust policy
+    /// explicitly excludes the calling service principal — the
+    /// high-signal failure mode users actually hit.
     fn validate(
         &self,
         account_id: &str,
         role_arn: &str,
         service_principal: &str,
     ) -> Result<(), PassRoleError> {
-        let name = role_name_from_arn(role_arn)
-            .ok_or_else(|| PassRoleError::RoleNotFound(role_arn.to_string()))?;
+        let Some(name) = role_name_from_arn(role_arn) else {
+            return Ok(());
+        };
 
         let mas = self.state.read();
         let Some(state) = mas.get(account_id) else {
-            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+            return Ok(());
         };
         let Some(role) = state.roles.get(name) else {
-            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+            return Ok(());
         };
 
-        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
-            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
+        let parsed: Value = match serde_json::from_str(&role.assume_role_policy_document) {
+            Ok(v) => v,
+            Err(_) => return Ok(()),
+        };
 
         if trust_policy_allows(&parsed, service_principal) {
             Ok(())

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -1,0 +1,201 @@
+//! IAM PassRole trust-policy validator.
+//!
+//! When a service like Lambda or ECS is given a role to assume, the
+//! caller's `iam:PassRole` permission is one half of the check; the
+//! other half is the role's own trust policy (the
+//! `AssumeRolePolicyDocument`). Real AWS rejects the operation when the
+//! role's trust policy does not include the relevant service principal
+//! in an `Allow` statement, regardless of the caller's identity policy.
+//!
+//! This module implements the trust-policy half via
+//! [`fakecloud_core::auth::RoleTrustValidator`]. The identity-policy
+//! half lives in the existing IAM evaluator and is invoked separately
+//! at the IAM evaluator boundary.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use fakecloud_core::auth::{PassRoleError, RoleTrustValidator};
+
+use crate::state::SharedIamState;
+
+/// `RoleTrustValidator` impl backed by the in-process IAM state.
+pub struct IamRoleTrustValidator {
+    state: SharedIamState,
+}
+
+impl IamRoleTrustValidator {
+    pub fn new(state: SharedIamState) -> Self {
+        Self { state }
+    }
+
+    pub fn shared(state: SharedIamState) -> Arc<dyn RoleTrustValidator> {
+        Arc::new(Self::new(state))
+    }
+}
+
+/// Parse `arn:aws:iam::<account>:role[/<path>]/<name>` into role name.
+/// Returns `None` if the ARN is not an IAM role ARN.
+fn role_name_from_arn(role_arn: &str) -> Option<&str> {
+    // Format: arn:aws:iam::<account>:role/<optional-path>/<name>
+    // Extract the substring after the last "/".
+    let role_part = role_arn.strip_prefix("arn:aws:iam::")?;
+    let (_account, rest) = role_part.split_once(':')?;
+    let role_path = rest.strip_prefix("role/")?;
+    role_path.rsplit('/').next()
+}
+
+impl RoleTrustValidator for IamRoleTrustValidator {
+    fn validate(
+        &self,
+        account_id: &str,
+        role_arn: &str,
+        service_principal: &str,
+    ) -> Result<(), PassRoleError> {
+        let name = role_name_from_arn(role_arn)
+            .ok_or_else(|| PassRoleError::RoleNotFound(role_arn.to_string()))?;
+
+        let mas = self.state.read();
+        let Some(state) = mas.get(account_id) else {
+            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+        };
+        let Some(role) = state.roles.get(name) else {
+            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+        };
+
+        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
+            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
+
+        if trust_policy_allows(&parsed, service_principal) {
+            Ok(())
+        } else {
+            Err(PassRoleError::TrustPolicyDenies {
+                role_arn: role_arn.to_string(),
+                service_principal: service_principal.to_string(),
+            })
+        }
+    }
+}
+
+/// Returns `true` when the trust policy contains an `Allow` statement
+/// with `sts:AssumeRole` in its `Action` list and `Principal.Service`
+/// listing the supplied service principal.
+fn trust_policy_allows(policy: &Value, service_principal: &str) -> bool {
+    let statements = match policy.get("Statement") {
+        Some(Value::Array(arr)) => arr.clone(),
+        Some(stmt) => vec![stmt.clone()],
+        None => return false,
+    };
+
+    for stmt in &statements {
+        let effect = stmt
+            .get("Effect")
+            .and_then(Value::as_str)
+            .unwrap_or("Allow"); // AWS default is Allow when absent.
+        if !effect.eq_ignore_ascii_case("Allow") {
+            continue;
+        }
+        if !action_includes(stmt.get("Action"), "sts:AssumeRole") {
+            continue;
+        }
+        let Some(principal) = stmt.get("Principal") else {
+            continue;
+        };
+        if principal_service_includes(principal, service_principal) {
+            return true;
+        }
+    }
+    false
+}
+
+fn action_includes(action: Option<&Value>, target: &str) -> bool {
+    match action {
+        Some(Value::String(s)) => s == target || s == "*",
+        Some(Value::Array(arr)) => arr.iter().any(|v| match v {
+            Value::String(s) => s == target || s == "*",
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+fn principal_service_includes(principal: &Value, service_principal: &str) -> bool {
+    let Some(svc) = principal.get("Service") else {
+        return false;
+    };
+    match svc {
+        Value::String(s) => s == service_principal,
+        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(service_principal)),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allow(service: &str) -> Value {
+        serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": service}
+            }]
+        })
+    }
+
+    #[test]
+    fn parses_role_name_from_arn() {
+        assert_eq!(
+            role_name_from_arn("arn:aws:iam::000000000000:role/MyRole"),
+            Some("MyRole")
+        );
+        assert_eq!(
+            role_name_from_arn("arn:aws:iam::000000000000:role/service-role/MyRole"),
+            Some("MyRole")
+        );
+        assert_eq!(role_name_from_arn("not-an-arn"), None);
+    }
+
+    #[test]
+    fn allows_matching_service_principal() {
+        assert!(trust_policy_allows(
+            &allow("lambda.amazonaws.com"),
+            "lambda.amazonaws.com"
+        ));
+    }
+
+    #[test]
+    fn rejects_other_service_principal() {
+        assert!(!trust_policy_allows(
+            &allow("ec2.amazonaws.com"),
+            "lambda.amazonaws.com"
+        ));
+    }
+
+    #[test]
+    fn allows_array_principal() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": ["sts:AssumeRole"],
+                "Principal": {"Service": ["lambda.amazonaws.com", "ec2.amazonaws.com"]}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));
+    }
+
+    #[test]
+    fn rejects_deny_statement() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Deny",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "lambda.amazonaws.com"}
+            }]
+        });
+        assert!(!trust_policy_allows(&policy, "lambda.amazonaws.com"));
+    }
+}

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -121,12 +121,28 @@ fn action_includes(action: Option<&Value>, target: &str) -> bool {
 }
 
 fn principal_service_includes(principal: &Value, service_principal: &str) -> bool {
+    // `"Principal": "*"` (or the equivalent `{"AWS": "*"}`) trusts any
+    // principal — service principals included.
+    if let Value::String(s) = principal {
+        return s == "*";
+    }
+    if let Some(aws) = principal.get("AWS") {
+        match aws {
+            Value::String(s) if s == "*" => return true,
+            Value::Array(arr) if arr.iter().any(|v| v.as_str() == Some("*")) => return true,
+            _ => {}
+        }
+    }
     let Some(svc) = principal.get("Service") else {
         return false;
     };
     match svc {
-        Value::String(s) => s == service_principal,
-        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(service_principal)),
+        Value::String(s) => s == "*" || s == service_principal,
+        Value::Array(arr) => arr.iter().any(|v| match v.as_str() {
+            Some("*") => true,
+            Some(p) => p == service_principal,
+            None => false,
+        }),
         _ => false,
     }
 }
@@ -182,6 +198,42 @@ mod tests {
                 "Effect": "Allow",
                 "Action": ["sts:AssumeRole"],
                 "Principal": {"Service": ["lambda.amazonaws.com", "ec2.amazonaws.com"]}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_principal_string() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": "*"
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "lambda.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_principal_aws() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"AWS": "*"}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ecs-tasks.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_service() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "*"}
             }]
         });
         assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -74,10 +74,8 @@ impl RoleTrustValidator for IamRoleTrustValidator {
             return Ok(());
         };
 
-        let parsed: Value = match serde_json::from_str(&role.assume_role_policy_document) {
-            Ok(v) => v,
-            Err(_) => return Ok(()),
-        };
+        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
+            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
 
         if trust_policy_allows(&parsed, service_principal) {
             Ok(())

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -233,6 +233,7 @@ pub struct LambdaService {
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
     pub(crate) delivery_bus: Option<Arc<fakecloud_core::delivery::DeliveryBus>>,
+    pub(crate) role_trust_validator: Option<Arc<dyn fakecloud_core::auth::RoleTrustValidator>>,
 }
 
 impl LambdaService {
@@ -243,6 +244,7 @@ impl LambdaService {
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             delivery_bus: None,
+            role_trust_validator: None,
         }
     }
 
@@ -258,6 +260,14 @@ impl LambdaService {
 
     pub fn with_delivery_bus(mut self, bus: Arc<fakecloud_core::delivery::DeliveryBus>) -> Self {
         self.delivery_bus = Some(bus);
+        self
+    }
+
+    pub fn with_role_trust_validator(
+        mut self,
+        validator: Arc<dyn fakecloud_core::auth::RoleTrustValidator>,
+    ) -> Self {
+        self.role_trust_validator = Some(validator);
         self
     }
 
@@ -727,6 +737,22 @@ impl LambdaService {
     fn create_function(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
         let input = CreateFunctionInput::from_body(&body)?;
+
+        // PassRole trust-policy check: the supplied execution role must
+        // have a trust policy that allows lambda.amazonaws.com to call
+        // sts:AssumeRole. Real AWS rejects with InvalidParameterValueException
+        // when the trust policy doesn't include the service principal.
+        if let Some(ref validator) = self.role_trust_validator {
+            if let Err(err) =
+                validator.validate(&req.account_id, &input.role, "lambda.amazonaws.com")
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    err.to_string(),
+                ));
+            }
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -994,6 +994,9 @@ async fn main() {
     let dynamodb_state_for_register = dynamodb_state.clone();
     let delivery_for_dynamodb_register = delivery_for_dynamodb;
     let mut lambda_service = LambdaService::new(lambda_state.clone());
+    lambda_service = lambda_service.with_role_trust_validator(
+        fakecloud_iam::pass_role::IamRoleTrustValidator::shared(iam_state.clone()),
+    );
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
     }
@@ -1889,6 +1892,9 @@ async fn main() {
             None
         };
     let mut ecs_service = EcsService::new(ecs_state.clone());
+    ecs_service = ecs_service.with_role_trust_validator(
+        fakecloud_iam::pass_role::IamRoleTrustValidator::shared(iam_state.clone()),
+    );
     if let Some(store) = ecs_snapshot_store {
         ecs_service = ecs_service.with_snapshot_store(store);
     }

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -48,6 +48,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.
 - **ECS -> EventBridge** — Task state transitions emit `ECS Task State Change` events on the default bus.
+- **IAM PassRole trust enforcement** — Lambda `CreateFunction` / `UpdateFunctionConfiguration` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
 
 ## Testing a cross-service flow
 

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -48,7 +48,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.
 - **ECS -> EventBridge** — Task state transitions emit `ECS Task State Change` events on the default bus.
-- **IAM PassRole trust enforcement** — Lambda `CreateFunction` / `UpdateFunctionConfiguration` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
+- **IAM PassRole trust enforcement** — Lambda `CreateFunction` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
 
 ## Testing a cross-service flow
 

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -18,7 +18,7 @@ fakecloud implements **176 of 176** IAM operations at 100% Smithy conformance.
 - **Account management** — aliases, password policy, summary
 - **Tags** — on users, roles, policies, and policy versions
 - **Service-linked roles** — CRUD with service name validation
-- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`, `UpdateFunctionConfiguration`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
+- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
 
 ## PassRole trust policy example
 

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -18,6 +18,22 @@ fakecloud implements **176 of 176** IAM operations at 100% Smithy conformance.
 - **Account management** — aliases, password policy, summary
 - **Tags** — on users, roles, policies, and policy versions
 - **Service-linked roles** — CRUD with service name validation
+- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`, `UpdateFunctionConfiguration`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
+
+## PassRole trust policy example
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+For ECS, replace `lambda.amazonaws.com` with `ecs-tasks.amazonaws.com`. Multiple service principals can be granted in one statement using `"Service": ["lambda.amazonaws.com", "ecs-tasks.amazonaws.com"]`.
 
 ## Protocol
 


### PR DESCRIPTION
## Summary

- Real AWS rejects `CreateFunction` / `RegisterTaskDefinition` / `RunTask` when the supplied role's `AssumeRolePolicyDocument` doesn't list the calling service principal — regardless of the caller's identity policy. fakecloud now does the same.
- New `RoleTrustValidator` trait in `fakecloud-core` so service crates emit a wire-shaped error without depending on `fakecloud-iam`. `IamRoleTrustValidator` (in `fakecloud-iam/src/pass_role.rs`) parses the trust policy, walks Allow statements, and matches `Principal.Service` against the supplied service principal.
- Lambda `CreateFunction` rejects roles that don't trust `lambda.amazonaws.com`. ECS `RegisterTaskDefinition` (taskRoleArn + executionRoleArn) and `RunTask` overrides reject roles that don't trust `ecs-tasks.amazonaws.com`. Both raise `InvalidParameterValueException` / `InvalidParameterException`.

## Test plan

- [x] `cargo test -p fakecloud-iam pass_role` — 5 unit tests for trust-policy parsing
- [x] `cargo test -p fakecloud-e2e --test iam_pass_role` — 4 e2e tests (Lambda + ECS, accept + reject)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

The identity-policy half of `iam:PassRole` (caller permission) lives in the existing IAM evaluator and runs at the IAM evaluator boundary; this PR covers the trust-policy half real AWS enforces unconditionally at the service boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces PassRole trust-policy checks in Lambda and ECS. Roles that don’t trust the service principal are rejected; malformed trust policies now fail, while non-role ARNs or missing roles/accounts remain allowed.

- **New Features**
  - Lambda `CreateFunction` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject roles whose `AssumeRolePolicyDocument` excludes `lambda.amazonaws.com` or `ecs-tasks.amazonaws.com`, returning `InvalidParameterValueException` / `InvalidParameterException`.
  - Added `RoleTrustValidator` in `fakecloud-core` and `IamRoleTrustValidator` in `fakecloud-iam`; wired into `fakecloud-lambda`, `fakecloud-ecs`, and server with unit + e2e tests.

- **Bug Fixes**
  - Trust-policy parsing accepts wildcard principals (`"*"` / `{"AWS":"*"}` / `{"Service":"*"}`), matching AWS.
  - Malformed trust policy JSON now rejects PassRole; permissive only when the ARN isn’t an IAM role or the account/role isn’t in state. Docs clarify enforcement is on `CreateFunction` only.

<sup>Written for commit e591a5e629ebcce5b96abcb376abf7ee06737f2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

