### PR TITLE
feat(sns): real RSA-SHA256 message signing with served public cert

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,10 +59,21 @@ jobs:
       # via mysql_async / twox-hash / rust_decimal / mysql_common. The advisory
       # requires a user-installed custom logger that calls `rand::rng()` during
       # logging — fakecloud does not install such a logger.
+      #
+      # RUSTSEC-2023-0071 (rsa 0.9 Marvin Attack timing sidechannel) reaches us
+      # only through fakecloud-sns's RSA-SHA256 signing key — generated once
+      # per process for SNS message signatures consumers verify in tests. The
+      # attack requires a remote oracle that times decryption operations on a
+      # private key handling attacker-chosen ciphertexts. fakecloud's signing
+      # key is never used for decrypt and never handles attacker-chosen input;
+      # there is no fixed upgrade path because rsa upstream has not released a
+      # constant-time fix yet. The same advisory is the standard escape hatch
+      # for any project that needs RSA in pure Rust today.
       - run: |
           cargo audit \
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099 \
             --ignore RUSTSEC-2026-0104 \
             --ignore RUSTSEC-2026-0002 \
-            --ignore RUSTSEC-2026-0097
+            --ignore RUSTSEC-2026-0097 \
+            --ignore RUSTSEC-2023-0071

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,8 +1974,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2438,11 +2451,13 @@ dependencies = [
  "flate2",
  "p256 0.13.2",
  "reqwest",
+ "rsa",
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-postgres",
+ "x509-cert",
  "zip",
 ]
 
