### PR TITLE
feat(kms): real S3 SSE-KMS + SSM SecureString encryption via KMS hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | EventBridge Scheduler  |  12 | at/rate/cron, SQS targets, DLQ routing, one-shot self-delete           |
 | Lambda                 |  85 | Real code execution in Docker, 13 runtimes, event source mappings      |
 | DynamoDB               |  57 | Transactions, PartiQL, backups, global tables, streams                 |
-| IAM                    | 176 | Users, roles, policies, groups, instance profiles, OIDC/SAML           |
+| IAM                    | 176 | Users, roles, policies, groups, OIDC/SAML, **PassRole trust enforcement** |
 | STS                    |  11 | AssumeRole, session tokens, federation                                 |
 | SSM                    | 146 | Parameters, documents, commands, maintenance, patch baselines          |
 | Secrets Manager        |  23 | Versioning, rotation via Lambda, replication, **real KMS encrypt/decrypt** |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
-| S3                     | 107 | Versioning, lifecycle, notifications, multipart, replication, website  |
+| S3                     | 107 | Versioning, lifecycle, notifications, multipart, replication, website, **real SSE-KMS encrypt/decrypt** |
 | SQS                    |  23 | FIFO, DLQs, long polling, batch                                        |
 | SNS                    |  42 | Fan-out to SQS/Lambda/HTTP, filter policies                            |
 | EventBridge            |  57 | Pattern matching, schedules, archives, replay, API destinations        |
@@ -61,7 +61,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | DynamoDB               |  57 | Transactions, PartiQL, backups, global tables, streams                 |
 | IAM                    | 176 | Users, roles, policies, groups, OIDC/SAML, **PassRole trust enforcement** |
 | STS                    |  11 | AssumeRole, session tokens, federation                                 |
-| SSM                    | 146 | Parameters, documents, commands, maintenance, patch baselines          |
+| SSM                    | 146 | Parameters, documents, commands, maintenance, patch baselines, **SecureString -> real KMS encrypt/decrypt** |
 | Secrets Manager        |  23 | Versioning, rotation via Lambda, replication, **real KMS encrypt/decrypt** |
 | CloudWatch Logs        | 113 | Groups, streams, subscription filters, query language                  |
 | KMS                    |  53 | Encryption, aliases, grants, real ECDH, key import, **cross-service hook** |

--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -413,6 +413,62 @@ pub trait ResourcePolicyProvider: Send + Sync {
     fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String>;
 }
 
+/// Failure mode for IAM PassRole trust-policy validation.
+///
+/// Exists in `fakecloud-core` so service crates (Lambda, ECS, …) can
+/// surface a wire-shaped error without taking a dependency on
+/// `fakecloud-iam`. The server crate wires the concrete validator that
+/// reads the IAM state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassRoleError {
+    /// No role with this ARN exists in the IAM state.
+    RoleNotFound(String),
+    /// Role exists but its `AssumeRolePolicyDocument` does not allow the
+    /// service principal to call `sts:AssumeRole`. Real AWS returns
+    /// `InvalidParameterValueException` in this shape.
+    TrustPolicyDenies {
+        role_arn: String,
+        service_principal: String,
+    },
+    /// Role's `AssumeRolePolicyDocument` could not be parsed as JSON.
+    InvalidTrustPolicy(String),
+}
+
+impl std::fmt::Display for PassRoleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RoleNotFound(arn) => write!(f, "role not found: {arn}"),
+            Self::TrustPolicyDenies {
+                role_arn,
+                service_principal,
+            } => write!(
+                f,
+                "Role's trust policy does not allow {service_principal} to assume the role: {role_arn}"
+            ),
+            Self::InvalidTrustPolicy(arn) => {
+                write!(f, "invalid trust policy on role {arn}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PassRoleError {}
+
+/// Validator that checks whether a role can be passed to a given
+/// service. Used by Lambda / ECS / EC2 etc. to reject `CreateFunction`,
+/// `RegisterTaskDefinition`, etc. when the supplied role's trust policy
+/// doesn't allow the service principal — matching the `iam:PassRole`
+/// trust-side behavior real AWS enforces unconditionally (separate from
+/// identity-policy `iam:PassRole`, which sits behind the IAM evaluator).
+pub trait RoleTrustValidator: Send + Sync {
+    fn validate(
+        &self,
+        account_id: &str,
+        role_arn: &str,
+        service_principal: &str,
+    ) -> Result<(), PassRoleError>;
+}
+
 /// Composite [`ResourcePolicyProvider`] that delegates to a list of
 /// sub-providers in order, returning the first `Some` hit.
 ///

--- a/crates/fakecloud-e2e/tests/iam_pass_role.rs
+++ b/crates/fakecloud-e2e/tests/iam_pass_role.rs
@@ -1,0 +1,190 @@
+//! IAM PassRole trust-policy enforcement across services that accept a
+//! role ARN (Lambda CreateFunction, ECS RegisterTaskDefinition / RunTask).
+//!
+//! AWS validates two things when a service is given a role:
+//!   1. caller has `iam:PassRole` on the role (identity-policy half),
+//!   2. role's `AssumeRolePolicyDocument` allows the service principal
+//!      (trust-policy half).
+//!
+//! These tests cover the trust-policy half — the service-side check
+//! that real AWS enforces unconditionally regardless of the caller's
+//! identity policy.
+
+mod helpers;
+
+use aws_sdk_ecs::types::ContainerDefinition;
+use helpers::TestServer;
+
+const LAMBDA_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+const ECS_TASKS_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+const EC2_TRUST: &str = r#"{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ec2.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}"#;
+
+async fn create_role(iam: &aws_sdk_iam::Client, name: &str, trust: &str) -> String {
+    iam.create_role()
+        .role_name(name)
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap()
+        .role()
+        .unwrap()
+        .arn()
+        .to_string()
+}
+
+#[tokio::test]
+async fn lambda_create_function_rejects_role_without_lambda_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let lambda = server.lambda_client().await;
+
+    let bad_role = create_role(&iam, "ec2-only-role", EC2_TRUST).await;
+
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    let err = lambda
+        .create_function()
+        .function_name("rejects-bad-role")
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role(bad_role.clone())
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err(
+            "CreateFunction should fail when role's trust policy excludes lambda.amazonaws.com",
+        );
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("trust policy")
+            || msg.contains("InvalidParameterValueException")
+            || msg.contains("lambda.amazonaws.com"),
+        "expected PassRole trust-policy rejection, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn lambda_create_function_accepts_role_with_lambda_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let lambda = server.lambda_client().await;
+
+    let good_role = create_role(&iam, "lambda-exec", LAMBDA_TRUST).await;
+
+    let zip = aws_sdk_lambda::primitives::Blob::new(minimal_zip());
+    let resp = lambda
+        .create_function()
+        .function_name("trust-policy-ok")
+        .runtime(aws_sdk_lambda::types::Runtime::Provided)
+        .role(good_role)
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(zip)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("CreateFunction should succeed when role trusts lambda.amazonaws.com");
+    assert_eq!(resp.function_name(), Some("trust-policy-ok"));
+}
+
+#[tokio::test]
+async fn ecs_register_task_definition_rejects_role_without_ecs_tasks_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let ecs = server.ecs_client().await;
+
+    let bad_role = create_role(&iam, "lambda-only-role", LAMBDA_TRUST).await;
+
+    let cd = ContainerDefinition::builder()
+        .name("app")
+        .image("public.ecr.aws/docker/library/alpine:3.19")
+        .build();
+
+    let err = ecs
+        .register_task_definition()
+        .family("rejects-bad-task-role")
+        .container_definitions(cd)
+        .task_role_arn(bad_role.clone())
+        .send()
+        .await
+        .expect_err("RegisterTaskDefinition should fail when taskRoleArn doesn't trust ecs-tasks.amazonaws.com");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("trust policy")
+            || msg.contains("InvalidParameterException")
+            || msg.contains("ecs-tasks.amazonaws.com"),
+        "expected PassRole trust-policy rejection, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ecs_register_task_definition_accepts_role_with_ecs_tasks_trust() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let ecs = server.ecs_client().await;
+
+    let good_role = create_role(&iam, "ecs-task", ECS_TASKS_TRUST).await;
+    let exec_role = create_role(&iam, "ecs-exec", ECS_TASKS_TRUST).await;
+
+    let cd = ContainerDefinition::builder()
+        .name("app")
+        .image("public.ecr.aws/docker/library/alpine:3.19")
+        .build();
+
+    let resp = ecs
+        .register_task_definition()
+        .family("good-roles")
+        .container_definitions(cd)
+        .task_role_arn(good_role)
+        .execution_role_arn(exec_role)
+        .send()
+        .await
+        .expect("RegisterTaskDefinition should accept ecs-tasks.amazonaws.com-trusting roles");
+    assert_eq!(resp.task_definition().unwrap().family(), Some("good-roles"));
+}
+
+/// Smallest possible zip with a single empty file. Lambda CreateFunction
+/// won't actually invoke the function in this test — we only need the
+/// service to accept the upload and complete the create.
+fn minimal_zip() -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+        zip.start_file("index.sh", opts).unwrap();
+        zip.write_all(b"#!/bin/sh\necho hi\n").unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}

