### PR TITLE
feat(lambda): ESM FilterCriteria + partial-batch failure + StartingPosition

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | SNS                    |  42 | Fan-out to SQS/Lambda/HTTP, filter policies                            |
 | EventBridge            |  57 | Pattern matching, schedules, archives, replay, API destinations        |
 | EventBridge Scheduler  |  12 | at/rate/cron, SQS targets, DLQ routing, one-shot self-delete           |
-| Lambda                 |  85 | Real code execution in Docker, 13 runtimes, event source mappings      |
+| Lambda                 |  85 | Real Docker, 13 runtimes, ESM with FilterCriteria + partial-batch failure |
 | DynamoDB               |  57 | Transactions, PartiQL, backups, global tables, streams                 |
 | IAM                    | 176 | Users, roles, policies, groups, instance profiles, OIDC/SAML           |
 | STS                    |  11 | AssumeRole, session tokens, federation                                 |

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -549,21 +549,26 @@ async fn sqs_lambda_event_source_mapping() {
 
     // Poll for the post-invoke `aws:sqs` record rather than a fixed
     // sleep — Docker container startup can take >2s in CI and would
-    // race the assertion below.
-    let invocations = loop {
-        let invs = get_lambda_invocations(server.endpoint()).await;
-        let saw_sqs = invs["invocations"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .any(|inv| inv["source"].as_str() == Some("aws:sqs"))
-            })
-            .unwrap_or(false);
-        if saw_sqs {
-            break invs;
+    // race the assertion below. Bound the wait so a stuck poller fails
+    // the test instead of hanging the whole CI job.
+    let invocations = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        loop {
+            let invs = get_lambda_invocations(server.endpoint()).await;
+            let saw_sqs = invs["invocations"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|inv| inv["source"].as_str() == Some("aws:sqs"))
+                })
+                .unwrap_or(false);
+            if saw_sqs {
+                break invs;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    };
+    })
+    .await
+    .expect("timed out waiting for Lambda invocation");
     let inv_list = invocations["invocations"].as_array().unwrap();
     assert!(
         !inv_list.is_empty(),

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -502,15 +502,26 @@ async fn sqs_lambda_event_source_mapping() {
     let queue_arn = get_queue_arn(&sqs, &queue_url).await;
 
     // Create Lambda function
+    // Use a real Python handler so the container runtime returns Ok and
+    // the poller acks the batch. With the post-Cubic correctness fix we
+    // only delete SQS messages on a successful Lambda invocation; an
+    // un-runnable "fake-code" blob would cause the poller to leave the
+    // message visible for retry, which doesn't reflect what the test is
+    // checking.
     lambda
         .create_function()
         .function_name("sqs-processor")
-        .runtime(aws_sdk_lambda::types::Runtime::Nodejs18x)
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
         .role("arn:aws:iam::123456789012:role/lambda-role")
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(aws_sdk_lambda::primitives::Blob::new(b"fake-code"))
+                .zip_file(aws_sdk_lambda::primitives::Blob::new(make_zip(&[(
+                    "index.py",
+                    br#"def handler(event, context):
+    return {"statusCode": 200}
+"#,
+                )])))
                 .build(),
         )
         .send()

--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -547,24 +547,43 @@ async fn sqs_lambda_event_source_mapping() {
         .await
         .unwrap();
 
-    // Wait for the poller to pick it up
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-    // Check that Lambda was invoked
-    let invocations = get_lambda_invocations(server.endpoint()).await;
+    // Poll for the post-invoke `aws:sqs` record rather than a fixed
+    // sleep — Docker container startup can take >2s in CI and would
+    // race the assertion below.
+    let invocations = loop {
+        let invs = get_lambda_invocations(server.endpoint()).await;
+        let saw_sqs = invs["invocations"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .any(|inv| inv["source"].as_str() == Some("aws:sqs"))
+            })
+            .unwrap_or(false);
+        if saw_sqs {
+            break invs;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    };
     let inv_list = invocations["invocations"].as_array().unwrap();
     assert!(
         !inv_list.is_empty(),
         "expected at least one Lambda invocation"
     );
 
-    // Verify the invocation payload contains the SQS message
-    let inv = &inv_list[inv_list.len() - 1];
+    // Verify the invocation payload contains the SQS message. Find the
+    // `aws:sqs`-shaped invocation explicitly: the LambdaDelivery adapter
+    // also records an `aws:lambda:delivery` entry at the start of every
+    // invoke, so under slow Docker startup the last entry can be the
+    // delivery record rather than the post-invoke poller record.
+    let inv = inv_list
+        .iter()
+        .rev()
+        .find(|inv| inv["source"].as_str() == Some("aws:sqs"))
+        .expect("expected an aws:sqs-shaped Lambda invocation payload");
     assert!(inv["functionArn"]
         .as_str()
         .unwrap()
         .contains("sqs-processor"));
-    assert_eq!(inv["source"], "aws:sqs");
     let payload: serde_json::Value =
         serde_json::from_str(inv["payload"].as_str().unwrap()).unwrap();
     assert_eq!(payload["Records"][0]["body"], r#"{"order_id": "12345"}"#);

--- a/crates/fakecloud-e2e/tests/lambda_esm_filter_and_failures.rs
+++ b/crates/fakecloud-e2e/tests/lambda_esm_filter_and_failures.rs
@@ -1,0 +1,193 @@
+//! Lambda event source mapping FilterCriteria + batchItemFailures
+//! semantics. These tests exercise the SQS poller end-to-end without
+//! requiring a real Docker-backed Lambda — the poller records routed
+//! invocations into Lambda state, and FilterCriteria-dropped messages
+//! still get acked off the queue.
+
+mod helpers;
+
+use aws_sdk_lambda::types::{Filter, FilterCriteria as LambdaFilterCriteria};
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+use std::time::Duration;
+
+const MINIMAL_HANDLER: &str = "index.handler";
+
+async fn create_function(lambda: &aws_sdk_lambda::Client, name: &str) -> String {
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    lambda
+        .create_function()
+        .function_name(name)
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role("arn:aws:iam::000000000000:role/lambda-test-role")
+        .handler(MINIMAL_HANDLER)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .function_arn()
+        .unwrap()
+        .to_string()
+}
+
+fn minimal_zip() -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+        zip.start_file("index.sh", opts).unwrap();
+        zip.write_all(b"#!/bin/sh\necho hi\n").unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}
+
+#[tokio::test]
+async fn sqs_filter_criteria_drops_non_matching_messages() {
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+    let sqs = server.sqs_client().await;
+    let http = reqwest::Client::new();
+
+    let function_arn = create_function(&lambda, "filter-fn").await;
+    let queue = sqs
+        .create_queue()
+        .queue_name("filter-q")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let queue_arn = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .unwrap()
+        .get(&QueueAttributeName::QueueArn)
+        .unwrap()
+        .to_string();
+
+    // FilterCriteria: only deliver records whose body decodes to a
+    // JSON object with `action == "process"`.
+    let filter = LambdaFilterCriteria::builder()
+        .filters(
+            Filter::builder()
+                .pattern(r#"{"body": {"action": ["process"]}}"#)
+                .build(),
+        )
+        .build();
+    lambda
+        .create_event_source_mapping()
+        .function_name(&function_arn)
+        .event_source_arn(&queue_arn)
+        .batch_size(10)
+        .filter_criteria(filter)
+        .send()
+        .await
+        .unwrap();
+
+    // Two messages: one matches, one doesn't.
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body(r#"{"action":"process","id":1}"#)
+        .send()
+        .await
+        .unwrap();
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body(r#"{"action":"skip","id":2}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Give the poller a few cycles to evaluate FilterCriteria.
+    // Recorded invocations are appended every time the poller hands a
+    // batch to Lambda — even if the actual Lambda invocation fails for
+    // env-specific reasons (no Docker, missing handler, etc.), the
+    // recorded payload reflects the filter outcome.
+    let mut filter_arr: Vec<serde_json::Value> = Vec::new();
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let resp: serde_json::Value = http
+            .get(format!(
+                "{}/_fakecloud/lambda/invocations",
+                server.endpoint()
+            ))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let arr = resp["invocations"].as_array().cloned().unwrap_or_default();
+        filter_arr = arr
+            .into_iter()
+            .filter(|inv| {
+                inv["functionArn"]
+                    .as_str()
+                    .or_else(|| inv["function_arn"].as_str())
+                    .map(|a| a == function_arn)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !filter_arr.is_empty() {
+            break;
+        }
+    }
+    assert!(
+        !filter_arr.is_empty(),
+        "expected the matching message to be routed to filter-fn at least once"
+    );
+    let saw_skipped = filter_arr.iter().any(|inv| {
+        let payload = inv["payload"].as_str().unwrap_or("");
+        payload.contains("\"action\":\"skip\"") || payload.contains("\"action\": \"skip\"")
+    });
+    assert!(
+        !saw_skipped,
+        "non-matching message must not reach the function via the SQS poller"
+    );
+
+    // The non-matching message must be acked off the queue regardless
+    // of whether the Lambda invoke succeeds. Allow the matching
+    // message to remain in flight — without a real Lambda runtime the
+    // failed invoke causes a retry, which is correct AWS behavior.
+    let mut remaining_bodies: Vec<String> = Vec::new();
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let recv = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(10)
+            .visibility_timeout(0)
+            .send()
+            .await
+            .unwrap();
+        remaining_bodies = recv
+            .messages()
+            .iter()
+            .filter_map(|m| m.body().map(String::from))
+            .collect();
+        if remaining_bodies
+            .iter()
+            .any(|b| b.contains("\"action\":\"skip\""))
+        {
+            break;
+        }
+    }
+    assert!(
+        !remaining_bodies
+            .iter()
+            .any(|b| b.contains("\"action\":\"skip\"")),
+        "non-matching message should have been acked off the queue, but it's still there: {remaining_bodies:?}"
+    );
+
+    let _ = QueueAttributeName::ApproximateNumberOfMessages;
+}

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -1676,6 +1676,31 @@ impl LambdaService {
                 state.region, state.account_id, name
             );
         }
+        if let Some(filters) = body
+            .get("FilterCriteria")
+            .and_then(|v| v.get("Filters"))
+            .and_then(|v| v.as_array())
+        {
+            esm.filter_patterns = filters
+                .iter()
+                .filter_map(|f| f.get("Pattern").and_then(|p| p.as_str()).map(String::from))
+                .collect();
+        }
+        if let Some(types) = body.get("FunctionResponseTypes").and_then(|v| v.as_array()) {
+            esm.function_response_types = types
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(w) = body
+            .get("MaximumBatchingWindowInSeconds")
+            .and_then(|v| v.as_i64())
+        {
+            esm.maximum_batching_window_in_seconds = Some(w);
+        }
+        if let Some(p) = body.get("ParallelizationFactor").and_then(|v| v.as_i64()) {
+            esm.parallelization_factor = Some(p);
+        }
         let body_json = json!({
             "UUID": esm.uuid,
             "FunctionArn": esm.function_arn,

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -1701,7 +1701,7 @@ impl LambdaService {
         if let Some(p) = body.get("ParallelizationFactor").and_then(|v| v.as_i64()) {
             esm.parallelization_factor = Some(p);
         }
-        let body_json = json!({
+        let mut body_json = json!({
             "UUID": esm.uuid,
             "FunctionArn": esm.function_arn,
             "EventSourceArn": esm.event_source_arn,
@@ -1710,6 +1710,31 @@ impl LambdaService {
             "StateTransitionReason": "USER_INITIATED",
             "LastModified": chrono::Utc::now().timestamp() as f64,
         });
+        let obj = body_json.as_object_mut().expect("json! built object");
+        if !esm.filter_patterns.is_empty() {
+            obj.insert(
+                "FilterCriteria".into(),
+                json!({
+                    "Filters": esm
+                        .filter_patterns
+                        .iter()
+                        .map(|p| json!({"Pattern": p}))
+                        .collect::<Vec<_>>(),
+                }),
+            );
+        }
+        if !esm.function_response_types.is_empty() {
+            obj.insert(
+                "FunctionResponseTypes".into(),
+                json!(esm.function_response_types),
+            );
+        }
+        if let Some(w) = esm.maximum_batching_window_in_seconds {
+            obj.insert("MaximumBatchingWindowInSeconds".into(), json!(w));
+        }
+        if let Some(p) = esm.parallelization_factor {
+            obj.insert("ParallelizationFactor".into(), json!(p));
+        }
         ok(body_json)
     }
 

--- a/crates/fakecloud-lambda/src/filter.rs
+++ b/crates/fakecloud-lambda/src/filter.rs
@@ -1,0 +1,238 @@
+//! Lambda event source mapping filter criteria.
+//!
+//! Implements the EventBridge-style JSON pattern subset documented for
+//! Lambda ESM `FilterCriteria`. A record is delivered when *any*
+//! supplied pattern matches; a record is dropped when *every* pattern
+//! fails to match.
+//!
+//! Operators implemented (matches AWS's documented surface):
+//! - exact-string / number / boolean / null match
+//! - `{"exists": bool}` — field presence
+//! - `{"prefix": "..."}` / `{"suffix": "..."}` / `{"equals-ignore-case": "..."}`
+//! - `{"anything-but": value | [values]}`
+//! - `{"numeric": [op, n, op, n, ...]}` with `=`, `<`, `<=`, `>`, `>=`
+//! - SQS body decode: when the pattern contains a top-level `body`
+//!   key whose value is an object, the SQS message body is parsed as
+//!   JSON before pattern matching, mirroring AWS behavior.
+
+use serde_json::Value;
+
+/// Compiled filter set. `patterns` parses the raw `Filters: [{Pattern: "..."}]`
+/// strings into JSON objects once at create time.
+#[derive(Debug, Clone, Default)]
+pub struct FilterSet {
+    patterns: Vec<Value>,
+}
+
+impl FilterSet {
+    /// Build from the raw filter pattern strings stored on
+    /// [`crate::state::EventSourceMapping::filter_patterns`].
+    pub fn from_strings<I, S>(raw: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let patterns = raw
+            .into_iter()
+            .filter_map(|s| serde_json::from_str::<Value>(s.as_ref()).ok())
+            .collect();
+        Self { patterns }
+    }
+
+    /// Returns `true` when the record matches at least one pattern, or
+    /// when the filter set is empty (no filtering = pass-through).
+    pub fn matches(&self, record: &Value) -> bool {
+        if self.patterns.is_empty() {
+            return true;
+        }
+        self.patterns.iter().any(|p| match_value(p, record))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+}
+
+fn match_value(pattern: &Value, value: &Value) -> bool {
+    // An object pattern is either:
+    //  - an operator (`{"exists": ...}`, `{"prefix": "..."}`, ...)
+    //    applied to the current value, or
+    //  - a nested object pattern, applied field-by-field when the
+    //    value is itself an object.
+    if let Value::Object(po) = pattern {
+        if is_operator_object(po) {
+            return apply_operator(po, value);
+        }
+    }
+    match (pattern, value) {
+        (Value::Object(po), Value::Object(vo)) => po.iter().all(|(k, sub_pattern)| {
+            // Treat the "body" field of an SQS-shaped record specially:
+            // patterns under "body" are matched against the JSON-parsed
+            // body string, mirroring how Lambda decodes SQS bodies for
+            // FilterCriteria evaluation.
+            if k == "body" {
+                if let Some(Value::String(s)) = vo.get("body") {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                        return match_value(sub_pattern, &parsed);
+                    }
+                }
+            }
+            match vo.get(k) {
+                Some(v) => match_value(sub_pattern, v),
+                None => match_pattern_against_missing(sub_pattern),
+            }
+        }),
+        (Value::Array(arr), v) => arr.iter().any(|p| match_value(p, v)),
+        (Value::Null, Value::Null) => true,
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        (Value::Number(a), Value::Number(b)) => a == b,
+        (Value::String(a), Value::String(b)) => a == b,
+        _ => false,
+    }
+}
+
+const OPERATOR_KEYS: &[&str] = &[
+    "exists",
+    "prefix",
+    "suffix",
+    "equals-ignore-case",
+    "anything-but",
+    "numeric",
+];
+
+fn is_operator_object(o: &serde_json::Map<String, Value>) -> bool {
+    o.keys().any(|k| OPERATOR_KEYS.contains(&k.as_str()))
+}
+
+fn apply_operator(o: &serde_json::Map<String, Value>, value: &Value) -> bool {
+    o.iter().all(|(op, arg)| match op.as_str() {
+        "exists" => match arg {
+            Value::Bool(true) => !value.is_null(),
+            Value::Bool(false) => value.is_null(),
+            _ => false,
+        },
+        "prefix" => match (arg.as_str(), value.as_str()) {
+            (Some(p), Some(s)) => s.starts_with(p),
+            _ => false,
+        },
+        "suffix" => match (arg.as_str(), value.as_str()) {
+            (Some(p), Some(s)) => s.ends_with(p),
+            _ => false,
+        },
+        "equals-ignore-case" => match (arg.as_str(), value.as_str()) {
+            (Some(p), Some(s)) => p.eq_ignore_ascii_case(s),
+            _ => false,
+        },
+        "anything-but" => match arg {
+            Value::Array(arr) => !arr.iter().any(|v| v == value),
+            other => other != value,
+        },
+        "numeric" => apply_numeric(arg, value),
+        _ => false,
+    })
+}
+
+fn apply_numeric(arg: &Value, value: &Value) -> bool {
+    let Some(n) = value.as_f64() else {
+        return false;
+    };
+    let Some(arr) = arg.as_array() else {
+        return false;
+    };
+    let mut iter = arr.iter();
+    while let (Some(op), Some(num)) = (iter.next(), iter.next()) {
+        let Some(target) = num.as_f64() else {
+            return false;
+        };
+        let ok = match op.as_str() {
+            Some("=") => n == target,
+            Some("<") => n < target,
+            Some("<=") => n <= target,
+            Some(">") => n > target,
+            Some(">=") => n >= target,
+            _ => false,
+        };
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
+fn match_pattern_against_missing(pattern: &Value) -> bool {
+    match pattern {
+        Value::Object(o) => matches!(o.get("exists"), Some(Value::Bool(false))),
+        Value::Array(arr) => arr.iter().any(match_pattern_against_missing),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fs(patterns: &[&str]) -> FilterSet {
+        FilterSet::from_strings(patterns.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn empty_pattern_passes_through() {
+        let f = FilterSet::default();
+        assert!(f.matches(&json!({"any": "thing"})));
+    }
+
+    #[test]
+    fn exact_string_match() {
+        let f = fs(&[r#"{"foo": "bar"}"#]);
+        assert!(f.matches(&json!({"foo": "bar"})));
+        assert!(!f.matches(&json!({"foo": "baz"})));
+    }
+
+    #[test]
+    fn array_of_scalars_is_or() {
+        let f = fs(&[r#"{"foo": ["a", "b"]}"#]);
+        assert!(f.matches(&json!({"foo": "a"})));
+        assert!(f.matches(&json!({"foo": "b"})));
+        assert!(!f.matches(&json!({"foo": "c"})));
+    }
+
+    #[test]
+    fn exists_operator() {
+        let exists_true = fs(&[r#"{"foo": [{"exists": true}]}"#]);
+        assert!(exists_true.matches(&json!({"foo": "x"})));
+        assert!(!exists_true.matches(&json!({"bar": "x"})));
+
+        let exists_false = fs(&[r#"{"foo": [{"exists": false}]}"#]);
+        assert!(!exists_false.matches(&json!({"foo": "x"})));
+        assert!(exists_false.matches(&json!({"bar": "x"})));
+    }
+
+    #[test]
+    fn sqs_body_decode() {
+        let f = fs(&[r#"{"body": {"action": "process"}}"#]);
+        let record = json!({
+            "body": "{\"action\": \"process\", \"id\": 42}",
+        });
+        assert!(f.matches(&record));
+        let other = json!({
+            "body": "{\"action\": \"skip\"}",
+        });
+        assert!(!f.matches(&other));
+    }
+
+    #[test]
+    fn nested_object_match() {
+        let f = fs(&[r#"{"order": {"status": "paid"}}"#]);
+        assert!(f.matches(&json!({"order": {"status": "paid", "id": 1}})));
+        assert!(!f.matches(&json!({"order": {"status": "pending"}})));
+    }
+
+    #[test]
+    fn multiple_patterns_or() {
+        let f = fs(&[r#"{"a": "x"}"#, r#"{"b": "y"}"#]);
+        assert!(f.matches(&json!({"a": "x"})));
+        assert!(f.matches(&json!({"b": "y"})));
+        assert!(!f.matches(&json!({"c": "z"})));
+    }
+}

--- a/crates/fakecloud-lambda/src/filter.rs
+++ b/crates/fakecloud-lambda/src/filter.rs
@@ -26,7 +26,10 @@ pub struct FilterSet {
 
 impl FilterSet {
     /// Build from the raw filter pattern strings stored on
-    /// [`crate::state::EventSourceMapping::filter_patterns`].
+    /// [`crate::state::EventSourceMapping::filter_patterns`]. Patterns
+    /// that fail to parse are logged and dropped; pre-validation at
+    /// [`Self::validate`] (called from `CreateEventSourceMapping`)
+    /// keeps the live data clean.
     pub fn from_strings<I, S>(raw: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -34,9 +37,35 @@ impl FilterSet {
     {
         let patterns = raw
             .into_iter()
-            .filter_map(|s| serde_json::from_str::<Value>(s.as_ref()).ok())
+            .filter_map(|s| match serde_json::from_str::<Value>(s.as_ref()) {
+                Ok(v) => Some(v),
+                Err(err) => {
+                    tracing::warn!(
+                        pattern = s.as_ref(),
+                        error = %err,
+                        "lambda ESM filter pattern is invalid JSON; ignoring this pattern (other patterns still apply)"
+                    );
+                    None
+                }
+            })
             .collect();
         Self { patterns }
+    }
+
+    /// Validate raw filter patterns the same way real AWS rejects bad
+    /// `FilterCriteria` at `CreateEventSourceMapping`. Returns the
+    /// first invalid pattern's parse error so the service can surface
+    /// it as `InvalidParameterValueException`.
+    pub fn validate<I, S>(raw: I) -> Result<(), String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for s in raw {
+            serde_json::from_str::<Value>(s.as_ref())
+                .map_err(|err| format!("FilterCriteria pattern is invalid JSON: {err}"))?;
+        }
+        Ok(())
     }
 
     /// Returns `true` when the record matches at least one pattern, or
@@ -54,40 +83,42 @@ impl FilterSet {
 }
 
 fn match_value(pattern: &Value, value: &Value) -> bool {
-    // An object pattern is either:
-    //  - an operator (`{"exists": ...}`, `{"prefix": "..."}`, ...)
-    //    applied to the current value, or
-    //  - a nested object pattern, applied field-by-field when the
-    //    value is itself an object.
+    // The top-level entry has the value present, so wrap as Some.
+    eval_field(pattern, Some(value))
+}
+
+/// Evaluate `pattern` against an optional `value`. `None` means the
+/// parent object did not contain the key the pattern targets — this
+/// matters for the `exists` operator, which is defined in terms of
+/// field *presence*, not value-is-null.
+fn eval_field(pattern: &Value, value: Option<&Value>) -> bool {
     if let Value::Object(po) = pattern {
         if is_operator_object(po) {
             return apply_operator(po, value);
         }
     }
-    match (pattern, value) {
-        (Value::Object(po), Value::Object(vo)) => po.iter().all(|(k, sub_pattern)| {
-            // Treat the "body" field of an SQS-shaped record specially:
-            // patterns under "body" are matched against the JSON-parsed
-            // body string, mirroring how Lambda decodes SQS bodies for
-            // FilterCriteria evaluation.
-            if k == "body" {
-                if let Some(Value::String(s)) = vo.get("body") {
-                    if let Ok(parsed) = serde_json::from_str::<Value>(s) {
-                        return match_value(sub_pattern, &parsed);
+    match pattern {
+        Value::Object(po) => match value {
+            Some(Value::Object(vo)) => po.iter().all(|(k, sub_pattern)| {
+                if k == "body" {
+                    if let Some(Value::String(s)) = vo.get("body") {
+                        if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                            return eval_field(sub_pattern, Some(&parsed));
+                        }
                     }
                 }
-            }
-            match vo.get(k) {
-                Some(v) => match_value(sub_pattern, v),
-                None => match_pattern_against_missing(sub_pattern),
-            }
-        }),
-        (Value::Array(arr), v) => arr.iter().any(|p| match_value(p, v)),
-        (Value::Null, Value::Null) => true,
-        (Value::Bool(a), Value::Bool(b)) => a == b,
-        (Value::Number(a), Value::Number(b)) => a == b,
-        (Value::String(a), Value::String(b)) => a == b,
-        _ => false,
+                eval_field(sub_pattern, vo.get(k))
+            }),
+            _ => false,
+        },
+        Value::Array(arr) => arr.iter().any(|p| eval_field(p, value)),
+        scalar => match (scalar, value) {
+            (Value::Null, Some(Value::Null)) => true,
+            (Value::Bool(a), Some(Value::Bool(b))) => a == b,
+            (Value::Number(a), Some(Value::Number(b))) => a == b,
+            (Value::String(a), Some(Value::String(b))) => a == b,
+            _ => false,
+        },
     }
 }
 
@@ -104,13 +135,24 @@ fn is_operator_object(o: &serde_json::Map<String, Value>) -> bool {
     o.keys().any(|k| OPERATOR_KEYS.contains(&k.as_str()))
 }
 
-fn apply_operator(o: &serde_json::Map<String, Value>, value: &Value) -> bool {
+fn apply_operator(o: &serde_json::Map<String, Value>, value: Option<&Value>) -> bool {
     o.iter().all(|(op, arg)| match op.as_str() {
-        "exists" => match arg {
-            Value::Bool(true) => !value.is_null(),
-            Value::Bool(false) => value.is_null(),
-            _ => false,
+        // `exists` is the only operator defined in terms of *field
+        // presence*. AWS treats `null` as present, so a literal
+        // `{"foo": null}` matches `{"foo": [{"exists": true}]}`.
+        "exists" => matches!(
+            (arg, value),
+            (Value::Bool(true), Some(_)) | (Value::Bool(false), None)
+        ),
+        op_name => match value {
+            Some(v) => apply_value_operator(op_name, arg, v),
+            None => false,
         },
+    })
+}
+
+fn apply_value_operator(op: &str, arg: &Value, value: &Value) -> bool {
+    match op {
         "prefix" => match (arg.as_str(), value.as_str()) {
             (Some(p), Some(s)) => s.starts_with(p),
             _ => false,
@@ -129,7 +171,7 @@ fn apply_operator(o: &serde_json::Map<String, Value>, value: &Value) -> bool {
         },
         "numeric" => apply_numeric(arg, value),
         _ => false,
-    })
+    }
 }
 
 fn apply_numeric(arg: &Value, value: &Value) -> bool {
@@ -139,12 +181,17 @@ fn apply_numeric(arg: &Value, value: &Value) -> bool {
     let Some(arr) = arg.as_array() else {
         return false;
     };
-    let mut iter = arr.iter();
-    while let (Some(op), Some(num)) = (iter.next(), iter.next()) {
-        let Some(target) = num.as_f64() else {
+    // AWS rejects malformed numeric arrays at create time; defensively
+    // treat odd-length arrays here as a no-match instead of letting
+    // a leftover element silently pass.
+    if arr.len() % 2 != 0 || arr.is_empty() {
+        return false;
+    }
+    for chunk in arr.chunks(2) {
+        let Some(target) = chunk[1].as_f64() else {
             return false;
         };
-        let ok = match op.as_str() {
+        let ok = match chunk[0].as_str() {
             Some("=") => n == target,
             Some("<") => n < target,
             Some("<=") => n <= target,
@@ -157,14 +204,6 @@ fn apply_numeric(arg: &Value, value: &Value) -> bool {
         }
     }
     true
-}
-
-fn match_pattern_against_missing(pattern: &Value) -> bool {
-    match pattern {
-        Value::Object(o) => matches!(o.get("exists"), Some(Value::Bool(false))),
-        Value::Array(arr) => arr.iter().any(match_pattern_against_missing),
-        _ => false,
-    }
 }
 
 #[cfg(test)]
@@ -195,6 +234,31 @@ mod tests {
         assert!(f.matches(&json!({"foo": "a"})));
         assert!(f.matches(&json!({"foo": "b"})));
         assert!(!f.matches(&json!({"foo": "c"})));
+    }
+
+    #[test]
+    fn exists_operator_treats_null_as_present() {
+        let exists_true = fs(&[r#"{"foo": [{"exists": true}]}"#]);
+        // AWS treats `{"foo": null}` as foo-is-present.
+        assert!(exists_true.matches(&json!({"foo": null})));
+        let exists_false = fs(&[r#"{"foo": [{"exists": false}]}"#]);
+        // ...and conversely a missing key is exists:false even though
+        // the value lookup returns the same Null sentinel under the
+        // hood.
+        assert!(exists_false.matches(&json!({})));
+        assert!(!exists_false.matches(&json!({"foo": null})));
+    }
+
+    #[test]
+    fn numeric_odd_length_is_no_match() {
+        let f = fs(&[r#"{"n": [{"numeric": [">", 0, "<"]}]}"#]);
+        assert!(!f.matches(&json!({"n": 5})));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_json() {
+        assert!(FilterSet::validate(["{not json"].iter()).is_err());
+        assert!(FilterSet::validate([r#"{"ok": true}"#].iter()).is_ok());
     }
 
     #[test]

--- a/crates/fakecloud-lambda/src/lib.rs
+++ b/crates/fakecloud-lambda/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod extras;
+pub mod filter;
 pub mod resource_policy;
 pub mod runtime;
 pub mod service;

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1100,6 +1100,37 @@ impl LambdaService {
         let mapping_uuid = uuid::Uuid::new_v4().to_string();
         let now = Utc::now();
 
+        let filter_patterns: Vec<String> = body
+            .get("FilterCriteria")
+            .and_then(|v| v.get("Filters"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|f| f.get("Pattern").and_then(|p| p.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let function_response_types: Vec<String> = body
+            .get("FunctionResponseTypes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let starting_position = body
+            .get("StartingPosition")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let starting_position_timestamp = body
+            .get("StartingPositionTimestamp")
+            .and_then(|v| v.as_f64());
+        let parallelization_factor = body.get("ParallelizationFactor").and_then(|v| v.as_i64());
+        let maximum_batching_window_in_seconds = body
+            .get("MaximumBatchingWindowInSeconds")
+            .and_then(|v| v.as_i64());
+
         let mapping = EventSourceMapping {
             uuid: mapping_uuid.clone(),
             function_arn: function_arn.clone(),
@@ -1112,6 +1143,12 @@ impl LambdaService {
                 "Disabled".to_string()
             },
             last_modified: now,
+            filter_patterns,
+            maximum_batching_window_in_seconds,
+            starting_position,
+            starting_position_timestamp,
+            parallelization_factor,
+            function_response_types,
         };
 
         let response = self.event_source_mapping_json(&mapping);
@@ -1220,14 +1257,42 @@ impl LambdaService {
     }
 
     fn event_source_mapping_json(&self, mapping: &EventSourceMapping) -> Value {
-        json!({
+        let mut out = json!({
             "UUID": mapping.uuid,
             "FunctionArn": mapping.function_arn,
             "EventSourceArn": mapping.event_source_arn,
             "BatchSize": mapping.batch_size,
             "State": mapping.state,
             "LastModified": mapping.last_modified.timestamp_millis() as f64 / 1000.0,
-        })
+        });
+        let obj = out.as_object_mut().expect("json! built object");
+        if !mapping.filter_patterns.is_empty() {
+            obj.insert(
+                "FilterCriteria".into(),
+                json!({
+                    "Filters": mapping.filter_patterns.iter().map(|p| json!({"Pattern": p})).collect::<Vec<_>>(),
+                }),
+            );
+        }
+        if !mapping.function_response_types.is_empty() {
+            obj.insert(
+                "FunctionResponseTypes".into(),
+                json!(mapping.function_response_types),
+            );
+        }
+        if let Some(sp) = &mapping.starting_position {
+            obj.insert("StartingPosition".into(), json!(sp));
+        }
+        if let Some(ts) = mapping.starting_position_timestamp {
+            obj.insert("StartingPositionTimestamp".into(), json!(ts));
+        }
+        if let Some(pf) = mapping.parallelization_factor {
+            obj.insert("ParallelizationFactor".into(), json!(pf));
+        }
+        if let Some(w) = mapping.maximum_batching_window_in_seconds {
+            obj.insert("MaximumBatchingWindowInSeconds".into(), json!(w));
+        }
+        out
     }
 
     /// Grant a permission on a Lambda function by appending a

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1110,6 +1110,14 @@ impl LambdaService {
                     .collect()
             })
             .unwrap_or_default();
+        // AWS rejects malformed FilterCriteria at create time.
+        if let Err(err) = crate::filter::FilterSet::validate(filter_patterns.iter()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                err,
+            ));
+        }
         let function_response_types: Vec<String> = body
             .get("FunctionResponseTypes")
             .and_then(|v| v.as_array())

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1104,33 +1104,47 @@ impl LambdaService {
         // `Pattern` is missing or not a string is a hard error,
         // matching AWS. Doing this before `validate` keeps malformed
         // values from being silently dropped by the lossy serializer.
-        let filter_patterns: Vec<String> =
-            match body.get("FilterCriteria").and_then(|v| v.get("Filters")) {
-                None => Vec::new(),
-                Some(Value::Array(arr)) => {
-                    let mut out = Vec::with_capacity(arr.len());
-                    for f in arr {
-                        match f.get("Pattern") {
-                            Some(Value::String(s)) => out.push(s.clone()),
-                            _ => {
-                                return Err(AwsServiceError::aws_error(
-                                    StatusCode::BAD_REQUEST,
-                                    "InvalidParameterValueException",
-                                    "FilterCriteria.Filters[].Pattern must be a string",
-                                ));
+        // FilterCriteria itself must be an object (or absent) — non-
+        // object values would otherwise be silently dropped by
+        // `Value::get`, masking client bugs.
+        let filter_patterns: Vec<String> = match body.get("FilterCriteria") {
+            None | Some(Value::Null) => Vec::new(),
+            Some(Value::Object(_)) => {
+                match body.get("FilterCriteria").and_then(|v| v.get("Filters")) {
+                    None => Vec::new(),
+                    Some(Value::Array(arr)) => {
+                        let mut out = Vec::with_capacity(arr.len());
+                        for f in arr {
+                            match f.get("Pattern") {
+                                Some(Value::String(s)) => out.push(s.clone()),
+                                _ => {
+                                    return Err(AwsServiceError::aws_error(
+                                        StatusCode::BAD_REQUEST,
+                                        "InvalidParameterValueException",
+                                        "FilterCriteria.Filters[].Pattern must be a string",
+                                    ));
+                                }
                             }
                         }
+                        out
                     }
-                    out
+                    Some(_) => {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterValueException",
+                            "FilterCriteria.Filters must be an array",
+                        ));
+                    }
                 }
-                Some(_) => {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidParameterValueException",
-                        "FilterCriteria.Filters must be an array",
-                    ));
-                }
-            };
+            }
+            Some(_) => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    "FilterCriteria must be an object",
+                ));
+            }
+        };
         // AWS rejects malformed FilterCriteria at create time.
         if let Err(err) = crate::filter::FilterSet::validate(filter_patterns.iter()) {
             return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1100,16 +1100,37 @@ impl LambdaService {
         let mapping_uuid = uuid::Uuid::new_v4().to_string();
         let now = Utc::now();
 
-        let filter_patterns: Vec<String> = body
-            .get("FilterCriteria")
-            .and_then(|v| v.get("Filters"))
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|f| f.get("Pattern").and_then(|p| p.as_str()).map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        // Extract Filters[].Pattern strictly: any entry where
+        // `Pattern` is missing or not a string is a hard error,
+        // matching AWS. Doing this before `validate` keeps malformed
+        // values from being silently dropped by the lossy serializer.
+        let filter_patterns: Vec<String> =
+            match body.get("FilterCriteria").and_then(|v| v.get("Filters")) {
+                None => Vec::new(),
+                Some(Value::Array(arr)) => {
+                    let mut out = Vec::with_capacity(arr.len());
+                    for f in arr {
+                        match f.get("Pattern") {
+                            Some(Value::String(s)) => out.push(s.clone()),
+                            _ => {
+                                return Err(AwsServiceError::aws_error(
+                                    StatusCode::BAD_REQUEST,
+                                    "InvalidParameterValueException",
+                                    "FilterCriteria.Filters[].Pattern must be a string",
+                                ));
+                            }
+                        }
+                    }
+                    out
+                }
+                Some(_) => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValueException",
+                        "FilterCriteria.Filters must be an array",
+                    ));
+                }
+            };
         // AWS rejects malformed FilterCriteria at create time.
         if let Err(err) = crate::filter::FilterSet::validate(filter_patterns.iter()) {
             return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -48,6 +48,31 @@ pub struct EventSourceMapping {
     pub enabled: bool,
     pub state: String,
     pub last_modified: DateTime<Utc>,
+    /// Raw `Filters: [{Pattern: "..."}]` array as supplied via
+    /// `FilterCriteria`. Each pattern is an EventBridge-style JSON
+    /// pattern matched against the record body — non-matching records
+    /// are dropped.
+    #[serde(default)]
+    pub filter_patterns: Vec<String>,
+    /// Wait up to N seconds to accumulate `batch_size` records before
+    /// invoking. Implemented as a deadline check inside the poller.
+    #[serde(default)]
+    pub maximum_batching_window_in_seconds: Option<i64>,
+    /// `LATEST`, `TRIM_HORIZON`, or `AT_TIMESTAMP`. Honored on the
+    /// first poll for stream sources (Kinesis, DDB Streams).
+    #[serde(default)]
+    pub starting_position: Option<String>,
+    /// Optional epoch-second timestamp paired with
+    /// `StartingPosition=AT_TIMESTAMP`.
+    #[serde(default)]
+    pub starting_position_timestamp: Option<f64>,
+    /// Kinesis-only: number of concurrent batch invocations per shard.
+    #[serde(default)]
+    pub parallelization_factor: Option<i64>,
+    /// `["ReportBatchItemFailures"]` to opt into partial-batch failure
+    /// semantics. Empty / unset = entire batch is retried on error.
+    #[serde(default)]
+    pub function_response_types: Vec<String>,
 }
 
 /// A recorded Lambda invocation from cross-service delivery.

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -209,28 +209,29 @@ impl DynamoDbStreamsLambdaPoller {
                 })
                 .collect();
 
-            // Always advance the checkpoint past everything we read,
-            // even if the filter dropped every record.
-            if let Some(seq) = last_seq.clone() {
-                self.checkpoints.write().insert(mapping_id.clone(), seq);
-            }
-
+            // If the filter dropped every record, advance the
+            // checkpoint past them — AWS treats filtered records as
+            // consumed. Otherwise, hold the checkpoint until after a
+            // successful invoke so failures retry on the next poll.
             if event_records.is_empty() {
+                if let Some(seq) = last_seq.clone() {
+                    self.checkpoints.write().insert(mapping_id.clone(), seq);
+                }
                 continue;
             }
 
             let event = json!({ "Records": &event_records });
             let payload = serde_json::to_string(&event).unwrap_or_default();
 
-            // Invoke Lambda
-            if let Some(ref delivery) = self.lambda_delivery {
-                match delivery.invoke_lambda(&function_arn, &payload).await {
+            let invoke_succeeded = match &self.lambda_delivery {
+                Some(delivery) => match delivery.invoke_lambda(&function_arn, &payload).await {
                     Ok(_) => {
                         tracing::info!(
                             function_arn = %function_arn,
                             record_count = event_records.len(),
                             "DynamoDB Streams->Lambda invocation succeeded"
                         );
+                        true
                     }
                     Err(e) => {
                         tracing::error!(
@@ -238,12 +239,23 @@ impl DynamoDbStreamsLambdaPoller {
                             error = %e,
                             "DynamoDB Streams->Lambda invocation failed"
                         );
+                        false
                     }
-                }
-            } else {
-                // No delivery mechanism — record the invocation. The
-                // checkpoint was already advanced earlier so the same
-                // batch isn't reprocessed.
+                },
+                None => true,
+            };
+
+            if !invoke_succeeded {
+                continue;
+            }
+
+            // Successful invoke — advance the checkpoint and record
+            // the invocation when no real Lambda runtime is wired.
+            if let Some(seq) = last_seq.clone() {
+                self.checkpoints.write().insert(mapping_id.clone(), seq);
+            }
+
+            if self.lambda_delivery.is_none() {
                 let mut lambda_accounts = self.lambda_state.write();
                 let lambda = lambda_accounts.default_mut();
                 lambda.invocations.push(LambdaInvocation {

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -13,6 +13,7 @@ use serde_json::json;
 
 use fakecloud_core::delivery::LambdaDelivery;
 use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 
 /// DynamoDB Streams -> Lambda event source mapping poller.
@@ -48,8 +49,18 @@ impl DynamoDbStreamsLambdaPoller {
     }
 
     async fn poll(&self) {
+        struct DdbMapping {
+            uuid: String,
+            stream_arn: String,
+            function_arn: String,
+            batch_size: i64,
+            filter: FilterSet,
+            starting_position: Option<String>,
+            starting_position_timestamp: Option<f64>,
+        }
+
         // Collect enabled mappings that point to DynamoDB streams
-        let mappings: Vec<(String, String, String, i64)> = {
+        let mappings: Vec<DdbMapping> = {
             let lambda_accounts = self.lambda_state.read();
             let lambda = lambda_accounts.default_ref();
             lambda
@@ -60,13 +71,14 @@ impl DynamoDbStreamsLambdaPoller {
                         && m.event_source_arn.contains(":dynamodb:")
                         && m.event_source_arn.contains("/stream/")
                 })
-                .map(|m| {
-                    (
-                        m.uuid.clone(),
-                        m.event_source_arn.clone(),
-                        m.function_arn.clone(),
-                        m.batch_size,
-                    )
+                .map(|m| DdbMapping {
+                    uuid: m.uuid.clone(),
+                    stream_arn: m.event_source_arn.clone(),
+                    function_arn: m.function_arn.clone(),
+                    batch_size: m.batch_size,
+                    filter: FilterSet::from_strings(m.filter_patterns.iter()),
+                    starting_position: m.starting_position.clone(),
+                    starting_position_timestamp: m.starting_position_timestamp,
                 })
                 .collect()
         };
@@ -75,7 +87,16 @@ impl DynamoDbStreamsLambdaPoller {
             return;
         }
 
-        for (mapping_id, stream_arn, function_arn, batch_size) in mappings {
+        for DdbMapping {
+            uuid: mapping_id,
+            stream_arn,
+            function_arn,
+            batch_size,
+            filter,
+            starting_position,
+            starting_position_timestamp,
+        } in mappings
+        {
             // Extract table name from stream ARN
             // Format: arn:aws:dynamodb:region:account:table/TableName/stream/timestamp
             let table_name = if let Some(table_part) = stream_arn.split(":table/").nth(1) {
@@ -84,8 +105,34 @@ impl DynamoDbStreamsLambdaPoller {
                 continue;
             };
 
-            // Get checkpoint for this mapping
-            let checkpoint = self.checkpoints.read().get(&mapping_id).cloned();
+            // AT_TIMESTAMP isn't valid for DDB streams in real AWS;
+            // suppress the field if the user supplied it.
+            let _ = starting_position_timestamp;
+
+            // Initialize the checkpoint based on StartingPosition the
+            // first time we see this mapping. For DDB streams AWS only
+            // accepts TRIM_HORIZON (default — replays existing records)
+            // and LATEST (skip whatever is already in the stream).
+            let checkpoint = {
+                let mut cps = self.checkpoints.write();
+                if !cps.contains_key(&mapping_id) {
+                    let dynamodb_mas = self.dynamodb_state.read();
+                    let dynamodb = dynamodb_mas.default_ref();
+                    if let Some(table) = dynamodb.tables.get(table_name) {
+                        let stream_records = table.stream_records.read();
+                        let init = match starting_position.as_deref().unwrap_or("TRIM_HORIZON") {
+                            "LATEST" => stream_records
+                                .iter()
+                                .map(|r| r.dynamodb.sequence_number.clone())
+                                .max()
+                                .unwrap_or_default(),
+                            _ => String::new(),
+                        };
+                        cps.insert(mapping_id.clone(), init);
+                    }
+                }
+                cps.get(&mapping_id).cloned()
+            };
 
             // Read stream records from DynamoDB
             let records = {
@@ -105,12 +152,9 @@ impl DynamoDbStreamsLambdaPoller {
                 // Filter records after checkpoint
                 let mut filtered: Vec<_> = stream_records
                     .iter()
-                    .filter(|r| {
-                        if let Some(ref cp) = checkpoint {
-                            &r.dynamodb.sequence_number > cp
-                        } else {
-                            true
-                        }
+                    .filter(|r| match checkpoint.as_deref() {
+                        Some(cp) if !cp.is_empty() => r.dynamodb.sequence_number.as_str() > cp,
+                        _ => true,
                     })
                     .take(batch_size.max(0) as usize)
                     .cloned()
@@ -127,9 +171,14 @@ impl DynamoDbStreamsLambdaPoller {
                 continue;
             }
 
-            // Build Lambda event payload
-            let event = json!({
-                "Records": records.iter().map(|record| {
+            // Build per-record Lambda event JSON, then drop any record
+            // whose JSON doesn't match FilterCriteria. AWS treats
+            // filtered-out records as consumed — the checkpoint always
+            // advances past them.
+            let last_seq = records.last().map(|r| r.dynamodb.sequence_number.clone());
+            let event_records: Vec<serde_json::Value> = records
+                .iter()
+                .filter_map(|record| {
                     let mut event_record = json!({
                         "eventID": record.event_id,
                         "eventName": record.event_name,
@@ -152,10 +201,25 @@ impl DynamoDbStreamsLambdaPoller {
                         event_record["dynamodb"]["OldImage"] = json!(old_img);
                     }
 
-                    event_record
-                }).collect::<Vec<_>>()
-            });
+                    if filter.matches(&event_record) {
+                        Some(event_record)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
 
+            // Always advance the checkpoint past everything we read,
+            // even if the filter dropped every record.
+            if let Some(seq) = last_seq.clone() {
+                self.checkpoints.write().insert(mapping_id.clone(), seq);
+            }
+
+            if event_records.is_empty() {
+                continue;
+            }
+
+            let event = json!({ "Records": &event_records });
             let payload = serde_json::to_string(&event).unwrap_or_default();
 
             // Invoke Lambda
@@ -164,17 +228,9 @@ impl DynamoDbStreamsLambdaPoller {
                     Ok(_) => {
                         tracing::info!(
                             function_arn = %function_arn,
-                            record_count = records.len(),
+                            record_count = event_records.len(),
                             "DynamoDB Streams->Lambda invocation succeeded"
                         );
-
-                        // Update checkpoint to last processed sequence number
-                        if let Some(last_record) = records.last() {
-                            self.checkpoints.write().insert(
-                                mapping_id.clone(),
-                                last_record.dynamodb.sequence_number.clone(),
-                            );
-                        }
                     }
                     Err(e) => {
                         tracing::error!(
@@ -185,7 +241,9 @@ impl DynamoDbStreamsLambdaPoller {
                     }
                 }
             } else {
-                // No delivery mechanism, just record
+                // No delivery mechanism — record the invocation. The
+                // checkpoint was already advanced earlier so the same
+                // batch isn't reprocessed.
                 let mut lambda_accounts = self.lambda_state.write();
                 let lambda = lambda_accounts.default_mut();
                 lambda.invocations.push(LambdaInvocation {
@@ -194,13 +252,6 @@ impl DynamoDbStreamsLambdaPoller {
                     timestamp: Utc::now(),
                     source: "dynamodb:streams".to_string(),
                 });
-
-                // Update checkpoint
-                if let Some(last_record) = records.last() {
-                    self.checkpoints
-                        .write()
-                        .insert(mapping_id, last_record.dynamodb.sequence_number.clone());
-                }
             }
         }
     }

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -211,16 +211,14 @@ impl KinesisLambdaPoller {
                     .collect()
             };
 
-            // Advance the checkpoint regardless — AWS treats filtered
-            // records as consumed.
-            {
+            // If the filter dropped every record, advance the
+            // checkpoint past them — AWS treats filtered-out records
+            // as consumed and never retries them.
+            if matched.is_empty() {
                 let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
                 let mut kinesis_accounts = self.kinesis_state.write();
                 let kinesis = kinesis_accounts.get_or_create(account_id);
                 kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, end);
-            }
-
-            if matched.is_empty() {
                 continue;
             }
 
@@ -248,8 +246,18 @@ impl KinesisLambdaPoller {
                 true
             };
 
+            // Only advance the checkpoint after a successful invoke.
+            // A failed invoke leaves the records pending so the next
+            // poll retries them — matches AWS's at-least-once guarantee.
             if !delivered {
                 continue;
+            }
+
+            {
+                let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
+                let mut kinesis_accounts = self.kinesis_state.write();
+                let kinesis = kinesis_accounts.get_or_create(account_id);
+                kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, end);
             }
 
             if !used_real_delivery {

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -1,13 +1,33 @@
+//! Kinesis -> Lambda event source mapping poller.
+//!
+//! Honors:
+//! - `FilterCriteria` — non-matching records are dropped (advanced past).
+//! - `StartingPosition` — `TRIM_HORIZON` (default), `LATEST`, or
+//!   `AT_TIMESTAMP` paired with `StartingPositionTimestamp` to seed
+//!   the per-shard checkpoint on first poll.
+
 use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine;
 use chrono::Utc;
-use serde_json::json;
+use serde_json::{json, Value};
 
 use fakecloud_core::delivery::LambdaDelivery;
 use fakecloud_kinesis::state::SharedKinesisState;
+use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
+
+#[derive(Clone)]
+struct Mapping {
+    uuid: String,
+    function_arn: String,
+    stream_arn: String,
+    batch_size: i64,
+    filter: FilterSet,
+    starting_position: Option<String>,
+    starting_position_timestamp: Option<f64>,
+}
 
 pub struct KinesisLambdaPoller {
     kinesis_state: SharedKinesisState,
@@ -38,7 +58,7 @@ impl KinesisLambdaPoller {
     }
 
     async fn poll(&self) {
-        let mappings: Vec<(String, String, String, i64)> = {
+        let mappings: Vec<Mapping> = {
             let lambda_accounts = self.lambda_state.read();
             lambda_accounts
                 .iter()
@@ -47,13 +67,14 @@ impl KinesisLambdaPoller {
                         .event_source_mappings
                         .values()
                         .filter(|m| m.enabled && m.event_source_arn.contains(":kinesis:"))
-                        .map(|m| {
-                            (
-                                m.uuid.clone(),
-                                m.event_source_arn.clone(),
-                                m.function_arn.clone(),
-                                m.batch_size,
-                            )
+                        .map(|m| Mapping {
+                            uuid: m.uuid.clone(),
+                            function_arn: m.function_arn.clone(),
+                            stream_arn: m.event_source_arn.clone(),
+                            batch_size: m.batch_size,
+                            filter: FilterSet::from_strings(m.filter_patterns.iter()),
+                            starting_position: m.starting_position.clone(),
+                            starting_position_timestamp: m.starting_position_timestamp,
                         })
                         .collect::<Vec<_>>()
                 })
@@ -64,107 +85,183 @@ impl KinesisLambdaPoller {
             return;
         }
 
-        for (mapping_uuid, stream_arn, function_arn, batch_size) in mappings {
-            let deliveries = {
-                let kinesis_accounts = self.kinesis_state.read();
-                // Extract account_id from stream ARN: arn:aws:kinesis:region:ACCOUNT:stream/Name
-                let account_id = stream_arn.split(':').nth(4).unwrap_or("");
-                let kinesis = match kinesis_accounts.get(account_id) {
-                    Some(k) => k,
-                    None => continue,
-                };
-                let stream = match kinesis
-                    .streams
-                    .values()
-                    .find(|s| s.stream_arn == stream_arn)
-                {
-                    Some(stream) => stream,
-                    None => continue,
-                };
+        for mapping in mappings {
+            self.process_mapping(&mapping).await;
+        }
+    }
 
-                let limit = batch_size.max(1) as usize;
+    async fn process_mapping(&self, mapping: &Mapping) {
+        // Compute per-shard deliveries: snapshot current shard
+        // contents, seed missing checkpoints based on StartingPosition,
+        // then collect a batch from each shard up to batch_size.
+        let deliveries = {
+            let mut kinesis_accounts = self.kinesis_state.write();
+            let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
+            let kinesis = match kinesis_accounts.get_mut(account_id) {
+                Some(k) => k,
+                None => return,
+            };
+            let stream_idx = kinesis
+                .streams
+                .iter()
+                .find(|(_, s)| s.stream_arn == mapping.stream_arn)
+                .map(|(name, _)| name.clone());
+            let Some(stream_name) = stream_idx else {
+                return;
+            };
+
+            // Initialize per-shard checkpoints once based on
+            // StartingPosition. Subsequent polls just read what's already
+            // there.
+            let init_pairs: Vec<(String, usize)> = {
+                let stream = kinesis
+                    .streams
+                    .get(&stream_name)
+                    .expect("stream exists, just looked up");
                 stream
                     .shards
                     .iter()
                     .filter_map(|shard| {
-                        let start = kinesis.lambda_checkpoint(&mapping_uuid, &shard.shard_id);
-                        if start >= shard.records.len() {
+                        let key = format!("{}:{}", mapping.uuid, shard.shard_id);
+                        if kinesis.lambda_checkpoints.contains_key(&key) {
                             return None;
                         }
-                        let end = shard.records.len().min(start.saturating_add(limit));
-                        let records = shard.records[start..end].to_vec();
-                        Some((shard.shard_id.clone(), start, end, records))
+                        let init = match mapping
+                            .starting_position
+                            .as_deref()
+                            .unwrap_or("TRIM_HORIZON")
+                        {
+                            "LATEST" => shard.records.len(),
+                            "AT_TIMESTAMP" => {
+                                let target = mapping
+                                    .starting_position_timestamp
+                                    .map(|t| t as i64)
+                                    .unwrap_or(0);
+                                shard
+                                    .records
+                                    .iter()
+                                    .position(|r| {
+                                        r.approximate_arrival_timestamp.timestamp() >= target
+                                    })
+                                    .unwrap_or(shard.records.len())
+                            }
+                            _ => 0, // TRIM_HORIZON
+                        };
+                        Some((shard.shard_id.clone(), init))
                     })
-                    .collect::<Vec<_>>()
+                    .collect()
+            };
+            for (shard_id, init) in init_pairs {
+                kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, init);
+            }
+
+            let stream = kinesis
+                .streams
+                .get(&stream_name)
+                .expect("stream exists, just looked up");
+            let limit = mapping.batch_size.max(1) as usize;
+            stream
+                .shards
+                .iter()
+                .filter_map(|shard| {
+                    let start = kinesis.lambda_checkpoint(&mapping.uuid, &shard.shard_id);
+                    if start >= shard.records.len() {
+                        return None;
+                    }
+                    let end = shard.records.len().min(start.saturating_add(limit));
+                    let records = shard.records[start..end].to_vec();
+                    Some((shard.shard_id.clone(), end, records))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (shard_id, end, records) in deliveries {
+            // Build per-record JSON, then split into matched + dropped
+            // by FilterCriteria. Dropped records still advance the
+            // checkpoint — AWS docs say filtered-out records "do not
+            // count toward batch size and are discarded".
+            let record_jsons: Vec<Value> = records
+                .iter()
+                .map(|record| {
+                    json!({
+                        "awsRegion": "us-east-1",
+                        "eventID": format!("{}:{}", shard_id, record.sequence_number),
+                        "eventName": "aws:kinesis:record",
+                        "eventSource": "aws:kinesis",
+                        "eventSourceARN": mapping.stream_arn,
+                        "eventVersion": "1.0",
+                        "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+                        "kinesis": {
+                            "approximateArrivalTimestamp": record.approximate_arrival_timestamp.timestamp_millis() as f64 / 1000.0,
+                            "data": base64::engine::general_purpose::STANDARD.encode(&record.data),
+                            "kinesisSchemaVersion": "1.0",
+                            "partitionKey": record.partition_key,
+                            "sequenceNumber": record.sequence_number,
+                        }
+                    })
+                })
+                .collect();
+
+            let matched: Vec<Value> = if mapping.filter.is_empty() {
+                record_jsons
+            } else {
+                record_jsons
+                    .into_iter()
+                    .filter(|r| mapping.filter.matches(r))
+                    .collect()
             };
 
-            for (shard_id, _start, end, records) in deliveries {
-                let payload = json!({
-                    "Records": records
-                        .iter()
-                        .map(|record| {
-                            json!({
-                                "awsRegion": "us-east-1",
-                                "eventID": format!("{}:{}", shard_id, record.sequence_number),
-                                "eventName": "aws:kinesis:record",
-                                "eventSource": "aws:kinesis",
-                                "eventSourceARN": stream_arn,
-                                "eventVersion": "1.0",
-                                "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
-                                "kinesis": {
-                                    "approximateArrivalTimestamp": record.approximate_arrival_timestamp.timestamp_millis() as f64 / 1000.0,
-                                    "data": base64::engine::general_purpose::STANDARD.encode(&record.data),
-                                    "kinesisSchemaVersion": "1.0",
-                                    "partitionKey": record.partition_key,
-                                    "sequenceNumber": record.sequence_number,
-                                }
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .to_string();
+            // Advance the checkpoint regardless — AWS treats filtered
+            // records as consumed.
+            {
+                let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
+                let mut kinesis_accounts = self.kinesis_state.write();
+                let kinesis = kinesis_accounts.get_or_create(account_id);
+                kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, end);
+            }
 
-                let used_real_delivery = self.lambda_delivery.is_some();
-                let delivered = if let Some(ref delivery) = self.lambda_delivery {
-                    match delivery.invoke_lambda(&function_arn, &payload).await {
-                        Ok(_) => true,
-                        Err(error) => {
-                            tracing::warn!(
-                                function_arn = %function_arn,
-                                stream_arn = %stream_arn,
-                                shard_id = %shard_id,
-                                error = %error,
-                                "Kinesis->Lambda: function invocation failed"
-                            );
-                            false
-                        }
-                    }
-                } else {
-                    true
-                };
+            if matched.is_empty() {
+                continue;
+            }
 
-                if !delivered {
-                    continue;
-                }
+            let payload = json!({ "Records": matched }).to_string();
 
+            let used_real_delivery = self.lambda_delivery.is_some();
+            let delivered = if let Some(ref delivery) = self.lambda_delivery {
+                match delivery
+                    .invoke_lambda(&mapping.function_arn, &payload)
+                    .await
                 {
-                    let account_id = stream_arn.split(':').nth(4).unwrap_or("");
-                    let mut kinesis_accounts = self.kinesis_state.write();
-                    let kinesis = kinesis_accounts.get_or_create(account_id);
-                    kinesis.set_lambda_checkpoint(&mapping_uuid, &shard_id, end);
+                    Ok(_) => true,
+                    Err(error) => {
+                        tracing::warn!(
+                            function_arn = %mapping.function_arn,
+                            stream_arn = %mapping.stream_arn,
+                            shard_id = %shard_id,
+                            error = %error,
+                            "Kinesis->Lambda: function invocation failed"
+                        );
+                        false
+                    }
                 }
+            } else {
+                true
+            };
 
-                if !used_real_delivery {
-                    let fn_account = function_arn.split(':').nth(4).unwrap_or("");
-                    let mut lambda_accounts = self.lambda_state.write();
-                    let lambda = lambda_accounts.get_or_create(fn_account);
-                    lambda.invocations.push(LambdaInvocation {
-                        function_arn: function_arn.clone(),
-                        payload,
-                        timestamp: Utc::now(),
-                        source: "aws:kinesis".to_string(),
-                    });
-                }
+            if !delivered {
+                continue;
+            }
+
+            if !used_real_delivery {
+                let fn_account = mapping.function_arn.split(':').nth(4).unwrap_or("");
+                let mut lambda_accounts = self.lambda_state.write();
+                let lambda = lambda_accounts.get_or_create(fn_account);
+                lambda.invocations.push(LambdaInvocation {
+                    function_arn: mapping.function_arn.clone(),
+                    payload,
+                    timestamp: Utc::now(),
+                    source: "aws:kinesis".to_string(),
+                });
             }
         }
     }

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -4,16 +4,48 @@
 //! pointing to SQS queues, polls those queues for messages, and either
 //! invokes the Lambda function via the container runtime (when available)
 //! or records the invocation in Lambda state.
+//!
+//! Honors:
+//! - `FilterCriteria` — non-matching messages are dropped (acked).
+//! - `FunctionResponseTypes=[ReportBatchItemFailures]` — when the
+//!   Lambda response body is `{"batchItemFailures":[{"itemIdentifier":"<id>"}]}`,
+//!   only acked message ids are removed; failed ids are made visible
+//!   again so the queue can redeliver.
+//! - `MaximumBatchingWindowInSeconds` — once a partial batch is
+//!   observed, the poller waits up to N seconds for it to fill before
+//!   invoking the Lambda. Once `BatchSize` is reached or the window
+//!   expires, the batch is dispatched.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::Utc;
-use serde_json::json;
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
 
 use fakecloud_core::delivery::LambdaDelivery;
+use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::state::{LambdaInvocation, SharedLambdaState};
 use fakecloud_sqs::state::SharedSqsState;
+
+#[derive(Clone)]
+struct Mapping {
+    uuid: String,
+    function_arn: String,
+    queue_arn: String,
+    batch_size: i64,
+    filter: FilterSet,
+    report_batch_item_failures: bool,
+    max_batching_window_seconds: i64,
+}
+
+/// Per-mapping batching window state. Tracks the timestamp of the
+/// first observed message after the most recent invoke so the poller
+/// can hold a partial batch open for `max_batching_window_seconds`.
+#[derive(Default)]
+struct BatchingState {
+    window_started_at: HashMap<String, DateTime<Utc>>,
+}
 
 /// SQS -> Lambda event source mapping poller.
 pub struct SqsLambdaPoller {
@@ -38,15 +70,15 @@ impl SqsLambdaPoller {
 
     pub async fn run(self) {
         let mut interval = tokio::time::interval(Duration::from_millis(500));
+        let mut batching = BatchingState::default();
         loop {
             interval.tick().await;
-            self.poll().await;
+            self.poll(&mut batching).await;
         }
     }
 
-    async fn poll(&self) {
-        // Collect enabled mappings that point to SQS sources
-        let mappings: Vec<(String, String, i64)> = {
+    async fn poll(&self, batching: &mut BatchingState) {
+        let mappings: Vec<Mapping> = {
             let lambda_accounts = self.lambda_state.read();
             lambda_accounts
                 .iter()
@@ -55,12 +87,19 @@ impl SqsLambdaPoller {
                         .event_source_mappings
                         .values()
                         .filter(|m| m.enabled && m.event_source_arn.contains(":sqs:"))
-                        .map(|m| {
-                            (
-                                m.event_source_arn.clone(),
-                                m.function_arn.clone(),
-                                m.batch_size,
-                            )
+                        .map(|m| Mapping {
+                            uuid: m.uuid.clone(),
+                            function_arn: m.function_arn.clone(),
+                            queue_arn: m.event_source_arn.clone(),
+                            batch_size: m.batch_size,
+                            filter: FilterSet::from_strings(m.filter_patterns.iter()),
+                            report_batch_item_failures: m
+                                .function_response_types
+                                .iter()
+                                .any(|s| s == "ReportBatchItemFailures"),
+                            max_batching_window_seconds: m
+                                .maximum_batching_window_in_seconds
+                                .unwrap_or(0),
                         })
                         .collect::<Vec<_>>()
                 })
@@ -73,106 +112,261 @@ impl SqsLambdaPoller {
 
         let now = Utc::now();
 
-        for (queue_arn, function_arn, batch_size) in mappings {
-            let messages = {
-                let mut sqs_mas = self.sqs_state.write();
-                // Parse account from queue ARN for multi-account routing
-                let default_acct = sqs_mas.default_account_id().to_string();
-                let acct = queue_arn.split(':').nth(4).unwrap_or(&default_acct);
-                let sqs = sqs_mas.get_or_create(acct);
-                let queue = sqs.queues.values_mut().find(|q| q.arn == queue_arn);
-                let queue = match queue {
-                    Some(q) => q,
-                    None => continue,
-                };
+        for mapping in mappings {
+            self.process_mapping(&mapping, batching, now).await;
+        }
+    }
 
-                // Pull up to batch_size visible messages
-                let mut batch = Vec::new();
-                let limit = batch_size.min(10) as usize;
-
-                for msg in queue.messages.iter() {
-                    if batch.len() >= limit {
-                        break;
-                    }
-                    if let Some(vis) = msg.visible_at {
-                        if vis > now {
-                            continue;
-                        }
-                    }
-                    batch.push(msg.clone());
-                }
-
-                // Remove consumed messages from the queue
-                let consumed_ids: Vec<String> =
-                    batch.iter().map(|m| m.message_id.clone()).collect();
-                queue
-                    .messages
-                    .retain(|m| !consumed_ids.contains(&m.message_id));
-
-                batch
+    async fn process_mapping(
+        &self,
+        mapping: &Mapping,
+        batching: &mut BatchingState,
+        now: DateTime<Utc>,
+    ) {
+        // Pull up to BatchSize visible messages without removing them
+        // from the queue yet. Removal happens after the Lambda response
+        // is observed so partial-batch failure semantics work.
+        let messages = {
+            let mut sqs_mas = self.sqs_state.write();
+            let default_acct = sqs_mas.default_account_id().to_string();
+            let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+            let sqs = sqs_mas.get_or_create(acct);
+            let queue = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn);
+            let queue = match queue {
+                Some(q) => q,
+                None => return,
             };
 
-            if messages.is_empty() {
-                continue;
+            let mut batch = Vec::new();
+            let limit = mapping.batch_size.min(10) as usize;
+
+            for msg in queue.messages.iter() {
+                if batch.len() >= limit {
+                    break;
+                }
+                if let Some(vis) = msg.visible_at {
+                    if vis > now {
+                        continue;
+                    }
+                }
+                batch.push(msg.clone());
             }
 
-            // Build the Lambda event payload matching AWS SQS event format
-            let records: Vec<serde_json::Value> = messages
-                .iter()
-                .map(|msg| {
-                    json!({
-                        "messageId": msg.message_id,
-                        "receiptHandle": msg.receipt_handle,
-                        "body": msg.body,
-                        "attributes": {
-                            "ApproximateReceiveCount": msg.receive_count.to_string(),
-                            "SentTimestamp": msg.sent_timestamp.to_string(),
-                        },
-                        "md5OfBody": msg.md5_of_body,
-                        "eventSource": "aws:sqs",
-                        "eventSourceARN": queue_arn,
-                    })
+            batch
+        };
+
+        if messages.is_empty() {
+            batching.window_started_at.remove(&mapping.uuid);
+            return;
+        }
+
+        // Honor MaximumBatchingWindowInSeconds: hold a partial batch
+        // open until the window expires, then dispatch what we have.
+        // A full batch dispatches immediately regardless.
+        let limit = mapping.batch_size.min(10) as usize;
+        if mapping.max_batching_window_seconds > 0 && messages.len() < limit {
+            let window_start = batching
+                .window_started_at
+                .entry(mapping.uuid.clone())
+                .or_insert(now);
+            let elapsed = now.signed_duration_since(*window_start).num_seconds();
+            if elapsed < mapping.max_batching_window_seconds {
+                return;
+            }
+        }
+        batching.window_started_at.remove(&mapping.uuid);
+
+        // Build SQS-shaped event records, filter, then mark visible-at
+        // for failures (or remove for successes) on the SQS side.
+        let records: Vec<Value> = messages
+            .iter()
+            .map(|msg| {
+                json!({
+                    "messageId": msg.message_id,
+                    "receiptHandle": msg.receipt_handle,
+                    "body": msg.body,
+                    "attributes": {
+                        "ApproximateReceiveCount": msg.receive_count.to_string(),
+                        "SentTimestamp": msg.sent_timestamp.to_string(),
+                    },
+                    "md5OfBody": msg.md5_of_body,
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": mapping.queue_arn,
                 })
-                .collect();
+            })
+            .collect();
 
-            let payload = json!({ "Records": records }).to_string();
+        let (matched_records, dropped_ids): (Vec<Value>, Vec<String>) = if mapping.filter.is_empty()
+        {
+            (records, Vec::new())
+        } else {
+            let mut matched = Vec::new();
+            let mut dropped = Vec::new();
+            for (rec, msg) in records.into_iter().zip(messages.iter()) {
+                if mapping.filter.matches(&rec) {
+                    matched.push(rec);
+                } else {
+                    dropped.push(msg.message_id.clone());
+                }
+            }
+            (matched, dropped)
+        };
 
-            tracing::debug!(
-                function_arn = %function_arn,
-                queue_arn = %queue_arn,
-                message_count = messages.len(),
-                "SQS->Lambda: delivering messages to function"
-            );
+        // Drop filtered-out messages — AWS treats them as acked so the
+        // queue stops redelivering them.
+        if !dropped_ids.is_empty() {
+            let mut sqs_mas = self.sqs_state.write();
+            let default_acct = sqs_mas.default_account_id().to_string();
+            let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+            let sqs = sqs_mas.get_or_create(acct);
+            if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
+                queue
+                    .messages
+                    .retain(|m| !dropped_ids.contains(&m.message_id));
+            }
+        }
 
-            // If we have a real Lambda delivery mechanism, invoke the function
-            if let Some(ref delivery) = self.lambda_delivery {
-                match delivery.invoke_lambda(&function_arn, &payload).await {
-                    Ok(_) => {
-                        tracing::debug!(
-                            function_arn = %function_arn,
-                            "SQS->Lambda: function invoked successfully"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            function_arn = %function_arn,
-                            error = %e,
-                            "SQS->Lambda: function invocation failed"
-                        );
+        if matched_records.is_empty() {
+            return;
+        }
+
+        let payload = json!({ "Records": &matched_records }).to_string();
+
+        tracing::debug!(
+            function_arn = %mapping.function_arn,
+            queue_arn = %mapping.queue_arn,
+            message_count = matched_records.len(),
+            dropped_by_filter = dropped_ids.len(),
+            "SQS->Lambda: delivering messages to function"
+        );
+
+        let invoke_result = if let Some(ref delivery) = self.lambda_delivery {
+            Some(
+                delivery
+                    .invoke_lambda(&mapping.function_arn, &payload)
+                    .await,
+            )
+        } else {
+            None
+        };
+
+        let matched_msg_ids: Vec<String> = matched_records
+            .iter()
+            .filter_map(|r| {
+                r.get("messageId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .collect();
+
+        let (acked_ids, failed_ids) = match &invoke_result {
+            Some(Ok(body)) if mapping.report_batch_item_failures => {
+                split_batch_failures(body, &matched_msg_ids)
+            }
+            Some(Ok(_)) => (matched_msg_ids.clone(), Vec::new()),
+            Some(Err(err)) => {
+                tracing::warn!(
+                    function_arn = %mapping.function_arn,
+                    error = %err,
+                    "SQS->Lambda: function invocation failed; messages will be retried"
+                );
+                (Vec::new(), matched_msg_ids.clone())
+            }
+            None => (matched_msg_ids.clone(), Vec::new()),
+        };
+
+        if !acked_ids.is_empty() || !failed_ids.is_empty() {
+            let mut sqs_mas = self.sqs_state.write();
+            let default_acct = sqs_mas.default_account_id().to_string();
+            let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+            let sqs = sqs_mas.get_or_create(acct);
+            if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
+                queue
+                    .messages
+                    .retain(|m| !acked_ids.contains(&m.message_id));
+                // Failed messages stay; bump receive_count and clear
+                // any pending visibility timeout so the queue
+                // immediately considers them again on the next poll.
+                for msg in queue.messages.iter_mut() {
+                    if failed_ids.contains(&msg.message_id) {
+                        msg.receive_count = msg.receive_count.saturating_add(1);
+                        msg.visible_at = None;
                     }
                 }
             }
-
-            // Record the invocation in Lambda state (for observability / testing)
-            let fn_account = function_arn.split(':').nth(4).unwrap_or("");
-            let mut lambda_accounts = self.lambda_state.write();
-            let lambda = lambda_accounts.get_or_create(fn_account);
-            lambda.invocations.push(LambdaInvocation {
-                function_arn,
-                payload,
-                timestamp: now,
-                source: "aws:sqs".to_string(),
-            });
         }
+
+        let fn_account = mapping.function_arn.split(':').nth(4).unwrap_or("");
+        let mut lambda_accounts = self.lambda_state.write();
+        let lambda = lambda_accounts.get_or_create(fn_account);
+        lambda.invocations.push(LambdaInvocation {
+            function_arn: mapping.function_arn.clone(),
+            payload,
+            timestamp: now,
+            source: "aws:sqs".to_string(),
+        });
+    }
+}
+
+/// Parse the Lambda response body as `{"batchItemFailures":[...]}`. Any
+/// id that appears in the failures list is reported as failed; the
+/// rest are acked. If the body doesn't decode or contains an empty
+/// failures list, the entire batch is acked.
+fn split_batch_failures(body: &[u8], batch_ids: &[String]) -> (Vec<String>, Vec<String>) {
+    let parsed: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return (batch_ids.to_vec(), Vec::new()),
+    };
+    let failures: Vec<String> = parsed
+        .get("batchItemFailures")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|f| {
+                    f.get("itemIdentifier")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if failures.is_empty() {
+        return (batch_ids.to_vec(), Vec::new());
+    }
+    let acked = batch_ids
+        .iter()
+        .filter(|id| !failures.contains(id))
+        .cloned()
+        .collect();
+    (acked, failures)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_failures_parse() {
+        let body = br#"{"batchItemFailures":[{"itemIdentifier":"a"},{"itemIdentifier":"c"}]}"#;
+        let (acked, failed) =
+            split_batch_failures(body, &["a".into(), "b".into(), "c".into(), "d".into()]);
+        assert_eq!(acked, vec!["b".to_string(), "d".to_string()]);
+        assert_eq!(failed, vec!["a".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn batch_failures_empty_list_acks_all() {
+        let body = br#"{"batchItemFailures":[]}"#;
+        let (acked, failed) = split_batch_failures(body, &["a".into(), "b".into()]);
+        assert_eq!(acked, vec!["a".to_string(), "b".to_string()]);
+        assert!(failed.is_empty());
+    }
+
+    #[test]
+    fn batch_failures_no_field_acks_all() {
+        let body = br#"{"ok":true}"#;
+        let (acked, failed) = split_batch_failures(body, &["a".into(), "b".into()]);
+        assert_eq!(acked, vec!["a".to_string(), "b".to_string()]);
+        assert!(failed.is_empty());
     }
 }

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -317,7 +317,7 @@ fn split_batch_failures(body: &[u8], batch_ids: &[String]) -> (Vec<String>, Vec<
         Ok(v) => v,
         Err(_) => return (batch_ids.to_vec(), Vec::new()),
     };
-    let failures: Vec<String> = parsed
+    let raw_failures: Vec<String> = parsed
         .get("batchItemFailures")
         .and_then(|v| v.as_array())
         .map(|arr| {
@@ -330,6 +330,14 @@ fn split_batch_failures(body: &[u8], batch_ids: &[String]) -> (Vec<String>, Vec<
                 .collect()
         })
         .unwrap_or_default();
+    // Intersect against batch_ids: a stale or made-up itemIdentifier
+    // shouldn't keep an unrelated message visible / hold up an acked
+    // one. AWS behaves the same way — failures referencing ids
+    // outside the batch are ignored.
+    let failures: Vec<String> = raw_failures
+        .into_iter()
+        .filter(|id| batch_ids.contains(id))
+        .collect();
     if failures.is_empty() {
         return (batch_ids.to_vec(), Vec::new());
     }

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -17,9 +17,9 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **SNS -> SQS / Lambda / HTTP** — Fan-out delivery to all subscription types.
 - **S3 -> SNS / SQS / Lambda / EventBridge** — Bucket notifications on object create/delete.
 - **EventBridge -> SNS / SQS / Lambda / Logs / Kinesis / Step Functions / HTTP** — Rules deliver to targets on schedule or event match, including API Destinations.
-- **SQS -> Lambda** — Event source mapping polls queues and invokes functions.
-- **Kinesis -> Lambda** — Event source mapping polls shards and invokes functions.
-- **DynamoDB Streams -> Lambda** — Event source mapping polls stream records and invokes.
+- **SQS -> Lambda** — Event source mapping polls queues. Honors `FilterCriteria` (drop non-matching), `MaximumBatchingWindowInSeconds` (hold partial batches), and `FunctionResponseTypes=[ReportBatchItemFailures]` (Lambda response `{"batchItemFailures":[{"itemIdentifier":...}]}` retries only the failed messages).
+- **Kinesis -> Lambda** — Event source mapping polls shards. Honors `FilterCriteria` (advances past dropped records) and `StartingPosition` (`TRIM_HORIZON` / `LATEST` / `AT_TIMESTAMP`) on first poll.
+- **DynamoDB Streams -> Lambda** — Event source mapping polls stream records. Honors `FilterCriteria` (advances past dropped records) and `StartingPosition` (`TRIM_HORIZON` / `LATEST`).
 - **DynamoDB -> Kinesis** — Table changes stream to Kinesis Data Streams.
 - **CloudWatch Logs -> Lambda / Kinesis / SQS** — Subscription filters deliver log events.
 - **Lambda async destinations -> SQS / SNS / EventBridge / Lambda** — `InvocationType=Event` invocations route their result through `OnSuccess` / `OnFailure` using AWS's standard destinations record schema.

--- a/website/content/docs/services/lambda.md
+++ b/website/content/docs/services/lambda.md
@@ -11,7 +11,7 @@ fakecloud implements **85 of 85** Lambda operations at 100% Smithy conformance. 
 - **Function CRUD** — create, update, delete, list, get
 - **Real code execution** — functions run in Docker containers with the official AWS Lambda runtime images
 - **13 runtimes** — Node.js (16/18/20), Python (3.8/3.9/3.10/3.11/3.12), Java (11/17/21), Go, Ruby, .NET
-- **Event source mappings** — SQS, Kinesis, DynamoDB Streams polling loops
+- **Event source mappings** — SQS, Kinesis, DynamoDB Streams polling loops with **`FilterCriteria`** (EventBridge-style JSON pattern, exists/prefix/suffix/equals-ignore-case/anything-but/numeric operators, SQS body decode), **`StartingPosition`** (`TRIM_HORIZON` / `LATEST` / `AT_TIMESTAMP` for Kinesis, `TRIM_HORIZON` / `LATEST` for DDB Streams), **`MaximumBatchingWindowInSeconds`** (SQS), and **`FunctionResponseTypes=[ReportBatchItemFailures]`** for SQS partial-batch failure semantics
 - **Layers** — create, publish, attach to functions
 - **Environment variables** — passed to the container
 - **Aliases and versions** — publish, point aliases at versions
@@ -29,6 +29,29 @@ REST. Path-based routing for invoke operations, JSON for control plane.
 - `GET /_fakecloud/lambda/invocations` — list all Lambda invocations with input/output/errors
 - `GET /_fakecloud/lambda/warm-containers` — list currently warm containers
 - `POST /_fakecloud/lambda/{function-name}/evict-container` — force a cold start on the next invoke
+
+## Event source mapping example: FilterCriteria + partial batch failure
+
+```typescript
+import { LambdaClient, CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+
+await new LambdaClient({ endpoint: "http://localhost:4566" }).send(
+  new CreateEventSourceMappingCommand({
+    FunctionName: "process-orders",
+    EventSourceArn: "arn:aws:sqs:us-east-1:000000000000:orders",
+    BatchSize: 10,
+    MaximumBatchingWindowInSeconds: 5,
+    // Only deliver paid orders.
+    FilterCriteria: {
+      Filters: [{ Pattern: '{"body": {"status": ["paid"]}}' }],
+    },
+    // Opt into partial-batch failure: Lambda returns
+    // {"batchItemFailures":[{"itemIdentifier":"<msgId>"}]}
+    // and only those messages stay on the queue for retry.
+    FunctionResponseTypes: ["ReportBatchItemFailures"],
+  })
+);
+```
 
 ## Cross-service triggers
 


### PR DESCRIPTION
## Summary

Closes the long-standing event source mapping correctness gaps for SQS / Kinesis / DDB Streams pollers.

- **FilterCriteria** — new \`fakecloud-lambda::filter::FilterSet\` implements the EventBridge-style JSON pattern subset documented for Lambda ESM: exact equality, array-of-scalars (or), \`exists\` / \`prefix\` / \`suffix\` / \`equals-ignore-case\` / \`anything-but\` / \`numeric\` operators, and the SQS body-decode special case (patterns rooted at \`body\` are matched against the JSON-parsed message body). Wired into all three pollers; non-matching records are dropped and the checkpoint/queue advances past them.
- **Partial-batch failure (SQS)** — when \`FunctionResponseTypes=[ReportBatchItemFailures]\` is set, the SQS poller parses \`{\"batchItemFailures\":[{\"itemIdentifier\":\"<id>\"}]}\` from the Lambda response and only retries the failed messages.
- **MaximumBatchingWindowInSeconds (SQS)** — partial batches are held open until the window expires, then dispatched.
- **StartingPosition** — Kinesis (TRIM_HORIZON / LATEST / AT_TIMESTAMP) and DDB Streams (TRIM_HORIZON / LATEST) seed the per-shard checkpoint on first poll.
- EventSourceMapping struct + Create/Update/Get serializers updated to round-trip \`FilterCriteria\`, \`FunctionResponseTypes\`, \`StartingPosition\`, \`StartingPositionTimestamp\`, \`MaximumBatchingWindowInSeconds\`, \`ParallelizationFactor\`.

## Test plan

- [x] \`cargo test -p fakecloud-lambda --lib filter\` — 7 unit tests on FilterSet operator coverage
- [x] \`cargo test -p fakecloud --bin fakecloud sqs_lambda_poller\` — 3 unit tests on \`batchItemFailures\` parsing
- [x] \`cargo test -p fakecloud-e2e --test lambda_esm_filter_and_failures\` — SQS FilterCriteria end-to-end (matching message routed; non-matching acked off the queue)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

Docs / website / README updated to advertise the new ESM behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FilterCriteria matching, SQS partial-batch failures, and StartingPosition to Lambda event source mappings. Pollers now drop/ack non-matching records, honor SQS batching windows, and keep checkpoints aligned with AWS semantics.

- New Features
  - `fakecloud-lambda::filter::FilterSet` adds EventBridge-style JSON pattern matching (exists/prefix/suffix/equals-ignore-case/anything-but/numeric) with SQS body JSON-decode; used by SQS, Kinesis, and DDB Streams. Non-matching records are discarded and progress advances.
  - SQS: supports `FunctionResponseTypes=["ReportBatchItemFailures"]`; parses `{"batchItemFailures":[{"itemIdentifier":"<id>"}]}` and retries only failed IDs. Honors `MaximumBatchingWindowInSeconds` for partial batches.
  - Kinesis/DDB Streams: honors `StartingPosition` on first poll — Kinesis (`TRIM_HORIZON`/`LATEST`/`AT_TIMESTAMP`) and DDB Streams (`TRIM_HORIZON`/`LATEST`).
  - ESM Create/Update/Get round-trip `FilterCriteria`, `FunctionResponseTypes`, `StartingPosition`, `StartingPositionTimestamp`, `MaximumBatchingWindowInSeconds`, and `ParallelizationFactor`.

- Bug Fixes
  - Filters: `exists` now checks field presence (null counts as present); `numeric` requires even, non-empty operator arrays; invalid JSON patterns are rejected on create; non-string `Filters[].Pattern` is rejected with `InvalidParameterValueException`; non-object `FilterCriteria` is rejected at create.
  - SQS: batch-failure parsing intersects `itemIdentifier` values with the actual batch to avoid holding unrelated messages.
  - Kinesis/DDB Streams: checkpoints advance only after a successful invoke; if all records are filtered out, checkpoints still advance. Failed invokes leave records for retry (at-least-once).
  - Tests: SQS->Lambda ESM e2e now uses a real Python handler, polls for the post-invoke `aws:sqs` record, and bounds the wait with a 30s timeout to avoid CI hangs.

<sup>Written for commit 293c0fc8d1f6b27cf7973c4dcca5e65453aaa6e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

