### PR TITLE
fix(conformance): map every shipped service to its real wire protocol

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,70 +1,82 @@
 {
-  "variants_passed": 61741,
-  "total_variants": 61743,
+  "variants_passed": 64998,
+  "total_variants": 65630,
   "per_service": {
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
-    },
     "dynamodb": {
       "passed": 2123,
       "total": 2123
-    },
-    "elasticache": {
-      "passed": 2219,
-      "total": 2219
-    },
-    "iam": {
-      "passed": 5962,
-      "total": 5962
-    },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
-    },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
     },
     "logs": {
       "passed": 3911,
       "total": 3911
     },
-    "apigateway": {
-      "passed": 2769,
-      "total": 2769
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
+    "cloudformation": {
+      "passed": 3420,
+      "total": 3420
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "ecs": {
+      "passed": 1733,
+      "total": 2327
+    },
+    "ssm": {
+      "passed": 5303,
+      "total": 5303
+    },
+    "bedrock": {
+      "passed": 3591,
+      "total": 3591
+    },
+    "sts": {
+      "passed": 438,
+      "total": 438
+    },
+    "kms": {
+      "passed": 2196,
+      "total": 2196
+    },
+    "s3": {
+      "passed": 3620,
+      "total": 3620
     },
     "scheduler": {
       "passed": 491,
       "total": 491
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "apigateway": {
+      "passed": 2769,
+      "total": 2769
     },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
+    "events": {
+      "passed": 2108,
+      "total": 2108
+    },
+    "states": {
+      "passed": 1256,
+      "total": 1292
+    },
+    "elasticache": {
+      "passed": 2219,
+      "total": 2219
+    },
+    "lambda": {
+      "passed": 3347,
+      "total": 3347
+    },
+    "iam": {
+      "passed": 5962,
+      "total": 5962
     },
     "rds": {
       "passed": 5376,
@@ -74,29 +86,25 @@
       "passed": 852,
       "total": 852
     },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+    "ses": {
+      "passed": 2858,
+      "total": 2858
     },
-    "states": {
-      "passed": 1292,
-      "total": 1292
-    },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
-    },
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
     "ecr": {
       "passed": 1787,
       "total": 1789
+    },
+    "elasticloadbalancing": {
+      "passed": 1560,
+      "total": 1560
+    },
+    "cognito-idp": {
+      "passed": 4479,
+      "total": 4479
     }
   }
 }

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -9,7 +9,7 @@ use crate::shape_validator;
 use crate::smithy::ServiceModel;
 
 /// Protocol used by a service for request/response encoding.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
     /// Query protocol: form-encoded body with `Action` param, XML responses.
     /// Used by: SQS, SNS, IAM, STS, CloudFormation.
@@ -93,6 +93,13 @@ pub fn service_protocol(service_name: &str) -> Protocol {
         "ecr" => Protocol::Json {
             target_prefix: "AmazonEC2ContainerRegistry_V20150921",
         },
+        "ecs" => Protocol::Json {
+            target_prefix: "AmazonEC2ContainerServiceV20141113",
+        },
+        // Smithy service_name for Step Functions is `states`; SDK calls it SFN.
+        "states" => Protocol::Json {
+            target_prefix: "AWSStepFunctions",
+        },
         "s3" => Protocol::Rest,
         "lambda" => Protocol::Rest,
         // `service_name` in `service-map.json` for API Gateway v2 is
@@ -100,6 +107,16 @@ pub fn service_protocol(service_name: &str) -> Protocol {
         // fakecloud's `ApiGatewayV2Service`. restJson1 wire format; no
         // hardcoded op table, relies on the generic `@http`-driven builder.
         "apigateway" => Protocol::Rest,
+        // restJson1 services — REST routing with @http traits + JSON bodies.
+        "ses" => Protocol::Rest,
+        "bedrock" => Protocol::Rest,
+        "bedrock-runtime" => Protocol::Rest,
+        "scheduler" => Protocol::Rest,
+        // awsQuery services — RDS, ElastiCache, ELBv2 — explicitly listed
+        // for clarity instead of relying on the default fall-through.
+        "rds" => Protocol::Query,
+        "elasticache" => Protocol::Query,
+        "elasticloadbalancing" => Protocol::Query,
         _ => Protocol::Query,
     }
 }
