### PR TITLE
feat(elasticache): real Memcached engine via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 - **100% conformance** per implemented service. Every operation validated against AWS's own Smithy models — 59,000+ generated test variants on every commit.
 - **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud. Catches waiter/field-presence/drift bugs that pure SDK tests miss.
 - **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, and 15+ more integrations actually execute end-to-end.
-- **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey.
+- **Real infrastructure for stateful services.** Lambda runs in Docker containers (13 runtimes). RDS runs real Postgres/MySQL/MariaDB. ElastiCache runs real Redis/Valkey/Memcached.
 - **Single binary.** ~19 MB, ~10 MiB idle memory, ~500ms startup. No Docker required to run fakecloud itself (only to exercise the services that need real containers).
 - **Bedrock, the whole surface.** 111 operations across runtime + full control plane: `InvokeModel`/`Converse` (with streaming), guardrails (real content evaluation + PII detection), custom model jobs, model import, inference profiles, provisioned throughput, async batch via S3, prompt management, agreements, automated reasoning. Configurable responses per prompt + fault injection for deterministic Bedrock tests. LocalStack's Ultimate-tier Bedrock covers 4 ops backed by Ollama; fakecloud is free and covers the full Bedrock shape. See [`/bedrock-emulator/`](https://fakecloud.dev/bedrock-emulator/).
 - **First-party test SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert on what your code called without writing raw HTTP.
@@ -70,7 +70,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | Cognito User Pools     | 122 | Pools, clients, MFA, identity providers, full auth flows; verification email -> SES, SMS -> SNS, all 12 Lambda triggers |
 | Kinesis                |  39 | Streams, records, shard iterators, retention                           |
 | RDS                    | 163 | Real Postgres, MySQL, MariaDB via Docker; lifecycle ops emit `aws.rds` EventBridge events |
-| ElastiCache            |  75 | Real Redis, Valkey via Docker                                          |
+| ElastiCache            |  75 | Real Redis, Valkey, Memcached via Docker                               |
 | Step Functions         |  37 | Full ASL interpreter, Lambda/SQS/SNS/EventBridge/DynamoDB tasks        |
 | API Gateway v2         | 103 | HTTP APIs, routes, integrations, stages, deployments, authorizers, domains, models, VPC links, routing rules, developer portals, CORS, tags |
 | Bedrock                | 101 | Foundation models, guardrails, custom models, invocation/eval jobs    |
@@ -113,7 +113,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | SES v2              | Full send + templates + DKIM + suppression         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES inbound email   | Real receipt rule action execution                 | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 | RDS                 | 163 operations, PostgreSQL/MySQL/MariaDB via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
-| ElastiCache         | 75 operations, Redis and Valkey via Docker         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| ElastiCache         | 75 operations, Redis, Valkey, Memcached via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | API Gateway v2      | 103 operations — HTTP APIs + developer portals     | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Bedrock             | 111 operations (control plane + runtime)           | Not available                                                                  |
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2,6 +2,16 @@ mod helpers;
 
 use helpers::TestServer;
 
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
 // CacheCluster tests
 
 #[tokio::test]