--- a/crates/fakecloud-e2e/tests/s3_sse_kms.rs
+++ b/crates/fakecloud-e2e/tests/s3_sse_kms.rs
@@ -1,0 +1,136 @@
+//! S3 SSE-KMS end-to-end:
+//! - PutObject with `ServerSideEncryption=aws:kms` triggers
+//!   `kms:GenerateDataKey` with the bucket-arn encryption context
+//! - GetObject decrypts via `kms:Decrypt` and returns the original bytes
+//! - Both calls land in `/_fakecloud/kms/usage`
+//! - Range reads against an SSE-KMS object slice plaintext, not ciphertext
+
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::ServerSideEncryption;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn s3_put_get_sse_kms_round_trip() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    let http = reqwest::Client::new();
+
+    s3.create_bucket().bucket("encrypted").send().await.unwrap();
+    s3.put_object()
+        .bucket("encrypted")
+        .key("note.txt")
+        .body(ByteStream::from_static(b"top-secret-payload"))
+        .server_side_encryption(ServerSideEncryption::AwsKms)
+        .ssekms_key_id("alias/aws/s3")
+        .send()
+        .await
+        .unwrap();
+
+    let got = s3
+        .get_object()
+        .bucket("encrypted")
+        .key("note.txt")
+        .send()
+        .await
+        .unwrap();
+    let bytes = got.body.collect().await.unwrap().into_bytes();
+    assert_eq!(
+        &bytes[..],
+        b"top-secret-payload",
+        "GetObject must return plaintext after SSE-KMS round-trip"
+    );
+
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    let s3_records: Vec<&serde_json::Value> = records
+        .iter()
+        .filter(|r| r["servicePrincipal"].as_str() == Some("s3.amazonaws.com"))
+        .collect();
+    assert!(
+        s3_records.iter().any(|r| {
+            r["operation"].as_str() == Some("GenerateDataKey")
+                && r["encryptionContext"]["aws:s3:arn"].as_str() == Some("arn:aws:s3:::encrypted")
+        }),
+        "expected GenerateDataKey bound to bucket arn, got: {s3_records:?}"
+    );
+    assert!(
+        s3_records.iter().any(|r| {
+            r["operation"].as_str() == Some("Decrypt")
+                && r["encryptionContext"]["aws:s3:arn"].as_str() == Some("arn:aws:s3:::encrypted")
+        }),
+        "expected Decrypt bound to bucket arn, got: {s3_records:?}"
+    );
+}
+
+#[tokio::test]
+async fn s3_sse_kms_range_read_returns_plaintext_slice() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket().bucket("ranges").send().await.unwrap();
+    s3.put_object()
+        .bucket("ranges")
+        .key("doc")
+        .body(ByteStream::from_static(b"abcdefghij"))
+        .server_side_encryption(ServerSideEncryption::AwsKms)
+        .ssekms_key_id("alias/aws/s3")
+        .send()
+        .await
+        .unwrap();
+
+    let got = s3
+        .get_object()
+        .bucket("ranges")
+        .key("doc")
+        .range("bytes=2-5")
+        .send()
+        .await
+        .unwrap();
+    let bytes = got.body.collect().await.unwrap().into_bytes();
+    assert_eq!(
+        &bytes[..],
+        b"cdef",
+        "ranged read of SSE-KMS object must slice plaintext, not the stored ciphertext envelope"
+    );
+}
+
+#[tokio::test]
+async fn s3_plain_put_does_not_invoke_kms() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    let http = reqwest::Client::new();
+
+    s3.create_bucket().bucket("plain").send().await.unwrap();
+    s3.put_object()
+        .bucket("plain")
+        .key("k")
+        .body(ByteStream::from_static(b"v"))
+        .send()
+        .await
+        .unwrap();
+
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    assert!(
+        !records
+            .iter()
+            .any(|r| r["servicePrincipal"].as_str() == Some("s3.amazonaws.com")),
+        "PutObject without SSE-KMS must not record KMS usage, got: {records:?}"
+    );
+}

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -368,7 +368,11 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
 
-    // Get WITHOUT WithDecryption (default) - returns kms-prefixed "encrypted" form
+    // Get WITHOUT WithDecryption (default) — returns the ciphertext
+    // envelope under the `kms:<key>:` prefix the rest of fakecloud uses.
+    // The body is opaque base64; assert only the shape and the absence
+    // of the plaintext, matching real AWS where the un-decrypted value
+    // is an opaque KMS ciphertext blob.
     let resp = client
         .get_parameter()
         .name("/secret/password")
@@ -376,7 +380,15 @@ async fn ssm_secure_string_with_decryption() {
         .await
         .unwrap();
     let param = resp.parameter().unwrap();
-    assert_eq!(param.value().unwrap(), "kms:alias/aws/ssm:super-secret-123");
+    let value = param.value().unwrap();
+    assert!(
+        value.starts_with("kms:alias/aws/ssm:"),
+        "expected kms-prefixed envelope, got: {value}"
+    );
+    assert!(
+        !value.contains("super-secret-123"),
+        "un-decrypted SecureString must not leak plaintext, got: {value}"
+    );
 
     // Get WITH WithDecryption=true - should return actual value
     let resp = client

--- a/crates/fakecloud-e2e/tests/ssm_kms.rs
+++ b/crates/fakecloud-e2e/tests/ssm_kms.rs
@@ -1,0 +1,98 @@
+//! SSM SecureString + KMS hook end-to-end:
+//! - PutParameter with `Type=SecureString` triggers `kms:GenerateDataKey`
+//! - GetParameter with `WithDecryption=true` triggers `kms:Decrypt` and
+//!   returns the original plaintext (transparent round-trip)
+//! - Both calls land in `/_fakecloud/kms/usage` with the
+//!   parameter-arn-shaped encryption context
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn ssm_securestring_round_trips_through_kms() {
+    let server = TestServer::start().await;
+    let ssm = server.ssm_client().await;
+    let http = reqwest::Client::new();
+
+    ssm.put_parameter()
+        .name("/app/db/password")
+        .value("hunter2")
+        .r#type(aws_sdk_ssm::types::ParameterType::SecureString)
+        .send()
+        .await
+        .unwrap();
+
+    let got = ssm
+        .get_parameter()
+        .name("/app/db/password")
+        .with_decryption(true)
+        .send()
+        .await
+        .unwrap();
+    let p = got.parameter().expect("parameter present");
+    assert_eq!(
+        p.value(),
+        Some("hunter2"),
+        "SecureString GetParameter with WithDecryption=true must return plaintext"
+    );
+
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    let svc_records: Vec<&serde_json::Value> = records
+        .iter()
+        .filter(|r| r["servicePrincipal"].as_str() == Some("ssm.amazonaws.com"))
+        .collect();
+    assert!(
+        svc_records.iter().any(|r| {
+            r["operation"].as_str() == Some("GenerateDataKey")
+                && r["encryptionContext"]["PARAMETER_ARN"].as_str().is_some()
+        }),
+        "expected GenerateDataKey record bound to PARAMETER_ARN, got: {svc_records:?}"
+    );
+    assert!(
+        svc_records.iter().any(|r| {
+            r["operation"].as_str() == Some("Decrypt")
+                && r["encryptionContext"]["PARAMETER_ARN"].as_str().is_some()
+        }),
+        "expected Decrypt record bound to PARAMETER_ARN, got: {svc_records:?}"
+    );
+}
+
+#[tokio::test]
+async fn ssm_string_does_not_record_kms_usage() {
+    let server = TestServer::start().await;
+    let ssm = server.ssm_client().await;
+    let http = reqwest::Client::new();
+
+    ssm.put_parameter()
+        .name("/app/feature-flag")
+        .value("on")
+        .r#type(aws_sdk_ssm::types::ParameterType::String)
+        .send()
+        .await
+        .unwrap();
+
+    let usage: serde_json::Value = http
+        .get(format!("{}/_fakecloud/kms/usage", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let records = usage["records"].as_array().expect("records array");
+    assert!(
+        !records
+            .iter()
+            .any(|r| r["servicePrincipal"].as_str() == Some("ssm.amazonaws.com")),
+        "plain String parameters must not trigger KMS calls, got: {records:?}"
+    );
+}

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -126,6 +126,7 @@ pub struct EcsService {
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
     runtime: Option<Arc<crate::runtime::EcsRuntime>>,
+    role_trust_validator: Option<Arc<dyn fakecloud_core::auth::RoleTrustValidator>>,
 }
 
 impl EcsService {
@@ -135,6 +136,7 @@ impl EcsService {
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             runtime: None,
+            role_trust_validator: None,
         }
     }
 
@@ -146,6 +148,28 @@ impl EcsService {
     pub fn with_runtime(mut self, runtime: Arc<crate::runtime::EcsRuntime>) -> Self {
         self.runtime = Some(runtime);
         self
+    }
+
+    pub fn with_role_trust_validator(
+        mut self,
+        validator: Arc<dyn fakecloud_core::auth::RoleTrustValidator>,
+    ) -> Self {
+        self.role_trust_validator = Some(validator);
+        self
+    }
+
+    fn check_pass_role(&self, account_id: &str, role_arn: &str) -> Result<(), AwsServiceError> {
+        let Some(ref validator) = self.role_trust_validator else {
+            return Ok(());
+        };
+        if let Err(err) = validator.validate(account_id, role_arn, "ecs-tasks.amazonaws.com") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                err.to_string(),
+            ));
+        }
+        Ok(())
     }
 
     pub fn state_handle(&self) -> &SharedEcsState {
@@ -831,6 +855,16 @@ impl EcsService {
                 ));
             }
         }
+        // PassRole trust check on the task + execution roles. Real AWS
+        // rejects RegisterTaskDefinition when the role's trust policy
+        // doesn't list `ecs-tasks.amazonaws.com`.
+        if let Some(role_arn) = opt_str(&body, "taskRoleArn") {
+            self.check_pass_role(&request.account_id, role_arn)?;
+        }
+        if let Some(role_arn) = opt_str(&body, "executionRoleArn") {
+            self.check_pass_role(&request.account_id, role_arn)?;
+        }
+
         let tags = parse_tags(&body);
         let requires_compatibilities: Vec<String> = body
             .get("requiresCompatibilities")
