### PR TITLE
feat(ssm): real patch + association + document metadata tracking

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm_patch_tracking.rs
+++ b/crates/fakecloud-e2e/tests/ssm_patch_tracking.rs
@@ -1,0 +1,294 @@
+mod helpers;
+
+use std::collections::HashMap;
+
+use aws_sdk_ssm::types::{
+    DocumentMetadataEnum, DocumentReviewAction, DocumentReviewCommentSource,
+    DocumentReviewCommentType, DocumentReviews, InventoryItem, OperatingSystem,
+    PatchOrchestratorFilter, PatchProperty, Target,
+};
+use helpers::TestServer;
+
+#[tokio::test]
+async fn describe_patch_properties_returns_aws_classifications() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let resp = client
+        .describe_patch_properties()
+        .operating_system(OperatingSystem::Windows)
+        .property(PatchProperty::PatchClassification)
+        .send()
+        .await
+        .unwrap();
+
+    let props = resp.properties();
+    assert!(!props.is_empty(), "expected windows classifications");
+    assert!(props
+        .iter()
+        .any(|p| p.get("CLASSIFICATION").map(|s| s.as_str()) == Some("SecurityUpdates")));
+}
+
+#[tokio::test]
+async fn describe_effective_patches_projects_baseline_approvals() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let baseline = client
+        .create_patch_baseline()
+        .name("e2e-baseline")
+        .operating_system(OperatingSystem::Windows)
+        .approved_patches("KB-1001")
+        .approved_patches("KB-1002")
+        .approved_patches_compliance_level(aws_sdk_ssm::types::PatchComplianceLevel::Critical)
+        .send()
+        .await
+        .unwrap();
+    let baseline_id = baseline.baseline_id().unwrap().to_string();
+
+    let resp = client
+        .describe_effective_patches_for_patch_baseline()
+        .baseline_id(baseline_id)
+        .send()
+        .await
+        .unwrap();
+
+    let effective = resp.effective_patches();
+    assert_eq!(effective.len(), 2);
+    let ids: Vec<&str> = effective
+        .iter()
+        .filter_map(|p| p.patch().and_then(|x| x.id()))
+        .collect();
+    assert!(ids.contains(&"KB-1001"));
+    assert!(ids.contains(&"KB-1002"));
+}
+
+#[tokio::test]
+async fn describe_instance_patches_surfaces_inventory_compliance() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let mut row = HashMap::new();
+    row.insert("Title".to_string(), "KB-9000 Critical update".to_string());
+    row.insert("KBId".to_string(), "KB-9000".to_string());
+    row.insert("Classification".to_string(), "SecurityUpdates".to_string());
+    row.insert("Severity".to_string(), "Critical".to_string());
+    row.insert("State".to_string(), "Installed".to_string());
+    row.insert(
+        "InstalledTime".to_string(),
+        "2026-04-25T12:00:00Z".to_string(),
+    );
+
+    let item = InventoryItem::builder()
+        .type_name("AWS:PatchCompliance")
+        .schema_version("1.0")
+        .capture_time("2026-04-25T12:00:00Z")
+        .content(row)
+        .build()
+        .unwrap();
+
+    client
+        .put_inventory()
+        .instance_id("i-e2etest1234567890")
+        .items(item)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_instance_patches()
+        .instance_id("i-e2etest1234567890")
+        .send()
+        .await
+        .unwrap();
+
+    let patches = resp.patches();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0].kb_id(), "KB-9000");
+    assert_eq!(patches[0].classification(), "SecurityUpdates");
+    assert_eq!(patches[0].severity(), "Critical");
+}
+
+#[tokio::test]
+async fn describe_instance_patch_states_uses_inventory_summary() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let mut row = HashMap::new();
+    row.insert(
+        "BaselineId".to_string(),
+        "pb-summary-test-12345".to_string(),
+    );
+    row.insert("PatchGroup".to_string(), "prod".to_string());
+    row.insert("InstalledCount".to_string(), "12".to_string());
+    row.insert("MissingCount".to_string(), "3".to_string());
+    row.insert("FailedCount".to_string(), "1".to_string());
+    row.insert("Operation".to_string(), "Scan".to_string());
+    row.insert(
+        "OperationStartTime".to_string(),
+        "2026-04-25T11:00:00Z".to_string(),
+    );
+    row.insert(
+        "OperationEndTime".to_string(),
+        "2026-04-25T11:05:00Z".to_string(),
+    );
+
+    let item = InventoryItem::builder()
+        .type_name("AWS:PatchSummary")
+        .schema_version("1.0")
+        .capture_time("2026-04-25T11:05:00Z")
+        .content(row)
+        .build()
+        .unwrap();
+
+    client
+        .put_inventory()
+        .instance_id("i-summary-test-1234")
+        .items(item)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_instance_patch_states()
+        .instance_ids("i-summary-test-1234")
+        .send()
+        .await
+        .unwrap();
+
+    let states = resp.instance_patch_states();
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0].installed_count(), 12);
+    assert_eq!(states[0].missing_count(), 3);
+    assert_eq!(states[0].failed_count(), 1);
+    assert_eq!(states[0].patch_group(), "prod");
+}
+
+#[tokio::test]
+async fn document_metadata_history_round_trip() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    client
+        .create_document()
+        .name("e2e-review-doc")
+        .content(r#"{"schemaVersion":"2.2","mainSteps":[]}"#)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let comment = DocumentReviewCommentSource::builder()
+        .r#type(DocumentReviewCommentType::Comment)
+        .content("approved by e2e")
+        .build();
+
+    let reviews = DocumentReviews::builder()
+        .action(DocumentReviewAction::Approve)
+        .comment(comment)
+        .build()
+        .unwrap();
+
+    client
+        .update_document_metadata()
+        .name("e2e-review-doc")
+        .document_reviews(reviews)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_document_metadata_history()
+        .name("e2e-review-doc")
+        .metadata(DocumentMetadataEnum::DocumentReviews)
+        .send()
+        .await
+        .unwrap();
+
+    let metadata = resp.metadata().unwrap();
+    let responses = metadata.reviewer_response();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].review_status().unwrap().as_str(), "APPROVED");
+    let comments = responses[0].comment();
+    assert_eq!(comments.len(), 1);
+    assert_eq!(comments[0].content().unwrap(), "approved by e2e");
+}
+
+#[tokio::test]
+async fn start_associations_once_marks_pending() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    client
+        .create_document()
+        .name("e2e-assoc-doc")
+        .content(r#"{"schemaVersion":"2.2","mainSteps":[]}"#)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let assoc = client
+        .create_association()
+        .name("e2e-assoc-doc")
+        .targets(
+            Target::builder()
+                .key("InstanceIds")
+                .values("i-assoc1234")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let assoc_id = assoc
+        .association_description()
+        .and_then(|a| a.association_id())
+        .unwrap()
+        .to_string();
+
+    client
+        .start_associations_once()
+        .association_ids(assoc_id.clone())
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_association()
+        .association_id(assoc_id)
+        .send()
+        .await
+        .unwrap();
+
+    let desc = resp.association_description().unwrap();
+    assert_eq!(desc.status().unwrap().name().as_str(), "Pending");
+    assert!(desc.last_execution_date().is_some());
+}
+
+#[tokio::test]
+async fn describe_patch_baselines_filter_unknown_keys_passthrough() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    client
+        .create_patch_baseline()
+        .name("e2e-filter-baseline")
+        .operating_system(OperatingSystem::AmazonLinux2)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .describe_patch_baselines()
+        .filters(
+            PatchOrchestratorFilter::builder()
+                .key("UnknownKey")
+                .values("ignored")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert!(!resp.baseline_identities().is_empty());
+}

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -406,10 +406,28 @@ impl SsmService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _association_ids = body["AssociationIds"]
+        let association_ids = body["AssociationIds"]
             .as_array()
             .ok_or_else(|| missing("AssociationIds"))?;
-        // No-op: return success
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let now = Utc::now();
+
+        for id in association_ids.iter().filter_map(|v| v.as_str()) {
+            if let Some(assoc) = state.associations.get_mut(id) {
+                assoc.status = "Pending".to_string();
+                assoc.status_date = now;
+                assoc.last_update_association_date = now;
+                assoc.last_execution_date = Some(now);
+            } else {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "AssociationDoesNotExist",
+                    format!("The specified association {id} does not exist."),
+                ));
+            }
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-ssm/src/service/associations.rs
+++ b/crates/fakecloud-ssm/src/service/associations.rs
@@ -410,22 +410,33 @@ impl SsmService {
             .as_array()
             .ok_or_else(|| missing("AssociationIds"))?;
 
+        let ids: Vec<String> = association_ids
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let now = Utc::now();
 
-        for id in association_ids.iter().filter_map(|v| v.as_str()) {
-            if let Some(assoc) = state.associations.get_mut(id) {
-                assoc.status = "Pending".to_string();
-                assoc.status_date = now;
-                assoc.last_update_association_date = now;
-                assoc.last_execution_date = Some(now);
-            } else {
+        // Validate every association exists before mutating any of them so we
+        // never leave half the batch flipped to Pending on a failed call.
+        for id in &ids {
+            if !state.associations.contains_key(id) {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "AssociationDoesNotExist",
                     format!("The specified association {id} does not exist."),
                 ));
+            }
+        }
+
+        let now = Utc::now();
+        for id in &ids {
+            if let Some(assoc) = state.associations.get_mut(id) {
+                assoc.status = "Pending".to_string();
+                assoc.status_date = now;
+                assoc.last_update_association_date = now;
+                assoc.last_execution_date = Some(now);
             }
         }
         Ok(AwsResponse::ok_json(json!({})))

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -812,6 +812,7 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("Metadata"))?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
 
         let accounts = self.state.read();
         let empty = SsmState::new(&req.account_id, &req.region);
