### PR TITLE
feat(stepfunctions): real activity worker pool

### DIFF
--- a/crates/fakecloud-conformance/tests/stepfunctions.rs
+++ b/crates/fakecloud-conformance/tests/stepfunctions.rs
@@ -530,6 +530,32 @@ async fn sfn_task_token_round_trip() {
         .unwrap()
         .activity_arn()
         .to_string();
+
+    // GetActivityTask is a long-poll worker API: it returns a real token
+    // only when an activity execution is waiting. Inject pending tasks
+    // via the introspection endpoint so this test exercises SendTask*
+    // without spinning up a state-machine execution.
+    let http = reqwest::Client::new();
+    let enqueue = |arn: &str| {
+        let url = format!(
+            "{}/_fakecloud/stepfunctions/enqueue-activity-task",
+            server.endpoint()
+        );
+        let arn = arn.to_string();
+        let http = http.clone();
+        async move {
+            http.post(&url)
+                .json(&serde_json::json!({"activityArn": arn, "input": "{}"}))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap()
+        }
+    };
+
+    enqueue(&act).await;
     let token = client
         .get_activity_task()
         .activity_arn(&act)
@@ -539,6 +565,11 @@ async fn sfn_task_token_round_trip() {
         .task_token()
         .unwrap()
         .to_string();
+    assert!(
+        !token.is_empty(),
+        "expected non-empty token for pending task"
+    );
+
     client
         .send_task_heartbeat()
         .task_token(&token)
@@ -552,7 +583,8 @@ async fn sfn_task_token_round_trip() {
         .send()
         .await
         .unwrap();
-    // Same token can also be failed (test second token).
+
+    enqueue(&act).await;
     let token2 = client
         .get_activity_task()
         .activity_arn(&act)

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -3555,3 +3555,175 @@ async fn sfn_interpreter_panic_does_not_kill_server() {
         .unwrap();
     assert_eq!(describe.name(), "panic-check-sm");
 }
+
+#[tokio::test]
+async fn sfn_activity_worker_pool_round_trip() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let activity_arn = client
+        .create_activity()
+        .name("real-activity")
+        .send()
+        .await
+        .unwrap()
+        .activity_arn()
+        .to_string();
+
+    let definition = serde_json::json!({
+        "Comment": "Single activity Task",
+        "StartAt": "DoIt",
+        "States": {
+            "DoIt": {
+                "Type": "Task",
+                "Resource": activity_arn,
+                "End": true
+            }
+        }
+    })
+    .to_string();
+    let sm_arn = client
+        .create_state_machine()
+        .name("activity-sm")
+        .definition(&definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap()
+        .state_machine_arn()
+        .to_string();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(&sm_arn)
+        .input(r#"{"hello":"world"}"#)
+        .send()
+        .await
+        .unwrap();
+    let exec_arn = start.execution_arn().to_string();
+
+    // Worker side: long-poll for the activity task, send back success.
+    let worker = tokio::spawn({
+        let client = client.clone();
+        let activity_arn = activity_arn.clone();
+        async move {
+            for _ in 0..30 {
+                let resp = client
+                    .get_activity_task()
+                    .activity_arn(&activity_arn)
+                    .send()
+                    .await
+                    .unwrap();
+                let token = resp.task_token().unwrap_or("").to_string();
+                if !token.is_empty() {
+                    let input = resp.input().unwrap_or("{}").to_string();
+                    assert!(input.contains("\"hello\""));
+                    client
+                        .send_task_success()
+                        .task_token(&token)
+                        .output(r#"{"done":true}"#)
+                        .send()
+                        .await
+                        .unwrap();
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            panic!("worker never received activity task");
+        }
+    });
+
+    let status = wait_for_execution(&client, &exec_arn).await;
+    worker.await.unwrap();
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = client
+        .describe_execution()
+        .execution_arn(&exec_arn)
+        .send()
+        .await
+        .unwrap();
+    let output = desc.output().unwrap_or("");
+    assert!(
+        output.contains("\"done\":true") || output.contains("\"done\": true"),
+        "expected worker output, got {output}"
+    );
+}
+
+#[tokio::test]
+async fn sfn_activity_failure_propagates_to_execution() {
+    let server = TestServer::start().await;
+    let client = server.sfn_client().await;
+
+    let activity_arn = client
+        .create_activity()
+        .name("fail-activity")
+        .send()
+        .await
+        .unwrap()
+        .activity_arn()
+        .to_string();
+
+    let definition = serde_json::json!({
+        "StartAt": "F",
+        "States": {
+            "F": {
+                "Type": "Task",
+                "Resource": activity_arn,
+                "End": true
+            }
+        }
+    })
+    .to_string();
+    let sm_arn = client
+        .create_state_machine()
+        .name("fail-sm")
+        .definition(&definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap()
+        .state_machine_arn()
+        .to_string();
+
+    let start = client
+        .start_execution()
+        .state_machine_arn(&sm_arn)
+        .send()
+        .await
+        .unwrap();
+    let exec_arn = start.execution_arn().to_string();
+
+    let worker = tokio::spawn({
+        let client = client.clone();
+        let activity_arn = activity_arn.clone();
+        async move {
+            for _ in 0..30 {
+                let resp = client
+                    .get_activity_task()
+                    .activity_arn(&activity_arn)
+                    .send()
+                    .await
+                    .unwrap();
+                let token = resp.task_token().unwrap_or("").to_string();
+                if !token.is_empty() {
+                    client
+                        .send_task_failure()
+                        .task_token(&token)
+                        .error("HandlerCrashed")
+                        .cause("simulated worker crash")
+                        .send()
+                        .await
+                        .unwrap();
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            panic!("worker never received activity task");
+        }
+    });
+
+    let status = wait_for_execution(&client, &exec_arn).await;
+    worker.await.unwrap();
+    assert_eq!(status, "FAILED");
+}

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -465,6 +465,24 @@ pub struct StepFunctionsExecutionsResponse {
     pub executions: Vec<StepFunctionsExecution>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SfnEnqueueActivityTaskRequest {
+    pub activity_arn: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heartbeat_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SfnEnqueueActivityTaskResponse {
+    pub task_token: String,
+}
+
 // ── Cognito ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3872,18 +3872,17 @@ async fn main() {
                     let ss = ss.clone();
                     async move {
                         let activity_arn = req.activity_arn;
-                        let account_id = activity_arn
-                            .split(':')
-                            .nth(4)
-                            .unwrap_or("")
-                            .to_string();
                         let token = format!(
                             "FCToken-injected-{}-{}",
                             chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
                             uuid::Uuid::new_v4().simple(),
                         );
                         let mut accounts = ss.write();
-                        let state = accounts.get_or_create(&account_id);
+                        // Default-account namespace keeps the introspection
+                        // endpoint simple. Multi-account callers can switch
+                        // FAKECLOUD's default account before calling, or
+                        // create the activity in the default account.
+                        let state = accounts.default_mut();
                         if !state.activities.contains_key(&activity_arn) {
                             return (
                                 axum::http::StatusCode::NOT_FOUND,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3862,6 +3862,60 @@ async fn main() {
             }),
         )
         .route(
+            // Direct injection of an activity task (skipping a state-machine
+            // execution). Used by tests that want to exercise the worker
+            // pool API surface without spinning up an ASL workflow.
+            "/_fakecloud/stepfunctions/enqueue-activity-task",
+            axum::routing::post({
+                let ss = stepfunctions_state.clone();
+                move |axum::Json(req): axum::Json<types::SfnEnqueueActivityTaskRequest>| {
+                    let ss = ss.clone();
+                    async move {
+                        let activity_arn = req.activity_arn;
+                        let account_id = activity_arn
+                            .split(':')
+                            .nth(4)
+                            .unwrap_or("")
+                            .to_string();
+                        let token = format!(
+                            "FCToken-injected-{}-{}",
+                            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+                            uuid::Uuid::new_v4().simple(),
+                        );
+                        let mut accounts = ss.write();
+                        let state = accounts.get_or_create(&account_id);
+                        if !state.activities.contains_key(&activity_arn) {
+                            return (
+                                axum::http::StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({
+                                    "error": "ActivityDoesNotExist"
+                                })),
+                            );
+                        }
+                        state.task_tokens.insert(
+                            token.clone(),
+                            fakecloud_stepfunctions::state::TaskTokenState {
+                                activity_arn: activity_arn.clone(),
+                                status: "PENDING".to_string(),
+                                output: None,
+                                error: None,
+                                cause: None,
+                                input: Some(req.input.unwrap_or_else(|| "{}".to_string())),
+                                created_at: chrono::Utc::now(),
+                                last_heartbeat_at: None,
+                                heartbeat_seconds: req.heartbeat_seconds,
+                                timeout_seconds: req.timeout_seconds,
+                            },
+                        );
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::json!({ "taskToken": token })),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/lambda/{function_name}/evict-container",
             axum::routing::post({
                 let rt = lambda_sim_evict_runtime;

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -739,6 +739,7 @@ async fn execute_task_state(
 
     let retriers = state_def["Retry"].as_array().cloned().unwrap_or_default();
     let timeout_seconds = state_def["TimeoutSeconds"].as_u64();
+    let heartbeat_seconds = state_def["HeartbeatSeconds"].as_u64();
     let mut attempt = 0u32;
 
     loop {
@@ -768,6 +769,8 @@ async fn execute_task_state(
             delivery,
             dynamodb_state,
             timeout_seconds,
+            heartbeat_seconds,
+            shared_state,
         )
         .await;
 
@@ -1056,13 +1059,28 @@ async fn execute_map_state(
 }
 
 /// Invoke a resource (Lambda function or SDK integration).
+#[allow(clippy::too_many_arguments)]
 async fn invoke_resource(
     resource: &str,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
     timeout_seconds: Option<u64>,
+    heartbeat_seconds: Option<u64>,
+    shared_state: &SharedStepFunctionsState,
 ) -> Result<Value, (String, String)> {
+    // Direct activity ARN: arn:aws:states:<region>:<account>:activity:<name>
+    if resource.contains(":states:") && resource.contains(":activity:") {
+        return invoke_activity(
+            resource,
+            input,
+            shared_state,
+            timeout_seconds,
+            heartbeat_seconds,
+        )
+        .await;
+    }
+
     // Direct Lambda ARN: arn:aws:lambda:<region>:<account>:function:<name>
     if resource.contains(":lambda:") && resource.contains(":function:") {
         return invoke_lambda_direct(resource, input, delivery, timeout_seconds).await;
@@ -1815,6 +1833,132 @@ async fn invoke_lambda_direct(
             // No runtime available — return empty result
             Ok(json!({}))
         }
+    }
+}
+
+/// Invoke an activity worker. Inserts a `PENDING` token into shared state
+/// so a worker can claim it via `GetActivityTask`, then polls until the
+/// worker calls `SendTaskSuccess` / `SendTaskFailure` or the heartbeat /
+/// timeout windows expire.
+async fn invoke_activity(
+    activity_arn: &str,
+    input: &Value,
+    shared_state: &SharedStepFunctionsState,
+    timeout_seconds: Option<u64>,
+    heartbeat_seconds: Option<u64>,
+) -> Result<Value, (String, String)> {
+    use crate::state::TaskTokenState;
+
+    // Activity must exist (look up across accounts via ARN segment).
+    let activity_account = activity_arn.split(':').nth(4).unwrap_or("").to_string();
+    {
+        let accounts = shared_state.read();
+        let exists = accounts
+            .get(&activity_account)
+            .map(|s| s.activities.contains_key(activity_arn))
+            .unwrap_or(false);
+        if !exists {
+            return Err((
+                "States.TaskFailed".to_string(),
+                format!("Activity does not exist: {activity_arn}"),
+            ));
+        }
+    }
+
+    let token = format!(
+        "FCToken-{}-{}",
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        uuid::Uuid::new_v4().simple(),
+    );
+    let now = chrono::Utc::now();
+    let input_str = serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
+    {
+        let mut accounts = shared_state.write();
+        let state = accounts.get_or_create(&activity_account);
+        state.task_tokens.insert(
+            token.clone(),
+            TaskTokenState {
+                activity_arn: activity_arn.to_string(),
+                status: "PENDING".to_string(),
+                output: None,
+                error: None,
+                cause: None,
+                input: Some(input_str),
+                created_at: now,
+                last_heartbeat_at: None,
+                heartbeat_seconds: heartbeat_seconds.map(|s| s as i64),
+                timeout_seconds: timeout_seconds.map(|s| s as i64),
+            },
+        );
+    }
+
+    // Poll for completion. Default poll cadence 200ms; 1 hour absolute
+    // ceiling so a stuck activity can't block the interpreter forever
+    // when no TimeoutSeconds is set on the Task state.
+    let absolute_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(timeout_seconds.unwrap_or(3600));
+    loop {
+        let now_ts = chrono::Utc::now();
+        let snapshot = {
+            let accounts = shared_state.read();
+            accounts
+                .get(&activity_account)
+                .and_then(|s| s.task_tokens.get(&token).cloned())
+        };
+        let Some(entry) = snapshot else {
+            return Err((
+                "States.TaskFailed".to_string(),
+                "Activity task token disappeared".to_string(),
+            ));
+        };
+        match entry.status.as_str() {
+            "SUCCEEDED" => {
+                cleanup_token(shared_state, &activity_account, &token);
+                let output = entry.output.unwrap_or_else(|| "{}".to_string());
+                let value: Value = serde_json::from_str(&output).unwrap_or(Value::String(output));
+                return Ok(value);
+            }
+            "FAILED" => {
+                cleanup_token(shared_state, &activity_account, &token);
+                return Err((
+                    entry
+                        .error
+                        .unwrap_or_else(|| "States.TaskFailed".to_string()),
+                    entry.cause.unwrap_or_default(),
+                ));
+            }
+            _ => {}
+        }
+        // Heartbeat timeout: only enforced once a worker has picked up the
+        // task (status == IN_PROGRESS) and a heartbeat window is set.
+        if entry.status == "IN_PROGRESS" {
+            if let Some(hb) = entry.heartbeat_seconds {
+                let last = entry.last_heartbeat_at.unwrap_or(entry.created_at);
+                if (now_ts - last).num_seconds() > hb {
+                    cleanup_token(shared_state, &activity_account, &token);
+                    return Err((
+                        "States.HeartbeatTimeout".to_string(),
+                        format!("Activity worker missed heartbeat ({hb}s window)"),
+                    ));
+                }
+            }
+        }
+        if std::time::Instant::now() >= absolute_deadline {
+            cleanup_token(shared_state, &activity_account, &token);
+            let secs = timeout_seconds.unwrap_or(3600);
+            return Err((
+                "States.Timeout".to_string(),
+                format!("Activity timed out after {secs} seconds"),
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+fn cleanup_token(shared_state: &SharedStepFunctionsState, account_id: &str, token: &str) {
+    let mut accounts = shared_state.write();
+    if let Some(state) = accounts.get_mut(account_id) {
+        state.task_tokens.remove(token);
     }
 }
 

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -173,7 +173,7 @@ impl AwsService for StepFunctionsService {
             "DeleteActivity" => self.delete_activity(&req),
             "DescribeActivity" => self.describe_activity(&req),
             "ListActivities" => self.list_activities(&req),
-            "GetActivityTask" => self.get_activity_task(&req),
+            "GetActivityTask" => self.get_activity_task(&req).await,
             "SendTaskFailure" => self.send_task_failure(&req),
             "SendTaskHeartbeat" => self.send_task_heartbeat(&req),
             "SendTaskSuccess" => self.send_task_success(&req),
@@ -862,41 +862,65 @@ impl StepFunctionsService {
         Ok(AwsResponse::ok_json(body))
     }
 
-    fn get_activity_task(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn get_activity_task(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let arn = body["activityArn"]
             .as_str()
             .ok_or_else(|| missing("activityArn"))?
             .to_string();
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        if !state.activities.contains_key(&arn) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ActivityDoesNotExist",
-                format!("Activity does not exist: {arn}"),
-            ));
+        // Activity must exist before we'll accept long-poll calls.
+        {
+            let accounts = self.state.read();
+            let state = accounts
+                .get(&req.account_id)
+                .ok_or_else(|| activity_not_found(&arn))?;
+            if !state.activities.contains_key(&arn) {
+                return Err(activity_not_found(&arn));
+            }
         }
-        // Mint a synthetic task token tied to this activity. No worker
-        // pool to dispatch from in fakecloud, so we return an empty input.
-        let token = format!(
-            "FCToken-{}",
-            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
-        );
-        state.task_tokens.insert(
-            token.clone(),
-            crate::state::TaskTokenState {
-                activity_arn: arn,
-                status: "PENDING".to_string(),
-                output: None,
-                error: None,
-                cause: None,
-            },
-        );
-        Ok(AwsResponse::ok_json(json!({
-            "taskToken": token,
-            "input": "{}",
-        })))
+
+        // AWS GetActivityTask blocks up to 60s. fakecloud defaults to 5s
+        // so test suites don't stall when no worker is feeding the queue.
+        let max_wait_secs: u64 = std::env::var("FAKECLOUD_SFN_GET_ACTIVITY_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_wait_secs);
+
+        loop {
+            // Try to dequeue oldest PENDING token for this activity.
+            {
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(&req.account_id);
+                let mut candidates: Vec<(String, chrono::DateTime<chrono::Utc>)> = state
+                    .task_tokens
+                    .iter()
+                    .filter(|(_, t)| t.activity_arn == arn && t.status == "PENDING")
+                    .map(|(k, t)| (k.clone(), t.created_at))
+                    .collect();
+                candidates.sort_by_key(|c| c.1);
+                if let Some((token, _)) = candidates.into_iter().next() {
+                    let now = chrono::Utc::now();
+                    let entry = state.task_tokens.get_mut(&token).expect("just looked up");
+                    entry.status = "IN_PROGRESS".to_string();
+                    entry.last_heartbeat_at = Some(now);
+                    let input = entry.input.clone().unwrap_or_else(|| "{}".to_string());
+                    return Ok(AwsResponse::ok_json(json!({
+                        "taskToken": token,
+                        "input": input,
+                    })));
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                // No task available in window — return empty token (matches
+                // AWS behavior).
+                return Ok(AwsResponse::ok_json(json!({
+                    "taskToken": "",
+                    "input": "",
+                })));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
     }
 
     fn send_task_success(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -908,7 +932,23 @@ impl StepFunctionsService {
     }
 
     fn send_task_heartbeat(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        self.update_task_token(req, "HEARTBEAT")
+        // Heartbeats only refresh `last_heartbeat_at`; they don't change
+        // the task's lifecycle status. The interpreter's heartbeat-timeout
+        // check reads `last_heartbeat_at` to decide whether to fail the
+        // task with `States.HeartbeatTimeout`.
+        let body = req.json_body();
+        let token = body["taskToken"]
+            .as_str()
+            .ok_or_else(|| missing("taskToken"))?
+            .to_string();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let entry = state
+            .task_tokens
+            .get_mut(&token)
+            .ok_or_else(|| task_does_not_exist(&token))?;
+        entry.last_heartbeat_at = Some(chrono::Utc::now());
+        Ok(AwsResponse::ok_json(json!({})))
     }
 
     fn update_task_token(
@@ -923,13 +963,10 @@ impl StepFunctionsService {
             .to_string();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let entry = state.task_tokens.get_mut(&token).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "TaskDoesNotExist",
-                format!("Task does not exist: {token}"),
-            )
-        })?;
+        let entry = state
+            .task_tokens
+            .get_mut(&token)
+            .ok_or_else(|| task_does_not_exist(&token))?;
         entry.status = new_status.to_string();
         if new_status == "SUCCEEDED" {
             entry.output = body["output"].as_str().map(String::from);
@@ -1403,6 +1440,22 @@ fn state_machine_not_found(arn: &str) -> AwsServiceError {
         StatusCode::BAD_REQUEST,
         "StateMachineDoesNotExist",
         format!("State Machine Does Not Exist: '{arn}'"),
+    )
+}
+
+fn activity_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ActivityDoesNotExist",
+        format!("Activity does not exist: {arn}"),
+    )
+}
+
+fn task_does_not_exist(token: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "TaskDoesNotExist",
+        format!("Task does not exist: {token}"),
     )
 }
 

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -97,10 +97,33 @@ pub struct MapRun {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskTokenState {
     pub activity_arn: String,
-    pub status: String, // PENDING / SUCCEEDED / FAILED / HEARTBEAT
+    /// PENDING (waiting for `GetActivityTask` to dequeue) /
+    /// IN_PROGRESS (worker has picked it up) /
+    /// SUCCEEDED / FAILED / TIMED_OUT.
+    pub status: String,
     pub output: Option<String>,
     pub error: Option<String>,
     pub cause: Option<String>,
+    /// Input the state machine wanted the worker to process. `None`
+    /// for tokens minted by external `GetActivityTask` callers without
+    /// any associated activity execution (legacy synthetic path).
+    #[serde(default)]
+    pub input: Option<String>,
+    #[serde(default = "default_now")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+    /// Per AWS docs: state machine fails the task if no heartbeat in
+    /// this many seconds while the worker is running.
+    #[serde(default)]
+    pub heartbeat_seconds: Option<i64>,
+    /// Overall timeout for the task; counted from `created_at`.
+    #[serde(default)]
+    pub timeout_seconds: Option<i64>,
+}
+
+fn default_now() -> DateTime<Utc> {
+    Utc::now()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/website/content/docs/services/stepfunctions.md
+++ b/website/content/docs/services/stepfunctions.md
@@ -16,7 +16,7 @@ fakecloud implements **37 of 37** Step Functions operations at 100% Smithy confo
 - **Task integrations** — Lambda (invoke, invoke.waitForTaskToken), SQS (sendMessage), SNS (publish), EventBridge (putEvents), DynamoDB (getItem/putItem/updateItem/deleteItem)
 - **Map state** — parallel item processing with concurrency control
 - **Parallel state** — concurrent branch execution
-- **Activities** — task workers, GetActivityTask, SendTaskSuccess/Failure
+- **Activities** — real worker pool. A `Task` state with an activity ARN inserts a pending task; `GetActivityTask` long-polls (up to `FAKECLOUD_SFN_GET_ACTIVITY_TIMEOUT_SECS`, default 5s) for the next pending task; `SendTaskSuccess` / `SendTaskFailure` resolve the workflow. `HeartbeatSeconds` and `TimeoutSeconds` are enforced.
 - **State machine execution history** — full event log per execution
 - **Error handling** — states.ALL, states.TaskFailed, custom error names
 
@@ -27,6 +27,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 ## Introspection
 
 - `GET /_fakecloud/stepfunctions/executions` — list all executions with status, input, output, and timestamps
+- `POST /_fakecloud/stepfunctions/enqueue-activity-task` — directly insert a pending activity task (skipping a state-machine execution). Body: `{"activityArn": "...", "input": "{}", "heartbeatSeconds": 60, "timeoutSeconds": 300}`. Returns `{"taskToken": "..."}`. Useful for testing worker pool clients without authoring a full ASL workflow.
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

Replaces the synthetic GetActivityTask shortcut with a real worker pool: a Task state inserts a PENDING token, GetActivityTask long-polls for the oldest pending task, SendTaskSuccess/Failure unblocks the interpreter. Heartbeat + timeout windows enforced. New introspection endpoint lets tests inject pending tasks directly.

- Extends TaskTokenState with input/created_at/last_heartbeat_at/heartbeat_seconds/timeout_seconds
- Interpreter \`invoke_activity\` polls until the worker resolves the token, with HeartbeatSeconds and TimeoutSeconds enforced
- GetActivityTask returns empty taskToken after FAKECLOUD_SFN_GET_ACTIVITY_TIMEOUT_SECS (default 5s) when no task is queued, matching AWS
- SendTaskHeartbeat now refreshes last_heartbeat_at instead of mutating status
- New POST /_fakecloud/stepfunctions/enqueue-activity-task introspection endpoint
- Conformance test sfn_task_token_round_trip rewired to use the introspection endpoint (old shortcut no longer applies)
- New E2E tests cover round-trip success + worker failure propagation

## Test plan

- [x] cargo test -p fakecloud-stepfunctions --lib (137 pass)
- [x] cargo test -p fakecloud-conformance --test stepfunctions sfn_task_token_round_trip
- [x] cargo test -p fakecloud-e2e --test stepfunctions sfn_activity_worker_pool_round_trip + sfn_activity_failure_propagates_to_execution
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a real Step Functions activity worker pool: Task states enqueue pending work, workers long‑poll `GetActivityTask`, and executions resolve via `SendTaskSuccess`/`SendTaskFailure` with `HeartbeatSeconds`/`TimeoutSeconds` enforced. Adds a test-only endpoint to enqueue tasks directly (uses the default account).

- **New Features**
  - Real worker pool for activities: oldest pending task is dequeued by `GetActivityTask` (long-polls up to `FAKECLOUD_SFN_GET_ACTIVITY_TIMEOUT_SECS`, default 5s; returns empty token on timeout).
  - Heartbeat/timeout enforcement in the interpreter; `SendTaskHeartbeat` now updates `last_heartbeat_at` only; emits `States.HeartbeatTimeout` or `States.Timeout` when windows close.
  - Introspection: `POST /_fakecloud/stepfunctions/enqueue-activity-task` inserts a pending task for an activity (accepts `activityArn`, optional `input`, `heartbeatSeconds`, `timeoutSeconds`; returns `taskToken`). Tasks are enqueued in the default account namespace.
  - `TaskTokenState` extended with `input`, `created_at`, `last_heartbeat_at`, `heartbeat_seconds`, `timeout_seconds`; tokens are cleaned up on completion.

- **Migration**
  - Code relying on synthetic `GetActivityTask` tokens must handle empty tokens and poll until a task is available.
  - Tests that exercised `SendTask*` without a state machine should use `/_fakecloud/stepfunctions/enqueue-activity-task` or start a real execution; for multi-account setups, switch the default account or create the activity in the default account.
  - When `HeartbeatSeconds` is set, workers must call `SendTaskHeartbeat` periodically.
  - Adjust long‑poll window via `FAKECLOUD_SFN_GET_ACTIVITY_TIMEOUT_SECS` if needed.

<sup>Written for commit c70cb0bd2da908014f5159f699e0a13e90b403aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

