### PR TITLE
feat(elbv2): listeners + rules + certificates (Batch 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-26 services, 1,810 operations, 100% conformance per implemented service.
+26 services, 1,819 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -77,7 +77,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
 | ECS                    |  60 | **Full API** — clusters, task definitions, real task execution, services + rolling deployments, container instances, capacity providers, task sets, ECS Exec |
-| Elastic Load Balancing v2 |  12 | ALB/NLB/GWLB CRUD: load balancers, subnets, security groups, IP address types, IPAM, account limits, SSL policies, tags |
+| Elastic Load Balancing v2 |  21 | ALB/NLB/GWLB CRUD: load balancers, **target groups + targets + health**, subnets, security groups, IP types, IPAM, account limits, SSL policies, attributes, tags |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -118,7 +118,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
 | ECS                 | **60 operations — full API** incl. real task execution, services, task sets, capacity providers | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
-| Elastic Load Balancing v2 | ALB/NLB/GWLB load balancer CRUD + tags + SSL policies | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| Elastic Load Balancing v2 | ALB/NLB/GWLB load balancers + target groups + targets + health + SSL policies | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-26 services, 1,819 operations, 100% conformance per implemented service.
+26 services, 1,833 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -77,7 +77,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
 | ECS                    |  60 | **Full API** — clusters, task definitions, real task execution, services + rolling deployments, container instances, capacity providers, task sets, ECS Exec |
-| Elastic Load Balancing v2 |  21 | ALB/NLB/GWLB CRUD: load balancers, **target groups + targets + health**, subnets, security groups, IP types, IPAM, account limits, SSL policies, attributes, tags |
+| Elastic Load Balancing v2 |  35 | ALB/NLB/GWLB CRUD: load balancers, target groups + targets + health, **listeners + rules + certificates**, attributes, SSL policies, tags |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 

--- a/crates/fakecloud-conformance/tests/elbv2.rs
+++ b/crates/fakecloud-conformance/tests/elbv2.rs
@@ -7,7 +7,8 @@
 mod helpers;
 
 use aws_sdk_elasticloadbalancingv2::types::{
-    IpAddressType, LoadBalancerSchemeEnum, LoadBalancerTypeEnum, Tag,
+    IpAddressType, LoadBalancerSchemeEnum, LoadBalancerTypeEnum, ProtocolEnum, Tag,
+    TargetDescription, TargetGroupAttribute, TargetTypeEnum,
 };
 use fakecloud_conformance_macros::test_action;
 use helpers::TestServer;
@@ -287,4 +288,264 @@ async fn elbv2_modify_ip_pools() {
         .load_balancer_arn()
         .unwrap();
     let _ = client.modify_ip_pools().load_balancer_arn(arn).send().await;
+}
+
+// ── Batch 2: TargetGroups + Targets ─────────────────────────────────
+
+#[test_action("elasticloadbalancingv2", "CreateTargetGroup", checksum = "1f017667")]
+#[tokio::test]
+async fn elbv2_create_target_group() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let resp = client
+        .create_target_group()
+        .name("confo-tg-create")
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .target_type(TargetTypeEnum::Ip)
+        .vpc_id("vpc-1234")
+        .send()
+        .await
+        .unwrap();
+    let tg = resp.target_groups().first().unwrap();
+    assert_eq!(tg.target_group_name(), Some("confo-tg-create"));
+    assert_eq!(tg.port(), Some(80));
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "DescribeTargetGroups",
+    checksum = "46b00b84"
+)]
+#[tokio::test]
+async fn elbv2_describe_target_groups() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    client
+        .create_target_group()
+        .name("confo-tg-desc")
+        .send()
+        .await
+        .unwrap();
+    let resp = client.describe_target_groups().send().await.unwrap();
+    assert!(resp
+        .target_groups()
+        .iter()
+        .any(|tg| tg.target_group_name() == Some("confo-tg-desc")));
+}
+
+#[test_action("elasticloadbalancingv2", "ModifyTargetGroup", checksum = "24ab6b92")]
+#[tokio::test]
+async fn elbv2_modify_target_group() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-mod")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    let resp = client
+        .modify_target_group()
+        .target_group_arn(arn)
+        .health_check_path("/healthz")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.target_groups().first().unwrap().health_check_path(),
+        Some("/healthz")
+    );
+}
+
+#[test_action("elasticloadbalancingv2", "DeleteTargetGroup", checksum = "4d18f3de")]
+#[tokio::test]
+async fn elbv2_delete_target_group() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-del")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    client
+        .delete_target_group()
+        .target_group_arn(arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticloadbalancingv2", "RegisterTargets", checksum = "9c96083e")]
+#[tokio::test]
+async fn elbv2_register_targets() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-reg")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    client
+        .register_targets()
+        .target_group_arn(arn)
+        .targets(TargetDescription::builder().id("i-aaaa").port(80).build())
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticloadbalancingv2", "DeregisterTargets", checksum = "a2e93f46")]
+#[tokio::test]
+async fn elbv2_deregister_targets() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-dereg")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    client
+        .register_targets()
+        .target_group_arn(arn)
+        .targets(TargetDescription::builder().id("i-bbbb").build())
+        .send()
+        .await
+        .unwrap();
+    client
+        .deregister_targets()
+        .target_group_arn(arn)
+        .targets(TargetDescription::builder().id("i-bbbb").build())
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "DescribeTargetHealth",
+    checksum = "e09fc1ce"
+)]
+#[tokio::test]
+async fn elbv2_describe_target_health() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-health")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    client
+        .register_targets()
+        .target_group_arn(arn)
+        .targets(TargetDescription::builder().id("i-cccc").build())
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_target_health()
+        .target_group_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.target_health_descriptions().len(), 1);
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "ModifyTargetGroupAttributes",
+    checksum = "70f22772"
+)]
+#[tokio::test]
+async fn elbv2_modify_target_group_attributes() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-attrs")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    client
+        .modify_target_group_attributes()
+        .target_group_arn(arn)
+        .attributes(
+            TargetGroupAttribute::builder()
+                .key("deregistration_delay.timeout_seconds")
+                .value("30")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "DescribeTargetGroupAttributes",
+    checksum = "f426a1b9"
+)]
+#[tokio::test]
+async fn elbv2_describe_target_group_attributes() {
+    let server = TestServer::start().await;
+    let client = server.elbv2_client().await;
+    let create = client
+        .create_target_group()
+        .name("confo-tg-getattrs")
+        .send()
+        .await
+        .unwrap();
+    let arn = create
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap();
+    let resp = client
+        .describe_target_group_attributes()
+        .target_group_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.attributes().is_empty());
 }

--- a/crates/fakecloud-conformance/tests/elbv2.rs
+++ b/crates/fakecloud-conformance/tests/elbv2.rs
@@ -7,7 +7,8 @@
 mod helpers;
 
 use aws_sdk_elasticloadbalancingv2::types::{
-    IpAddressType, LoadBalancerSchemeEnum, LoadBalancerTypeEnum, ProtocolEnum, Tag,
+    Action, ActionTypeEnum, Certificate, FixedResponseActionConfig, IpAddressType,
+    LoadBalancerSchemeEnum, LoadBalancerTypeEnum, ProtocolEnum, RuleCondition, Tag,
     TargetDescription, TargetGroupAttribute, TargetTypeEnum,
 };
 use fakecloud_conformance_macros::test_action;