@@ -821,7 +822,7 @@ impl SsmService {
             .get(name)
             .ok_or_else(|| doc_not_found(name))?;
 
-        let reviewer_response: Vec<Value> = doc
+        let all_responses: Vec<Value> = doc
             .reviews
             .iter()
             .map(|r| {
@@ -838,14 +839,21 @@ impl SsmService {
             })
             .collect();
 
-        Ok(AwsResponse::ok_json(json!({
+        let (page, next_token) = paginate(&all_responses, body["NextToken"].as_str(), max_results);
+
+        let mut resp = json!({
             "Name": name,
             "DocumentVersion": doc.default_version,
             "Author": doc.owner,
             "Metadata": {
-                "ReviewerResponse": reviewer_response,
+                "ReviewerResponse": page,
             },
-        })))
+        });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn update_document_metadata(

--- a/crates/fakecloud-ssm/src/service/documents.rs
+++ b/crates/fakecloud-ssm/src/service/documents.rs
@@ -13,6 +13,15 @@ use sha2::{Digest, Sha256};
 
 use super::{missing, SsmService};
 
+fn review_status_for_action(action: &str) -> &'static str {
+    match action {
+        "Approve" => "APPROVED",
+        "Reject" => "REJECTED",
+        "SendForReview" => "PENDING",
+        _ => "NOT_REVIEWED",
+    }
+}
+
 /// Resolve which `SsmDocumentVersion` a `GetDocument`-style request is
 /// asking for. AWS lets the caller pin a version with `DocumentVersion`,
 /// `VersionName`, both, or neither (in which case we return the document's
@@ -142,6 +151,7 @@ fn document_matches_list_filters(
             "Name" if !values.contains(&doc.name.as_str()) => {
                 return false;
             }
+            // Unknown filter keys: AWS silently ignores them.
             _ => {}
         }
     }
@@ -248,6 +258,7 @@ impl SsmService {
             owner: state.account_id.clone(),
             status: "Active".to_string(),
             permissions: HashMap::new(),
+            reviews: Vec::new(),
         };
 
         state.documents.insert(name.clone(), doc);
@@ -794,7 +805,7 @@ impl SsmService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
         validate_required("Metadata", &body["Metadata"])?;
         validate_optional_enum("Metadata", body["Metadata"].as_str(), &["DocumentReviews"])?;
         let _metadata = body["Metadata"]
@@ -802,13 +813,38 @@ impl SsmService {
             .ok_or_else(|| missing("Metadata"))?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
 
-        // Stub: return empty metadata
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let doc = state
+            .documents
+            .get(name)
+            .ok_or_else(|| doc_not_found(name))?;
+
+        let reviewer_response: Vec<Value> = doc
+            .reviews
+            .iter()
+            .map(|r| {
+                json!({
+                    "Reviewer": r.reviewer,
+                    "ReviewStatus": review_status_for_action(&r.action),
+                    "Comment": r.comment.iter().map(|c| json!({
+                        "Type": c.comment_type,
+                        "Content": c.content,
+                    })).collect::<Vec<_>>(),
+                    "CreateTime": r.created_time.timestamp_millis() as f64 / 1000.0,
+                    "UpdatedTime": r.updated_time.timestamp_millis() as f64 / 1000.0,
+                })
+            })
+            .collect();
+
         Ok(AwsResponse::ok_json(json!({
-            "Name": _name,
-            "Author": "",
+            "Name": name,
+            "DocumentVersion": doc.default_version,
+            "Author": doc.owner,
             "Metadata": {
-                "ReviewerResponse": []
-            }
+                "ReviewerResponse": reviewer_response,
+            },
         })))
     }
 
