### PR TITLE
feat(scheduler): cross-account target delivery

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -106,9 +106,26 @@ pub trait SnsDelivery: Send + Sync {
 
 /// Trait for putting events onto an EventBridge bus from cross-service integrations.
 pub trait EventBridgeDelivery: Send + Sync {
-    /// Put an event onto the specified event bus.
+    /// Put an event onto the specified event bus in the default account.
     /// The implementation should handle rule matching and target delivery.
     fn put_event(&self, source: &str, detail_type: &str, detail: &str, event_bus_name: &str);
+
+    /// Put an event onto the specified event bus owned by `target_account_id`.
+    /// Used for cross-account delivery where the source service (e.g. Scheduler)
+    /// has a target ARN containing the destination account. The default impl
+    /// falls back to the default-account `put_event` for backwards compat —
+    /// real implementations should override and route to the target account's
+    /// state.
+    fn put_event_to_account(
+        &self,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+        event_bus_name: &str,
+        _target_account_id: &str,
+    ) {
+        self.put_event(source, detail_type, detail, event_bus_name);
+    }
 }
 
 /// Trait for invoking Lambda functions from cross-service integrations.
@@ -291,7 +308,7 @@ impl DeliveryBus {
         }
     }
 
-    /// Put an event onto an EventBridge bus.
+    /// Put an event onto an EventBridge bus in the default account.
     pub fn put_event_to_eventbridge(
         &self,
         source: &str,
@@ -301,6 +318,27 @@ impl DeliveryBus {
     ) {
         if let Some(ref sender) = self.eventbridge_sender {
             sender.put_event(source, detail_type, detail, event_bus_name);
+        }
+    }
+
+    /// Put an event onto an EventBridge bus in a specific account. Used by
+    /// Scheduler to deliver to cross-account event buses.
+    pub fn put_event_to_eventbridge_for_account(
+        &self,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+        event_bus_name: &str,
+        target_account_id: &str,
+    ) {
+        if let Some(ref sender) = self.eventbridge_sender {
+            sender.put_event_to_account(
+                source,
+                detail_type,
+                detail,
+                event_bus_name,
+                target_account_id,
+            );
         }
     }
 

--- a/crates/fakecloud-e2e/tests/scheduler.rs
+++ b/crates/fakecloud-e2e/tests/scheduler.rs
@@ -387,3 +387,63 @@ async fn scheduler_dlq_routing_on_missing_target_queue() {
     assert!(attrs.contains_key("X-Amz-Scheduler-Schedule-Arn"));
     assert!(attrs.contains_key("X-Amz-Scheduler-Error-Code"));
 }
+
+#[tokio::test]
+async fn cross_account_sqs_target_delivers_to_target_account_queue() {
+    use aws_credential_types::Credentials;
+
+    const ACCOUNT_A: &str = "111111111111";
+    const ACCOUNT_B: &str = "222222222222";
+
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "soft")]).await;
+
+    // Bootstrap admins in both accounts so we can sign as either.
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+
+    let cfg_a = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(&a_akid, &a_secret, None, None, "a"))
+        .load()
+        .await;
+    let cfg_b = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(&b_akid, &b_secret, None, None, "b"))
+        .load()
+        .await;
+
+    // Account B owns the destination queue.
+    let sqs_b = aws_sdk_sqs::Client::new(&cfg_b);
+    let dest_url = queue_url(&sqs_b, "xacct-dest").await;
+    let dest_arn = queue_arn(&sqs_b, &dest_url).await;
+    assert!(
+        dest_arn.contains(ACCOUNT_B),
+        "queue ARN should include account B"
+    );
+
+    // Account A creates a schedule whose target points at account B's queue.
+    let scheduler_a = aws_sdk_scheduler::Client::new(&cfg_a);
+    let target = Target::builder()
+        .arn(&dest_arn)
+        .role_arn(format!("arn:aws:iam::{ACCOUNT_A}:role/scheduler"))
+        .input("{\"crossAccount\":true}")
+        .build()
+        .unwrap();
+    scheduler_a
+        .create_schedule()
+        .name("xacct-sched")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    // Account B receives the message via the same queue.
+    let msg = wait_for_message(&sqs_b, &dest_url, Duration::from_secs(10))
+        .await
+        .expect("cross-account schedule should deliver to account B queue");
+    assert_eq!(msg.body.unwrap(), "{\"crossAccount\":true}");
+}

--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -21,8 +21,15 @@ impl EventBridgeDeliveryImpl {
     }
 }
 
