### PR TITLE
feat(cloudfront): OAC + cache, origin request, response headers, continuous deployment policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-28 services, 2,077 operations, 100% conformance per implemented service.
+28 services, 2,107 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -79,7 +79,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
 | ECS                    |  60 | **Full API** — clusters, task definitions, real task execution, services + rolling deployments, container instances, capacity providers, task sets, ECS Exec |
 | Elastic Load Balancing v2 |  51 | ALB/NLB/GWLB CRUD: load balancers, target groups + targets + real health probes, **listeners + rules + certificates**, LB/listener/target-group attributes, capacity reservations, **mTLS trust stores + revocations**, SSL policies, resource policies, tags. **In-process HTTP data plane** for ALBs — per-LB TCP bind, rule matching, forward / fixed-response / redirect, sticky sessions, X-Forwarded-* headers |
-| CloudFront                |  29 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags), invalidations, distribution-by-X listings, web ACL associate/disassociate, alias associate, tags. REST-XML protocol, full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
+| CloudFront                |  59 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags), invalidations, distribution-by-X listings, web ACL associate/disassociate, alias associate, tags. **Origin Access Controls + Cache, Origin Request, Response Headers, Continuous Deployment policies** — full CRUD with AWS-managed policies pre-seeded. REST-XML protocol, full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -122,7 +122,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
 | ECS                 | **60 operations — full API** incl. real task execution, services, task sets, capacity providers | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Elastic Load Balancing v2 | **51 operations** ALB/NLB/GWLB incl. mTLS trust stores, capacity reservations, attributes, resource policies, plus an in-process HTTP data plane (rule matching + forward/fixed-response/redirect + sticky sessions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
-| CloudFront                | **29 operations** — distributions (full CRUD + ETag/If-Match concurrency, WithTags, copy, by-X listings), invalidations, web ACL associate/disassociate, alias associate, tags. Full `DistributionConfig` round-trip (origins, cache behaviors, custom error responses, viewer certificates, geo restrictions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| CloudFront                | **59 operations** — distributions (full CRUD + ETag/If-Match concurrency, WithTags, copy, by-X listings), invalidations, web ACL associate/disassociate, alias associate, tags. **Origin Access Controls + Cache, Origin Request, Response Headers, Continuous Deployment policies** — full CRUD, AWS-managed policies pre-seeded by well-known IDs. Full `DistributionConfig` round-trip (origins, cache behaviors, custom error responses, viewer certificates, geo restrictions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -6,6 +6,8 @@
 //! `us-east-1`.
 
 pub mod model;
+pub mod policies;
+pub mod policies_service;
 pub mod router;
 pub mod service;
 pub mod state;

--- a/crates/fakecloud-cloudfront/src/policies.rs
+++ b/crates/fakecloud-cloudfront/src/policies.rs
@@ -589,7 +589,7 @@ const MANAGED_RESPONSE_HEADERS_POLICIES: &[(&str, &str)] = &[
         "Managed-CORS-with-preflight",
     ),
     (
-        "60669652-455b-4ae9-85a4-c4c02393f86c",
+        "e61eb60c-9c35-4d20-a928-2b84e02af89c",
         "Managed-CORS-and-SecurityHeadersPolicy",
     ),
     (
@@ -600,7 +600,7 @@ const MANAGED_RESPONSE_HEADERS_POLICIES: &[(&str, &str)] = &[
         "eaab4381-ed33-4a86-88ca-d9558dc6cd63",
         "Managed-CORS-with-preflight-and-SecurityHeadersPolicy",
     ),
-    ("5cc3b908-e619-4b99-88e5-2cf7f45965bd", "Managed-SimpleCORS"),
+    ("60669652-455b-4ae9-85a4-c4c02393f86c", "Managed-SimpleCORS"),
 ];
 
 // ─── Handlers (impl on CloudFrontService is in service.rs via these
@@ -771,4 +771,49 @@ pub(crate) fn precondition_failed() -> AwsServiceError {
 
 pub(crate) fn rfc3339(t: &DateTime<Utc>) -> String {
     t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn managed_cache_policy_ids_are_unique() {
+        let mut seen = HashSet::new();
+        for entry in MANAGED_CACHE_POLICIES {
+            let id = entry.0;
+            assert!(seen.insert(id), "duplicate cache policy id: {id}");
+        }
+    }
+
+    #[test]
+    fn managed_origin_request_policy_ids_are_unique() {
+        let mut seen = HashSet::new();
+        for (id, _) in MANAGED_ORIGIN_REQUEST_POLICIES {
+            assert!(seen.insert(*id), "duplicate origin request policy id: {id}");
+        }
+    }
+
+    #[test]
+    fn managed_response_headers_policy_ids_are_unique() {
+        let mut seen = HashSet::new();
+        for (id, _) in MANAGED_RESPONSE_HEADERS_POLICIES {
+            assert!(
+                seen.insert(*id),
+                "duplicate response headers policy id: {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn seeded_response_headers_count_matches_unique_ids() {
+        let mut acc = AccountState::default();
+        seed_managed(&mut acc);
+        assert_eq!(
+            acc.response_headers_policies.len(),
+            MANAGED_RESPONSE_HEADERS_POLICIES.len(),
+            "duplicate IDs would reduce the seeded count"
+        );
+    }
 }

--- a/crates/fakecloud-cloudfront/src/policies.rs
+++ b/crates/fakecloud-cloudfront/src/policies.rs
@@ -1,0 +1,774 @@
+//! Origin Access Control + the four policy resources (cache, origin
+//! request, response headers, continuous deployment). Models are defined
+//! here and the [`CloudFrontService`] handlers live in this module too —
+//! `service.rs` only dispatches by action name.
+//!
+//! AWS-managed policies for `CachePolicy`, `OriginRequestPolicy`, and
+//! `ResponseHeadersPolicy` are pre-seeded by [`seed_managed`] so
+//! Terraform / CDK code that looks them up by their well-known IDs
+//! resolves them without the caller having to create them first.
+
+use chrono::{DateTime, Utc};
+use http::header::{ETAG, IF_MATCH, LOCATION};
+use http::{HeaderMap, HeaderValue, StatusCode};
+use serde::{Deserialize, Serialize};
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError, ResponseBody};
+
+use crate::router::Route;
+use crate::service::{aws_error, esc, invalid_argument, xml_response};
+use crate::state::AccountState;
+
+const XML_DECL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>"#;
+const NS: &str = crate::NAMESPACE;
+
+fn skip_if_none<T>(x: &Option<T>) -> bool {
+    x.is_none()
+}
+
+// ─── Origin Access Control ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct OriginAccessControlConfig {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub description: Option<String>,
+    pub signing_protocol: String,
+    pub signing_behavior: String,
+    pub origin_access_control_origin_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredOriginAccessControl {
+    pub id: String,
+    pub etag: String,
+    pub config: OriginAccessControlConfig,
+}
+
+// ─── Cache Policy ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct CachePolicyConfig {
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub comment: Option<String>,
+    pub name: String,
+    #[serde(rename = "DefaultTTL", default, skip_serializing_if = "skip_if_none")]
+    pub default_ttl: Option<i64>,
+    #[serde(rename = "MaxTTL", default, skip_serializing_if = "skip_if_none")]
+    pub max_ttl: Option<i64>,
+    #[serde(rename = "MinTTL")]
+    pub min_ttl: i64,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub parameters_in_cache_key_and_forwarded_to_origin:
+        Option<ParametersInCacheKeyAndForwardedToOrigin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ParametersInCacheKeyAndForwardedToOrigin {
+    pub enable_accept_encoding_gzip: bool,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub enable_accept_encoding_brotli: Option<bool>,
+    pub headers_config: CachePolicyHeadersConfig,
+    pub cookies_config: CachePolicyCookiesConfig,
+    pub query_strings_config: CachePolicyQueryStringsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct CachePolicyHeadersConfig {
+    pub header_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub headers: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct NameWrapper {
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<NameItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct NameItems {
+    #[serde(default, rename = "Name")]
+    pub name: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct CachePolicyCookiesConfig {
+    pub cookie_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub cookies: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct CachePolicyQueryStringsConfig {
+    pub query_string_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub query_strings: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredCachePolicy {
+    pub id: String,
+    pub etag: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub config: CachePolicyConfig,
+    /// "managed" or "custom".
+    pub policy_type: String,
+}
+
+// ─── Origin Request Policy ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct OriginRequestPolicyConfig {
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub comment: Option<String>,
+    pub name: String,
+    pub headers_config: OriginRequestPolicyHeadersConfig,
+    pub cookies_config: OriginRequestPolicyCookiesConfig,
+    pub query_strings_config: OriginRequestPolicyQueryStringsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct OriginRequestPolicyHeadersConfig {
+    pub header_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub headers: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct OriginRequestPolicyCookiesConfig {
+    pub cookie_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub cookies: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct OriginRequestPolicyQueryStringsConfig {
+    pub query_string_behavior: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub query_strings: Option<NameWrapper>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredOriginRequestPolicy {
+    pub id: String,
+    pub etag: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub config: OriginRequestPolicyConfig,
+    pub policy_type: String,
+}
+
+// ─── Response Headers Policy ──────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyConfig {
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub comment: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub cors_config: Option<ResponseHeadersPolicyCorsConfig>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub security_headers_config: Option<ResponseHeadersPolicySecurityHeadersConfig>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub server_timing_headers_config: Option<ResponseHeadersPolicyServerTimingHeadersConfig>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub custom_headers_config: Option<ResponseHeadersPolicyCustomHeadersConfig>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub remove_headers_config: Option<ResponseHeadersPolicyRemoveHeadersConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyCorsConfig {
+    pub access_control_allow_origins: NameWrapper,
+    pub access_control_allow_headers: NameWrapper,
+    pub access_control_allow_methods: ResponseHeadersPolicyAccessControlAllowMethods,
+    pub access_control_allow_credentials: bool,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub access_control_expose_headers: Option<NameWrapper>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub access_control_max_age_sec: Option<i32>,
+    pub origin_override: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyAccessControlAllowMethods {
+    pub quantity: i32,
+    pub items: ResponseHeadersPolicyMethodItems,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyMethodItems {
+    #[serde(default, rename = "Method")]
+    pub method: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicySecurityHeadersConfig {
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub xss_protection: Option<XssProtection>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub frame_options: Option<FrameOptions>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub referrer_policy: Option<ReferrerPolicy>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub content_security_policy: Option<ContentSecurityPolicy>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub content_type_options: Option<ContentTypeOptions>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub strict_transport_security: Option<StrictTransportSecurity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct XssProtection {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+    pub protection: bool,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub mode_block: Option<bool>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub report_uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct FrameOptions {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+    pub frame_option: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ReferrerPolicy {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+    pub referrer_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContentSecurityPolicy {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+    pub content_security_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContentTypeOptions {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StrictTransportSecurity {
+    #[serde(rename = "Override")]
+    pub override_: bool,
+    pub access_control_max_age_sec: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub include_subdomains: Option<bool>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub preload: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyServerTimingHeadersConfig {
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub sampling_rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyCustomHeadersConfig {
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<ResponseHeadersPolicyCustomHeaderItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyCustomHeaderItems {
+    #[serde(default, rename = "ResponseHeadersPolicyCustomHeader")]
+    pub response_headers_policy_custom_header: Vec<ResponseHeadersPolicyCustomHeader>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyCustomHeader {
+    pub header: String,
+    pub value: String,
+    #[serde(rename = "Override")]
+    pub override_: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyRemoveHeadersConfig {
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<ResponseHeadersPolicyRemoveHeaderItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyRemoveHeaderItems {
+    #[serde(default, rename = "ResponseHeadersPolicyRemoveHeader")]
+    pub response_headers_policy_remove_header: Vec<ResponseHeadersPolicyRemoveHeader>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ResponseHeadersPolicyRemoveHeader {
+    pub header: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredResponseHeadersPolicy {
+    pub id: String,
+    pub etag: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub config: ResponseHeadersPolicyConfig,
+    pub policy_type: String,
+}
+
+// ─── Continuous Deployment Policy ─────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContinuousDeploymentPolicyConfig {
+    pub staging_distribution_dns_names: StagingDistributionDnsNames,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub traffic_config: Option<TrafficConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StagingDistributionDnsNames {
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<StagingDistributionDnsNameItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StagingDistributionDnsNameItems {
+    #[serde(default, rename = "DnsName")]
+    pub dns_name: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct TrafficConfig {
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub single_weight_config: Option<ContinuousDeploymentSingleWeightConfig>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub single_header_config: Option<ContinuousDeploymentSingleHeaderConfig>,
+    #[serde(rename = "Type")]
+    pub traffic_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContinuousDeploymentSingleWeightConfig {
+    pub weight: f32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub session_stickiness_config: Option<SessionStickinessConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct SessionStickinessConfig {
+    pub idle_ttl: i32,
+    pub maximum_ttl: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContinuousDeploymentSingleHeaderConfig {
+    pub header: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredContinuousDeploymentPolicy {
+    pub id: String,
+    pub etag: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub config: ContinuousDeploymentPolicyConfig,
+}
+
+// ─── Managed-policy seeding ───────────────────────────────────────────
+
+/// Pre-populate AWS-managed policies. Called once per account on first
+/// touch from `CloudFrontService`. Mirrors the IDs / names AWS returns
+/// from `aws cloudfront list-cache-policies --type managed` so
+/// Terraform / CDK lookups by well-known ID resolve.
+pub fn seed_managed(account: &mut AccountState) {
+    if !account.cache_policies.is_empty() {
+        return;
+    }
+    let now = Utc::now();
+    for (id, name, default_ttl, max_ttl, gzip, brotli) in MANAGED_CACHE_POLICIES {
+        account.cache_policies.insert(
+            (*id).to_string(),
+            StoredCachePolicy {
+                id: (*id).to_string(),
+                etag: format!("MANAGED-{id}"),
+                last_modified_time: now,
+                policy_type: "managed".to_string(),
+                config: CachePolicyConfig {
+                    name: (*name).to_string(),
+                    comment: Some(format!("AWS managed cache policy {name}")),
+                    default_ttl: Some(*default_ttl),
+                    max_ttl: Some(*max_ttl),
+                    min_ttl: 1,
+                    parameters_in_cache_key_and_forwarded_to_origin: Some(
+                        ParametersInCacheKeyAndForwardedToOrigin {
+                            enable_accept_encoding_gzip: *gzip,
+                            enable_accept_encoding_brotli: Some(*brotli),
+                            headers_config: CachePolicyHeadersConfig {
+                                header_behavior: "none".to_string(),
+                                headers: None,
+                            },
+                            cookies_config: CachePolicyCookiesConfig {
+                                cookie_behavior: "none".to_string(),
+                                cookies: None,
+                            },
+                            query_strings_config: CachePolicyQueryStringsConfig {
+                                query_string_behavior: "none".to_string(),
+                                query_strings: None,
+                            },
+                        },
+                    ),
+                },
+            },
+        );
+    }
+    for (id, name) in MANAGED_ORIGIN_REQUEST_POLICIES {
+        account.origin_request_policies.insert(
+            (*id).to_string(),
+            StoredOriginRequestPolicy {
+                id: (*id).to_string(),
+                etag: format!("MANAGED-{id}"),
+                last_modified_time: now,
+                policy_type: "managed".to_string(),
+                config: OriginRequestPolicyConfig {
+                    name: (*name).to_string(),
+                    comment: Some(format!("AWS managed origin request policy {name}")),
+                    headers_config: OriginRequestPolicyHeadersConfig {
+                        header_behavior: "allViewer".to_string(),
+                        headers: None,
+                    },
+                    cookies_config: OriginRequestPolicyCookiesConfig {
+                        cookie_behavior: "all".to_string(),
+                        cookies: None,
+                    },
+                    query_strings_config: OriginRequestPolicyQueryStringsConfig {
+                        query_string_behavior: "all".to_string(),
+                        query_strings: None,
+                    },
+                },
+            },
+        );
+    }
+    for (id, name) in MANAGED_RESPONSE_HEADERS_POLICIES {
+        account.response_headers_policies.insert(
+            (*id).to_string(),
+            StoredResponseHeadersPolicy {
+                id: (*id).to_string(),
+                etag: format!("MANAGED-{id}"),
+                last_modified_time: now,
+                policy_type: "managed".to_string(),
+                config: ResponseHeadersPolicyConfig {
+                    name: (*name).to_string(),
+                    comment: Some(format!("AWS managed response headers policy {name}")),
+                    cors_config: None,
+                    security_headers_config: None,
+                    server_timing_headers_config: None,
+                    custom_headers_config: None,
+                    remove_headers_config: None,
+                },
+            },
+        );
+    }
+}
+
+const MANAGED_CACHE_POLICIES: &[(&str, &str, i64, i64, bool, bool)] = &[
+    (
+        "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        "Managed-CachingOptimized",
+        86400,
+        31536000,
+        true,
+        true,
+    ),
+    (
+        "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+        "Managed-CachingDisabled",
+        0,
+        0,
+        false,
+        false,
+    ),
+    (
+        "b2884449-e4de-46a7-ac36-70bc7f1ddd6d",
+        "Managed-CachingOptimizedForUncompressedObjects",
+        86400,
+        31536000,
+        false,
+        false,
+    ),
+    (
+        "08627262-05a9-4f76-9ded-b50ca2e3a84f",
+        "Managed-Elemental-MediaPackage",
+        86400,
+        31536000,
+        true,
+        true,
+    ),
+    (
+        "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+        "Managed-AmplifyDefault",
+        2,
+        600,
+        true,
+        true,
+    ),
+];
+
+const MANAGED_ORIGIN_REQUEST_POLICIES: &[(&str, &str)] = &[
+    (
+        "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
+        "Managed-CORS-S3Origin",
+    ),
+    (
+        "59781a5b-3903-41f3-afcb-af62929ccde1",
+        "Managed-CORS-CustomOrigin",
+    ),
+    ("b689b0a8-53d0-40ab-baf2-68738e2966ac", "Managed-AllViewer"),
+    (
+        "33f36d7e-f396-46d9-90e0-52428a34d9dc",
+        "Managed-UserAgentRefererHeaders",
+    ),
+    (
+        "775133bc-15f2-49f9-abea-afb2e0bf67d2",
+        "Managed-AllViewerExceptHostHeader",
+    ),
+    (
+        "acba4595-bd28-49b8-b9fe-13317c0390fa",
+        "Managed-AllViewerAndCloudFrontHeaders-2022-06",
+    ),
+];
+
+const MANAGED_RESPONSE_HEADERS_POLICIES: &[(&str, &str)] = &[
+    (
+        "5cc3b908-e619-4b99-88e5-2cf7f45965bd",
+        "Managed-CORS-with-preflight",
+    ),
+    (
+        "60669652-455b-4ae9-85a4-c4c02393f86c",
+        "Managed-CORS-and-SecurityHeadersPolicy",
+    ),
+    (
+        "67f7725c-6f97-4210-82d7-5512b31e9d03",
+        "Managed-SecurityHeadersPolicy",
+    ),
+    (
+        "eaab4381-ed33-4a86-88ca-d9558dc6cd63",
+        "Managed-CORS-with-preflight-and-SecurityHeadersPolicy",
+    ),
+    ("5cc3b908-e619-4b99-88e5-2cf7f45965bd", "Managed-SimpleCORS"),
+];
+
+// ─── Handlers (impl on CloudFrontService is in service.rs via these
+// free functions, which take `&self_state` rather than `&self` so this
+// module doesn't have to know about the service type) ────────────────
+
+use crate::state::SharedCloudFrontState;
+
+pub(crate) fn touch_account(state: &SharedCloudFrontState, account_id: &str) {
+    let mut s = state.write();
+    let needs_seed = s
+        .accounts
+        .get(account_id)
+        .is_none_or(|a| a.cache_policies.is_empty());
+    if needs_seed {
+        let account = s.entry(account_id);
+        seed_managed(account);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PolicyView {
+    pub id: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub config_xml: String,
+}
+
+impl From<StoredCachePolicy> for PolicyView {
+    fn from(p: StoredCachePolicy) -> Self {
+        let config_xml =
+            quick_xml::se::to_string_with_root("CachePolicyConfig", &p.config).unwrap_or_default();
+        Self {
+            id: p.id,
+            last_modified_time: p.last_modified_time,
+            config_xml,
+        }
+    }
+}
+
+impl From<StoredOriginRequestPolicy> for PolicyView {
+    fn from(p: StoredOriginRequestPolicy) -> Self {
+        let config_xml = quick_xml::se::to_string_with_root("OriginRequestPolicyConfig", &p.config)
+            .unwrap_or_default();
+        Self {
+            id: p.id,
+            last_modified_time: p.last_modified_time,
+            config_xml,
+        }
+    }
+}
+
+impl From<StoredResponseHeadersPolicy> for PolicyView {
+    fn from(p: StoredResponseHeadersPolicy) -> Self {
+        let config_xml =
+            quick_xml::se::to_string_with_root("ResponseHeadersPolicyConfig", &p.config)
+                .unwrap_or_default();
+        Self {
+            id: p.id,
+            last_modified_time: p.last_modified_time,
+            config_xml,
+        }
+    }
+}
+
+impl From<StoredContinuousDeploymentPolicy> for PolicyView {
+    fn from(p: StoredContinuousDeploymentPolicy) -> Self {
+        let config_xml =
+            quick_xml::se::to_string_with_root("ContinuousDeploymentPolicyConfig", &p.config)
+                .unwrap_or_default();
+        Self {
+            id: p.id,
+            last_modified_time: p.last_modified_time,
+            config_xml,
+        }
+    }
+}
+
+pub(crate) fn render_simple_policy(p: PolicyView, root: &str) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<{root} xmlns=\"{NS}\">"));
+    out.push_str(&format!("<Id>{}</Id>", esc(&p.id)));
+    out.push_str(&format!(
+        "<LastModifiedTime>{}</LastModifiedTime>",
+        rfc3339(&p.last_modified_time)
+    ));
+    out.push_str(&p.config_xml);
+    out.push_str(&format!("</{root}>"));
+    out
+}
+
+pub(crate) fn render_oac(oac: &StoredOriginAccessControl) -> String {
+    let mut out = String::with_capacity(384);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<OriginAccessControl xmlns=\"{NS}\">"));
+    out.push_str(&format!("<Id>{}</Id>", esc(&oac.id)));
+    out.push_str(
+        &quick_xml::se::to_string_with_root("OriginAccessControlConfig", &oac.config)
+            .unwrap_or_default(),
+    );
+    out.push_str("</OriginAccessControl>");
+    out
+}
+
+pub(crate) fn xml_with_etag(
+    status: StatusCode,
+    body: String,
+    etag: &str,
+    location_id: Option<&str>,
+) -> AwsResponse {
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = HeaderValue::from_str(etag) {
+        headers.insert(ETAG, v);
+    }
+    if let Some(id) = location_id {
+        if let Ok(v) = HeaderValue::from_str(id) {
+            headers.insert(LOCATION, v);
+        }
+    }
+    xml_response(status, body, headers)
+}
+
+pub(crate) fn empty(status: StatusCode) -> AwsResponse {
+    AwsResponse {
+        status,
+        content_type: "text/xml".to_string(),
+        body: ResponseBody::Bytes(bytes::Bytes::new()),
+        headers: HeaderMap::new(),
+    }
+}
+
+pub(crate) fn route_id(route: &Route, what: &str) -> Result<String, AwsServiceError> {
+    route
+        .id
+        .clone()
+        .ok_or_else(|| invalid_argument(format!("missing {what} id")))
+}
+
+pub(crate) fn require_if_match(req: &AwsRequest) -> Result<String, AwsServiceError> {
+    req.headers
+        .get(IF_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidIfMatchVersion",
+                "Missing If-Match header",
+            )
+        })
+}
+
+pub(crate) fn not_found(kind: &str, id: &str) -> AwsServiceError {
+    aws_error(
+        StatusCode::NOT_FOUND,
+        format!("NoSuch{kind}"),
+        format!("The specified {kind} does not exist: {id}"),
+    )
+}
+
+pub(crate) fn precondition_failed() -> AwsServiceError {
+    aws_error(
+        StatusCode::PRECONDITION_FAILED,
+        "PreconditionFailed",
+        "If-Match header does not match the current ETag",
+    )
+}
+
+pub(crate) fn rfc3339(t: &DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}

--- a/crates/fakecloud-cloudfront/src/policies_service.rs
+++ b/crates/fakecloud-cloudfront/src/policies_service.rs
@@ -1,0 +1,981 @@
+//! Handlers for Batch 2 policy resources. The CRUD shape is identical
+//! across all five resource types — every one of them parses a `*Config`
+//! XML body, stores an ETag-versioned record, and emits a small
+//! `<Resource><Id/><LastModifiedTime/><Config/></Resource>` envelope.
+//! These handlers are split into their own module to keep `service.rs`
+//! focused on the distribution / invalidation surface.
+
+use std::collections::HashMap;
+
+use chrono::Utc;
+use http::{HeaderMap, StatusCode};
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::policies::{
+    empty, not_found, precondition_failed, render_oac, render_simple_policy, require_if_match,
+    rfc3339, route_id, touch_account, xml_with_etag, CachePolicyConfig,
+    ContinuousDeploymentPolicyConfig, OriginAccessControlConfig, OriginRequestPolicyConfig,
+    PolicyView, ResponseHeadersPolicyConfig, StoredCachePolicy, StoredContinuousDeploymentPolicy,
+    StoredOriginAccessControl, StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
+};
+use crate::router::Route;
+use crate::service::{
+    aws_error, esc, generate_id_with_prefix, invalid_argument, xml_response, CloudFrontService,
+    DEFAULT_ACCOUNT,
+};
+use crate::xml_io;
+
+// ─── Origin Access Control ────────────────────────────────────────────
+
+impl CloudFrontService {
+    pub(crate) fn create_origin_access_control(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let cfg: OriginAccessControlConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid OriginAccessControlConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "OriginAccessControlConfig.Name is required",
+            ));
+        }
+        let id = generate_id_with_prefix("E");
+        let etag = generate_id_with_prefix("E");
+        let stored = StoredOriginAccessControl {
+            id: id.clone(),
+            etag: etag.clone(),
+            config: cfg,
+        };
+        let mut state = self.state.write();
+        state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default()
+            .origin_access_controls
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_oac(&stored);
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_origin_access_control(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginAccessControl")?;
+        let oac = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.origin_access_controls.get(&id).cloned())
+            .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+        let body = render_oac(&oac);
+        Ok(xml_with_etag(StatusCode::OK, body, &oac.etag, None))
+    }
+
+    pub(crate) fn get_origin_access_control_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginAccessControl")?;
+        let oac = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.origin_access_controls.get(&id).cloned())
+            .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+        let body = quick_xml::se::to_string_with_root("OriginAccessControlConfig", &oac.config)
+            .map(|inner| {
+                format!(
+                    "{XML_DECL}{}",
+                    inner.replacen(
+                        "<OriginAccessControlConfig>",
+                        &format!(
+                            "<OriginAccessControlConfig xmlns=\"{NS}\">",
+                            NS = crate::NAMESPACE
+                        ),
+                        1,
+                    ),
+                    XML_DECL = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                )
+            })
+            .map_err(|e| {
+                aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    format!("xml encode failed: {e}"),
+                )
+            })?;
+        Ok(xml_with_etag(StatusCode::OK, body, &oac.etag, None))
+    }
+
+    pub(crate) fn update_origin_access_control(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginAccessControl")?;
+        let if_match = require_if_match(req)?;
+        let cfg: OriginAccessControlConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid OriginAccessControlConfig XML: {e}")))?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+        let oac = account
+            .origin_access_controls
+            .get_mut(&id)
+            .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+        if oac.etag != if_match {
+            return Err(precondition_failed());
+        }
+        oac.config = cfg;
+        oac.etag = generate_id_with_prefix("E");
+        let snapshot = oac.clone();
+        drop(state);
+        let body = render_oac(&snapshot);
+        Ok(xml_with_etag(StatusCode::OK, body, &snapshot.etag, None))
+    }
+
+    pub(crate) fn delete_origin_access_control(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginAccessControl")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+        {
+            let oac = account
+                .origin_access_controls
+                .get(&id)
+                .ok_or_else(|| not_found("OriginAccessControl", &id))?;
+            if oac.etag != if_match {
+                return Err(precondition_failed());
+            }
+        }
+        account.origin_access_controls.remove(&id);
+        Ok(empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_origin_access_controls(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredOriginAccessControl> = state
+            .accounts
+            .values()
+            .flat_map(|a| a.origin_access_controls.values().cloned())
+            .collect();
+        drop(state);
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+        let mut body = String::new();
+        body.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        body.push_str(&format!(
+            "<OriginAccessControlList xmlns=\"{NS}\">",
+            NS = crate::NAMESPACE
+        ));
+        body.push_str("<Marker></Marker>");
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str("<IsTruncated>false</IsTruncated>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        if !items.is_empty() {
+            body.push_str("<Items>");
+            for o in &items {
+                body.push_str("<OriginAccessControlSummary>");
+                body.push_str(&format!("<Id>{}</Id>", esc(&o.id)));
+                body.push_str(&format!(
+                    "<Description>{}</Description>",
+                    esc(o.config.description.as_deref().unwrap_or(""))
+                ));
+                body.push_str(&format!("<Name>{}</Name>", esc(&o.config.name)));
+                body.push_str(&format!(
+                    "<SigningProtocol>{}</SigningProtocol>",
+                    esc(&o.config.signing_protocol)
+                ));
+                body.push_str(&format!(
+                    "<SigningBehavior>{}</SigningBehavior>",
+                    esc(&o.config.signing_behavior)
+                ));
+                body.push_str(&format!(
+                    "<OriginAccessControlOriginType>{}</OriginAccessControlOriginType>",
+                    esc(&o.config.origin_access_control_origin_type)
+                ));
+                body.push_str("</OriginAccessControlSummary>");
+            }
+            body.push_str("</Items>");
+        }
+        body.push_str("</OriginAccessControlList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Cache Policy ─────────────────────────────────────────────────────
+
+impl CloudFrontService {
+    pub(crate) fn create_cache_policy(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let cfg: CachePolicyConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid CachePolicyConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument("CachePolicyConfig.Name is required"));
+        }
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let id = generate_id_with_prefix("C");
+        let etag = generate_id_with_prefix("E");
+        let stored = StoredCachePolicy {
+            id: id.clone(),
+            etag: etag.clone(),
+            last_modified_time: Utc::now(),
+            config: cfg,
+            policy_type: "custom".to_string(),
+        };
+        let mut state = self.state.write();
+        state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default()
+            .cache_policies
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(stored), "CachePolicy");
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_cache_policy(&self, route: &Route) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "CachePolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let cp = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.cache_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("CachePolicy", &id))?;
+        let body = render_simple_policy(PolicyView::from(cp.clone()), "CachePolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &cp.etag, None))
+    }
+
+    pub(crate) fn get_cache_policy_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "CachePolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let cp = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.cache_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("CachePolicy", &id))?;
+        let body = config_xml("CachePolicyConfig", &cp.config)?;
+        Ok(xml_with_etag(StatusCode::OK, body, &cp.etag, None))
+    }
+
+    pub(crate) fn update_cache_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "CachePolicy")?;
+        let if_match = require_if_match(req)?;
+        let cfg: CachePolicyConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid CachePolicyConfig XML: {e}")))?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("CachePolicy", &id))?;
+        let cp = account
+            .cache_policies
+            .get_mut(&id)
+            .ok_or_else(|| not_found("CachePolicy", &id))?;
+        if cp.policy_type == "managed" {
+            return Err(aws_error(
+                StatusCode::FORBIDDEN,
+                "IllegalUpdate",
+                "Managed cache policies cannot be updated",
+            ));
+        }
+        if cp.etag != if_match {
+            return Err(precondition_failed());
+        }
+        cp.config = cfg;
+        cp.etag = generate_id_with_prefix("E");
+        cp.last_modified_time = Utc::now();
+        let snapshot = cp.clone();
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(snapshot.clone()), "CachePolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &snapshot.etag, None))
+    }
+
+    pub(crate) fn delete_cache_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "CachePolicy")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("CachePolicy", &id))?;
+        {
+            let cp = account
+                .cache_policies
+                .get(&id)
+                .ok_or_else(|| not_found("CachePolicy", &id))?;
+            if cp.policy_type == "managed" {
+                return Err(aws_error(
+                    StatusCode::FORBIDDEN,
+                    "IllegalDelete",
+                    "Managed cache policies cannot be deleted",
+                ));
+            }
+            if cp.etag != if_match {
+                return Err(precondition_failed());
+            }
+        }
+        account.cache_policies.remove(&id);
+        Ok(empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_cache_policies(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let filter = parse_type_filter(&req.raw_query);
+        let state = self.state.read();
+        let mut items: Vec<StoredCachePolicy> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.cache_policies.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        if let Some(t) = filter.as_deref() {
+            items.retain(|p| p.policy_type == t);
+        }
+        items.sort_by(|a, b| a.config.name.cmp(&b.config.name));
+        let mut body = String::new();
+        body.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        body.push_str(&format!(
+            "<CachePolicyList xmlns=\"{NS}\">",
+            NS = crate::NAMESPACE
+        ));
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        if !items.is_empty() {
+            body.push_str("<Items>");
+            for cp in &items {
+                body.push_str("<CachePolicySummary>");
+                body.push_str(&format!("<Type>{}</Type>", esc(&cp.policy_type)));
+                body.push_str("<CachePolicy>");
+                body.push_str(&format!("<Id>{}</Id>", esc(&cp.id)));
+                body.push_str(&format!(
+                    "<LastModifiedTime>{}</LastModifiedTime>",
+                    rfc3339(&cp.last_modified_time)
+                ));
+                body.push_str(
+                    &quick_xml::se::to_string_with_root("CachePolicyConfig", &cp.config)
+                        .unwrap_or_default(),
+                );
+                body.push_str("</CachePolicy>");
+                body.push_str("</CachePolicySummary>");
+            }
+            body.push_str("</Items>");
+        }
+        body.push_str("</CachePolicyList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Origin Request Policy ────────────────────────────────────────────
+
+impl CloudFrontService {
+    pub(crate) fn create_origin_request_policy(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let cfg: OriginRequestPolicyConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid OriginRequestPolicyConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "OriginRequestPolicyConfig.Name is required",
+            ));
+        }
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let id = generate_id_with_prefix("O");
+        let etag = generate_id_with_prefix("E");
+        let stored = StoredOriginRequestPolicy {
+            id: id.clone(),
+            etag: etag.clone(),
+            last_modified_time: Utc::now(),
+            config: cfg,
+            policy_type: "custom".to_string(),
+        };
+        let mut state = self.state.write();
+        state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default()
+            .origin_request_policies
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(stored), "OriginRequestPolicy");
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_origin_request_policy(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginRequestPolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let p = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.origin_request_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+        let body = render_simple_policy(PolicyView::from(p.clone()), "OriginRequestPolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &p.etag, None))
+    }
+
+    pub(crate) fn get_origin_request_policy_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginRequestPolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let p = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.origin_request_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+        let body = config_xml("OriginRequestPolicyConfig", &p.config)?;
+        Ok(xml_with_etag(StatusCode::OK, body, &p.etag, None))
+    }
+
+    pub(crate) fn update_origin_request_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginRequestPolicy")?;
+        let if_match = require_if_match(req)?;
+        let cfg: OriginRequestPolicyConfig = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid OriginRequestPolicyConfig XML: {e}")))?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+        let p = account
+            .origin_request_policies
+            .get_mut(&id)
+            .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+        if p.policy_type == "managed" {
+            return Err(aws_error(
+                StatusCode::FORBIDDEN,
+                "IllegalUpdate",
+                "Managed origin request policies cannot be updated",
+            ));
+        }
+        if p.etag != if_match {
+            return Err(precondition_failed());
+        }
+        p.config = cfg;
+        p.etag = generate_id_with_prefix("E");
+        p.last_modified_time = Utc::now();
+        let snapshot = p.clone();
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(snapshot.clone()), "OriginRequestPolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &snapshot.etag, None))
+    }
+
+    pub(crate) fn delete_origin_request_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "OriginRequestPolicy")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+        {
+            let p = account
+                .origin_request_policies
+                .get(&id)
+                .ok_or_else(|| not_found("OriginRequestPolicy", &id))?;
+            if p.policy_type == "managed" {
+                return Err(aws_error(
+                    StatusCode::FORBIDDEN,
+                    "IllegalDelete",
+                    "Managed origin request policies cannot be deleted",
+                ));
+            }
+            if p.etag != if_match {
+                return Err(precondition_failed());
+            }
+        }
+        account.origin_request_policies.remove(&id);
+        Ok(empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_origin_request_policies(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let filter = parse_type_filter(&req.raw_query);
+        let state = self.state.read();
+        let mut items: Vec<StoredOriginRequestPolicy> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.origin_request_policies.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        if let Some(t) = filter.as_deref() {
+            items.retain(|p| p.policy_type == t);
+        }
+        items.sort_by(|a, b| a.config.name.cmp(&b.config.name));
+        let mut body = String::new();
+        body.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        body.push_str(&format!(
+            "<OriginRequestPolicyList xmlns=\"{NS}\">",
+            NS = crate::NAMESPACE
+        ));
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        if !items.is_empty() {
+            body.push_str("<Items>");
+            for p in &items {
+                body.push_str("<OriginRequestPolicySummary>");
+                body.push_str(&format!("<Type>{}</Type>", esc(&p.policy_type)));
+                body.push_str("<OriginRequestPolicy>");
+                body.push_str(&format!("<Id>{}</Id>", esc(&p.id)));
+                body.push_str(&format!(
+                    "<LastModifiedTime>{}</LastModifiedTime>",
+                    rfc3339(&p.last_modified_time)
+                ));
+                body.push_str(
+                    &quick_xml::se::to_string_with_root("OriginRequestPolicyConfig", &p.config)
+                        .unwrap_or_default(),
+                );
+                body.push_str("</OriginRequestPolicy>");
+                body.push_str("</OriginRequestPolicySummary>");
+            }
+            body.push_str("</Items>");
+        }
+        body.push_str("</OriginRequestPolicyList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Response Headers Policy ──────────────────────────────────────────
+
+impl CloudFrontService {
+    pub(crate) fn create_response_headers_policy(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let cfg: ResponseHeadersPolicyConfig = xml_io::from_xml_root(&req.body).map_err(|e| {
+            invalid_argument(format!("invalid ResponseHeadersPolicyConfig XML: {e}"))
+        })?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "ResponseHeadersPolicyConfig.Name is required",
+            ));
+        }
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let id = generate_id_with_prefix("R");
+        let etag = generate_id_with_prefix("E");
+        let stored = StoredResponseHeadersPolicy {
+            id: id.clone(),
+            etag: etag.clone(),
+            last_modified_time: Utc::now(),
+            config: cfg,
+            policy_type: "custom".to_string(),
+        };
+        let mut state = self.state.write();
+        state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default()
+            .response_headers_policies
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(stored), "ResponseHeadersPolicy");
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_response_headers_policy(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ResponseHeadersPolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let p = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.response_headers_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+        let body = render_simple_policy(PolicyView::from(p.clone()), "ResponseHeadersPolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &p.etag, None))
+    }
+
+    pub(crate) fn get_response_headers_policy_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ResponseHeadersPolicy")?;
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let p = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.response_headers_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+        let body = config_xml("ResponseHeadersPolicyConfig", &p.config)?;
+        Ok(xml_with_etag(StatusCode::OK, body, &p.etag, None))
+    }
+
+    pub(crate) fn update_response_headers_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ResponseHeadersPolicy")?;
+        let if_match = require_if_match(req)?;
+        let cfg: ResponseHeadersPolicyConfig = xml_io::from_xml_root(&req.body).map_err(|e| {
+            invalid_argument(format!("invalid ResponseHeadersPolicyConfig XML: {e}"))
+        })?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+        let p = account
+            .response_headers_policies
+            .get_mut(&id)
+            .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+        if p.policy_type == "managed" {
+            return Err(aws_error(
+                StatusCode::FORBIDDEN,
+                "IllegalUpdate",
+                "Managed response headers policies cannot be updated",
+            ));
+        }
+        if p.etag != if_match {
+            return Err(precondition_failed());
+        }
+        p.config = cfg;
+        p.etag = generate_id_with_prefix("E");
+        p.last_modified_time = Utc::now();
+        let snapshot = p.clone();
+        drop(state);
+        let body =
+            render_simple_policy(PolicyView::from(snapshot.clone()), "ResponseHeadersPolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &snapshot.etag, None))
+    }
+
+    pub(crate) fn delete_response_headers_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ResponseHeadersPolicy")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+        {
+            let p = account
+                .response_headers_policies
+                .get(&id)
+                .ok_or_else(|| not_found("ResponseHeadersPolicy", &id))?;
+            if p.policy_type == "managed" {
+                return Err(aws_error(
+                    StatusCode::FORBIDDEN,
+                    "IllegalDelete",
+                    "Managed response headers policies cannot be deleted",
+                ));
+            }
+            if p.etag != if_match {
+                return Err(precondition_failed());
+            }
+        }
+        account.response_headers_policies.remove(&id);
+        Ok(empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_response_headers_policies(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        touch_account(&self.state, DEFAULT_ACCOUNT);
+        let filter = parse_type_filter(&req.raw_query);
+        let state = self.state.read();
+        let mut items: Vec<StoredResponseHeadersPolicy> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.response_headers_policies.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        if let Some(t) = filter.as_deref() {
+            items.retain(|p| p.policy_type == t);
+        }
+        items.sort_by(|a, b| a.config.name.cmp(&b.config.name));
+        let mut body = String::new();
+        body.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        body.push_str(&format!(
+            "<ResponseHeadersPolicyList xmlns=\"{NS}\">",
+            NS = crate::NAMESPACE
+        ));
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        if !items.is_empty() {
+            body.push_str("<Items>");
+            for p in &items {
+                body.push_str("<ResponseHeadersPolicySummary>");
+                body.push_str(&format!("<Type>{}</Type>", esc(&p.policy_type)));
+                body.push_str("<ResponseHeadersPolicy>");
+                body.push_str(&format!("<Id>{}</Id>", esc(&p.id)));
+                body.push_str(&format!(
+                    "<LastModifiedTime>{}</LastModifiedTime>",
+                    rfc3339(&p.last_modified_time)
+                ));
+                body.push_str(
+                    &quick_xml::se::to_string_with_root("ResponseHeadersPolicyConfig", &p.config)
+                        .unwrap_or_default(),
+                );
+                body.push_str("</ResponseHeadersPolicy>");
+                body.push_str("</ResponseHeadersPolicySummary>");
+            }
+            body.push_str("</Items>");
+        }
+        body.push_str("</ResponseHeadersPolicyList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Continuous Deployment Policy ─────────────────────────────────────
+
+impl CloudFrontService {
+    pub(crate) fn create_continuous_deployment_policy(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let cfg: ContinuousDeploymentPolicyConfig =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid ContinuousDeploymentPolicyConfig XML: {e}"))
+            })?;
+        let id = generate_id_with_prefix("D");
+        let etag = generate_id_with_prefix("E");
+        let stored = StoredContinuousDeploymentPolicy {
+            id: id.clone(),
+            etag: etag.clone(),
+            last_modified_time: Utc::now(),
+            config: cfg,
+        };
+        let mut state = self.state.write();
+        state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default()
+            .continuous_deployment_policies
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_simple_policy(PolicyView::from(stored), "ContinuousDeploymentPolicy");
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_continuous_deployment_policy(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ContinuousDeploymentPolicy")?;
+        let cdp = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.continuous_deployment_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+        let body =
+            render_simple_policy(PolicyView::from(cdp.clone()), "ContinuousDeploymentPolicy");
+        Ok(xml_with_etag(StatusCode::OK, body, &cdp.etag, None))
+    }
+
+    pub(crate) fn get_continuous_deployment_policy_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ContinuousDeploymentPolicy")?;
+        let cdp = self
+            .shared_state()
+            .read()
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.continuous_deployment_policies.get(&id).cloned())
+            .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+        let body = config_xml("ContinuousDeploymentPolicyConfig", &cdp.config)?;
+        Ok(xml_with_etag(StatusCode::OK, body, &cdp.etag, None))
+    }
+
+    pub(crate) fn update_continuous_deployment_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ContinuousDeploymentPolicy")?;
+        let if_match = require_if_match(req)?;
+        let cfg: ContinuousDeploymentPolicyConfig =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid ContinuousDeploymentPolicyConfig XML: {e}"))
+            })?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+        let cdp = account
+            .continuous_deployment_policies
+            .get_mut(&id)
+            .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+        if cdp.etag != if_match {
+            return Err(precondition_failed());
+        }
+        cdp.config = cfg;
+        cdp.etag = generate_id_with_prefix("E");
+        cdp.last_modified_time = Utc::now();
+        let snapshot = cdp.clone();
+        drop(state);
+        let body = render_simple_policy(
+            PolicyView::from(snapshot.clone()),
+            "ContinuousDeploymentPolicy",
+        );
+        Ok(xml_with_etag(StatusCode::OK, body, &snapshot.etag, None))
+    }
+
+    pub(crate) fn delete_continuous_deployment_policy(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "ContinuousDeploymentPolicy")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+        {
+            let cdp = account
+                .continuous_deployment_policies
+                .get(&id)
+                .ok_or_else(|| not_found("ContinuousDeploymentPolicy", &id))?;
+            if cdp.etag != if_match {
+                return Err(precondition_failed());
+            }
+        }
+        account.continuous_deployment_policies.remove(&id);
+        Ok(empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_continuous_deployment_policies(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredContinuousDeploymentPolicy> = state
+            .accounts
+            .values()
+            .flat_map(|a| a.continuous_deployment_policies.values().cloned())
+            .collect();
+        drop(state);
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+        let mut body = String::new();
+        body.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        body.push_str(&format!(
+            "<ContinuousDeploymentPolicyList xmlns=\"{NS}\">",
+            NS = crate::NAMESPACE
+        ));
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        if !items.is_empty() {
+            body.push_str("<Items>");
+            for cdp in &items {
+                body.push_str("<ContinuousDeploymentPolicySummary>");
+                body.push_str("<ContinuousDeploymentPolicy>");
+                body.push_str(&format!("<Id>{}</Id>", esc(&cdp.id)));
+                body.push_str(&format!(
+                    "<LastModifiedTime>{}</LastModifiedTime>",
+                    rfc3339(&cdp.last_modified_time)
+                ));
+                body.push_str(
+                    &quick_xml::se::to_string_with_root(
+                        "ContinuousDeploymentPolicyConfig",
+                        &cdp.config,
+                    )
+                    .unwrap_or_default(),
+                );
+                body.push_str("</ContinuousDeploymentPolicy>");
+                body.push_str("</ContinuousDeploymentPolicySummary>");
+            }
+            body.push_str("</Items>");
+        }
+        body.push_str("</ContinuousDeploymentPolicyList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+fn config_xml<T: serde::Serialize>(root: &str, cfg: &T) -> Result<String, AwsServiceError> {
+    let inner = quick_xml::se::to_string_with_root(root, cfg).map_err(|e| {
+        aws_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "InternalError",
+            format!("xml encode failed: {e}"),
+        )
+    })?;
+    let stamped = inner.replacen(
+        &format!("<{root}>"),
+        &format!("<{root} xmlns=\"{NS}\">", NS = crate::NAMESPACE),
+        1,
+    );
+    Ok(format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>{stamped}"
+    ))
+}
+
+fn parse_type_filter(query: &str) -> Option<String> {
+    let pairs: HashMap<&str, &str> = query.split('&').filter_map(|p| p.split_once('=')).collect();
+    pairs.get("Type").map(|v| v.to_string())
+}

--- a/crates/fakecloud-cloudfront/src/policies_service.rs
+++ b/crates/fakecloud-cloudfront/src/policies_service.rs
@@ -121,6 +121,11 @@ impl CloudFrontService {
         let if_match = require_if_match(req)?;
         let cfg: OriginAccessControlConfig = xml_io::from_xml_root(&req.body)
             .map_err(|e| invalid_argument(format!("invalid OriginAccessControlConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "OriginAccessControlConfig.Name is required",
+            ));
+        }
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -293,6 +298,9 @@ impl CloudFrontService {
         let if_match = require_if_match(req)?;
         let cfg: CachePolicyConfig = xml_io::from_xml_root(&req.body)
             .map_err(|e| invalid_argument(format!("invalid CachePolicyConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument("CachePolicyConfig.Name is required"));
+        }
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -482,6 +490,11 @@ impl CloudFrontService {
         let if_match = require_if_match(req)?;
         let cfg: OriginRequestPolicyConfig = xml_io::from_xml_root(&req.body)
             .map_err(|e| invalid_argument(format!("invalid OriginRequestPolicyConfig XML: {e}")))?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "OriginRequestPolicyConfig.Name is required",
+            ));
+        }
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -673,6 +686,11 @@ impl CloudFrontService {
         let cfg: ResponseHeadersPolicyConfig = xml_io::from_xml_root(&req.body).map_err(|e| {
             invalid_argument(format!("invalid ResponseHeadersPolicyConfig XML: {e}"))
         })?;
+        if cfg.name.is_empty() {
+            return Err(invalid_argument(
+                "ResponseHeadersPolicyConfig.Name is required",
+            ));
+        }
         let mut state = self.state.write();
         let account = state
             .accounts

--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -21,7 +21,7 @@ use crate::state::{
 };
 use crate::xml_io;
 
-const DEFAULT_ACCOUNT: &str = "000000000000";
+pub(crate) const DEFAULT_ACCOUNT: &str = "000000000000";
 
 const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateDistribution",
@@ -54,10 +54,40 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ListDistributionsByRealtimeLogConfig",
     "AssociateDistributionWebACL",
     "DisassociateDistributionWebACL",
+    "CreateOriginAccessControl",
+    "GetOriginAccessControl",
+    "GetOriginAccessControlConfig",
+    "UpdateOriginAccessControl",
+    "DeleteOriginAccessControl",
+    "ListOriginAccessControls",
+    "CreateCachePolicy",
+    "GetCachePolicy",
+    "GetCachePolicyConfig",
+    "UpdateCachePolicy",
+    "DeleteCachePolicy",
+    "ListCachePolicies",
+    "CreateOriginRequestPolicy",
+    "GetOriginRequestPolicy",
+    "GetOriginRequestPolicyConfig",
+    "UpdateOriginRequestPolicy",
+    "DeleteOriginRequestPolicy",
+    "ListOriginRequestPolicies",
+    "CreateResponseHeadersPolicy",
+    "GetResponseHeadersPolicy",
+    "GetResponseHeadersPolicyConfig",
+    "UpdateResponseHeadersPolicy",
+    "DeleteResponseHeadersPolicy",
+    "ListResponseHeadersPolicies",
+    "CreateContinuousDeploymentPolicy",
+    "GetContinuousDeploymentPolicy",
+    "GetContinuousDeploymentPolicyConfig",
+    "UpdateContinuousDeploymentPolicy",
+    "DeleteContinuousDeploymentPolicy",
+    "ListContinuousDeploymentPolicies",
 ];
 
 pub struct CloudFrontService {
-    state: SharedCloudFrontState,
+    pub(crate) state: SharedCloudFrontState,
 }
 
 impl CloudFrontService {
@@ -129,6 +159,42 @@ impl AwsService for CloudFrontService {
             | "ListDistributionsByOwnedResource"
             | "ListDistributionsByTrustStore"
             | "ListDistributionsByRealtimeLogConfig" => self.list_distributions_by(resolved.action),
+            "CreateOriginAccessControl" => self.create_origin_access_control(&req),
+            "GetOriginAccessControl" => self.get_origin_access_control(&resolved),
+            "GetOriginAccessControlConfig" => self.get_origin_access_control_config(&resolved),
+            "UpdateOriginAccessControl" => self.update_origin_access_control(&req, &resolved),
+            "DeleteOriginAccessControl" => self.delete_origin_access_control(&req, &resolved),
+            "ListOriginAccessControls" => self.list_origin_access_controls(&req),
+            "CreateCachePolicy" => self.create_cache_policy(&req),
+            "GetCachePolicy" => self.get_cache_policy(&resolved),
+            "GetCachePolicyConfig" => self.get_cache_policy_config(&resolved),
+            "UpdateCachePolicy" => self.update_cache_policy(&req, &resolved),
+            "DeleteCachePolicy" => self.delete_cache_policy(&req, &resolved),
+            "ListCachePolicies" => self.list_cache_policies(&req),
+            "CreateOriginRequestPolicy" => self.create_origin_request_policy(&req),
+            "GetOriginRequestPolicy" => self.get_origin_request_policy(&resolved),
+            "GetOriginRequestPolicyConfig" => self.get_origin_request_policy_config(&resolved),
+            "UpdateOriginRequestPolicy" => self.update_origin_request_policy(&req, &resolved),
+            "DeleteOriginRequestPolicy" => self.delete_origin_request_policy(&req, &resolved),
+            "ListOriginRequestPolicies" => self.list_origin_request_policies(&req),
+            "CreateResponseHeadersPolicy" => self.create_response_headers_policy(&req),
+            "GetResponseHeadersPolicy" => self.get_response_headers_policy(&resolved),
+            "GetResponseHeadersPolicyConfig" => self.get_response_headers_policy_config(&resolved),
+            "UpdateResponseHeadersPolicy" => self.update_response_headers_policy(&req, &resolved),
+            "DeleteResponseHeadersPolicy" => self.delete_response_headers_policy(&req, &resolved),
+            "ListResponseHeadersPolicies" => self.list_response_headers_policies(&req),
+            "CreateContinuousDeploymentPolicy" => self.create_continuous_deployment_policy(&req),
+            "GetContinuousDeploymentPolicy" => self.get_continuous_deployment_policy(&resolved),
+            "GetContinuousDeploymentPolicyConfig" => {
+                self.get_continuous_deployment_policy_config(&resolved)
+            }
+            "UpdateContinuousDeploymentPolicy" => {
+                self.update_continuous_deployment_policy(&req, &resolved)
+            }
+            "DeleteContinuousDeploymentPolicy" => {
+                self.delete_continuous_deployment_policy(&req, &resolved)
+            }
+            "ListContinuousDeploymentPolicies" => self.list_continuous_deployment_policies(&req),
             other => Err(aws_error(
                 StatusCode::NOT_IMPLEMENTED,
                 "InvalidAction",
@@ -821,7 +887,7 @@ struct AssociateAliasRequest {
 /// everything else passes through unchanged. Keep this in sync with
 /// `quick_xml`'s entity table — using their own primitive would mean a
 /// `Writer` per call and we serialize directly into a `String`.
-fn esc(s: &str) -> String {
+pub(crate) fn esc(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {
@@ -1060,16 +1126,26 @@ fn generate_invalidation_id() -> String {
     format!("I{}", &raw[..13])
 }
 
-fn generate_etag() -> String {
+pub(crate) fn generate_etag() -> String {
     let raw = Uuid::new_v4().simple().to_string().to_uppercase();
     format!("E{}", &raw[..13])
+}
+
+/// Generate an AWS-shaped CloudFront resource ID with the given prefix.
+/// Used by Batch 2 policy resources (cache, origin request, response
+/// headers, continuous deployment, OAC) so each gets a recognizable
+/// alphabetic prefix in addition to the random suffix.
+pub(crate) fn generate_id_with_prefix(prefix: &str) -> String {
+    let raw = Uuid::new_v4().simple().to_string().to_uppercase();
+    let suffix_len = 14usize.saturating_sub(prefix.len()).min(raw.len());
+    format!("{prefix}{}", &raw[..suffix_len])
 }
 
 fn rfc3339(t: &chrono::DateTime<chrono::Utc>) -> String {
     t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-fn invalid_argument(msg: impl Into<String>) -> AwsServiceError {
+pub(crate) fn invalid_argument(msg: impl Into<String>) -> AwsServiceError {
     aws_error(StatusCode::BAD_REQUEST, "InvalidArgument", msg)
 }
 
@@ -1093,8 +1169,12 @@ fn internal_error(msg: impl Into<String>) -> AwsServiceError {
     aws_error(StatusCode::INTERNAL_SERVER_ERROR, "InternalError", msg)
 }
 
-fn aws_error(status: StatusCode, code: &str, msg: impl Into<String>) -> AwsServiceError {
-    AwsServiceError::aws_error(status, code, msg)
+pub(crate) fn aws_error(
+    status: StatusCode,
+    code: impl Into<String>,
+    msg: impl Into<String>,
+) -> AwsServiceError {
+    AwsServiceError::aws_error(status, code.into(), msg)
 }
 
 fn set_header(headers: &mut HeaderMap, name: HeaderName, value: &str) {
@@ -1103,7 +1183,7 @@ fn set_header(headers: &mut HeaderMap, name: HeaderName, value: &str) {
     }
 }
 
-fn xml_response(status: StatusCode, body: String, headers: HeaderMap) -> AwsResponse {
+pub(crate) fn xml_response(status: StatusCode, body: String, headers: HeaderMap) -> AwsResponse {
     AwsResponse {
         status,
         content_type: "text/xml".to_string(),

--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -462,14 +462,8 @@ impl CloudFrontService {
             | "ListDistributionsByOriginRequestPolicyId"
             | "ListDistributionsByResponseHeadersPolicyId"
             | "ListDistributionsByKeyGroup"
-            | "ListDistributionsByWebACLId"
-            | "ListDistributionsByVpcOriginId"
-            | "ListDistributionsByAnycastIpListId"
-            | "ListDistributionsByRealtimeLogConfig"
-            | "ListDistributionsByTrustStore"
-            | "ListDistributionsByConnectionMode"
-            | "ListDistributionsByConnectionFunction" => "DistributionIdList",
-            "ListDistributionsByOwnedResource" => "DistributionList",
+            | "ListDistributionsByVpcOriginId" => "DistributionIdList",
+            "ListDistributionsByOwnedResource" => "DistributionIdOwnerList",
             _ => "DistributionList",
         };
         let body = build_empty_distribution_id_list(root);

--- a/crates/fakecloud-cloudfront/src/state.rs
+++ b/crates/fakecloud-cloudfront/src/state.rs
@@ -8,6 +8,10 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 use crate::model::{DistributionConfig, InvalidationBatch};
+use crate::policies::{
+    StoredCachePolicy, StoredContinuousDeploymentPolicy, StoredOriginAccessControl,
+    StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
+};
 
 pub type SharedCloudFrontState = Arc<RwLock<CloudFrontAccounts>>;
 
@@ -40,6 +44,24 @@ pub struct AccountState {
     pub invalidations: HashMap<String, StoredInvalidation>,
     /// Tags keyed by ARN.
     pub tags: HashMap<String, Vec<Tag>>,
+    pub origin_access_controls: HashMap<String, StoredOriginAccessControl>,
+    pub cache_policies: HashMap<String, StoredCachePolicy>,
+    pub origin_request_policies: HashMap<String, StoredOriginRequestPolicy>,
+    pub response_headers_policies: HashMap<String, StoredResponseHeadersPolicy>,
+    pub continuous_deployment_policies: HashMap<String, StoredContinuousDeploymentPolicy>,
+}
+
+impl CloudFrontAccounts {
+    /// Pre-seed the AWS-managed Cache, Origin Request, and Response
+    /// Headers policies into the default account so callers that look
+    /// them up by their well-known IDs (Terraform, CDK) get the same
+    /// shape they get against AWS. The IDs and names mirror the AWS
+    /// console output verbatim — the easiest way to keep tests source
+    /// of truth.
+    pub fn seed_managed_policies(&mut self, account_id: &str) {
+        let account = self.entry(account_id);
+        crate::policies::seed_managed(account);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-conformance/tests/cloudfront.rs
+++ b/crates/fakecloud-conformance/tests/cloudfront.rs
@@ -390,3 +390,262 @@ async fn cloudfront_list_conflicting_aliases() {
         .await
         .unwrap();
 }
+
+// ─── Distribution-by-X listings (gap-fill for audit) ───────────────────
+
+async fn make_dist(server: &TestServer, caller_ref: &str) -> String {
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_distribution()
+        .distribution_config(minimal_config(caller_ref))
+        .send()
+        .await
+        .unwrap();
+    create.distribution().unwrap().id().to_string()
+}
+
+#[test_action("cloudfront", "CreateDistributionWithTags", checksum = "7c7b9e91")]
+#[tokio::test]
+async fn cloudfront_create_distribution_with_tags() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_distribution_with_tags()
+        .distribution_config_with_tags(
+            aws_sdk_cloudfront::types::DistributionConfigWithTags::builder()
+                .distribution_config(minimal_config("conf-cdwt"))
+                .tags(
+                    Tags::builder()
+                        .items(Tag::builder().key("env").value("test").build().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "CopyDistribution", checksum = "bfdbe0c0")]
+#[tokio::test]
+async fn cloudfront_copy_distribution() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_distribution()
+        .distribution_config(minimal_config("conf-copy-src"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.distribution().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.copy_distribution()
+        .primary_distribution_id(&id)
+        .if_match(&etag)
+        .caller_reference("conf-copy-1")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "AssociateDistributionWebACL", checksum = "b3ceaafe")]
+#[tokio::test]
+async fn cloudfront_associate_web_acl() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let id = make_dist(&server, "conf-webacl").await;
+    cf.associate_distribution_web_acl()
+        .id(&id)
+        .web_acl_arn("arn:aws:wafv2:us-east-1:000000000000:global/webacl/conf/abc")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DisassociateDistributionWebACL", checksum = "f95fc84d")]
+#[tokio::test]
+async fn cloudfront_disassociate_web_acl() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let id = make_dist(&server, "conf-webacl-dis").await;
+    cf.disassociate_distribution_web_acl()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByCachePolicyId",
+    checksum = "12e1b4fd"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_cache_policy_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_cache_policy_id()
+        .cache_policy_id("658327ea-f89d-4fab-a63d-7e88639e58f6")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByOriginRequestPolicyId",
+    checksum = "90a0f8fa"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_origin_request_policy_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_origin_request_policy_id()
+        .origin_request_policy_id("88a5eaf4-2fd4-4709-b370-b4c650ea3fcf")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByResponseHeadersPolicyId",
+    checksum = "cea636c9"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_response_headers_policy_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_response_headers_policy_id()
+        .response_headers_policy_id("60669652-455b-4ae9-85a4-c4c02393f86c")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListDistributionsByKeyGroup", checksum = "a1b7c588")]
+#[tokio::test]
+async fn cloudfront_list_dist_by_key_group() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_key_group()
+        .key_group_id("conf-kg")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListDistributionsByWebACLId", checksum = "1c6d1942")]
+#[tokio::test]
+async fn cloudfront_list_dist_by_web_acl_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_web_acl_id()
+        .web_acl_id("conf-acl")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListDistributionsByVpcOriginId", checksum = "39d538d7")]
+#[tokio::test]
+async fn cloudfront_list_dist_by_vpc_origin_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_vpc_origin_id()
+        .vpc_origin_id("conf-vpc")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByAnycastIpListId",
+    checksum = "b33414cb"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_anycast_ip_list_id() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_anycast_ip_list_id()
+        .anycast_ip_list_id("conf-anycast")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByConnectionMode",
+    checksum = "81cf0669"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_connection_mode() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_connection_mode()
+        .connection_mode(aws_sdk_cloudfront::types::ConnectionMode::Direct)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByOwnedResource",
+    checksum = "3c795df1"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_owned_resource() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_owned_resource()
+        .resource_arn("arn:aws:wafv2:us-east-1:000000000000:global/webacl/x/y")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListDistributionsByTrustStore", checksum = "85eee3eb")]
+#[tokio::test]
+async fn cloudfront_list_dist_by_trust_store() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_trust_store()
+        .trust_store_identifier("conf-trust")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByRealtimeLogConfig",
+    checksum = "e9954bf8"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_realtime_log_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_realtime_log_config()
+        .realtime_log_config_arn("arn:aws:cloudfront::000000000000:realtime-log-config/conf-rt")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionsByConnectionFunction",
+    checksum = "40b924ce"
+)]
+#[tokio::test]
+async fn cloudfront_list_dist_by_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distributions_by_connection_function()
+        .connection_function_identifier("conf-cf")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-conformance/tests/cloudfront_policies.rs
+++ b/crates/fakecloud-conformance/tests/cloudfront_policies.rs
@@ -1,0 +1,691 @@
+//! CloudFront Batch 2 conformance tests: OAC + Cache, Origin Request,
+//! Response Headers, and Continuous Deployment policies.
+#![allow(deprecated)]
+
+mod helpers;
+
+use aws_sdk_cloudfront::types::{
+    CachePolicyConfig, CachePolicyCookieBehavior, CachePolicyCookiesConfig,
+    CachePolicyHeaderBehavior, CachePolicyHeadersConfig, CachePolicyQueryStringBehavior,
+    CachePolicyQueryStringsConfig, ContinuousDeploymentPolicyConfig,
+    ContinuousDeploymentPolicyType, ContinuousDeploymentSingleHeaderConfig,
+    OriginAccessControlConfig, OriginAccessControlOriginTypes, OriginAccessControlSigningBehaviors,
+    OriginAccessControlSigningProtocols, OriginRequestPolicyConfig,
+    OriginRequestPolicyCookieBehavior, OriginRequestPolicyCookiesConfig,
+    OriginRequestPolicyHeaderBehavior, OriginRequestPolicyHeadersConfig,
+    OriginRequestPolicyQueryStringBehavior, OriginRequestPolicyQueryStringsConfig,
+    ParametersInCacheKeyAndForwardedToOrigin, ResponseHeadersPolicyAccessControlAllowHeaders,
+    ResponseHeadersPolicyAccessControlAllowMethods,
+    ResponseHeadersPolicyAccessControlAllowMethodsValues,
+    ResponseHeadersPolicyAccessControlAllowOrigins, ResponseHeadersPolicyConfig,
+    ResponseHeadersPolicyCorsConfig, StagingDistributionDnsNames, TrafficConfig,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+fn oac_cfg(name: &str) -> OriginAccessControlConfig {
+    OriginAccessControlConfig::builder()
+        .name(name)
+        .origin_access_control_origin_type(OriginAccessControlOriginTypes::S3)
+        .signing_behavior(OriginAccessControlSigningBehaviors::Always)
+        .signing_protocol(OriginAccessControlSigningProtocols::Sigv4)
+        .build()
+        .unwrap()
+}
+
+fn cache_cfg(name: &str) -> CachePolicyConfig {
+    CachePolicyConfig::builder()
+        .name(name)
+        .min_ttl(0)
+        .parameters_in_cache_key_and_forwarded_to_origin(
+            ParametersInCacheKeyAndForwardedToOrigin::builder()
+                .enable_accept_encoding_gzip(false)
+                .headers_config(
+                    CachePolicyHeadersConfig::builder()
+                        .header_behavior(CachePolicyHeaderBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .cookies_config(
+                    CachePolicyCookiesConfig::builder()
+                        .cookie_behavior(CachePolicyCookieBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .query_strings_config(
+                    CachePolicyQueryStringsConfig::builder()
+                        .query_string_behavior(CachePolicyQueryStringBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+fn orp_cfg(name: &str) -> OriginRequestPolicyConfig {
+    OriginRequestPolicyConfig::builder()
+        .name(name)
+        .headers_config(
+            OriginRequestPolicyHeadersConfig::builder()
+                .header_behavior(OriginRequestPolicyHeaderBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .cookies_config(
+            OriginRequestPolicyCookiesConfig::builder()
+                .cookie_behavior(OriginRequestPolicyCookieBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .query_strings_config(
+            OriginRequestPolicyQueryStringsConfig::builder()
+                .query_string_behavior(OriginRequestPolicyQueryStringBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+fn rhp_cfg(name: &str) -> ResponseHeadersPolicyConfig {
+    ResponseHeadersPolicyConfig::builder()
+        .name(name)
+        .cors_config(
+            ResponseHeadersPolicyCorsConfig::builder()
+                .access_control_allow_credentials(false)
+                .access_control_allow_headers(
+                    ResponseHeadersPolicyAccessControlAllowHeaders::builder()
+                        .quantity(1)
+                        .items("*")
+                        .build()
+                        .unwrap(),
+                )
+                .access_control_allow_methods(
+                    ResponseHeadersPolicyAccessControlAllowMethods::builder()
+                        .quantity(1)
+                        .items(ResponseHeadersPolicyAccessControlAllowMethodsValues::Get)
+                        .build()
+                        .unwrap(),
+                )
+                .access_control_allow_origins(
+                    ResponseHeadersPolicyAccessControlAllowOrigins::builder()
+                        .quantity(1)
+                        .items("*")
+                        .build()
+                        .unwrap(),
+                )
+                .origin_override(true)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+fn cdp_cfg() -> ContinuousDeploymentPolicyConfig {
+    ContinuousDeploymentPolicyConfig::builder()
+        .staging_distribution_dns_names(
+            StagingDistributionDnsNames::builder()
+                .quantity(1)
+                .items("staging.example.com")
+                .build()
+                .unwrap(),
+        )
+        .enabled(true)
+        .traffic_config(
+            TrafficConfig::builder()
+                .r#type(ContinuousDeploymentPolicyType::SingleHeader)
+                .single_header_config(
+                    ContinuousDeploymentSingleHeaderConfig::builder()
+                        .header("aws-cf-cd-staging")
+                        .value("true")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+// ─── Origin Access Control ────────────────────────────────────────────
+
+#[test_action("cloudfront", "CreateOriginAccessControl", checksum = "44c68eac")]
+#[tokio::test]
+async fn cloudfront_create_oac() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_origin_access_control()
+        .origin_access_control_config(oac_cfg("conf-oac-1"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetOriginAccessControl", checksum = "17549377")]
+#[tokio::test]
+async fn cloudfront_get_oac() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(oac_cfg("conf-oac-2"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_access_control().unwrap().id().to_string();
+    cf.get_origin_access_control().id(&id).send().await.unwrap();
+}
+
+#[test_action("cloudfront", "GetOriginAccessControlConfig", checksum = "0371dca1")]
+#[tokio::test]
+async fn cloudfront_get_oac_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(oac_cfg("conf-oac-3"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_access_control().unwrap().id().to_string();
+    cf.get_origin_access_control_config()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateOriginAccessControl", checksum = "1c18f112")]
+#[tokio::test]
+async fn cloudfront_update_oac() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(oac_cfg("conf-oac-4"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_access_control().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.update_origin_access_control()
+        .id(&id)
+        .if_match(&etag)
+        .origin_access_control_config(oac_cfg("conf-oac-4-updated"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteOriginAccessControl", checksum = "ec5f8552")]
+#[tokio::test]
+async fn cloudfront_delete_oac() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(oac_cfg("conf-oac-5"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_access_control().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.delete_origin_access_control()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListOriginAccessControls", checksum = "979cec68")]
+#[tokio::test]
+async fn cloudfront_list_oac() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_origin_access_controls().send().await.unwrap();
+}
+
+// ─── Cache Policy ─────────────────────────────────────────────────────
+
+#[test_action("cloudfront", "CreateCachePolicy", checksum = "f5cf05a9")]
+#[tokio::test]
+async fn cloudfront_create_cache_policy() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_cache_policy()
+        .cache_policy_config(cache_cfg("conf-cp-1"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetCachePolicy", checksum = "bb136706")]
+#[tokio::test]
+async fn cloudfront_get_cache_policy() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_cache_policy()
+        .cache_policy_config(cache_cfg("conf-cp-2"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.cache_policy().unwrap().id().to_string();
+    cf.get_cache_policy().id(&id).send().await.unwrap();
+}
+
+#[test_action("cloudfront", "GetCachePolicyConfig", checksum = "9c2b70f4")]
+#[tokio::test]
+async fn cloudfront_get_cache_policy_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_cache_policy()
+        .cache_policy_config(cache_cfg("conf-cp-3"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.cache_policy().unwrap().id().to_string();
+    cf.get_cache_policy_config().id(&id).send().await.unwrap();
+}
+
+#[test_action("cloudfront", "UpdateCachePolicy", checksum = "6e7e0f85")]
+#[tokio::test]
+async fn cloudfront_update_cache_policy() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_cache_policy()
+        .cache_policy_config(cache_cfg("conf-cp-4"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.cache_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.update_cache_policy()
+        .id(&id)
+        .if_match(&etag)
+        .cache_policy_config(cache_cfg("conf-cp-4-updated"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteCachePolicy", checksum = "54d0fda4")]
+#[tokio::test]
+async fn cloudfront_delete_cache_policy() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_cache_policy()
+        .cache_policy_config(cache_cfg("conf-cp-5"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.cache_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.delete_cache_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListCachePolicies", checksum = "792038f5")]
+#[tokio::test]
+async fn cloudfront_list_cache_policies() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_cache_policies().send().await.unwrap();
+}
+
+// ─── Origin Request Policy ────────────────────────────────────────────
+
+#[test_action("cloudfront", "CreateOriginRequestPolicy", checksum = "7ce8ece6")]
+#[tokio::test]
+async fn cloudfront_create_orp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_origin_request_policy()
+        .origin_request_policy_config(orp_cfg("conf-orp-1"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetOriginRequestPolicy", checksum = "3e460804")]
+#[tokio::test]
+async fn cloudfront_get_orp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_request_policy()
+        .origin_request_policy_config(orp_cfg("conf-orp-2"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_request_policy().unwrap().id().to_string();
+    cf.get_origin_request_policy().id(&id).send().await.unwrap();
+}
+
+#[test_action("cloudfront", "GetOriginRequestPolicyConfig", checksum = "66a5d04d")]
+#[tokio::test]
+async fn cloudfront_get_orp_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_request_policy()
+        .origin_request_policy_config(orp_cfg("conf-orp-3"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_request_policy().unwrap().id().to_string();
+    cf.get_origin_request_policy_config()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateOriginRequestPolicy", checksum = "ec4ca50e")]
+#[tokio::test]
+async fn cloudfront_update_orp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_request_policy()
+        .origin_request_policy_config(orp_cfg("conf-orp-4"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_request_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.update_origin_request_policy()
+        .id(&id)
+        .if_match(&etag)
+        .origin_request_policy_config(orp_cfg("conf-orp-4-updated"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteOriginRequestPolicy", checksum = "8c0709fe")]
+#[tokio::test]
+async fn cloudfront_delete_orp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_request_policy()
+        .origin_request_policy_config(orp_cfg("conf-orp-5"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_request_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.delete_origin_request_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListOriginRequestPolicies", checksum = "0b630441")]
+#[tokio::test]
+async fn cloudfront_list_orp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_origin_request_policies().send().await.unwrap();
+}
+
+// ─── Response Headers Policy ──────────────────────────────────────────
+
+#[test_action("cloudfront", "CreateResponseHeadersPolicy", checksum = "56ba5ee4")]
+#[tokio::test]
+async fn cloudfront_create_rhp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_response_headers_policy()
+        .response_headers_policy_config(rhp_cfg("conf-rhp-1"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetResponseHeadersPolicy", checksum = "50650ae2")]
+#[tokio::test]
+async fn cloudfront_get_rhp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_response_headers_policy()
+        .response_headers_policy_config(rhp_cfg("conf-rhp-2"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.response_headers_policy().unwrap().id().to_string();
+    cf.get_response_headers_policy()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetResponseHeadersPolicyConfig", checksum = "c5f37364")]
+#[tokio::test]
+async fn cloudfront_get_rhp_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_response_headers_policy()
+        .response_headers_policy_config(rhp_cfg("conf-rhp-3"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.response_headers_policy().unwrap().id().to_string();
+    cf.get_response_headers_policy_config()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateResponseHeadersPolicy", checksum = "16926921")]
+#[tokio::test]
+async fn cloudfront_update_rhp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_response_headers_policy()
+        .response_headers_policy_config(rhp_cfg("conf-rhp-4"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.response_headers_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.update_response_headers_policy()
+        .id(&id)
+        .if_match(&etag)
+        .response_headers_policy_config(rhp_cfg("conf-rhp-4-updated"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteResponseHeadersPolicy", checksum = "2e942a96")]
+#[tokio::test]
+async fn cloudfront_delete_rhp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_response_headers_policy()
+        .response_headers_policy_config(rhp_cfg("conf-rhp-5"))
+        .send()
+        .await
+        .unwrap();
+    let id = create.response_headers_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.delete_response_headers_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListResponseHeadersPolicies", checksum = "107dfed9")]
+#[tokio::test]
+async fn cloudfront_list_rhp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_response_headers_policies().send().await.unwrap();
+}
+
+// ─── Continuous Deployment Policy ─────────────────────────────────────
+
+#[test_action(
+    "cloudfront",
+    "CreateContinuousDeploymentPolicy",
+    checksum = "1d68722d"
+)]
+#[tokio::test]
+async fn cloudfront_create_cdp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetContinuousDeploymentPolicy", checksum = "9a7b09f7")]
+#[tokio::test]
+async fn cloudfront_get_cdp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+    let id = create
+        .continuous_deployment_policy()
+        .unwrap()
+        .id()
+        .to_string();
+    cf.get_continuous_deployment_policy()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "GetContinuousDeploymentPolicyConfig",
+    checksum = "c8d8580a"
+)]
+#[tokio::test]
+async fn cloudfront_get_cdp_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+    let id = create
+        .continuous_deployment_policy()
+        .unwrap()
+        .id()
+        .to_string();
+    cf.get_continuous_deployment_policy_config()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "UpdateContinuousDeploymentPolicy",
+    checksum = "c9b379a1"
+)]
+#[tokio::test]
+async fn cloudfront_update_cdp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+    let id = create
+        .continuous_deployment_policy()
+        .unwrap()
+        .id()
+        .to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.update_continuous_deployment_policy()
+        .id(&id)
+        .if_match(&etag)
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "DeleteContinuousDeploymentPolicy",
+    checksum = "c3294626"
+)]
+#[tokio::test]
+async fn cloudfront_delete_cdp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cdp_cfg())
+        .send()
+        .await
+        .unwrap();
+    let id = create
+        .continuous_deployment_policy()
+        .unwrap()
+        .id()
+        .to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    cf.delete_continuous_deployment_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListContinuousDeploymentPolicies",
+    checksum = "e7bbc957"
+)]
+#[tokio::test]
+async fn cloudfront_list_cdp() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_continuous_deployment_policies()
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-e2e/tests/cloudfront_policies.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_policies.rs
@@ -336,3 +336,42 @@ async fn continuous_deployment_policy_lifecycle() {
         .await
         .expect("delete");
 }
+
+#[tokio::test]
+async fn update_oac_with_empty_name_is_rejected() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(
+            OriginAccessControlConfig::builder()
+                .name("oac-validate")
+                .origin_access_control_origin_type(OriginAccessControlOriginTypes::S3)
+                .signing_behavior(OriginAccessControlSigningBehaviors::Always)
+                .signing_protocol(OriginAccessControlSigningProtocols::Sigv4)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let id = create.origin_access_control().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    let bad = OriginAccessControlConfig::builder()
+        .name("")
+        .origin_access_control_origin_type(OriginAccessControlOriginTypes::S3)
+        .signing_behavior(OriginAccessControlSigningBehaviors::Always)
+        .signing_protocol(OriginAccessControlSigningProtocols::Sigv4)
+        .build()
+        .unwrap();
+
+    let res = cf
+        .update_origin_access_control()
+        .id(&id)
+        .if_match(&etag)
+        .origin_access_control_config(bad)
+        .send()
+        .await;
+    assert!(res.is_err(), "empty Name on update must be rejected");
+}

--- a/crates/fakecloud-e2e/tests/cloudfront_policies.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_policies.rs
@@ -1,0 +1,338 @@
+//! CloudFront Batch 2 E2E: Origin Access Controls + Cache, Origin
+//! Request, Response Headers, and Continuous Deployment policies.
+#![allow(deprecated)]
+
+mod helpers;
+
+use aws_sdk_cloudfront::types::{
+    CachePolicyConfig, CachePolicyCookieBehavior, CachePolicyCookiesConfig,
+    CachePolicyHeaderBehavior, CachePolicyHeadersConfig, CachePolicyQueryStringBehavior,
+    CachePolicyQueryStringsConfig, ContinuousDeploymentPolicyConfig,
+    ContinuousDeploymentPolicyType, ContinuousDeploymentSingleHeaderConfig,
+    OriginAccessControlConfig, OriginAccessControlOriginTypes, OriginAccessControlSigningBehaviors,
+    OriginAccessControlSigningProtocols, OriginRequestPolicyConfig,
+    OriginRequestPolicyCookieBehavior, OriginRequestPolicyCookiesConfig,
+    OriginRequestPolicyHeaderBehavior, OriginRequestPolicyHeadersConfig,
+    OriginRequestPolicyQueryStringBehavior, OriginRequestPolicyQueryStringsConfig,
+    ParametersInCacheKeyAndForwardedToOrigin, ResponseHeadersPolicyAccessControlAllowHeaders,
+    ResponseHeadersPolicyAccessControlAllowMethods,
+    ResponseHeadersPolicyAccessControlAllowMethodsValues,
+    ResponseHeadersPolicyAccessControlAllowOrigins, ResponseHeadersPolicyConfig,
+    ResponseHeadersPolicyCorsConfig, StagingDistributionDnsNames, TrafficConfig,
+};
+use helpers::TestServer;
+
+#[tokio::test]
+async fn origin_access_control_lifecycle() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let cfg = OriginAccessControlConfig::builder()
+        .name("oac-e2e")
+        .description("test oac")
+        .origin_access_control_origin_type(OriginAccessControlOriginTypes::S3)
+        .signing_behavior(OriginAccessControlSigningBehaviors::Always)
+        .signing_protocol(OriginAccessControlSigningProtocols::Sigv4)
+        .build()
+        .unwrap();
+
+    let create = cf
+        .create_origin_access_control()
+        .origin_access_control_config(cfg)
+        .send()
+        .await
+        .expect("create_oac");
+    let oac = create.origin_access_control().expect("oac");
+    let id = oac.id().to_string();
+    let etag = create.e_tag().expect("etag").to_string();
+
+    let got = cf
+        .get_origin_access_control()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_oac");
+    assert_eq!(got.origin_access_control().unwrap().id(), id);
+
+    let new_cfg = OriginAccessControlConfig::builder()
+        .name("oac-e2e-renamed")
+        .description("updated")
+        .origin_access_control_origin_type(OriginAccessControlOriginTypes::S3)
+        .signing_behavior(OriginAccessControlSigningBehaviors::Always)
+        .signing_protocol(OriginAccessControlSigningProtocols::Sigv4)
+        .build()
+        .unwrap();
+
+    let updated = cf
+        .update_origin_access_control()
+        .id(&id)
+        .if_match(&etag)
+        .origin_access_control_config(new_cfg)
+        .send()
+        .await
+        .expect("update_oac");
+    let new_etag = updated.e_tag().expect("etag").to_string();
+    assert_ne!(new_etag, etag);
+
+    let list = cf
+        .list_origin_access_controls()
+        .send()
+        .await
+        .expect("list_oac");
+    let items = list.origin_access_control_list().unwrap();
+    assert!(items.quantity() >= 1);
+
+    cf.delete_origin_access_control()
+        .id(&id)
+        .if_match(&new_etag)
+        .send()
+        .await
+        .expect("delete_oac");
+
+    let err = cf.get_origin_access_control().id(&id).send().await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn cache_policy_lifecycle_and_managed_seeded() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let list = cf.list_cache_policies().send().await.expect("list");
+    let managed_count = list
+        .cache_policy_list()
+        .unwrap()
+        .items()
+        .iter()
+        .filter(|i| i.r#type().as_str() == "managed")
+        .count();
+    assert!(managed_count >= 4, "expected AWS-managed cache policies");
+
+    let cfg = CachePolicyConfig::builder()
+        .name("custom-cache")
+        .min_ttl(0)
+        .max_ttl(86400)
+        .default_ttl(3600)
+        .parameters_in_cache_key_and_forwarded_to_origin(
+            ParametersInCacheKeyAndForwardedToOrigin::builder()
+                .enable_accept_encoding_gzip(true)
+                .headers_config(
+                    CachePolicyHeadersConfig::builder()
+                        .header_behavior(CachePolicyHeaderBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .cookies_config(
+                    CachePolicyCookiesConfig::builder()
+                        .cookie_behavior(CachePolicyCookieBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .query_strings_config(
+                    CachePolicyQueryStringsConfig::builder()
+                        .query_string_behavior(CachePolicyQueryStringBehavior::None)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let create = cf
+        .create_cache_policy()
+        .cache_policy_config(cfg)
+        .send()
+        .await
+        .expect("create");
+    let id = create.cache_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    let got = cf.get_cache_policy().id(&id).send().await.expect("get");
+    assert_eq!(got.cache_policy().unwrap().id(), id);
+
+    cf.delete_cache_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .expect("delete");
+}
+
+#[tokio::test]
+async fn managed_cache_policy_cannot_be_deleted() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    // Trigger seeding by listing first.
+    let _ = cf.list_cache_policies().send().await.expect("list");
+
+    let managed_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"; // CachingOptimized
+    let got = cf
+        .get_cache_policy()
+        .id(managed_id)
+        .send()
+        .await
+        .expect("get managed");
+    let etag = got.e_tag().unwrap().to_string();
+
+    let res = cf
+        .delete_cache_policy()
+        .id(managed_id)
+        .if_match(&etag)
+        .send()
+        .await;
+    assert!(res.is_err(), "managed policy must not be deletable");
+}
+
+#[tokio::test]
+async fn origin_request_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let cfg = OriginRequestPolicyConfig::builder()
+        .name("custom-orp")
+        .headers_config(
+            OriginRequestPolicyHeadersConfig::builder()
+                .header_behavior(OriginRequestPolicyHeaderBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .cookies_config(
+            OriginRequestPolicyCookiesConfig::builder()
+                .cookie_behavior(OriginRequestPolicyCookieBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .query_strings_config(
+            OriginRequestPolicyQueryStringsConfig::builder()
+                .query_string_behavior(OriginRequestPolicyQueryStringBehavior::None)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let create = cf
+        .create_origin_request_policy()
+        .origin_request_policy_config(cfg)
+        .send()
+        .await
+        .expect("create");
+    let id = create.origin_request_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    cf.delete_origin_request_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .expect("delete");
+}
+
+#[tokio::test]
+async fn response_headers_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let cfg = ResponseHeadersPolicyConfig::builder()
+        .name("custom-rhp")
+        .cors_config(
+            ResponseHeadersPolicyCorsConfig::builder()
+                .access_control_allow_credentials(false)
+                .access_control_allow_headers(
+                    ResponseHeadersPolicyAccessControlAllowHeaders::builder()
+                        .quantity(1)
+                        .items("*")
+                        .build()
+                        .unwrap(),
+                )
+                .access_control_allow_methods(
+                    ResponseHeadersPolicyAccessControlAllowMethods::builder()
+                        .quantity(1)
+                        .items(ResponseHeadersPolicyAccessControlAllowMethodsValues::Get)
+                        .build()
+                        .unwrap(),
+                )
+                .access_control_allow_origins(
+                    ResponseHeadersPolicyAccessControlAllowOrigins::builder()
+                        .quantity(1)
+                        .items("*")
+                        .build()
+                        .unwrap(),
+                )
+                .origin_override(true)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let create = cf
+        .create_response_headers_policy()
+        .response_headers_policy_config(cfg)
+        .send()
+        .await
+        .expect("create");
+    let id = create.response_headers_policy().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    cf.delete_response_headers_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .expect("delete");
+}
+
+#[tokio::test]
+async fn continuous_deployment_policy_lifecycle() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let cfg = ContinuousDeploymentPolicyConfig::builder()
+        .staging_distribution_dns_names(
+            StagingDistributionDnsNames::builder()
+                .quantity(1)
+                .items("staging.example.com")
+                .build()
+                .unwrap(),
+        )
+        .enabled(true)
+        .traffic_config(
+            TrafficConfig::builder()
+                .r#type(ContinuousDeploymentPolicyType::SingleHeader)
+                .single_header_config(
+                    ContinuousDeploymentSingleHeaderConfig::builder()
+                        .header("aws-cf-cd-staging")
+                        .value("true")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let create = cf
+        .create_continuous_deployment_policy()
+        .continuous_deployment_policy_config(cfg)
+        .send()
+        .await
+        .expect("create");
+    let id = create
+        .continuous_deployment_policy()
+        .unwrap()
+        .id()
+        .to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    cf.delete_continuous_deployment_policy()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .expect("delete");
+}

--- a/website/content/docs/services/_index.md
+++ b/website/content/docs/services/_index.md
@@ -7,7 +7,7 @@ template = "docs.html"
 page_template = "docs-page.html"
 +++
 
-fakecloud implements 28 AWS services with 2,077 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
+fakecloud implements 28 AWS services with 2,107 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -38,6 +38,6 @@ fakecloud implements 28 AWS services with 2,077 total operations, all at 100% Sm
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle eval, scanning, pull-through cache, registry templates, real cosign signature verification |
 | ECS                    |  60 | Full API — clusters, real Fargate-style task execution via Docker, services + rolling deployments, task sets, container instances, ECS Exec, awslogs -> Logs, secrets injection, task role credentials |
 | Elastic Load Balancing v2 |  51 | Full control plane — ALB/NLB/GWLB CRUD, target groups + targets + real health probes, listeners + rules + certificates, attributes, capacity reservations, **mTLS trust stores + revocations**, resource policies, SSL policies, tags. **In-process HTTP data plane for ALBs** — per-LB TCP bind, rule matching, forward / fixed-response / redirect, sticky sessions |
-| CloudFront                |  29 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags + copy + by-X listings), invalidations, web ACL associate/disassociate, alias associate, tags. Full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
+| CloudFront                |  59 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags + copy + by-X listings), invalidations, web ACL associate/disassociate, alias associate, tags. **Origin Access Controls + Cache, Origin Request, Response Headers, Continuous Deployment policies** — full CRUD with AWS-managed policies pre-seeded by well-known IDs. Full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
 
 Detailed per-service pages are coming. If you need specifics on a service today, the conformance baseline at [`conformance-baseline.json`](https://github.com/faiscadev/fakecloud/blob/main/conformance-baseline.json) lists every operation fakecloud handles, and the AWS Smithy models in [`aws-models/`](https://github.com/faiscadev/fakecloud/tree/main/aws-models) are the authoritative source of truth.

--- a/website/content/docs/services/cloudfront.md
+++ b/website/content/docs/services/cloudfront.md
@@ -4,9 +4,9 @@ description = "CloudFront control plane — distributions, invalidations, web AC
 weight = 24
 +++
 
-fakecloud implements CloudFront's REST-XML control plane focused on the operations real applications and Terraform stacks rely on: distribution lifecycle, invalidations, alias and web ACL association, tags, and read-only "by predicate" listings. 29 operations in this batch.
+fakecloud implements CloudFront's REST-XML control plane focused on the operations real applications and Terraform stacks rely on: distribution lifecycle, invalidations, alias and web ACL association, tags, and the full Origin Access Control + policy resource surface. 59 operations.
 
-**Status: Batch 1 — distributions, invalidations, tagging, alias/web-ACL associations.** Origin Access Control, cache policies, origin request policies, response headers policies, CloudFront Functions, key groups, OAIs, streaming distributions, and the rest of the surface ship in subsequent batches.
+**Status: Batches 1-2 shipped.** CloudFront Functions, key groups, OAIs (legacy), public keys, streaming distributions, field-level encryption, real-time log config, VPC origins, anycast IP lists, trust stores, distribution tenants, and connection functions/groups are still pending across subsequent batches.
 
 ## Supported today
 
@@ -15,6 +15,11 @@ fakecloud implements CloudFront's REST-XML control plane focused on the operatio
 - **Invalidations** — `CreateInvalidation` (returns `Completed` immediately for deterministic tests), `GetInvalidation`, `ListInvalidations`.
 - **Tags** — `TagResource`, `UntagResource`, `ListTagsForResource` keyed by distribution ARN.
 - **Aliases / Web ACL** — `AssociateAlias`, `ListConflictingAliases`, `AssociateDistributionWebACL`, `DisassociateDistributionWebACL`.
+- **Origin Access Control** — `CreateOriginAccessControl`, `GetOriginAccessControl`, `GetOriginAccessControlConfig`, `UpdateOriginAccessControl`, `DeleteOriginAccessControl`, `ListOriginAccessControls`. Full ETag/If-Match concurrency.
+- **Cache Policy** — `CreateCachePolicy`, `GetCachePolicy`, `GetCachePolicyConfig`, `UpdateCachePolicy`, `DeleteCachePolicy`, `ListCachePolicies` with `?Type=managed|custom`. AWS-managed `Managed-CachingOptimized`, `Managed-CachingDisabled`, `Managed-CachingOptimizedForUncompressedObjects`, `Managed-Elemental*` are pre-seeded by their well-known IDs and reject `Update`/`Delete`.
+- **Origin Request Policy** — `CreateOriginRequestPolicy`, `GetOriginRequestPolicy`, `GetOriginRequestPolicyConfig`, `UpdateOriginRequestPolicy`, `DeleteOriginRequestPolicy`, `ListOriginRequestPolicies`. Managed `Managed-CORS-S3Origin`, `Managed-CORS-CustomOrigin`, `Managed-AllViewer`, `Managed-UserAgentRefererHeaders`, `Managed-AllViewerExceptHostHeader` pre-seeded.
+- **Response Headers Policy** — `CreateResponseHeadersPolicy`, `GetResponseHeadersPolicy`, `GetResponseHeadersPolicyConfig`, `UpdateResponseHeadersPolicy`, `DeleteResponseHeadersPolicy`, `ListResponseHeadersPolicies`. Managed `Managed-SimpleCORS`, `Managed-CORS-With-Preflight`, `Managed-SecurityHeadersPolicy` pre-seeded.
+- **Continuous Deployment Policy** — `CreateContinuousDeploymentPolicy`, `GetContinuousDeploymentPolicy`, `GetContinuousDeploymentPolicyConfig`, `UpdateContinuousDeploymentPolicy`, `DeleteContinuousDeploymentPolicy`, `ListContinuousDeploymentPolicies`.
 
 ### Concurrency semantics
 
@@ -68,9 +73,7 @@ aws --endpoint-url http://localhost:4566 cloudfront list-invalidations --distrib
 
 | Surface                                | Status                  |
 |----------------------------------------|-------------------------|
-| Origin Access Control + OAI (legacy)   | Batch 2 / 3             |
-| Cache / Origin Request / Response Headers policies | Batch 2     |
-| Continuous Deployment Policy           | Batch 2                 |
+| Origin Access Identity (legacy OAI)    | Batch 3                 |
 | CloudFront Functions + Key Value Stores | Batch 3                |
 | Public Keys + Key Groups               | Batch 3                 |
 | Field-Level Encryption                 | Batch 4                 |


### PR DESCRIPTION
## Summary
- Origin Access Control: full CRUD + List with ETag/If-Match concurrency
- Cache Policy: full CRUD + List with `?Type=managed|custom` filter
- Origin Request Policy: full CRUD + List
- Response Headers Policy: full CRUD + List
- Continuous Deployment Policy: full CRUD + List
- AWS-managed cache, origin-request, response-headers policies pre-seeded by their well-known IDs (`Managed-CachingOptimized` etc.) and reject `Update`/`Delete` with `IllegalUpdate`/`IllegalDelete`
- **+30 ops** (cloudfront 29 -> 59, total 2,077 -> 2,107)

## Test plan
- [x] `cargo test -p fakecloud-cloudfront` — 16 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test cloudfront_policies` — 6 E2E tests pass
- [x] `FAKECLOUD_RUN_CONFORMANCE=1 cargo test -p fakecloud-conformance --test cloudfront_policies` — 30 conformance tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] README + website docs updated to reflect new ops + managed-policy seeding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFront OAC and Cache/Origin Request/Response Headers/Continuous Deployment policies with full CRUD + List. Seeds AWS‑managed policies, enforces ETag/If-Match, fixes managed Response Headers policy IDs and by‑X ListDistributions response roots, validates Name on Update, and bumps CloudFront ops 29→59 (total 2,107).

- **New Features**
  - Full CRUD + List for OAC, CachePolicy, OriginRequestPolicy, ResponseHeadersPolicy, ContinuousDeploymentPolicy.
  - ETag/If-Match concurrency and separate `Get*` and `Get*Config` endpoints.
  - AWS‑managed Cache/OriginRequest/ResponseHeaders policies pre-seeded; `Update`/`Delete` return `IllegalUpdate`/`IllegalDelete`; `ListCachePolicies` supports `?Type=managed|custom`.

<sup>Written for commit b29585b2583639d7e8d50f3fb9b70d54875f56f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

