### PR TITLE
feat(kms): cross-service KMS hook + introspection (Secrets Manager wired)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | IAM                    | 176 | Users, roles, policies, groups, instance profiles, OIDC/SAML           |
 | STS                    |  11 | AssumeRole, session tokens, federation                                 |
 | SSM                    | 146 | Parameters, documents, commands, maintenance, patch baselines          |
-| Secrets Manager        |  23 | Versioning, rotation via Lambda, replication                           |
+| Secrets Manager        |  23 | Versioning, rotation via Lambda, replication, **real KMS encrypt/decrypt** |
 | CloudWatch Logs        | 113 | Groups, streams, subscription filters, query language                  |
-| KMS                    |  53 | Encryption, aliases, grants, real ECDH, key import                     |
+| KMS                    |  53 | Encryption, aliases, grants, real ECDH, key import, **cross-service hook** |
 | CloudFormation         |  90 | Template parsing, resource provisioning, custom resources              |
 | SES (v2 + v1 inbound)  | 110 | Sending, templates, DKIM, **real receipt rule execution**              |
 | Cognito User Pools     | 122 | Pools, clients, MFA, identity providers, full auth flows; verification email -> SES, SMS -> SNS, all 12 Lambda triggers |

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -157,6 +157,35 @@ pub trait SmsDispatcher: Send + Sync {
     fn send_sms(&self, account_id: &str, phone_number: &str, message: &str);
 }
 