@@ -1765,4 +1775,123 @@ async fn elasticache_delete_nonexistent_serverless_cache_snapshot_errors() {
         .await;
 
     assert!(result.is_err());
+}
+
+// Memcached engine tests
+
+#[tokio::test]
+async fn elasticache_create_memcached_cluster_and_connect() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let create_resp = client
+        .create_cache_cluster()
+        .cache_cluster_id("mc-cluster")
+        .cache_node_type("cache.t3.micro")
+        .engine("memcached")
+        .send()
+        .await
+        .unwrap();
+
+    let cluster = create_resp.cache_cluster().expect("cache cluster");
+    assert_eq!(cluster.engine(), Some("memcached"));
+    assert_eq!(cluster.engine_version(), Some("1.6.22"));
+    assert_eq!(cluster.cache_cluster_status(), Some("available"));
+
+    let describe = client
+        .describe_cache_clusters()
+        .cache_cluster_id("mc-cluster")
+        .show_cache_node_info(true)
+        .send()
+        .await
+        .unwrap();
+    let endpoint = describe.cache_clusters()[0].cache_nodes()[0]
+        .endpoint()
+        .expect("endpoint");
+    let port = endpoint.port().expect("port");
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .expect("memcached connect");
+    stream.write_all(b"set foo 0 0 3\r\nbar\r\n").await.unwrap();
+    let mut buf = vec![0u8; 32];
+    let n = stream.read(&mut buf).await.unwrap();
+    assert!(
+        std::str::from_utf8(&buf[..n]).unwrap().starts_with("STORED"),
+        "memcached SET should return STORED"
+    );
+    stream.write_all(b"get foo\r\n").await.unwrap();
+    let mut buf = vec![0u8; 64];
+    let n = stream.read(&mut buf).await.unwrap();
+    let response = std::str::from_utf8(&buf[..n]).unwrap();
+    assert!(response.contains("bar"), "expected bar in {response}");
+
+    client
+        .delete_cache_cluster()
+        .cache_cluster_id("mc-cluster")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn elasticache_memcached_replication_group_rejected() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let result = client
+        .create_replication_group()
+        .replication_group_id("mc-rg")
+        .replication_group_description("memcached should be rejected")
+        .engine("memcached")
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn elasticache_describe_engine_default_parameters_memcached() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_engine_default_parameters()
+        .cache_parameter_group_family("memcached1.6")
+        .send()
+        .await
+        .unwrap();
+
+    let defaults = response.engine_defaults().expect("engine defaults");
+    assert_eq!(defaults.cache_parameter_group_family(), Some("memcached1.6"));
+    let params = defaults.parameters();
+    assert_eq!(params.len(), 2);
+    assert!(params
+        .iter()
+        .any(|p| p.parameter_name() == Some("max_item_size")));
+}
+
+#[tokio::test]
+async fn elasticache_describe_cache_engine_versions_includes_memcached() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let response = client
+        .describe_cache_engine_versions()
+        .engine("memcached")
+        .send()
+        .await
+        .unwrap();
+
+    let versions = response.cache_engine_versions();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].engine(), Some("memcached"));
+    assert_eq!(versions[0].engine_version(), Some("1.6.22"));
+    assert_eq!(
+        versions[0].cache_parameter_group_family(),
+        Some("memcached1.6")
+    );
 }

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -1821,7 +1821,9 @@ async fn elasticache_create_memcached_cluster_and_connect() {
     let mut buf = vec![0u8; 32];
     let n = stream.read(&mut buf).await.unwrap();
     assert!(
-        std::str::from_utf8(&buf[..n]).unwrap().starts_with("STORED"),
+        std::str::from_utf8(&buf[..n])
+            .unwrap()
+            .starts_with("STORED"),
         "memcached SET should return STORED"
     );
     stream.write_all(b"get foo\r\n").await.unwrap();
@@ -1866,7 +1868,10 @@ async fn elasticache_describe_engine_default_parameters_memcached() {
         .unwrap();
 
     let defaults = response.engine_defaults().expect("engine defaults");
-    assert_eq!(defaults.cache_parameter_group_family(), Some("memcached1.6"));
+    assert_eq!(
+        defaults.cache_parameter_group_family(),
+        Some("memcached1.6")
+    );
     let params = defaults.parameters();
     assert_eq!(params.len(), 2);
     assert!(params

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -9,6 +9,12 @@ pub struct RunningCacheContainer {
     pub host_port: u16,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum CacheEngineKind {
+    Redis,
+    Memcached,
+}
+
 pub struct ElastiCacheRuntime {
     cli: String,
     containers: RwLock<HashMap<String, RunningCacheContainer>>,
@@ -54,18 +60,42 @@ impl ElastiCacheRuntime {
         &self,
         resource_id: &str,
     ) -> Result<RunningCacheContainer, RuntimeError> {
+        self.spawn_container(resource_id, "redis:7-alpine", 6379, CacheEngineKind::Redis)
+            .await
+    }
+
+    pub async fn ensure_memcached(
+        &self,
+        resource_id: &str,
+    ) -> Result<RunningCacheContainer, RuntimeError> {
+        self.spawn_container(
+            resource_id,
+            "memcached:1.6-alpine",
+            11211,
+            CacheEngineKind::Memcached,
+        )
+        .await
+    }
+
+    async fn spawn_container(
+        &self,
+        resource_id: &str,
+        image: &str,
+        container_port: u16,
+        engine: CacheEngineKind,
+    ) -> Result<RunningCacheContainer, RuntimeError> {
         self.stop_container(resource_id).await;
 
         let output = tokio::process::Command::new(&self.cli)
             .args([
                 "create",
                 "-p",
-                ":6379",
+                &format!(":{container_port}"),
                 "--label",
                 &format!("fakecloud-elasticache={resource_id}"),
                 "--label",
                 &format!("fakecloud-instance={}", self.instance_id),
-                "redis:7-alpine",
+                image,
             ])
             .output()
             .await
@@ -92,7 +122,7 @@ impl ElastiCacheRuntime {
             )));
         }
 
-        let host_port = match self.lookup_port(&container_id, 6379).await {
+        let host_port = match self.lookup_port(&container_id, container_port).await {
             Ok(host_port) => host_port,
             Err(error) => {
                 self.remove_container(&container_id).await;
@@ -100,7 +130,11 @@ impl ElastiCacheRuntime {
             }
         };
 
-        if let Err(error) = self.wait_for_redis(host_port).await {
+        let wait_result = match engine {
+            CacheEngineKind::Redis => self.wait_for_redis(host_port).await,
+            CacheEngineKind::Memcached => self.wait_for_memcached(host_port).await,
+        };
+        if let Err(error) = wait_result {
             self.remove_container(&container_id).await;
             return Err(error);
         }
@@ -180,6 +214,30 @@ impl ElastiCacheRuntime {
 
         Err(RuntimeError::ContainerStartFailed(
             "redis container did not become ready within 20 seconds".to_string(),
+        ))
+    }
+
+    async fn wait_for_memcached(&self, host_port: u16) -> Result<(), RuntimeError> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let Ok(mut stream) =
+                tokio::net::TcpStream::connect(format!("127.0.0.1:{host_port}")).await
+            else {
+                continue;
+            };
+            if stream.write_all(b"version\r\n").await.is_err() {
+                continue;
+            }
+            let mut buf = [0u8; 32];
+            match tokio::time::timeout(Duration::from_secs(2), stream.read(&mut buf)).await {
+                Ok(Ok(n)) if n > 0 && buf.starts_with(b"VERSION") => return Ok(()),
+                _ => continue,
+            }
+        }
+
+        Err(RuntimeError::ContainerStartFailed(
+            "memcached container did not become ready within 20 seconds".to_string(),
         ))
     }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -26,14 +26,28 @@ const ELASTICACHE_NS: &str = "http://elasticache.amazonaws.com/doc/2015-02-02/";
 /// validated against this list at the wire boundary so a typo can't slip in.
 const ENGINE_REDIS: &str = "redis";
 const ENGINE_VALKEY: &str = "valkey";
-const SUPPORTED_ENGINES: &[&str] = &[ENGINE_REDIS, ENGINE_VALKEY];
+const ENGINE_MEMCACHED: &str = "memcached";
+const SUPPORTED_ENGINES: &[&str] = &[ENGINE_REDIS, ENGINE_VALKEY, ENGINE_MEMCACHED];
 
 fn validate_engine(engine: &str) -> Result<(), AwsServiceError> {
     if !SUPPORTED_ENGINES.contains(&engine) {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InvalidParameterValue",
-            format!("Invalid value for Engine: {engine}. Supported engines: redis, valkey"),
+            format!(
+                "Invalid value for Engine: {engine}. Supported engines: redis, valkey, memcached"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn reject_memcached_for(engine: &str, feature: &str) -> Result<(), AwsServiceError> {
+    if engine == ENGINE_MEMCACHED {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            format!("{feature} is not supported for the memcached engine."),
         ));
     }
     Ok(())
@@ -772,10 +786,10 @@ impl ElastiCacheService {
         let engine = optional_param(request, "Engine").unwrap_or_else(|| ENGINE_REDIS.to_string());
         validate_engine(&engine)?;
 
-        let default_version = if engine == ENGINE_VALKEY {
-            "8.0"
-        } else {
-            "7.1"
+        let default_version = match engine.as_str() {
+            ENGINE_VALKEY => "8.0",
+            ENGINE_MEMCACHED => "1.6.22",
+            _ => "7.1",
         };
         let engine_version =
             optional_param(request, "EngineVersion").unwrap_or_else(|| default_version.to_string());
@@ -831,6 +845,15 @@ impl ElastiCacheService {
             }
 
             if let Some(ref group_id) = replication_group_id {
+                if engine == ENGINE_MEMCACHED {
+                    state.cancel_cache_cluster_creation(&cache_cluster_id);
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValue",
+                        "Replication groups are not supported for the memcached engine."
+                            .to_string(),
+                    ));
+                }
                 if !state.replication_groups.contains_key(group_id) {
                     state.cancel_cache_cluster_creation(&cache_cluster_id);
                     return Err(AwsServiceError::aws_error(
@@ -863,7 +886,12 @@ impl ElastiCacheService {
             )
         })?;
 
-        let running = match runtime.ensure_redis(&cache_cluster_id).await {
+        let runtime_result = if engine == ENGINE_MEMCACHED {
+            runtime.ensure_memcached(&cache_cluster_id).await
+        } else {
+            runtime.ensure_redis(&cache_cluster_id).await
+        };
+        let running = match runtime_result {
             Ok(r) => r,
             Err(e) => {
                 self.state
@@ -1020,6 +1048,7 @@ impl ElastiCacheService {
         let description = required_param(request, "ReplicationGroupDescription")?;
         let engine = optional_param(request, "Engine").unwrap_or_else(|| ENGINE_REDIS.to_string());
         validate_engine(&engine)?;
+        reject_memcached_for(&engine, "Replication groups")?;
         let default_version = if engine == ENGINE_VALKEY {
             "8.0"
         } else {
@@ -4086,7 +4115,15 @@ fn parse_required_bool(req: &AwsRequest, name: &str) -> Result<bool, AwsServiceE
 }
 
 fn validate_serverless_engine(engine: &str) -> Result<(), AwsServiceError> {
-    validate_engine(engine)
+    validate_engine(engine)?;
+    if engine == ENGINE_MEMCACHED {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "Serverless caches are not supported for the memcached engine.".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn default_major_engine_version(engine: &str) -> &'static str {
@@ -5405,10 +5442,18 @@ mod tests {
     }
 
     #[test]
-    fn filter_engine_versions_no_match() {
+    fn filter_engine_versions_by_memcached() {
         let versions = default_engine_versions();
         let filtered =
             filter_engine_versions(&versions, &Some("memcached".to_string()), &None, &None);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].engine, "memcached");
+    }
+
+    #[test]
+    fn filter_engine_versions_unknown_engine() {
+        let versions = default_engine_versions();
+        let filtered = filter_engine_versions(&versions, &Some("oracle".to_string()), &None, &None);
         assert!(filtered.is_empty());
     }
 
@@ -5959,9 +6004,41 @@ mod tests {
 
         let req = request(
             "CreateCacheCluster",
-            &[("CacheClusterId", "bad-engine"), ("Engine", "memcached")],
+            &[("CacheClusterId", "bad-engine"), ("Engine", "oracle")],
         );
         assert!(service.create_cache_cluster(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_replication_group_rejects_memcached() {
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateReplicationGroup",
+            &[
+                ("ReplicationGroupId", "rg-mc"),
+                ("ReplicationGroupDescription", "no memcached"),
+                ("Engine", "memcached"),
+            ],
+        );
+        assert!(service.create_replication_group(&req).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_serverless_cache_rejects_memcached() {
+        let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        let service = ElastiCacheService::new(shared);
+
+        let req = request(
+            "CreateServerlessCache",
+            &[("ServerlessCacheName", "sc-mc"), ("Engine", "memcached")],
+        );
+        assert!(service.create_serverless_cache(&req).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -738,7 +738,7 @@ pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter
                 minimum_engine_version: "1.4.5".to_string(),
             },
             EngineDefaultParameter {
-                parameter_name: "max_connections".to_string(),
+                parameter_name: "max_simultaneous_connections".to_string(),
                 parameter_value: "65000".to_string(),
                 description: "Maximum number of concurrent connections".to_string(),
                 source: "system".to_string(),

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -593,6 +593,13 @@ pub fn default_engine_versions() -> Vec<CacheEngineVersion> {
             cache_engine_description: "Valkey".to_string(),
             cache_engine_version_description: "Valkey 8.0".to_string(),
         },
+        CacheEngineVersion {
+            engine: "memcached".to_string(),
+            engine_version: "1.6.22".to_string(),
+            cache_parameter_group_family: "memcached1.6".to_string(),
+            cache_engine_description: "Memcached".to_string(),
+            cache_engine_version_description: "Memcached 1.6.22".to_string(),
+        },
     ]
 }
 
@@ -621,6 +628,19 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
                 region,
                 account_id,
                 "parametergroup:default.valkey8",
+            )
+            .to_string(),
+        },
+        CacheParameterGroup {
+            cache_parameter_group_name: "default.memcached1.6".to_string(),
+            cache_parameter_group_family: "memcached1.6".to_string(),
+            description: "Default parameter group for memcached1.6".to_string(),
+            is_global: false,
+            arn: Arn::new(
+                "elasticache",
+                region,
+                account_id,
+                "parametergroup:default.memcached1.6",
             )
             .to_string(),
         },
@@ -706,6 +726,28 @@ pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter
                 minimum_engine_version: "8.0.0".to_string(),
             },
         ],
+        "memcached1.6" => vec![
+            EngineDefaultParameter {
+                parameter_name: "max_item_size".to_string(),
+                parameter_value: "1048576".to_string(),
+                description: "Maximum item size".to_string(),
+                source: "system".to_string(),
+                data_type: "integer".to_string(),
+                allowed_values: "1048576-1073741824".to_string(),
+                is_modifiable: true,
+                minimum_engine_version: "1.4.5".to_string(),
+            },
+            EngineDefaultParameter {
+                parameter_name: "max_connections".to_string(),
+                parameter_value: "65000".to_string(),
+                description: "Maximum number of concurrent connections".to_string(),
+                source: "system".to_string(),
+                data_type: "integer".to_string(),
+                allowed_values: "1-65000".to_string(),
+                is_modifiable: false,
+                minimum_engine_version: "1.4.5".to_string(),
+            },
+        ],
         _ => Vec::new(),
     }
 }
@@ -746,19 +788,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_engine_versions_contains_redis_and_valkey() {
+    fn default_engine_versions_contains_redis_valkey_memcached() {
         let versions = default_engine_versions();
-        assert_eq!(versions.len(), 2);
+        assert_eq!(versions.len(), 3);
         assert_eq!(versions[0].engine, "redis");
         assert_eq!(versions[0].engine_version, "7.1");
         assert_eq!(versions[1].engine, "valkey");
         assert_eq!(versions[1].engine_version, "8.0");
+        assert_eq!(versions[2].engine, "memcached");
+        assert_eq!(versions[2].engine_version, "1.6.22");
     }
 
     #[test]
     fn state_new_creates_default_parameter_groups() {
         let state = ElastiCacheState::new("123456789012", "us-east-1");
-        assert_eq!(state.parameter_groups.len(), 2);
+        assert_eq!(state.parameter_groups.len(), 3);
         assert_eq!(
             state.parameter_groups[0].cache_parameter_group_name,
             "default.redis7"
@@ -766,6 +810,10 @@ mod tests {
         assert_eq!(
             state.parameter_groups[1].cache_parameter_group_name,
             "default.valkey8"
+        );
+        assert_eq!(
+            state.parameter_groups[2].cache_parameter_group_name,
+            "default.memcached1.6"
         );
     }
 
@@ -790,7 +838,7 @@ mod tests {
         state.parameter_groups.clear();
         assert!(state.parameter_groups.is_empty());
         state.reset();
-        assert_eq!(state.parameter_groups.len(), 2);
+        assert_eq!(state.parameter_groups.len(), 3);
     }
 
     #[test]

--- a/website/content/docs/about/architecture.md
+++ b/website/content/docs/about/architecture.md
@@ -29,7 +29,7 @@ fakecloud is a single Rust binary built from a Cargo workspace. Each AWS service
 | `fakecloud-cognito`        | Cognito User Pools                                                       |
 | `fakecloud-kinesis`        | Kinesis                                                                  |
 | `fakecloud-rds`            | RDS with Docker-backed database execution                                |
-| `fakecloud-elasticache`    | ElastiCache with Docker-backed Redis/Valkey                              |
+| `fakecloud-elasticache`    | ElastiCache with Docker-backed Redis/Valkey/Memcached                    |
 | `fakecloud-bedrock`        | Bedrock + Bedrock Runtime                                                |
 | `fakecloud-apigatewayv2`   | API Gateway v2 (HTTP APIs)                                               |
 | `fakecloud-stepfunctions`  | Step Functions (ASL interpreter)                                         |

--- a/website/content/docs/services/elasticache.md
+++ b/website/content/docs/services/elasticache.md
@@ -1,23 +1,23 @@
 +++
 title = "ElastiCache"
-description = "Real Redis and Valkey clusters via Docker. Replication groups, snapshots, user/group management."
+description = "Real Redis, Valkey, and Memcached clusters via Docker. Replication groups, snapshots, user/group management."
 weight = 18
 +++
 
-fakecloud implements **75 of 75** ElastiCache operations at 100% Smithy conformance. Cache clusters run in **real Docker containers** — your code connects to a real Redis or Valkey instance.
+fakecloud implements **75 of 75** ElastiCache operations at 100% Smithy conformance. Cache clusters run in **real Docker containers** — your code connects to a real Redis, Valkey, or Memcached instance.
 
 ## Supported features
 
 - **Cache clusters** — CreateCacheCluster, ModifyCacheCluster, DeleteCacheCluster, DescribeCacheClusters
-- **Real engines via Docker** — Redis, Valkey
-- **Replication groups** — CreateReplicationGroup with primary/replica topology
+- **Real engines via Docker** — Redis, Valkey, Memcached
+- **Replication groups** — CreateReplicationGroup with primary/replica topology (Redis/Valkey only — matches AWS)
 - **Global replication groups** — cross-region global datastores (CRUD)
-- **Serverless caches** — CreateServerlessCache, ModifyServerlessCache
+- **Serverless caches** — CreateServerlessCache, ModifyServerlessCache (Redis/Valkey only — matches AWS)
 - **Snapshots** — CreateSnapshot, CopySnapshot, DeleteSnapshot, RestoreReplicationGroupFromSnapshot
 - **Serverless cache snapshots** — CRUD
 - **Subnet groups** — CRUD
 - **Users and user groups** — IAM-integrated auth
-- **Parameter groups** — CRUD
+- **Parameter groups** — CRUD (default groups for redis7, valkey8, memcached1.6)
 - **Security groups** — cache security group CRUD
 - **Failover** — TestFailover, TestMigration
 - **Tagging** — AddTagsToResource, RemoveTagsFromResource
@@ -29,13 +29,13 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses.
 
 ## How the Docker integration works
 
-When you call `CreateCacheCluster` or `CreateReplicationGroup` for a Redis/Valkey topology, fakecloud starts real Docker containers running the corresponding official image and reports the mapped host port(s). Your application connects with a normal Redis client.
+When you call `CreateCacheCluster` (or `CreateReplicationGroup` for Redis/Valkey topologies), fakecloud starts a real Docker container running the corresponding official image (`redis:7-alpine`, `valkey:8-alpine`, or `memcached:1.6-alpine`) and reports the mapped host port. Your application connects with a normal Redis or Memcached client.
 
 ## Gotchas
 
 - **Requires a Docker socket.** ElastiCache needs access to `/var/run/docker.sock`.
-- **First use pulls the image.** Expect a slower first run while the Redis/Valkey image downloads.
-- **Memcached is not supported via Docker.** Memcached cluster operations conform to AWS (CRUD works) but don't run a real backing process.
+- **First use pulls the image.** Expect a slower first run while the Redis/Valkey/Memcached image downloads.
+- **Memcached is cache-cluster only.** AWS does not support replication groups or serverless caches for Memcached, and neither does fakecloud. Use `CreateCacheCluster` with `Engine=memcached`.
 
 ## Source
 

--- a/website/content/fake-aws-server.md
+++ b/website/content/fake-aws-server.md
@@ -17,7 +17,7 @@ Listens on `http://localhost:4566`. Any AWS SDK in any language points at it and
 
 - **Real HTTP server**, not an in-process mock. Your Go / Java / Kotlin / Node / Rust / PHP / Python code uses the regular AWS SDK with `endpoint_url` set to `http://localhost:4566`.
 - **Speaks the AWS wire protocol** at 100% conformance per implemented service. 26 services, 1,924 operations, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
-- **Real execution** for stateful services: Lambda runs your function code in Docker containers across 13 runtimes, RDS runs real PostgreSQL/MySQL/MariaDB, ElastiCache runs real Redis/Valkey.
+- **Real execution** for stateful services: Lambda runs your function code in Docker containers across 13 runtimes, RDS runs real PostgreSQL/MySQL/MariaDB, ElastiCache runs real Redis/Valkey/Memcached.
 - **Real cross-service wiring**: S3 -> Lambda, SQS -> Lambda, SNS fan-out, EventBridge -> Step Functions, and 15+ more integrations execute end-to-end, not as stubs.
 - **Free, open-source, AGPL-3.0.** No account, no auth token, no paid tier.
 

--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -36,7 +36,7 @@ Yes. RDS emulation pulls real PostgreSQL / MySQL / MariaDB Docker images and run
 
 ### Does fakecloud run real Redis for ElastiCache?
 
-Yes. ElastiCache runs real Redis / Valkey Docker images. `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work. See [Local ElastiCache for tests](/local-elasticache/).
+Yes. ElastiCache runs real Redis / Valkey / Memcached Docker images. `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts on Redis/Valkey — and the full memcached text protocol on Memcached — all work. See [Local ElastiCache for tests](/local-elasticache/).
 
 ### Do S3 notifications fire Lambda?
 
@@ -113,7 +113,7 @@ GitHub issues: [github.com/faiscadev/fakecloud/issues](https://github.com/faisca
     {"@type": "Question", "name": "Which AWS services are supported?", "acceptedAnswer": {"@type": "Answer", "text": "S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, KMS, Secrets Manager, SSM, CloudWatch Logs, CloudFormation, EventBridge, EventBridge Scheduler, SES, Cognito User Pools, Kinesis, RDS, ElastiCache, Step Functions, API Gateway v2, Bedrock, Bedrock Runtime."}},
     {"@type": "Question", "name": "Does fakecloud execute Lambda code for real?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. fakecloud pulls real AWS Lambda runtime containers and executes your handler against them. All 13 official runtimes are supported."}},
     {"@type": "Question", "name": "Does fakecloud run real databases for RDS?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. RDS emulation pulls real PostgreSQL, MySQL, and MariaDB Docker images and runs them as the DB instance."}},
-    {"@type": "Question", "name": "Does fakecloud run real Redis for ElastiCache?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. ElastiCache runs real Redis and Valkey Docker images, so all Redis commands including streams, pub/sub, and Lua scripts work."}},
+    {"@type": "Question", "name": "Does fakecloud run real Redis for ElastiCache?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. ElastiCache runs real Redis, Valkey, and Memcached Docker images, so all Redis commands including streams, pub/sub, and Lua scripts work, and the full memcached text protocol works."}},
     {"@type": "Question", "name": "Do S3 notifications fire Lambda?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, end-to-end. When an object is created in S3, any Lambda subscribed via bucket notification fires for real in a runtime container. Same for SNS and SQS subscriptions."}},
     {"@type": "Question", "name": "How do I install fakecloud?", "acceptedAnswer": {"@type": "Answer", "text": "One-line install script: curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh | bash. Or Docker: docker run --rm -p 4566:4566 ghcr.io/faiscadev/fakecloud. Or cargo install fakecloud."}},
     {"@type": "Question", "name": "Does fakecloud work with Terraform?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. CI runs the upstream hashicorp/terraform-provider-aws TestAcc suites against fakecloud on every commit."}},

--- a/website/content/local-elasticache.md
+++ b/website/content/local-elasticache.md
@@ -1,6 +1,6 @@
 +++
 title = "Local ElastiCache for integration tests"
-description = "Run local ElastiCache for integration tests with fakecloud. 75 operations, real Redis/Valkey via Docker, replication groups, serverless caches. Free, no account required."
+description = "Run local ElastiCache for integration tests with fakecloud. 75 operations, real Redis/Valkey/Memcached via Docker, replication groups, serverless caches. Free, no account required."
 template = "page.html"
 +++
 
@@ -11,12 +11,12 @@ curl -fsSL https://raw.githubusercontent.com/faiscadev/fakecloud/main/install.sh
 fakecloud
 ```
 
-Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud runs **real** Redis / Valkey.
+Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud runs **real** Redis / Valkey / Memcached.
 
 ## Why fakecloud for ElastiCache
 
 - **75 ElastiCache operations** at 100% conformance — cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users / user groups, failover, tagging.
-- **Real Redis and real Valkey.** fakecloud pulls real Redis / Valkey Docker images and runs them as the ElastiCache node. Your `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work because the engine is real.
+- **Real Redis, Valkey, and Memcached.** fakecloud pulls real Redis / Valkey / Memcached Docker images and runs them as the ElastiCache node. Your `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work because the engine is real. Memcached gets a real `memcached:1.6-alpine` container with the full text protocol.
 - **Endpoint works.** `DescribeCacheClusters` returns a real connectable host. Your application connects with a regular Redis client (redis-py, ioredis, lettuce, go-redis).
 - **Paid on LocalStack; free here.** ElastiCache has always been LocalStack Pro-only.
 - **No account, no auth token, no paid tier.** AGPL-3.0.
@@ -74,6 +74,18 @@ aws --endpoint-url http://localhost:4566 elasticache create-replication-group \
 
 Real primary + replica nodes via Redis replication.
 
+## Memcached
+
+```sh
+aws --endpoint-url http://localhost:4566 elasticache create-cache-cluster \
+  --cache-cluster-id mymc \
+  --engine memcached \
+  --cache-node-type cache.t3.micro \
+  --num-cache-nodes 1
+```
+
+Real `memcached` text protocol — `set`, `get`, `delete`, `stats`, CAS, all work. AWS does not support replication groups or serverless caches for Memcached, and neither does fakecloud.
+
 ## Serverless caches
 
 ```sh
@@ -110,13 +122,13 @@ test('app caches via real redis behind ElastiCache emulation', async () => {
 
 ## How it differs from alternatives
 
-| Tool | Real Redis | Real Valkey | Replication groups | Serverless caches | Price |
-|---|---|---|---|---|---|
-| fakecloud | Yes (Docker) | Yes (Docker) | Yes | Yes | Free |
-| LocalStack Pro | Yes | Yes | Yes | Partial | Paid |
-| LocalStack Community | **No** | **No** | — | — | — (not available) |
-| Plain `docker run redis` | Yes | N/A | Manual | N/A | Free, but no ElastiCache API |
-| Moto | Stubbed | Stubbed | Stubbed | Stubbed | Free |
+| Tool | Real Redis | Real Valkey | Real Memcached | Replication groups | Serverless caches | Price |
+|---|---|---|---|---|---|---|
+| fakecloud | Yes (Docker) | Yes (Docker) | Yes (Docker) | Yes | Yes | Free |
+| LocalStack Pro | Yes | Yes | Yes | Yes | Partial | Paid |
+| LocalStack Community | **No** | **No** | **No** | — | — | — (not available) |
+| Plain `docker run redis` | Yes | N/A | N/A | Manual | N/A | Free, but no ElastiCache API |
+| Moto | Stubbed | Stubbed | Stubbed | Stubbed | Stubbed | Free |
 
 ## Links
 

--- a/website/content/localstack-alternative.md
+++ b/website/content/localstack-alternative.md
@@ -19,7 +19,7 @@ Point any AWS SDK or CLI at `http://localhost:4566` with dummy credentials. That
 
 fakecloud aims at every AWS service, each at 100% behavioral conformance, including every cross-service integration. Services land depth-first: a service is supported when it matches real AWS across every documented operation and cross-service wire-up — not when the API surface looks filled in. 26 services are there today (see below); the rest are on the roadmap, prioritized by real-project demand.
 
-This is why fakecloud runs real Lambda code in real runtime containers, runs real PostgreSQL/MySQL/MariaDB for RDS, runs real Redis/Valkey for ElastiCache, fires real S3 -> Lambda and SES inbound -> S3/SNS/Lambda flows, and validates every operation against AWS's own Smithy models on every commit.
+This is why fakecloud runs real Lambda code in real runtime containers, runs real PostgreSQL/MySQL/MariaDB for RDS, runs real Redis/Valkey/Memcached for ElastiCache, fires real S3 -> Lambda and SES inbound -> S3/SNS/Lambda flows, and validates every operation against AWS's own Smithy models on every commit.
 
 ## What fakecloud gives you
 
@@ -27,7 +27,7 @@ This is why fakecloud runs real Lambda code in real runtime containers, runs rea
 - **1,924 API operations. 100% conformance** per implemented service, validated against AWS's own Smithy models on every commit (59,000+ generated test variants).
 - **Tested against upstream Terraform acceptance tests.** CI runs `hashicorp/terraform-provider-aws` `TestAcc*` suites against fakecloud, catching waiter and field-presence drift that pure SDK tests miss.
 - **Real Lambda execution.** 13 runtimes in Docker containers. Not a mock, not a stub. Node, Python, Java, Go, .NET, Ruby, custom runtimes.
-- **Real stateful services.** RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey. Your Lambda talking to RDS is talking to a real Postgres.
+- **Real stateful services.** RDS runs real PostgreSQL/MySQL/MariaDB. ElastiCache runs real Redis/Valkey/Memcached. Your Lambda talking to RDS is talking to a real Postgres.
 - **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, 15+ more end-to-end integrations.
 - **Fast.** ~500ms startup. ~10 MiB idle memory. ~19 MB binary. No Docker required to run fakecloud itself.
 - **Test-assertion SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert that an email was sent, an SNS message published, a Lambda invoked, without writing raw HTTP.
@@ -51,7 +51,7 @@ This is why fakecloud runs real Lambda code in real runtime containers, runs rea
 | SES v2 | 110 operations, full send + templates + DKIM | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
 | RDS | 163 ops, real PostgreSQL/MySQL/MariaDB via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| ElastiCache | 75 ops, real Redis/Valkey via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+| ElastiCache | 75 ops, real Redis/Valkey/Memcached via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | API Gateway v2 | 103 ops, HTTP APIs + developer portals + JWT/Lambda authorizers | [Paid only](https://docs.localstack.cloud/references/licensing/) |
 | Bedrock | 111 ops (control plane + runtime) | Not available |
 

--- a/website/content/vs/floci.md
+++ b/website/content/vs/floci.md
@@ -16,7 +16,7 @@ Both are free, open-source, local AWS emulators. Real HTTP server speaking the A
 
 **floci's approach** (check their site for the current details — the project publishes performance claims like startup time, memory, and SDK-test pass rate): a free LocalStack replacement. Verify their numbers against the version you'd actually run.
 
-**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. A service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 26 services shipped today (including full ECR with OCI v2 `docker push`/`pull`, full ECS, full ELBv2 ALB/NLB/GWLB control plane). Built around real Lambda execution (13 runtimes in Docker), real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), real cross-service wiring, and validation on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. A service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 26 services shipped today (including full ECR with OCI v2 `docker push`/`pull`, full ECS, full ELBv2 ALB/NLB/GWLB control plane). Built around real Lambda execution (13 runtimes in Docker), real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey/Memcached via Docker), real cross-service wiring, and validation on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
 
 Breadth-first and depth-first are both valid tradeoffs. Pick by whether your tests need real downstream execution and cross-service flows, or surface-level plausibility across more services.
 
@@ -35,7 +35,7 @@ Run your actual test suite against both. Numbers published on landing pages are 
 | Services covered today | 26 (1,924 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
 | Lambda execution | Real code in 13 Docker runtime containers |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
-| ElastiCache | Real Redis/Valkey via Docker |
+| ElastiCache | Real Redis/Valkey/Memcached via Docker |
 | Cross-service wiring | S3 -> Lambda, SNS fan-out, EventBridge -> Step Functions, SES inbound -> S3/SNS/Lambda, 15+ more fire end-to-end |
 | Conformance methodology | Smithy-validated, 59k+ test variants per commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |

--- a/website/content/vs/localstack.md
+++ b/website/content/vs/localstack.md
@@ -26,7 +26,7 @@ Since LocalStack replaced its open-source Community Edition with a proprietary i
 | SES v2 | 110 ops, send + templates + DKIM | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
 | SES inbound email | Real receipt rule action execution | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) | Stored but never executed |
 | RDS | 163 ops, real PostgreSQL/MySQL/MariaDB | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
-| ElastiCache | 75 ops, real Redis/Valkey | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
+| ElastiCache | 75 ops, real Redis/Valkey/Memcached | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
 | API Gateway v2 | 103 ops | [Paid only](https://docs.localstack.cloud/references/licensing/) | Yes |
 | ECR | 58 ops + real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/) (and push is [flaky](https://github.com/localstack/localstack/issues/8128) when paid) | Yes |
 | Bedrock | 111 ops (control plane + runtime) | Not available | Not available |

--- a/website/content/vs/ministack.md
+++ b/website/content/vs/ministack.md
@@ -16,7 +16,7 @@ Free, open-source, local AWS emulation. Real HTTP server speaking the AWS wire p
 
 **MiniStack's approach** (check their repo for current details — it's moving fast): positions as a free LocalStack replacement. Evaluate their service coverage and architecture directly against your test suite.
 
-**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land one at a time; a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 26 services shipped today (including full ECR with OCI v2 `docker push`/`pull`, full ECS, full ELBv2 ALB/NLB/GWLB control plane); more progressively. Built around real Lambda execution, real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey via Docker), and real cross-service wiring, validated on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
+**fakecloud's approach:** depth-first, explicit goal. 100% of AWS services, each at 100% behavioral conformance, with 100% of cross-service integrations. Services land one at a time; a service is added when it passes the full Smithy-model test variants and cross-service wire-ups, not when the API surface looks filled in. 26 services shipped today (including full ECR with OCI v2 `docker push`/`pull`, full ECS, full ELBv2 ALB/NLB/GWLB control plane); more progressively. Built around real Lambda execution, real stateful backends (Postgres/MySQL/MariaDB/Redis/Valkey/Memcached via Docker), and real cross-service wiring, validated on every commit against AWS's own Smithy models (59,000+ generated test variants) plus the upstream `hashicorp/terraform-provider-aws` `TestAcc*` suites.
 
 These are philosophies, not rankings. Breadth-first and depth-first are different tradeoffs. A team whose tests lean lightly on many services will prefer breadth. A team whose tests exercise real cross-service flows or need real code execution will prefer depth.
 
@@ -38,7 +38,7 @@ These are philosophies, not rankings. Breadth-first and depth-first are differen
 | Services covered today | 26 (1,924 ops) at 100% conformance, incl. ECR + ECS + ELBv2 |
 | Lambda execution | Real, 13 runtimes in Docker |
 | RDS | Real PostgreSQL/MySQL/MariaDB via Docker |
-| ElastiCache | Real Redis/Valkey via Docker |
+| ElastiCache | Real Redis/Valkey/Memcached via Docker |
 | Conformance methodology | Smithy-validated, 59k+ test variants on every commit |
 | Terraform TestAcc CI | Yes (upstream suites run against fakecloud) |
 | Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust |

--- a/website/content/vs/moto.md
+++ b/website/content/vs/moto.md
@@ -24,7 +24,7 @@ fakecloud is a different tool for a different problem.
 | Works with AWS CLI | Yes | **No** |
 | Real Lambda execution | Yes (13 runtimes, real containers) | **No** (stubbed responses) |
 | Real RDS databases | Yes (PostgreSQL/MySQL/MariaDB via Docker) | **No** (in-memory stubs) |
-| Real ElastiCache | Yes (Redis/Valkey via Docker) | **No** |
+| Real ElastiCache | Yes (Redis/Valkey/Memcached via Docker) | **No** |
 | Real `docker push`/`pull` to ECR | Yes (OCI v2 Distribution) | **No** (Moto ships the JSON control plane only) |
 | Real cross-service wiring | Yes (S3 -> Lambda, SNS fan-out, etc fire end-to-end) | Partial (Moto simulates some events, not real execution) |
 | Setup for Python unit tests | HTTP endpoint override + fakecloud running | `@mock_aws` decorator |


### PR DESCRIPTION
## Summary

- Adds memcached as a third real-engine option in ElastiCache. `CreateCacheCluster` with `Engine=memcached` spawns `memcached:1.6-alpine` and exposes the mapped host port.
- `wait_for_memcached` probes via the memcached `version` command before reporting `available`.
- Rejects memcached for `CreateReplicationGroup` and `CreateServerlessCache` (matches AWS — memcached only supports cluster topology).
- Adds default engine version (1.6.22), `memcached1.6` parameter-group family, and default parameters (`max_item_size`, `max_connections`).
- Updates README, website docs, and comparison pages to reflect the third real engine.

## Test plan

- [x] `cargo test -p fakecloud-elasticache --lib` — 177 tests pass (new state/service tests covering memcached defaults + rejection paths)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New E2E test `elasticache_create_memcached_cluster_and_connect` exercises real container, SET/GET round-trip via memcached text protocol
- [x] New E2E test `elasticache_memcached_replication_group_rejected` confirms AWS-parity rejection
- [x] New E2E test `elasticache_describe_engine_default_parameters_memcached` + `elasticache_describe_cache_engine_versions_includes_memcached`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real Memcached support to ElastiCache. `CreateCacheCluster` with `Engine=memcached` now starts a `memcached:1.6-alpine` container, waits on `version`, and exposes a connectable host port; replication groups and serverless caches reject Memcached to match AWS.

- **New Features**
  - Real Memcached runtime via Docker with readiness probe (`version`).
  - Defaults: engine version `1.6.22`, parameter group family `memcached1.6`, default params `max_item_size`, `max_simultaneous_connections`.
  - API: `CreateReplicationGroup` and `CreateServerlessCache` reject `Engine=memcached`; `DescribeCacheEngineVersions` and engine default parameters include Memcached.
  - Docs updated to list Memcached as a supported real engine.

- **Bug Fixes**
  - Corrected Memcached default parameter name to `max_simultaneous_connections` (was `max_connections`).

<sup>Written for commit a18d660e722f6b1f08e32f6788eadb576ce78fb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