-impl EventBridgeDelivery for EventBridgeDeliveryImpl {
-    fn put_event(&self, source: &str, detail_type: &str, detail: &str, event_bus_name: &str) {
+impl EventBridgeDeliveryImpl {
+    fn put_event_in_account(
+        &self,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+        event_bus_name: &str,
+        target_account_id: Option<&str>,
+    ) {
         let event_id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now();
 
@@ -37,7 +44,10 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
         };
 
         let mut accounts = self.state.write();
-        let state = accounts.default_mut();
+        let state = match target_account_id {
+            Some(account_id) if !account_id.is_empty() => accounts.get_or_create(account_id),
+            _ => accounts.default_mut(),
+        };
         state.events.push(event);
 
         // Find matching rules and their targets
@@ -95,6 +105,29 @@ impl EventBridgeDelivery for EventBridgeDeliveryImpl {
             }
             // Lambda and other targets could be added here
         }
+    }
+}
+
+impl EventBridgeDelivery for EventBridgeDeliveryImpl {
+    fn put_event(&self, source: &str, detail_type: &str, detail: &str, event_bus_name: &str) {
+        self.put_event_in_account(source, detail_type, detail, event_bus_name, None);
+    }
+
+    fn put_event_to_account(
+        &self,
+        source: &str,
+        detail_type: &str,
+        detail: &str,
+        event_bus_name: &str,
+        target_account_id: &str,
+    ) {
+        self.put_event_in_account(
+            source,
+            detail_type,
+            detail,
+            event_bus_name,
+            Some(target_account_id),
+        );
     }
 }
 
@@ -289,5 +322,48 @@ mod tests {
         assert_eq!(calls.len(), 1);
         let env: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
         assert_eq!(env["detail"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn put_event_to_account_writes_to_target_account_bus() {
+        let state = make_shared();
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = EventBridgeDeliveryImpl::new(state.clone(), bus);
+        delivery.put_event_to_account("scheduler", "Fired", r#"{}"#, "default", "999988887777");
+
+        let guard = state.read();
+        let target = guard
+            .get("999988887777")
+            .expect("target account should be created on demand");
+        assert_eq!(target.events.len(), 1);
+        assert_eq!(target.events[0].source, "scheduler");
+        // The default account's bus should be untouched.
+        assert!(guard.default_ref().events.is_empty());
+    }
+
+    #[test]
+    fn put_event_to_account_dispatches_to_rules_in_target_account() {
+        let state = make_shared();
+        let q_arn = "arn:aws:sqs:us-east-1:999988887777:cross-q".to_string();
+        {
+            let mut s_accounts = state.write();
+            let s = s_accounts.get_or_create("999988887777");
+            let rule = make_rule("xacct-rule", None, &q_arn);
+            s.rules
+                .insert(("default".to_string(), "xacct-rule".to_string()), rule);
+        }
+        let recorder = Arc::new(Recorder::default());
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let delivery = EventBridgeDeliveryImpl::new(state, bus);
+        delivery.put_event_to_account(
+            "scheduler",
+            "Cross",
+            r#"{"hi":1}"#,
+            "default",
+            "999988887777",
+        );
+        let calls = recorder.sqs.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, q_arn);
     }
 }

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -65,7 +65,19 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
 
     if arn.contains(":events:") {
         let bus_name = event_bus_name_from_arn(arn);
-        bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, &bus_name);
+        let target_account = account_id_from_arn(arn);
+        match target_account {
+            Some(account) => bus.put_event_to_eventbridge_for_account(
+                "aws.scheduler",
+                "Scheduled Event",
+                body,
+                &bus_name,
+                &account,
+            ),
+            None => {
+                bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, &bus_name)
+            }
+        }
         return Ok(());
     }
 
@@ -156,6 +168,17 @@ fn fifo_dedup_id(queue_arn: &str, _schedule_arn: &str) -> Option<String> {
         return None;
     }
     Some(uuid::Uuid::new_v4().to_string())
+}
+
+/// Extract the account-id segment from any AWS ARN. Returns `None` when
+/// the ARN is malformed or omits the account (some service ARNs do).
+fn account_id_from_arn(arn: &str) -> Option<String> {
+    let account = arn.split(':').nth(4)?;
+    if account.is_empty() {
+        None
+    } else {
+        Some(account.to_string())
+    }
 }
 
 /// Extract the EventBridge bus name from a `:events:` target ARN.
@@ -383,6 +406,42 @@ mod tests {
             "default"
         );
         assert_eq!(event_bus_name_from_arn("arn:malformed"), "default");