@@ -1451,6 +1485,20 @@ impl EcsService {
         let group = opt_str(&body, "group").map(String::from);
         let started_by = opt_str(&body, "startedBy").map(String::from);
         let tags = parse_tags(&body);
+
+        // PassRole trust check on any role overrides supplied via the
+        // overrides.taskRoleArn / overrides.executionRoleArn fields.
+        // The base task definition was already checked at Register time,
+        // but RunTask can override either role and AWS re-validates the
+        // trust policy on every call.
+        if let Some(overrides) = body.get("overrides") {
+            if let Some(role_arn) = opt_str(overrides, "taskRoleArn") {
+                self.check_pass_role(&request.account_id, role_arn)?;
+            }
+            if let Some(role_arn) = opt_str(overrides, "executionRoleArn") {
+                self.check_pass_role(&request.account_id, role_arn)?;
+            }
+        }
 
         let account = request.account_id.clone();
         let runtime = self.runtime.clone();

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -2,6 +2,7 @@ pub mod condition;
 pub mod credential_resolver;
 pub mod evaluator;
 pub mod iam_service;
+pub mod pass_role;
 pub mod persistence;
 pub mod policy_evaluator;
 pub mod policy_validation;

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -47,25 +47,37 @@ fn role_name_from_arn(role_arn: &str) -> Option<&str> {
 }
 
 impl RoleTrustValidator for IamRoleTrustValidator {
+    /// Validate a role's trust policy against a service principal.
+    ///
+    /// fakecloud is intentionally permissive when the role is not
+    /// present in IAM state: real AWS requires the role to exist, but
+    /// long-standing fakecloud tests pass arbitrary role ARNs without
+    /// creating IAM roles first. To keep that test culture working we
+    /// only reject when the role *does* exist *and* its trust policy
+    /// explicitly excludes the calling service principal — the
+    /// high-signal failure mode users actually hit.
     fn validate(
         &self,
         account_id: &str,
         role_arn: &str,
         service_principal: &str,
     ) -> Result<(), PassRoleError> {
-        let name = role_name_from_arn(role_arn)
-            .ok_or_else(|| PassRoleError::RoleNotFound(role_arn.to_string()))?;
+        let Some(name) = role_name_from_arn(role_arn) else {
+            return Ok(());
+        };
 
         let mas = self.state.read();
         let Some(state) = mas.get(account_id) else {
-            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+            return Ok(());
         };
         let Some(role) = state.roles.get(name) else {
-            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+            return Ok(());
         };
 
-        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
-            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
+        let parsed: Value = match serde_json::from_str(&role.assume_role_policy_document) {
+            Ok(v) => v,
+            Err(_) => return Ok(()),
+        };
 
         if trust_policy_allows(&parsed, service_principal) {
             Ok(())

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -1,0 +1,201 @@
+//! IAM PassRole trust-policy validator.
+//!
+//! When a service like Lambda or ECS is given a role to assume, the
+//! caller's `iam:PassRole` permission is one half of the check; the
+//! other half is the role's own trust policy (the
+//! `AssumeRolePolicyDocument`). Real AWS rejects the operation when the
+//! role's trust policy does not include the relevant service principal
+//! in an `Allow` statement, regardless of the caller's identity policy.
+//!
+//! This module implements the trust-policy half via
+//! [`fakecloud_core::auth::RoleTrustValidator`]. The identity-policy
+//! half lives in the existing IAM evaluator and is invoked separately
+//! at the IAM evaluator boundary.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use fakecloud_core::auth::{PassRoleError, RoleTrustValidator};
+
+use crate::state::SharedIamState;
+
+/// `RoleTrustValidator` impl backed by the in-process IAM state.
+pub struct IamRoleTrustValidator {
+    state: SharedIamState,
+}
+
+impl IamRoleTrustValidator {
+    pub fn new(state: SharedIamState) -> Self {
+        Self { state }
+    }
+
+    pub fn shared(state: SharedIamState) -> Arc<dyn RoleTrustValidator> {
+        Arc::new(Self::new(state))
+    }
+}
+
+/// Parse `arn:aws:iam::<account>:role[/<path>]/<name>` into role name.
+/// Returns `None` if the ARN is not an IAM role ARN.
+fn role_name_from_arn(role_arn: &str) -> Option<&str> {
+    // Format: arn:aws:iam::<account>:role/<optional-path>/<name>
+    // Extract the substring after the last "/".
+    let role_part = role_arn.strip_prefix("arn:aws:iam::")?;
+    let (_account, rest) = role_part.split_once(':')?;
+    let role_path = rest.strip_prefix("role/")?;
+    role_path.rsplit('/').next()
+}
+
+impl RoleTrustValidator for IamRoleTrustValidator {
+    fn validate(
+        &self,
+        account_id: &str,
+        role_arn: &str,
+        service_principal: &str,
+    ) -> Result<(), PassRoleError> {
+        let name = role_name_from_arn(role_arn)
+            .ok_or_else(|| PassRoleError::RoleNotFound(role_arn.to_string()))?;
+
+        let mas = self.state.read();
+        let Some(state) = mas.get(account_id) else {
+            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+        };
+        let Some(role) = state.roles.get(name) else {
+            return Err(PassRoleError::RoleNotFound(role_arn.to_string()));
+        };
+
+        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
+            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
+
+        if trust_policy_allows(&parsed, service_principal) {
+            Ok(())
+        } else {
+            Err(PassRoleError::TrustPolicyDenies {
+                role_arn: role_arn.to_string(),
+                service_principal: service_principal.to_string(),
+            })
+        }
+    }
+}
+
+/// Returns `true` when the trust policy contains an `Allow` statement
+/// with `sts:AssumeRole` in its `Action` list and `Principal.Service`
+/// listing the supplied service principal.
+fn trust_policy_allows(policy: &Value, service_principal: &str) -> bool {
+    let statements = match policy.get("Statement") {
+        Some(Value::Array(arr)) => arr.clone(),
+        Some(stmt) => vec![stmt.clone()],
+        None => return false,
+    };
+
+    for stmt in &statements {
+        let effect = stmt
+            .get("Effect")
+            .and_then(Value::as_str)
+            .unwrap_or("Allow"); // AWS default is Allow when absent.
+        if !effect.eq_ignore_ascii_case("Allow") {
+            continue;
+        }
+        if !action_includes(stmt.get("Action"), "sts:AssumeRole") {
+            continue;
+        }
+        let Some(principal) = stmt.get("Principal") else {
+            continue;
+        };
+        if principal_service_includes(principal, service_principal) {
+            return true;
+        }
+    }
+    false
+}
+
+fn action_includes(action: Option<&Value>, target: &str) -> bool {
+    match action {
+        Some(Value::String(s)) => s == target || s == "*",
+        Some(Value::Array(arr)) => arr.iter().any(|v| match v {
+            Value::String(s) => s == target || s == "*",
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+fn principal_service_includes(principal: &Value, service_principal: &str) -> bool {
+    let Some(svc) = principal.get("Service") else {
+        return false;
+    };
+    match svc {
+        Value::String(s) => s == service_principal,
+        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(service_principal)),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allow(service: &str) -> Value {
+        serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": service}
+            }]
+        })
+    }
+
+    #[test]
+    fn parses_role_name_from_arn() {
+        assert_eq!(
+            role_name_from_arn("arn:aws:iam::000000000000:role/MyRole"),
+            Some("MyRole")
+        );
+        assert_eq!(
+            role_name_from_arn("arn:aws:iam::000000000000:role/service-role/MyRole"),
+            Some("MyRole")
+        );
+        assert_eq!(role_name_from_arn("not-an-arn"), None);
+    }
+
+    #[test]
+    fn allows_matching_service_principal() {
+        assert!(trust_policy_allows(
+            &allow("lambda.amazonaws.com"),
+            "lambda.amazonaws.com"
+        ));
+    }
+
+    #[test]
+    fn rejects_other_service_principal() {
+        assert!(!trust_policy_allows(
+            &allow("ec2.amazonaws.com"),
+            "lambda.amazonaws.com"
+        ));
+    }
+
+    #[test]
+    fn allows_array_principal() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": ["sts:AssumeRole"],
+                "Principal": {"Service": ["lambda.amazonaws.com", "ec2.amazonaws.com"]}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));
+    }
+
+    #[test]
+    fn rejects_deny_statement() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Deny",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "lambda.amazonaws.com"}
+            }]
+        });
+        assert!(!trust_policy_allows(&policy, "lambda.amazonaws.com"));
+    }
+}

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -121,12 +121,28 @@ fn action_includes(action: Option<&Value>, target: &str) -> bool {
 }
 
 fn principal_service_includes(principal: &Value, service_principal: &str) -> bool {
+    // `"Principal": "*"` (or the equivalent `{"AWS": "*"}`) trusts any
+    // principal — service principals included.
+    if let Value::String(s) = principal {
+        return s == "*";
+    }
+    if let Some(aws) = principal.get("AWS") {
+        match aws {
+            Value::String(s) if s == "*" => return true,
+            Value::Array(arr) if arr.iter().any(|v| v.as_str() == Some("*")) => return true,
+            _ => {}
+        }
+    }
     let Some(svc) = principal.get("Service") else {
         return false;
     };
     match svc {
-        Value::String(s) => s == service_principal,
-        Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(service_principal)),
+        Value::String(s) => s == "*" || s == service_principal,
+        Value::Array(arr) => arr.iter().any(|v| match v.as_str() {
+            Some("*") => true,
+            Some(p) => p == service_principal,
+            None => false,
+        }),
         _ => false,
     }
 }
