### PR TITLE
feat(lambda): support legacy runtimes (nodejs16, python3.8-3.10, java11, go1.x)

### DIFF
--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -640,14 +640,20 @@ pub fn runtime_to_image(runtime: &str) -> Option<String> {
         "python3.13" => ("python", "3.13"),
         "python3.12" => ("python", "3.12"),
         "python3.11" => ("python", "3.11"),
+        "python3.10" => ("python", "3.10"),
+        "python3.9" => ("python", "3.9"),
+        "python3.8" => ("python", "3.8"),
         "nodejs22.x" => ("nodejs", "22"),
         "nodejs20.x" => ("nodejs", "20"),
         "nodejs18.x" => ("nodejs", "18"),
+        "nodejs16.x" => ("nodejs", "16"),
         "ruby3.4" => ("ruby", "3.4"),
         "ruby3.3" => ("ruby", "3.3"),
         "java21" => ("java", "21"),
         "java17" => ("java", "17"),
+        "java11" => ("java", "11"),
         "dotnet8" => ("dotnet", "8"),
+        "go1.x" => ("go", "1"),
         "provided.al2023" => ("provided", "al2023"),
         "provided.al2" => ("provided", "al2"),
         _ => return None,
@@ -777,6 +783,30 @@ mod tests {
         assert_eq!(
             runtime_to_image("dotnet8"),
             Some("public.ecr.aws/lambda/dotnet:8".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("nodejs16.x"),
+            Some("public.ecr.aws/lambda/nodejs:16".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("python3.10"),
+            Some("public.ecr.aws/lambda/python:3.10".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("python3.9"),
+            Some("public.ecr.aws/lambda/python:3.9".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("python3.8"),
+            Some("public.ecr.aws/lambda/python:3.8".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("java11"),
+            Some("public.ecr.aws/lambda/java:11".to_string())
+        );
+        assert_eq!(
+            runtime_to_image("go1.x"),
+            Some("public.ecr.aws/lambda/go:1".to_string())
         );
         assert_eq!(runtime_to_image("unknown"), None);
     }


### PR DESCRIPTION
## Summary
- Lambda docs claimed support for nodejs16, python3.8/3.9/3.10, java11, go1.x — none existed in `runtime_to_image`.
- Adds those mappings so docs match reality (runtime IDs map to public AWS ECR Lambda images).
- Issue #772 also flagged that the docs are missing nodejs22 + python3.13 (which already exist in code). Doc patch left for the reporter to send if they want.

## Test plan
- [x] `cargo test -p fakecloud-lambda runtime::tests::test_runtime_to_image`
- [x] `cargo build -p fakecloud-lambda`

Refs #772

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for legacy AWS Lambda runtimes by mapping them to public ECR images, aligning code with our docs. Users can now resolve images for nodejs16.x, python3.10/3.9/3.8, java11, and go1.x.

- **New Features**
  - Added image mappings for nodejs16.x, python3.10/3.9/3.8, java11, go1.x.
  - Added unit tests for the new runtimes.

<sup>Written for commit 4b2d72cb9b1be77435586fde34174f7c5f3d420b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

