### PR TITLE
release: 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2493,7 +2493,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.11.0"
+version = "0.12.0"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -83,32 +83,32 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.11.0" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.11.0" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.11.0" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.11.0" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.11.0" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.11.0" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.11.0" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.11.0" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.11.0" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.11.0" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.11.0" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.11.0" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.11.0" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.11.0" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.11.0" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.11.0" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.11.0" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.11.0" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.11.0" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.11.0" }
-fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.11.0" }
-fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.11.0" }
-fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.11.0" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.11.0" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.11.0" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.11.0" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.11.0" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.11.0" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.11.0" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.12.0" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.12.0" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.12.0" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.12.0" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.12.0" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.12.0" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.12.0" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.12.0" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.12.0" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.12.0" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.12.0" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.12.0" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.12.0" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.12.0" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.12.0" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.12.0" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.12.0" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.12.0" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.12.0" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.12.0" }
+fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.12.0" }
+fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.12.0" }
+fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.12.0" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.12.0" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.12.0" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.12.0" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.12.0" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.12.0" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.12.0" }

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.11.0")
+    testImplementation("dev.fakecloud:fakecloud:0.12.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.11.0"
+version = "0.12.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/website/content/docs/getting-started/sdk-setup.md
+++ b/website/content/docs/getting-started/sdk-setup.md
@@ -81,7 +81,7 @@ $emails = $fc->ses()->getEmails()->emails;
 
 ```kotlin
 // build.gradle.kts
-testImplementation("dev.fakecloud:fakecloud:0.11.0")
+testImplementation("dev.fakecloud:fakecloud:0.12.0")
 ```
 
 ```java

--- a/website/content/docs/sdks/_index.md
+++ b/website/content/docs/sdks/_index.md
@@ -19,7 +19,7 @@ These SDKs are **not** the AWS SDK. Your application code still talks to fakeclo
 | Python     | `pip install fakecloud`                         | [Python SDK](/docs/sdks/python/) |
 | Go         | `go get github.com/faiscadev/fakecloud/sdks/go` | [Go SDK](/docs/sdks/go/) |
 | PHP        | `composer require fakecloud/fakecloud`          | [PHP SDK](/docs/sdks/php/) |
-| Java       | `dev.fakecloud:fakecloud:0.11.0`                 | [Java SDK](/docs/sdks/java/) |
+| Java       | `dev.fakecloud:fakecloud:0.12.0`                 | [Java SDK](/docs/sdks/java/) |
 | Rust       | `cargo add fakecloud-sdk`                       | [Rust SDK](/docs/sdks/rust/) |
 
 ## Common surface

--- a/website/content/docs/sdks/java.md
+++ b/website/content/docs/sdks/java.md
@@ -10,7 +10,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.11.0")
+    testImplementation("dev.fakecloud:fakecloud:0.12.0")
 }
 ```
 
@@ -20,7 +20,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Summary

Workspace + all SDKs to 0.12.0.

**New since 0.11.0:**
- **ELBv2 service** — full 51-op control plane (ALB/NLB/GWLB): load balancers, target groups + targets + health, listeners + rules + certificates, attributes, capacity reservations, mTLS trust stores + revocations, resource policies, tags. PRs #746-#750.
- **Go/PHP/Java SDK clients** for ELBv2 introspection (TS+Python shipped earlier).
- **ECS awslogs race fix** — log forwarding now happens before the STOPPED transition so polling on STOPPED no longer races against `DescribeLogStreams`. PR #752.
- **release.yml** publishes `fakecloud-elbv2`. PR #751.

## Test plan

- [x] `cargo build --workspace` clean at 0.12.0
- [ ] CI green
- [ ] Tag `v0.12.0` triggers crates.io / npm / PyPI / Maven / Composer / Go publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.12.0 adds a full ELBv2 control plane and bumps the workspace and all SDKs to 0.12.0. It also fixes an ECS awslogs race and publishes the `fakecloud-elbv2` artifact in CI.

- **New Features**
  - ELBv2 service (ALB/NLB/GWLB): load balancers, target groups/targets/health, listeners/rules/certificates, attributes, capacity reservations, mTLS trust stores/revocations, resource policies, tags.
  - Go, PHP, and Java SDK clients for ELBv2 introspection.

- **Bug Fixes**
  - ECS awslogs forwarding runs before the task transitions to STOPPED, removing the `DescribeLogStreams` race.

<sup>Written for commit 46865ed6a9af4f553351f976c21027b11233fdd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