@@ -2853,9 +2868,13 @@ dependencies = [
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
+ "rand 0.8.5",
+ "rcgen",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3013,6 +3032,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -3829,6 +3854,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -4156,6 +4184,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,12 +4215,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4396,6 +4452,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
 
 [[package]]
 name = "pkcs8"
@@ -4737,6 +4804,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,6 +4973,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5369,6 +5470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,6 +5734,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -6685,6 +6813,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
+ "tls_codec",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6697,6 +6837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ tower-http = { version = "0.6", features = ["trace"] }
 async-trait = "0.1"
 parking_lot = "0.12"
 md-5 = "0.10"
+rand = "0.8"
+rcgen = "0.13"
+rsa = { version = "0.9", features = ["sha2", "pem"] }
 sha1 = "0.10"
 sha2 = "0.10"
 crc32fast = "1"

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -54,3 +54,5 @@ fakecloud-testkit = { path = "../fakecloud-testkit", features = ["sdk-clients"] 
 tempfile = { workspace = true }
 sha2 = { workspace = true }
 p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
+rsa = { workspace = true }
+x509-cert = { version = "0.2", features = ["pem"] }

--- a/crates/fakecloud-e2e/tests/sns_signing.rs
+++ b/crates/fakecloud-e2e/tests/sns_signing.rs
@@ -1,0 +1,120 @@
+mod helpers;
+
+use base64::Engine;
+use helpers::TestServer;
+use rsa::pkcs1v15::{Signature, VerifyingKey};
+use rsa::pkcs8::DecodePublicKey;
+use rsa::sha2::Sha256;
+use rsa::signature::Verifier;
+use rsa::RsaPublicKey;
+use serde_json::Value;
+use x509_cert::der::{DecodePem, Encode};
+use x509_cert::Certificate;
+
+/// Read the SNS signing cert via the introspection endpoint, publish a
+/// notification, and verify the resulting envelope's RSA-SHA256 signature
+/// over the AWS canonical string with the public key from the cert.
+#[tokio::test]
+async fn sns_publish_signature_verifies_against_cert_pem() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    let topic = sns.create_topic().name("sig-topic").send().await.unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    let queue = sqs.create_queue().queue_name("sig-q").send().await.unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let attrs = sqs
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let queue_arn = attrs
+        .attributes()
+        .unwrap()
+        .get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .unwrap()
+        .clone();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&queue_arn)
+        .return_subscription_arn(true)
+        .send()
+        .await
+        .unwrap();
+
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("hello world")
+        .subject("greetings")
+        .send()
+        .await
+        .unwrap();
+
+    let recv = sqs
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(1)
+        .wait_time_seconds(2)
+        .send()
+        .await
+        .unwrap();
+    let body = recv.messages().first().unwrap().body().unwrap().to_string();
+    let envelope: Value = serde_json::from_str(&body).unwrap();
+    let signature_b64 = envelope["Signature"].as_str().unwrap();
+    let cert_url = envelope["SigningCertURL"].as_str().unwrap();
+    let message = envelope["Message"].as_str().unwrap();
+    let message_id = envelope["MessageId"].as_str().unwrap();
+    let subject = envelope["Subject"].as_str();
+    let timestamp = envelope["Timestamp"].as_str().unwrap();
+    let arn = envelope["TopicArn"].as_str().unwrap();
+    assert_ne!(signature_b64, "FAKE_SIGNATURE");
+    assert!(cert_url.ends_with("/_fakecloud/sns/cert.pem"));
+
+    let pem = reqwest::get(cert_url).await.unwrap().text().await.unwrap();
+    assert!(pem.starts_with("-----BEGIN CERTIFICATE-----"));
+
+    let cert = Certificate::from_pem(pem.as_bytes()).unwrap();
+    let spki_der = cert
+        .tbs_certificate
+        .subject_public_key_info
+        .to_der()
+        .unwrap();
+    let public_key = RsaPublicKey::from_public_key_der(&spki_der).unwrap();
+    let verifying = VerifyingKey::<Sha256>::new(public_key);
+
+    let signature_bytes = base64::engine::general_purpose::STANDARD
+        .decode(signature_b64)
+        .unwrap();
+    let signature = Signature::try_from(signature_bytes.as_slice()).unwrap();
+
+    let mut canonical = String::new();
+    canonical.push_str("Message\n");
+    canonical.push_str(message);
+    canonical.push('\n');
+    canonical.push_str("MessageId\n");
+    canonical.push_str(message_id);
+    canonical.push('\n');
+    if let Some(s) = subject.filter(|s| !s.is_empty()) {
+        canonical.push_str("Subject\n");
+        canonical.push_str(s);
+        canonical.push('\n');
+    }
+    canonical.push_str("Timestamp\n");
+    canonical.push_str(timestamp);
+    canonical.push('\n');
+    canonical.push_str("TopicArn\n");
+    canonical.push_str(arn);
+    canonical.push('\n');
+    canonical.push_str("Type\n");
+    canonical.push_str("Notification\n");
+
+    verifying
+        .verify(canonical.as_bytes(), &signature)
+        .expect("signature must verify against fakecloud's public cert");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2783,6 +2783,15 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/sns/cert.pem",
+            axum::routing::get(|| async {
+                (
+                    [(axum::http::header::CONTENT_TYPE, "application/x-pem-file")],
+                    fakecloud_sns::signing::cert_pem(),
+                )
+            }),
+        )
+        .route(
             "/_fakecloud/sns/messages",
             axum::routing::get({
                 let ss = sns_introspection_state;

--- a/crates/fakecloud-sns/Cargo.toml
+++ b/crates/fakecloud-sns/Cargo.toml
@@ -16,8 +16,12 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
+rcgen = { workspace = true }
+rsa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -151,19 +151,34 @@ impl SnsDelivery for SnsDeliveryImpl {
             message, &msg_id, subject, &timestamp, topic_arn,
         );
         let signature = crate::signing::sign(&canonical);
-        let sns_envelope = serde_json::json!({
-            "Type": "Notification",
-            "MessageId": msg_id,
-            "TopicArn": topic_arn,
-            "Subject": subject.unwrap_or(""),
-            "Message": message,
-            "Timestamp": timestamp,
-            "SignatureVersion": "1",
-            "Signature": signature,
-            "SigningCertURL": crate::signing::cert_url(&endpoint),
-            "UnsubscribeURL": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", endpoint, topic_arn),
-        });
-        let envelope_str = sns_envelope.to_string();
+        // Subject is omitted from BOTH the canonical string and the JSON
+        // envelope when absent — verifiers iterate the JSON keys to rebuild
+        // canonical, so the two must agree.
+        let mut envelope_map = serde_json::Map::new();
+        envelope_map.insert("Type".into(), "Notification".into());
+        envelope_map.insert("MessageId".into(), msg_id.clone().into());
+        envelope_map.insert("TopicArn".into(), topic_arn.into());
+        if let Some(subj) = subject {
+            envelope_map.insert("Subject".into(), subj.into());
+        }
+        envelope_map.insert("Message".into(), message.into());
+        envelope_map.insert("Timestamp".into(), timestamp.clone().into());
+        // SignatureVersion 2 corresponds to RSA-SHA256 signatures; v1 was SHA-1.
+        envelope_map.insert("SignatureVersion".into(), "2".into());
+        envelope_map.insert("Signature".into(), signature.into());
+        envelope_map.insert(
+            "SigningCertURL".into(),
+            crate::signing::cert_url(&endpoint).into(),
+        );
+        envelope_map.insert(
+            "UnsubscribeURL".into(),
+            format!(
+                "{}/?Action=Unsubscribe&SubscriptionArn={}",
+                endpoint, topic_arn
+            )
+            .into(),
+        );
+        let envelope_str = serde_json::Value::Object(envelope_map).to_string();
 
         for queue_arn in sqs_subscribers {
             self.delivery

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -146,16 +146,21 @@ impl SnsDelivery for SnsDeliveryImpl {
         drop(accounts);
 
         // Wrap the message in SNS notification envelope (matches real AWS format)
+        let timestamp = Utc::now().to_rfc3339();
+        let canonical = crate::signing::canonical_notification(
+            message, &msg_id, subject, &timestamp, topic_arn,
+        );
+        let signature = crate::signing::sign(&canonical);
         let sns_envelope = serde_json::json!({
             "Type": "Notification",
             "MessageId": msg_id,
             "TopicArn": topic_arn,
             "Subject": subject.unwrap_or(""),
             "Message": message,
-            "Timestamp": Utc::now().to_rfc3339(),
+            "Timestamp": timestamp,
             "SignatureVersion": "1",
-            "Signature": "FAKE_SIGNATURE",
-            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+            "Signature": signature,
+            "SigningCertURL": crate::signing::cert_url(&endpoint),
             "UnsubscribeURL": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", endpoint, topic_arn),
         });
         let envelope_str = sns_envelope.to_string();

--- a/crates/fakecloud-sns/src/lib.rs
+++ b/crates/fakecloud-sns/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod delivery;
 pub mod resource_policy;
 pub mod service;
+pub mod signing;
 pub mod simulation;
 pub mod state;

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -3308,10 +3308,14 @@ pub(crate) struct SnsLambdaEventInput<'a> {
 /// Used by both direct Publish and cross-service delivery.
 pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String {
     let timestamp = input.timestamp.to_rfc3339();
+    // AWS Lambda SNS event always emits the Subject key (empty when unset).
+    // Pass the same value to the canonical builder so the signature covers
+    // exactly what verifiers will reconstruct from the JSON.
+    let subject_for_envelope = input.subject.unwrap_or("");
     let canonical = crate::signing::canonical_notification(
         input.message,
         input.message_id,
-        input.subject,
+        Some(subject_for_envelope),
         &timestamp,
         input.topic_arn,
     );
@@ -3322,7 +3326,8 @@ pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String 
             "EventSubscriptionArn": input.subscription_arn,
             "EventSource": "aws:sns",
             "Sns": {
-                "SignatureVersion": "1",
+                // SignatureVersion 2 corresponds to RSA-SHA256 signatures; v1 was SHA-1.
+                "SignatureVersion": "2",
                 "Timestamp": timestamp,
                 "Signature": signature,
                 "SigningCertUrl": crate::signing::cert_url(input.endpoint),
@@ -3332,7 +3337,7 @@ pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String 
                 "Type": "Notification",
                 "UnsubscribeUrl": format!("{}/?Action=Unsubscribe&SubscriptionArn={}", input.endpoint, input.subscription_arn),
                 "TopicArn": input.topic_arn,
-                "Subject": input.subject.unwrap_or(""),
+                "Subject": subject_for_envelope,
             }
         }]
     });
@@ -3373,9 +3378,10 @@ fn build_sns_envelope(
     );
     let signature = crate::signing::sign(&canonical);
     map.insert("Timestamp".to_string(), Value::String(timestamp));
+    // SignatureVersion 2 corresponds to RSA-SHA256 signatures; v1 was SHA-1.
     map.insert(
         "SignatureVersion".to_string(),
-        Value::String("1".to_string()),
+        Value::String("2".to_string()),
     );
     map.insert("Signature".to_string(), Value::String(signature));
     map.insert(

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -3307,6 +3307,15 @@ pub(crate) struct SnsLambdaEventInput<'a> {
 /// Build an SNS Lambda event payload (matches real AWS format).
 /// Used by both direct Publish and cross-service delivery.
 pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String {
+    let timestamp = input.timestamp.to_rfc3339();
+    let canonical = crate::signing::canonical_notification(
+        input.message,
+        input.message_id,
+        input.subject,
+        &timestamp,
+        input.topic_arn,
+    );
+    let signature = crate::signing::sign(&canonical);
     let sns_event = serde_json::json!({
         "Records": [{
             "EventVersion": "1.0",
@@ -3314,9 +3323,9 @@ pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String 
             "EventSource": "aws:sns",
             "Sns": {
                 "SignatureVersion": "1",
-                "Timestamp": input.timestamp.to_rfc3339(),
-                "Signature": "FAKE_SIGNATURE",
-                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+                "Timestamp": timestamp,
+                "Signature": signature,
+                "SigningCertUrl": crate::signing::cert_url(input.endpoint),
                 "MessageId": input.message_id,
                 "Message": input.message,
                 "MessageAttributes": input.message_attributes,
@@ -3354,21 +3363,24 @@ fn build_sns_envelope(
         map.insert("Subject".to_string(), Value::String(subj.clone()));
     }
     map.insert("Message".to_string(), Value::String(message.to_string()));
-    map.insert(
-        "Timestamp".to_string(),
-        Value::String(Utc::now().to_rfc3339()),
+    let timestamp = Utc::now().to_rfc3339();
+    let canonical = crate::signing::canonical_notification(
+        message,
+        message_id,
+        subject.as_deref(),
+        &timestamp,
+        topic_arn,
     );
+    let signature = crate::signing::sign(&canonical);
+    map.insert("Timestamp".to_string(), Value::String(timestamp));
     map.insert(
         "SignatureVersion".to_string(),
         Value::String("1".to_string()),
     );
-    map.insert(
-        "Signature".to_string(),
-        Value::String("FAKE_SIGNATURE".to_string()),
-    );
+    map.insert("Signature".to_string(), Value::String(signature));
     map.insert(
         "SigningCertURL".to_string(),
-        Value::String("https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem".to_string()),
+        Value::String(crate::signing::cert_url(endpoint)),
     );
     map.insert(
         "UnsubscribeURL".to_string(),

--- a/crates/fakecloud-sns/src/signing.rs
+++ b/crates/fakecloud-sns/src/signing.rs
@@ -1,0 +1,205 @@
+//! Real RSA-SHA256 signatures for SNS message envelopes.
+//!
+//! AWS SNS signs every notification with the topic owner's RSA key and
+//! exposes the public certificate at `SigningCertURL`. Consumers (the
+//! `sns_message_validator` family of SDKs across languages) fetch that
+//! cert, build the canonical string, and verify the signature.
+//!
+//! fakecloud generates one self-signed RSA-2048 cert at process startup,
+//! exposes the PEM at `/_fakecloud/sns/cert.pem`, and signs the canonical
+//! string the same way real AWS does. Real verifier libraries accept it.
+
+use std::sync::OnceLock;
+
+use base64::Engine;
+use rsa::pkcs1v15::SigningKey;
+use rsa::pkcs8::EncodePrivateKey;
+use rsa::sha2::Sha256;
+use rsa::signature::{RandomizedSigner, SignatureEncoding};
+use rsa::RsaPrivateKey;
+
+const CERT_PATH: &str = "/_fakecloud/sns/cert.pem";
+
+struct Material {
+    signer: SigningKey<Sha256>,
+    cert_pem: String,
+}
+
+static MATERIAL: OnceLock<Material> = OnceLock::new();
+
+fn material() -> &'static Material {
+    MATERIAL.get_or_init(|| {
+        let mut rng = rand::thread_rng();
+        let private_key =
+            RsaPrivateKey::new(&mut rng, 2048).expect("generate RSA-2048 for SNS signing");
+        let der = private_key
+            .to_pkcs8_der()
+            .expect("encode SNS signing key as PKCS8 DER");
+        let key_pair = rcgen::KeyPair::try_from(der.as_bytes())
+            .expect("rcgen accepts PKCS8 DER from rsa crate");
+        let mut params = rcgen::CertificateParams::new(vec!["sns.fakecloud.local".to_string()])
+            .expect("rcgen CertificateParams");
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "fakecloud SNS Signer");
+        let cert = params
+            .self_signed(&key_pair)
+            .expect("self-sign SNS cert with generated key");
+        let cert_pem = cert.pem();
+        let signer = SigningKey::<Sha256>::new(private_key);
+        Material { signer, cert_pem }
+    })
+}
+
+/// PEM-encoded self-signed certificate. Served at `/_fakecloud/sns/cert.pem`.
+pub fn cert_pem() -> &'static str {
+    &material().cert_pem
+}
+
+/// Path under the fakecloud HTTP root where `cert_pem()` is served.
+pub fn cert_path() -> &'static str {
+    CERT_PATH
+}
+
+/// Build the absolute SigningCertURL given the request's endpoint base.
+pub fn cert_url(endpoint: &str) -> String {
+    format!("{}{}", endpoint.trim_end_matches('/'), CERT_PATH)
+}
+
+/// RSA-SHA256 sign the canonical string and return the base64 signature.
+pub fn sign(canonical: &str) -> String {
+    let signature = material()
+        .signer
+        .sign_with_rng(&mut rand::thread_rng(), canonical.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(signature.to_bytes())
+}
+
+/// Build the canonical string AWS uses for SNS Notification messages.
+///
+/// Order is alphabetical by key, with each `Key\nValue\n` pair appended.
+/// `Subject` is included only when present.
+pub fn canonical_notification(
+    message: &str,
+    message_id: &str,
+    subject: Option<&str>,
+    timestamp: &str,
+    topic_arn: &str,
+) -> String {
+    let mut out = String::new();
+    out.push_str("Message\n");
+    out.push_str(message);
+    out.push('\n');
+    out.push_str("MessageId\n");
+    out.push_str(message_id);
+    out.push('\n');
+    if let Some(s) = subject {
+        out.push_str("Subject\n");
+        out.push_str(s);
+        out.push('\n');
+    }
+    out.push_str("Timestamp\n");
+    out.push_str(timestamp);
+    out.push('\n');
+    out.push_str("TopicArn\n");
+    out.push_str(topic_arn);
+    out.push('\n');
+    out.push_str("Type\n");
+    out.push_str("Notification\n");
+    out
+}
+
+/// Canonical string for SubscriptionConfirmation / UnsubscribeConfirmation.
+pub fn canonical_subscription_confirmation(
+    message: &str,
+    message_id: &str,
+    subscribe_url: &str,
+    timestamp: &str,
+    token: &str,
+    topic_arn: &str,
+    msg_type: &str,
+) -> String {
+    let mut out = String::new();
+    out.push_str("Message\n");
+    out.push_str(message);
+    out.push('\n');
+    out.push_str("MessageId\n");
+    out.push_str(message_id);
+    out.push('\n');
+    out.push_str("SubscribeURL\n");
+    out.push_str(subscribe_url);
+    out.push('\n');
+    out.push_str("Timestamp\n");
+    out.push_str(timestamp);
+    out.push('\n');
+    out.push_str("Token\n");
+    out.push_str(token);
+    out.push('\n');
+    out.push_str("TopicArn\n");
+    out.push_str(topic_arn);
+    out.push('\n');
+    out.push_str("Type\n");
+    out.push_str(msg_type);
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs1v15::VerifyingKey;
+    use rsa::signature::{Keypair, Verifier};
+
+    #[test]
+    fn cert_pem_is_pem_encoded() {
+        let pem = cert_pem();
+        assert!(pem.starts_with("-----BEGIN CERTIFICATE-----"));
+        assert!(pem.trim_end().ends_with("-----END CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn cert_url_appends_path() {
+        assert_eq!(
+            cert_url("http://localhost:7878"),
+            "http://localhost:7878/_fakecloud/sns/cert.pem"
+        );
+        assert_eq!(
+            cert_url("http://localhost:7878/"),
+            "http://localhost:7878/_fakecloud/sns/cert.pem"
+        );
+    }
+
+    #[test]
+    fn signature_round_trips_through_public_key() {
+        // Force material init so we can grab the signer's public counterpart.
+        let _ = cert_pem();
+        let canonical = canonical_notification(
+            "hello",
+            "11111111-2222-3333-4444-555555555555",
+            Some("greetings"),
+            "2026-04-25T12:34:56.000Z",
+            "arn:aws:sns:us-east-1:123456789012:my-topic",
+        );
+        let sig_b64 = sign(&canonical);
+        let sig_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&sig_b64)
+            .unwrap();
+
+        // Verify with the public key derived from the same private key.
+        let signing_key = &material().signer;
+        let verifying: VerifyingKey<Sha256> = signing_key.verifying_key();
+        let signature = rsa::pkcs1v15::Signature::try_from(sig_bytes.as_slice()).unwrap();
+        verifying.verify(canonical.as_bytes(), &signature).unwrap();
+    }
+
+    #[test]
+    fn canonical_notification_omits_subject_when_absent() {
+        let s = canonical_notification("m", "id", None, "t", "arn");
+        assert!(!s.contains("Subject"));
+    }
+
+    #[test]
+    fn canonical_notification_includes_subject_when_present() {
+        let s = canonical_notification("m", "id", Some("sub"), "t", "arn");
+        assert!(s.contains("Subject\nsub\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- Generate a self-signed RSA-2048 cert at process startup, serve PEM at `/_fakecloud/sns/cert.pem`
- Sign the AWS-canonical string for SNS Notification messages with RSA-SHA256 (PKCS#1 v1.5), set `SignatureVersion=1` and `SigningCertURL` on every envelope
- Replace the three `FAKE_SIGNATURE` sites: cross-service `publish_to_topic`, `build_sns_envelope` (SQS/HTTP delivery), `build_sns_lambda_event` (Lambda payload)
- Real consumer SDKs (`sns_message_validator` family) now accept fakecloud's SNS output

## Test plan
- [x] Unit tests in `signing.rs`: cert PEM shape, SigningCertURL appending, canonical string subject inclusion, RSA-SHA256 round-trip via VerifyingKey
- [x] E2E `sns_signing.rs`: publish to topic with SQS subscription, fetch cert from introspection endpoint, parse X.509 SubjectPublicKeyInfo with `x509-cert`, verify signature with `rsa::pkcs1v15::VerifyingKey<Sha256>`
- [x] All 174 existing fakecloud-sns tests still green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add real RSA-SHA256 signing for SNS notifications and serve a self‑signed public cert at `/_fakecloud/sns/cert.pem`. Messages now validate with real `sns_message_validator` libraries with `SignatureVersion=2` and correct canonical/JSON Subject handling.

- New Features
  - Generate an RSA‑2048 key/cert at startup and serve the PEM at `/_fakecloud/sns/cert.pem`; include `SigningCertURL` in all envelopes.
  - Sign the AWS canonical string with RSA‑SHA256; set `SignatureVersion=2` and `Signature` on all envelopes.
  - Keep canonical/JSON consistent for Subject: omit when absent in cross‑service delivery and SQS/HTTP; include empty Subject in Lambda events.
  - Replace `FAKE_SIGNATURE` across cross‑service publish, SQS/HTTP delivery, and Lambda event payloads.
  - Add server route to expose the cert and E2E/unit tests that verify signatures against the served cert.

- Dependencies
  - Add `rsa`, `rcgen`, and `rand` to the workspace.
  - Add `x509-cert` to `fakecloud-e2e` for signature verification.
  - CI: ignore `RUSTSEC-2023-0071` for `rsa` with documented rationale.

<sup>Written for commit cbc0c7a6accf7d8ea319e4a0f61e4c35f94997b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

