### PR TITLE
feat(kms): AWS-shaped binary ciphertext blob with AES-256-GCM

### DIFF
--- a/crates/fakecloud-e2e/tests/kms_blob_format.rs
+++ b/crates/fakecloud-e2e/tests/kms_blob_format.rs
@@ -1,0 +1,103 @@
+mod helpers;
+
+use aws_sdk_kms::primitives::Blob;
+use base64::Engine;
+use helpers::TestServer;
+
+const VERSION_HEADER: [u8; 4] = [0x01, 0x02, 0x02, 0x00];
+
+#[tokio::test]
+async fn encrypt_decrypt_round_trips_through_blob_format() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .description("blob-test")
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let plaintext = b"plaintext-bytes-for-blob-test";
+    let resp = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(plaintext.to_vec()))
+        .send()
+        .await
+        .unwrap();
+    let ct = resp.ciphertext_blob().unwrap();
+
+    // Verify it's the AWS-shaped binary blob (version header) and never
+    // contains plaintext bytes.
+    let raw = ct.as_ref();
+    assert_eq!(&raw[0..4], VERSION_HEADER, "expected version header");
+    assert!(
+        raw.windows(plaintext.len()).all(|w| w != plaintext),
+        "plaintext must not appear anywhere in the ciphertext"
+    );
+
+    // Round-trip through Decrypt
+    let decrypted = client
+        .decrypt()
+        .ciphertext_blob(ct.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(decrypted.plaintext().unwrap().as_ref(), plaintext);
+}
+
+#[tokio::test]
+async fn legacy_textual_envelope_still_decrypts() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    // Build a legacy envelope `fakecloud-kms:<key>:<base64-plaintext>`. The
+    // SDK base64-encodes the bytes for wire transport; the server decodes
+    // once and parses the inner envelope.
+    let plaintext = b"legacy-envelope-payload";
+    let pt_b64 = base64::engine::general_purpose::STANDARD.encode(plaintext);
+    let envelope = format!("fakecloud-kms:{key_id}:{pt_b64}");
+
+    let resp = client
+        .decrypt()
+        .ciphertext_blob(Blob::new(envelope.into_bytes()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.plaintext().unwrap().as_ref(), plaintext);
+}
+
+#[tokio::test]
+async fn generate_data_key_returns_blob_format() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let resp = client
+        .generate_data_key()
+        .key_id(&key_id)
+        .key_spec(aws_sdk_kms::types::DataKeySpec::Aes256)
+        .send()
+        .await
+        .unwrap();
+
+    let ct = resp.ciphertext_blob().unwrap();
+    assert_eq!(&ct.as_ref()[0..4], VERSION_HEADER);
+
+    // Decrypt the wrapped data key — should match plaintext.
+    let plaintext = resp.plaintext().unwrap();
+    let decrypted = client
+        .decrypt()
+        .ciphertext_blob(ct.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(decrypted.plaintext().unwrap().as_ref(), plaintext.as_ref());
+}

