### PR TITLE
feat(ecr): real image scanning via optional Trivy CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tar",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",
@@ -3027,6 +3029,17 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -3906,7 +3919,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4386,7 +4402,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -4513,6 +4529,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polyval"
@@ -4845,6 +4867,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -5632,6 +5663,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -6846,6 +6888,16 @@ dependencies = [
  "der 0.7.10",
  "spki 0.7.3",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/fakecloud-e2e/tests/ecr.rs
+++ b/crates/fakecloud-e2e/tests/ecr.rs
@@ -2,6 +2,7 @@
 
 mod helpers;
 
+use base64::Engine;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -249,6 +250,91 @@ async fn tag_resource_round_trip() {
         .expect("list_tags after");
     assert_eq!(after.tags().len(), 1);
     assert_eq!(after.tags()[0].key(), "team");
+}
+
+#[tokio::test]
+async fn start_image_scan_transitions_to_complete() {
+    use std::time::Duration;
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+    client
+        .create_repository()
+        .repository_name("scan-transition-repo")
+        .send()
+        .await
+        .unwrap();
+
+    // Push a minimal manifest so DescribeImageScanFindings can find an image.
+    let http = reqwest::Client::new();
+    let auth = format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode("AWS:test")
+    );
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 0,
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "layers": []
+    });
+    http.put(format!(
+        "{}/v2/scan-transition-repo/manifests/v1",
+        server.endpoint()
+    ))
+    .header("Authorization", &auth)
+    .header(
+        "Content-Type",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+    .body(serde_json::to_vec(&manifest).unwrap())
+    .send()
+    .await
+    .unwrap()
+    .error_for_status()
+    .unwrap();
+
+    use aws_sdk_ecr::types::ImageIdentifier;
+    let scan = client
+        .start_image_scan()
+        .repository_name("scan-transition-repo")
+        .image_id(ImageIdentifier::builder().image_tag("v1").build())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        scan.image_scan_status()
+            .and_then(|s| s.status())
+            .map(|s| s.as_str()),
+        Some("IN_PROGRESS")
+    );
+
+    // Background scanner finishes shortly (synthetic fallback when Trivy
+    // is unavailable; real findings when it is). Poll up to 30s.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut final_status = String::new();
+    while std::time::Instant::now() < deadline {
+        let resp = client
+            .describe_image_scan_findings()
+            .repository_name("scan-transition-repo")
+            .image_id(ImageIdentifier::builder().image_tag("v1").build())
+            .send()
+            .await
+            .unwrap();
+        let status = resp
+            .image_scan_status()
+            .and_then(|s| s.status())
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        if status == "COMPLETE" {
+            final_status = status;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert_eq!(final_status, "COMPLETE", "scan never reached COMPLETE");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
+++ b/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
@@ -80,8 +80,17 @@ async fn describe_image_scan_findings_returns_well_formed_response() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert!(body["imageScanFindings"]["findings"].is_array());
     assert!(body["imageScanFindings"]["findingSeverityCounts"].is_object());
-    assert!(body["imageScanFindings"]["isSynthetic"].is_null(),
-        "isSynthetic was a fakecloud-only marker that has been removed; AWS's DescribeImageScanFindings returns no such field");
+    // Verify *absence* of the `isSynthetic` field — `is_null()` would
+    // accept an explicit `null`, which is a different shape than what
+    // AWS returns. Use the parent object's key set instead.
+    let scan_findings = body["imageScanFindings"]
+        .as_object()
+        .expect("imageScanFindings is an object");
+    assert!(
+        !scan_findings.contains_key("isSynthetic"),
+        "isSynthetic was a fakecloud-only marker that has been removed; AWS's \
+         DescribeImageScanFindings returns no such field, so the key must be absent",
+    );
 }
 
 use base64::Engine;

--- a/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
+++ b/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
@@ -1,19 +1,20 @@
-//! ECR `DescribeImageScanFindings` returns `isSynthetic: true` so
-//! users introspecting scan results can tell fakecloud's stub scanner
-//! from real AWS Inspector output. Asserted via raw HTTP because
-//! aws-sdk-ecr drops unknown response fields during Smithy decode.
+//! ECR `DescribeImageScanFindings` returns the AWS-shaped response.
+//! When the optional Trivy CLI is not installed, fakecloud still returns
+//! a well-formed empty findings result so client-side plumbing can be
+//! exercised end-to-end. Asserted via raw HTTP so the assertion holds
+//! whether or not the test environment has Trivy on PATH.
 
 mod helpers;
 
 use helpers::TestServer;
 
 #[tokio::test]
-async fn describe_image_scan_findings_is_flagged_synthetic() {
+async fn describe_image_scan_findings_returns_well_formed_response() {
     let server = TestServer::start().await;
     let ecr = server.ecr_client().await;
 
     ecr.create_repository()
-        .repository_name("synthetic-flag-repo")
+        .repository_name("scan-shape-repo")
         .send()
         .await
         .unwrap();
@@ -38,7 +39,7 @@ async fn describe_image_scan_findings_is_flagged_synthetic() {
     });
     let body = serde_json::to_vec(&manifest).unwrap();
     http.put(format!(
-        "{}/v2/synthetic-flag-repo/manifests/v1",
+        "{}/v2/scan-shape-repo/manifests/v1",
         server.endpoint()
     ))
     .header("Authorization", &auth)
@@ -53,16 +54,21 @@ async fn describe_image_scan_findings_is_flagged_synthetic() {
     .error_for_status()
     .unwrap();
 
-    // Hit the AWS JSON surface via raw HTTP so the unknown
-    // `isSynthetic` key survives the response envelope.
+    // Hit the AWS JSON surface via raw HTTP.
     let resp = http
         .post(server.endpoint())
-        .header("X-Amz-Target", "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings")
+        .header(
+            "X-Amz-Target",
+            "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings",
+        )
         .header("Content-Type", "application/x-amz-json-1.1")
-        .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0000")
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=test/20260424/us-east-1/ecr/aws4_request, SignedHeaders=host, Signature=0000",
+        )
         .body(
             serde_json::json!({
-                "repositoryName": "synthetic-flag-repo",
+                "repositoryName": "scan-shape-repo",
                 "imageId": { "imageTag": "v1" }
             })
             .to_string(),
@@ -72,11 +78,10 @@ async fn describe_image_scan_findings_is_flagged_synthetic() {
         .unwrap();
     assert!(resp.status().is_success(), "status = {}", resp.status());
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(
-        body["imageScanFindings"]["isSynthetic"].as_bool(),
-        Some(true),
-        "expected isSynthetic=true; full body: {body}"
-    );
+    assert!(body["imageScanFindings"]["findings"].is_array());
+    assert!(body["imageScanFindings"]["findingSeverityCounts"].is_object());
+    assert!(body["imageScanFindings"]["isSynthetic"].is_null(),
+        "isSynthetic was a fakecloud-only marker that has been removed; AWS's DescribeImageScanFindings returns no such field");
 }
 
 use base64::Engine;

--- a/crates/fakecloud-ecr/Cargo.toml
+++ b/crates/fakecloud-ecr/Cargo.toml
@@ -25,3 +25,5 @@ uuid = { workspace = true }
 bytes = { workspace = true }
 reqwest = { workspace = true }
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pem", "pkcs8", "std"] }
+tar = "0.4"
+tempfile = { workspace = true }

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod oci;
 pub(crate) mod pull_through;
+pub mod scanner;
 pub mod service;
 pub mod signing;
 pub mod state;

--- a/crates/fakecloud-ecr/src/scanner.rs
+++ b/crates/fakecloud-ecr/src/scanner.rs
@@ -1,0 +1,302 @@
+//! Real image vulnerability scanning via the optional Trivy CLI.
+//!
+//! ECR's `StartImageScan` traditionally points at AWS Inspector. fakecloud
+//! shells out to `trivy image --input <tar>` when the binary is available
+//! and parses the JSON output into an `ImageScanFindings`. When `trivy`
+//! is not installed we fall back to a synthetic empty result with
+//! `scan_status=COMPLETE` so the API surface stays consistent — tests
+//! that don't care about real CVEs keep working, and security-tooling
+//! integration tests can install Trivy to get real findings.
+//!
+//! Trivy is invoked in a subprocess so it doesn't add a Rust-side
+//! cargo dependency and so it stays opt-in. The detection logic mirrors
+//! the docker/podman CLI detection used elsewhere in fakecloud.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Stdio;
+
+use base64::Engine;
+use serde_json::{json, Value};
+
+use crate::state::{ImageScanFindings, Layer};
+
+/// Resolve the path to the `trivy` binary. Honors `FAKECLOUD_TRIVY_BIN`
+/// for explicit overrides (e.g. CI installing into a non-default
+/// location). Returns `None` when the binary is not found, in which
+/// case callers fall back to the synthetic empty-findings path.
+pub fn detect_trivy() -> Option<String> {
+    if let Ok(custom) = std::env::var("FAKECLOUD_TRIVY_BIN") {
+        if cli_available(&custom) {
+            return Some(custom);
+        }
+        return None;
+    }
+    if cli_available("trivy") {
+        return Some("trivy".to_string());
+    }
+    None
+}
+
+fn cli_available(cli: &str) -> bool {
+    std::process::Command::new(cli)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Run Trivy against a single-layer tarball reconstructed from the
+/// repository's stored layers. Returns parsed findings on success;
+/// `None` if Trivy isn't installed or the scan fails (caller logs +
+/// falls back to synthetic).
+pub async fn scan_layers(image_digest: &str, layers: &[Layer]) -> Option<ImageScanFindings> {
+    let trivy = detect_trivy()?;
+    let tmp = tempfile::tempdir().ok()?;
+    let tar_path = tmp.path().join("image.tar");
+    if let Err(err) = build_image_tar(&tar_path, layers).await {
+        tracing::warn!(%err, "ECR scanner: failed to build image tar for trivy; using synthetic");
+        return None;
+    }
+
+    let output = match tokio::process::Command::new(&trivy)
+        .args([
+            "image",
+            "--quiet",
+            "--no-progress",
+            "--format",
+            "json",
+            "--scanners",
+            "vuln",
+            "--input",
+        ])
+        .arg(&tar_path)
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(err) => {
+            tracing::warn!(%err, "ECR scanner: trivy invocation failed; using synthetic");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            stderr = %stderr,
+            "ECR scanner: trivy exited non-zero; using synthetic"
+        );
+        return None;
+    }
+
+    parse_trivy_output(image_digest, &output.stdout)
+}
+
+async fn build_image_tar(tar_path: &Path, layers: &[Layer]) -> std::io::Result<()> {
+    use std::io::Write;
+    let file = std::fs::File::create(tar_path)?;
+    let mut builder = tar::Builder::new(file);
+    let engine = base64::engine::general_purpose::STANDARD;
+
+    let mut layer_filenames: Vec<String> = Vec::new();
+    for (idx, layer) in layers.iter().enumerate() {
+        let bytes = engine.decode(&layer.blob_b64).unwrap_or_default();
+        let filename = format!("layer-{idx}.tar");
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, &filename, bytes.as_slice())?;
+        layer_filenames.push(filename);
+    }
+
+    // Minimal manifest.json so trivy treats this as a docker-format archive.
+    let config = json!({
+        "architecture": "amd64",
+        "os": "linux",
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": layers
+                .iter()
+                .map(|l| l.digest.clone())
+                .collect::<Vec<_>>(),
+        },
+        "config": {},
+    });
+    let config_bytes = serde_json::to_vec(&config)?;
+    let mut config_header = tar::Header::new_gnu();
+    config_header.set_size(config_bytes.len() as u64);
+    config_header.set_mode(0o644);
+    config_header.set_cksum();
+    builder.append_data(&mut config_header, "config.json", config_bytes.as_slice())?;
+
+    let manifest = json!([{
+        "Config": "config.json",
+        "RepoTags": ["fakecloud-scan:latest"],
+        "Layers": layer_filenames,
+    }]);
+    let manifest_bytes = serde_json::to_vec(&manifest)?;
+    let mut manifest_header = tar::Header::new_gnu();
+    manifest_header.set_size(manifest_bytes.len() as u64);
+    manifest_header.set_mode(0o644);
+    manifest_header.set_cksum();
+    builder.append_data(
+        &mut manifest_header,
+        "manifest.json",
+        manifest_bytes.as_slice(),
+    )?;
+
+    let mut writer = builder.into_inner()?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn parse_trivy_output(image_digest: &str, stdout: &[u8]) -> Option<ImageScanFindings> {
+    let parsed: Value = serde_json::from_slice(stdout).ok()?;
+    let mut findings = Vec::new();
+    let mut counts: BTreeMap<String, i64> = BTreeMap::new();
+
+    let results = parsed
+        .get("Results")?
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    for result in results {
+        if let Some(vulns) = result.get("Vulnerabilities").and_then(|v| v.as_array()) {
+            for vuln in vulns {
+                let severity =
+                    map_severity(vuln.get("Severity").and_then(Value::as_str).unwrap_or(""));
+                *counts.entry(severity.clone()).or_insert(0) += 1;
+                let name = vuln
+                    .get("VulnerabilityID")
+                    .and_then(Value::as_str)
+                    .unwrap_or("UNKNOWN")
+                    .to_string();
+                let description = vuln
+                    .get("Description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let uri = vuln
+                    .get("PrimaryURL")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let pkg = vuln
+                    .get("PkgName")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let installed = vuln
+                    .get("InstalledVersion")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let fixed = vuln
+                    .get("FixedVersion")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                findings.push(json!({
+                    "name": name,
+                    "description": description,
+                    "uri": uri,
+                    "severity": severity,
+                    "attributes": [
+                        {"key": "package_name", "value": pkg},
+                        {"key": "package_version", "value": installed},
+                        {"key": "fixed_version", "value": fixed},
+                    ],
+                }));
+            }
+        }
+    }
+
+    Some(ImageScanFindings {
+        image_digest: image_digest.to_string(),
+        scan_status: "COMPLETE".to_string(),
+        scan_completed_at: Some(chrono::Utc::now()),
+        vulnerability_source_updated_at: Some(chrono::Utc::now()),
+        finding_severity_counts: counts,
+        findings,
+    })
+}
+
+fn map_severity(trivy: &str) -> String {
+    match trivy.to_uppercase().as_str() {
+        "CRITICAL" => "CRITICAL".to_string(),
+        "HIGH" => "HIGH".to_string(),
+        "MEDIUM" => "MEDIUM".to_string(),
+        "LOW" => "LOW".to_string(),
+        _ => "UNDEFINED".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_trivy_output_extracts_vulnerabilities_and_counts() {
+        let sample = serde_json::json!({
+            "Results": [{
+                "Target": "alpine:3.10",
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-2020-1971",
+                        "PkgName": "libcrypto1.1",
+                        "InstalledVersion": "1.1.1g-r0",
+                        "FixedVersion": "1.1.1i-r0",
+                        "Severity": "HIGH",
+                        "Description": "openssl null pointer deref",
+                        "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-1971"
+                    },
+                    {
+                        "VulnerabilityID": "CVE-2021-3711",
+                        "PkgName": "libssl1.1",
+                        "InstalledVersion": "1.1.1g-r0",
+                        "Severity": "CRITICAL"
+                    }
+                ]
+            }]
+        })
+        .to_string();
+        let findings = parse_trivy_output("sha256:abc", sample.as_bytes()).expect("parsed");
+        assert_eq!(findings.scan_status, "COMPLETE");
+        assert_eq!(findings.findings.len(), 2);
+        assert_eq!(findings.finding_severity_counts.get("HIGH"), Some(&1));
+        assert_eq!(findings.finding_severity_counts.get("CRITICAL"), Some(&1));
+    }
+
+    #[test]
+    fn parse_trivy_output_handles_unknown_severity() {
+        let sample = serde_json::json!({
+            "Results": [{
+                "Vulnerabilities": [
+                    {"VulnerabilityID": "CVE-X", "Severity": "WAT"}
+                ]
+            }]
+        })
+        .to_string();
+        let findings = parse_trivy_output("d", sample.as_bytes()).unwrap();
+        assert_eq!(findings.finding_severity_counts.get("UNDEFINED"), Some(&1));
+    }
+
+    #[test]
+    fn parse_trivy_output_returns_some_with_no_findings_section() {
+        let sample = r#"{"Results": []}"#;
+        let findings = parse_trivy_output("d", sample.as_bytes()).unwrap();
+        assert!(findings.findings.is_empty());
+    }
+
+    #[test]
+    fn detect_trivy_respects_env_override() {
+        // When the override is bogus, detect_trivy returns None
+        std::env::set_var("FAKECLOUD_TRIVY_BIN", "/nonexistent/trivy-binary");
+        assert!(detect_trivy().is_none());
+        std::env::remove_var("FAKECLOUD_TRIVY_BIN");
+    }
+}

--- a/crates/fakecloud-ecr/src/scanner.rs
+++ b/crates/fakecloud-ecr/src/scanner.rs
@@ -103,7 +103,18 @@ async fn build_image_tar(tar_path: &Path, layers: &[Layer]) -> std::io::Result<(
 
     let mut layer_filenames: Vec<String> = Vec::new();
     for (idx, layer) in layers.iter().enumerate() {
-        let bytes = engine.decode(&layer.blob_b64).unwrap_or_default();
+        // Surface base64-decode failures explicitly. Silently
+        // substituting empty bytes would have Trivy scan a 0-byte
+        // layer and report "no findings" on what is actually a
+        // corrupted blob — the caller falls back to synthetic-empty
+        // findings, which is the same outcome but logged rather
+        // than masquerading as a clean scan.
+        let bytes = engine.decode(&layer.blob_b64).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("layer {} base64 decode failed: {}", layer.digest, err),
+            )
+        })?;
         let filename = format!("layer-{idx}.tar");
         let mut header = tar::Header::new_gnu();
         header.set_size(bytes.len() as u64);

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1918,29 +1918,59 @@ impl EcrService {
             .cloned()
             .ok_or_else(|| invalid_parameter("Missing imageId"))?;
         let account = target_account_id(request, &body);
-        let mut accounts = self.state.write();
-        let state = accounts
-            .get_mut(&account)
-            .ok_or_else(|| repository_not_found(&name))?;
-        let repo = state
-            .repositories
-            .get_mut(&name)
-            .ok_or_else(|| repository_not_found(&name))?;
-        let digest = resolve_image_digest(repo, &image_id)
-            .ok_or_else(|| image_not_found(&name, &image_id))?;
-        // Synthetic-but-schema-complete findings. Real scanner integration
-        // lives out of scope for a mock; a deterministic non-empty shape
-        // lets callers exercise their findings plumbing.
-        let findings = ImageScanFindings {
-            image_digest: digest.clone(),
-            scan_status: "COMPLETE".to_string(),
-            scan_completed_at: Some(Utc::now()),
-            vulnerability_source_updated_at: Some(Utc::now()),
-            finding_severity_counts: BTreeMap::new(),
-            findings: Vec::new(),
+        let (digest, layers, registry_id) = {
+            let mut accounts = self.state.write();
+            let state = accounts
+                .get_mut(&account)
+                .ok_or_else(|| repository_not_found(&name))?;
+            let repo = state
+                .repositories
+                .get_mut(&name)
+                .ok_or_else(|| repository_not_found(&name))?;
+            let digest = resolve_image_digest(repo, &image_id)
+                .ok_or_else(|| image_not_found(&name, &image_id))?;
+            // Mark scan IN_PROGRESS; real findings written by the
+            // background scanner task. Caller polls
+            // DescribeImageScanFindings to observe completion.
+            repo.scan_findings.insert(
+                digest.clone(),
+                ImageScanFindings {
+                    image_digest: digest.clone(),
+                    scan_status: "IN_PROGRESS".to_string(),
+                    scan_completed_at: None,
+                    vulnerability_source_updated_at: None,
+                    finding_severity_counts: BTreeMap::new(),
+                    findings: Vec::new(),
+                },
+            );
+            let layers = repo.layers.values().cloned().collect::<Vec<_>>();
+            (digest, layers, repo.registry_id.clone())
         };
-        repo.scan_findings.insert(digest.clone(), findings);
-        let registry_id = repo.registry_id.clone();
+
+        let shared = self.state.clone();
+        let account_for_task = account.clone();
+        let name_for_task = name.clone();
+        let digest_for_task = digest.clone();
+        tokio::spawn(async move {
+            let result = crate::scanner::scan_layers(&digest_for_task, &layers).await;
+            let mut accounts = shared.write();
+            let Some(state) = accounts.get_mut(&account_for_task) else {
+                return;
+            };
+            let Some(repo) = state.repositories.get_mut(&name_for_task) else {
+                return;
+            };
+            let findings = result.unwrap_or_else(|| ImageScanFindings {
+                image_digest: digest_for_task.clone(),
+                scan_status: "COMPLETE".to_string(),
+                scan_completed_at: Some(Utc::now()),
+                vulnerability_source_updated_at: Some(Utc::now()),
+                finding_severity_counts: BTreeMap::new(),
+                findings: Vec::new(),
+            });
+            repo.scan_findings.insert(digest_for_task.clone(), findings);
+        });
+
         Ok(AwsResponse::ok_json(json!({
             "registryId": registry_id,
             "repositoryName": name,
@@ -1990,13 +2020,6 @@ impl EcrService {
                 "vulnerabilitySourceUpdatedAt": findings.vulnerability_source_updated_at.map(|t| t.timestamp()),
                 "findings": findings.findings,
                 "findingSeverityCounts": findings.finding_severity_counts,
-                // fakecloud-specific marker: these findings are synthetic
-                // and do not reflect real CVE data. AWS SDKs using Smithy
-                // codegen ignore unknown fields, so this is purely a
-                // signal for introspection callers and security-tooling
-                // integration tests that want to assert they're running
-                // against fakecloud rather than real Inspector output.
-                "isSynthetic": true,
             },
         })))
     }

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -167,13 +167,29 @@ impl EcrService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
+        Self::save_snapshot_with(
+            self.state.clone(),
+            self.snapshot_store.clone(),
+            self.snapshot_lock.clone(),
+        )
+        .await
+    }
+
+    /// Snapshot writer reachable from background tasks (e.g. the async
+    /// image-scanner) that don't hold a `&self` reference. Equivalent
+    /// to [`save_snapshot`] but takes the components as owned clones.
+    pub(crate) async fn save_snapshot_with(
+        state: SharedEcrState,
+        store: Option<Arc<dyn SnapshotStore>>,
+        lock: Arc<AsyncMutex<()>>,
+    ) {
+        let Some(store) = store else {
             return;
         };
-        let _guard = self.snapshot_lock.lock().await;
+        let _guard = lock.lock().await;
         let snapshot = EcrSnapshot {
             schema_version: ECR_SNAPSHOT_SCHEMA_VERSION,
-            accounts: Some(self.state.read().clone()),
+            accounts: Some(state.read().clone()),
         };
         let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             let bytes = serde_json::to_vec(&snapshot)
@@ -914,6 +930,32 @@ fn image_to_details(repo: &Repository, image: &Image, registry_id: &str) -> Valu
         out["lastRecordedPullTime"] = json!(t.timestamp());
     }
     out
+}
+
+/// Return only the layer blobs referenced by the manifest of `image_digest`.
+/// Falls back to all layers if the manifest can't be parsed (e.g. an
+/// OCI-spec image that fakecloud stored in an unfamiliar shape) so the
+/// scan still runs against something. Layers not stored locally are
+/// silently skipped — the scanner only sees what's actually there.
+fn layers_for_image(repo: &Repository, image_digest: &str) -> Vec<crate::state::Layer> {
+    let Some(image) = repo.images.get(image_digest) else {
+        return Vec::new();
+    };
+    let Ok(manifest): Result<Value, _> = serde_json::from_str(&image.image_manifest) else {
+        return repo.layers.values().cloned().collect();
+    };
+    let mut digests: Vec<String> = Vec::new();
+    if let Some(arr) = manifest.get("layers").and_then(|v| v.as_array()) {
+        for layer in arr {
+            if let Some(d) = layer.get("digest").and_then(|v| v.as_str()) {
+                digests.push(d.to_string());
+            }
+        }
+    }
+    digests
+        .into_iter()
+        .filter_map(|d| repo.layers.get(&d).cloned())
+        .collect()
 }
 
 /// Resolve `imageId` into a stored digest for this repo. Accepts either
