### PR TITLE
release: 0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,11 +181,13 @@ jobs:
 
           # Layer 4: depend on layer 3 crates
           publish fakecloud-s3             # depends on kms
+          publish fakecloud-ecr            # depends on kms
           publish fakecloud-ssm            # depends on secretsmanager
           publish fakecloud-eventbridge    # depends on lambda, logs
 
           # Layer 5: depends on layer 4
           publish fakecloud-dynamodb       # depends on s3
+          publish fakecloud-ecs            # depends on logs, secretsmanager, ssm
 
           # Layer 6: depends on layer 5
           publish fakecloud-stepfunctions  # depends on dynamodb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.10.1"
+version = "0.11.0"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -82,31 +82,31 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.10.1" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.10.1" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.10.1" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.10.1" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.10.1" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.10.1" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.10.1" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.10.1" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.10.1" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.10.1" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.10.1" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.10.1" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.10.1" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.10.1" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.10.1" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.10.1" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.10.1" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.10.1" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.10.1" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.10.1" }
-fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.10.1" }
-fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.10.1" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.10.1" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.10.1" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.10.1" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.10.1" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.10.1" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.10.1" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.11.0" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.11.0" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.11.0" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.11.0" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.11.0" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.11.0" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.11.0" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.11.0" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.11.0" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.11.0" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.11.0" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.11.0" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.11.0" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.11.0" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.11.0" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.11.0" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.11.0" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.11.0" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.11.0" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.11.0" }
+fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.11.0" }
+fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.11.0" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.11.0" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.11.0" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.11.0" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.11.0" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.11.0" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.11.0" }

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.10.1")
+    testImplementation("dev.fakecloud:fakecloud:0.11.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.10.1</version>
+    <version>0.11.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.10.1"
+version = "0.11.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.10.1"
+version = "0.11.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -81,7 +81,7 @@ $emails = $fc->ses()->getEmails()->emails;
 
 ```kotlin
 // build.gradle.kts
-testImplementation("dev.fakecloud:fakecloud:0.10.1")
+testImplementation("dev.fakecloud:fakecloud:0.11.0")
 ```
 
 ```java

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.10.1`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.11.0`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.10.1")
+    testImplementation("dev.fakecloud:fakecloud:0.11.0")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.10.1</version>
+    <version>0.11.0</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Summary
- Bump workspace to 0.11.0 (Cargo.toml + Cargo.lock)
- Bump SDK versions to 0.11.0: TypeScript, Python, Java (PHP/Go are tag-driven)
- Add `fakecloud-ecr` (Layer 4 — depends on kms) and `fakecloud-ecs` (Layer 5 — depends on logs/secretsmanager/ssm) to `release.yml` publish list
- Update Java version refs in website docs + sdks/java/README

## Tag
After merge: `git tag v0.11.0 && git push origin v0.11.0` to trigger Release workflow (binaries + crates + npm + PyPI + Maven + Packagist + Go).

## Test plan
- [ ] CI green
- [ ] Cubic clean
- [ ] Tag pushed -> Release workflow publishes all artifacts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 0.11.0 release by bumping workspace and SDK versions and updating docs. The release workflow now publishes `fakecloud-ecr` and `fakecloud-ecs`.

- **Dependencies**
  - Set workspace and all internal crates to 0.11.0 (`Cargo.toml`/`Cargo.lock`).
  - Bumped SDKs to 0.11.0: `sdks/typescript`, `sdks/python`, `sdks/java`; updated Java references in docs.
  - Updated `.github/workflows/release.yml` to publish `fakecloud-ecr` (Layer 4, depends on `kms`) and `fakecloud-ecs` (Layer 5, depends on `logs`, `secretsmanager`, `ssm`).

- **Migration**
  - Update your `fakecloud` SDK to v0.11.0 (TypeScript, Python, Java).
  - After merge, push tag `v0.11.0` to trigger the release workflow.

<sup>Written for commit 099640b3a0e42d5a8243d377b4b57fa0ed0da445. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

