### PR TITLE
docs(numbers): bump APIGW v2 28 -> 103, total 1,849 -> 1,924

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-26 services, 1,849 operations, 100% conformance per implemented service.
+26 services, 1,924 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -72,7 +72,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | RDS                    | 163 | Real Postgres, MySQL, MariaDB via Docker; lifecycle ops emit `aws.rds` EventBridge events |
 | ElastiCache            |  75 | Real Redis, Valkey via Docker                                          |
 | Step Functions         |  37 | Full ASL interpreter, Lambda/SQS/SNS/EventBridge/DynamoDB tasks        |
-| API Gateway v2         |  28 | HTTP APIs, Lambda proxy, JWT/Lambda authorizers, CORS                  |
+| API Gateway v2         | 103 | HTTP APIs, routes, integrations, stages, deployments, authorizers, domains, models, VPC links, routing rules, developer portals, CORS, tags |
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
@@ -114,7 +114,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | SES inbound email   | Real receipt rule action execution                 | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 | RDS                 | 163 operations, PostgreSQL/MySQL/MariaDB via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | ElastiCache         | 75 operations, Redis and Valkey via Docker         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
-| API Gateway v2      | 28 operations, full HTTP API support               | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| API Gateway v2      | 103 operations — HTTP APIs + developer portals     | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
 | ECS                 | **60 operations — full API** incl. real task execution, services, task sets, capacity providers | [Paid only](https://docs.localstack.cloud/references/licensing/)               |

--- a/website/content/docs/services/_index.md
+++ b/website/content/docs/services/_index.md
@@ -7,7 +7,7 @@ template = "docs.html"
 page_template = "docs-page.html"
 +++
 
-fakecloud implements 26 AWS services with 1,849 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
+fakecloud implements 26 AWS services with 1,924 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -31,7 +31,7 @@ fakecloud implements 26 AWS services with 1,849 total operations, all at 100% Sm
 | RDS                    | 163 | Real Postgres, MySQL, MariaDB via Docker; lifecycle ops emit `aws.rds` EventBridge events |
 | ElastiCache            |  75 | Real Redis, Valkey via Docker                                          |
 | Step Functions         |  37 | Full ASL interpreter, Lambda/SQS/SNS/EventBridge/DynamoDB tasks        |
-| API Gateway v2         |  28 | HTTP APIs, Lambda proxy, JWT/Lambda authorizers, CORS                  |
+| API Gateway v2         | 103 | HTTP APIs, routes, integrations, stages, deployments, authorizers, domains, models, VPC links, routing rules, developer portals, CORS, tags |
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
 | Bedrock Runtime        |  10 | InvokeModel, Converse, streaming, configurable responses, fault inject |
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle eval, scanning, pull-through cache, registry templates, real cosign signature verification |

--- a/website/content/docs/services/apigatewayv2.md
+++ b/website/content/docs/services/apigatewayv2.md
@@ -4,7 +4,7 @@ description = "HTTP APIs, Lambda proxy integration, JWT and Lambda authorizers, 
 weight = 20
 +++
 
-fakecloud implements **28 of 28** API Gateway v2 operations at 100% conformance (HTTP APIs; REST APIs are a separate v1 service not yet implemented).
+fakecloud implements **103 of 103** API Gateway v2 operations at 100% conformance (HTTP APIs; REST APIs are a separate v1 service not yet implemented).
 
 ## Supported features
 

--- a/website/content/fake-aws-server.md
+++ b/website/content/fake-aws-server.md
@@ -16,7 +16,7 @@ Listens on `http://localhost:4566`. Any AWS SDK in any language points at it and
 ## What "fake AWS server" means here
 
 - **Real HTTP server**, not an in-process mock. Your Go / Java / Kotlin / Node / Rust / PHP / Python code uses the regular AWS SDK with `endpoint_url` set to `http://localhost:4566`.
-- **Speaks the AWS wire protocol** at 100% conformance per implemented service. 26 services, 1,849 operations, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
+- **Speaks the AWS wire protocol** at 100% conformance per implemented service. 26 services, 1,924 operations, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
 - **Real execution** for stateful services: Lambda runs your function code in Docker containers across 13 runtimes, RDS runs real PostgreSQL/MySQL/MariaDB, ElastiCache runs real Redis/Valkey.
 - **Real cross-service wiring**: S3 -> Lambda, SQS -> Lambda, SNS fan-out, EventBridge -> Step Functions, and 15+ more integrations execute end-to-end, not as stubs.
 - **Free, open-source, AGPL-3.0.** No account, no auth token, no paid tier.

--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -20,7 +20,7 @@ Yes. LocalStack replaced its open-source Community Edition with a proprietary im
 
 ### How many AWS services does fakecloud support?
 
-26 services and 1,849 API operations at 100% conformance per implemented service today, with more on the roadmap. The explicit goal is 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups.
+26 services and 1,924 API operations at 100% conformance per implemented service today, with more on the roadmap. The explicit goal is 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups.
 
 ### Which AWS services are supported?
 
@@ -109,7 +109,7 @@ GitHub issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faisca
     {"@type": "Question", "name": "What is fakecloud?", "acceptedAnswer": {"@type": "Answer", "text": "fakecloud is a free, open-source local AWS cloud emulator for integration testing and local development. It runs on a single port (4566), requires no account or auth token, and aims for 100% behavioral conformance with real AWS on every service it implements. AGPL-3.0 licensed."}},
     {"@type": "Question", "name": "Is fakecloud free?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. AGPL-3.0, free for commercial use. Using fakecloud as a dev/test dependency has zero AGPL implications for your application."}},
     {"@type": "Question", "name": "Is fakecloud a LocalStack alternative?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. LocalStack replaced its open-source Community Edition with a proprietary image in March 2026 that requires an account and auth token. fakecloud is a free, open-source replacement."}},