@@ -548,4 +549,614 @@ async fn elbv2_describe_target_group_attributes() {
         .await
         .unwrap();
     assert!(!resp.attributes().is_empty());
+}
+
+// ── Batch 3: Listeners + Rules ──────────────────────────────────────
+
+async fn make_lb_and_tg(
+    server: &TestServer,
+) -> (aws_sdk_elasticloadbalancingv2::Client, String, String) {
+    let client = server.elbv2_client().await;
+    let lb = client
+        .create_load_balancer()
+        .name("confo-stack")
+        .send()
+        .await
+        .unwrap();
+    let lb_arn = lb
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    let tg = client
+        .create_target_group()
+        .name("confo-stack-tg")
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .send()
+        .await
+        .unwrap();
+    let tg_arn = tg
+        .target_groups()
+        .first()
+        .unwrap()
+        .target_group_arn()
+        .unwrap()
+        .to_string();
+    (client, lb_arn, tg_arn)
+}
+
+#[test_action("elasticloadbalancingv2", "CreateListener", checksum = "ad4f2eb9")]
+#[tokio::test]
+async fn elbv2_create_listener() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let resp = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.listeners().first().unwrap().port(), Some(80));
+}
+
+#[test_action("elasticloadbalancingv2", "DescribeListeners", checksum = "05130066")]
+#[tokio::test]
+async fn elbv2_describe_listeners() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(8080)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_listeners()
+        .load_balancer_arn(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.listeners().len(), 1);
+}
+
+#[test_action("elasticloadbalancingv2", "ModifyListener", checksum = "7e814e05")]
+#[tokio::test]
+async fn elbv2_modify_listener() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    let resp = client
+        .modify_listener()
+        .listener_arn(arn)
+        .port(8081)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.listeners().first().unwrap().port(), Some(8081));
+}
+
+#[test_action("elasticloadbalancingv2", "DeleteListener", checksum = "de5fd7c9")]
+#[tokio::test]
+async fn elbv2_delete_listener() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    client
+        .delete_listener()
+        .listener_arn(arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "ModifyListenerAttributes",
+    checksum = "f838206c"
+)]
+#[tokio::test]
+async fn elbv2_modify_listener_attributes() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    client
+        .modify_listener_attributes()
+        .listener_arn(arn)
+        .attributes(
+            aws_sdk_elasticloadbalancingv2::types::ListenerAttribute::builder()
+                .key("tcp.idle_timeout.seconds")
+                .value("350")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "DescribeListenerAttributes",
+    checksum = "3ab0c50b"
+)]
+#[tokio::test]
+async fn elbv2_describe_listener_attributes() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    let _resp = client
+        .describe_listener_attributes()
+        .listener_arn(arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "AddListenerCertificates",
+    checksum = "83647a8c"
+)]
+#[tokio::test]
+async fn elbv2_add_listener_certificates() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(443)
+        .protocol(ProtocolEnum::Https)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    client
+        .add_listener_certificates()
+        .listener_arn(arn)
+        .certificates(
+            Certificate::builder()
+                .certificate_arn("arn:aws:acm:us-east-1:123:certificate/abc")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "RemoveListenerCertificates",
+    checksum = "5f8d4fb1"
+)]
+#[tokio::test]
+async fn elbv2_remove_listener_certificates() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(443)
+        .protocol(ProtocolEnum::Https)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    client
+        .add_listener_certificates()
+        .listener_arn(arn)
+        .certificates(
+            Certificate::builder()
+                .certificate_arn("arn:aws:acm:us-east-1:123:certificate/extra")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    client
+        .remove_listener_certificates()
+        .listener_arn(arn)
+        .certificates(
+            Certificate::builder()
+                .certificate_arn("arn:aws:acm:us-east-1:123:certificate/extra")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "elasticloadbalancingv2",
+    "DescribeListenerCertificates",
+    checksum = "c640a1d4"
+)]
+#[tokio::test]
+async fn elbv2_describe_listener_certificates() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let create = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(443)
+        .protocol(ProtocolEnum::Https)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let arn = create.listeners().first().unwrap().listener_arn().unwrap();
+    let _ = client
+        .describe_listener_certificates()
+        .listener_arn(arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticloadbalancingv2", "CreateRule", checksum = "9ef2043e")]
+#[tokio::test]
+async fn elbv2_create_rule() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let listener = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap();
+    let resp = client
+        .create_rule()
+        .listener_arn(listener_arn)
+        .priority(10)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .values("/api/*")
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::FixedResponse)
+                .fixed_response_config(
+                    FixedResponseActionConfig::builder()
+                        .status_code("200")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.rules().first().unwrap().priority(), Some("10"));
+}
+
+#[test_action("elasticloadbalancingv2", "DescribeRules", checksum = "8a119620")]
+#[tokio::test]
+async fn elbv2_describe_rules() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let listener = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap();
+    client
+        .create_rule()
+        .listener_arn(listener_arn)
+        .priority(20)
+        .conditions(
+            RuleCondition::builder()
+                .field("host-header")
+                .values("api.example.com")
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::FixedResponse)
+                .fixed_response_config(
+                    FixedResponseActionConfig::builder()
+                        .status_code("404")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .describe_rules()
+        .listener_arn(listener_arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.rules().len(), 1);
+}
+
+#[test_action("elasticloadbalancingv2", "ModifyRule", checksum = "dc4ec5b1")]
+#[tokio::test]
+async fn elbv2_modify_rule() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let listener = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap();
+    let rule = client
+        .create_rule()
+        .listener_arn(listener_arn)
+        .priority(30)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .values("/v1/*")
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rules().first().unwrap().rule_arn().unwrap();
+    client
+        .modify_rule()
+        .rule_arn(rule_arn)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .values("/v2/*")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticloadbalancingv2", "DeleteRule", checksum = "dd15d3f9")]
+#[tokio::test]
+async fn elbv2_delete_rule() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let listener = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap();
+    let rule = client
+        .create_rule()
+        .listener_arn(listener_arn)
+        .priority(40)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .values("/del/*")
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rules().first().unwrap().rule_arn().unwrap();
+    client
+        .delete_rule()
+        .rule_arn(rule_arn)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("elasticloadbalancingv2", "SetRulePriorities", checksum = "f7ddaac0")]
+#[tokio::test]
+async fn elbv2_set_rule_priorities() {
+    let server = TestServer::start().await;
+    let (client, lb_arn, tg_arn) = make_lb_and_tg(&server).await;
+    let listener = client
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .port(80)
+        .protocol(ProtocolEnum::Http)
+        .default_actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let listener_arn = listener
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap();
+    let rule = client
+        .create_rule()
+        .listener_arn(listener_arn)
+        .priority(50)
+        .conditions(
+            RuleCondition::builder()
+                .field("path-pattern")
+                .values("/p/*")
+                .build(),
+        )
+        .actions(
+            Action::builder()
+                .r#type(ActionTypeEnum::Forward)
+                .target_group_arn(&tg_arn)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let rule_arn = rule.rules().first().unwrap().rule_arn().unwrap();
+    client
+        .set_rule_priorities()
+        .rule_priorities(
+            aws_sdk_elasticloadbalancingv2::types::RulePriorityPair::builder()
+                .rule_arn(rule_arn)
+                .priority(60)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
 }

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -33,6 +33,15 @@ const ELBV2_SUPPORTED_ACTIONS: &[&str] = &[
     "DescribeTags",
     "DescribeAccountLimits",
     "DescribeSSLPolicies",
+    "CreateTargetGroup",
+    "DescribeTargetGroups",
+    "ModifyTargetGroup",
+    "DeleteTargetGroup",
+    "RegisterTargets",
+    "DeregisterTargets",
+    "DescribeTargetHealth",
+    "ModifyTargetGroupAttributes",
+    "DescribeTargetGroupAttributes",
 ];
 
 pub struct Elbv2Service {
@@ -73,6 +82,15 @@ impl AwsService for Elbv2Service {
             "DescribeTags" => self.describe_tags(&req),
             "DescribeAccountLimits" => self.describe_account_limits(&req),
             "DescribeSSLPolicies" => self.describe_ssl_policies(&req),
+            "CreateTargetGroup" => self.create_target_group(&req),
+            "DescribeTargetGroups" => self.describe_target_groups(&req),
+            "ModifyTargetGroup" => self.modify_target_group(&req),
+            "DeleteTargetGroup" => self.delete_target_group(&req),
+            "RegisterTargets" => self.register_targets(&req),
+            "DeregisterTargets" => self.deregister_targets(&req),
+            "DescribeTargetHealth" => self.describe_target_health(&req),
+            "ModifyTargetGroupAttributes" => self.modify_target_group_attributes(&req),
+            "DescribeTargetGroupAttributes" => self.describe_target_group_attributes(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "elasticloadbalancing",
                 &req.action,
@@ -923,6 +941,565 @@ impl Elbv2Service {
             &req.request_id,
         ))
     }
+
+    // ───────────── Target Group ops ─────────────
+
+    fn create_target_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let name = required_query_param(req, "Name")?;
+        validate_tg_name(&name)?;
+        let target_type =
+            optional_query_param(req, "TargetType").unwrap_or_else(|| "instance".into());
+        if !matches!(target_type.as_str(), "instance" | "ip" | "lambda" | "alb") {
+            return Err(invalid_param(format!(
+                "TargetType must be one of instance|ip|lambda|alb, got '{target_type}'"
+            )));
+        }
+        let protocol = optional_query_param(req, "Protocol");
+        let port = optional_query_param(req, "Port").and_then(|s| s.parse().ok());
+        let vpc_id = optional_query_param(req, "VpcId");
+        let ip_address_type =
+            optional_query_param(req, "IpAddressType").unwrap_or_else(|| "ipv4".into());
+        let protocol_version = optional_query_param(req, "ProtocolVersion");
+        let health_check_protocol =
+            optional_query_param(req, "HealthCheckProtocol").or_else(|| protocol.clone());
+        let health_check_port =
+            optional_query_param(req, "HealthCheckPort").or_else(|| Some("traffic-port".into()));
+        let health_check_path = optional_query_param(req, "HealthCheckPath");
+        let health_check_enabled = optional_query_param(req, "HealthCheckEnabled")
+            .map(|s| s != "false")
+            .unwrap_or(true);
+        let health_check_interval_seconds = optional_query_param(req, "HealthCheckIntervalSeconds")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30);
+        let health_check_timeout_seconds = optional_query_param(req, "HealthCheckTimeoutSeconds")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let healthy_threshold_count = optional_query_param(req, "HealthyThresholdCount")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let unhealthy_threshold_count = optional_query_param(req, "UnhealthyThresholdCount")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2);
+        let matcher_http_code = optional_query_param(req, "Matcher.HttpCode");
+        let matcher_grpc_code = optional_query_param(req, "Matcher.GrpcCode");
+        let mut tags = parse_tags(req);
+        tags.dedup_by(|a, b| a.key == b.key);
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+
+        if let Some(existing) = st.target_groups.values().find(|tg| tg.name == name) {
+            let inner = format!(
+                "<TargetGroups><member>{}</member></TargetGroups>",
+                render_target_group_xml(existing)
+            );
+            return Ok(xml_resp("CreateTargetGroup", inner, &req.request_id));
+        }
+
+        let suffix = alphanumeric_id(16);
+        let arn = format!(
+            "arn:aws:elasticloadbalancing:{}:{}:targetgroup/{}/{}",
+            req.region, req.account_id, name, suffix
+        );
+        let tg = crate::state::TargetGroup {
+            arn: arn.clone(),
+            name,
+            protocol,
+            port,
+            vpc_id,
+            target_type,
+            ip_address_type,
+            protocol_version,
+            health_check_protocol,
+            health_check_port,
+            health_check_enabled,
+            health_check_path,
+            health_check_interval_seconds,
+            health_check_timeout_seconds,
+            healthy_threshold_count,
+            unhealthy_threshold_count,
+            matcher_http_code,
+            matcher_grpc_code,
+            load_balancer_arns: Vec::new(),
+            targets: Vec::new(),
+            tags,
+            attributes: default_target_group_attributes(),
+            created_time: Utc::now(),
+        };
+        let tg_xml = render_target_group_xml(&tg);
+        st.target_groups.insert(arn, tg);
+        Ok(xml_resp(
+            "CreateTargetGroup",
+            format!("<TargetGroups><member>{tg_xml}</member></TargetGroups>"),
+            &req.request_id,
+        ))
+    }
+
+    fn describe_target_groups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arns: HashSet<String> = parse_member_list(req, "TargetGroupArns")
+            .into_iter()
+            .collect();
+        let names: HashSet<String> = parse_member_list(req, "Names").into_iter().collect();
+        let lb_arn = optional_query_param(req, "LoadBalancerArn");
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut tgs: Vec<&crate::state::TargetGroup> = st.target_groups.values().collect();
+        if !arns.is_empty() {
+            let kept: Vec<&crate::state::TargetGroup> = tgs
+                .iter()
+                .filter(|t| arns.contains(&t.arn))
+                .copied()
+                .collect();
+            if kept.len() != arns.len() {
+                let missing = arns
+                    .iter()
+                    .find(|a| !kept.iter().any(|t| t.arn == **a))
+                    .cloned()
+                    .unwrap_or_default();
+                return Err(target_group_not_found(&missing));
+            }
+            tgs = kept;
+        }
+        if !names.is_empty() {
+            let kept: Vec<&crate::state::TargetGroup> = tgs
+                .iter()
+                .filter(|t| names.contains(&t.name))
+                .copied()
+                .collect();
+            if kept.len() != names.len() {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "TargetGroupNotFound",
+                    "One or more named target groups not found",
+                ));
+            }
+            tgs = kept;
+        }
+        if let Some(lb) = lb_arn.as_deref() {
+            tgs.retain(|t| t.load_balancer_arns.iter().any(|a| a == lb));
+        }
+        tgs.sort_by_key(|a| a.created_time);
+        let inner = format!(
+            "<TargetGroups>{}</TargetGroups>",
+            tgs.iter()
+                .map(|tg| format!("<member>{}</member>", render_target_group_xml(tg)))
+                .collect::<String>()
+        );
+        Ok(xml_resp("DescribeTargetGroups", inner, &req.request_id))
+    }
+
+    fn modify_target_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let tg = st
+            .target_groups
+            .get_mut(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        if let Some(p) = optional_query_param(req, "HealthCheckProtocol") {
+            tg.health_check_protocol = Some(p);
+        }
+        if let Some(p) = optional_query_param(req, "HealthCheckPort") {
+            tg.health_check_port = Some(p);
+        }
+        if let Some(p) = optional_query_param(req, "HealthCheckPath") {
+            tg.health_check_path = Some(p);
+        }
+        if let Some(e) = optional_query_param(req, "HealthCheckEnabled") {
+            tg.health_check_enabled = e != "false";
+        }
+        if let Some(s) =
+            optional_query_param(req, "HealthCheckIntervalSeconds").and_then(|s| s.parse().ok())
+        {
+            tg.health_check_interval_seconds = s;
+        }
+        if let Some(s) =
+            optional_query_param(req, "HealthCheckTimeoutSeconds").and_then(|s| s.parse().ok())
+        {
+            tg.health_check_timeout_seconds = s;
+        }
+        if let Some(s) =
+            optional_query_param(req, "HealthyThresholdCount").and_then(|s| s.parse().ok())
+        {
+            tg.healthy_threshold_count = s;
+        }
+        if let Some(s) =
+            optional_query_param(req, "UnhealthyThresholdCount").and_then(|s| s.parse().ok())
+        {
+            tg.unhealthy_threshold_count = s;
+        }
+        if let Some(c) = optional_query_param(req, "Matcher.HttpCode") {
+            tg.matcher_http_code = Some(c);
+        }
+        if let Some(c) = optional_query_param(req, "Matcher.GrpcCode") {
+            tg.matcher_grpc_code = Some(c);
+        }
+        let xml = render_target_group_xml(tg);
+        Ok(xml_resp(
+            "ModifyTargetGroup",
+            format!("<TargetGroups><member>{xml}</member></TargetGroups>"),
+            &req.request_id,
+        ))
+    }
+
+    fn delete_target_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        // Reject if the TG is still referenced by listeners/rules.
+        let referenced = st.listeners.values().any(|l| {
+            l.default_actions
+                .iter()
+                .any(|a| a.target_group_arn.as_deref() == Some(arn.as_str()))
+                || l.default_actions.iter().any(|a| {
+                    a.forward
+                        .as_ref()
+                        .map(|f| f.target_groups.iter().any(|t| t.target_group_arn == arn))
+                        .unwrap_or(false)
+                })
+        }) || st.rules.values().any(|r| {
+            r.actions
+                .iter()
+                .any(|a| a.target_group_arn.as_deref() == Some(arn.as_str()))
+        });
+        if referenced {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceInUse",
+                "Target group is currently in use by a listener or a rule",
+            ));
+        }
+        st.target_groups.remove(&arn);
+        Ok(xml_metadata_only("DeleteTargetGroup", &req.request_id))
+    }
+
+    fn register_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let targets = parse_target_descriptions(req);
+        if targets.is_empty() {
+            return Err(invalid_param("Targets is required"));
+        }
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let tg = st
+            .target_groups
+            .get_mut(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        for t in targets {
+            // Replace existing entry with same id+port, otherwise append.
+            tg.targets.retain(|x| !(x.id == t.id && x.port == t.port));
+            tg.targets.push(t);
+        }
+        Ok(xml_metadata_only("RegisterTargets", &req.request_id))
+    }
+
+    fn deregister_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let targets = parse_target_descriptions(req);
+        if targets.is_empty() {
+            return Err(invalid_param("Targets is required"));
+        }
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let tg = st
+            .target_groups
+            .get_mut(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        for t in targets {
+            tg.targets
+                .retain(|x| !(x.id == t.id && (t.port.is_none() || x.port == t.port)));
+        }
+        Ok(xml_metadata_only("DeregisterTargets", &req.request_id))
+    }
+
+    fn describe_target_health(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let filter = parse_target_descriptions(req);
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let tg = st
+            .target_groups
+            .get(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        let entries: Vec<&crate::state::TargetDescription> = if filter.is_empty() {
+            tg.targets.iter().collect()
+        } else {
+            tg.targets
+                .iter()
+                .filter(|t| {
+                    filter
+                        .iter()
+                        .any(|f| f.id == t.id && (f.port.is_none() || f.port == t.port))
+                })
+                .collect()
+        };
+        let xml = entries
+            .iter()
+            .map(|t| {
+                let port_xml = t
+                    .port
+                    .map(|p| format!("<Port>{p}</Port>"))
+                    .unwrap_or_default();
+                let az_xml = t
+                    .availability_zone
+                    .as_deref()
+                    .map(|a| format!("<AvailabilityZone>{}</AvailabilityZone>", xml_escape(a)))
+                    .unwrap_or_default();
+                let reason = t
+                    .health
+                    .reason
+                    .as_deref()
+                    .map(|r| format!("<Reason>{}</Reason>", xml_escape(r)))
+                    .unwrap_or_default();
+                let desc = t
+                    .health
+                    .description
+                    .as_deref()
+                    .map(|d| format!("<Description>{}</Description>", xml_escape(d)))
+                    .unwrap_or_default();
+                format!(
+                    "<member><Target><Id>{}</Id>{port_xml}{az_xml}</Target><TargetHealth><State>{}</State>{reason}{desc}</TargetHealth></member>",
+                    xml_escape(&t.id),
+                    xml_escape(&t.health.state),
+                )
+            })
+            .collect::<String>();
+        Ok(xml_resp(
+            "DescribeTargetHealth",
+            format!("<TargetHealthDescriptions>{xml}</TargetHealthDescriptions>"),
+            &req.request_id,
+        ))
+    }
+
+    fn modify_target_group_attributes(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let new_attrs = parse_attributes(req);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let tg = st
+            .target_groups
+            .get_mut(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        for (k, v) in &new_attrs {
+            tg.attributes.insert(k.clone(), v.clone());
+        }
+        Ok(xml_resp(
+            "ModifyTargetGroupAttributes",
+            render_attributes_xml(&tg.attributes),
+            &req.request_id,
+        ))
+    }
+
+    fn describe_target_group_attributes(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "TargetGroupArn")?;
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let tg = st
+            .target_groups
+            .get(&arn)
+            .ok_or_else(|| target_group_not_found(&arn))?;
+        Ok(xml_resp(
+            "DescribeTargetGroupAttributes",
+            render_attributes_xml(&tg.attributes),
+            &req.request_id,
+        ))
+    }
+}
+
+fn validate_tg_name(name: &str) -> Result<(), AwsServiceError> {
+    if name.is_empty() || name.len() > 32 {
+        return Err(invalid_param(
+            "TargetGroup name must be between 1 and 32 characters",
+        ));
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(invalid_param(
+            "TargetGroup name must contain only ASCII letters, digits, and hyphens",
+        ));
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err(invalid_param(
+            "TargetGroup name cannot start or end with a hyphen",
+        ));
+    }
+    Ok(())
+}
+
+fn target_group_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "TargetGroupNotFound",
+        format!("Target group '{arn}' not found"),
+    )
+}
+
+fn render_target_group_xml(tg: &crate::state::TargetGroup) -> String {
+    let lb_xml = tg
+        .load_balancer_arns
+        .iter()
+        .map(|a| format!("<member>{}</member>", xml_escape(a)))
+        .collect::<String>();
+    let port = tg
+        .port
+        .map(|p| format!("<Port>{p}</Port>"))
+        .unwrap_or_default();
+    let proto = tg
+        .protocol
+        .as_deref()
+        .map(|p| format!("<Protocol>{}</Protocol>", xml_escape(p)))
+        .unwrap_or_default();
+    let vpc = tg
+        .vpc_id
+        .as_deref()
+        .map(|v| format!("<VpcId>{}</VpcId>", xml_escape(v)))
+        .unwrap_or_default();
+    let proto_ver = tg
+        .protocol_version
+        .as_deref()
+        .map(|p| format!("<ProtocolVersion>{}</ProtocolVersion>", xml_escape(p)))
+        .unwrap_or_default();
+    let hc_proto = tg
+        .health_check_protocol
+        .as_deref()
+        .map(|p| {
+            format!(
+                "<HealthCheckProtocol>{}</HealthCheckProtocol>",
+                xml_escape(p)
+            )
+        })
+        .unwrap_or_default();
+    let hc_port = tg
+        .health_check_port
+        .as_deref()
+        .map(|p| format!("<HealthCheckPort>{}</HealthCheckPort>", xml_escape(p)))
+        .unwrap_or_default();
+    let hc_path = tg
+        .health_check_path
+        .as_deref()
+        .map(|p| format!("<HealthCheckPath>{}</HealthCheckPath>", xml_escape(p)))
+        .unwrap_or_default();
+    let matcher = tg
+        .matcher_http_code
+        .as_deref()
+        .map(|m| format!("<Matcher><HttpCode>{}</HttpCode></Matcher>", xml_escape(m)))
+        .unwrap_or_default();
+    format!(
+        "<TargetGroupArn>{arn}</TargetGroupArn>\
+         <TargetGroupName>{name}</TargetGroupName>\
+         {proto}{port}{vpc}{proto_ver}\
+         <TargetType>{tt}</TargetType>\
+         <IpAddressType>{ipt}</IpAddressType>\
+         <HealthCheckEnabled>{hce}</HealthCheckEnabled>\
+         {hc_proto}{hc_port}{hc_path}\
+         <HealthCheckIntervalSeconds>{hci}</HealthCheckIntervalSeconds>\
+         <HealthCheckTimeoutSeconds>{hct}</HealthCheckTimeoutSeconds>\
+         <HealthyThresholdCount>{ht}</HealthyThresholdCount>\
+         <UnhealthyThresholdCount>{uht}</UnhealthyThresholdCount>\
+         {matcher}\
+         <LoadBalancerArns>{lb_xml}</LoadBalancerArns>",
+        arn = xml_escape(&tg.arn),
+        name = xml_escape(&tg.name),
+        tt = xml_escape(&tg.target_type),
+        ipt = xml_escape(&tg.ip_address_type),
+        hce = tg.health_check_enabled,
+        hci = tg.health_check_interval_seconds,
+        hct = tg.health_check_timeout_seconds,
+        ht = tg.healthy_threshold_count,
+        uht = tg.unhealthy_threshold_count,
+    )
+}
+
+fn parse_target_descriptions(req: &AwsRequest) -> Vec<crate::state::TargetDescription> {
+    let mut out = Vec::new();
+    for n in 1..=100 {
+        let id = req
+            .query_params
+            .get(&format!("Targets.member.{n}.Id"))
+            .cloned();
+        if let Some(id) = id {
+            let port = req
+                .query_params
+                .get(&format!("Targets.member.{n}.Port"))
+                .and_then(|s| s.parse().ok());
+            let az = req
+                .query_params
+                .get(&format!("Targets.member.{n}.AvailabilityZone"))
+                .cloned();
+            out.push(crate::state::TargetDescription {
+                id,
+                port,
+                availability_zone: az,
+                health: crate::state::TargetHealth::default(),
+            });
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn parse_attributes(req: &AwsRequest) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for n in 1..=50 {
+        let key = req
+            .query_params
+            .get(&format!("Attributes.member.{n}.Key"))
+            .cloned();
+        if let Some(k) = key {
+            let v = req
+                .query_params
+                .get(&format!("Attributes.member.{n}.Value"))
+                .cloned()
+                .unwrap_or_default();
+            out.push((k, v));
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn render_attributes_xml(attrs: &HashMap<String, String>) -> String {
+    let entries = attrs
+        .iter()
+        .map(|(k, v)| {
+            format!(
+                "<member><Key>{}</Key><Value>{}</Value></member>",
+                xml_escape(k),
+                xml_escape(v)
+            )
+        })
+        .collect::<String>();
+    format!("<Attributes>{entries}</Attributes>")
+}
+
+fn default_target_group_attributes() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert(
+        "deregistration_delay.timeout_seconds".to_string(),
+        "300".to_string(),
+    );
+    m.insert("stickiness.enabled".to_string(), "false".to_string());
+    m.insert("stickiness.type".to_string(), "lb_cookie".to_string());
+    m.insert(
+        "stickiness.lb_cookie.duration_seconds".to_string(),
+        "86400".to_string(),
+    );
+    m.insert(
+        "load_balancing.algorithm.type".to_string(),
+        "round_robin".to_string(),
+    );
+    m.insert("slow_start.duration_seconds".to_string(), "0".to_string());
+    m
 }
 
 fn apply_tags(

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -42,6 +42,20 @@ const ELBV2_SUPPORTED_ACTIONS: &[&str] = &[
     "DescribeTargetHealth",
     "ModifyTargetGroupAttributes",
     "DescribeTargetGroupAttributes",
+    "CreateListener",
+    "DescribeListeners",
+    "ModifyListener",
+    "DeleteListener",
+    "DescribeListenerAttributes",
+    "ModifyListenerAttributes",
+    "AddListenerCertificates",
+    "RemoveListenerCertificates",
+    "DescribeListenerCertificates",
+    "CreateRule",
+    "DescribeRules",
+    "ModifyRule",
+    "DeleteRule",
+    "SetRulePriorities",
 ];
 
 pub struct Elbv2Service {
@@ -91,6 +105,20 @@ impl AwsService for Elbv2Service {
             "DescribeTargetHealth" => self.describe_target_health(&req),
             "ModifyTargetGroupAttributes" => self.modify_target_group_attributes(&req),
             "DescribeTargetGroupAttributes" => self.describe_target_group_attributes(&req),
+            "CreateListener" => self.create_listener(&req),
+            "DescribeListeners" => self.describe_listeners(&req),
+            "ModifyListener" => self.modify_listener(&req),
+            "DeleteListener" => self.delete_listener(&req),
+            "DescribeListenerAttributes" => self.describe_listener_attributes(&req),
+            "ModifyListenerAttributes" => self.modify_listener_attributes(&req),
+            "AddListenerCertificates" => self.add_listener_certificates(&req),
+            "RemoveListenerCertificates" => self.remove_listener_certificates(&req),
+            "DescribeListenerCertificates" => self.describe_listener_certificates(&req),
+            "CreateRule" => self.create_rule(&req),
+            "DescribeRules" => self.describe_rules(&req),
+            "ModifyRule" => self.modify_rule(&req),
+            "DeleteRule" => self.delete_rule(&req),
+            "SetRulePriorities" => self.set_rule_priorities(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "elasticloadbalancing",
                 &req.action,
@@ -1313,6 +1341,837 @@ impl Elbv2Service {
             &req.request_id,
         ))
     }
+
+    // ───────────── Listener ops ─────────────
+
+    fn create_listener(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let lb_arn = required_query_param(req, "LoadBalancerArn")?;
+        let protocol = optional_query_param(req, "Protocol");
+        let port = optional_query_param(req, "Port").and_then(|s| s.parse().ok());
+        let ssl_policy = optional_query_param(req, "SslPolicy");
+        let alpn_policy = parse_member_list(req, "AlpnPolicy");
+        let certificates = parse_certificates(req);
+        let actions = parse_actions(req, "DefaultActions");
+        if actions.is_empty() {
+            return Err(invalid_param("DefaultActions is required"));
+        }
+        let mut tags = parse_tags(req);
+        tags.dedup_by(|a, b| a.key == b.key);
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if !st.load_balancers.contains_key(&lb_arn) {
+            return Err(lb_not_found(&lb_arn));
+        }
+        // Validate referenced target groups exist (forward action targets).
+        for action in &actions {
+            if let Some(tg_arn) = &action.target_group_arn {
+                if !st.target_groups.contains_key(tg_arn) {
+                    return Err(target_group_not_found(tg_arn));
+                }
+            }
+            if let Some(forward) = &action.forward {
+                for tgt in &forward.target_groups {
+                    if !st.target_groups.contains_key(&tgt.target_group_arn) {
+                        return Err(target_group_not_found(&tgt.target_group_arn));
+                    }
+                }
+            }
+        }
+        let suffix = alphanumeric_id(16);
+        let arn = format!("{lb_arn}/{suffix}").replace(":loadbalancer/", ":listener/");
+        // Mark referenced target groups as attached to this LB.
+        let referenced_tgs: HashSet<String> = actions
+            .iter()
+            .filter_map(|a| a.target_group_arn.clone())
+            .chain(actions.iter().flat_map(|a| {
+                a.forward
+                    .as_ref()
+                    .map(|f| {
+                        f.target_groups
+                            .iter()
+                            .map(|t| t.target_group_arn.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            }))
+            .collect();
+        for tg_arn in &referenced_tgs {
+            if let Some(tg) = st.target_groups.get_mut(tg_arn) {
+                if !tg.load_balancer_arns.contains(&lb_arn) {
+                    tg.load_balancer_arns.push(lb_arn.clone());
+                }
+            }
+        }
+        let listener = crate::state::Listener {
+            arn: arn.clone(),
+            load_balancer_arn: lb_arn,
+            port,
+            protocol,
+            certificates,
+            ssl_policy,
+            default_actions: actions,
+            alpn_policy,
+            mutual_authentication: parse_mutual_authentication(req),
+            tags,
+            attributes: HashMap::new(),
+        };
+        let listener_xml = render_listener_xml(&listener);
+        st.listeners.insert(arn, listener);
+        Ok(xml_resp(
+            "CreateListener",
+            format!("<Listeners><member>{listener_xml}</member></Listeners>"),
+            &req.request_id,
+        ))
+    }
+
+    fn describe_listeners(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let lb_arn = optional_query_param(req, "LoadBalancerArn");
+        let listener_arns: HashSet<String> =
+            parse_member_list(req, "ListenerArns").into_iter().collect();
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut listeners: Vec<&crate::state::Listener> = st
+            .listeners
+            .values()
+            .filter(|l| {
+                lb_arn.as_deref().is_none_or(|a| l.load_balancer_arn == a)
+                    && (listener_arns.is_empty() || listener_arns.contains(&l.arn))
+            })
+            .collect();
+        listeners.sort_by_key(|l| l.port.unwrap_or(0));
+        let inner = format!(
+            "<Listeners>{}</Listeners>",
+            listeners
+                .iter()
+                .map(|l| format!("<member>{}</member>", render_listener_xml(l)))
+                .collect::<String>()
+        );
+        Ok(xml_resp("DescribeListeners", inner, &req.request_id))
+    }
+
+    fn modify_listener(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let listener = st
+            .listeners
+            .get_mut(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        if let Some(p) = optional_query_param(req, "Port").and_then(|s| s.parse().ok()) {
+            listener.port = Some(p);
+        }
+        if let Some(p) = optional_query_param(req, "Protocol") {
+            listener.protocol = Some(p);
+        }
+        if let Some(p) = optional_query_param(req, "SslPolicy") {
+            listener.ssl_policy = Some(p);
+        }
+        let new_certs = parse_certificates(req);
+        if !new_certs.is_empty() {
+            listener.certificates = new_certs;
+        }
+        let new_actions = parse_actions(req, "DefaultActions");
+        if !new_actions.is_empty() {
+            listener.default_actions = new_actions;
+        }
+        let alpn = parse_member_list(req, "AlpnPolicy");
+        if !alpn.is_empty() {
+            listener.alpn_policy = alpn;
+        }
+        let xml = render_listener_xml(listener);
+        Ok(xml_resp(
+            "ModifyListener",
+            format!("<Listeners><member>{xml}</member></Listeners>"),
+            &req.request_id,
+        ))
+    }
+
+    fn delete_listener(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        st.listeners.remove(&arn);
+        st.rules.retain(|_, r| r.listener_arn != arn);
+        Ok(xml_metadata_only("DeleteListener", &req.request_id))
+    }
+
+    fn describe_listener_attributes(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let listener = st
+            .listeners
+            .get(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        Ok(xml_resp(
+            "DescribeListenerAttributes",
+            render_attributes_xml(&listener.attributes),
+            &req.request_id,
+        ))
+    }
+
+    fn modify_listener_attributes(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let new_attrs = parse_attributes(req);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let listener = st
+            .listeners
+            .get_mut(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        for (k, v) in &new_attrs {
+            listener.attributes.insert(k.clone(), v.clone());
+        }
+        Ok(xml_resp(
+            "ModifyListenerAttributes",
+            render_attributes_xml(&listener.attributes),
+            &req.request_id,
+        ))
+    }
+
+    fn add_listener_certificates(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let new_certs = parse_certificates(req);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let listener = st
+            .listeners
+            .get_mut(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        for c in &new_certs {
+            listener
+                .certificates
+                .retain(|x| x.certificate_arn != c.certificate_arn);
+            listener.certificates.push(c.clone());
+        }
+        let cert_xml = listener
+            .certificates
+            .iter()
+            .map(render_certificate_xml)
+            .collect::<String>();
+        Ok(xml_resp(
+            "AddListenerCertificates",
+            format!("<Certificates>{cert_xml}</Certificates>"),
+            &req.request_id,
+        ))
+    }
+
+    fn remove_listener_certificates(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let to_remove = parse_certificates(req);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let listener = st
+            .listeners
+            .get_mut(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        let remove_arns: HashSet<String> = to_remove
+            .iter()
+            .map(|c| c.certificate_arn.clone())
+            .collect();
+        listener
+            .certificates
+            .retain(|c| !remove_arns.contains(&c.certificate_arn));
+        Ok(xml_metadata_only(
+            "RemoveListenerCertificates",
+            &req.request_id,
+        ))
+    }
+
+    fn describe_listener_certificates(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "ListenerArn")?;
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let listener = st
+            .listeners
+            .get(&arn)
+            .ok_or_else(|| listener_not_found(&arn))?;
+        let cert_xml = listener
+            .certificates
+            .iter()
+            .map(render_certificate_xml)
+            .collect::<String>();
+        Ok(xml_resp(
+            "DescribeListenerCertificates",
+            format!("<Certificates>{cert_xml}</Certificates>"),
+            &req.request_id,
+        ))
+    }
+
+    // ───────────── Rule ops ─────────────
+
+    fn create_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let listener_arn = required_query_param(req, "ListenerArn")?;
+        let priority = required_query_param(req, "Priority")?;
+        if priority.parse::<i32>().is_err() {
+            return Err(invalid_param(format!(
+                "Priority must be a positive integer, got '{priority}'"
+            )));
+        }
+        let conditions = parse_conditions(req);
+        if conditions.is_empty() {
+            return Err(invalid_param("Conditions is required"));
+        }
+        let actions = parse_actions(req, "Actions");
+        if actions.is_empty() {
+            return Err(invalid_param("Actions is required"));
+        }
+        let mut tags = parse_tags(req);
+        tags.dedup_by(|a, b| a.key == b.key);
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if !st.listeners.contains_key(&listener_arn) {
+            return Err(listener_not_found(&listener_arn));
+        }
+        if st
+            .rules
+            .values()
+            .any(|r| r.listener_arn == listener_arn && r.priority == priority && !r.is_default)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "PriorityInUse",
+                format!("Priority '{priority}' already in use on listener '{listener_arn}'"),
+            ));
+        }
+        let suffix = alphanumeric_id(16);
+        let arn = format!("{listener_arn}/{suffix}").replace(":listener/", ":listener-rule/");
+        let rule = crate::state::Rule {
+            arn: arn.clone(),
+            listener_arn,
+            priority,
+            conditions,
+            actions,
+            is_default: false,
+            tags,
+        };
+        let rule_xml = render_rule_xml(&rule);
+        st.rules.insert(arn, rule);
+        Ok(xml_resp(
+            "CreateRule",
+            format!("<Rules><member>{rule_xml}</member></Rules>"),
+            &req.request_id,
+        ))
+    }
+
+    fn describe_rules(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let listener_arn = optional_query_param(req, "ListenerArn");
+        let rule_arns: HashSet<String> = parse_member_list(req, "RuleArns").into_iter().collect();
+        let accounts = self.state.read();
+        let empty = crate::state::Elbv2State::new(&req.account_id);
+        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut rules: Vec<&crate::state::Rule> = st
+            .rules
+            .values()
+            .filter(|r| {
+                listener_arn.as_deref().is_none_or(|a| r.listener_arn == a)
+                    && (rule_arns.is_empty() || rule_arns.contains(&r.arn))
+            })
+            .collect();
+        rules.sort_by(|a, b| {
+            let ap = a.priority.parse::<i32>().unwrap_or(i32::MAX);
+            let bp = b.priority.parse::<i32>().unwrap_or(i32::MAX);
+            ap.cmp(&bp)
+        });
+        let inner = format!(
+            "<Rules>{}</Rules>",
+            rules
+                .iter()
+                .map(|r| format!("<member>{}</member>", render_rule_xml(r)))
+                .collect::<String>()
+        );
+        Ok(xml_resp("DescribeRules", inner, &req.request_id))
+    }
+
+    fn modify_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "RuleArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let new_conditions = parse_conditions(req);
+        let new_actions = parse_actions(req, "Actions");
+        let rule = st.rules.get_mut(&arn).ok_or_else(|| rule_not_found(&arn))?;
+        if !new_conditions.is_empty() {
+            rule.conditions = new_conditions;
+        }
+        if !new_actions.is_empty() {
+            rule.actions = new_actions;
+        }
+        let xml = render_rule_xml(rule);
+        Ok(xml_resp(
+            "ModifyRule",
+            format!("<Rules><member>{xml}</member></Rules>"),
+            &req.request_id,
+        ))
+    }
+
+    fn delete_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let arn = required_query_param(req, "RuleArn")?;
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        st.rules.remove(&arn);
+        Ok(xml_metadata_only("DeleteRule", &req.request_id))
+    }
+
+    fn set_rule_priorities(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let mut updates: Vec<(String, String)> = Vec::new();
+        for n in 1..=100 {
+            let arn = req
+                .query_params
+                .get(&format!("RulePriorities.member.{n}.RuleArn"))
+                .cloned();
+            if let Some(arn) = arn {
+                let priority = req
+                    .query_params
+                    .get(&format!("RulePriorities.member.{n}.Priority"))
+                    .cloned()
+                    .unwrap_or_default();
+                updates.push((arn, priority));
+            } else {
+                break;
+            }
+        }
+        if updates.is_empty() {
+            return Err(invalid_param("RulePriorities is required"));
+        }
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let mut updated = Vec::new();
+        for (arn, priority) in updates {
+            let rule = st.rules.get_mut(&arn).ok_or_else(|| rule_not_found(&arn))?;
+            rule.priority = priority;
+            updated.push(rule.arn.clone());
+        }
+        let arns: Vec<String> = updated;
+        let rules_xml = arns
+            .iter()
+            .filter_map(|a| st.rules.get(a))
+            .map(|r| format!("<member>{}</member>", render_rule_xml(r)))
+            .collect::<String>();
+        Ok(xml_resp(
+            "SetRulePriorities",
+            format!("<Rules>{rules_xml}</Rules>"),
+            &req.request_id,
+        ))
+    }
+}
+
+fn listener_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ListenerNotFound",
+        format!("Listener '{arn}' not found"),
+    )
+}
+
+fn rule_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "RuleNotFound",
+        format!("Rule '{arn}' not found"),
+    )
+}
+
+fn parse_certificates(req: &AwsRequest) -> Vec<crate::state::Certificate> {
+    let mut out = Vec::new();
+    for n in 1..=25 {
+        let arn = req
+            .query_params
+            .get(&format!("Certificates.member.{n}.CertificateArn"))
+            .cloned();
+        if let Some(arn) = arn {
+            let is_default = req
+                .query_params
+                .get(&format!("Certificates.member.{n}.IsDefault"))
+                .map(|s| s == "true")
+                .unwrap_or(false);
+            out.push(crate::state::Certificate {
+                certificate_arn: arn,
+                is_default,
+            });
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn parse_actions(req: &AwsRequest, prefix: &str) -> Vec<crate::state::Action> {
+    let mut out = Vec::new();
+    for n in 1..=10 {
+        let p = format!("{prefix}.member.{n}");
+        let action_type = req.query_params.get(&format!("{p}.Type")).cloned();
+        if let Some(t) = action_type {
+            let target_group_arn = req
+                .query_params
+                .get(&format!("{p}.TargetGroupArn"))
+                .cloned();
+            let order = req
+                .query_params
+                .get(&format!("{p}.Order"))
+                .and_then(|s| s.parse().ok());
+            let redirect = parse_redirect(req, &p);
+            let fixed_response = parse_fixed_response(req, &p);
+            let forward = parse_forward(req, &p);
+            out.push(crate::state::Action {
+                action_type: t,
+                target_group_arn,
+                order,
+                redirect,
+                fixed_response,
+                forward,
+                authenticate_cognito: None,
+                authenticate_oidc: None,
+            });
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn parse_redirect(req: &AwsRequest, prefix: &str) -> Option<crate::state::RedirectConfig> {
+    let status = req
+        .query_params
+        .get(&format!("{prefix}.RedirectConfig.StatusCode"))
+        .cloned()?;
+    Some(crate::state::RedirectConfig {
+        protocol: req
+            .query_params
+            .get(&format!("{prefix}.RedirectConfig.Protocol"))
+            .cloned(),
+        port: req
+            .query_params
+            .get(&format!("{prefix}.RedirectConfig.Port"))
+            .cloned(),
+        host: req
+            .query_params
+            .get(&format!("{prefix}.RedirectConfig.Host"))
+            .cloned(),
+        path: req
+            .query_params
+            .get(&format!("{prefix}.RedirectConfig.Path"))
+            .cloned(),
+        query: req
+            .query_params
+            .get(&format!("{prefix}.RedirectConfig.Query"))
+            .cloned(),
+        status_code: status,
+    })
+}
+
+fn parse_fixed_response(
+    req: &AwsRequest,
+    prefix: &str,
+) -> Option<crate::state::FixedResponseConfig> {
+    let status = req
+        .query_params
+        .get(&format!("{prefix}.FixedResponseConfig.StatusCode"))
+        .cloned()?;
+    Some(crate::state::FixedResponseConfig {
+        message_body: req
+            .query_params
+            .get(&format!("{prefix}.FixedResponseConfig.MessageBody"))
+            .cloned(),
+        status_code: status,
+        content_type: req
+            .query_params
+            .get(&format!("{prefix}.FixedResponseConfig.ContentType"))
+            .cloned(),
+    })
+}
+
+fn parse_forward(req: &AwsRequest, prefix: &str) -> Option<crate::state::ForwardConfig> {
+    let mut target_groups = Vec::new();
+    for n in 1..=5 {
+        let key = format!("{prefix}.ForwardConfig.TargetGroups.member.{n}.TargetGroupArn");
+        if let Some(arn) = req.query_params.get(&key) {
+            let weight = req
+                .query_params
+                .get(&format!(
+                    "{prefix}.ForwardConfig.TargetGroups.member.{n}.Weight"
+                ))
+                .and_then(|s| s.parse().ok());
+            target_groups.push(crate::state::TargetGroupTuple {
+                target_group_arn: arn.clone(),
+                weight,
+            });
+        } else {
+            break;
+        }
+    }
+    if target_groups.is_empty() {
+        return None;
+    }
+    Some(crate::state::ForwardConfig {
+        target_groups,
+        stickiness: None,
+    })
+}
+
+fn parse_mutual_authentication(req: &AwsRequest) -> Option<crate::state::MutualAuthentication> {
+    let mode = req.query_params.get("MutualAuthentication.Mode").cloned()?;
+    Some(crate::state::MutualAuthentication {
+        mode: Some(mode),
+        trust_store_arn: req
+            .query_params
+            .get("MutualAuthentication.TrustStoreArn")
+            .cloned(),
+        ignore_client_certificate_expiry: req
+            .query_params
+            .get("MutualAuthentication.IgnoreClientCertificateExpiry")
+            .map(|s| s == "true"),
+        trust_store_association_status: None,
+        advertise_trust_store_ca_names: req
+            .query_params
+            .get("MutualAuthentication.AdvertiseTrustStoreCaNames")
+            .cloned(),
+    })
+}
+
+fn parse_conditions(req: &AwsRequest) -> Vec<crate::state::RuleCondition> {
+    let mut out = Vec::new();
+    for n in 1..=10 {
+        let p = format!("Conditions.member.{n}");
+        let field = req.query_params.get(&format!("{p}.Field")).cloned();
+        if let Some(field) = field {
+            out.push(crate::state::RuleCondition {
+                field,
+                values: parse_member_list(req, &format!("{p}.Values")),
+                host_header_values: parse_member_list(req, &format!("{p}.HostHeaderConfig.Values")),
+                path_pattern_values: parse_member_list(
+                    req,
+                    &format!("{p}.PathPatternConfig.Values"),
+                ),
+                http_header_name: req
+                    .query_params
+                    .get(&format!("{p}.HttpHeaderConfig.HttpHeaderName"))
+                    .cloned(),
+                http_header_values: parse_member_list(req, &format!("{p}.HttpHeaderConfig.Values")),
+                query_string_values: Vec::new(),
+                http_request_method_values: parse_member_list(
+                    req,
+                    &format!("{p}.HttpRequestMethodConfig.Values"),
+                ),
+                source_ip_values: parse_member_list(req, &format!("{p}.SourceIpConfig.Values")),
+            });
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn render_listener_xml(l: &crate::state::Listener) -> String {
+    let port = l
+        .port
+        .map(|p| format!("<Port>{p}</Port>"))
+        .unwrap_or_default();
+    let proto = l
+        .protocol
+        .as_deref()
+        .map(|p| format!("<Protocol>{}</Protocol>", xml_escape(p)))
+        .unwrap_or_default();
+    let ssl = l
+        .ssl_policy
+        .as_deref()
+        .map(|p| format!("<SslPolicy>{}</SslPolicy>", xml_escape(p)))
+        .unwrap_or_default();
+    let cert_xml = l
+        .certificates
+        .iter()
+        .map(render_certificate_xml)
+        .collect::<String>();
+    let actions_xml = l
+        .default_actions
+        .iter()
+        .map(render_action_xml)
+        .collect::<String>();
+    let alpn_xml = l
+        .alpn_policy
+        .iter()
+        .map(|p| format!("<member>{}</member>", xml_escape(p)))
+        .collect::<String>();
+    let ma_xml = l
+        .mutual_authentication
+        .as_ref()
+        .map(render_mutual_auth_xml)
+        .unwrap_or_default();
+    format!(
+        "<ListenerArn>{arn}</ListenerArn>\
+         <LoadBalancerArn>{lb}</LoadBalancerArn>\
+         {port}{proto}\
+         <Certificates>{cert_xml}</Certificates>\
+         {ssl}\
+         <DefaultActions>{actions_xml}</DefaultActions>\
+         <AlpnPolicy>{alpn_xml}</AlpnPolicy>\
+         {ma_xml}",
+        arn = xml_escape(&l.arn),
+        lb = xml_escape(&l.load_balancer_arn),
+    )
+}
+
+fn render_certificate_xml(c: &crate::state::Certificate) -> String {
+    format!(
+        "<member><CertificateArn>{}</CertificateArn><IsDefault>{}</IsDefault></member>",
+        xml_escape(&c.certificate_arn),
+        c.is_default
+    )
+}
+
+fn render_action_xml(a: &crate::state::Action) -> String {
+    let order = a
+        .order
+        .map(|o| format!("<Order>{o}</Order>"))
+        .unwrap_or_default();
+    let tg = a
+        .target_group_arn
+        .as_deref()
+        .map(|t| format!("<TargetGroupArn>{}</TargetGroupArn>", xml_escape(t)))
+        .unwrap_or_default();
+    let redirect = a
+        .redirect
+        .as_ref()
+        .map(|r| {
+            let mut s = String::from("<RedirectConfig>");
+            if let Some(p) = &r.protocol {
+                s.push_str(&format!("<Protocol>{}</Protocol>", xml_escape(p)));
+            }
+            if let Some(p) = &r.port {
+                s.push_str(&format!("<Port>{}</Port>", xml_escape(p)));
+            }
+            if let Some(p) = &r.host {
+                s.push_str(&format!("<Host>{}</Host>", xml_escape(p)));
+            }
+            if let Some(p) = &r.path {
+                s.push_str(&format!("<Path>{}</Path>", xml_escape(p)));
+            }
+            if let Some(p) = &r.query {
+                s.push_str(&format!("<Query>{}</Query>", xml_escape(p)));
+            }
+            s.push_str(&format!(
+                "<StatusCode>{}</StatusCode>",
+                xml_escape(&r.status_code)
+            ));
+            s.push_str("</RedirectConfig>");
+            s
+        })
+        .unwrap_or_default();
+    let fixed = a
+        .fixed_response
+        .as_ref()
+        .map(|f| {
+            let mb = f
+                .message_body
+                .as_deref()
+                .map(|m| format!("<MessageBody>{}</MessageBody>", xml_escape(m)))
+                .unwrap_or_default();
+            let ct = f
+                .content_type
+                .as_deref()
+                .map(|c| format!("<ContentType>{}</ContentType>", xml_escape(c)))
+                .unwrap_or_default();
+            format!(
+                "<FixedResponseConfig>{mb}<StatusCode>{}</StatusCode>{ct}</FixedResponseConfig>",
+                xml_escape(&f.status_code)
+            )
+        })
+        .unwrap_or_default();
+    let forward = a
+        .forward
+        .as_ref()
+        .map(|f| {
+            let groups = f
+                .target_groups
+                .iter()
+                .map(|g| {
+                    let weight = g
+                        .weight
+                        .map(|w| format!("<Weight>{w}</Weight>"))
+                        .unwrap_or_default();
+                    format!(
+                        "<member><TargetGroupArn>{}</TargetGroupArn>{weight}</member>",
+                        xml_escape(&g.target_group_arn)
+                    )
+                })
+                .collect::<String>();
+            format!("<ForwardConfig><TargetGroups>{groups}</TargetGroups></ForwardConfig>")
+        })
+        .unwrap_or_default();
+    format!(
+        "<member><Type>{ty}</Type>{tg}{order}{redirect}{fixed}{forward}</member>",
+        ty = xml_escape(&a.action_type),
+    )
+}
+
+fn render_mutual_auth_xml(ma: &crate::state::MutualAuthentication) -> String {
+    let mode = ma
+        .mode
+        .as_deref()
+        .map(|m| format!("<Mode>{}</Mode>", xml_escape(m)))
+        .unwrap_or_default();
+    let ts = ma
+        .trust_store_arn
+        .as_deref()
+        .map(|t| format!("<TrustStoreArn>{}</TrustStoreArn>", xml_escape(t)))
+        .unwrap_or_default();
+    let ig = ma
+        .ignore_client_certificate_expiry
+        .map(|b| format!("<IgnoreClientCertificateExpiry>{b}</IgnoreClientCertificateExpiry>"))
+        .unwrap_or_default();
+    let adv = ma
+        .advertise_trust_store_ca_names
+        .as_deref()
+        .map(|a| {
+            format!(
+                "<AdvertiseTrustStoreCaNames>{}</AdvertiseTrustStoreCaNames>",
+                xml_escape(a)
+            )
+        })
+        .unwrap_or_default();
+    format!("<MutualAuthentication>{mode}{ts}{ig}{adv}</MutualAuthentication>")
+}
+
+fn render_rule_xml(r: &crate::state::Rule) -> String {
+    let conditions_xml = r
+        .conditions
+        .iter()
+        .map(|c| {
+            let values = c
+                .values
+                .iter()
+                .map(|v| format!("<member>{}</member>", xml_escape(v)))
+                .collect::<String>();
+            format!(
+                "<member><Field>{}</Field><Values>{values}</Values></member>",
+                xml_escape(&c.field)
+            )
+        })
+        .collect::<String>();
+    let actions_xml = r.actions.iter().map(render_action_xml).collect::<String>();
+    format!(
+        "<RuleArn>{arn}</RuleArn>\
+         <Priority>{priority}</Priority>\
+         <Conditions>{conditions_xml}</Conditions>\
+         <Actions>{actions_xml}</Actions>\
+         <IsDefault>{is_default}</IsDefault>",
+        arn = xml_escape(&r.arn),
+        priority = xml_escape(&r.priority),
+        is_default = r.is_default,
+    )
 }
 
 fn validate_tg_name(name: &str) -> Result<(), AwsServiceError> {

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1616,10 +1616,13 @@ impl Elbv2Service {
     fn create_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let listener_arn = required_query_param(req, "ListenerArn")?;
         let priority = required_query_param(req, "Priority")?;
-        if priority.parse::<i32>().is_err() {
-            return Err(invalid_param(format!(
-                "Priority must be a positive integer, got '{priority}'"
-            )));
+        match priority.parse::<i32>() {
+            Ok(n) if n > 0 => {}
+            _ => {
+                return Err(invalid_param(format!(
+                    "Priority must be a positive integer, got '{priority}'"
+                )));
+            }
         }
         let conditions = parse_conditions(req);
         if conditions.is_empty() {
@@ -1636,6 +1639,21 @@ impl Elbv2Service {
         let st = accounts.get_or_create(&req.account_id);
         if !st.listeners.contains_key(&listener_arn) {
             return Err(listener_not_found(&listener_arn));
+        }
+        // Reject any forward action that references a target group not in this account.
+        for action in &actions {
+            if let Some(arn) = action.target_group_arn.as_deref() {
+                if !st.target_groups.contains_key(arn) {
+                    return Err(target_group_not_found(arn));
+                }
+            }
+            if let Some(forward) = action.forward.as_ref() {
+                for t in &forward.target_groups {
+                    if !st.target_groups.contains_key(&t.target_group_arn) {
+                        return Err(target_group_not_found(&t.target_group_arn));
+                    }
+                }
+            }
         }
         if st
             .rules

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1147,22 +1147,22 @@ impl Elbv2Service {
         let arn = required_query_param(req, "TargetGroupArn")?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        // Reject if the TG is still referenced by listeners/rules.
-        let referenced = st.listeners.values().any(|l| {
-            l.default_actions
-                .iter()
-                .any(|a| a.target_group_arn.as_deref() == Some(arn.as_str()))
-                || l.default_actions.iter().any(|a| {
-                    a.forward
-                        .as_ref()
-                        .map(|f| f.target_groups.iter().any(|t| t.target_group_arn == arn))
-                        .unwrap_or(false)
-                })
-        }) || st.rules.values().any(|r| {
-            r.actions
-                .iter()
-                .any(|a| a.target_group_arn.as_deref() == Some(arn.as_str()))
-        });
+        // Reject if the TG is still referenced by listeners/rules — including
+        // ForwardConfig.TargetGroups blocks on either default actions or rule actions.
+        let action_refs_tg = |a: &crate::state::Action| {
+            a.target_group_arn.as_deref() == Some(arn.as_str())
+                || a.forward
+                    .as_ref()
+                    .is_some_and(|f| f.target_groups.iter().any(|t| t.target_group_arn == arn))
+        };
+        let referenced = st
+            .listeners
+            .values()
+            .any(|l| l.default_actions.iter().any(action_refs_tg))
+            || st
+                .rules
+                .values()
+                .any(|r| r.actions.iter().any(action_refs_tg));
         if referenced {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -1387,11 +1387,29 @@ fn render_target_group_xml(tg: &crate::state::TargetGroup) -> String {
         .as_deref()
         .map(|p| format!("<HealthCheckPath>{}</HealthCheckPath>", xml_escape(p)))
         .unwrap_or_default();
-    let matcher = tg
-        .matcher_http_code
-        .as_deref()
-        .map(|m| format!("<Matcher><HttpCode>{}</HttpCode></Matcher>", xml_escape(m)))
-        .unwrap_or_default();
+    let matcher = match (
+        tg.matcher_http_code.as_deref(),
+        tg.matcher_grpc_code.as_deref(),
+    ) {
+        (Some(http), Some(grpc)) => format!(
+            "<Matcher><HttpCode>{}</HttpCode><GrpcCode>{}</GrpcCode></Matcher>",
+            xml_escape(http),
+            xml_escape(grpc)
+        ),
+        (Some(http), None) => {
+            format!(
+                "<Matcher><HttpCode>{}</HttpCode></Matcher>",
+                xml_escape(http)
+            )
+        }
+        (None, Some(grpc)) => {
+            format!(
+                "<Matcher><GrpcCode>{}</GrpcCode></Matcher>",
+                xml_escape(grpc)
+            )
+        }
+        (None, None) => String::new(),
+    };
     format!(
         "<TargetGroupArn>{arn}</TargetGroupArn>\
          <TargetGroupName>{name}</TargetGroupName>\

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -2630,8 +2630,10 @@ mod tests {
     #[tokio::test]
     async fn unimplemented_action_errors() {
         let svc = svc();
+        // Use a name that is not in the AWS Smithy model so this test
+        // remains stable as new ops are implemented.
         let err = svc
-            .handle(req("CreateListener", &[]))
+            .handle(req("ThisActionDoesNotExist", &[]))
             .await
             .err()
             .expect("expected error");

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -4,7 +4,7 @@
 
 - **Goal:** 100% of AWS services, each at 100% conformance, with 100% of cross-service integrations. Approach is depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in.
 - Single static binary (~19 MB), ~500ms startup, ~10 MiB idle memory, no Docker required to run fakecloud itself
-- **26 AWS services shipped today, 1,819 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
+- **26 AWS services shipped today, 1,833 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
 - Services: S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, ECR, ECS, Elastic Load Balancing v2, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
 - 30+ cross-service integrations: S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
 - Real Lambda execution via Docker across 13 runtimes (Node.js 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom `provided.al2` / `provided.al2023`)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -4,7 +4,7 @@
 
 - **Goal:** 100% of AWS services, each at 100% conformance, with 100% of cross-service integrations. Approach is depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in.
 - Single static binary (~19 MB), ~500ms startup, ~10 MiB idle memory, no Docker required to run fakecloud itself
-- **26 AWS services shipped today, 1,810 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
+- **26 AWS services shipped today, 1,819 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
 - Services: S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, ECR, ECS, Elastic Load Balancing v2, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
 - 30+ cross-service integrations: S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
 - Real Lambda execution via Docker across 13 runtimes (Node.js 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom `provided.al2` / `provided.al2023`)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -57,7 +57,7 @@
 - **Bedrock Runtime** (10 ops): InvokeModel (Anthropic, Titan, Meta, Cohere, Mistral), Converse, streaming, ApplyGuardrail, CountTokens, async invoke, configurable responses, fault injection
 - **ECR** (58 ops): full registry — repos, images (real OCI v2 push/pull via `docker push`/`pull`), lifecycle policies, scanning, pull-through cache, registry settings, signing
 - **ECS** (60 ops): clusters, task definitions, real Fargate-style task execution via Docker, services with rolling deployments, container instances, capacity providers, task sets, ECS Exec
-- **Elastic Load Balancing v2** (Application/Network/Gateway): load balancer CRUD, subnets, security groups, IP address types, IPAM pools, account limits, SSL policies, tags
+- **Elastic Load Balancing v2** (35 ops, Application/Network/Gateway): load balancer CRUD, target groups + targets + health, listeners + rules + certificates, attributes, subnets, security groups, IP address types, IPAM pools, SSL policies, tags
 
 ## Introspection endpoints (for tests)
 


### PR DESCRIPTION
## Summary

Batch 3 of the ELBv2 rollout — completes the request-routing surface (listeners attach to LBs; rules route requests to target groups).

**14 new ops:** `CreateListener`, `DescribeListeners`, `ModifyListener`, `DeleteListener`, `DescribeListenerAttributes`, `ModifyListenerAttributes`, `AddListenerCertificates`, `RemoveListenerCertificates`, `DescribeListenerCertificates`, `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule`, `SetRulePriorities`.

- `CreateListener` validates referenced target groups exist and marks them attached to the LB (`LoadBalancerArns` is now populated for every TG used as a default action target — needed for Batch 5's auto-register flow).
- Default actions parsing covers `forward` (single TG and multi-TG `ForwardConfig`), `redirect`, `fixed-response`.
- `CreateRule` validates priority is a positive integer and is unique per-listener; same-priority returns `PriorityInUse` matching AWS.
- Rule conditions parse `path-pattern`, `host-header`, `http-header`, `http-request-method`, `source-ip` configs.
- `DeleteListener` cascades to rules; `DeleteLoadBalancer` already cascaded to listeners + rules in Batch 1.

This is Batch 3 of 6. Stack: PR #746 (Batch 1, **merged**) -> PR #747 (Batch 2, in CI) -> this PR -> Batch 4 (LB attrs + trust stores + capacity) -> Batch 5 (real HTTP routing + ECS auto-register) -> Batch 6 (final docs).

## Test plan

- [x] `cargo test -p fakecloud-conformance --test elbv2` — 35 tests pass (12 + 9 + 14)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (Batch 3 crate)
- [x] `cargo fmt --all -- --check` clean
- [x] Smithy checksums computed against current AWS models

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ELBv2 target groups + targets + health and listeners + rules + certificates to complete request routing and health reporting. ELBv2 now exposes 35 operations with stricter validation, cascading deletes, and updated docs/tests.

- **New Features**
  - Target groups + targets + health (9 ops): create/describe/modify/delete TGs, register/deregister targets, describe target health, modify/describe TG attributes. Idempotent create, default TG attributes match AWS, TargetType validation, and DeleteTargetGroup is blocked when referenced by listeners or rules (incl. `ForwardConfig`).
  - Listeners, rules, certificates (14 ops): create/describe/modify/delete listeners; describe/modify listener attributes; add/remove/describe listener certificates; create/describe/modify/delete rules; set rule priorities. Default actions support forward (single + `ForwardConfig`), redirect, fixed-response; referenced target groups are validated and default-action TGs are attached to the LB; rule priorities are per-listener unique; supported conditions: path-pattern, host-header, http-header, http-request-method, source-ip; `DeleteListener` cascades to rules.
  - Conformance/docs: 35 ELBv2 conformance tests pass; README and `website/static/llms.txt` updated with 35 ops.

- **Bug Fixes**
  - Enforced CreateRule priority > 0 and validated rule action target groups exist (both top-level and in `ForwardConfig`).
  - DeleteTargetGroup also rejects when a rule action’s `ForwardConfig` references the TG.
  - DescribeTargetGroups now emits `Matcher.GrpcCode` when present.
  - Unit test now uses a synthetic action name to assert the ActionNotImplemented path without coupling to implemented ops.

<sup>Written for commit ded121698f778912e102a44fa27aff260610b9a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

