### PR TITLE
fix(ecs): forward awslogs before flipping task to STOPPED

### DIFF
--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -406,6 +406,11 @@ impl EcsRuntime {
             .await;
         self.containers.write().remove(task_id);
 
+        // Forward logs BEFORE flipping the task to STOPPED so a client
+        // that polls DescribeTasks and immediately queries DescribeLogStreams
+        // can't observe the STOPPED transition before the awslogs group/stream
+        // has been materialised.
+        self.forward_awslogs_if_configured(state, account_id, task_id, &captured);
         finalize_stopped(
             state,
             account_id,
@@ -415,7 +420,6 @@ impl EcsRuntime {
             "EssentialContainerExited",
             None,
         );
-        self.forward_awslogs_if_configured(state, account_id, task_id, &captured);
         self.emit_state_change(
             state,
             account_id,


### PR DESCRIPTION
## Summary

CI was flaking on `ecs_task_awslogs_forwards_to_cloudwatch` because the runtime called `finalize_stopped` (writes `last_status=STOPPED` to ECS state) before `forward_awslogs_if_configured` (creates the log group/stream and ingests events into fakecloud-logs).

A client polling `DescribeTasks` until STOPPED and immediately calling `DescribeLogStreams` could observe STOPPED before the log group existed, getting `ResourceNotFoundException`.

Reorder so the awslogs forwarding happens first; the STOPPED transition is now the visible signal that "logs are ready."

## Test plan

- [x] `cargo build -p fakecloud-ecs` clean
- [x] `cargo clippy -p fakecloud-ecs --all-targets -- -D warnings` clean
- [ ] `ecs_task_awslogs_forwards_to_cloudwatch` E2E passes in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward awslogs to CloudWatch before marking ECS tasks as STOPPED to remove a race with clients that query logs right after STOPPED. STOPPED now reliably means the log group/stream exists and logs are ingested.

- **Bug Fixes**
  - Reordered runtime shutdown: call `forward_awslogs_if_configured(...)` before `finalize_stopped(...)`.
  - Prevents `ResourceNotFoundException` when clients poll `DescribeTasks` until STOPPED and immediately call `DescribeLogStreams`.

<sup>Written for commit 34b8a3b7cff3dffa85794a5d25496c0fdebd2201. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

