### PR TITLE
feat(sqs): rate-limited async message move tasks with cancellation

### DIFF
--- a/crates/fakecloud-e2e/tests/sqs_message_move.rs
+++ b/crates/fakecloud-e2e/tests/sqs_message_move.rs
@@ -1,0 +1,252 @@
+mod helpers;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use aws_sdk_sqs::types::QueueAttributeName;
+use helpers::TestServer;
+
+async fn create_dlq_pair(client: &aws_sdk_sqs::Client, name_prefix: &str) -> (String, String) {
+    let dlq = client
+        .create_queue()
+        .queue_name(format!("{name_prefix}-dlq"))
+        .send()
+        .await
+        .unwrap();
+    let dlq_url = dlq.queue_url().unwrap().to_string();
+
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let dlq_arn = attrs
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::QueueArn))
+        .unwrap()
+        .to_string();
+
+    let mut redrive = HashMap::new();
+    redrive.insert(
+        QueueAttributeName::RedrivePolicy,
+        format!("{{\"deadLetterTargetArn\":\"{dlq_arn}\",\"maxReceiveCount\":\"3\"}}",),
+    );
+    let src = client
+        .create_queue()
+        .queue_name(format!("{name_prefix}-src"))
+        .set_attributes(Some(redrive))
+        .send()
+        .await
+        .unwrap();
+    let src_url = src.queue_url().unwrap().to_string();
+
+    (dlq_url, src_url)
+}
+
+#[tokio::test]
+async fn rate_limited_move_progresses_and_completes() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    let (dlq_url, src_url) = create_dlq_pair(&client, "ratelimit").await;
+
+    // Seed DLQ with 5 messages
+    for i in 0..5 {
+        client
+            .send_message()
+            .queue_url(&dlq_url)
+            .message_body(format!("msg-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let dlq_arn = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::QueueArn))
+        .unwrap()
+        .to_string();
+
+    let src_arn = client
+        .get_queue_attributes()
+        .queue_url(&src_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::QueueArn))
+        .unwrap()
+        .to_string();
+
+    // 50/sec rate -> 5 messages drain in ~100ms but task is observable as Running first.
+    let resp = client
+        .start_message_move_task()
+        .source_arn(&dlq_arn)
+        .destination_arn(&src_arn)
+        .max_number_of_messages_per_second(50)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.task_handle().is_some());
+
+    // Wait until completion (poll up to 5s)
+    let mut final_status = None;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let list = client
+            .list_message_move_tasks()
+            .source_arn(&dlq_arn)
+            .max_results(10)
+            .send()
+            .await
+            .unwrap();
+        let tasks = list.results();
+        if let Some(t) = tasks.first() {
+            let status = t.status().unwrap().to_string();
+            if status == "COMPLETED" {
+                final_status = Some(status);
+                break;
+            }
+        }
+    }
+    assert_eq!(final_status.as_deref(), Some("COMPLETED"));
+
+    // Source DLQ drained
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::ApproximateNumberOfMessages)
+        .send()
+        .await
+        .unwrap();
+    let dlq_count: i32 = attrs
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::ApproximateNumberOfMessages))
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(dlq_count, 0);
+
+    // Destination has messages
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&src_url)
+        .attribute_names(QueueAttributeName::ApproximateNumberOfMessages)
+        .send()
+        .await
+        .unwrap();
+    let src_count: i32 = attrs
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::ApproximateNumberOfMessages))
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(src_count, 5);
+}
+
+#[tokio::test]
+async fn cancel_message_move_task_stops_in_flight_mover() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    let (dlq_url, src_url) = create_dlq_pair(&client, "cancel").await;
+
+    // Seed DLQ with 100 messages
+    for i in 0..100 {
+        client
+            .send_message()
+            .queue_url(&dlq_url)
+            .message_body(format!("msg-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let dlq_arn = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::QueueArn))
+        .unwrap()
+        .to_string();
+
+    let src_arn = client
+        .get_queue_attributes()
+        .queue_url(&src_url)
+        .attribute_names(QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap()
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::QueueArn))
+        .unwrap()
+        .to_string();
+
+    // Slow rate (5/sec) so cancellation lands mid-flight.
+    let resp = client
+        .start_message_move_task()
+        .source_arn(&dlq_arn)
+        .destination_arn(&src_arn)
+        .max_number_of_messages_per_second(5)
+        .send()
+        .await
+        .unwrap();
+    let handle = resp.task_handle().unwrap().to_string();
+
+    // Wait briefly to let some moves happen.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let cancel = client
+        .cancel_message_move_task()
+        .task_handle(&handle)
+        .send()
+        .await
+        .unwrap();
+    assert!(cancel.approximate_number_of_messages_moved() > 0);
+
+    // Wait briefly for mover to observe cancel and exit.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let list = client
+        .list_message_move_tasks()
+        .source_arn(&dlq_arn)
+        .max_results(10)
+        .send()
+        .await
+        .unwrap();
+    let task = list.results().first().unwrap();
+    let status = task.status().unwrap().to_string();
+    assert!(
+        status == "CANCELLED" || status == "CANCELLING",
+        "expected CANCELLED/CANCELLING, got {status}"
+    );
+
+    // DLQ still has messages (we didn't drain them all)
+    let attrs = client
+        .get_queue_attributes()
+        .queue_url(&dlq_url)
+        .attribute_names(QueueAttributeName::ApproximateNumberOfMessages)
+        .send()
+        .await
+        .unwrap();
+    let remaining: i32 = attrs
+        .attributes()
+        .and_then(|m| m.get(&QueueAttributeName::ApproximateNumberOfMessages))
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(remaining > 0, "expected leftover messages in DLQ");
+}

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -805,7 +805,9 @@ async fn run_message_move_task(
         let step: Step = {
             let mut accounts = state_handle.write();
             let state = accounts.get_or_create(&account_id);
-            let Some(source_queue) = state.queues.get_mut(&source_url) else {
+
+            // Source queue must exist (immutable check before any mutation).
+            if !state.queues.contains_key(&source_url) {
                 drop(accounts);
                 finalize_move_task(
                     &state_handle,
@@ -815,41 +817,64 @@ async fn run_message_move_task(
                     MessageMoveTaskStatus::Failed,
                 );
                 return;
+            }
+
+            // Resolve and verify the target before popping anything off the
+            // source — AWS treats the source as the durable copy until the
+            // destination commit, so we must never pop a message we can't
+            // deliver. If the destination is gone, leave the source untouched
+            // and finalize Failed.
+            let target_url_opt = if let Some(ref dest_arn) = destination_arn {
+                state
+                    .queues
+                    .values()
+                    .find(|q| &q.arn == dest_arn)
+                    .map(|q| q.queue_url.clone())
+            } else if dlq_targets.is_empty() {
+                None
+            } else {
+                let url = dlq_targets[idx % dlq_targets.len()].clone();
+                Some(url)
             };
-
-            match source_queue.messages.pop_front() {
-                None => Step::SourceDrained,
-                Some(mut msg) => {
-                    msg.visible_at = None;
-                    msg.receive_count = 0;
-
-                    let target_url = if let Some(ref dest_arn) = destination_arn {
-                        state
-                            .queues
-                            .values()
-                            .find(|q| &q.arn == dest_arn)
-                            .map(|q| q.queue_url.clone())
-                    } else if dlq_targets.is_empty() {
-                        None
-                    } else {
-                        let url = dlq_targets[idx % dlq_targets.len()].clone();
-                        idx += 1;
-                        Some(url)
-                    };
-
-                    match target_url.as_deref().and_then(|u| state.queues.get_mut(u)) {
-                        Some(target_queue) => {
-                            target_queue.messages.push_back(msg);
-                            if let Some(task) = state
-                                .message_move_tasks
-                                .iter_mut()
-                                .find(|t| t.task_handle == task_handle)
-                            {
-                                task.messages_moved += 1;
+            match target_url_opt.filter(|u| state.queues.contains_key(u)) {
+                None => Step::Failed,
+                Some(target_url) => {
+                    // Source is guaranteed to exist (checked above); pop one message.
+                    let popped = state
+                        .queues
+                        .get_mut(&source_url)
+                        .and_then(|q| q.messages.pop_front());
+                    match popped {
+                        None => Step::SourceDrained,
+                        Some(mut msg) => {
+                            msg.visible_at = None;
+                            msg.receive_count = 0;
+                            match state.queues.get_mut(&target_url) {
+                                Some(target_queue) => {
+                                    target_queue.messages.push_back(msg);
+                                    if destination_arn.is_none() {
+                                        idx += 1;
+                                    }
+                                    if let Some(task) = state
+                                        .message_move_tasks
+                                        .iter_mut()
+                                        .find(|t| t.task_handle == task_handle)
+                                    {
+                                        task.messages_moved += 1;
+                                    }
+                                    Step::Moved
+                                }
+                                None => {
+                                    // Target vanished between resolution and
+                                    // the get_mut here. Push the message back
+                                    // to the source so it isn't lost.
+                                    if let Some(source_queue) = state.queues.get_mut(&source_url) {
+                                        source_queue.messages.push_front(msg);
+                                    }
+                                    Step::Failed
+                                }
                             }
-                            Step::Moved
                         }
-                        None => Step::Failed,
                     }
                 }
             }

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -5,6 +5,7 @@ use md5::Md5;
 use serde_json::{json, Value};
 use sha2::Sha256;
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -758,6 +759,146 @@ fn sqs_resource_for(action: &str, account: &str, region: &str, body: &Value) -> 
             .and_then(|url| url.rsplit('/').next())
             .map(queue_arn)
             .unwrap_or_else(|| "*".to_string()),
+    }
+}
+
+/// Background message-move worker. Drains the source queue one message at a
+/// time, sleeping `interval` between moves to enforce the requested rate.
+/// Updates the matching task's `messages_moved` counter on each move and
+/// flips status to `Completed` when the source drains, or `Cancelled` when
+/// the cancel flag is set. Exits silently if the source/destination queue
+/// or the task itself disappears (e.g. queue deleted while moving).
+#[allow(clippy::too_many_arguments)]
+async fn run_message_move_task(
+    state_handle: SharedSqsState,
+    account_id: String,
+    region: String,
+    task_handle: String,
+    source_url: String,
+    destination_arn: Option<String>,
+    dlq_targets: Vec<String>,
+    interval: std::time::Duration,
+    cancel_flag: Arc<AtomicBool>,
+) {
+    enum Step {
+        Moved,
+        SourceDrained,
+        Failed,
+    }
+
+    let mut idx: usize = 0;
+    loop {
+        if cancel_flag.load(Ordering::SeqCst) {
+            finalize_move_task(
+                &state_handle,
+                &account_id,
+                &region,
+                &task_handle,
+                MessageMoveTaskStatus::Cancelled,
+            );
+            return;
+        }
+
+        // Each iteration acquires the write lock for exactly one move and
+        // drops it before sleeping or finalizing — `finalize_move_task` also
+        // acquires the lock, so we can't hold one when we call it.
+        let step: Step = {
+            let mut accounts = state_handle.write();
+            let state = accounts.get_or_create(&account_id);
+            let Some(source_queue) = state.queues.get_mut(&source_url) else {
+                drop(accounts);
+                finalize_move_task(
+                    &state_handle,
+                    &account_id,
+                    &region,
+                    &task_handle,
+                    MessageMoveTaskStatus::Failed,
+                );
+                return;
+            };
+
+            match source_queue.messages.pop_front() {
+                None => Step::SourceDrained,
+                Some(mut msg) => {
+                    msg.visible_at = None;
+                    msg.receive_count = 0;
+
+                    let target_url = if let Some(ref dest_arn) = destination_arn {
+                        state
+                            .queues
+                            .values()
+                            .find(|q| &q.arn == dest_arn)
+                            .map(|q| q.queue_url.clone())
+                    } else if dlq_targets.is_empty() {
+                        None
+                    } else {
+                        let url = dlq_targets[idx % dlq_targets.len()].clone();
+                        idx += 1;
+                        Some(url)
+                    };
+
+                    match target_url.as_deref().and_then(|u| state.queues.get_mut(u)) {
+                        Some(target_queue) => {
+                            target_queue.messages.push_back(msg);
+                            if let Some(task) = state
+                                .message_move_tasks
+                                .iter_mut()
+                                .find(|t| t.task_handle == task_handle)
+                            {
+                                task.messages_moved += 1;
+                            }
+                            Step::Moved
+                        }
+                        None => Step::Failed,
+                    }
+                }
+            }
+        };
+
+        match step {
+            Step::Moved => {
+                tokio::time::sleep(interval).await;
+            }
+            Step::SourceDrained => {
+                finalize_move_task(
+                    &state_handle,
+                    &account_id,
+                    &region,
+                    &task_handle,
+                    MessageMoveTaskStatus::Completed,
+                );
+                return;
+            }
+            Step::Failed => {
+                finalize_move_task(
+                    &state_handle,
+                    &account_id,
+                    &region,
+                    &task_handle,
+                    MessageMoveTaskStatus::Failed,
+                );
+                return;
+            }
+        }
+    }
+}
+
+fn finalize_move_task(
+    state_handle: &SharedSqsState,
+    account_id: &str,
+    region: &str,
+    task_handle: &str,
+    final_status: MessageMoveTaskStatus,
+) {
+    let _ = region; // currently only used for symmetry with constructor
+    let mut accounts = state_handle.write();
+    let state = accounts.get_or_create(account_id);
+    if let Some(task) = state
+        .message_move_tasks
+        .iter_mut()
+        .find(|t| t.task_handle == task_handle)
+    {
+        task.status = final_status;
     }
 }
 
@@ -3164,68 +3305,123 @@ impl SqsService {
             ));
         }
 
-        // Move messages synchronously: drain source queue, redirect to destination
-        // (or to each redrive-source's queue if destination unspecified).
-        let source_messages: Vec<SqsMessage> = state
+        let total = state
             .queues
-            .get_mut(&source_url)
-            .map(|q| {
-                let drained: Vec<_> = q.messages.drain(..).collect();
-                q.inflight.clear();
-                drained
-            })
-            .unwrap_or_default();
-        let total = source_messages.len() as u64;
+            .get(&source_url)
+            .map(|q| q.messages.len() as u64)
+            .unwrap_or(0);
+        let task_handle = format!("FakeCloudMessageMoveTask-{}", uuid::Uuid::new_v4().simple());
 
-        let mut moved: u64 = 0;
-        if let Some(ref dest) = destination_arn {
-            let dest_url = state
+        // Fast path: if no rate was supplied AND there is no work to throttle,
+        // drain synchronously and mark the task COMPLETED before returning.
+        // The async path below is only useful when the caller wants real
+        // backpressure (rate limit) or the ability to observe / cancel mid-flight.
+        if max_per_sec.is_none() {
+            let source_messages: Vec<SqsMessage> = state
                 .queues
-                .values()
-                .find(|q| &q.arn == dest)
-                .map(|q| q.queue_url.clone());
-            if let Some(dest_url) = dest_url {
-                if let Some(dq) = state.queues.get_mut(&dest_url) {
-                    for msg in source_messages {
+                .get_mut(&source_url)
+                .map(|q| {
+                    let drained: Vec<_> = q.messages.drain(..).collect();
+                    q.inflight.clear();
+                    drained
+                })
+                .unwrap_or_default();
+            let mut moved: u64 = 0;
+            if let Some(ref dest) = destination_arn {
+                let dest_url = state
+                    .queues
+                    .values()
+                    .find(|q| &q.arn == dest)
+                    .map(|q| q.queue_url.clone());
+                if let Some(dest_url) = dest_url {
+                    if let Some(dq) = state.queues.get_mut(&dest_url) {
+                        for msg in source_messages {
+                            let mut new_msg = msg;
+                            new_msg.visible_at = None;
+                            new_msg.receive_count = 0;
+                            dq.messages.push_back(new_msg);
+                            moved += 1;
+                        }
+                    }
+                }
+            } else {
+                let targets = dlq_sources.clone();
+                for (idx, msg) in source_messages.into_iter().enumerate() {
+                    if targets.is_empty() {
+                        break;
+                    }
+                    let target_url = &targets[idx % targets.len()];
+                    if let Some(tq) = state.queues.get_mut(target_url) {
                         let mut new_msg = msg;
                         new_msg.visible_at = None;
                         new_msg.receive_count = 0;
-                        dq.messages.push_back(new_msg);
+                        tq.messages.push_back(new_msg);
                         moved += 1;
                     }
                 }
             }
-        } else {
-            // Round-robin back to each source queue.
-            let targets = dlq_sources.clone();
-            for (idx, msg) in source_messages.into_iter().enumerate() {
-                if targets.is_empty() {
-                    break;
-                }
-                let target_url = &targets[idx % targets.len()];
-                if let Some(tq) = state.queues.get_mut(target_url) {
-                    let mut new_msg = msg;
-                    new_msg.visible_at = None;
-                    new_msg.receive_count = 0;
-                    tq.messages.push_back(new_msg);
-                    moved += 1;
-                }
-            }
+
+            state.message_move_tasks.push(MessageMoveTask {
+                task_handle: task_handle.clone(),
+                source_arn,
+                destination_arn,
+                max_messages_per_second: max_per_sec,
+                status: MessageMoveTaskStatus::Completed,
+                messages_moved: moved,
+                messages_to_move: total,
+                started_timestamp: Utc::now().timestamp_millis(),
+                failure_reason: None,
+                cancel_flag: Arc::new(AtomicBool::new(false)),
+            });
+            return Ok(sqs_response(
+                "StartMessageMoveTask",
+                json!({ "TaskHandle": task_handle }),
+                &req.request_id,
+                req.is_query_protocol,
+            ));
         }
 
-        let task_handle = format!("FakeCloudMessageMoveTask-{}", uuid::Uuid::new_v4().simple());
+        // Async path: insert a Running task, spawn a background mover that
+        // drains one message at a time at the requested rate. Cancellation is
+        // signalled through the task's `cancel_flag`.
+        let cancel_flag = Arc::new(AtomicBool::new(false));
         state.message_move_tasks.push(MessageMoveTask {
             task_handle: task_handle.clone(),
-            source_arn,
-            destination_arn,
+            source_arn: source_arn.clone(),
+            destination_arn: destination_arn.clone(),
             max_messages_per_second: max_per_sec,
-            status: MessageMoveTaskStatus::Completed,
-            messages_moved: moved,
+            status: MessageMoveTaskStatus::Running,
+            messages_moved: 0,
             messages_to_move: total,
             started_timestamp: Utc::now().timestamp_millis(),
             failure_reason: None,
+            cancel_flag: cancel_flag.clone(),
         });
-        // Cap retained tasks at 10 per source per AWS docs.
+        drop(accounts);
+
+        let state_handle = self.state.clone();
+        let account_id = req.account_id.clone();
+        let region = req.region.clone();
+        let handle_for_task = task_handle.clone();
+        let dlq_targets = dlq_sources.clone();
+        let rate = max_per_sec.unwrap_or(1).max(1) as u64;
+        let interval = std::time::Duration::from_nanos(1_000_000_000 / rate);
+
+        tokio::spawn(async move {
+            run_message_move_task(
+                state_handle,
+                account_id,
+                region,
+                handle_for_task,
+                source_url,
+                destination_arn,
+                dlq_targets,
+                interval,
+                cancel_flag,
+            )
+            .await;
+        });
+
         Ok(sqs_response(
             "StartMessageMoveTask",
             json!({ "TaskHandle": task_handle }),
@@ -3257,7 +3453,12 @@ impl SqsService {
         let moved = task.messages_moved;
         match task.status {
             MessageMoveTaskStatus::Running => {
-                task.status = MessageMoveTaskStatus::Cancelled;
+                // Signal the background mover to stop on its next tick.
+                // The mover flips status to Cancelled when it observes the
+                // flag and exits its loop; we mark Cancelling here so the
+                // request doesn't have to wait for that observation.
+                task.cancel_flag.store(true, Ordering::SeqCst);
+                task.status = MessageMoveTaskStatus::Cancelling;
             }
             MessageMoveTaskStatus::Completed
             | MessageMoveTaskStatus::Cancelled
@@ -5766,11 +5967,13 @@ mod tests {
         dlq_arn
     }
 
-    #[test]
-    fn start_message_move_task_query_protocol_parses_string_rate() {
+    #[tokio::test]
+    async fn start_message_move_task_query_protocol_parses_string_rate() {
         let svc = make_service();
         let dlq_arn = create_dlq_with_source(&svc, "qp-dlq", "qp-src");
         // Query protocol passes integers as strings; this should parse fine.
+        // The rate-bound path spawns a background mover, so this test runs
+        // on the tokio runtime.
         let req = make_query_request(
             "StartMessageMoveTask",
             &[
@@ -5980,7 +6183,7 @@ mod tests {
             let mut accounts = svc.state.write();
             let state = accounts.get_or_create("123456789012");
             state.message_move_tasks.push(MessageMoveTask {
-                task_handle: "FakeCloudMessageMoveTask-stub".to_string(),
+                task_handle: "FakeCloudMessageMoveTask-running".to_string(),
                 source_arn: dlq_arn.clone(),
                 destination_arn: None,
                 max_messages_per_second: None,
@@ -5989,6 +6192,7 @@ mod tests {
                 messages_to_move: 0,
                 started_timestamp: 0,
                 failure_reason: None,
+                cancel_flag: Arc::new(AtomicBool::new(false)),
             });
         }
         let req = make_request("StartMessageMoveTask", json!({ "SourceArn": dlq_arn }));
@@ -6014,6 +6218,7 @@ mod tests {
                 messages_to_move: 10,
                 started_timestamp: 0,
                 failure_reason: None,
+                cancel_flag: Arc::new(AtomicBool::new(false)),
             });
         }
         let resp = svc
@@ -6048,6 +6253,7 @@ mod tests {
                     messages_to_move: 0,
                     started_timestamp: i,
                     failure_reason: None,
+                    cancel_flag: Arc::new(AtomicBool::new(false)),
                 });
             }
         }

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -95,6 +96,16 @@ pub struct MessageMoveTask {
     pub messages_to_move: u64,
     pub started_timestamp: i64,
     pub failure_reason: Option<String>,
+    /// Set to `true` by `CancelMessageMoveTask` to request that the
+    /// background mover stop after its current iteration. Not persisted
+    /// — restored snapshots resume with a fresh flag in its default
+    /// state (no in-flight cancellation).
+    #[serde(skip, default = "default_cancel_flag")]
+    pub cancel_flag: Arc<AtomicBool>,
+}
+
+fn default_cancel_flag() -> Arc<AtomicBool> {
+    Arc::new(AtomicBool::new(false))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Replaces the synchronous-only message-move flow with a rate-aware async mover so callers can observe a moving task in RUNNING state, cancel it mid-flight, and rely on `MaxNumberOfMessagesPerSecond` as a real ceiling. Part of batch 8/10 of the gap-fill plan.

- `StartMessageMoveTask` with a rate spawns a background mover that drains one message per tick.
- `CancelMessageMoveTask` flips an `AtomicBool` cancellation flag and marks the task `CANCELLING`; the mover observes the flag on its next tick and finalizes `CANCELLED`.
- The mover updates `messages_moved` per move so `ListMessageMoveTasks` reflects real progress.
- Without a rate, the existing fast path still drains synchronously to `COMPLETED` (no behavior change for callers that didn't set a rate).
- Cancellation flag lives in a `#[serde(skip)]` field on `MessageMoveTask`; snapshots unaffected.

Critical detail noted in the commit body: the mover acquires the state write lock for exactly one move per tick and drops it before sleeping or finalizing — `finalize_move_task` also takes the write lock and parking_lot's RwLock is non-reentrant.

## Test plan

- [x] 129 SQS unit tests pass (`cargo test -p fakecloud-sqs --lib`)
- [x] 2 new E2E tests in `crates/fakecloud-e2e/tests/sqs_message_move.rs` (rate-limited drain + mid-flight cancel)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rate-aware async worker for moving SQS messages with observable progress and mid-flight cancellation. Also fixes an edge case to prevent message loss if the destination queue disappears during a move.

- New Features
  - `StartMessageMoveTask` with a rate spawns a background worker that moves one message per tick and updates `messages_moved`.
  - `CancelMessageMoveTask` sets a cancellation flag and marks `CANCELLING`; the worker finalizes `CANCELLED` on the next tick.
  - Progress is visible via `ListMessageMoveTasks`; tasks end as `COMPLETED` on drain or `FAILED` if queues/tasks disappear.
  - No-rate path keeps the previous synchronous drain to `COMPLETED`.
  - Locking: the worker holds the write lock for one move per tick and releases it before sleeping/finalizing to avoid deadlocks with the non-reentrant RwLock.
  - The cancellation flag is stored in `#[serde(skip)]` on `MessageMoveTask`, so snapshots remain unchanged.

- Bug Fixes
  - Prevent message loss when the target queue disappears mid-flight by validating the destination before popping, pushing the message back if a race occurs, and advancing the round-robin index only after a successful commit.

<sup>Written for commit 911e90605e0cd7f100f04c4e65bcbf3cec1df5fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