@@ -182,6 +198,42 @@ mod tests {
                 "Effect": "Allow",
                 "Action": ["sts:AssumeRole"],
                 "Principal": {"Service": ["lambda.amazonaws.com", "ec2.amazonaws.com"]}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_principal_string() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": "*"
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "lambda.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_principal_aws() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"AWS": "*"}
+            }]
+        });
+        assert!(trust_policy_allows(&policy, "ecs-tasks.amazonaws.com"));
+    }
+
+    #[test]
+    fn allows_wildcard_service() {
+        let policy = serde_json::json!({
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "*"}
             }]
         });
         assert!(trust_policy_allows(&policy, "ec2.amazonaws.com"));

--- a/crates/fakecloud-iam/src/pass_role.rs
+++ b/crates/fakecloud-iam/src/pass_role.rs
@@ -74,10 +74,8 @@ impl RoleTrustValidator for IamRoleTrustValidator {
             return Ok(());
         };
 
-        let parsed: Value = match serde_json::from_str(&role.assume_role_policy_document) {
-            Ok(v) => v,
-            Err(_) => return Ok(()),
-        };
+        let parsed: Value = serde_json::from_str(&role.assume_role_policy_document)
+            .map_err(|_| PassRoleError::InvalidTrustPolicy(role_arn.to_string()))?;
 
         if trust_policy_allows(&parsed, service_principal) {
             Ok(())

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -233,6 +233,7 @@ pub struct LambdaService {
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
     pub(crate) delivery_bus: Option<Arc<fakecloud_core::delivery::DeliveryBus>>,
+    pub(crate) role_trust_validator: Option<Arc<dyn fakecloud_core::auth::RoleTrustValidator>>,
 }
 
 impl LambdaService {
@@ -243,6 +244,7 @@ impl LambdaService {
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             delivery_bus: None,
+            role_trust_validator: None,
         }
     }
 
@@ -258,6 +260,14 @@ impl LambdaService {
 
     pub fn with_delivery_bus(mut self, bus: Arc<fakecloud_core::delivery::DeliveryBus>) -> Self {
         self.delivery_bus = Some(bus);
+        self
+    }
+
+    pub fn with_role_trust_validator(
+        mut self,
+        validator: Arc<dyn fakecloud_core::auth::RoleTrustValidator>,
+    ) -> Self {
+        self.role_trust_validator = Some(validator);
         self
     }
 
@@ -727,6 +737,22 @@ impl LambdaService {
     fn create_function(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
         let input = CreateFunctionInput::from_body(&body)?;
+
+        // PassRole trust-policy check: the supplied execution role must
+        // have a trust policy that allows lambda.amazonaws.com to call
+        // sts:AssumeRole. Real AWS rejects with InvalidParameterValueException
+        // when the trust policy doesn't include the service principal.
+        if let Some(ref validator) = self.role_trust_validator {
+            if let Err(err) =
+                validator.validate(&req.account_id, &input.role, "lambda.amazonaws.com")
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    err.to_string(),
+                ));
+            }
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -105,8 +105,15 @@ impl S3Service {
     }
 
     /// Encrypt object body bytes for SSE-KMS storage. Returns ciphertext as
-    /// raw bytes (a UTF-8 fakecloud-kms envelope), or the plaintext unchanged
-    /// when no hook is configured (preserving legacy in-process tests).
+    /// raw bytes (a UTF-8 fakecloud-kms envelope) on success.
+    ///
+    /// Fail-closed: if the KMS hook reports an error (key denied, key not
+    /// found, etc.), this returns `Err` so PutObject aborts with a 500
+    /// rather than silently storing plaintext. AWS S3 has the same
+    /// behavior — `KMS.NotFoundException` and friends surface as
+    /// `AccessDenied` / `KMS.*` errors back to the caller. When no hook is
+    /// wired (legacy / in-process tests with no KMS dependency), the
+    /// plaintext is returned unchanged so existing tests keep working.
     pub(crate) fn encrypt_object_body(
         &self,
         account_id: &str,
@@ -114,53 +121,64 @@ impl S3Service {
         bucket: &str,
         plaintext: &[u8],
         kms_key_id: Option<&str>,
-    ) -> bytes::Bytes {
+    ) -> Result<bytes::Bytes, AwsServiceError> {
         let Some(hook) = &self.kms_hook else {
-            return bytes::Bytes::copy_from_slice(plaintext);
+            return Ok(bytes::Bytes::copy_from_slice(plaintext));
         };
         let key = kms_key_id.filter(|k| !k.is_empty()).unwrap_or("aws/s3");
         let bucket_arn = format!("arn:aws:s3:::{bucket}");
         let mut ctx = std::collections::HashMap::new();
         ctx.insert("aws:s3:arn".to_string(), bucket_arn);
         match hook.encrypt(account_id, region, key, plaintext, "s3.amazonaws.com", ctx) {
-            Ok(envelope) => bytes::Bytes::from(envelope.into_bytes()),
+            Ok(envelope) => Ok(bytes::Bytes::from(envelope.into_bytes())),
             Err(err) => {
-                tracing::warn!(
-                    bucket = %bucket,
-                    error = %err,
-                    "KMS encrypt failed for S3 object; storing plaintext"
-                );
-                bytes::Bytes::copy_from_slice(plaintext)
+                tracing::warn!(bucket = %bucket, error = %err, "SSE-KMS encrypt failed");
+                Err(AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMS.InternalFailureException",
+                    format!("Failed to encrypt object via KMS: {err}"),
+                ))
             }
         }
     }
 
     /// Decrypt object body bytes that were stored as a fakecloud-kms
     /// envelope. Caller is expected to gate this on
-    /// `obj.sse_algorithm == Some("aws:kms")`. Bytes that fail to decrypt
-    /// (legacy snapshots written before the hook landed) are returned
-    /// as-is rather than producing an error response.
+    /// `obj.sse_algorithm == Some("aws:kms")`.
+    ///
+    /// Fail-closed: when a hook is wired and the bytes look like an
+    /// envelope but don't decrypt (key revoked, malformed ciphertext),
+    /// this returns `Err` so GetObject surfaces a 500. When no hook is
+    /// wired, or the bytes aren't UTF-8 (legacy snapshots from before
+    /// the hook landed), the bytes are returned unchanged.
     pub(crate) fn decrypt_object_body(
         &self,
         account_id: &str,
         bucket: &str,
         ciphertext: &[u8],
-    ) -> bytes::Bytes {
+    ) -> Result<bytes::Bytes, AwsServiceError> {
         let Some(hook) = &self.kms_hook else {
-            return bytes::Bytes::copy_from_slice(ciphertext);
+            return Ok(bytes::Bytes::copy_from_slice(ciphertext));
         };
-        // Stored envelope is base64 ASCII; bytes outside that range can't
-        // be decrypted, so short-circuit to plaintext.
+        // Stored envelope is base64 ASCII; non-UTF-8 bytes are pre-hook
+        // legacy snapshots, return as-is.
         let envelope = match std::str::from_utf8(ciphertext) {
             Ok(s) => s,
-            Err(_) => return bytes::Bytes::copy_from_slice(ciphertext),
+            Err(_) => return Ok(bytes::Bytes::copy_from_slice(ciphertext)),
         };
         let bucket_arn = format!("arn:aws:s3:::{bucket}");
         let mut ctx = std::collections::HashMap::new();
         ctx.insert("aws:s3:arn".to_string(), bucket_arn);
         match hook.decrypt(account_id, envelope, "s3.amazonaws.com", ctx) {
-            Ok(bytes) => bytes::Bytes::from(bytes),
-            Err(_) => bytes::Bytes::copy_from_slice(ciphertext),
+            Ok(bytes) => Ok(bytes::Bytes::from(bytes)),
+            Err(err) => {
+                tracing::warn!(bucket = %bucket, error = %err, "SSE-KMS decrypt failed");
+                Err(AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMS.InternalFailureException",
+                    format!("Failed to decrypt object via KMS: {err}"),
+                ))
+            }
         }
     }
 }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -48,6 +48,7 @@ pub struct S3Service {
     state: SharedS3State,
     delivery: Arc<DeliveryBus>,
     kms_state: Option<SharedKmsState>,
+    pub(crate) kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
     #[allow(dead_code)]
     store: Arc<dyn S3Store>,
 }
@@ -88,6 +89,7 @@ impl S3Service {
             state,
             delivery,
             kms_state: None,
+            kms_hook: None,
             store,
         }
     }
