### PR TITLE
feat(logs): real GetLogGroupFields, ListLogGroupsForQuery, StartLiveTail

### DIFF
--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -406,19 +406,51 @@ impl LogsService {
         let accounts = self.state.read();
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        if !state.log_groups.contains_key(&group_name) {
-            return Err(AwsServiceError::aws_error(
+        let group = state.log_groups.get(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ResourceNotFoundException",
                 format!("The specified log group does not exist: {group_name}"),
-            ));
-        }
+            )
+        })?;
 
-        // Stub response with common fields
-        let fields = json!([
-            { "fieldName": "@timestamp", "percent": 100 },
-            { "fieldName": "@message", "percent": 100 },
-        ]);
+        // Walk every event in every stream and tally how often each
+        // discovered field appears. JSON-shaped events contribute their
+        // top-level keys; every event always contributes @timestamp +
+        // @message + @logStream.
+        let mut total: u64 = 0;
+        let mut counts: std::collections::BTreeMap<String, u64> = Default::default();
+        for stream in group.log_streams.values() {
+            for ev in &stream.events {
+                total += 1;
+                *counts.entry("@timestamp".to_string()).or_insert(0) += 1;
+                *counts.entry("@message".to_string()).or_insert(0) += 1;
+                *counts.entry("@logStream".to_string()).or_insert(0) += 1;
+                if let Ok(serde_json::Value::Object(map)) =
+                    serde_json::from_str::<serde_json::Value>(&ev.message)
+                {
+                    for k in map.keys() {
+                        *counts.entry(k.clone()).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+        let denom = total.max(1) as f64;
+        let mut fields: Vec<Value> = counts
+            .into_iter()
+            .map(|(name, n)| {
+                let percent = ((n as f64 / denom) * 100.0).round() as i64;
+                json!({ "name": name, "percent": percent })
+            })
+            .collect();
+        // No events yet: still surface the always-present synthetic fields.
+        if total == 0 {
+            fields = vec![
+                json!({ "name": "@timestamp", "percent": 100 }),
+                json!({ "name": "@message", "percent": 100 }),
+                json!({ "name": "@logStream", "percent": 100 }),
+            ];
+        }
 
         Ok(AwsResponse::json(
             StatusCode::OK,

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -572,14 +572,24 @@ impl LogsService {
             0,
             1024,
         )?;
-        let identifiers: Vec<String> = body["logGroupIdentifiers"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let arr = body["logGroupIdentifiers"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logGroupIdentifiers must be an array of strings",
+            )
+        })?;
+        let mut identifiers: Vec<String> = Vec::with_capacity(arr.len());
+        for v in arr {
+            let s = v.as_str().ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logGroupIdentifiers entries must be strings",
+                )
+            })?;
+            identifiers.push(s.to_string());
+        }
         let session_id = uuid::Uuid::new_v4().to_string();
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1081,15 +1091,16 @@ mod tests {
     }
 
     #[test]
-    fn list_log_groups_for_query_returns_empty() {
+    fn list_log_groups_for_query_unknown_query_errors() {
         let svc = make_service();
         let req = make_request(
             "ListLogGroupsForQuery",
             json!({ "queryId": "some-query-id" }),
         );
-        let resp = svc.list_log_groups_for_query(&req).unwrap();
-        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["logGroupIdentifiers"].as_array().unwrap().is_empty());
+        match svc.list_log_groups_for_query(&req) {
+            Err(e) => assert_eq!(e.code(), "ResourceNotFoundException"),
+            Ok(_) => panic!("expected ResourceNotFoundException"),
+        }
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -572,6 +572,14 @@ impl LogsService {
             0,
             1024,
         )?;
+        let identifiers: Vec<String> = body["logGroupIdentifiers"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
         let session_id = uuid::Uuid::new_v4().to_string();
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -579,7 +587,7 @@ impl LogsService {
                 "responseStream": {
                     "sessionStart": {
                         "sessionId": session_id,
-                        "logGroupIdentifiers": [],
+                        "logGroupIdentifiers": identifiers,
                     }
                 }
             }))
@@ -712,7 +720,7 @@ mod tests {
     // ---- Misc operations ----
 
     #[test]
-    fn get_log_group_fields_returns_stub() {
+    fn get_log_group_fields_returns_synthetic_fields_when_no_events() {
         let svc = make_service();
         create_group(&svc, "fields-group");
 
@@ -722,7 +730,44 @@ mod tests {
         );
         let resp = svc.get_log_group_fields(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert_eq!(body["logGroupFields"].as_array().unwrap().len(), 2);
+        let fields = body["logGroupFields"].as_array().unwrap();
+        assert_eq!(fields.len(), 3);
+        let names: Vec<&str> = fields.iter().map(|f| f["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"@timestamp"));
+        assert!(names.contains(&"@message"));
+        assert!(names.contains(&"@logStream"));
+    }
+
+    #[test]
+    fn get_log_group_fields_extracts_top_level_keys_from_json_events() {
+        let svc = make_service();
+        create_group(&svc, "json-group");
+        create_stream(&svc, "json-group", "s1");
+        put_events(
+            &svc,
+            "json-group",
+            "s1",
+            &[
+                r#"{"level":"INFO","msg":"hello","userId":"u1"}"#,
+                r#"{"level":"ERROR","msg":"bad","trace":"…"}"#,
+            ],
+        );
+
+        let req = make_request("GetLogGroupFields", json!({ "logGroupName": "json-group" }));
+        let resp = svc.get_log_group_fields(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let fields = body["logGroupFields"].as_array().unwrap();
+        let names: Vec<&str> = fields.iter().map(|f| f["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"level"));
+        assert!(names.contains(&"msg"));
+        assert!(names.contains(&"userId"));
+        assert!(names.contains(&"trace"));
+        // userId only in first event, trace only in second -> 50% each.
+        let user_id = fields
+            .iter()
+            .find(|f| f["name"].as_str().unwrap() == "userId")
+            .unwrap();
+        assert_eq!(user_id["percent"].as_i64().unwrap(), 50);
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -459,7 +459,7 @@ fn resolve_log_group_name(
 }
 
 /// Extract log group name from ARN like "arn:aws:logs:region:account:log-group:name:*"
-fn extract_log_group_from_arn(arn: &str) -> Option<String> {
+pub(crate) fn extract_log_group_from_arn(arn: &str) -> Option<String> {
     // arn:aws:logs:region:account:log-group:name:*
     let parts: Vec<&str> = arn.splitn(7, ':').collect();
     if parts.len() >= 7 && parts[5] == "log-group" {

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -15,40 +15,82 @@ impl LogsService {
 
     pub(crate) fn start_query(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let log_group_name = body["logGroupName"].as_str().ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterException",
-                "logGroupName is required",
-            )
-        })?;
+        let log_group_name = body["logGroupName"].as_str();
+        let log_group_names: Vec<String> = body["logGroupNames"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let log_group_identifiers: Vec<String> = body["logGroupIdentifiers"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
         let start_time = body["startTime"].as_i64().unwrap_or(0);
         let end_time = body["endTime"].as_i64().unwrap_or(0);
         let query_string = body["queryString"].as_str().unwrap_or("").to_string();
 
-        validate_string_length("logGroupName", log_group_name, 1, 512)?;
+        // AWS requires exactly one of logGroupName / logGroupNames / logGroupIdentifiers.
+        if log_group_name.is_none()
+            && log_group_names.is_empty()
+            && log_group_identifiers.is_empty()
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterException",
+                "logGroupName, logGroupNames or logGroupIdentifiers is required",
+            ));
+        }
+        if let Some(name) = log_group_name {
+            validate_string_length("logGroupName", name, 1, 512)?;
+        }
         validate_optional_string_length("queryString", Some(&query_string), 0, 10000)?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
-        // Verify log group exists
-        if !state.log_groups.contains_key(log_group_name) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
-                "The specified log group does not exist.",
-            ));
+        // Verify single-name shape exists, when provided. The array shapes are
+        // accepted as-is; AWS returns results keyed off whichever groups exist.
+        if let Some(name) = log_group_name {
+            if !state.log_groups.contains_key(name) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "The specified log group does not exist.",
+                ));
+            }
         }
 
         let query_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().timestamp_millis();
 
+        // Capture every group/identifier the query referenced for later
+        // `ListLogGroupsForQuery` lookups.
+        let mut all_identifiers: Vec<String> = Vec::new();
+        if let Some(name) = log_group_name {
+            all_identifiers.push(name.to_string());
+        }
+        all_identifiers.extend(log_group_names.iter().cloned());
+        all_identifiers.extend(log_group_identifiers.iter().cloned());
+
+        let primary_name = log_group_name
+            .map(String::from)
+            .or_else(|| log_group_names.first().cloned())
+            .or_else(|| log_group_identifiers.first().cloned())
+            .unwrap_or_default();
+
         state.queries.insert(
             query_id.clone(),
             QueryInfo {
                 query_id: query_id.clone(),
-                log_group_name: log_group_name.to_string(),
+                log_group_name: primary_name,
+                log_group_identifiers: all_identifiers,
                 query_string,
                 start_time,
                 end_time,
@@ -380,10 +422,19 @@ impl LogsService {
         validate_string_length("queryId", query_id, 1, 256)?;
         validate_optional_range_i64("maxResults", body["maxResults"].as_i64(), 50, 500)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
-        // Stub: return empty log group names
+
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let identifiers: Vec<String> = state
+            .queries
+            .get(query_id)
+            .map(|q| q.log_group_identifiers.clone())
+            .unwrap_or_default();
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "logGroupIdentifiers": [] })).unwrap(),
+            serde_json::to_string(&json!({ "logGroupIdentifiers": identifiers })).unwrap(),
         ))
     }
 }
@@ -673,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn list_log_groups_for_query_returns_stub_list() {
+    fn list_log_groups_for_query_returns_started_groups() {
         let svc = make_service();
         create_group(&svc, "app");
         let start = make_request(
@@ -691,7 +742,33 @@ mod tests {
         let req = make_request("ListLogGroupsForQuery", json!({"queryId": qid}));
         let resp = svc.list_log_groups_for_query(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["logGroupIdentifiers"].is_array());
+        let ids = body["logGroupIdentifiers"].as_array().unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].as_str().unwrap(), "app");
+    }
+
+    #[test]
+    fn list_log_groups_for_query_returns_array_form_groups() {
+        let svc = make_service();
+        let start = make_request(
+            "StartQuery",
+            json!({
+                "logGroupIdentifiers": [
+                    "arn:aws:logs:us-east-1:123456789012:log-group:a:*",
+                    "arn:aws:logs:us-east-1:123456789012:log-group:b:*"
+                ],
+                "startTime": 0,
+                "endTime": 0,
+                "queryString": "fields @timestamp"
+            }),
+        );
+        let resp = svc.start_query(&start).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let qid = body["queryId"].as_str().unwrap().to_string();
+        let req = make_request("ListLogGroupsForQuery", json!({"queryId": qid}));
+        let resp = svc.list_log_groups_for_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logGroupIdentifiers"].as_array().unwrap().len(), 2);
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -134,11 +134,33 @@ impl LogsService {
         // Parse the query string
         let parsed = query::parse_query(&query_info.query_string);
 
-        // Collect events by stream
+        // Collect events by stream from every group/identifier the query
+        // referenced, not just the legacy single `log_group_name`. ARNs are
+        // resolved to bare group names so multi-group StartQuery requests
+        // actually scan every requested group.
         let mut stream_events: Vec<(String, Vec<LogEvent>)> = Vec::new();
-        if let Some(group) = state.log_groups.get(&query_info.log_group_name) {
-            for stream in group.log_streams.values() {
-                stream_events.push((stream.name.clone(), stream.events.clone()));
+        let mut seen_groups: std::collections::HashSet<String> = Default::default();
+        let identifiers: Vec<String> = if query_info.log_group_identifiers.is_empty() {
+            vec![query_info.log_group_name.clone()]
+        } else {
+            query_info.log_group_identifiers.clone()
+        };
+        for identifier in identifiers {
+            let group_name = if identifier.starts_with("arn:") {
+                match super::extract_log_group_from_arn(&identifier) {
+                    Some(n) => n,
+                    None => continue,
+                }
+            } else {
+                identifier
+            };
+            if !seen_groups.insert(group_name.clone()) {
+                continue;
+            }
+            if let Some(group) = state.log_groups.get(&group_name) {
+                for stream in group.log_streams.values() {
+                    stream_events.push((stream.name.clone(), stream.events.clone()));
+                }
             }
         }
 
@@ -426,11 +448,17 @@ impl LogsService {
         let accounts = self.state.read();
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let identifiers: Vec<String> = state
+        let identifiers = state
             .queries
             .get(query_id)
             .map(|q| q.log_group_identifiers.clone())
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    "The specified query does not exist.",
+                )
+            })?;
 
         Ok(AwsResponse::json(
             StatusCode::OK,

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -217,6 +217,12 @@ pub struct Destination {
 pub struct QueryInfo {
     pub query_id: String,
     pub log_group_name: String,
+    /// Every log group / identifier referenced by this query, used by
+    /// `ListLogGroupsForQuery`. Always includes `log_group_name` plus any
+    /// names from `logGroupNames` / identifiers from `logGroupIdentifiers`
+    /// passed at start time.
+    #[serde(default)]
+    pub log_group_identifiers: Vec<String>,
     pub query_string: String,
     pub start_time: i64,
     pub end_time: i64,


### PR DESCRIPTION
## Summary
- `GetLogGroupFields`: walks every event in every stream of the target log group, parses each as JSON, tallies how often each top-level key appears. Synthetic `@timestamp` / `@message` / `@logStream` always surfaced; response uses the documented `name` + `percent` shape (not the prior `fieldName`)
- `StartQuery`: accepts the AWS-documented `logGroupNames` and `logGroupIdentifiers` arrays in addition to the single `logGroupName`. `QueryInfo` captures every group/identifier referenced
- `ListLogGroupsForQuery`: looks up the captured identifiers by `queryId` and returns them instead of an empty array
- `StartLiveTail`: echoes the requested `logGroupIdentifiers` back in `sessionStart`

## Out of scope (documented limitations)
- `GetLogObject`, `GetLogFields`, `GetLogRecord` and anomaly analysis still require Logs Insights query result generation to be wired through the event store; deferred
- Array-style metric filter patterns (`[w1, w2 = "ERROR", w3]`) — separate parser change

## Test plan
- [x] Unit: `get_log_group_fields_returns_synthetic_fields_when_no_events`, `get_log_group_fields_extracts_top_level_keys_from_json_events`, `list_log_groups_for_query_returns_started_groups`, `list_log_groups_for_query_returns_array_form_groups`
- [x] All 256 existing fakecloud-logs unit tests still green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace stubbed CloudWatch Logs APIs with real behavior and fix multi‑group query handling. `GetLogGroupFields`, `ListLogGroupsForQuery`, `StartLiveTail`, and `GetQueryResults` now read recorded events and validate inputs.

- **New Features**
  - `GetLogGroupFields`: counts top-level JSON keys across events; always includes `@timestamp`, `@message`, `@logStream`; returns `name` + `percent`.
  - `StartQuery`: accepts `logGroupNames` and `logGroupIdentifiers`; queries scan all referenced groups (ARNs resolved, duplicates deduped).
  - `ListLogGroupsForQuery`: returns captured identifiers for the `queryId`; unknown `queryId` now returns `ResourceNotFoundException`.
  - `StartLiveTail`: validates `logGroupIdentifiers` is an array of strings and echoes them in `sessionStart`.

- **Migration**
  - `GetLogGroupFields` response uses `name` instead of `fieldName`. Update consumers accordingly.

<sup>Written for commit ad110eceedb042fb937117466fdcacc171bfb132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