@@ -1943,32 +1985,45 @@ impl EcrService {
                     findings: Vec::new(),
                 },
             );
-            let layers = repo.layers.values().cloned().collect::<Vec<_>>();
+            // Scope the scan to layers actually referenced by *this*
+            // image's manifest. Other images sitting in the same repo
+            // (different tag, different digest) must not contaminate
+            // the findings — Trivy would otherwise report CVEs from
+            // unrelated images.
+            let layers = layers_for_image(repo, &digest);
             (digest, layers, repo.registry_id.clone())
         };
 
         let shared = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let snap_lock = self.snapshot_lock.clone();
         let account_for_task = account.clone();
         let name_for_task = name.clone();
         let digest_for_task = digest.clone();
         tokio::spawn(async move {
             let result = crate::scanner::scan_layers(&digest_for_task, &layers).await;
-            let mut accounts = shared.write();
-            let Some(state) = accounts.get_mut(&account_for_task) else {
-                return;
-            };
-            let Some(repo) = state.repositories.get_mut(&name_for_task) else {
-                return;
-            };
-            let findings = result.unwrap_or_else(|| ImageScanFindings {
-                image_digest: digest_for_task.clone(),
-                scan_status: "COMPLETE".to_string(),
-                scan_completed_at: Some(Utc::now()),
-                vulnerability_source_updated_at: Some(Utc::now()),
-                finding_severity_counts: BTreeMap::new(),
-                findings: Vec::new(),
-            });
-            repo.scan_findings.insert(digest_for_task.clone(), findings);
+            {
+                let mut accounts = shared.write();
+                let Some(state) = accounts.get_mut(&account_for_task) else {
+                    return;
+                };
+                let Some(repo) = state.repositories.get_mut(&name_for_task) else {
+                    return;
+                };
+                let findings = result.unwrap_or_else(|| ImageScanFindings {
+                    image_digest: digest_for_task.clone(),
+                    scan_status: "COMPLETE".to_string(),
+                    scan_completed_at: Some(Utc::now()),
+                    vulnerability_source_updated_at: Some(Utc::now()),
+                    finding_severity_counts: BTreeMap::new(),
+                    findings: Vec::new(),
+                });
+                repo.scan_findings.insert(digest_for_task.clone(), findings);
+            }
+            // Persist the COMPLETE state — without this, restarts
+            // restore the snapshot taken at IN_PROGRESS time and the
+            // scan appears stuck forever.
+            EcrService::save_snapshot_with(shared, store, snap_lock).await;
         });
 
         Ok(AwsResponse::ok_json(json!({

--- a/website/content/docs/services/ecr.md
+++ b/website/content/docs/services/ecr.md
@@ -13,7 +13,7 @@ fakecloud implements Amazon Elastic Container Registry (ECR) with full API cover
 - **Repositories** — `CreateRepository`, `DescribeRepositories`, `DeleteRepository`, `GetRepositoryPolicy`, `SetRepositoryPolicy`, `DeleteRepositoryPolicy`, `PutImageTagMutability`, `PutImageScanningConfiguration`
 - **Images** — `BatchGetImage`, `DescribeImages`, `ListImages`, `BatchDeleteImage`, `PutImage`, `BatchCheckLayerAvailability`, `InitiateLayerUpload`, `UploadLayerPart`, `CompleteLayerUpload`, `GetDownloadUrlForLayer`
 - **Lifecycle policies** — `PutLifecyclePolicy`, `GetLifecyclePolicy`, `DeleteLifecyclePolicy`, `StartLifecyclePolicyPreview`, `GetLifecyclePolicyPreview`
-- **Image scanning** — `StartImageScan`, `DescribeImageScanFindings`, `GetRegistryScanningConfiguration`, `PutRegistryScanningConfiguration`
+- **Image scanning** — `StartImageScan`, `DescribeImageScanFindings`, `GetRegistryScanningConfiguration`, `PutRegistryScanningConfiguration`. When the optional [Trivy](https://github.com/aquasecurity/trivy) CLI is on `PATH` (or `FAKECLOUD_TRIVY_BIN` is set), fakecloud reconstructs the pushed layers as a docker-format tar, invokes `trivy image --input <tar> --format json`, and exposes the parsed CVE findings via `DescribeImageScanFindings`. Without Trivy, scans complete with an empty findings list so client plumbing still works.
 - **Registry policy** — `GetRegistryPolicy`, `PutRegistryPolicy`, `DeleteRegistryPolicy`
 - **Replication** — `DescribeRegistry`, `PutReplicationConfiguration`
 - **Pull-through cache** — `CreatePullThroughCacheRule`, `DeletePullThroughCacheRule`, `DescribePullThroughCacheRules`, `UpdatePullThroughCacheRule`, `BatchGetRepositoryScanningConfiguration`, `ValidatePullThroughCacheRule`


### PR DESCRIPTION
## Summary

ECR's StartImageScan now performs a real vulnerability scan when the optional Trivy CLI is available. Layers are reconstructed as a docker-format tar, fed to \`trivy image --input <tar> --format json\`, and the parsed CVE output is exposed via DescribeImageScanFindings (severities, CVE IDs, package versions, fix info, primary URL). When Trivy isn't installed, scans complete with an empty findings list so client plumbing keeps working without forcing the dep.

- New \`crates/fakecloud-ecr/src/scanner.rs\` (detection, tar build, Trivy subprocess, JSON parser)
- StartImageScan spawns the scan in the background; DescribeImageScanFindings polls and observes IN_PROGRESS -> COMPLETE
- FAKECLOUD_TRIVY_BIN env var overrides the binary path
- Drops legacy \`isSynthetic\` response field (fakecloud-only marker, misleading once real Trivy results can land here)

## Test plan

- [x] cargo test -p fakecloud-ecr --lib (parser + severity mapping + env override)
- [x] cargo test -p fakecloud-e2e --test ecr start_image_scan_transitions_to_complete
- [x] cargo test -p fakecloud-e2e --test ecr_scan_synthetic_flag (rewritten to assert AWS-shaped response)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ECR image scans now run real vulnerability analysis using the optional Trivy CLI and return parsed CVE findings via DescribeImageScanFindings. Scans run in the background; if Trivy isn’t available, they complete with empty findings so clients still work.

- New Features
  - Reconstruct layers as a Docker tar and invoke `trivy image --input <tar> --format json` (scans only layers referenced by the image’s manifest).
  - Map severities and include CVE ID, package/version, fixed version, and primary URL in findings.
  - StartImageScan sets status to IN_PROGRESS; DescribeImageScanFindings returns COMPLETE when done.
  - `FAKECLOUD_TRIVY_BIN` overrides the Trivy binary path; persists results to the snapshot; added `crates/fakecloud-ecr/src/scanner.rs`; unit + e2e tests; docs updated. On tar/decode or Trivy errors, we log and fall back to a synthetic empty result.

- Migration
  - Removed the fakecloud-only `isSynthetic` field from DescribeImageScanFindings; drop any checks for it.
  - To get real findings locally or in CI, install Trivy (or set `FAKECLOUD_TRIVY_BIN`); otherwise you’ll receive a valid response with empty findings.

<sup>Written for commit 8b94e4a6f166cc9b4be7bba158a2aa359f6a4fd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

