### PR TITLE
feat(sdks): Go/PHP/Java introspection clients for ELBv2 + docs

### DIFF
--- a/sdks/go/elbv2.go
+++ b/sdks/go/elbv2.go
@@ -1,0 +1,48 @@
+package fakecloud
+
+import "context"
+
+// ELBv2Client provides access to ELBv2 introspection endpoints —
+// the persisted control-plane state of every Application/Network/Gateway
+// load balancer fakecloud has seen, plus their target groups, listeners,
+// and rules.
+type ELBv2Client struct {
+	fc *FakeCloud
+}
+
+// GetLoadBalancers lists every load balancer across every account.
+func (c *ELBv2Client) GetLoadBalancers(ctx context.Context) (*Elbv2LoadBalancersResponse, error) {
+	var out Elbv2LoadBalancersResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/elbv2/load-balancers", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTargetGroups lists every target group across every account.
+func (c *ELBv2Client) GetTargetGroups(ctx context.Context) (*Elbv2TargetGroupsResponse, error) {
+	var out Elbv2TargetGroupsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/elbv2/target-groups", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetListeners lists every listener across every account.
+func (c *ELBv2Client) GetListeners(ctx context.Context) (*Elbv2ListenersResponse, error) {
+	var out Elbv2ListenersResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/elbv2/listeners", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetRules lists every listener rule across every account, including
+// the default rules that AWS auto-creates for each listener.
+func (c *ELBv2Client) GetRules(ctx context.Context) (*Elbv2RulesResponse, error) {
+	var out Elbv2RulesResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/elbv2/rules", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/fakecloud.go
+++ b/sdks/go/fakecloud.go
@@ -115,6 +115,9 @@ func (fc *FakeCloud) Bedrock() *BedrockClient { return &BedrockClient{fc: fc} }
 // ECS returns the ECS sub-client.
 func (fc *FakeCloud) ECS() *ECSClient { return &ECSClient{fc: fc} }
 
+// ELBv2 returns the Elastic Load Balancing v2 sub-client.
+func (fc *FakeCloud) ELBv2() *ELBv2Client { return &ELBv2Client{fc: fc} }
+
 // ── Error type ─────────────────────────────────────────────────────
 
 // APIError is returned when the server responds with a non-2xx status.

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -713,3 +713,95 @@ type EcsLifecycleEvent struct {
 type EcsEventsResponse struct {
 	Events []EcsLifecycleEvent `json:"events"`
 }
+
+// ── ELBv2 ──────────────────────────────────────────────────────────
+
+type Elbv2Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Elbv2AvailabilityZone struct {
+	ZoneName string `json:"zoneName"`
+	SubnetID string `json:"subnetId"`
+}
+
+// Elbv2LoadBalancer is a snapshot of one ALB / NLB / GWLB.
+type Elbv2LoadBalancer struct {
+	ARN               string                  `json:"arn"`
+	Name              string                  `json:"name"`
+	DNSName           string                  `json:"dnsName"`
+	Scheme            string                  `json:"scheme"`
+	VpcID             string                  `json:"vpcId"`
+	StateCode         string                  `json:"stateCode"`
+	StateReason       *string                 `json:"stateReason,omitempty"`
+	LbType            string                  `json:"lbType"`
+	IPAddressType     string                  `json:"ipAddressType"`
+	AvailabilityZones []Elbv2AvailabilityZone `json:"availabilityZones"`
+	SecurityGroups    []string                `json:"securityGroups"`
+	CreatedTime       string                  `json:"createdTime"`
+	Tags              []Elbv2Tag              `json:"tags"`
+}
+
+type Elbv2LoadBalancersResponse struct {
+	LoadBalancers []Elbv2LoadBalancer `json:"loadBalancers"`
+}
+
+type Elbv2Target struct {
+	ID                string  `json:"id"`
+	Port              *int32  `json:"port,omitempty"`
+	AvailabilityZone  *string `json:"availabilityZone,omitempty"`
+	HealthState       string  `json:"healthState"`
+	HealthReason      *string `json:"healthReason,omitempty"`
+	HealthDescription *string `json:"healthDescription,omitempty"`
+}
+
+type Elbv2TargetGroup struct {
+	ARN                     string        `json:"arn"`
+	Name                    string        `json:"name"`
+	Protocol                *string       `json:"protocol,omitempty"`
+	Port                    *int32        `json:"port,omitempty"`
+	VpcID                   *string       `json:"vpcId,omitempty"`
+	TargetType              string        `json:"targetType"`
+	LoadBalancerARNs        []string      `json:"loadBalancerArns"`
+	Targets                 []Elbv2Target `json:"targets"`
+	HealthCheckProtocol     *string       `json:"healthCheckProtocol,omitempty"`
+	HealthCheckPort         *string       `json:"healthCheckPort,omitempty"`
+	HealthCheckPath         *string       `json:"healthCheckPath,omitempty"`
+	HealthyThresholdCount   int32         `json:"healthyThresholdCount"`
+	UnhealthyThresholdCount int32         `json:"unhealthyThresholdCount"`
+	CreatedTime             string        `json:"createdTime"`
+	Tags                    []Elbv2Tag    `json:"tags"`
+}
+
+type Elbv2TargetGroupsResponse struct {
+	TargetGroups []Elbv2TargetGroup `json:"targetGroups"`
+}
+
+type Elbv2Listener struct {
+	ARN                   string   `json:"arn"`
+	LoadBalancerARN       string   `json:"loadBalancerArn"`
+	Port                  *int32   `json:"port,omitempty"`
+	Protocol              *string  `json:"protocol,omitempty"`
+	SslPolicy             *string  `json:"sslPolicy,omitempty"`
+	CertificateARNs       []string `json:"certificateArns"`
+	DefaultActionType     *string  `json:"defaultActionType,omitempty"`
+	DefaultTargetGroupARN *string  `json:"defaultTargetGroupArn,omitempty"`
+}
+
+type Elbv2ListenersResponse struct {
+	Listeners []Elbv2Listener `json:"listeners"`
+}
+
+type Elbv2Rule struct {
+	ARN             string   `json:"arn"`
+	ListenerARN     string   `json:"listenerArn"`
+	Priority        string   `json:"priority"`
+	IsDefault       bool     `json:"isDefault"`
+	ConditionFields []string `json:"conditionFields"`
+	ActionType      *string  `json:"actionType,omitempty"`
+}
+
+type Elbv2RulesResponse struct {
+	Rules []Elbv2Rule `json:"rules"`
+}

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -21,6 +21,10 @@ import dev.fakecloud.Types.EcrImagesResponse;
 import dev.fakecloud.Types.EcrPullThroughRulesResponse;
 import dev.fakecloud.Types.EcrRepositoriesResponse;
 import dev.fakecloud.Types.EcsClustersResponse;
+import dev.fakecloud.Types.Elbv2ListenersResponse;
+import dev.fakecloud.Types.Elbv2LoadBalancersResponse;
+import dev.fakecloud.Types.Elbv2RulesResponse;
+import dev.fakecloud.Types.Elbv2TargetGroupsResponse;
 import dev.fakecloud.Types.ElastiCacheClustersResponse;
 import dev.fakecloud.Types.ElastiCacheReplicationGroupsResponse;
 import dev.fakecloud.Types.ElastiCacheServerlessCachesResponse;
@@ -88,6 +92,7 @@ public final class FakeCloud {
     private final StepFunctionsClient stepfunctions;
     private final BedrockClient bedrock;
     private final EcsClient ecs;
+    private final Elbv2Client elbv2;
 
     public FakeCloud() {
         this(DEFAULT_BASE_URL);
@@ -112,6 +117,7 @@ public final class FakeCloud {
         this.stepfunctions = new StepFunctionsClient(http);
         this.bedrock = new BedrockClient(http);
         this.ecs = new EcsClient(http);
+        this.elbv2 = new Elbv2Client(http);
     }
 
     static String trimTrailingSlashes(String url) {
@@ -168,6 +174,7 @@ public final class FakeCloud {
     public StepFunctionsClient stepfunctions() { return stepfunctions; }
     public BedrockClient bedrock() { return bedrock; }
     public EcsClient ecs() { return ecs; }
+    public Elbv2Client elbv2() { return elbv2; }
 
     // ── Sub-clients ────────────────────────────────────────────────
 
@@ -501,6 +508,27 @@ public final class FakeCloud {
 
         public EcsClustersResponse getClusters() {
             return http.get("/_fakecloud/ecs/clusters", EcsClustersResponse.class);
+        }
+    }
+
+    public static final class Elbv2Client {
+        private final HttpTransport http;
+        Elbv2Client(HttpTransport http) { this.http = http; }
+
+        public Elbv2LoadBalancersResponse getLoadBalancers() {
+            return http.get("/_fakecloud/elbv2/load-balancers", Elbv2LoadBalancersResponse.class);
+        }
+
+        public Elbv2TargetGroupsResponse getTargetGroups() {
+            return http.get("/_fakecloud/elbv2/target-groups", Elbv2TargetGroupsResponse.class);
+        }
+
+        public Elbv2ListenersResponse getListeners() {
+            return http.get("/_fakecloud/elbv2/listeners", Elbv2ListenersResponse.class);
+        }
+
+        public Elbv2RulesResponse getRules() {
+            return http.get("/_fakecloud/elbv2/rules", Elbv2RulesResponse.class);
         }
     }
 }

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -481,4 +481,87 @@ public final class Types {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record EcsClustersResponse(List<EcsCluster> clusters) {}
+
+    // ── ELBv2 ─────────────────────────────────────────────────────
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2Tag(String key, String value) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2AvailabilityZone(String zoneName, String subnetId) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2LoadBalancer(
+            String arn,
+            String name,
+            String dnsName,
+            String scheme,
+            String vpcId,
+            String stateCode,
+            String stateReason,
+            String lbType,
+            String ipAddressType,
+            List<Elbv2AvailabilityZone> availabilityZones,
+            List<String> securityGroups,
+            String createdTime,
+            List<Elbv2Tag> tags) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2LoadBalancersResponse(List<Elbv2LoadBalancer> loadBalancers) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2Target(
+            String id,
+            Integer port,
+            String availabilityZone,
+            String healthState,
+            String healthReason,
+            String healthDescription) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2TargetGroup(
+            String arn,
+            String name,
+            String protocol,
+            Integer port,
+            String vpcId,
+            String targetType,
+            List<String> loadBalancerArns,
+            List<Elbv2Target> targets,
+            String healthCheckProtocol,
+            String healthCheckPort,
+            String healthCheckPath,
+            int healthyThresholdCount,
+            int unhealthyThresholdCount,
+            String createdTime,
+            List<Elbv2Tag> tags) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2TargetGroupsResponse(List<Elbv2TargetGroup> targetGroups) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2Listener(
+            String arn,
+            String loadBalancerArn,
+            Integer port,
+            String protocol,
+            String sslPolicy,
+            List<String> certificateArns,
+            String defaultActionType,
+            String defaultTargetGroupArn) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2ListenersResponse(List<Elbv2Listener> listeners) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2Rule(
+            String arn,
+            String listenerArn,
+            String priority,
+            boolean isDefault,
+            List<String> conditionFields,
+            String actionType) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Elbv2RulesResponse(List<Elbv2Rule> rules) {}
 }

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -35,6 +35,7 @@ final class FakeCloud
     private StepFunctionsClient $stepfunctions;
     private BedrockClient $bedrock;
     private EcsClient $ecs;
+    private Elbv2Client $elbv2;
 
     public function __construct(string $baseUrl = self::DEFAULT_BASE_URL)
     {
@@ -56,6 +57,7 @@ final class FakeCloud
         $this->stepfunctions = new StepFunctionsClient($this->http);
         $this->bedrock = new BedrockClient($this->http);
         $this->ecs = new EcsClient($this->http);
+        $this->elbv2 = new Elbv2Client($this->http);
     }
 
     public function baseUrl(): string
@@ -114,6 +116,7 @@ final class FakeCloud
     public function stepfunctions(): StepFunctionsClient { return $this->stepfunctions; }
     public function bedrock(): BedrockClient { return $this->bedrock; }
     public function ecs(): EcsClient { return $this->ecs; }
+    public function elbv2(): Elbv2Client { return $this->elbv2; }
 }
 
 // ── Sub-clients ────────────────────────────────────────────────
@@ -524,6 +527,39 @@ final class EcsClient
     {
         return EcsClustersResponse::fromArray(
             $this->http->get('/_fakecloud/ecs/clusters')
+        );
+    }
+}
+
+final class Elbv2Client
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function getLoadBalancers(): Elbv2LoadBalancersResponse
+    {
+        return Elbv2LoadBalancersResponse::fromArray(
+            $this->http->get('/_fakecloud/elbv2/load-balancers')
+        );
+    }
+
+    public function getTargetGroups(): Elbv2TargetGroupsResponse
+    {
+        return Elbv2TargetGroupsResponse::fromArray(
+            $this->http->get('/_fakecloud/elbv2/target-groups')
+        );
+    }
+
+    public function getListeners(): Elbv2ListenersResponse
+    {
+        return Elbv2ListenersResponse::fromArray(
+            $this->http->get('/_fakecloud/elbv2/listeners')
+        );
+    }
+
+    public function getRules(): Elbv2RulesResponse
+    {
+        return Elbv2RulesResponse::fromArray(
+            $this->http->get('/_fakecloud/elbv2/rules')
         );
     }
 }

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1468,3 +1468,247 @@ final class EcsClustersResponse
         return new self(array_map(EcsCluster::fromArray(...), $data['clusters'] ?? []));
     }
 }
+
+// ── ELBv2 ──────────────────────────────────────────────────────
+
+final class Elbv2Tag
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly string $value,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['key'], $data['value']);
+    }
+}
+
+final class Elbv2AvailabilityZone
+{
+    public function __construct(
+        public readonly string $zoneName,
+        public readonly string $subnetId,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['zoneName'], $data['subnetId']);
+    }
+}
+
+final class Elbv2LoadBalancer
+{
+    public function __construct(
+        public readonly string $arn,
+        public readonly string $name,
+        public readonly string $dnsName,
+        public readonly string $scheme,
+        public readonly string $vpcId,
+        public readonly string $stateCode,
+        public readonly ?string $stateReason,
+        public readonly string $lbType,
+        public readonly string $ipAddressType,
+        /** @var Elbv2AvailabilityZone[] */
+        public readonly array $availabilityZones,
+        /** @var string[] */
+        public readonly array $securityGroups,
+        public readonly string $createdTime,
+        /** @var Elbv2Tag[] */
+        public readonly array $tags,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['arn'],
+            $data['name'],
+            $data['dnsName'],
+            $data['scheme'],
+            $data['vpcId'],
+            $data['stateCode'],
+            $data['stateReason'] ?? null,
+            $data['lbType'],
+            $data['ipAddressType'],
+            array_map(Elbv2AvailabilityZone::fromArray(...), $data['availabilityZones'] ?? []),
+            $data['securityGroups'] ?? [],
+            $data['createdTime'],
+            array_map(Elbv2Tag::fromArray(...), $data['tags'] ?? []),
+        );
+    }
+}
+
+final class Elbv2LoadBalancersResponse
+{
+    public function __construct(
+        /** @var Elbv2LoadBalancer[] */
+        public readonly array $loadBalancers,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(Elbv2LoadBalancer::fromArray(...), $data['loadBalancers'] ?? []));
+    }
+}
+
+final class Elbv2Target
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly ?int $port,
+        public readonly ?string $availabilityZone,
+        public readonly string $healthState,
+        public readonly ?string $healthReason,
+        public readonly ?string $healthDescription,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['id'],
+            isset($data['port']) ? (int) $data['port'] : null,
+            $data['availabilityZone'] ?? null,
+            $data['healthState'],
+            $data['healthReason'] ?? null,
+            $data['healthDescription'] ?? null,
+        );
+    }
+}
+
+final class Elbv2TargetGroup
+{
+    public function __construct(
+        public readonly string $arn,
+        public readonly string $name,
+        public readonly ?string $protocol,
+        public readonly ?int $port,
+        public readonly ?string $vpcId,
+        public readonly string $targetType,
+        /** @var string[] */
+        public readonly array $loadBalancerArns,
+        /** @var Elbv2Target[] */
+        public readonly array $targets,
+        public readonly ?string $healthCheckProtocol,
+        public readonly ?string $healthCheckPort,
+        public readonly ?string $healthCheckPath,
+        public readonly int $healthyThresholdCount,
+        public readonly int $unhealthyThresholdCount,
+        public readonly string $createdTime,
+        /** @var Elbv2Tag[] */
+        public readonly array $tags,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['arn'],
+            $data['name'],
+            $data['protocol'] ?? null,
+            isset($data['port']) ? (int) $data['port'] : null,
+            $data['vpcId'] ?? null,
+            $data['targetType'],
+            $data['loadBalancerArns'] ?? [],
+            array_map(Elbv2Target::fromArray(...), $data['targets'] ?? []),
+            $data['healthCheckProtocol'] ?? null,
+            $data['healthCheckPort'] ?? null,
+            $data['healthCheckPath'] ?? null,
+            (int) ($data['healthyThresholdCount'] ?? 0),
+            (int) ($data['unhealthyThresholdCount'] ?? 0),
+            $data['createdTime'],
+            array_map(Elbv2Tag::fromArray(...), $data['tags'] ?? []),
+        );
+    }
+}
+
+final class Elbv2TargetGroupsResponse
+{
+    public function __construct(
+        /** @var Elbv2TargetGroup[] */
+        public readonly array $targetGroups,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(Elbv2TargetGroup::fromArray(...), $data['targetGroups'] ?? []));
+    }
+}
+
+final class Elbv2Listener
+{
+    public function __construct(
+        public readonly string $arn,
+        public readonly string $loadBalancerArn,
+        public readonly ?int $port,
+        public readonly ?string $protocol,
+        public readonly ?string $sslPolicy,
+        /** @var string[] */
+        public readonly array $certificateArns,
+        public readonly ?string $defaultActionType,
+        public readonly ?string $defaultTargetGroupArn,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['arn'],
+            $data['loadBalancerArn'],
+            isset($data['port']) ? (int) $data['port'] : null,
+            $data['protocol'] ?? null,
+            $data['sslPolicy'] ?? null,
+            $data['certificateArns'] ?? [],
+            $data['defaultActionType'] ?? null,
+            $data['defaultTargetGroupArn'] ?? null,
+        );
+    }
+}
+
+final class Elbv2ListenersResponse
+{
+    public function __construct(
+        /** @var Elbv2Listener[] */
+        public readonly array $listeners,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(Elbv2Listener::fromArray(...), $data['listeners'] ?? []));
+    }
+}
+
+final class Elbv2Rule
+{
+    public function __construct(
+        public readonly string $arn,
+        public readonly string $listenerArn,
+        public readonly string $priority,
+        public readonly bool $isDefault,
+        /** @var string[] */
+        public readonly array $conditionFields,
+        public readonly ?string $actionType,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['arn'],
+            $data['listenerArn'],
+            $data['priority'],
+            (bool) ($data['isDefault'] ?? false),
+            $data['conditionFields'] ?? [],
+            $data['actionType'] ?? null,
+        );
+    }
+}
+
+final class Elbv2RulesResponse
+{
+    public function __construct(
+        /** @var Elbv2Rule[] */
+        public readonly array $rules,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(Elbv2Rule::fromArray(...), $data['rules'] ?? []));
+    }
+}