-    {"@type": "Question", "name": "How many AWS services does fakecloud support?", "acceptedAnswer": {"@type": "Answer", "text": "26 services and 1,849 API operations at 100% conformance per implemented service today, with more on the roadmap. The goal is 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations."}},
+    {"@type": "Question", "name": "How many AWS services does fakecloud support?", "acceptedAnswer": {"@type": "Answer", "text": "26 services and 1,924 API operations at 100% conformance per implemented service today, with more on the roadmap. The goal is 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations."}},
     {"@type": "Question", "name": "Which AWS services are supported?", "acceptedAnswer": {"@type": "Answer", "text": "S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES, Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime."}},
     {"@type": "Question", "name": "Does fakecloud execute Lambda code for real?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. fakecloud pulls real AWS Lambda runtime containers and executes your handler against them. All 13 official runtimes are supported."}},
     {"@type": "Question", "name": "Does fakecloud run real databases for RDS?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. RDS emulation pulls real PostgreSQL, MySQL, and MariaDB Docker images and runs them as the DB instance."}},

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -1,6 +1,6 @@
 +++
 title = "Free, open-source LocalStack alternative"
-description = "fakecloud is a free, open-source local AWS emulator: 26 services, 1,849 operations, 100% conformance, 6 test-assertion SDKs. No account, no token, no paid tier. Drop-in replacement for LocalStack Community."
+description = "fakecloud is a free, open-source local AWS emulator: 26 services, 1,924 operations, 100% conformance, 6 test-assertion SDKs. No account, no token, no paid tier. Drop-in replacement for LocalStack Community."
 template = "page.html"
 +++
 
@@ -24,7 +24,7 @@ This is why fakecloud runs real Lambda code in real runtime containers, runs rea
 ## What fakecloud gives you
 
 - **26 AWS services.** S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, ECR, ECS, Elastic Load Balancing v2, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime.
-- **1,849 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
+- **1,924 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
 - **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud, catching waiter and field-presence drift that pure SDK tests miss.
 - **Real Lambda execution.** 13 runtimes in Docker containers. Not a mock, not a stub. Node, Python, Java, Go, .NET, Ruby, custom runtimes.
 - **Real stateful services.** RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey. Your Lambda talking to RDS is talking to a real Postgres.