+    }
+
+    #[test]
+    fn deliver_target_sqs_cross_account_routes_by_arn_account() {
+        // The SQS target points to account 999988887777 even though the
+        // schedule lives in account 1. Account-aware SQS routing is the
+        // SqsDelivery impl's responsibility — at this layer we just verify
+        // the ARN is forwarded unchanged to the bus, so a real impl can
+        // route it to the right account's state.
+        let recorder = Arc::new(Recorder {
+            calls: Mutex::new(Vec::new()),
+            fail_arn: None,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(recorder.clone()));
+        let sched = make_schedule(
+            "arn:aws:sqs:us-east-1:999988887777:cross-q",
+            None,
+            Some(r#"{"v":1}"#),
+        );
+        assert!(deliver_target(&bus, &sched).is_ok());
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "arn:aws:sqs:us-east-1:999988887777:cross-q");
+    }
+
+    #[test]
+    fn account_id_from_arn_extracts_account_segment() {
+        assert_eq!(
+            account_id_from_arn("arn:aws:events:us-east-1:111122223333:event-bus/main"),
+            Some("111122223333".to_string())
+        );
+        assert_eq!(
+            account_id_from_arn("arn:aws:events:us-east-1::event-bus/x"),
+            None
+        );
+        assert_eq!(account_id_from_arn("arn:malformed"), None);
     }
 
     #[test]

--- a/website/content/docs/services/scheduler.md
+++ b/website/content/docs/services/scheduler.md
@@ -11,6 +11,7 @@ fakecloud implements the full **EventBridge Scheduler** surface (`scheduler.amaz
 - **Schedules** — `at(yyyy-mm-ddThh:mm:ss)` one-shot, `rate(N unit)` recurring, `cron(...)` recurring
 - **Schedule groups** — create/get/delete/list; a `default` group is seeded per account and cannot be deleted
 - **Targets** — SQS (with `Target.Input` JSON), SNS, Lambda, Step Functions, EventBridge; `Target.RoleArn` is accepted (STS assume-role is a no-op in fakecloud)
+- **Cross-account targets** — `Target.Arn` may point to a queue/topic/function/state-machine/event-bus in a different account. Delivery routes by the ARN's account segment, matching fakecloud's ARN-routed multi-account model. Trust verification is a no-op (matches the existing fakecloud STS posture)
 - **Flexible time window** — `OFF` and `FLEXIBLE` modes; `MaximumWindowInMinutes` is required when `FLEXIBLE`
 - **ActionAfterCompletion: DELETE** — one-shot `at(...)` schedules self-delete after firing
 - **Dead-letter routing** — when target delivery fails (e.g. queue missing), the `Target.Input` is forwarded to `DeadLetterConfig.Arn` with `X-Amz-Scheduler-*` metadata attributes (Attempt, Schedule-Arn, Target-Arn, Error-Code, Error-Message, Group)
@@ -40,7 +41,6 @@ Scheduler shares fakecloud's cross-service delivery bus, so targets resolve to l
 ## Non-goals
 
 - KMS encryption on schedule state
-- Cross-account target delivery (use the single-account surface)
 - End-to-end IAM policy evaluation beyond the existing `test/test` root bypass
 
 ## Source


### PR DESCRIPTION
## Summary

EventBridge Scheduler can now deliver to targets in any account, not just the schedule's source account. Routing is ARN-driven (matching fakecloud's existing multi-account model). SQS/SNS/Lambda/Step Functions already routed by ARN account; this PR closes the EventBridge gap.

- Adds `put_event_to_account` on `EventBridgeDelivery` trait + `DeliveryBus::put_event_to_eventbridge_for_account`
- `EventBridgeDeliveryImpl` shares one inner impl so rule matching + target dispatch run against the destination account's state
- Scheduler `deliver_target` extracts the account from `:events:` target ARNs and uses the new method
- Drops the "no cross-account targets" non-goal in `scheduler.md`

## Test plan

- [x] `cargo test -p fakecloud-eventbridge --lib` — new unit tests `put_event_to_account_writes_to_target_account_bus` + `put_event_to_account_dispatches_to_rules_in_target_account`
- [x] `cargo test -p fakecloud-scheduler --lib` — new unit tests for ARN parsing + cross-account SQS routing through bus
- [x] `cargo test -p fakecloud-e2e --test scheduler cross_account_sqs_target_delivers_to_target_account_queue` — end-to-end via real fakecloud server, account A schedule fires into account B's queue
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables cross-account delivery for EventBridge Scheduler targets. EventBridge targets now write to the destination account’s bus and rules based on the ARN’s account, matching existing SQS/SNS/Lambda/Step Functions behavior.

- **New Features**
  - Added `EventBridgeDelivery::put_event_to_account` and `DeliveryBus::put_event_to_eventbridge_for_account`.
  - `EventBridgeDeliveryImpl` shares a single path so rule matching and target dispatch run in the target account’s state.
  - Scheduler extracts the account from `:events:` target ARNs and routes via the new method; other targets are unchanged.
  - Docs updated to note cross-account targets; new unit and e2e tests cover ARN parsing and cross-account delivery.

<sup>Written for commit e56f252e1849b353d2ea74d250326699d6f502d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

