### PR TITLE
feat(core): make request body cap env-tunable, raise default to 1 GiB

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -26,13 +26,14 @@ pub async fn dispatch(
     let request_id = uuid::Uuid::new_v4().to_string();
 
     let (parts, body) = request.into_parts();
-    // TODO: plumb streaming request bodies end-to-end to remove the cap.
-    // 128 MiB comfortably covers every legitimate single-PutObject (AWS
-    // recommends multipart above ~100 MiB) and each multipart part is
-    // dispatched through here separately, so a 20 GiB upload stays under this
-    // limit per-request.
-    const MAX_BODY_BYTES: usize = 128 * 1024 * 1024;
-    let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
+    // The dispatch path materializes request bodies into memory so each
+    // service handler sees a `Bytes` payload it can parse synchronously.
+    // The cap is configurable via `FAKECLOUD_MAX_REQUEST_BODY_BYTES`
+    // (default 1 GiB) — enough to absorb the largest legitimate single
+    // S3 PutObject (5 GiB cap on multipart parts; AWS recommends
+    // multipart above ~100 MiB) without OOM risk in tests.
+    let max_body_bytes = max_request_body_bytes();
+    let body_bytes = match axum::body::to_bytes(body, max_body_bytes).await {
         Ok(b) => b,
         Err(_) => {
             return build_error_response(
@@ -611,6 +612,28 @@ impl DispatchConfig {
 /// Extract the 12-digit account ID segment from an AWS ARN.
 ///
 /// ARNs follow `arn:<partition>:<service>:<region>:<account>:<resource>`.
+/// Default request-body buffering cap. fakecloud reads the entire
+/// request body into memory before handing it to a service handler,
+/// so this ceiling caps RAM usage per in-flight request.
+///
+/// Default 1 GiB — comfortably above legitimate single S3 PutObject
+/// payloads (AWS recommends multipart above ~100 MiB) and each
+/// multipart part dispatches through here separately. Override with
+/// `FAKECLOUD_MAX_REQUEST_BODY_BYTES` (decimal bytes) when running
+/// stress tests that push past the default.
+const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024 * 1024;
+
+fn max_request_body_bytes() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("FAKECLOUD_MAX_REQUEST_BODY_BYTES")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_MAX_REQUEST_BODY_BYTES)
+    })
+}
+
 /// For the cross-account decision in IAM enforcement, the "resource
 /// account" is the ARN's account segment. Some services (notably S3)
 /// produce ARNs with an empty account field — for those we return
@@ -770,6 +793,14 @@ impl ProtocolExt for AwsProtocol {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_max_request_body_bytes_is_one_gib() {
+        // Without the env override, the cap defaults to 1 GiB. The
+        // public function caches via OnceLock so only the first call
+        // in the process matters; we assert the constant directly.
+        assert_eq!(DEFAULT_MAX_REQUEST_BODY_BYTES, 1024 * 1024 * 1024);
+    }
 
     #[test]
     fn dispatch_config_new_defaults_to_off() {

--- a/website/content/docs/reference/configuration.md
+++ b/website/content/docs/reference/configuration.md
@@ -16,6 +16,7 @@ fakecloud is configured via CLI flags or environment variables. Flags take prece
 | `--data-path`        | `FAKECLOUD_DATA_PATH`       | —                  | Directory to persist state to. Required when `--storage-mode=persistent`.                |
 | `--s3-cache-size`    | `FAKECLOUD_S3_CACHE_SIZE`   | `268435456`        | In-memory LRU cache for S3 object bodies in persistent mode. Default 256 MiB.            |
 |                      | `FAKECLOUD_CONTAINER_CLI`   | auto-detect        | Container CLI to use (`docker` or `podman`)                                              |
+|                      | `FAKECLOUD_MAX_REQUEST_BODY_BYTES` | `1073741824` | Max bytes a request body can buffer before fakecloud returns 413. Default 1 GiB. Each request materializes its body into RAM, so raise this only when stress-testing past 1 GiB single-request payloads. |
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Replace the hard-coded 128 MiB cap on dispatched request bodies with a 1 GiB default that's overridable via \`FAKECLOUD_MAX_REQUEST_BODY_BYTES\` (decimal bytes).
- Cap value is cached via \`OnceLock\` so env is read once per process.
- Documented in \`website/content/docs/reference/configuration.md\`.

Why 1 GiB: AWS S3 caps single \`PutObject\` payloads at 5 GiB (multipart parts) and recommends multipart above ~100 MiB; 1 GiB comfortably covers the legitimate-single-object range without OOM risk in tests. The cap is configurable so stress-test runs can push higher.

Why not full streaming: ending the buffered model requires per-service handler refactor — every service except S3 PutObject and ECR blob upload uses the parsed \`Bytes\` payload. That's its own multi-week project; raising + tunable-ing the ceiling unblocks the immediate use case (large single PutObjects) without that surface.

## Test plan
- [x] \`cargo test -p fakecloud-core --lib\` — 170/170 pass (added \`default_max_request_body_bytes_is_one_gib\`).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [ ] Watch CI + Cubic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the in-memory request body cap from 128 MiB to a 1 GiB default and makes it configurable via `FAKECLOUD_MAX_REQUEST_BODY_BYTES`. This supports large single S3 PutObject payloads while keeping a clear per-request RAM ceiling.

- **New Features**
  - Add `FAKECLOUD_MAX_REQUEST_BODY_BYTES` (decimal bytes) to set the buffering limit; default 1 GiB.
  - Cache the cap per process via `OnceLock`; requests over the limit return 413.
  - Update configuration docs and add a unit test for the default.

<sup>Written for commit acf2bd90459394fdacf1954833eec90d5f61a3c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