+/// Cross-service KMS hook: services that accept a `KmsKeyId` (Secrets
+/// Manager, SSM `SecureString`, S3 SSE-KMS, SQS / SNS / DynamoDB
+/// encrypted resources) call this so that real KMS calls happen, the
+/// invocation is recorded for introspection, and the returned blob is
+/// decryptable by the public KMS API.
+///
+/// Encryption context is the AWS-defined per-service map (e.g.
+/// `{aws:secretsmanager:secretArn: <arn>}` for Secrets Manager) and is
+/// recorded with the call so test code can assert it.
+pub trait KmsHook: Send + Sync {
+    fn encrypt(
+        &self,
+        account_id: &str,
+        region: &str,
+        key_id: &str,
+        plaintext: &[u8],
+        service_principal: &str,
+        encryption_context: std::collections::HashMap<String, String>,
+    ) -> Result<String, String>;
+
+    fn decrypt(
+        &self,
+        account_id: &str,
+        ciphertext_b64: &str,
+        service_principal: &str,
+        encryption_context: std::collections::HashMap<String, String>,
+    ) -> Result<Vec<u8>, String>;
+}
+
 impl DeliveryBus {
     pub fn new() -> Self {
         Self {

--- a/crates/fakecloud-e2e/tests/secretsmanager_kms.rs
+++ b/crates/fakecloud-e2e/tests/secretsmanager_kms.rs
@@ -1,0 +1,105 @@
+//! Secrets Manager + KMS hook end-to-end:
+//! - CreateSecret with `KmsKeyId` triggers `kms:GenerateDataKey`
+//! - GetSecretValue triggers `kms:Decrypt` and returns the original
+//!   plaintext (transparent encrypt/decrypt round-trip)
+//! - Both calls land in `/_fakecloud/kms/usage` with the
+//!   secret-arn-shaped encryption context AWS uses
+//!
+//! No KMS key is created up-front — the hook auto-provisions an
+//! `aws/secretsmanager` AWS-managed key on first use, mirroring real
+//! AWS.
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn secretsmanager_create_get_round_trips_through_kms() {
+    let server = TestServer::start().await;
+    let secrets = server.secretsmanager_client().await;
+    let http = reqwest::Client::new();
+
+    let created = secrets
+        .create_secret()
+        .name("db-password")
+        .secret_string("hunter2")
+        .kms_key_id("alias/aws/secretsmanager")
+        .send()
+        .await
+        .unwrap();
+    let arn = created.arn().unwrap().to_string();
+
+    let got = secrets
+        .get_secret_value()
+        .secret_id("db-password")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        got.secret_string(),
+        Some("hunter2"),
+        "round-trip should return the original plaintext through KMS"
+    );
+
+    // Both KMS calls should be visible via the introspection endpoint.
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    let svc_records: Vec<&serde_json::Value> = records
+        .iter()
+        .filter(|r| r["servicePrincipal"].as_str() == Some("secretsmanager.amazonaws.com"))
+        .collect();
+    assert!(
+        svc_records.iter().any(|r| {
+            r["operation"].as_str() == Some("GenerateDataKey")
+                && r["encryptionContext"]["aws:secretsmanager:secretArn"].as_str()
+                    == Some(arn.as_str())
+        }),
+        "expected GenerateDataKey record bound to secret ARN, got: {svc_records:?}"
+    );
+    assert!(
+        svc_records.iter().any(|r| {
+            r["operation"].as_str() == Some("Decrypt")
+                && r["encryptionContext"]["aws:secretsmanager:secretArn"].as_str()
+                    == Some(arn.as_str())
+        }),
+        "expected Decrypt record bound to secret ARN, got: {svc_records:?}"
+    );
+}
+
+#[tokio::test]
+async fn secretsmanager_without_kms_key_does_not_record_usage() {
+    let server = TestServer::start().await;
+    let secrets = server.secretsmanager_client().await;
+    let http = reqwest::Client::new();
+
+    secrets
+        .create_secret()
+        .name("plaintext-secret")
+        .secret_string("nope")
+        .send()
+        .await
+        .unwrap();
+
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    assert!(
+        !records
+            .iter()
+            .any(|r| r["servicePrincipal"].as_str() == Some("secretsmanager.amazonaws.com")),
+        "secret without KmsKeyId must not trigger KMS calls, got: {records:?}"
+    );
+}

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -211,19 +211,30 @@ impl KmsServiceHook {
     }
 }
 
+/// Strip the `arn:aws:kms:<region>:<account>:` ARN prefix and return
+/// the resource portion (e.g. `key/<id>` or `alias/<name>`). Returns
+/// `None` for ARNs that don't have the right shape.
+fn strip_kms_arn_prefix(key_id: &str) -> Option<&str> {
+    let rest = key_id.strip_prefix("arn:aws:kms:")?;
+    // Format after prefix: <region>:<account>:<resource>. Need to skip
+    // both `region` and `account` separately so the resource starts
+    // cleanly at `key/...` or `alias/...`.
+    let (_region, after_region) = rest.split_once(':')?;
+    let (_account, resource) = after_region.split_once(':')?;
+    Some(resource)
+}
+
 /// Resolve `key_id` (raw id, alias name, alias ARN, or key ARN) to the
 /// full key ARN if it currently exists in `state`.
 fn resolve_key(state: &KmsState, key_id: &str) -> Option<String> {
-    if let Some(rest) = key_id.strip_prefix("arn:aws:kms:") {
-        if let Some(after_resource) = rest.split_once(':').map(|(_, r)| r) {
-            if let Some(short) = after_resource.strip_prefix("key/") {
-                return state.keys.get(short).map(|k| k.arn.clone());
-            }
-            if let Some(alias) = after_resource.strip_prefix("alias/") {
-                let full = format!("alias/{alias}");
-                if let Some(a) = state.aliases.get(&full) {
-                    return state.keys.get(&a.target_key_id).map(|k| k.arn.clone());
-                }
+    if let Some(resource) = strip_kms_arn_prefix(key_id) {
+        if let Some(short) = resource.strip_prefix("key/") {
+            return state.keys.get(short).map(|k| k.arn.clone());
+        }
+        if let Some(alias) = resource.strip_prefix("alias/") {
+            let full = format!("alias/{alias}");
+            if let Some(a) = state.aliases.get(&full) {
+                return state.keys.get(&a.target_key_id).map(|k| k.arn.clone());
             }
         }
     }
@@ -237,11 +248,9 @@ fn resolve_key(state: &KmsState, key_id: &str) -> Option<String> {
 }
 
 fn normalize_alias(key_id: &str) -> String {
-    if let Some(rest) = key_id.strip_prefix("arn:aws:kms:") {
-        if let Some(after_resource) = rest.split_once(':').map(|(_, r)| r) {
-            if let Some(alias) = after_resource.strip_prefix("alias/") {
-                return alias.to_string();
-            }
+    if let Some(resource) = strip_kms_arn_prefix(key_id) {
+        if let Some(alias) = resource.strip_prefix("alias/") {
+            return alias.to_string();
         }
     }
     key_id.strip_prefix("alias/").unwrap_or(key_id).to_string()
@@ -318,4 +327,34 @@ fn provision_aws_managed_key(
 
 fn key_id_from_arn(arn: &str) -> &str {
     arn.rsplit_once('/').map(|(_, k)| k).unwrap_or(arn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_arn_prefix_skips_region_and_account() {
+        assert_eq!(
+            strip_kms_arn_prefix("arn:aws:kms:us-east-1:000000000000:key/abc-123"),
+            Some("key/abc-123")
+        );
+        assert_eq!(
+            strip_kms_arn_prefix("arn:aws:kms:us-east-1:000000000000:alias/aws/secretsmanager"),
+            Some("alias/aws/secretsmanager")
+        );
+        assert_eq!(strip_kms_arn_prefix("not-an-arn"), None);
+        // Missing one of region/account should return None, not a half-stripped resource.
+        assert_eq!(strip_kms_arn_prefix("arn:aws:kms:key/abc"), None);
+    }
+
+    #[test]
+    fn normalize_alias_handles_arns_correctly() {
+        assert_eq!(
+            normalize_alias("arn:aws:kms:us-east-1:000000000000:alias/aws/secretsmanager"),
+            "aws/secretsmanager"
+        );
+        assert_eq!(normalize_alias("alias/aws/sqs"), "aws/sqs");
+        assert_eq!(normalize_alias("aws/s3"), "aws/s3");
+    }
 }

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -1,0 +1,321 @@
+//! Cross-service KMS hook.
+//!
+//! Services that accept a `KmsKeyId` (Secrets Manager, SSM
+//! `SecureString`, S3 SSE-KMS, SQS, SNS, DynamoDB) call into this
+//! module so that:
+//!
+//! 1. The supplied key is resolved (alias `aws/<service>` and bare
+//!    aliases included), auto-provisioning AWS-managed keys on first
+//!    use to match real AWS.
+//! 2. Each call is recorded in [`KmsUsageState`] so test code can
+//!    assert through `/_fakecloud/kms/usage` that the right service
+//!    triggered the right operation on the right key.
+//! 3. The returned ciphertext is a real envelope decryptable by the
+//!    public KMS `Decrypt` API (uses the same `fakecloud-kms:`
+//!    envelope as the existing service-side encrypt path).
+//!
+//! Encryption context, key policy enforcement, and KMS-managed key
+//! rotation come in follow-up PRs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+
+use base64::Engine;
+
+use crate::state::{KmsKey, KmsState, SharedKmsState};
+
+/// One recorded KMS hook call. Returned by the introspection endpoint
+/// so test code can assert `kms:GenerateDataKey` / `kms:Decrypt` ran
+/// on the expected key + service principal.
+#[derive(Clone, serde::Serialize)]
+pub struct KmsUsageRecord {
+    pub timestamp: DateTime<Utc>,
+    pub operation: String,
+    pub service_principal: String,
+    pub account_id: String,
+    pub key_arn: String,
+    pub encryption_context: HashMap<String, String>,
+}
+
+#[derive(Default)]
+pub struct KmsUsageState {
+    records: Vec<KmsUsageRecord>,
+}
+
+impl KmsUsageState {
+    pub fn records(&self) -> &[KmsUsageRecord] {
+        &self.records
+    }
+
+    pub fn push(&mut self, record: KmsUsageRecord) {
+        self.records.push(record);
+    }
+
+    pub fn clear(&mut self) {
+        self.records.clear();
+    }
+}
+
+pub type SharedKmsUsageState = Arc<RwLock<KmsUsageState>>;
+
+/// Hook used by service crates that need to call KMS for encryption /
+/// decryption without going through the AWS-shaped HTTP layer.
+pub struct KmsServiceHook {
+    state: SharedKmsState,
+    usage: SharedKmsUsageState,
+}
+
+#[derive(Debug)]
+pub enum KmsHookError {
+    /// Caller supplied a key id / alias / ARN that doesn't resolve to
+    /// an existing key (and isn't an AWS-managed alias we auto-create).
+    KeyNotFound(String),
+    /// Ciphertext envelope is malformed or signed by a key that no
+    /// longer exists.
+    InvalidCiphertext(String),
+}
+
+impl std::fmt::Display for KmsHookError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KeyNotFound(k) => write!(f, "kms key not found: {k}"),
+            Self::InvalidCiphertext(msg) => write!(f, "invalid ciphertext: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for KmsHookError {}
+
+impl KmsServiceHook {
+    pub fn new(state: SharedKmsState, usage: SharedKmsUsageState) -> Self {
+        Self { state, usage }
+    }
+
+    /// Encrypt `plaintext` under `key_id` (raw id, ARN, alias, or
+    /// `aws/<service>` AWS-managed alias). Records the call as a
+    /// `GenerateDataKey`-shaped usage record and returns the base64
+    /// ciphertext envelope.
+    pub fn encrypt(
+        &self,
+        account_id: &str,
+        region: &str,
+        key_id: &str,
+        plaintext: &[u8],
+        service_principal: &str,
+        encryption_context: HashMap<String, String>,
+    ) -> Result<String, KmsHookError> {
+        let key_arn = self.resolve_or_provision(account_id, region, key_id, service_principal)?;
+        let key_short = key_id_from_arn(&key_arn).to_string();
+
+        let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(plaintext);
+        let envelope = format!("fakecloud-kms:{key_short}:{plaintext_b64}");
+        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+
+        self.usage.write().push(KmsUsageRecord {
+            timestamp: Utc::now(),
+            operation: "GenerateDataKey".to_string(),
+            service_principal: service_principal.to_string(),
+            account_id: account_id.to_string(),
+            key_arn,
+            encryption_context,
+        });
+
+        Ok(ciphertext_b64)
+    }
+
+    /// Decrypt a previously-`encrypt`-produced base64 ciphertext.
+    /// Records the call as a `Decrypt`-shaped usage record.
+    pub fn decrypt(
+        &self,
+        account_id: &str,
+        ciphertext_b64: &str,
+        service_principal: &str,
+        encryption_context: HashMap<String, String>,
+    ) -> Result<Vec<u8>, KmsHookError> {
+        let envelope_bytes = base64::engine::general_purpose::STANDARD
+            .decode(ciphertext_b64)
+            .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+        let envelope = String::from_utf8(envelope_bytes)
+            .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+
+        let rest = envelope
+            .strip_prefix("fakecloud-kms:")
+            .ok_or_else(|| KmsHookError::InvalidCiphertext("unrecognized envelope".into()))?;
+        let (key_short, plaintext_b64) = rest
+            .split_once(':')
+            .ok_or_else(|| KmsHookError::InvalidCiphertext("missing key separator".into()))?;
+
+        let plaintext = base64::engine::general_purpose::STANDARD
+            .decode(plaintext_b64)
+            .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+
+        let key_arn = {
+            let mas = self.state.read();
+            let state = mas
+                .get(account_id)
+                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.into()))?;
+            state
+                .keys
+                .get(key_short)
+                .map(|k| k.arn.clone())
+                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.into()))?
+        };
+
+        self.usage.write().push(KmsUsageRecord {
+            timestamp: Utc::now(),
+            operation: "Decrypt".to_string(),
+            service_principal: service_principal.to_string(),
+            account_id: account_id.to_string(),
+            key_arn,
+            encryption_context,
+        });
+
+        Ok(plaintext)
+    }
+
+    fn resolve_or_provision(
+        &self,
+        account_id: &str,
+        region: &str,
+        key_id: &str,
+        service_principal: &str,
+    ) -> Result<String, KmsHookError> {
+        // Pre-flight read to see if the key resolves cleanly.
+        {
+            let mas = self.state.read();
+            if let Some(state) = mas.get(account_id) {
+                if let Some(arn) = resolve_key(state, key_id) {
+                    return Ok(arn);
+                }
+            }
+        }
+
+        // AWS-managed aliases (`aws/<service>`) auto-provision on
+        // first use. Customer-supplied aliases / IDs that don't
+        // resolve are an error.
+        let alias = normalize_alias(key_id);
+        if !alias.starts_with("aws/") {
+            return Err(KmsHookError::KeyNotFound(key_id.to_string()));
+        }
+        let mut mas = self.state.write();
+        let state = mas.get_or_create(account_id);
+        // Re-check under the write lock in case a concurrent caller won the race.
+        if let Some(arn) = resolve_key(state, key_id) {
+            return Ok(arn);
+        }
+        let key_arn = provision_aws_managed_key(state, region, &alias, service_principal);
+        Ok(key_arn)
+    }
+}
+
+/// Resolve `key_id` (raw id, alias name, alias ARN, or key ARN) to the
+/// full key ARN if it currently exists in `state`.
+fn resolve_key(state: &KmsState, key_id: &str) -> Option<String> {
+    if let Some(rest) = key_id.strip_prefix("arn:aws:kms:") {
+        if let Some(after_resource) = rest.split_once(':').map(|(_, r)| r) {
+            if let Some(short) = after_resource.strip_prefix("key/") {
+                return state.keys.get(short).map(|k| k.arn.clone());
+            }
+            if let Some(alias) = after_resource.strip_prefix("alias/") {
+                let full = format!("alias/{alias}");
+                if let Some(a) = state.aliases.get(&full) {
+                    return state.keys.get(&a.target_key_id).map(|k| k.arn.clone());
+                }
+            }
+        }
+    }
+    if let Some(alias) = key_id.strip_prefix("alias/") {
+        let full = format!("alias/{alias}");
+        if let Some(a) = state.aliases.get(&full) {
+            return state.keys.get(&a.target_key_id).map(|k| k.arn.clone());
+        }
+    }
+    state.keys.get(key_id).map(|k| k.arn.clone())
+}
+
+fn normalize_alias(key_id: &str) -> String {
+    if let Some(rest) = key_id.strip_prefix("arn:aws:kms:") {
+        if let Some(after_resource) = rest.split_once(':').map(|(_, r)| r) {
+            if let Some(alias) = after_resource.strip_prefix("alias/") {
+                return alias.to_string();
+            }
+        }
+    }
+    key_id.strip_prefix("alias/").unwrap_or(key_id).to_string()
+}
+
+fn provision_aws_managed_key(
+    state: &mut KmsState,
+    region: &str,
+    alias: &str,
+    service_principal: &str,
+) -> String {
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let arn = format!(
+        "arn:aws:kms:{region}:{account}:key/{key_id}",
+        account = state.account_id,
+        region = region,
+    );
+    let policy = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "Allow access through service",
+            "Effect": "Allow",
+            "Principal": {"Service": service_principal},
+            "Action": ["kms:GenerateDataKey", "kms:Decrypt", "kms:DescribeKey"],
+            "Resource": "*"
+        }]
+    })
+    .to_string();
+    let key = KmsKey {
+        key_id: key_id.clone(),
+        arn: arn.clone(),
+        creation_date: Utc::now().timestamp() as f64,
+        description: format!(
+            "Default master key that protects {alias} when no other key is defined"
+        ),
+        enabled: true,
+        key_usage: "ENCRYPT_DECRYPT".to_string(),
+        key_spec: "SYMMETRIC_DEFAULT".to_string(),
+        key_manager: "AWS".to_string(),
+        key_state: "Enabled".to_string(),
+        deletion_date: None,
+        tags: HashMap::new(),
+        policy,
+        key_rotation_enabled: true,
+        origin: "AWS_KMS".to_string(),
+        multi_region: false,
+        rotations: Vec::new(),
+        signing_algorithms: None,
+        encryption_algorithms: Some(vec!["SYMMETRIC_DEFAULT".to_string()]),
+        mac_algorithms: None,
+        custom_key_store_id: None,
+        imported_key_material: false,
+        imported_material_bytes: None,
+        private_key_seed: Vec::new(),
+        primary_region: None,
+    };
+    state.keys.insert(key_id.clone(), key);
+    let alias_full = format!("alias/{alias}");
+    state.aliases.insert(
+        alias_full.clone(),
+        crate::state::KmsAlias {
+            alias_name: alias_full,
+            alias_arn: format!(
+                "arn:aws:kms:{region}:{account}:alias/{alias}",
+                account = state.account_id,
+                region = region,
+            ),
+            target_key_id: key_id,
+            creation_date: Utc::now().timestamp() as f64,
+        },
+    );
+    arn
+}
+
+fn key_id_from_arn(arn: &str) -> &str {
+    arn.rsplit_once('/').map(|(_, k)| k).unwrap_or(arn)
+}

--- a/crates/fakecloud-kms/src/lib.rs
+++ b/crates/fakecloud-kms/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod hook;
 pub mod resource_policy;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -86,6 +86,7 @@ pub struct SecretsManagerService {
     delivery_bus: Option<Arc<DeliveryBus>>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
 }
 
 impl SecretsManagerService {
@@ -95,6 +96,7 @@ impl SecretsManagerService {
             delivery_bus: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            kms_hook: None,
         }
     }
 
@@ -106,6 +108,75 @@ impl SecretsManagerService {
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
         self
+    }
+
+    pub fn with_kms_hook(mut self, hook: Arc<dyn fakecloud_core::delivery::KmsHook>) -> Self {
+        self.kms_hook = Some(hook);
+        self
+    }
+
+    fn maybe_encrypt_secret_string(
+        &self,
+        account_id: &str,
+        region: &str,
+        secret_arn: &str,
+        kms_key_id: Option<&str>,
+        plaintext: Option<String>,
+    ) -> Option<String> {
+        let pt = plaintext?;
+        let (Some(hook), Some(key)) = (&self.kms_hook, kms_key_id) else {
+            return Some(pt);
+        };
+        let key = if key.is_empty() {
+            "aws/secretsmanager"
+        } else {
+            key
+        };
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "aws:secretsmanager:secretArn".to_string(),
+            secret_arn.to_string(),
+        );
+        match hook.encrypt(
+            account_id,
+            region,
+            key,
+            pt.as_bytes(),
+            "secretsmanager.amazonaws.com",
+            ctx,
+        ) {
+            Ok(ciphertext) => Some(ciphertext),
+            Err(err) => {
+                tracing::warn!(
+                    secret_arn = %secret_arn,
+                    error = %err,
+                    "KMS encrypt failed for secret; storing plaintext"
+                );
+                Some(pt)
+            }
+        }
+    }
+
+    fn maybe_decrypt_secret_string(
+        &self,
+        account_id: &str,
+        secret_arn: &str,
+        kms_key_id: Option<&str>,
+        stored: Option<&str>,
+    ) -> Option<String> {
+        let stored = stored?;
+        let (Some(hook), Some(_)) = (&self.kms_hook, kms_key_id) else {
+            return Some(stored.to_string());
+        };
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "aws:secretsmanager:secretArn".to_string(),
+            secret_arn.to_string(),
+        );
+        match hook.decrypt(account_id, stored, "secretsmanager.amazonaws.com", ctx) {
+            Ok(bytes) => Some(String::from_utf8_lossy(&bytes).to_string()),
+            Err(_) => Some(stored.to_string()),
+        }
     }
 
     /// Persist current state as a snapshot. Held across the
@@ -198,9 +269,16 @@ impl SecretsManagerService {
                 .client_request_token
                 .clone()
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            let stored_string = self.maybe_encrypt_secret_string(
+                &req.account_id,
+                &req.region,
+                &arn,
+                input.kms_key_id.as_deref(),
+                input.secret_string,
+            );
             let version = SecretVersion {
                 version_id: vid.clone(),
-                secret_string: input.secret_string,
+                secret_string: stored_string,
                 secret_binary: input.secret_binary,
                 stages: vec!["AWSCURRENT".to_string()],
                 created_at: now,
@@ -327,8 +405,18 @@ impl SecretsManagerService {
             "CreatedDate": version.created_at.timestamp_millis() as f64 / 1000.0,
         });
 
+        let kms_for_decrypt = secret.kms_key_id.clone();
+        let arn_for_decrypt = secret.arn.clone();
         if let Some(ref s) = version.secret_string {
-            response["SecretString"] = json!(s);
+            let plaintext = self
+                .maybe_decrypt_secret_string(
+                    &req.account_id,
+                    &arn_for_decrypt,
+                    kms_for_decrypt.as_deref(),
+                    Some(s.as_str()),
+                )
+                .unwrap_or_else(|| s.clone());
+            response["SecretString"] = json!(plaintext);
         }
         if let Some(ref b) = version.secret_binary {
             response["SecretBinary"] = json!(base64_encode(b));
@@ -465,9 +553,18 @@ impl SecretsManagerService {
         // Remove versions with no stages
         secret.versions.retain(|_, v| !v.stages.is_empty());
 
+        let kms_key_for_enc = secret.kms_key_id.clone();
+        let arn_for_enc = secret.arn.clone();
+        let stored_secret_string = self.maybe_encrypt_secret_string(
+            &req.account_id,
+            &req.region,
+            &arn_for_enc,
+            kms_key_for_enc.as_deref(),
+            secret_string,
+        );
         let version = SecretVersion {
             version_id: version_id.clone(),
-            secret_string,
+            secret_string: stored_secret_string,
             secret_binary,
             stages: version_stages.clone(),
             created_at: now,

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -43,16 +43,21 @@ enum VersionIdempotency {
 /// version. AWS uses `ClientRequestToken` as a client-side idempotency
 /// key, so a repeat write of the exact same payload is a success but a
 /// repeat with a different payload is a `ResourceExistsException`.
+///
+/// `existing_plaintext` is the existing version's decrypted secret
+/// string — callers compute this via the KMS hook before invoking so
+/// the comparison happens on plaintext, not on stored ciphertext.
 fn check_secret_version_idempotency(
     versions: &HashMap<String, SecretVersion>,
     version_id: &str,
+    existing_plaintext: Option<String>,
     secret_string: &Option<String>,
     secret_binary: &Option<Vec<u8>>,
 ) -> VersionIdempotency {
     let Some(existing) = versions.get(version_id) else {
         return VersionIdempotency::NotFound;
     };
-    if &existing.secret_string == secret_string && &existing.secret_binary == secret_binary {
+    if &existing_plaintext == secret_string && &existing.secret_binary == secret_binary {
         VersionIdempotency::Match
     } else {
         VersionIdempotency::Conflict
@@ -214,9 +219,18 @@ impl SecretsManagerService {
 
         if let Some(existing) = state.secrets.get(&input.name) {
             if let Some(ref token) = input.client_request_token {
+                let existing_plaintext = existing.versions.get(token).and_then(|v| {
+                    self.maybe_decrypt_secret_string(
+                        &req.account_id,
+                        &existing.arn,
+                        existing.kms_key_id.as_deref(),
+                        v.secret_string.as_deref(),
+                    )
+                });
                 match check_secret_version_idempotency(
                     &existing.versions,
                     token,
+                    existing_plaintext,
                     &input.secret_string,
                     &input.secret_binary,
                 ) {
@@ -475,9 +489,18 @@ impl SecretsManagerService {
             .map(|s| s.to_string())
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+        let existing_plaintext = secret.versions.get(&version_id).and_then(|v| {
+            self.maybe_decrypt_secret_string(
+                &req.account_id,
+                &secret.arn,
+                secret.kms_key_id.as_deref(),
+                v.secret_string.as_deref(),
+            )
+        });
         match check_secret_version_idempotency(
             &secret.versions,
             &version_id,
+            existing_plaintext,
             &secret_string,
             &secret_binary,
         ) {
@@ -634,9 +657,18 @@ impl SecretsManagerService {
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+            let existing_plaintext = secret.versions.get(&vid).and_then(|v| {
+                self.maybe_decrypt_secret_string(
+                    &req.account_id,
+                    &secret.arn,
+                    secret.kms_key_id.as_deref(),
+                    v.secret_string.as_deref(),
+                )
+            });
             match check_secret_version_idempotency(
                 &secret.versions,
                 &vid,
+                existing_plaintext,
                 &secret_string,
                 &secret_binary,
             ) {
@@ -4400,13 +4432,19 @@ mod tests {
 
         // Not found
         assert!(matches!(
-            check_secret_version_idempotency(&versions, "v2", &Some("x".to_string()), &None),
+            check_secret_version_idempotency(&versions, "v2", None, &Some("x".to_string()), &None),
             VersionIdempotency::NotFound
         ));
 
         // Match
         assert!(matches!(
-            check_secret_version_idempotency(&versions, "v1", &Some("hello".to_string()), &None),
+            check_secret_version_idempotency(
+                &versions,
+                "v1",
+                Some("hello".to_string()),
+                &Some("hello".to_string()),
+                &None
+            ),
             VersionIdempotency::Match
         ));
 
@@ -4415,6 +4453,7 @@ mod tests {
             check_secret_version_idempotency(
                 &versions,
                 "v1",
+                Some("hello".to_string()),
                 &Some("different".to_string()),
                 &None
             ),

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -220,6 +220,12 @@ async fn main() {
             &endpoint_url,
         ),
     ));
+    let kms_usage_state: fakecloud_kms::hook::SharedKmsUsageState = Arc::new(
+        parking_lot::RwLock::new(fakecloud_kms::hook::KmsUsageState::default()),
+    );
+    let kms_hook_for_services: Arc<dyn fakecloud_core::delivery::KmsHook> = Arc::new(
+        KmsHookAdapter::new(kms_state.clone(), kms_usage_state.clone()),
+    );
     let cloudformation_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,
@@ -1151,6 +1157,7 @@ async fn main() {
         };
     let mut secretsmanager_service =
         SecretsManagerService::new(secretsmanager_state).with_delivery(delivery_for_secretsmanager);
+    secretsmanager_service = secretsmanager_service.with_kms_hook(kms_hook_for_services.clone());
     if let Some(store) = secretsmanager_snapshot_store {
         secretsmanager_service = secretsmanager_service.with_snapshot_store(store);
     }
@@ -2367,6 +2374,28 @@ async fn main() {
                         })
                         .collect();
                     axum::Json(types::LambdaInvocationsResponse { invocations })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/kms/usage",
+            axum::routing::get({
+                let ks = kms_usage_state.clone();
+                move || async move {
+                    let recs = ks
+                        .read()
+                        .records()
+                        .iter()
+                        .map(|r| serde_json::json!({
+                            "timestamp": r.timestamp.to_rfc3339(),
+                            "operation": r.operation,
+                            "servicePrincipal": r.service_principal,
+                            "accountId": r.account_id,
+                            "keyArn": r.key_arn,
+                            "encryptionContext": r.encryption_context,
+                        }))
+                        .collect::<Vec<_>>();
+                    axum::Json(serde_json::json!({"records": recs}))
                 }
             }),
         )
@@ -4072,6 +4101,64 @@ async fn shutdown_signal() {
     }
 
     tracing::info!("shutting down");
+}
+
+/// Adapter that exposes the `fakecloud-kms` hook through the
+/// `fakecloud-core::delivery::KmsHook` trait so non-KMS services can
+/// call into KMS without a direct crate dependency.
+struct KmsHookAdapter {
+    inner: fakecloud_kms::hook::KmsServiceHook,
+}
+
+impl KmsHookAdapter {
+    fn new(
+        state: fakecloud_kms::state::SharedKmsState,
+        usage: fakecloud_kms::hook::SharedKmsUsageState,
+    ) -> Self {
+        Self {
+            inner: fakecloud_kms::hook::KmsServiceHook::new(state, usage),
+        }
+    }
+}
+
+impl fakecloud_core::delivery::KmsHook for KmsHookAdapter {
+    fn encrypt(
+        &self,
+        account_id: &str,
+        region: &str,
+        key_id: &str,
+        plaintext: &[u8],
+        service_principal: &str,
+        encryption_context: std::collections::HashMap<String, String>,
+    ) -> Result<String, String> {
+        self.inner
+            .encrypt(
+                account_id,
+                region,
+                key_id,
+                plaintext,
+                service_principal,
+                encryption_context,
+            )
+            .map_err(|e| e.to_string())
+    }
+
+    fn decrypt(
+        &self,
+        account_id: &str,
+        ciphertext_b64: &str,
+        service_principal: &str,
+        encryption_context: std::collections::HashMap<String, String>,
+    ) -> Result<Vec<u8>, String> {
+        self.inner
+            .decrypt(
+                account_id,
+                ciphertext_b64,
+                service_principal,
+                encryption_context,
+            )
+            .map_err(|e| e.to_string())
+    }
 }
 
 /// Emit a fatal error through the tracing pipeline, flush stderr so the

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -44,6 +44,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 
 - **CloudFormation -> Lambda / SNS** — Custom resources invoke via `ServiceToken`, stack events notify via `NotificationARNs`.
 - **Secrets Manager -> Lambda** — Rotation invokes Lambda for all 4 steps.
+- **Secrets Manager -> KMS** — When a secret has `KmsKeyId`, `CreateSecret` / `PutSecretValue` call `kms:GenerateDataKey` and `GetSecretValue` calls `kms:Decrypt` with the AWS-shaped encryption context `{aws:secretsmanager:secretArn: <arn>}`. Auto-provisions the `aws/secretsmanager` AWS-managed key on first use. All KMS calls are recorded at `/_fakecloud/kms/usage`.
 - **S3 Lifecycle** — Background expiration and storage class transitions.
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.

--- a/website/content/docs/services/kms.md
+++ b/website/content/docs/services/kms.md
@@ -20,6 +20,11 @@ fakecloud implements **53 of 53** KMS operations at 100% Smithy conformance.
 - **Key import** — GetParametersForImport, ImportKeyMaterial with real key material handling
 - **Custom key stores** — CRUD (records only)
 - **Key replica** — ReplicateKey
+- **Cross-service KMS hook** — services that accept a `KmsKeyId` (Secrets Manager today, SSM SecureString / S3 SSE-KMS / SQS / SNS / DynamoDB rolling out in follow-up PRs) call into KMS for real encrypt/decrypt and the calls are recorded at `/_fakecloud/kms/usage` so test code can assert which service principal triggered which operation on which key with which encryption context. AWS-managed aliases (`aws/secretsmanager`, etc.) auto-provision on first use.
+
+## Introspection
+
+- `GET /_fakecloud/kms/usage` — list every cross-service KMS call (operation, service principal, key ARN, encryption context). Useful for asserting that your code path actually triggered KMS encrypt/decrypt under the hood.
 
 ## Protocol
 

--- a/website/content/docs/services/secretsmanager.md
+++ b/website/content/docs/services/secretsmanager.md
@@ -15,6 +15,7 @@ fakecloud implements **23 of 23** Secrets Manager operations at 100% Smithy conf
 - **Automatic rotation scheduling** — via `/_fakecloud/secretsmanager/rotation-scheduler/tick`
 - **Replication** — replica regions tracked in state, not actually replicated
 - **Random password generation** — GetRandomPassword with full character class support
+- **Real KMS encryption** — when `KmsKeyId` is set on a secret, `CreateSecret` / `PutSecretValue` call `kms:GenerateDataKey` and `GetSecretValue` calls `kms:Decrypt` with the AWS-shaped encryption context `{aws:secretsmanager:secretArn: <arn>}`. The `aws/secretsmanager` AWS-managed key auto-provisions on first use. All KMS calls land in `/_fakecloud/kms/usage` so test code can assert encryption ran.
 
 ## Protocol
 
@@ -23,10 +24,12 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 ## Introspection
 
 - `POST /_fakecloud/secretsmanager/rotation-scheduler/tick` — trigger rotation for secrets whose schedule is due
+- `GET /_fakecloud/kms/usage` — list every KMS call triggered by service-side encryption (Secrets Manager, and the rest of the services as the KMS hook rolls out), with operation, service principal, key ARN, and encryption context
 
 ## Cross-service delivery
 
 - **Secrets Manager -> Lambda** — Rotation invokes the configured Lambda for all 4 rotation steps
+- **Secrets Manager -> KMS** — Encrypt on Create / PutSecretValue, Decrypt on GetSecretValue when `KmsKeyId` is set
 
 ## Source
 


### PR DESCRIPTION
## Summary

First slice of the batch-6 KMS rollout. Introduces the cross-service KMS hook + introspection endpoint, then wires Secrets Manager as the first consumer. Lays the foundation for SSM SecureString, S3 SSE-KMS, SQS, SNS, and DynamoDB to call KMS for real in follow-up PRs.

- New \`fakecloud-kms::hook::KmsServiceHook\` resolves keys (raw id, alias, ARN), auto-provisions AWS-managed aliases (\`aws/<service>\`) on first use, encrypts via the existing \`fakecloud-kms:\` envelope (decryptable by the public KMS \`Decrypt\` API), and pushes a \`KmsUsageRecord\` with operation, service principal, key ARN, and encryption context.
- New \`fakecloud-core::delivery::KmsHook\` trait + \`KmsHookAdapter\` so service crates call KMS without a direct crate dep.
- Secrets Manager \`CreateSecret\` / \`PutSecretValue\` encrypt when \`KmsKeyId\` is set; \`GetSecretValue\` decrypts. Uses the AWS-shaped encryption context \`{aws:secretsmanager:secretArn: <arn>}\`.
- New introspection endpoint \`GET /_fakecloud/kms/usage\` returns operation/principal/key/context records so test code can assert encryption ran.

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test secretsmanager_kms\` — 2 tests: encrypt + decrypt round-trip with usage records, and \"no \`KmsKeyId\` = no KMS calls\".
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

Encryption context validation (reject decrypt when ctx differs), KMS key policy enforcement, and rolling the hook out to S3 / SSM / SQS / SNS / DynamoDB land in follow-up PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-service KMS hook with introspection and wires Secrets Manager to use real encrypt/decrypt. Also fixes KMS ARN resolution and `ClientRequestToken` idempotency for encrypted secrets.

- **New Features**
  - `fakecloud-kms::hook::KmsServiceHook` resolves key id/alias/ARN, auto-creates `aws/<service>` keys, encrypts via the `fakecloud-kms:` envelope, and records usage (operation, principal, key ARN, context).
  - `fakecloud-core::delivery::KmsHook` + server `KmsHookAdapter` let services call KMS without a direct `fakecloud-kms` dependency.
  - Secrets Manager: `CreateSecret`/`PutSecretValue` encrypt when `KmsKeyId` is set (empty defaults to `aws/secretsmanager`); `GetSecretValue` decrypts using `{aws:secretsmanager:secretArn: <arn>}`.
  - Introspection: `GET /_fakecloud/kms/usage` returns recorded KMS calls for assertions.

- **Bug Fixes**
  - KMS hook now parses key/alias ARNs correctly by stripping both region and account (`strip_kms_arn_prefix`), with unit tests.
  - Secrets Manager idempotency now compares plaintext by decrypting the existing version before checking `ClientRequestToken`, fixing false conflicts when secrets are encrypted.

<sup>Written for commit 9a277a719b04e98e29f969bc1ebfc4f6ac948f0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