@@ -1203,6 +1220,103 @@ fn truncate(s: &str, max: usize) -> &str {
 mod tests {
     use super::*;
     use crate::smithy::{Member, Operation, Shape, ShapeTraits, ShapeType};
+
+    #[test]
+    fn service_protocol_covers_every_shipped_service() {
+        // Every Smithy service_name fakecloud ships must have an explicit
+        // protocol mapping. Falling through to the `_ => Query` default
+        // misroutes JSON/REST services as form-encoded `Action=` requests
+        // that get caught by APIGW's catch-all and silently classified as
+        // Pass — masking real conformance gaps. See issue surfaced when
+        // ECS reported 76/76 pass while only 60 ops were actually routed.
+        let cases = [
+            ("sqs", Protocol::Query),
+            ("sns", Protocol::Query),
+            ("iam", Protocol::Query),
+            ("sts", Protocol::Query),
+            ("cloudformation", Protocol::Query),
+            ("rds", Protocol::Query),
+            ("elasticache", Protocol::Query),
+            ("elasticloadbalancing", Protocol::Query),
+            (
+                "ssm",
+                Protocol::Json {
+                    target_prefix: "AmazonSSM",
+                },
+            ),
+            (
+                "events",
+                Protocol::Json {
+                    target_prefix: "AWSEvents",
+                },
+            ),
+            (
+                "dynamodb",
+                Protocol::Json {
+                    target_prefix: "DynamoDB_20120810",
+                },
+            ),
+            (
+                "secretsmanager",
+                Protocol::Json {
+                    target_prefix: "secretsmanager",
+                },
+            ),
+            (
+                "logs",
+                Protocol::Json {
+                    target_prefix: "Logs_20140328",
+                },
+            ),
+            (
+                "kms",
+                Protocol::Json {
+                    target_prefix: "TrentService",
+                },
+            ),
+            (
+                "cognito-idp",
+                Protocol::Json {
+                    target_prefix: "AWSCognitoIdentityProviderService",
+                },
+            ),
+            (
+                "kinesis",
+                Protocol::Json {
+                    target_prefix: "Kinesis_20131202",
+                },
+            ),
+            (
+                "ecr",
+                Protocol::Json {
+                    target_prefix: "AmazonEC2ContainerRegistry_V20150921",
+                },
+            ),
+            (
+                "ecs",
+                Protocol::Json {
+                    target_prefix: "AmazonEC2ContainerServiceV20141113",
+                },
+            ),
+            (
+                "states",
+                Protocol::Json {
+                    target_prefix: "AWSStepFunctions",
+                },
+            ),
+            ("s3", Protocol::Rest),
+            ("lambda", Protocol::Rest),
+            ("apigateway", Protocol::Rest),
+            ("ses", Protocol::Rest),
+            ("bedrock", Protocol::Rest),
+            ("bedrock-runtime", Protocol::Rest),
+            ("scheduler", Protocol::Rest),
+        ];
+        for (svc, expected) in cases {
+            let got = service_protocol(svc);
+            assert_eq!(got, expected, "wrong protocol for {svc}");
+        }
+    }
 
     fn op_with_http(name: &str, method: &str, uri: &str, input_shape_id: &str) -> Operation {
         Operation {

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1375,13 +1375,36 @@ async fn logs_list_log_groups_for_query() {
     let server = TestServer::start().await;
     let client = server.logs_client().await;
 
-    let resp = client
-        .list_log_groups_for_query()
-        .query_id("dummy-query-id")
+    // ListLogGroupsForQuery looks up a queryId previously returned by
+    // StartQuery; AWS (and fakecloud) return ResourceNotFoundException for
+    // unknown ids, so create a real query first.
+    client
+        .create_log_group()
+        .log_group_name("/conf/list-for-query")
         .send()
         .await
         .unwrap();
-    assert!(resp.log_group_identifiers().is_empty());
+
+    let started = client
+        .start_query()
+        .log_group_name("/conf/list-for-query")
+        .start_time(0)
+        .end_time(1)
+        .query_string("fields @timestamp")
+        .send()
+        .await
+        .unwrap();
+    let query_id = started.query_id().unwrap().to_string();
+
+    // Just assert the call returns without error — the contents of
+    // logGroupIdentifiers are exercised by the unit tests in
+    // fakecloud-logs::service::queries.
+    client
+        .list_log_groups_for_query()
+        .query_id(query_id)
+        .send()
+        .await
+        .unwrap();
 }
 
 #[test_action("logs", "ListAggregateLogGroupSummaries", checksum = "06cc853e")]

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -1150,14 +1150,23 @@ async fn logs_misc_stubs() {
     let resp = client.list_log_groups().send().await.unwrap();
     assert!(!resp.log_groups().is_empty());
 
-    // ListLogGroupsForQuery
-    let resp = client
-        .list_log_groups_for_query()
-        .query_id("dummy-query")
+    // ListLogGroupsForQuery — needs a real queryId from StartQuery; AWS
+    // returns ResourceNotFoundException for unknown ids.
+    let started = client
+        .start_query()
+        .log_group_name("/misc/listgroups")
+        .start_time(0)
+        .end_time(1)
+        .query_string("fields @timestamp")
         .send()
         .await
         .unwrap();
-    assert!(resp.log_group_identifiers().is_empty());
+    client
+        .list_log_groups_for_query()
+        .query_id(started.query_id().unwrap())
+        .send()
+        .await
+        .unwrap();
 
     // DescribeConfigurationTemplates
     let resp = client

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -526,7 +526,11 @@ fn fail_definition() -> String {
 
 /// Helper to wait for an execution to finish (not RUNNING).
 async fn wait_for_execution(client: &aws_sdk_sfn::Client, arn: &str) -> String {
-    for _ in 0..50 {
+    // 200 * 50ms = 10s budget. Locally executions complete in <2s, but
+    // GitHub-hosted runners under heavy parallel load occasionally stretch
+    // to several seconds, especially when downstream task integrations
+    // (SNS RSA signing, DynamoDB serialization) do real work on first hit.
+    for _ in 0..200 {
         sleep(Duration::from_millis(50)).await;
         let desc = client
             .describe_execution()


### PR DESCRIPTION
## Summary

- `service_protocol()` only mapped 17 services. Everything else (ECS, Step Functions, Bedrock, Bedrock Runtime, Scheduler, SES, RDS, ElastiCache, ELBv2) fell through `_ => Protocol::Query`. JSON/REST services were probed as form-encoded `Action=…`, hit APIGW's catch-all, and returned 4xx — counted as Pass under lenient classification.
- Add explicit entries for the missing services. Add unit test forcing every shipped service to declare its protocol.
- Baseline regenerated. Pre: 61,741 / 61,743 variants pass. Post: 64,998 / 65,630. Real conformance gaps surface in ECS / ECR / Step Functions; 23 of 26 services still at 100%. Follow-up commits will close those gaps.

## Test plan
- [x] `cargo test --release -p fakecloud-conformance --lib service_protocol_covers_every_shipped_service` passes
- [x] `cargo test --release -p fakecloud-conformance --lib` (48+1 tests) passes
- [x] `fakecloud-conformance run` against current baseline = no regressions
- [ ] Cubic clean
- [ ] Full CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mapped every shipped service to its real wire protocol to stop JSON/REST services from being misrouted as Query and falsely counted as passes. Regenerated the conformance baseline to surface real gaps (notably in `ecs`, `ecr`, and `states`), and fixed CI tests for Logs and Step Functions to match current behavior.

- **Bug Fixes**
  - Added explicit protocol mappings: `ecs` (Json: AmazonEC2ContainerServiceV20141113), `states` (Json: AWSStepFunctions), `ses` (Rest), `bedrock` (Rest), `bedrock-runtime` (Rest), `scheduler` (Rest), `rds` (Query), `elasticache` (Query), `elasticloadbalancing` (Query).
  - Added a unit test in `fakecloud-conformance` that requires every shipped service to declare its protocol.
  - Derived `PartialEq`/`Eq` for `Protocol` to enable exact assertions in tests.
  - Fixed Logs tests to create a real query via `StartQuery` before `ListLogGroupsForQuery` in `fakecloud-conformance` and `fakecloud-e2e`.
  - Increased Step Functions `wait_for_execution` budget to 10s in `fakecloud-e2e` to avoid flakiness on CI.
  - Updated baseline: total variants 61,743 → 65,630; passes 61,741 → 64,998. 23/26 services at 100%; gaps now visible in `ecs`, `ecr`, and `states`.

<sup>Written for commit 331a4da25ca42f13b120707cda75d449608e3535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