@@ -95,6 +97,71 @@ impl S3Service {
     pub fn with_kms(mut self, kms_state: SharedKmsState) -> Self {
         self.kms_state = Some(kms_state);
         self
+    }
+
+    pub fn with_kms_hook(mut self, hook: Arc<dyn fakecloud_core::delivery::KmsHook>) -> Self {
+        self.kms_hook = Some(hook);
+        self
+    }
+
+    /// Encrypt object body bytes for SSE-KMS storage. Returns ciphertext as
+    /// raw bytes (a UTF-8 fakecloud-kms envelope), or the plaintext unchanged
+    /// when no hook is configured (preserving legacy in-process tests).
+    pub(crate) fn encrypt_object_body(
+        &self,
+        account_id: &str,
+        region: &str,
+        bucket: &str,
+        plaintext: &[u8],
+        kms_key_id: Option<&str>,
+    ) -> bytes::Bytes {
+        let Some(hook) = &self.kms_hook else {
+            return bytes::Bytes::copy_from_slice(plaintext);
+        };
+        let key = kms_key_id.filter(|k| !k.is_empty()).unwrap_or("aws/s3");
+        let bucket_arn = format!("arn:aws:s3:::{bucket}");
+        let mut ctx = std::collections::HashMap::new();
+        ctx.insert("aws:s3:arn".to_string(), bucket_arn);
+        match hook.encrypt(account_id, region, key, plaintext, "s3.amazonaws.com", ctx) {
+            Ok(envelope) => bytes::Bytes::from(envelope.into_bytes()),
+            Err(err) => {
+                tracing::warn!(
+                    bucket = %bucket,
+                    error = %err,
+                    "KMS encrypt failed for S3 object; storing plaintext"
+                );
+                bytes::Bytes::copy_from_slice(plaintext)
+            }
+        }
+    }
+
+    /// Decrypt object body bytes that were stored as a fakecloud-kms
+    /// envelope. Caller is expected to gate this on
+    /// `obj.sse_algorithm == Some("aws:kms")`. Bytes that fail to decrypt
+    /// (legacy snapshots written before the hook landed) are returned
+    /// as-is rather than producing an error response.
+    pub(crate) fn decrypt_object_body(
+        &self,
+        account_id: &str,
+        bucket: &str,
+        ciphertext: &[u8],
+    ) -> bytes::Bytes {
+        let Some(hook) = &self.kms_hook else {
+            return bytes::Bytes::copy_from_slice(ciphertext);
+        };
+        // Stored envelope is base64 ASCII; bytes outside that range can't
+        // be decrypted, so short-circuit to plaintext.
+        let envelope = match std::str::from_utf8(ciphertext) {
+            Ok(s) => s,
+            Err(_) => return bytes::Bytes::copy_from_slice(ciphertext),
+        };
+        let bucket_arn = format!("arn:aws:s3:::{bucket}");
+        let mut ctx = std::collections::HashMap::new();
+        ctx.insert("aws:s3:arn".to_string(), bucket_arn);
+        match hook.decrypt(account_id, envelope, "s3.amazonaws.com", ctx) {
+            Ok(bytes) => bytes::Bytes::from(bytes),
+            Err(_) => bytes::Bytes::copy_from_slice(ciphertext),
+        }
     }
 }
 

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -939,6 +939,9 @@ impl S3Service {
         // SSE-KMS: encrypt the body via the KMS hook so it lands as a
         // fakecloud-kms envelope on disk and through replication. Plaintext
         // size is preserved for headers via `data_size` further down.
+        // Fail-closed: a KMS error here aborts PutObject before any
+        // mutation, matching real S3 (which surfaces KMS errors back to
+        // the caller rather than silently storing plaintext).
         let stored_bytes = if sse_algorithm.as_deref() == Some("aws:kms") {
             self.encrypt_object_body(
                 account_id,
@@ -946,7 +949,7 @@ impl S3Service {
                 bucket,
                 &data,
                 sse_kms_key_id.as_deref(),
-            )
+            )?
         } else {
             data.clone()
         };
@@ -1170,11 +1173,13 @@ impl S3Service {
         let total_size = obj.size as usize;
         // SSE-KMS: pre-load and decrypt the full body so we can slice
         // ranged/multi-part reads against plaintext (matching real S3,
-        // which transparently decrypts on the read path).
+        // which transparently decrypts on the read path). Fail-closed —
+        // a KMS error surfaces as 500 KMS.InternalFailureException
+        // instead of returning the raw envelope to the caller.
         let decrypted_body: Option<Bytes> =
             if obj.sse_algorithm.as_deref() == Some("aws:kms") && self.kms_hook.is_some() {
                 let raw = state.read_body(&obj.body).map_err(super::io_to_aws)?;
-                Some(self.decrypt_object_body(account_id, bucket, &raw))
+                Some(self.decrypt_object_body(account_id, bucket, &raw)?)
             } else {
                 None
             };
@@ -2186,11 +2191,14 @@ impl S3Service {
         // Checksum: compute new if algorithm specified, or copy from source.
         // For SSE-KMS sources we work on plaintext so the checksum + the
         // destination's stored body line up with what the caller will get
-        // back from a future GetObject.
+        // back from a future GetObject. Fail-closed if the source can't
+        // be decrypted (revoked key, malformed envelope) — copying the
+        // ciphertext over to the destination would silently corrupt the
+        // copy.
         let raw_src_bytes = state.read_body(&src_obj.body).map_err(super::io_to_aws)?;
         let src_bytes =
             if src_obj.sse_algorithm.as_deref() == Some("aws:kms") && self.kms_hook.is_some() {
-                self.decrypt_object_body(account_id, src_bucket, &raw_src_bytes)
+                self.decrypt_object_body(account_id, src_bucket, &raw_src_bytes)?
             } else {
                 raw_src_bytes
             };
@@ -2217,7 +2225,7 @@ impl S3Service {
                 dest_bucket,
                 &src_bytes,
                 new_kms.as_deref(),
-            )
+            )?
         } else {
             src_bytes.clone()
         };

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -936,11 +936,26 @@ impl S3Service {
             }
         }
 
-        let store_body_bytes = data.clone();
+        // SSE-KMS: encrypt the body via the KMS hook so it lands as a
+        // fakecloud-kms envelope on disk and through replication. Plaintext
+        // size is preserved for headers via `data_size` further down.
+        let stored_bytes = if sse_algorithm.as_deref() == Some("aws:kms") {
+            self.encrypt_object_body(
+                account_id,
+                &region,
+                bucket,
+                &data,
+                sse_kms_key_id.as_deref(),
+            )
+        } else {
+            data.clone()
+        };
+        let plaintext_size = data.len() as u64;
+        let store_body_bytes = stored_bytes.clone();
         let obj = S3Object {
             key: key.to_string(),
-            size: data.len() as u64,
-            body: crate::state::memory_body(data),
+            size: plaintext_size,
+            body: crate::state::memory_body(stored_bytes),
             // The runtime body is replaced below with the BodyRef returned
             // from self.store.put_object — for memory mode this is still a
             // Memory variant; for persistent mode it points at the freshly
@@ -1153,6 +1168,16 @@ impl S3Service {
         // Conditional checks
         check_get_conditionals(req, obj)?;
         let total_size = obj.size as usize;
+        // SSE-KMS: pre-load and decrypt the full body so we can slice
+        // ranged/multi-part reads against plaintext (matching real S3,
+        // which transparently decrypts on the read path).
+        let decrypted_body: Option<Bytes> =
+            if obj.sse_algorithm.as_deref() == Some("aws:kms") && self.kms_hook.is_some() {
+                let raw = state.read_body(&obj.body).map_err(super::io_to_aws)?;
+                Some(self.decrypt_object_body(account_id, bucket, &raw))
+            } else {
+                None
+            };
         let mut headers = HeaderMap::new();
         headers.insert("etag", format!("\"{}\"", obj.etag).parse().unwrap());
         headers.insert(
@@ -1243,10 +1268,16 @@ impl S3Service {
                         );
                         let len = (end - start + 1) as u64;
                         headers.insert("content-length", len.to_string().parse().unwrap());
-                        response_body = state
-                            .read_body_range(&obj.body, start as u64, len)
-                            .map_err(super::io_to_aws)?
-                            .into();
+                        response_body = if let Some(plain) = &decrypted_body {
+                            let s = start.min(plain.len());
+                            let e = (start + len as usize).min(plain.len());
+                            plain.slice(s..e).into()
+                        } else {
+                            state
+                                .read_body_range(&obj.body, start as u64, len)
+                                .map_err(super::io_to_aws)?
+                                .into()
+                        };
                         response_status = StatusCode::PARTIAL_CONTENT;
                         is_range_request = true;
                     }
@@ -1263,12 +1294,20 @@ impl S3Service {
                     }
                     RangeResult::Ignored => {
                         headers.insert("content-length", total_size.to_string().parse().unwrap());
-                        response_body = full_body_response(state, &obj.body)?;
+                        response_body = if let Some(plain) = decrypted_body.clone() {
+                            plain.into()
+                        } else {
+                            full_body_response(state, &obj.body)?
+                        };
                     }
                 }
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = full_body_response(state, &obj.body)?;
+                response_body = if let Some(plain) = decrypted_body.clone() {
+                    plain.into()
+                } else {
+                    full_body_response(state, &obj.body)?
+                };
             }
         } else if let Some(part_num_str) = req.query_params.get("partNumber") {
             if let Ok(part_num) = part_num_str.parse::<u32>() {
@@ -1305,18 +1344,32 @@ impl S3Service {
                         .unwrap(),
                 );
                 headers.insert("content-length", part_size.to_string().parse().unwrap());
-                response_body = state
-                    .read_body_range(&obj.body, part_start as u64, part_size as u64)
-                    .map_err(super::io_to_aws)?
-                    .into();
+                response_body = if let Some(plain) = &decrypted_body {
+                    let s = part_start.min(plain.len());
+                    let e = (part_start + part_size).min(plain.len());
+                    plain.slice(s..e).into()
+                } else {
+                    state
+                        .read_body_range(&obj.body, part_start as u64, part_size as u64)
+                        .map_err(super::io_to_aws)?
+                        .into()
+                };
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {
                 headers.insert("content-length", total_size.to_string().parse().unwrap());
-                response_body = full_body_response(state, &obj.body)?;
+                response_body = if let Some(plain) = decrypted_body.clone() {
+                    plain.into()
+                } else {
+                    full_body_response(state, &obj.body)?
+                };
             }
         } else {
             headers.insert("content-length", total_size.to_string().parse().unwrap());
-            response_body = full_body_response(state, &obj.body)?;
+            response_body = if let Some(plain) = decrypted_body.clone() {
+                plain.into()
+            } else {
+                full_body_response(state, &obj.body)?
+            };
         }
         // Only include checksum headers for full (non-range) responses
         if !is_range_request {
@@ -2130,8 +2183,17 @@ impl S3Service {
             }
         });
 