@@ -52,7 +52,7 @@ This is why fakecloud runs real Lambda code in real runtime containers, runs rea
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 | RDS | 163 ops, real PostgreSQL/MySQL/MariaDB via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | ElastiCache | 75 ops, real Redis/Valkey via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| API Gateway v2 | 28 ops, HTTP APIs + JWT/Lambda authorizers | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| API Gateway v2 | 103 ops, HTTP APIs + developer portals + JWT/Lambda authorizers | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | Bedrock | 111 ops (control plane + runtime) | Not available |
 
 Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`. LocalStack numbers from a fresh `localstack start` on the same hardware.

--- a/website/content/vs/floci.md
+++ b/website/content/vs/floci.md
@@ -32,7 +32,7 @@ Run your actual test suite against both. Numbers published on landing pages are 
 | Distribution | Single static binary (~19 MB) + Docker image |
 | Startup | ~500ms |
 | Idle memory | ~10 MiB |
-| Services covered today | 26 (1,849 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
+| Services covered today | 26 (1,924 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
 | Lambda execution | Real code in 13 Docker runtime containers |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |

--- a/website/content/vs/localstack.md
+++ b/website/content/vs/localstack.md
@@ -27,7 +27,7 @@ Since LocalStack replaced its open-source Community Edition with a proprietary i
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) | Stored but never executed |
 | RDS | 163 ops, real PostgreSQL/MySQL/MariaDB | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
 | ElastiCache | 75 ops, real Redis/Valkey | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
-| API Gateway v2 | 28 ops | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| API Gateway v2 | 103 ops | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
 | ECR | 58 ops + real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/) (and push is [flaky](https://github.com/localstack/localstack/issues/8128) when paid) | Yes |
 | Bedrock | 111 ops (control plane + runtime) | Not available | Not available |
 | SCPs / multi-account | Yes (Organizations control plane + ceiling enforcement) | No | Partial |

--- a/website/content/vs/ministack.md
+++ b/website/content/vs/ministack.md
@@ -35,7 +35,7 @@ These are philosophies, not rankings. Breadth-first and depth-first are differen
 | Distribution | Single static binary (~19 MB) + Docker image |
 | Startup | ~500ms |
 | Idle memory | ~10 MiB |
-| Services covered today | 26 (1,849 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
+| Services covered today | 26 (1,924 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
 | Lambda execution | Real, 13 runtimes in Docker |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
 | ElastiCache | Real Redis/Valkey via Docker |

--- a/website/content/vs/sam-local.md
+++ b/website/content/vs/sam-local.md
@@ -13,7 +13,7 @@ fakecloud runs Lambda the same way — real runtime containers, 13 runtimes supp
 | | fakecloud | SAM Local |
 |---|---|---|
 | Lambda real code execution | Yes (13 runtimes in Docker) | Yes (13 runtimes in Docker) |
-| API Gateway v2 | 28 ops, HTTP APIs, JWT/Lambda authorizers | Limited (REST API emulation) |
+| API Gateway v2 | 103 ops, HTTP APIs, JWT/Lambda authorizers | Limited (REST API emulation) |
 | API Gateway v1 | Not yet | Yes (SAM focuses here) |
 | S3 | 107 ops, real storage + notifications | **No** |
 | SQS | 23 ops, real queues + event source mappings | **No** |

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6,7 +6,7 @@
 
 fakecloud emulates AWS locally for integration testing and development. It is a single Rust binary (~19 MB, ~500ms startup, ~10 MiB idle memory) — no Docker required to run fakecloud itself, no signup. Point any AWS SDK or the AWS CLI at `http://localhost:4566` with dummy credentials.
 
-**Coverage goal:** 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Approach is depth-first — a service lands when it passes the full Smithy-model test variants and the cross-service wire-ups that matter for it, not when the API surface looks filled in. 26 services (1,849 operations) are shipped today; more land progressively as they hit the bar.
+**Coverage goal:** 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Approach is depth-first — a service lands when it passes the full Smithy-model test variants and the cross-service wire-ups that matter for it, not when the API surface looks filled in. 26 services (1,924 operations) are shipped today; more land progressively as they hit the bar.
 
 Key design principles:
 - **Depth-first coverage**: every implemented service targets 100% conformance with real AWS, validated on every commit against AWS's own Smithy models (54,000+ generated test variants). CI also runs upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud.