--- a/crates/fakecloud-kms/src/blob.rs
+++ b/crates/fakecloud-kms/src/blob.rs
@@ -1,0 +1,185 @@
+//! AWS-shaped KMS ciphertext blobs.
+//!
+//! Real AWS KMS ciphertext is opaque binary that round-trips through
+//! `Encrypt` and `Decrypt`. Anyone inspecting the bytes sees a binary
+//! header followed by AES-GCM ciphertext, *not* their plaintext. The
+//! original fakecloud envelope (`fakecloud-kms:<key>:<base64-plaintext>`)
+//! round-tripped correctly through real SDKs but leaked plaintext to
+//! anyone who base64-decoded the blob.
+//!
+//! This module produces and consumes a binary envelope shaped like
+//! AWS's, using a per-process master key:
+//!
+//! ```text
+//! ┌──────────┬────────────┬──────────────┬────┬─────────────┬───────────────┐
+//! │ version  │ key-id len │ key-id bytes │ IV │ ciphertext  │ AES-GCM tag   │
+//! │ 4 bytes  │ 8 bytes BE │ N bytes UTF8 │ 12 │ M bytes     │ 16 bytes      │
+//! └──────────┴────────────┴──────────────┴────┴─────────────┴───────────────┘
+//! ```
+//!
+//! The version header (`0x01 0x02 0x02 0x00`) lets us distinguish
+//! fakecloud blobs from random base64 noise. The key-id is included so
+//! `Decrypt` can echo back the source `KeyId` without the caller having
+//! to specify it, matching AWS behavior.
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{AeadCore, Aes256Gcm, Key};
+
+const VERSION_HEADER: [u8; 4] = [0x01, 0x02, 0x02, 0x00];
+
+fn cipher_for(master_key_bytes: &[u8]) -> Option<Aes256Gcm> {
+    if master_key_bytes.len() != 32 {
+        return None;
+    }
+    let key = Key::<Aes256Gcm>::from_slice(master_key_bytes);
+    Some(Aes256Gcm::new(key))
+}
+
+/// Encode a plaintext byte slice into the AWS-shaped blob format. Uses
+/// AES-256-GCM with the supplied 32-byte master key and a fresh random
+/// IV. Output bytes are opaque — callers should base64 them before
+/// placing in JSON responses. Panics on a master key that isn't 32
+/// bytes; callers control the key, so this is a programming error.
+pub fn encode(master_key_bytes: &[u8], key_id: &str, plaintext: &[u8]) -> Vec<u8> {
+    let cipher =
+        cipher_for(master_key_bytes).expect("KMS master key must be 32 bytes for AES-256-GCM");
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+
+    // AES-GCM in this crate produces ciphertext || tag concatenated; we'll
+    // split tag off the back to keep the wire format aligned with the AWS
+    // shape (ciphertext segment followed by separate tag segment).
+    let combined = cipher
+        .encrypt(&nonce, plaintext)
+        .expect("AES-GCM encrypt with 96-bit nonce never fails on valid key");
+    debug_assert!(combined.len() >= 16, "AES-GCM output includes 16-byte tag");
+    let tag_split = combined.len() - 16;
+    let ciphertext = &combined[..tag_split];
+    let tag = &combined[tag_split..];
+
+    let key_bytes = key_id.as_bytes();
+    let mut out = Vec::with_capacity(
+        VERSION_HEADER.len() + 8 + key_bytes.len() + 12 + 4 + ciphertext.len() + 16,
+    );
+    out.extend_from_slice(&VERSION_HEADER);
+    out.extend_from_slice(&(key_bytes.len() as u64).to_be_bytes());
+    out.extend_from_slice(key_bytes);
+    out.extend_from_slice(nonce.as_slice());
+    out.extend_from_slice(&(ciphertext.len() as u32).to_be_bytes());
+    out.extend_from_slice(ciphertext);
+    out.extend_from_slice(tag);
+    out
+}
+
+/// A decoded blob from [`decode`]. Carries the embedded key-id and the
+/// recovered plaintext.
+pub struct Decoded {
+    pub key_id: String,
+    pub plaintext: Vec<u8>,
+}
+
+/// Decode an AWS-shaped fakecloud KMS blob back to its plaintext.
+/// Returns `None` if the bytes don't carry the version header or fail
+/// any structural check (including AEAD verification under the supplied
+/// master key); callers fall back to legacy envelope formats in that
+/// case.
+pub fn decode(master_key_bytes: &[u8], blob: &[u8]) -> Option<Decoded> {
+    if blob.len() < VERSION_HEADER.len() + 8 + 12 + 4 + 16 {
+        return None;
+    }
+    if blob[..VERSION_HEADER.len()] != VERSION_HEADER {
+        return None;
+    }
+    let mut cursor = VERSION_HEADER.len();
+
+    let key_len = u64::from_be_bytes(blob[cursor..cursor + 8].try_into().ok()?) as usize;
+    cursor += 8;
+    if cursor + key_len + 12 + 4 + 16 > blob.len() {
+        return None;
+    }
+    let key_id = std::str::from_utf8(&blob[cursor..cursor + key_len])
+        .ok()?
+        .to_string();
+    cursor += key_len;
+
+    let nonce = GenericArray::from_slice(&blob[cursor..cursor + 12]);
+    cursor += 12;
+
+    let ct_len = u32::from_be_bytes(blob[cursor..cursor + 4].try_into().ok()?) as usize;
+    cursor += 4;
+    if cursor + ct_len + 16 != blob.len() {
+        return None;
+    }
+    let ct_with_tag = &blob[cursor..cursor + ct_len + 16];
+
+    let cipher = cipher_for(master_key_bytes)?;
+    let plaintext = cipher.decrypt(nonce, ct_with_tag).ok()?;
+
+    Some(Decoded { key_id, plaintext })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_master() -> Vec<u8> {
+        // Deterministic 32-byte key so unit tests are reproducible.
+        (0u8..32).collect()
+    }
+
+    #[test]
+    fn round_trip_recovers_plaintext_and_key_id() {
+        let plaintext = b"super-secret-value";
+        let mk = fixed_master();
+        let blob = encode(&mk, "alias/my-key", plaintext);
+        let decoded = decode(&mk, &blob).unwrap();
+        assert_eq!(decoded.plaintext, plaintext);
+        assert_eq!(decoded.key_id, "alias/my-key");
+    }
+
+    #[test]
+    fn blob_does_not_leak_plaintext() {
+        let plaintext = b"NOT_TO_BE_FOUND_IN_BYTES";
+        let blob = encode(&fixed_master(), "key-1", plaintext);
+        assert!(blob.windows(plaintext.len()).all(|w| w != plaintext));
+    }
+
+    #[test]
+    fn decode_rejects_random_bytes() {
+        let mk = fixed_master();
+        assert!(decode(&mk, b"this-is-not-a-blob").is_none());
+        assert!(decode(&mk, &[0u8; 8]).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_wrong_header() {
+        let mk = fixed_master();
+        let mut blob = encode(&mk, "k", b"data");
+        blob[0] = 0xFF;
+        assert!(decode(&mk, &blob).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_tampered_ciphertext() {
+        let mk = fixed_master();
+        let mut blob = encode(&mk, "k", b"data");
+        let last = blob.len() - 1;
+        blob[last] ^= 0x01;
+        assert!(decode(&mk, &blob).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_wrong_master_key() {
+        let blob = encode(&fixed_master(), "k", b"data");
+        let other_key: Vec<u8> = (32u8..64).collect();
+        assert!(decode(&other_key, &blob).is_none());
+    }
+
+    #[test]
+    fn distinct_calls_produce_distinct_blobs() {
+        let mk = fixed_master();
+        let a = encode(&mk, "k", b"same");
+        let b = encode(&mk, "k", b"same");
+        assert_ne!(a, b, "fresh IV should make ciphertext non-deterministic");
+    }
+}

--- a/crates/fakecloud-kms/src/blob.rs
+++ b/crates/fakecloud-kms/src/blob.rs
@@ -23,7 +23,7 @@
 //! to specify it, matching AWS behavior.
 
 use aes_gcm::aead::generic_array::GenericArray;
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
 use aes_gcm::{AeadCore, Aes256Gcm, Key};
 
 const VERSION_HEADER: [u8; 4] = [0x01, 0x02, 0x02, 0x00];
@@ -49,8 +49,19 @@ pub fn encode(master_key_bytes: &[u8], key_id: &str, plaintext: &[u8]) -> Vec<u8
     // AES-GCM in this crate produces ciphertext || tag concatenated; we'll
     // split tag off the back to keep the wire format aligned with the AWS
     // shape (ciphertext segment followed by separate tag segment).
+    // Bind the key-id into the AAD so any tampering with the header
+    // bytes (e.g. flipping a single character of the embedded key-id)
+    // makes AEAD verification fail on decrypt. Without this, the
+    // header is a plain prefix and an attacker could rewrite the
+    // returned KeyId without breaking decryption.
     let combined = cipher
-        .encrypt(&nonce, plaintext)
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: plaintext,
+                aad: key_id.as_bytes(),
+            },
+        )
         .expect("AES-GCM encrypt with 96-bit nonce never fails on valid key");
     debug_assert!(combined.len() >= 16, "AES-GCM output includes 16-byte tag");
     let tag_split = combined.len() - 16;
@@ -113,7 +124,15 @@ pub fn decode(master_key_bytes: &[u8], blob: &[u8]) -> Option<Decoded> {
     let ct_with_tag = &blob[cursor..cursor + ct_len + 16];
 
     let cipher = cipher_for(master_key_bytes)?;
-    let plaintext = cipher.decrypt(nonce, ct_with_tag).ok()?;
+    let plaintext = cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: ct_with_tag,
+                aad: key_id.as_bytes(),
+            },
+        )
+        .ok()?;
 
     Some(Decoded { key_id, plaintext })
 }
@@ -173,6 +192,19 @@ mod tests {
         let blob = encode(&fixed_master(), "k", b"data");
         let other_key: Vec<u8> = (32u8..64).collect();
         assert!(decode(&other_key, &blob).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_tampered_key_id_header() {
+        let mk = fixed_master();
+        let mut blob = encode(&mk, "alias/original-key", b"data");
+        // The version header is 4 bytes, key-id length is the next 8.
+        // The first byte of the key-id sits at offset 12. Flip one
+        // character so the AAD no longer matches the bytes used at
+        // encrypt time and AES-GCM rejects the ciphertext.
+        let key_id_offset = 4 + 8;
+        blob[key_id_offset] ^= 0x01;
+        assert!(decode(&mk, &blob).is_none());
     }
 
     #[test]

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -110,9 +110,19 @@ impl KmsServiceHook {
         let key_arn = self.resolve_or_provision(account_id, region, key_id, service_principal)?;
         let key_short = key_id_from_arn(&key_arn).to_string();
 
-        let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(plaintext);
-        let envelope = format!("fakecloud-kms:{key_short}:{plaintext_b64}");
-        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+        // Default to the AWS-shaped binary blob (AES-256-GCM under the
+        // per-account master key persisted in `KmsState`). The legacy
+        // `fakecloud-kms:<key>:<b64>` textual envelope is still accepted on
+        // the decrypt side for back-compat with older snapshots and
+        // external callers.
+        let master_key_bytes = {
+            let mas = self.state.read();
+            mas.get(account_id)
+                .map(|s| s.master_key_bytes.clone())
+                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.clone()))?
+        };
+        let blob = crate::blob::encode(&master_key_bytes, &key_short, plaintext);
+        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         self.usage.write().push(KmsUsageRecord {
             timestamp: Utc::now(),
@@ -138,30 +148,44 @@ impl KmsServiceHook {
         let envelope_bytes = base64::engine::general_purpose::STANDARD
             .decode(ciphertext_b64)
             .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
-        let envelope = String::from_utf8(envelope_bytes)
-            .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
 
-        let rest = envelope
-            .strip_prefix("fakecloud-kms:")
-            .ok_or_else(|| KmsHookError::InvalidCiphertext("unrecognized envelope".into()))?;
-        let (key_short, plaintext_b64) = rest
-            .split_once(':')
-            .ok_or_else(|| KmsHookError::InvalidCiphertext("missing key separator".into()))?;
+        // Try AWS-shaped binary blob first using the account's master key;
+        // older textual envelopes fall through to the legacy parser below.
+        let master_key_bytes = {
+            let mas = self.state.read();
+            mas.get(account_id)
+                .map(|s| s.master_key_bytes.clone())
+                .unwrap_or_default()
+        };
+        let (key_short, plaintext) =
+            if let Some(decoded) = crate::blob::decode(&master_key_bytes, &envelope_bytes) {
+                (decoded.key_id, decoded.plaintext)
+            } else {
+                let envelope = String::from_utf8(envelope_bytes)
+                    .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+                let rest = envelope.strip_prefix("fakecloud-kms:").ok_or_else(|| {
+                    KmsHookError::InvalidCiphertext("unrecognized envelope".into())
+                })?;
+                let (key_short, plaintext_b64) = rest.split_once(':').ok_or_else(|| {
+                    KmsHookError::InvalidCiphertext("missing key separator".into())
+                })?;
 
-        let plaintext = base64::engine::general_purpose::STANDARD
-            .decode(plaintext_b64)
-            .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+                let plaintext = base64::engine::general_purpose::STANDARD
+                    .decode(plaintext_b64)
+                    .map_err(|e| KmsHookError::InvalidCiphertext(e.to_string()))?;
+                (key_short.to_string(), plaintext)
+            };
 
         let key_arn = {
             let mas = self.state.read();
             let state = mas
                 .get(account_id)
-                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.into()))?;
+                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.clone()))?;
             state
                 .keys
-                .get(key_short)
+                .get(&key_short)
                 .map(|k| k.arn.clone())
-                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.into()))?
+                .ok_or_else(|| KmsHookError::KeyNotFound(key_short.clone()))?
         };
 
         self.usage.write().push(KmsUsageRecord {

--- a/crates/fakecloud-kms/src/lib.rs
+++ b/crates/fakecloud-kms/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod blob;
 pub mod hook;
 pub mod resource_policy;
 pub mod service;

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -47,6 +47,26 @@ fn decode_ciphertext_envelope(
     let ciphertext_bytes = base64::engine::general_purpose::STANDARD
         .decode(ciphertext_b64)
         .map_err(|_| invalid_ciphertext())?;
+
+    // Modern AWS-shaped blob (AES-256-GCM under the per-account master
+    // key) — try this first. Older textual envelopes fall through.
+    if let Some(decoded) = crate::blob::decode(&state.master_key_bytes, &ciphertext_bytes) {
+        let key = state.keys.get(&decoded.key_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotFoundException",
+                format!("Key '{}' does not exist", decoded.key_id),
+            )
+        })?;
+        return Ok(DecodedCiphertext {
+            source_arn: key.arn.clone(),
+            plaintext_b64: base64::engine::general_purpose::STANDARD.encode(&decoded.plaintext),
+        });
+    }
+
+    // Legacy textual envelopes: `fakecloud-kms:<key>:<b64>` and
+    // `fakecloud-imported:<key>:<xored-b64>`. Kept for back-compat with
+    // ciphertexts persisted before the binary blob format shipped.
     let envelope = String::from_utf8(ciphertext_bytes).map_err(|_| invalid_ciphertext())?;
 
     if let Some(rest) = envelope.strip_prefix(IMPORTED_ENVELOPE_PREFIX) {
@@ -681,19 +701,33 @@ fn decode_plaintext(plaintext_b64: &str) -> Result<Vec<u8>, AwsServiceError> {
 /// against the material so the ciphertext is deterministic in the
 /// imported key; otherwise the fakecloud envelope just wraps the
 /// original base64 plaintext under a fixed prefix.
-fn build_encrypt_ciphertext(key: &KmsKey, plaintext_b64: &str, plaintext_bytes: &[u8]) -> String {
-    let envelope = if let Some(ref material) = key.imported_material_bytes {
+fn build_encrypt_ciphertext(
+    state: &KmsState,
+    key: &KmsKey,
+    plaintext_b64: &str,
+    plaintext_bytes: &[u8],
+) -> String {
+    let _ = plaintext_b64;
+    if let Some(ref material) = key.imported_material_bytes {
+        // Imported key material path: legacy XOR envelope wrapped in the
+        // textual `fakecloud-imported:<key>:<b64>` form, base64-encoded for
+        // wire transport. This format is preserved for back-compat with
+        // snapshots and external callers that may already have stored
+        // ciphertexts produced before the AES-GCM blob format landed.
         let xored: Vec<u8> = plaintext_bytes
             .iter()
             .enumerate()
             .map(|(i, b)| b ^ material[i % material.len()])
             .collect();
         let xored_b64 = base64::engine::general_purpose::STANDARD.encode(&xored);
-        format!("fakecloud-imported:{}:{xored_b64}", key.key_id)
-    } else {
-        format!("{FAKE_ENVELOPE_PREFIX}{}:{plaintext_b64}", key.key_id)
-    };
-    base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes())
+        let envelope = format!("fakecloud-imported:{}:{xored_b64}", key.key_id);
+        return base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+    }
+    // Default path: AWS-shaped binary blob with AES-256-GCM under the
+    // per-account master key persisted in `KmsState`. Round-trips through
+    // real SDKs and does not leak plaintext to anyone inspecting the bytes.
+    let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, plaintext_bytes);
+    base64::engine::general_purpose::STANDARD.encode(&blob)
 }
 
 /// Reject empty/undecodable base64 for `Verify`'s Message and Signature.
@@ -1165,7 +1199,7 @@ impl KmsService {
             ));
         }
 