@@ -817,16 +853,51 @@ impl SsmService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let name = body["Name"].as_str().ok_or_else(|| missing("Name"))?;
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        validate_required("DocumentReviews", &body["DocumentReviews"])?;
+        let action = body["DocumentReviews"]["Action"]
+            .as_str()
+            .ok_or_else(|| missing("DocumentReviews.Action"))?;
+        validate_optional_enum(
+            "DocumentReviews.Action",
+            Some(action),
+            &["SendForReview", "UpdateReview", "Approve", "Reject"],
+        )?;
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        if !state.documents.contains_key(name) {
-            return Err(doc_not_found(name));
-        }
+        let comments: Vec<crate::state::DocumentReviewComment> = body["DocumentReviews"]["Comment"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| {
+                        let content = c["Content"].as_str()?;
+                        Some(crate::state::DocumentReviewComment {
+                            comment_type: c["Type"].as_str().unwrap_or("Comment").to_string(),
+                            content: content.to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
-        // Stub: accept but do nothing
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let doc = state
+            .documents
+            .get_mut(&name)
+            .ok_or_else(|| doc_not_found(&name))?;
+
+        let now = chrono::Utc::now();
+        doc.reviews.push(crate::state::DocumentReview {
+            reviewer: state.account_id.clone(),
+            action: action.to_string(),
+            comment: comments,
+            created_time: now,
+            updated_time: now,
+        });
+
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -172,6 +172,7 @@ impl SsmService {
                                     return false;
                                 }
                             }
+                            // Unknown filter keys: AWS silently ignores them.
                             _ => {}
                         }
                     }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -841,13 +841,59 @@ mod tests {
     }
 
     #[test]
-    fn start_associations_once_noop() {
+    fn start_associations_once_unknown_id_errors() {
         let svc = make_service();
         let req = make_request(
             "StartAssociationsOnce",
             json!({ "AssociationIds": ["fake-id"] }),
         );
+        assert!(svc.start_associations_once(&req).is_err());
+    }
+
+    #[test]
+    fn start_associations_once_marks_pending_and_records_execution() {
+        let svc = make_service();
+
+        // Create a document to associate against
+        let req = make_request(
+            "CreateDocument",
+            json!({
+                "Name": "doc-for-assoc",
+                "Content": "{\"schemaVersion\": \"2.2\"}",
+                "DocumentType": "Command",
+            }),
+        );
+        svc.create_document(&req).unwrap();
+
+        // Create association
+        let req = make_request(
+            "CreateAssociation",
+            json!({
+                "Name": "doc-for-assoc",
+                "Targets": [{"Key": "InstanceIds", "Values": ["i-1234"]}],
+            }),
+        );
+        let resp = svc.create_association(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let assoc_id = body["AssociationDescription"]["AssociationId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Trigger StartAssociationsOnce
+        let req = make_request(
+            "StartAssociationsOnce",
+            json!({ "AssociationIds": [assoc_id] }),
+        );
         svc.start_associations_once(&req).unwrap();
+
+        // Verify status flipped to Pending and last_execution_date is set
+        let req = make_request("DescribeAssociation", json!({ "AssociationId": assoc_id }));
+        let resp = svc.describe_association(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let desc = &body["AssociationDescription"];
+        assert_eq!(desc["Status"]["Name"], "Pending");
+        assert!(desc["LastExecutionDate"].is_number());
     }
 
     // -- OpsItems --
@@ -1106,7 +1152,7 @@ mod tests {
     }
 
     #[test]
-    fn describe_patch_properties_returns_empty() {
+    fn describe_patch_properties_windows_products() {
         let svc = make_service();
         let req = make_request(
             "DescribePatchProperties",
@@ -1114,7 +1160,9 @@ mod tests {
         );
         let resp = svc.describe_patch_properties(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["Properties"].as_array().unwrap().is_empty());
+        let props = body["Properties"].as_array().unwrap();
+        assert!(!props.is_empty());
+        assert!(props.iter().any(|p| p["PRODUCT"] == "Windows10"));
     }
 
     // ── Inventory ─────────────────────────────────────────────────
@@ -1602,10 +1650,10 @@ mod tests {
         assert!(body["ResourceDataSyncItems"].as_array().unwrap().is_empty());
     }
 
-    // ── Patch stubs ───────────────────────────────────────────────
+    // ── Patch describes ───────────────────────────────────────────
 
     #[test]
-    fn describe_instance_patch_states_returns_empty() {
+    fn describe_instance_patch_states_returns_empty_for_unknown_instance() {
         let svc = make_service();
         let req = make_request(
             "DescribeInstancePatchStates",
@@ -1617,7 +1665,7 @@ mod tests {
     }
 
     #[test]
-    fn describe_instance_patches_returns_empty() {
+    fn describe_instance_patches_returns_empty_for_unknown_instance() {
         let svc = make_service();
         let req = make_request("DescribeInstancePatches", json!({ "InstanceId": "i-001" }));
         let resp = svc.describe_instance_patches(&req).unwrap();
@@ -1626,17 +1674,95 @@ mod tests {
     }
 
     #[test]
-    fn describe_effective_patches_returns_empty() {
+    fn describe_effective_patches_for_unknown_baseline_errors() {
         let svc = make_service();
         let req = make_request(
             "DescribeEffectivePatchesForPatchBaseline",
             json!({ "BaselineId": "pb-12345678901234567" }),
         );
+        assert!(svc
+            .describe_effective_patches_for_patch_baseline(&req)
+            .is_err());
+    }
+
+    #[test]
+    fn describe_effective_patches_returns_approved_for_real_baseline() {
+        let svc = make_service();
+        let req = make_request(
+            "CreatePatchBaseline",
+            json!({
+                "Name": "real-baseline",
+                "OperatingSystem": "WINDOWS",
+                "ApprovedPatches": ["KB12345", "KB67890"],
+                "ApprovedPatchesComplianceLevel": "CRITICAL",
+            }),
+        );
+        let resp = svc.create_patch_baseline(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let baseline_id = body["BaselineId"].as_str().unwrap().to_string();
+
+        let req = make_request(
+            "DescribeEffectivePatchesForPatchBaseline",
+            json!({ "BaselineId": baseline_id }),
+        );
         let resp = svc
             .describe_effective_patches_for_patch_baseline(&req)
             .unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["EffectivePatches"].as_array().unwrap().is_empty());
+        let patches = body["EffectivePatches"].as_array().unwrap();
+        assert_eq!(patches.len(), 2);
+        assert_eq!(patches[0]["PatchStatus"]["ComplianceLevel"], "CRITICAL");
+    }
+
+    #[test]
+    fn describe_patch_properties_returns_known_classifications() {
+        let svc = make_service();
+        let req = make_request(
+            "DescribePatchProperties",
+            json!({ "OperatingSystem": "WINDOWS", "Property": "CLASSIFICATION" }),
+        );
+        let resp = svc.describe_patch_properties(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let props = body["Properties"].as_array().unwrap();
+        assert!(!props.is_empty());
+        assert!(props
+            .iter()
+            .any(|p| p["CLASSIFICATION"] == "SecurityUpdates"));
+    }
+
+    #[test]
+    fn describe_instance_patches_surfaces_inventory_compliance() {
+        let svc = make_service();
+        let req = make_request(
+            "PutInventory",
+            json!({
+                "InstanceId": "i-002",
+                "Items": [{
+                    "TypeName": "AWS:PatchCompliance",
+                    "SchemaVersion": "1.0",
+                    "CaptureTime": "2026-04-25T20:00:00Z",
+                    "Content": [
+                        {
+                            "Title": "KB987654",
+                            "KBId": "KB987654",
+                            "Classification": "SecurityUpdates",
+                            "Severity": "Critical",
+                            "State": "Installed",
+                            "InstalledTime": "2026-04-25T19:00:00Z"
+                        }
+                    ]
+                }]
+            }),
+        );
+        svc.put_inventory(&req).unwrap();
+
+        let req = make_request("DescribeInstancePatches", json!({ "InstanceId": "i-002" }));
+        let resp = svc.describe_instance_patches(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let patches = body["Patches"].as_array().unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0]["KBId"], "KB987654");
+        assert_eq!(patches[0]["Classification"], "SecurityUpdates");
     }
 
     #[test]
@@ -4353,16 +4479,43 @@ mod tests {
     #[test]
     fn update_document_metadata_not_found() {
         let svc = make_service();
-        let req = make_request("UpdateDocumentMetadata", json!({"Name": "missing"}));
+        let req = make_request(
+            "UpdateDocumentMetadata",
+            json!({
+                "Name": "missing",
+                "DocumentReviews": {"Action": "SendForReview"},
+            }),
+        );
         assert!(svc.update_document_metadata(&req).is_err());
     }
 
     #[test]
-    fn update_document_metadata_existing() {
+    fn update_document_metadata_persists_review_history() {
         let svc = make_service();
         create_doc_basic(&svc, "DocB");
-        let req = make_request("UpdateDocumentMetadata", json!({"Name": "DocB"}));
+
+        let req = make_request(
+            "UpdateDocumentMetadata",
+            json!({
+                "Name": "DocB",
+                "DocumentReviews": {
+                    "Action": "Approve",
+                    "Comment": [{"Type": "Comment", "Content": "lgtm"}]
+                }
+            }),
+        );
         svc.update_document_metadata(&req).unwrap();
+
+        let req = make_request(
+            "ListDocumentMetadataHistory",
+            json!({"Name": "DocB", "Metadata": "DocumentReviews"}),
+        );
+        let resp = svc.list_document_metadata_history(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let responses = body["Metadata"]["ReviewerResponse"].as_array().unwrap();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["ReviewStatus"], "APPROVED");
+        assert_eq!(responses[0]["Comment"][0]["Content"], "lgtm");
     }
 
     #[test]

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -119,6 +119,7 @@ impl SsmService {
                                 if !values.contains(&pb.operating_system.as_str()) => {
                                     return false;
                                 }
+                            // Unknown filter keys: AWS silently ignores them.
                             _ => {}
                         }
                     }
@@ -404,6 +405,7 @@ impl SsmService {
                                     }
                                 }
                             }
+                            // Unknown filter keys: AWS silently ignores them.
                             _ => {}
                         }
                     }
@@ -525,11 +527,27 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
-        let _instance_ids = body["InstanceIds"]
+        let instance_ids = body["InstanceIds"]
             .as_array()
             .ok_or_else(|| missing("InstanceIds"))?;
-        // Return empty - no real instances in emulator
-        Ok(AwsResponse::ok_json(json!({ "InstancePatchStates": [] })))
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        let all: Vec<Value> = instance_ids
+            .iter()
+            .filter_map(|v| v.as_str())
+            .filter_map(|iid| build_instance_patch_state(state, iid))
+            .collect();
+
+        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let mut resp = json!({ "InstancePatchStates": page });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_instance_patch_states_for_patch_group(
@@ -539,10 +557,28 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_string_length("PatchGroup", body["PatchGroup"].as_str(), 1, 256)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
-        let _patch_group = body["PatchGroup"]
+        let patch_group = body["PatchGroup"]
             .as_str()
             .ok_or_else(|| missing("PatchGroup"))?;
-        Ok(AwsResponse::ok_json(json!({ "InstancePatchStates": [] })))
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        let all: Vec<Value> = state
+            .inventory_entries
+            .keys()
+            .filter(|iid| instance_in_patch_group(state, iid, patch_group))
+            .filter_map(|iid| build_instance_patch_state(state, iid))
+            .collect();
+
+        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let mut resp = json!({ "InstancePatchStates": page });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_instance_patches(
@@ -551,10 +587,50 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 10, 100)?;
-        let _instance_id = body["InstanceId"]
+        let instance_id = body["InstanceId"]
             .as_str()
             .ok_or_else(|| missing("InstanceId"))?;
-        Ok(AwsResponse::ok_json(json!({ "Patches": [] })))
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        let patches: Vec<Value> = state
+            .inventory_entries
+            .get(instance_id)
+            .map(|entry| {
+                entry
+                    .items
+                    .iter()
+                    .filter(|i| {
+                        i.type_name == "AWS:PatchCompliance" || i.type_name == "AWS:Patch"
+                    })
+                    .flat_map(|i| i.content.iter())
+                    .map(|row| {
+                        let installed_time = row
+                            .get("InstalledTime")
+                            .map(|s| parse_iso8601_epoch_seconds(s))
+                            .unwrap_or(0.0);
+                        json!({
+                            "Title": row.get("Title").cloned().unwrap_or_default(),
+                            "KBId": row.get("KBId").cloned().unwrap_or_default(),
+                            "Classification": row.get("Classification").cloned().unwrap_or_default(),
+                            "Severity": row.get("Severity").cloned().unwrap_or_default(),
+                            "State": row.get("State").cloned().unwrap_or_else(|| "Installed".to_string()),
+                            "InstalledTime": installed_time,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let (page, next_token) = paginate(&patches, body["NextToken"].as_str(), max_results);
+        let mut resp = json!({ "Patches": page });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_effective_patches_for_patch_baseline(
@@ -564,10 +640,62 @@ impl SsmService {
         let body = req.json_body();
         validate_optional_string_length("BaselineId", body["BaselineId"].as_str(), 20, 128)?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 100)?;
-        let _baseline_id = body["BaselineId"]
+        let baseline_id = body["BaselineId"]
             .as_str()
             .ok_or_else(|| missing("BaselineId"))?;
-        Ok(AwsResponse::ok_json(json!({ "EffectivePatches": [] })))
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let pb = state.patch_baselines.get(baseline_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DoesNotExistException",
+                format!("Patch baseline {baseline_id} does not exist"),
+            )
+        })?;
+
+        // Synthesize an effective patch entry from each approved patch ID.
+        // AWS effective patches come from a curated catalog; here we project
+        // baseline-approved IDs into the response shape so callers see the
+        // approval level/state mapping they configured.
+        let now = chrono::Utc::now();
+        let effective: Vec<Value> = pb
+            .approved_patches
+            .iter()
+            .map(|patch_id| {
+                json!({
+                    "Patch": {
+                        "Id": patch_id,
+                        "ReleaseDate": now.timestamp_millis() as f64 / 1000.0,
+                        "Title": patch_id,
+                        "Description": format!("Approved patch {patch_id} (synthetic)"),
+                        "ContentUrl": Value::Null,
+                        "Vendor": "AWS",
+                        "ProductFamily": "Linux",
+                        "Product": pb.operating_system,
+                        "Classification": "SecurityUpdates",
+                        "MsrcSeverity": pb.approved_patches_compliance_level,
+                        "KbNumber": patch_id,
+                        "MsrcNumber": Value::Null,
+                        "Language": Value::Null,
+                    },
+                    "PatchStatus": {
+                        "DeploymentStatus": "APPROVED",
+                        "ComplianceLevel": pb.approved_patches_compliance_level,
+                        "ApprovalDate": now.timestamp_millis() as f64 / 1000.0,
+                    },
+                })
+            })
+            .collect();
+
+        let (page, next_token) = paginate(&effective, body["NextToken"].as_str(), max_results);
+        let mut resp = json!({ "EffectivePatches": page });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_deployable_patch_snapshot_for_instance(
@@ -664,7 +792,26 @@ impl SsmService {
             &["OS", "APPLICATION"],
         )?;
         validate_optional_range_i64("MaxResults", body["MaxResults"].as_i64(), 1, 50)?;
-        Ok(AwsResponse::ok_json(json!({ "Properties": [] })))
+        let os = body["OperatingSystem"].as_str().unwrap_or("WINDOWS");
+        let property = body["Property"].as_str().unwrap_or("");
+        let max_results = body["MaxResults"].as_i64().unwrap_or(50) as usize;
+
+        let values = patch_property_values(os, property);
+        let all: Vec<Value> = values
+            .iter()
+            .map(|v| {
+                let mut entry = serde_json::Map::new();
+                entry.insert(property.to_string(), Value::String((*v).to_string()));
+                Value::Object(entry)
+            })
+            .collect();
+
+        let (page, next_token) = paginate(&all, body["NextToken"].as_str(), max_results);
+        let mut resp = json!({ "Properties": page });
+        if let Some(token) = next_token {
+            resp["NextToken"] = json!(token);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_default_patch_baseline(
@@ -886,6 +1033,151 @@ impl CreatePatchBaselineInput {
             client_token: body["ClientToken"].as_str().map(|s| s.to_string()),
             tags,
         })
+    }
+}
+
+/// Build a single `InstancePatchState` entry from inventory data captured for
+/// the instance via `PutInventory` (typically `AWS:PatchSummary` rows). Returns
+/// `None` if the instance is unknown or has no patch summary recorded.
+fn build_instance_patch_state(state: &SsmState, instance_id: &str) -> Option<Value> {
+    let entry = state.inventory_entries.get(instance_id)?;
+    let summary = entry
+        .items
+        .iter()
+        .find(|i| i.type_name == "AWS:PatchSummary");
+    let row = summary.and_then(|s| s.content.first());
+
+    let baseline_id = row
+        .and_then(|r| r.get("BaselineId").cloned())
+        .or_else(|| state.default_patch_baseline_id.clone())
+        .unwrap_or_default();
+    let patch_group = row
+        .and_then(|r| r.get("PatchGroup").cloned())
+        .or_else(|| {
+            state
+                .patch_groups
+                .iter()
+                .find(|pg| pg.baseline_id == baseline_id)
+                .map(|pg| pg.patch_group.clone())
+        })
+        .unwrap_or_default();
+
+    let i64_field = |key: &str| -> i64 {
+        row.and_then(|r| r.get(key))
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0)
+    };
+    let str_field = |key: &str, default: &str| -> String {
+        row.and_then(|r| r.get(key).cloned())
+            .unwrap_or_else(|| default.to_string())
+    };
+    let ts_field = |key: &str| -> f64 {
+        let raw = str_field(key, "1970-01-01T00:00:00Z");
+        parse_iso8601_epoch_seconds(&raw)
+    };
+
+    Some(json!({
+        "InstanceId": instance_id,
+        "PatchGroup": patch_group,
+        "BaselineId": baseline_id,
+        "OperationStartTime": ts_field("OperationStartTime"),
+        "OperationEndTime": ts_field("OperationEndTime"),
+        "Operation": str_field("Operation", "Scan"),
+        "InstalledCount": i64_field("InstalledCount"),
+        "InstalledOtherCount": i64_field("InstalledOtherCount"),
+        "InstalledPendingRebootCount": i64_field("InstalledPendingRebootCount"),
+        "InstalledRejectedCount": i64_field("InstalledRejectedCount"),
+        "MissingCount": i64_field("MissingCount"),
+        "FailedCount": i64_field("FailedCount"),
+        "UnreportedNotApplicableCount": i64_field("UnreportedNotApplicableCount"),
+        "NotApplicableCount": i64_field("NotApplicableCount"),
+        "CriticalNonCompliantCount": i64_field("CriticalNonCompliantCount"),
+        "SecurityNonCompliantCount": i64_field("SecurityNonCompliantCount"),
+        "OtherNonCompliantCount": i64_field("OtherNonCompliantCount"),
+    }))
+}
+
+/// Parse an RFC 3339 / ISO 8601 timestamp string into Unix epoch seconds as
+/// the floating-point form AWS Smithy clients expect for timestamp shapes.
+/// Falls back to 0.0 if the string isn't parseable.
+fn parse_iso8601_epoch_seconds(s: &str) -> f64 {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.timestamp_millis() as f64 / 1000.0)
+        .unwrap_or(0.0)
+}
+
+/// Decide whether an instance belongs to a patch group based on either the
+/// `AWS:PatchSummary` inventory tag or its `AWS:InstanceInformation` patch
+/// group association recorded by the agent.
+fn instance_in_patch_group(state: &SsmState, instance_id: &str, patch_group: &str) -> bool {
+    let Some(entry) = state.inventory_entries.get(instance_id) else {
+        return false;
+    };
+    entry.items.iter().any(|i| {
+        (i.type_name == "AWS:PatchSummary" || i.type_name == "AWS:InstanceInformation")
+            && i.content
+                .iter()
+                .any(|row| row.get("PatchGroup").map(|s| s.as_str()) == Some(patch_group))
+    })
+}
+
+/// Catalogue of values returned by `DescribePatchProperties`. Mirrors the
+/// AWS-published patch metadata catalog without pulling a live feed; covers
+/// the values realistic SSM clients filter on.
+fn patch_property_values(os: &str, property: &str) -> &'static [&'static str] {
+    match (os, property) {
+        ("WINDOWS", "PRODUCT") => &[
+            "Windows10",
+            "Windows11",
+            "WindowsServer2016",
+            "WindowsServer2019",
+            "WindowsServer2022",
+        ],
+        ("WINDOWS", "PRODUCT_FAMILY") => &["Windows"],
+        ("WINDOWS", "CLASSIFICATION") => &[
+            "CriticalUpdates",
+            "DefinitionUpdates",
+            "FeaturePacks",
+            "SecurityUpdates",
+            "ServicePacks",
+            "Tools",
+            "UpdateRollups",
+            "Updates",
+            "Upgrades",
+        ],
+        ("WINDOWS", "MSRC_SEVERITY") => {
+            &["Critical", "Important", "Low", "Moderate", "Unspecified"]
+        }
+        ("AMAZON_LINUX", "PRODUCT")
+        | ("AMAZON_LINUX_2", "PRODUCT")
+        | ("AMAZON_LINUX_2022", "PRODUCT")
+        | ("AMAZON_LINUX_2023", "PRODUCT") => &["AmazonLinux"],
+        ("UBUNTU", "PRODUCT") => &[
+            "Ubuntu14.04",
+            "Ubuntu16.04",
+            "Ubuntu18.04",
+            "Ubuntu20.04",
+            "Ubuntu22.04",
+        ],
+        ("REDHAT_ENTERPRISE_LINUX", "PRODUCT") => &[
+            "RedhatEnterpriseLinux7",
+            "RedhatEnterpriseLinux8",
+            "RedhatEnterpriseLinux9",
+        ],
+        ("DEBIAN", "PRODUCT") => &["Debian10", "Debian11", "Debian12"],
+        ("MACOS", "PRODUCT") => &["MacOS"],
+        ("MACOS", "PRODUCT_FAMILY") => &["macOS"],
+        (_, "PRODUCT_FAMILY") => &["Linux"],
+        (_, "CLASSIFICATION") => &[
+            "Security",
+            "Bugfix",
+            "Enhancement",
+            "Recommended",
+            "Newpackage",
+        ],
+        (_, "PRIORITY") => &["Critical", "Important", "Medium", "Low", "Unspecified"],
+        (_, "SEVERITY") => &["Critical", "Important", "Medium", "Low", "Unspecified"],
+        _ => &[],
     }
 }
 

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -1072,9 +1072,7 @@ fn build_instance_patch_state(state: &SsmState, instance_id: &str) -> Option<Val
             .unwrap_or(0)
     };
     let str_field = |key: &str, default: &str| -> String {
-        row.get(key)
-            .cloned()
-            .unwrap_or_else(|| default.to_string())
+        row.get(key).cloned().unwrap_or_else(|| default.to_string())
     };
     let ts_field = |key: &str| -> f64 {
         let raw = str_field(key, "1970-01-01T00:00:00Z");

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -1037,22 +1037,26 @@ impl CreatePatchBaselineInput {
 }
 
 /// Build a single `InstancePatchState` entry from inventory data captured for
-/// the instance via `PutInventory` (typically `AWS:PatchSummary` rows). Returns
-/// `None` if the instance is unknown or has no patch summary recorded.
+/// the instance via `PutInventory`. Requires an `AWS:PatchSummary` item with
+/// at least one row to exist for the instance — otherwise returns `None`, so
+/// instances that never reported back are omitted rather than reported with
+/// fabricated zero defaults.
 fn build_instance_patch_state(state: &SsmState, instance_id: &str) -> Option<Value> {
     let entry = state.inventory_entries.get(instance_id)?;
     let summary = entry
         .items
         .iter()
-        .find(|i| i.type_name == "AWS:PatchSummary");
-    let row = summary.and_then(|s| s.content.first());
+        .find(|i| i.type_name == "AWS:PatchSummary")?;
+    let row = summary.content.first()?;
 
     let baseline_id = row
-        .and_then(|r| r.get("BaselineId").cloned())
+        .get("BaselineId")
+        .cloned()
         .or_else(|| state.default_patch_baseline_id.clone())
         .unwrap_or_default();
     let patch_group = row
-        .and_then(|r| r.get("PatchGroup").cloned())
+        .get("PatchGroup")
+        .cloned()
         .or_else(|| {
             state
                 .patch_groups
@@ -1063,12 +1067,13 @@ fn build_instance_patch_state(state: &SsmState, instance_id: &str) -> Option<Val
         .unwrap_or_default();
 
     let i64_field = |key: &str| -> i64 {
-        row.and_then(|r| r.get(key))
+        row.get(key)
             .and_then(|v| v.parse::<i64>().ok())
             .unwrap_or(0)
     };
     let str_field = |key: &str, default: &str| -> String {
-        row.and_then(|r| r.get(key).cloned())
+        row.get(key)
+            .cloned()
             .unwrap_or_else(|| default.to_string())
     };
     let ts_field = |key: &str| -> f64 {

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -49,6 +49,23 @@ pub struct SsmDocument {
     pub owner: String,
     pub status: String,
     pub permissions: HashMap<String, Vec<String>>, // permission_type -> account_ids
+    #[serde(default)]
+    pub reviews: Vec<DocumentReview>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DocumentReview {
+    pub reviewer: String,
+    pub action: String, // SendForReview / Approve / Reject
+    pub comment: Vec<DocumentReviewComment>,
+    pub created_time: DateTime<Utc>,
+    pub updated_time: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DocumentReviewComment {
+    pub comment_type: String, // Comment
+    pub content: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary

Replace SSM patch and document-metadata stubs with real implementations driven by recorded state. Part of batch 7/10 of the gap-fill plan.

- DescribeInstancePatchStates / DescribeInstancePatchStatesForPatchGroup: derive from `AWS:PatchSummary` inventory items captured via PutInventory.
- DescribeInstancePatches: surface `AWS:PatchCompliance` / `AWS:Patch` inventory rows.
- DescribeEffectivePatchesForPatchBaseline: project the baseline's approved_patches list into Patch + PatchStatus envelopes; errors on unknown baseline IDs (matches AWS).
- DescribePatchProperties: return AWS-published per-OS product/classification/severity/priority catalogs.
- StartAssociationsOnce: flip association status to Pending, bump status_date / last_execution_date, error on unknown IDs.
- UpdateDocumentMetadata + ListDocumentMetadataHistory: persist DocumentReviews on the document with the AWS-canonical ReviewStatus mapping.
- Annotate unknown-filter-key match arms in patches / maintenance / documents.

Patch state timestamps are emitted as Smithy epoch seconds (the SDK rejects ISO strings on those fields).

## Test plan

- [x] 199 SSM unit tests pass (`cargo test -p fakecloud-ssm --lib`)
- [x] 7 new E2E tests in `crates/fakecloud-e2e/tests/ssm_patch_tracking.rs` exercise the new behavior through the AWS SDK
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces SSM patch and document-metadata stubs with real, state-backed implementations. Adds inventory-driven patch describes, paginated document review history, and atomic association execution.

- **New Features**
  - Patch describes
    - DescribeInstancePatchStates / ...ForPatchGroup derive from `AWS:PatchSummary` inventory and omit instances without a summary.
    - DescribeInstancePatches surfaces `AWS:PatchCompliance` / `AWS:Patch` rows; InstalledTime is returned as epoch seconds.
    - DescribeEffectivePatchesForPatchBaseline projects approved patches from the baseline and errors on unknown baseline IDs.
    - DescribePatchProperties returns AWS-style per-OS catalogs (products, classifications, severities, priorities).
  - Associations
    - StartAssociationsOnce sets status to Pending, updates timestamps, validates all IDs before mutating, and errors on unknown IDs.
  - Documents
    - UpdateDocumentMetadata persists reviews; ListDocumentMetadataHistory returns them with AWS ReviewStatus mapping and supports MaxResults/NextToken pagination.

- **Migration**
  - Patch state and installed-time timestamps are returned as epoch seconds, not ISO strings.
  - Existing state snapshots remain compatible; document reviews have serde defaults (no action needed).

<sup>Written for commit 6d908ed69c9b043d5ed47d4b08bc49df44b37a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