@@ -367,16 +367,29 @@ Features: Complete Amazon States Language (ASL) interpreter with all state types
 
 Protocol: JSON (JSON body, `X-Amz-Target` header, JSON responses)
 
-### API Gateway v2 (28 actions)
+### API Gateway v2 (103 actions)
 
-**APIs:** CreateApi, DeleteApi, GetApi, GetApis, UpdateApi
-**Routes:** CreateRoute, DeleteRoute, GetRoute, GetRoutes, UpdateRoute
+**APIs:** CreateApi, DeleteApi, GetApi, GetApis, UpdateApi, ImportApi, ReimportApi, ExportApi
+**Routes:** CreateRoute, DeleteRoute, GetRoute, GetRoutes, UpdateRoute, DeleteRouteRequestParameter, DeleteRouteSettings
+**Route Responses:** CreateRouteResponse, DeleteRouteResponse, GetRouteResponse, GetRouteResponses, UpdateRouteResponse
 **Integrations:** CreateIntegration, DeleteIntegration, GetIntegration, GetIntegrations, UpdateIntegration
-**Stages:** CreateStage, DeleteStage, GetStage, GetStages, UpdateStage
-**Deployments:** CreateDeployment, GetDeployment, GetDeployments
-**Authorizers:** CreateAuthorizer, DeleteAuthorizer, GetAuthorizer, GetAuthorizers, UpdateAuthorizer
+**Integration Responses:** CreateIntegrationResponse, DeleteIntegrationResponse, GetIntegrationResponse, GetIntegrationResponses, UpdateIntegrationResponse
+**Routing Rules:** CreateRoutingRule, DeleteRoutingRule, GetRoutingRule, ListRoutingRules, PutRoutingRule
+**Stages:** CreateStage, DeleteStage, GetStage, GetStages, UpdateStage, DeleteAccessLogSettings
+**Deployments:** CreateDeployment, DeleteDeployment, GetDeployment, GetDeployments, UpdateDeployment
+**Authorizers:** CreateAuthorizer, DeleteAuthorizer, GetAuthorizer, GetAuthorizers, UpdateAuthorizer, ResetAuthorizersCache
+**Domain Names:** CreateDomainName, DeleteDomainName, GetDomainName, GetDomainNames, UpdateDomainName
+**API Mappings:** CreateApiMapping, DeleteApiMapping, GetApiMapping, GetApiMappings, UpdateApiMapping
+**Models:** CreateModel, DeleteModel, GetModel, GetModels, UpdateModel, GetModelTemplate
+**VPC Links:** CreateVpcLink, DeleteVpcLink, GetVpcLink, GetVpcLinks, UpdateVpcLink
+**CORS:** DeleteCorsConfiguration
+**Tags:** TagResource, UntagResource, GetTags
+**Developer Portals:** CreatePortal, DeletePortal, DisablePortal, GetPortal, ListPortals, PreviewPortal, PublishPortal, UpdatePortal
+**Portal Products:** CreatePortalProduct, DeletePortalProduct, DeletePortalProductSharingPolicy, GetPortalProduct, GetPortalProductSharingPolicy, ListPortalProducts, PutPortalProductSharingPolicy, UpdatePortalProduct
+**Product Pages:** CreateProductPage, DeleteProductPage, GetProductPage, ListProductPages, UpdateProductPage
+**Product REST Endpoint Pages:** CreateProductRestEndpointPage, DeleteProductRestEndpointPage, GetProductRestEndpointPage, ListProductRestEndpointPages, UpdateProductRestEndpointPage
 