-        let ciphertext_b64 = build_encrypt_ciphertext(key, plaintext_b64, &plaintext_bytes);
+        let ciphertext_b64 = build_encrypt_ciphertext(state, key, plaintext_b64, &plaintext_bytes);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1243,25 +1277,27 @@ impl KmsService {
             )
         })?;
 
-        let new_envelope = if let Some(ref material) = dest_key.imported_material_bytes {
-            let plaintext_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&decoded.plaintext_b64)
-                .unwrap_or_default();
+        let plaintext_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&decoded.plaintext_b64)
+            .unwrap_or_default();
+        let new_ciphertext_b64 = if let Some(ref material) = dest_key.imported_material_bytes {
+            // Imported-key path: keep the legacy XOR envelope so consumers
+            // that already round-trip via key material can still decrypt.
             let xored: Vec<u8> = plaintext_bytes
                 .iter()
                 .enumerate()
                 .map(|(i, b)| b ^ material[i % material.len()])
                 .collect();
             let xored_b64 = base64::engine::general_purpose::STANDARD.encode(&xored);
-            format!("fakecloud-imported:{}:{xored_b64}", dest_key.key_id)
+            let envelope = format!("fakecloud-imported:{}:{xored_b64}", dest_key.key_id);
+            base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes())
         } else {
-            format!(
-                "{FAKE_ENVELOPE_PREFIX}{}:{}",
-                dest_key.key_id, decoded.plaintext_b64
-            )
+            // Default path: wrap the recovered plaintext under the
+            // destination key with the AWS-shaped binary blob.
+            let blob =
+                crate::blob::encode(&state.master_key_bytes, &dest_key.key_id, &plaintext_bytes);
+            base64::engine::general_purpose::STANDARD.encode(&blob)
         };