--- a/website/content/docs/services/_index.md
+++ b/website/content/docs/services/_index.md
@@ -7,7 +7,7 @@ template = "docs.html"
 page_template = "docs-page.html"
 +++
 
-fakecloud implements 25 AWS services with 1,798 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
+fakecloud implements 26 AWS services with 1,849 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -36,5 +36,6 @@ fakecloud implements 25 AWS services with 1,798 total operations, all at 100% Sm
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle eval, scanning, pull-through cache, registry templates, real cosign signature verification |
 | ECS                    |  60 | Full API — clusters, real Fargate-style task execution via Docker, services + rolling deployments, task sets, container instances, ECS Exec, awslogs -> Logs, secrets injection, task role credentials |
+| Elastic Load Balancing v2 |  51 | Full control plane — ALB/NLB/GWLB CRUD, target groups + targets + health, listeners + rules + certificates, attributes, capacity reservations, **mTLS trust stores + revocations**, resource policies, SSL policies, tags |
 
 Detailed per-service pages are coming. If you need specifics on a service today, the conformance baseline at [`conformance-baseline.json`](https://github.com/faiscadev/fakecloud/blob/main/conformance-baseline.json) lists every operation fakecloud handles, and the AWS Smithy models in [`aws-models/`](https://github.com/faiscadev/fakecloud/tree/main/aws-models) are the authoritative source of truth.

--- a/website/content/docs/services/elbv2.md
+++ b/website/content/docs/services/elbv2.md
@@ -1,0 +1,85 @@
++++
+title = "Elastic Load Balancing v2"
+description = "ELBv2 control plane — Application/Network/Gateway Load Balancer: load balancers, target groups + targets, listeners + rules + certificates, mTLS trust stores, attributes, capacity reservations, resource policies."
+weight = 23
++++
+
+fakecloud implements ELBv2 with full control-plane coverage across all three load balancer types: Application (ALB), Network (NLB), and Gateway (GWLB). 51 operations.
+
+**Status: full API.** Covers load balancer CRUD, target groups + targets + health, listeners + rules + certificates, listener/load-balancer/target-group attributes, capacity reservations, mTLS trust stores + revocations, resource policies, IP pools, IP address types, subnets, security groups, SSL policies, and tags.
+
+## Supported today (full API)
+
+- **Load balancers** — `CreateLoadBalancer`, `DescribeLoadBalancers`, `DeleteLoadBalancer`, `SetSubnets`, `SetSecurityGroups`, `SetIpAddressType`, `ModifyIpPools`
+- **Load balancer attributes** — `ModifyLoadBalancerAttributes`, `DescribeLoadBalancerAttributes`
+- **Capacity reservations** — `ModifyCapacityReservation`, `DescribeCapacityReservation`
+- **Target groups** — `CreateTargetGroup`, `DescribeTargetGroups`, `ModifyTargetGroup`, `DeleteTargetGroup` with cross-resource reference checks (rejects delete while a listener or rule still references the target group, including `ForwardConfig.TargetGroups`)
+- **Targets** — `RegisterTargets`, `DeregisterTargets`, `DescribeTargetHealth`
+- **Target group attributes** — `ModifyTargetGroupAttributes`, `DescribeTargetGroupAttributes`
+- **Listeners** — `CreateListener`, `DescribeListeners`, `ModifyListener`, `DeleteListener` (cascades to rules), `DescribeListenerAttributes`, `ModifyListenerAttributes`
+- **Listener certificates** — `AddListenerCertificates`, `RemoveListenerCertificates`, `DescribeListenerCertificates`
+- **Listener rules** — `CreateRule`, `DescribeRules`, `ModifyRule`, `DeleteRule`, `SetRulePriorities` with positive-integer priority validation and target-group existence checks on `Actions`
+- **mTLS trust stores** — `CreateTrustStore`, `DescribeTrustStores`, `ModifyTrustStore`, `DeleteTrustStore`, `DescribeTrustStoreAssociations`, `DeleteSharedTrustStoreAssociation`, `GetTrustStoreCaCertificatesBundle`
+- **Trust store revocations** — `AddTrustStoreRevocations`, `RemoveTrustStoreRevocations`, `DescribeTrustStoreRevocations`, `GetTrustStoreRevocationContent`
+- **Resource policies** — `GetResourcePolicy`
+- **Tags** — `AddTags`, `RemoveTags`, `DescribeTags` across load balancers, target groups, listeners, rules, and trust stores
+- **Limits / SSL policies** — `DescribeAccountLimits` returns AWS-published default limits; `DescribeSSLPolicies` returns predefined ALB security policies with exact protocol + cipher lists
+
+### Validation matches AWS
+
+- Load balancer name is 1-32 chars, alphanumeric or hyphens, no leading hyphen, no `internal-` prefix on `internet-facing` schemes — returns `ValidationError` with the same wire shape.
+- `IpAddressType` is restricted to `ipv4`, `dualstack`, `dualstack-without-public-ipv4` — same enum check on `CreateLoadBalancer`, `SetIpAddressType`, and `SetSubnets`.
+- Target group name validation, target type enum (`instance`, `ip`, `lambda`, `alb`), health check threshold ranges all match AWS.
+- `DeleteTargetGroup` returns `ResourceInUse` when any listener default action or rule action — including those wrapped in `ForwardConfig.TargetGroups` — still references the target group.
+- `CreateRule`/`ModifyRule` reject priority values <= 0 with `ValidationError`, and rule actions referencing a non-existent target group return `TargetGroupNotFound`.
+
+### Idempotent creates
+
+`CreateLoadBalancer` and `CreateTargetGroup` are idempotent on name within a single account: a second call with the same name returns the existing resource instead of throwing, matching AWS's documented idempotency behaviour.
+
+## Smoke test
+
+```sh
+fakecloud &
+
+# Create an ALB
+LB=$(aws --endpoint-url http://localhost:4566 elbv2 create-load-balancer \
+    --name web-alb --type application \
+    --subnets subnet-aaa subnet-bbb \
+    --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+
+# Create a target group
+TG=$(aws --endpoint-url http://localhost:4566 elbv2 create-target-group \
+    --name web-tg --protocol HTTP --port 80 --vpc-id vpc-12345 \
+    --target-type instance \
+    --query 'TargetGroups[0].TargetGroupArn' --output text)
+
+# Wire the listener -> target group
+aws --endpoint-url http://localhost:4566 elbv2 create-listener \
+    --load-balancer-arn "$LB" --protocol HTTP --port 80 \
+    --default-actions Type=forward,TargetGroupArn=$TG
+
+# Register a target
+aws --endpoint-url http://localhost:4566 elbv2 register-targets \
+    --target-group-arn "$TG" --targets Id=i-deadbeef,Port=80
+
+# Health is `healthy` by default — fakecloud doesn't probe the target.
+aws --endpoint-url http://localhost:4566 elbv2 describe-target-health \
+    --target-group-arn "$TG"
+```
+
+## Introspection
+
+The `/_fakecloud/elbv2/*` endpoints let your tests assert directly on the persisted control-plane state without parsing XML responses:
+
+- `GET /_fakecloud/elbv2/load-balancers` — every ALB/NLB/GWLB across every account
+- `GET /_fakecloud/elbv2/target-groups` — every target group, including registered targets and current health
+- `GET /_fakecloud/elbv2/listeners` — every listener, with port/protocol/SSL policy/default action
+- `GET /_fakecloud/elbv2/rules` — every rule, including the default rules AWS auto-creates per listener
+
+Wrapped by the first-party SDKs: `fc.elbv2().getLoadBalancers()` (TS/Java), `fc.elbv2.getLoadBalancers()` (Python), `fc.ELBv2().GetLoadBalancers(ctx)` (Go), `$fc->elbv2()->getLoadBalancers()` (PHP).
+
+## Not yet implemented
+
+- **In-process HTTP routing.** fakecloud stores the listener/rule wiring exactly, but does not bind a port per ALB and forward HTTP requests to registered targets. The control plane is complete; the data plane is the next axis. Open an issue if you have a use case that needs it.
+- **Health probes.** Targets default to `healthy` since fakecloud does not actually call the target's health check endpoint. `DescribeTargetHealth` returns the synthetic state.


### PR DESCRIPTION
## Summary

The ELBv2 service shipped with TypeScript and Python introspection clients in the original batch, but Go, PHP, and Java were left without an `elbv2()` accessor. This PR closes that gap and adds the website service detail page.

- **Go**: `sdks/go/elbv2.go` + types + `fc.ELBv2()` wired into `fakecloud.go`
- **PHP**: `Elbv2Client` + types appended to `FakeCloud.php` / `Types.php`, `$fc->elbv2()` accessor
- **Java**: `FakeCloud.Elbv2Client` nested record + `Elbv2*` records in `Types.java`, `fc.elbv2()` accessor
- **Docs**: new `website/content/docs/services/elbv2.md` describing the full 51-op control plane, validation rules, and the introspection endpoints; services index op count updated

All three new clients hit the same four endpoints:

- `GET /_fakecloud/elbv2/load-balancers`
- `GET /_fakecloud/elbv2/target-groups`
- `GET /_fakecloud/elbv2/listeners`
- `GET /_fakecloud/elbv2/rules`

## Test plan

- [x] `go build ./...` clean in `sdks/go/`
- [x] `./gradlew compileJava` clean in `sdks/java/`
- [ ] CI runs PHP / Java / TS / Go SDK builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ELBv2 introspection clients to the Go, PHP, and Java SDKs to match TS/Python, exposing four `/_fakecloud/elbv2/*` endpoints. Also adds ELBv2 service docs and updates the services index.

- **New Features**
  - Go: `fc.ELBv2()` with `GetLoadBalancers`, `GetTargetGroups`, `GetListeners`, `GetRules`.
  - PHP: `$fc->elbv2()` (`Elbv2Client`) with `getLoadBalancers`, `getTargetGroups`, `getListeners`, `getRules`.
  - Java: `fc.elbv2()` (`Elbv2Client`) with `getLoadBalancers`, `getTargetGroups`, `getListeners`, `getRules`.
  - Endpoints for all SDKs:
    - `GET /_fakecloud/elbv2/load-balancers`
    - `GET /_fakecloud/elbv2/target-groups`
    - `GET /_fakecloud/elbv2/listeners`
    - `GET /_fakecloud/elbv2/rules`
  - Docs: new `services/elbv2` page covering the 51‑op control plane, validation rules, and introspection; services index updated to 26 services and 1,849 ops.

<sup>Written for commit 3e8c3431da073e0d0ace62653e7fce4ca92b5745. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

