### PR TITLE
ci(release): publish fakecloud-elbv2 crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,7 @@ jobs:
           publish fakecloud-scheduler      # depends on aws + core + persistence
           publish fakecloud-apigatewayv2   # depends on core only
           publish fakecloud-bedrock        # depends on aws + core
+          publish fakecloud-elbv2          # depends on aws + core + persistence
 
           # Layer 4: depend on layer 3 crates
           publish fakecloud-s3             # depends on kms


### PR DESCRIPTION
## Summary

The release.yml `publish-crates` job was missing `fakecloud-elbv2`, so the next release would have skipped pushing the new crate to crates.io. Added it to Layer 3 alongside the other aws+core+persistence-only services.

## Test plan

- [x] Verified all crate dirs match published list (no remaining missing crates)
- [ ] Next release tag will publish fakecloud-elbv2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `fakecloud-elbv2` to the release workflow publish list so it gets published to crates.io in the next release. Placed in Layer 3 to keep the correct publish order.

<sup>Written for commit 10dff42be3d366e80c176900e57c5d6006fb7c1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