-        let new_ciphertext_b64 =
-            base64::engine::general_purpose::STANDARD.encode(new_envelope.as_bytes());
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1313,9 +1349,9 @@ impl KmsService {
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
         let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(&data_key_bytes);
 
-        // Encrypt the data key
-        let envelope = format!("{FAKE_ENVELOPE_PREFIX}{}:{plaintext_b64}", key.key_id);
-        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+        // Wrap the data key in the AWS-shaped binary blob.
+        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &data_key_bytes);
+        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1365,9 +1401,9 @@ impl KmsService {
 
         let num_bytes = data_key_size_from_body(&body)?;
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
-        let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(&data_key_bytes);
-        let envelope = format!("{FAKE_ENVELOPE_PREFIX}{}:{plaintext_b64}", key.key_id);
-        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+        let _ = base64::engine::general_purpose::STANDARD.encode(&data_key_bytes);
+        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &data_key_bytes);
+        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -2702,13 +2738,9 @@ impl KmsService {
         let private_plaintext_b64 =
             base64::engine::general_purpose::STANDARD.encode(&private_key_bytes);
 
-        // Encrypt private key
-        let envelope = format!(
-            "{FAKE_ENVELOPE_PREFIX}{}:{private_plaintext_b64}",
-            key.key_id
-        );
-        let private_ciphertext_b64 =
-            base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+        // Wrap the private key in the AWS-shaped binary blob.
+        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &private_key_bytes);
+        let private_ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -2765,15 +2797,9 @@ impl KmsService {
         let public_key_bytes = generate_fake_public_key(&key_pair_spec);
         let private_key_bytes = rand_bytes(256);
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
-        let private_plaintext_b64 =
-            base64::engine::general_purpose::STANDARD.encode(&private_key_bytes);
 
-        let envelope = format!(
-            "{FAKE_ENVELOPE_PREFIX}{}:{private_plaintext_b64}",
-            key.key_id
-        );
-        let private_ciphertext_b64 =
-            base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes());
+        let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &private_key_bytes);
+        let private_ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&blob);
 
         Ok(AwsResponse::json(
             StatusCode::OK,

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -19,6 +19,21 @@ pub struct KmsState {
     pub aliases: HashMap<String, KmsAlias>,
     pub grants: Vec<KmsGrant>,
     pub custom_key_stores: HashMap<String, CustomKeyStore>,
+    /// Per-account master key bytes (32 bytes for AES-256-GCM) used to
+    /// wrap plaintext in the AWS-shaped ciphertext blob format. Generated
+    /// lazily on first encrypt and persisted alongside the rest of the
+    /// state so that ciphertexts produced before a server restart still
+    /// decrypt afterwards.
+    #[serde(default = "default_master_key_bytes")]
+    pub master_key_bytes: Vec<u8>,
+}
+
+fn default_master_key_bytes() -> Vec<u8> {
+    use aes_gcm::aead::rand_core::RngCore;
+    use aes_gcm::aead::OsRng;
+    let mut bytes = vec![0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
 }
 
 impl KmsState {
@@ -30,6 +45,7 @@ impl KmsState {
             aliases: HashMap::new(),
             grants: Vec::new(),
             custom_key_stores: HashMap::new(),
+            master_key_bytes: default_master_key_bytes(),
         }
     }
 
@@ -38,6 +54,7 @@ impl KmsState {
         self.aliases.clear();
         self.grants.clear();
         self.custom_key_stores.clear();
+        // Keep the master key across resets so ciphertexts still decrypt.
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the textual envelope (`fakecloud-kms:<key>:<base64-plaintext>`) — which round-tripped through real SDKs but leaked plaintext to anyone who base64-decoded the bytes — with an AWS-compatible opaque binary ciphertext blob shaped as:

```
version (4) | key-id len (8) | key-id (N) | IV (12) | ct-len (4) | ciphertext (M) | AES-GCM tag (16)
```

Encrypted with AES-256-GCM under a per-account 32-byte master key generated lazily and persisted in `KmsState`, so ciphertexts produced before a server restart still decrypt afterwards.

- New module `fakecloud-kms::blob` (`encode` / `decode`) with unit coverage: round-trip, leakage check, tampering rejection, wrong-master-key rejection, IV non-determinism.
- All `Encrypt`, `GenerateDataKey(WithoutPlaintext)?`, `GenerateDataKeyPair(WithoutPlaintext)?`, `ReEncrypt`, and the cross-service `KmsServiceHook::encrypt` paths emit the new blob.
- `Decrypt` and the hook's `decrypt` accept three formats: new blob, legacy `fakecloud-kms:` text envelope, legacy `fakecloud-imported:` XOR envelope. Older ciphertexts persisted by prior versions still round-trip.
- `KmsState.master_key_bytes` is `#[serde(default = ...)]` so old snapshots load with a fresh master key (their pre-existing ciphertexts use the legacy textual envelope, which still decrypts).

Part of batch 9/10 of the gap-fill plan.

## Test plan

- [x] 133 KMS unit tests pass (`cargo test -p fakecloud-kms --lib`)
- [x] new E2E suite `kms_blob_format` (3 tests): version header, plaintext non-leakage, GenerateDataKey wrapping, legacy decrypt fallback
- [x] cross-service KMS suites (sqs_kms, ssm_kms, secretsmanager_kms, sns_ddb_kms, ecr_kms_encryption, s3_sse_kms) all pass
- [x] kms_persistence E2E pass (master key now survives restart)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch KMS ciphertext to an AWS-shaped opaque binary blob using AES-256-GCM, with the key-id bound as AEAD AAD to prevent plaintext leakage and header tampering. All encrypt paths now emit the blob; decrypt remains compatible with legacy formats.

- New Features
  - Added `fakecloud-kms::blob` (encode/decode) for the AWS-shaped binary format; the key-id is bound via AEAD AAD so any header tampering fails decryption.
  - Uses a per-account 32-byte AES-256-GCM master key persisted in `KmsState`.
  - `Encrypt`, `GenerateDataKey(WithoutPlaintext)?`, `GenerateDataKeyPair(WithoutPlaintext)?`, `ReEncrypt`, and `KmsServiceHook::encrypt` now return the blob.
  - `Decrypt` (and hook) accept: new blob, legacy `fakecloud-kms:` text, and legacy `fakecloud-imported:` XOR. New E2E tests cover version header, no plaintext leakage, wrapping behavior, and legacy fallback.

- Migration
  - No action required. Older ciphertexts still decrypt; new ciphertexts are opaque binary blobs (base64 on the wire).

<sup>Written for commit 015e561489ab3e369ef7801695f399154a69fcba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