-Features: HTTP APIs with route-based request handling, path parameters and wildcards (`/users/{userId}`, `/api/*`), Lambda proxy integration v2.0 format, HTTP proxy integration for external endpoints, Mock integration for static responses, CORS configuration, JWT and Lambda authorizers, request history introspection endpoint.
+Features: HTTP APIs with route-based request handling, path parameters and wildcards (`/users/{userId}`, `/api/*`), Lambda proxy integration v2.0 format, HTTP proxy integration for external endpoints, Mock integration for static responses, CORS configuration, JWT and Lambda authorizers, custom domains + API mappings, request models, routing rules, VPC links, OpenAPI import/reimport/export, full developer portal surface (portals, products, product pages, REST endpoint pages, sharing policies), request history introspection endpoint.
 
 Protocol: REST (HTTP method + path-based routing, JSON responses)
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -4,7 +4,7 @@
 
 - **Goal:** 100% of AWS services, each at 100% conformance, with 100% of cross-service integrations. Approach is depth-first — a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in.
 - Single static binary (~19 MB), ~500ms startup, ~10 MiB idle memory, no Docker required to run fakecloud itself
-- **26 AWS services shipped today, 1,849 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
+- **26 AWS services shipped today, 1,924 operations, 100% conformance per implemented service** — validated against AWS's own Smithy models on every commit (59,000+ generated test variants). More services land as they hit the conformance bar; roadmap is driven by real-project demand.
 - Services: S3, SQS, SNS, EventBridge, EventBridge Scheduler, IAM, STS, SSM, DynamoDB, Lambda, Secrets Manager, CloudWatch Logs, KMS, CloudFormation, SES (v2 + v1 inbound), Cognito User Pools, Kinesis, RDS, ElastiCache, ECR, ECS, Elastic Load Balancing v2, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime
 - 30+ cross-service integrations: S3 notifications, SNS fan-out, EventBridge rules, DynamoDB Streams, CloudWatch Logs subscriptions, Cognito triggers, API Gateway -> Lambda, Step Functions task integrations, SES inbound -> S3/SNS/Lambda, and more
 - Real Lambda execution via Docker across 13 runtimes (Node.js 18/20/22, Python 3.9-3.12, Java 11/17/21, .NET 6/8, Ruby 3.2, Go, custom `provided.al2` / `provided.al2023`)
@@ -52,7 +52,7 @@
 - **RDS** (163 ops): DB instances with real PostgreSQL/MySQL/MariaDB engines via Docker, snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging
 - **ElastiCache** (75 ops): cache clusters with real Redis/Valkey via Docker, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users/user groups, failover, tagging
 - **Step Functions** (37 ops): state machines, executions, full ASL interpreter (Pass, Task, Choice, Wait, Parallel, Map, Succeed, Fail), Retry/Catch, Lambda/SQS/SNS/EventBridge/DynamoDB task integrations
-- **API Gateway v2** (28 ops): HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration v2.0, HTTP proxy, mock integrations, stages, deployments, JWT and Lambda authorizers, CORS
+- **API Gateway v2** (103 ops): HTTP APIs, routes with path parameters and wildcards, Lambda proxy integration v2.0, HTTP proxy, mock integrations, stages, deployments, JWT and Lambda authorizers, domain names, API mappings, models, route responses, integration responses, routing rules, VPC links, CORS, developer portals + portal products + product pages, tags
 - **Bedrock** (101 ops): foundation models, guardrails, custom models, import/copy/invocation/evaluation jobs, inference profiles, prompt routers, marketplace endpoints, automated reasoning policies
 - **Bedrock Runtime** (10 ops): InvokeModel (Anthropic, Titan, Meta, Cohere, Mistral), Converse, streaming, ApplyGuardrail, CountTokens, async invoke, configurable responses, fault injection
 - **ECR** (58 ops): full registry — repos, images (real OCI v2 push/pull via `docker push`/`pull`), lifecycle policies, scanning, pull-through cache, registry settings, signing

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -12,7 +12,7 @@
   "applicationCategory": "DeveloperApplication",
   "applicationSubCategory": "CloudTestingTool",
   "operatingSystem": "Linux, macOS, Windows",