-        // Checksum: compute new if algorithm specified, or copy from source
-        let src_bytes = state.read_body(&src_obj.body).map_err(super::io_to_aws)?;
+        // Checksum: compute new if algorithm specified, or copy from source.
+        // For SSE-KMS sources we work on plaintext so the checksum + the
+        // destination's stored body line up with what the caller will get
+        // back from a future GetObject.
+        let raw_src_bytes = state.read_body(&src_obj.body).map_err(super::io_to_aws)?;
+        let src_bytes =
+            if src_obj.sse_algorithm.as_deref() == Some("aws:kms") && self.kms_hook.is_some() {
+                self.decrypt_object_body(account_id, src_bucket, &raw_src_bytes)
+            } else {
+                raw_src_bytes
+            };
         let (new_checksum_algo, new_checksum_val) = if let Some(ref algo) = checksum_algorithm {
             let val = compute_checksum(algo, &src_bytes);
             (Some(algo.clone()), Some(val))
@@ -2142,6 +2204,22 @@ impl S3Service {
             )
         } else {
             (None, None)
+        };
+        // Re-encrypt for the destination if it lands as SSE-KMS, so the
+        // stored body is a fresh envelope with the dest's encryption
+        // context (bucket arn).
+        let dest_region = state.region.clone();
+        let dest_stored_bytes = if new_sse.as_deref() == Some("aws:kms") && self.kms_hook.is_some()
+        {
+            self.encrypt_object_body(
+                account_id,
+                &dest_region,
+                dest_bucket,
+                &src_bytes,
+                new_kms.as_deref(),
+            )
+        } else {
+            src_bytes.clone()
         };
 
         let db = state
@@ -2170,8 +2248,10 @@ impl S3Service {
             // disk-backed BodyRef (which would point at the source's file).
             // The source bytes are read above; the destination's own on-disk
             // file is written below via `self.store.put_object`.
-            body: crate::state::memory_body(src_bytes.clone()),
-            size: src_obj.size,
+            body: crate::state::memory_body(dest_stored_bytes.clone()),
+            // size tracks plaintext bytes (matches what a future GetObject
+            // returns to the caller); see the put_object SSE-KMS path.
+            size: src_bytes.len() as u64,
             etag: etag.clone(),
             last_modified,
             content_type: new_content_type,
@@ -2219,7 +2299,7 @@ impl S3Service {
                 dest_bucket,
                 dest_key,
                 dest_meta.version_id.as_deref(),
-                BodySource::Bytes(src_bytes.clone()),
+                BodySource::Bytes(dest_stored_bytes.clone()),
                 &dest_meta,
             )
             .map_err(super::persistence_error)?;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1000,6 +1000,9 @@ async fn main() {
     let dynamodb_state_for_register = dynamodb_state.clone();
     let delivery_for_dynamodb_register = delivery_for_dynamodb;
     let mut lambda_service = LambdaService::new(lambda_state.clone());
+    lambda_service = lambda_service.with_role_trust_validator(
+        fakecloud_iam::pass_role::IamRoleTrustValidator::shared(iam_state.clone()),
+    );
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
     }
@@ -1896,6 +1899,9 @@ async fn main() {
             None
         };
     let mut ecs_service = EcsService::new(ecs_state.clone());
+    ecs_service = ecs_service.with_role_trust_validator(
+        fakecloud_iam::pass_role::IamRoleTrustValidator::shared(iam_state.clone()),
+    );
     if let Some(store) = ecs_snapshot_store {
         ecs_service = ecs_service.with_snapshot_store(store);
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -223,9 +223,16 @@ async fn main() {
     let kms_usage_state: fakecloud_kms::hook::SharedKmsUsageState = Arc::new(
         parking_lot::RwLock::new(fakecloud_kms::hook::KmsUsageState::default()),
     );
-    let kms_hook_for_services: Arc<dyn fakecloud_core::delivery::KmsHook> = Arc::new(
-        KmsHookAdapter::new(kms_state.clone(), kms_usage_state.clone()),
-    );
+    // Hook's snapshot store is set below once kms_snapshot_store is
+    // initialized (depends on the persistence config). The OnceLock
+    // wiring lets us hand the same Arc to all services up-front and
+    // populate the store after persistence is read in.
+    let kms_hook_adapter = Arc::new(KmsHookAdapter::new(
+        kms_state.clone(),
+        kms_usage_state.clone(),
+    ));
+    let kms_hook_for_services: Arc<dyn fakecloud_core::delivery::KmsHook> =
+        kms_hook_adapter.clone();
     let cloudformation_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,
@@ -1286,10 +1293,15 @@ async fn main() {
             None
         };
     let mut kms_service = KmsService::new(kms_state.clone());
-    if let Some(store) = kms_snapshot_store {
+    if let Some(store) = kms_snapshot_store.clone() {
         kms_service = kms_service.with_snapshot_store(store);
     }
     registry.register(Arc::new(kms_service));
+    // Wire the snapshot store into the hook adapter too, so hook-driven
+    // auto-provisioning (`aws/<service>` first-use) persists immediately.
+    if let Some(store) = kms_snapshot_store {
+        kms_hook_adapter.set_snapshot_store(store);
+    }
 
     registry.register(Arc::new(OrganizationsService::new(
         organizations_state.clone(),
@@ -4116,6 +4128,12 @@ async fn shutdown_signal() {
 /// call into KMS without a direct crate dependency.
 struct KmsHookAdapter {
     inner: fakecloud_kms::hook::KmsServiceHook,
+    /// Shared KMS state — used to snapshot after the hook auto-provisions
+    /// an `aws/<service>` AWS-managed key on first use, so the new key
+    /// survives a server restart and the corresponding ciphertext stays
+    /// decryptable.
+    state: fakecloud_kms::state::SharedKmsState,
+    snapshot_store: std::sync::OnceLock<Arc<dyn fakecloud_persistence::SnapshotStore>>,
 }
 
 impl KmsHookAdapter {
@@ -4124,7 +4142,36 @@ impl KmsHookAdapter {
         usage: fakecloud_kms::hook::SharedKmsUsageState,
     ) -> Self {
         Self {
-            inner: fakecloud_kms::hook::KmsServiceHook::new(state, usage),
+            inner: fakecloud_kms::hook::KmsServiceHook::new(state.clone(), usage),
+            state,
+            snapshot_store: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn set_snapshot_store(&self, store: Arc<dyn fakecloud_persistence::SnapshotStore>) {
+        let _ = self.snapshot_store.set(store);
+    }
+
+    fn key_count(&self) -> usize {
+        self.state.read().iter().map(|(_, s)| s.keys.len()).sum()
+    }
+
+    fn save_snapshot_blocking(&self) {
+        let Some(store) = self.snapshot_store.get() else {
+            return;
+        };
+        let snapshot = fakecloud_kms::state::KmsSnapshot {
+            schema_version: fakecloud_kms::state::KMS_SNAPSHOT_SCHEMA_VERSION,
+            accounts: Some(self.state.read().clone()),
+            state: None,
+        };
+        match serde_json::to_vec(&snapshot) {
+            Ok(bytes) => {
+                if let Err(err) = store.save(&bytes) {
+                    tracing::error!(%err, "kms hook snapshot save failed");
+                }
+            }
+            Err(err) => tracing::error!(%err, "kms hook snapshot serialize failed"),
         }
     }
 }
@@ -4139,7 +4186,9 @@ impl fakecloud_core::delivery::KmsHook for KmsHookAdapter {
         service_principal: &str,
         encryption_context: std::collections::HashMap<String, String>,
     ) -> Result<String, String> {
-        self.inner
+        let before = self.key_count();
+        let result = self
+            .inner
             .encrypt(
                 account_id,
                 region,
@@ -4148,7 +4197,13 @@ impl fakecloud_core::delivery::KmsHook for KmsHookAdapter {
                 service_principal,
                 encryption_context,
             )
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string());
+        // Auto-provisioned a new AWS-managed key — persist immediately so
+        // a restart can still decrypt its ciphertext.
+        if result.is_ok() && self.key_count() > before {
+            self.save_snapshot_blocking();
+        }
+        result
     }
 
     fn decrypt(

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -989,8 +989,9 @@ async fn main() {
         } else {
             None
         };
-    let mut ssm_service =
-        SsmService::new(ssm_state).with_secretsmanager(secretsmanager_state.clone());
+    let mut ssm_service = SsmService::new(ssm_state)
+        .with_secretsmanager(secretsmanager_state.clone())
+        .with_kms_hook(kms_hook_for_services.clone());
     if let Some(store) = ssm_snapshot_store {
         ssm_service = ssm_service.with_snapshot_store(store);
     }
@@ -1359,7 +1360,8 @@ async fn main() {
     }
     registry.register(Arc::new(
         S3Service::with_store(s3_state.clone(), delivery_for_s3, s3_store.clone())
-            .with_kms(kms_state.clone()),
+            .with_kms(kms_state.clone())
+            .with_kms_hook(kms_hook_for_services.clone()),
     ));
     // Snapshot store is only wired in persistent mode. In memory mode we
     // leave it unset so the service doesn't pay the per-mutation

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -122,6 +122,7 @@ pub struct SsmService {
     secretsmanager_state: Option<SharedSecretsManagerState>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    pub(crate) kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
 }
 
 impl SsmService {
@@ -131,6 +132,7 @@ impl SsmService {
             secretsmanager_state: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            kms_hook: None,
         }
     }
 
@@ -141,6 +143,11 @@ impl SsmService {
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_kms_hook(mut self, hook: Arc<dyn fakecloud_core::delivery::KmsHook>) -> Self {
+        self.kms_hook = Some(hook);
         self
     }
 

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -275,10 +275,33 @@ fn create_new_parameter(
 
 impl SsmService {
     pub(super) fn put_parameter(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let input = PutParameterInput::from_body(&req.json_body())?;
+        let mut input = PutParameterInput::from_body(&req.json_body())?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Determine effective param_type for KMS encryption decision.
+        // For overwrite, falls back to existing.param_type; for new params,
+        // the caller-supplied Type is required.
+        let effective_type = match lookup_param(&state.parameters, &input.name) {
+            Some(existing) => input
+                .param_type
+                .clone()
+                .unwrap_or_else(|| existing.param_type.clone()),
+            None => input.param_type.clone().unwrap_or_default(),
+        };
+        if effective_type == "SecureString" {
+            let key_id_for_enc = input.key_id.as_deref();
+            let arn = param_arn(&req.region, &state.account_id, &input.name);
+            input.value = self.encrypt_secure_value(
+                &req.account_id,
+                &req.region,
+                &arn,
+                key_id_for_enc,
+                &input.value,
+            );
+        }
+
         if let Some(existing) = lookup_param_mut(&mut state.parameters, &input.name) {
             return apply_overwrite(existing, input);
         }
@@ -291,6 +314,109 @@ impl SsmService {
             "Version": 1,
             "Tier": tier_for_response,
         })))
+    }
+
+    /// Encrypt a SecureString value via the configured KMS hook. Returns
+    /// plaintext unchanged if no hook is wired (preserves legacy fakecloud
+    /// behavior in tests that don't set up KMS).
+    fn encrypt_secure_value(
+        &self,
+        account_id: &str,
+        region: &str,
+        param_arn: &str,
+        key_id: Option<&str>,
+        plaintext: &str,
+    ) -> String {
+        let Some(hook) = &self.kms_hook else {
+            return plaintext.to_string();
+        };
+        let key = key_id.filter(|k| !k.is_empty()).unwrap_or("aws/ssm");
+        let mut ctx = HashMap::new();
+        ctx.insert("PARAMETER_ARN".to_string(), param_arn.to_string());
+        match hook.encrypt(
+            account_id,
+            region,
+            key,
+            plaintext.as_bytes(),
+            "ssm.amazonaws.com",
+            ctx,
+        ) {
+            Ok(ct) => ct,
+            Err(err) => {
+                tracing::warn!(
+                    parameter = %param_arn,
+                    error = %err,
+                    "KMS encrypt failed for SSM SecureString; storing plaintext"
+                );
+                plaintext.to_string()
+            }
+        }
+    }
+
+    /// Decrypt a stored SecureString value via the configured KMS hook.
+    /// Returns the value unchanged when no hook is wired or the value
+    /// can't be decrypted (e.g. snapshots from before the hook was
+    /// added). The ciphertext envelope is opaque base64 so we can't
+    /// pre-check it with a prefix; rely on `decrypt` to flag malformed
+    /// payloads and degrade gracefully.
+    pub(crate) fn decrypt_secure_value(
+        &self,
+        account_id: &str,
+        param_arn: &str,
+        ciphertext: &str,
+    ) -> String {
+        let Some(hook) = &self.kms_hook else {
+            return ciphertext.to_string();
+        };
+        let mut ctx = HashMap::new();
+        ctx.insert("PARAMETER_ARN".to_string(), param_arn.to_string());
+        match hook.decrypt(account_id, ciphertext, "ssm.amazonaws.com", ctx) {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Err(_) => ciphertext.to_string(),
+        }
+    }
+
+    /// Wrapper around [`param_to_json`] that decrypts SecureString values
+    /// via the KMS hook when `with_decryption` is true. Falls through to
+    /// the free function when no hook is configured or the param isn't a
+    /// SecureString.
+    pub(super) fn render_param_to_json(
+        &self,
+        p: &SsmParameter,
+        with_value: bool,
+        with_decryption: bool,
+        region: &str,
+        account_id: &str,
+    ) -> Value {
+        if with_value
+            && with_decryption
+            && p.param_type == "SecureString"
+            && self.kms_hook.is_some()
+        {
+            let mut clone = p.clone();
+            clone.value = self.decrypt_secure_value(account_id, &p.arn, &p.value);
+            return param_to_json(&clone, with_value, with_decryption, region);
+        }
+        param_to_json(p, with_value, with_decryption, region)
+    }
+
+    /// Wrapper around [`build_param_history_value`] that decrypts the
+    /// historical SecureString value via the KMS hook when
+    /// `with_decryption` is true.
+    pub(super) fn render_history_value(
+        &self,
+        param: &SsmParameter,
+        hist: &SsmParameterVersion,
+        with_decryption: bool,
+        region: &str,
+        account_id: &str,
+    ) -> Value {
+        if with_decryption && hist.param_type == "SecureString" && self.kms_hook.is_some() {
+            let mut clone = hist.clone();
+            clone.value = self.decrypt_secure_value(account_id, &param.arn, &hist.value);
+            return build_param_history_value(param, &clone, with_decryption, region);
+        }
+        build_param_history_value(param, hist, with_decryption, region)
     }
 
     /// Resolve a Secrets Manager reference parameter.
@@ -409,7 +535,7 @@ impl SsmService {
         if raw_name.starts_with("arn:aws:ssm:") {
             let param = resolve_param_by_name_or_arn(state, raw_name)?;
             return Ok(AwsResponse::ok_json(json!({
-                "Parameter": param_to_json(param, true, with_decryption, &req.region),
+                "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
             })));
         }
 
@@ -426,16 +552,22 @@ impl SsmService {
 
         match selector {
             ParamSelector::None => Ok(AwsResponse::ok_json(json!({
-                "Parameter": param_to_json(param, true, with_decryption, &req.region),
+                "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
             }))),
             ParamSelector::Version(ver) => {
                 if param.version == ver {
                     return Ok(AwsResponse::ok_json(json!({
-                        "Parameter": param_to_json(param, true, with_decryption, &req.region),
+                        "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
                     })));
                 }
                 if let Some(hist) = param.history.iter().find(|h| h.version == ver) {
-                    let v = build_param_history_value(param, hist, with_decryption, &req.region);
+                    let v = self.render_history_value(
+                        param,
+                        hist,
+                        with_decryption,
+                        &req.region,
+                        &req.account_id,
+                    );
                     return Ok(AwsResponse::ok_json(json!({ "Parameter": v })));
                 }
                 Err(AwsServiceError::aws_error(
@@ -453,15 +585,16 @@ impl SsmService {
                     if labels.contains(&label) {
                         if *ver == param.version {
                             return Ok(AwsResponse::ok_json(json!({
-                                "Parameter": param_to_json(param, true, with_decryption, &req.region),
+                                "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
                             })));
                         }
                         if let Some(hist) = param.history.iter().find(|h| h.version == *ver) {
-                            let v = build_param_history_value(
+                            let v = self.render_history_value(
                                 param,
                                 hist,
                                 with_decryption,
                                 &req.region,
+                                &req.account_id,
                             );
                             return Ok(AwsResponse::ok_json(json!({ "Parameter": v })));
                         }
@@ -523,11 +656,12 @@ impl SsmService {
                     }
                     ParamSelector::None => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            parameters.push(param_to_json(
+                            parameters.push(self.render_param_to_json(
                                 param,
                                 true,
                                 with_decryption,
                                 &req.region,
+                                &req.account_id,
                             ));
                         } else {
                             invalid.push(raw_name.to_string());
@@ -536,20 +670,22 @@ impl SsmService {
                     ParamSelector::Version(ver) => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
                             if param.version == ver {
-                                parameters.push(param_to_json(
+                                parameters.push(self.render_param_to_json(
                                     param,
                                     true,
                                     with_decryption,
                                     &req.region,
+                                    &req.account_id,
                                 ));
                             } else if let Some(hist) =
                                 param.history.iter().find(|h| h.version == ver)
                             {
-                                parameters.push(build_param_history_value(
+                                parameters.push(self.render_history_value(
                                     param,
                                     hist,
                                     with_decryption,
                                     &req.region,
+                                    &req.account_id,
                                 ));
                             } else {
                                 invalid.push(raw_name.to_string());
@@ -564,20 +700,22 @@ impl SsmService {
                             for (ver, labels) in &param.labels {
                                 if labels.contains(label) {
                                     if *ver == param.version {
-                                        parameters.push(param_to_json(
+                                        parameters.push(self.render_param_to_json(
                                             param,
                                             true,
                                             with_decryption,
                                             &req.region,
+                                            &req.account_id,
                                         ));
                                     } else if let Some(hist) =
                                         param.history.iter().find(|h| h.version == *ver)
                                     {
-                                        parameters.push(build_param_history_value(
+                                        parameters.push(self.render_history_value(
                                             param,
                                             hist,
                                             with_decryption,
                                             &req.region,
+                                            &req.account_id,
                                         ));
                                     }
                                     found = true;
@@ -650,7 +788,9 @@ impl SsmService {
             paginate(&all_params, body["NextToken"].as_str(), max_results);
         let parameters: Vec<Value> = page_params
             .iter()
-            .map(|p| param_to_json(p, true, with_decryption, &req.region))
+            .map(|p| {
+                self.render_param_to_json(p, true, with_decryption, &req.region, &req.account_id)
+            })
             .collect();
 
         let mut resp = json!({ "Parameters": parameters });
@@ -822,11 +962,16 @@ impl SsmService {
             .history
             .iter()
             .map(|h| {
+                let displayed = if with_decryption && h.param_type == "SecureString" {
+                    self.decrypt_secure_value(&req.account_id, &param.arn, &h.value)
+                } else {
+                    h.value.clone()
+                };
                 history_entry_json(
                     &param.name,
                     h.version,
                     &h.param_type,
-                    &h.value,
+                    &displayed,
                     h.key_id.as_deref(),
                     h.description.as_deref(),
                     h.last_modified.timestamp_millis() as f64 / 1000.0,
@@ -836,11 +981,16 @@ impl SsmService {
             })
             .collect();
 
+        let displayed = if with_decryption && param.param_type == "SecureString" {
+            self.decrypt_secure_value(&req.account_id, &param.arn, &param.value)
+        } else {
+            param.value.clone()
+        };
         all_history.push(history_entry_json(
             &param.name,
             param.version,
             &param.param_type,
-            &param.value,
+            &displayed,
             param.key_id.as_deref(),
             param.description.as_deref(),
             param.last_modified.timestamp_millis() as f64 / 1000.0,

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -49,6 +49,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.
 - **ECS -> EventBridge** — Task state transitions emit `ECS Task State Change` events on the default bus.
+- **IAM PassRole trust enforcement** — Lambda `CreateFunction` / `UpdateFunctionConfiguration` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
 
 ## Testing a cross-service flow
 

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -45,6 +45,8 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **CloudFormation -> Lambda / SNS** — Custom resources invoke via `ServiceToken`, stack events notify via `NotificationARNs`.
 - **Secrets Manager -> Lambda** — Rotation invokes Lambda for all 4 steps.
 - **Secrets Manager -> KMS** — When a secret has `KmsKeyId`, `CreateSecret` / `PutSecretValue` call `kms:GenerateDataKey` and `GetSecretValue` calls `kms:Decrypt` with the AWS-shaped encryption context `{aws:secretsmanager:secretArn: <arn>}`. Auto-provisions the `aws/secretsmanager` AWS-managed key on first use. All KMS calls are recorded at `/_fakecloud/kms/usage`.
+- **SSM SecureString -> KMS** — `PutParameter` with `Type=SecureString` calls `kms:GenerateDataKey`; `GetParameter*` with `WithDecryption=true` calls `kms:Decrypt`. The encryption context is `{PARAMETER_ARN: <arn>}` and the default `aws/ssm` key auto-provisions on first use; pass `KeyId` for a customer-managed key.
+- **S3 SSE-KMS -> KMS** — `PutObject` with `ServerSideEncryption=aws:kms` calls `kms:GenerateDataKey`; `GetObject` decrypts via `kms:Decrypt`. The encryption context is `{aws:s3:arn: arn:aws:s3:::<bucket>}` and ranged reads are sliced from plaintext, not the stored ciphertext envelope. The default `aws/s3` key auto-provisions on first use.
 - **S3 Lifecycle** — Background expiration and storage class transitions.
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.

--- a/website/content/docs/guides/cross-service-integration.md
+++ b/website/content/docs/guides/cross-service-integration.md
@@ -49,7 +49,7 @@ fakecloud actually executes the cross-service wiring. When an EventBridge rule m
 - **EventBridge Scheduler** — Cron and rate-based rules fire on schedule.
 - **RDS -> EventBridge** — DB instance and snapshot lifecycle ops (create, modify, delete, reboot, start, stop, snapshot create/delete, restore) emit `aws.rds` events that match the AWS event schema.
 - **ECS -> EventBridge** — Task state transitions emit `ECS Task State Change` events on the default bus.
-- **IAM PassRole trust enforcement** — Lambda `CreateFunction` / `UpdateFunctionConfiguration` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
+- **IAM PassRole trust enforcement** — Lambda `CreateFunction` and ECS `RegisterTaskDefinition` / `RunTask` overrides reject role ARNs whose `AssumeRolePolicyDocument` doesn't list the calling service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), the same way real AWS does.
 
 ## Testing a cross-service flow
 

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -18,7 +18,7 @@ fakecloud implements **176 of 176** IAM operations at 100% Smithy conformance.
 - **Account management** — aliases, password policy, summary
 - **Tags** — on users, roles, policies, and policy versions
 - **Service-linked roles** — CRUD with service name validation
-- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`, `UpdateFunctionConfiguration`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
+- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
 
 ## PassRole trust policy example
 

--- a/website/content/docs/services/iam.md
+++ b/website/content/docs/services/iam.md
@@ -18,6 +18,22 @@ fakecloud implements **176 of 176** IAM operations at 100% Smithy conformance.
 - **Account management** — aliases, password policy, summary
 - **Tags** — on users, roles, policies, and policy versions
 - **Service-linked roles** — CRUD with service name validation
+- **PassRole trust enforcement** — when a role ARN is passed to Lambda (`CreateFunction`, `UpdateFunctionConfiguration`) or ECS (`RegisterTaskDefinition`, `RunTask` overrides), the role's `AssumeRolePolicyDocument` is checked against the calling service's principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`). Roles whose trust policy doesn't allow the principal are rejected with `InvalidParameterValueException` / `InvalidParameterException`, matching real AWS
+
+## PassRole trust policy example
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+For ECS, replace `lambda.amazonaws.com` with `ecs-tasks.amazonaws.com`. Multiple service principals can be granted in one statement using `"Service": ["lambda.amazonaws.com", "ecs-tasks.amazonaws.com"]`.
 
 ## Protocol
 

--- a/website/content/docs/services/s3.md
+++ b/website/content/docs/services/s3.md
@@ -13,7 +13,7 @@ fakecloud implements **107 of 107** S3 operations at 100% Smithy conformance.
 - **Lifecycle** — expiration and storage class transitions via `/_fakecloud/s3/lifecycle-processor/tick`
 - **Notifications** — delivery to SNS, SQS, Lambda, and EventBridge on object create/delete
 - **Versioning** — enable/suspend, list object versions, delete specific versions
-- **Encryption** — SSE-S3, SSE-KMS, SSE-C
+- **Encryption** — SSE-S3, SSE-KMS (real envelope encryption through the KMS hook with the `aws:s3:arn` encryption context), SSE-C
 - **Bucket subresources** — policy, CORS, lifecycle, logging, website, public access block, object lock, replication, ownership, inventory, encryption, accelerate, request payment, tagging
 - **Object Lock** — legal hold, retention modes
 - **Website hosting** — index/error documents, redirect rules

--- a/website/content/docs/services/ssm.md
+++ b/website/content/docs/services/ssm.md
@@ -24,9 +24,15 @@ fakecloud implements **146 of 146** SSM operations at 100% Smithy conformance.
 
 JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
-## Gotchas
+## SecureString encryption
 
-- **SecureString parameters are stored unencrypted.** The AWS API accepts a `KeyId` and returns a decrypted value to authorized callers; fakecloud stores the value as-is since there's no KMS-level enforcement.
+SecureString parameters are encrypted through the KMS hook on `PutParameter`
+and decrypted on `GetParameter` / `GetParameters` / `GetParametersByPath` when
+the caller passes `WithDecryption=true`. The default `alias/aws/ssm`
+AWS-managed key is auto-provisioned on first use; passing an explicit `KeyId`
+routes encryption through that key instead. KMS calls land in
+`/_fakecloud/kms/usage` with the `PARAMETER_ARN` encryption context, so tests
+can assert that a parameter's plaintext is never persisted.
 
 ## Source
 


### PR DESCRIPTION
## Summary

Batch 6b extends the cross-service KMS hook landed in 6a to S3 PutObject/GetObject (SSE-KMS) and SSM PutParameter/GetParameter* (SecureString). Both services now generate a real ciphertext envelope through the hook on write, decrypt on read, and record GenerateDataKey + Decrypt calls in /_fakecloud/kms/usage with the AWS-shaped encryption context the upstream services use.

- **S3 SSE-KMS**: encryption context \`{aws:s3:arn: arn:aws:s3:::<bucket>}\`. Stored body is a fakecloud-kms envelope; ranged reads slice plaintext rather than ciphertext so callers never see the envelope. CopyObject decrypts the source and re-encrypts for the destination's bucket arn, avoiding ciphertext-of-ciphertext when both ends are SSE-KMS.
- **SSM SecureString**: encryption context \`{PARAMETER_ARN: <arn>}\`. Decrypts via render wrappers in get_parameter / get_parameters / get_parameters_by_path / get_parameter_history when WithDecryption=true. Default key is alias/aws/ssm; auto-provisions on first use.

Both round-trips degrade gracefully on legacy snapshots (decrypt failure returns the stored bytes unchanged).

## Test plan

- [x] \`cargo test -p fakecloud-e2e --test ssm_kms\` (2 new tests)
- [x] \`cargo test -p fakecloud-e2e --test s3_sse_kms\` (3 new tests, incl. ranged read on SSE-KMS object)
- [x] \`cargo test -p fakecloud-ssm\` (195 existing pass)
- [x] \`cargo test -p fakecloud-s3 --lib\` (280 existing pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] README + service pages + cross-service guide updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real KMS-backed encryption for S3 SSE-KMS and SSM SecureString, plus IAM PassRole trust enforcement for Lambda and ECS. KMS errors now fail closed on S3 reads/writes, and auto-provisioned `aws/<service>` keys persist so ciphertext survives restarts; legacy snapshots still read.

- **New Features**
  - S3 SSE-KMS: PutObject encrypts with context {aws:s3:arn: arn:aws:s3:::<bucket>}; GetObject decrypts and range reads slice plaintext; CopyObject decrypts source and re-encrypts for destination; default `aws/s3` key auto-provisions and persists; KMS usage recorded at /_fakecloud/kms/usage; KMS encrypt/decrypt failures abort the request.
  - SSM SecureString: PutParameter encrypts with context {PARAMETER_ARN: <arn>}; GetParameter/GetParameters/GetParametersByPath and GetParameterHistory decrypt when WithDecryption=true; default `alias/aws/ssm` key auto-provisions and persists; KMS usage recorded.
  - IAM PassRole trust enforcement: Lambda CreateFunction and ECS RegisterTaskDefinition/RunTask overrides reject role ARNs whose trust policy doesn’t allow the service principal (`lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`), returning AWS-shaped errors.

- **Migration**
  - No breaking changes. Legacy non-enveloped snapshots continue to read. S3 SSE-KMS errors now surface on Put/Get/Copy. Ensure roles passed to Lambda/ECS trust the relevant service principal. Auto-provisioned `aws/<service>` keys persist automatically; no action needed.

<sup>Written for commit f669b920dff281d9bbf0dbc9cae1d0e5a2cb93bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