-  "description": "Free, open-source local AWS cloud emulator. 26 services, 1,849 operations, 100% conformance per implemented service. Single binary, no account, no auth token.",
+  "description": "Free, open-source local AWS cloud emulator. 26 services, 1,924 operations, 100% conformance per implemented service. Single binary, no account, no auth token.",
   "url": "https://fakecloud.dev",
   "downloadUrl": "https://github.com/faiscadev/fakecloud/releases",
   "codeRepository": "https://github.com/faiscadev/fakecloud",
@@ -56,7 +56,7 @@
   <div class="container">
     <h1>fake<span>cloud</span></h1>
     <p class="tagline">Local AWS cloud emulator for integration tests. Run your app with normal AWS clients, stay fully local, and use fakecloud SDKs when your tests need deeper visibility.</p>
-    <p class="hero-proof">26 services. 1,849 operations. 100% conformance across implemented APIs.</p>
+    <p class="hero-proof">26 services. 1,924 operations. 100% conformance across implemented APIs.</p>
     <div class="btn-group">
       <a href="#quickstart" class="btn">Get Started</a>
       <a href="#compare" class="btn btn-outline">Why fakecloud</a>
@@ -101,7 +101,7 @@
       <div class="feature">
         <div class="label">Tested</div>
         <h3>Conformance tested</h3>
-        <p>100% conformance across all 1,849 implemented API operations, backed by 59,000+ Smithy-model-generated test variants plus end-to-end tests against the official AWS SDKs.</p>
+        <p>100% conformance across all 1,924 implemented API operations, backed by 59,000+ Smithy-model-generated test variants plus end-to-end tests against the official AWS SDKs.</p>
       </div>
       <div class="feature">
         <div class="label">Real behavior</div>
@@ -197,7 +197,7 @@
           <tr><td>SES inbound email</td><td class="check">Real receipt rule actions</td><td class="cross">Stored but never executed</td></tr>
           <tr><td>RDS</td><td class="check">163 operations, PostgreSQL/MySQL/MariaDB via Docker</td><td class="cross">Paid only</td></tr>
           <tr><td>ElastiCache</td><td class="check">75 operations, Redis and Valkey via Docker</td><td class="cross">Paid only</td></tr>
-          <tr><td>API Gateway v2</td><td class="check">28 operations, HTTP APIs + JWT/Lambda authorizers</td><td class="cross">Paid only</td></tr>
+          <tr><td>API Gateway v2</td><td class="check">103 operations, HTTP APIs + developer portals + JWT/Lambda authorizers</td><td class="cross">Paid only</td></tr>
           <tr><td>Bedrock</td><td class="check">111 operations (control plane + runtime)</td><td class="cross">Not available</td></tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Summary

- API Gateway v2 docs said "28 ops" but the crate's SUPPORTED list has 103 entries (matches the AWS Smithy model). Bump README/website/llms.txt/index.html to 103.
- Total ops sum across the per-service column therefore goes from 1,849 -> 1,924.
- ECS stays at 60 (matches its SUPPORTED list).
- Blog posts deliberately not touched (point-in-time per existing convention).

## Test plan
- [ ] `grep -rn "1,849\| 28 ops\|28 of 28\|28 actions\|28 operations" README.md website/content website/static website/templates` returns nothing
- [ ] Per-service ECS count remains 60
- [ ] Per-service APIGW v2 count is 103 everywhere

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected docs to show API Gateway v2 has 103 operations (not 28) and updated the overall total from 1,849 to 1,924. Aligns README and website with the crate’s SUPPORTED list and the AWS Smithy model; no behavior change.

- **Bug Fixes**
  - Updated counts in README, service index and APIGW v2 page, FAQ, comparison pages, landing page JSON-LD/hero, and `website/static/llms.txt` + `website/static/llms-full.txt`.
  - Expanded APIGW v2 feature list to reflect full surface (domains, API mappings, models, VPC links, routing rules, integration/route responses, developer portals, tags).
  - Left ECS at 60 ops; blog posts unchanged (point-in-time).

<sup>Written for commit 5d7a02938eec6ea2cb7fb865631677a167a52f8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

