### PR TITLE
feat(cloudfront): legacy Streaming Distributions (RTMP) — full CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 
 ## Supported services
 
-28 services, 2,141 operations, 100% conformance per implemented service.
+28 services, 2,148 operations, 100% conformance per implemented service.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -79,7 +79,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle, scanning, registry, pull-through |
 | ECS                    |  60 | **Full API** — clusters, task definitions, real task execution, services + rolling deployments, container instances, capacity providers, task sets, ECS Exec |
 | Elastic Load Balancing v2 |  51 | ALB/NLB/GWLB CRUD: load balancers, target groups + targets + real health probes, **listeners + rules + certificates**, LB/listener/target-group attributes, capacity reservations, **mTLS trust stores + revocations**, SSL policies, resource policies, tags. **In-process HTTP data plane** for ALBs — per-LB TCP bind, rule matching, forward / fixed-response / redirect, sticky sessions, X-Forwarded-* headers |
-| CloudFront                |  93 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags), invalidations, distribution-by-X listings, web ACL associate/disassociate, alias associate, tags. Origin Access Controls + Cache/Origin Request/Response Headers/Continuous Deployment policies. **CloudFront Functions (Create/Update/Publish/Test/Delete) + Public Keys + Key Groups + Key Value Stores + Origin Access Identities (legacy)** — full CRUD; **per-distribution Monitoring Subscriptions** (Create/Get/Delete; AWS has no Update for this resource). REST-XML protocol, full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
+| CloudFront                | 100 | Distributions + invalidations + tagging + by-X listings + web ACL/alias association. OAC + Cache/OriginRequest/ResponseHeaders/ContinuousDeployment policies. CloudFront Functions, Public Keys, Key Groups, Key Value Stores, OAIs (legacy), Monitoring Subscriptions. **Streaming Distributions (legacy RTMP) — full CRUD + WithTags, ETag/If-Match concurrency, `StreamingDistributionNotDisabled` enforced before Delete.** REST-XML protocol, full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
 
 Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
 
@@ -122,7 +122,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | ECR                 | 58 operations, real `docker push`/`pull` via OCI v2 | [Paid only](https://docs.localstack.cloud/references/licensing/)              |
 | ECS                 | **60 operations — full API** incl. real task execution, services, task sets, capacity providers | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | Elastic Load Balancing v2 | **51 operations** ALB/NLB/GWLB incl. mTLS trust stores, capacity reservations, attributes, resource policies, plus an in-process HTTP data plane (rule matching + forward/fixed-response/redirect + sticky sessions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
-| CloudFront                | **93 operations** — distributions (full CRUD + ETag/If-Match concurrency, WithTags, copy, by-X listings), invalidations, web ACL/alias association, tags. Origin Access Controls + Cache/Origin Request/Response Headers/Continuous Deployment policies. **CloudFront Functions, Public Keys, Key Groups, Key Value Stores, Origin Access Identities (legacy)** — full CRUD; per-distribution **Monitoring Subscriptions** (Create/Get/Delete only — AWS has no Update for this resource). Full `DistributionConfig` round-trip (origins, cache behaviors, custom error responses, viewer certificates, geo restrictions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| CloudFront                | **100 operations** — distributions, invalidations, tagging, by-X listings, web ACL/alias association. OAC + Cache/OriginRequest/ResponseHeaders/ContinuousDeployment policies. CloudFront Functions, Public Keys, Key Groups, Key Value Stores, Origin Access Identities (legacy), Monitoring Subscriptions. **Streaming Distributions (legacy RTMP) — full CRUD + WithTags + ETag/If-Match concurrency, `StreamingDistributionNotDisabled` rule enforced before delete.** Full `DistributionConfig` round-trip (origins, cache behaviors, custom error responses, viewer certificates, geo restrictions) | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -13,6 +13,8 @@ pub mod policies_service;
 pub mod router;
 pub mod service;
 pub mod state;
+pub mod streaming;
+pub mod streaming_service;
 pub mod xml_io;
 
 pub use service::CloudFrontService;

--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -118,6 +118,13 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "CreateMonitoringSubscription",
     "GetMonitoringSubscription",
     "DeleteMonitoringSubscription",
+    "CreateStreamingDistribution",
+    "CreateStreamingDistributionWithTags",
+    "GetStreamingDistribution",
+    "GetStreamingDistributionConfig",
+    "UpdateStreamingDistribution",
+    "DeleteStreamingDistribution",
+    "ListStreamingDistributions",
 ];
 
 pub struct CloudFrontService {
@@ -263,6 +270,13 @@ impl AwsService for CloudFrontService {
             "CreateMonitoringSubscription" => self.create_monitoring_subscription(&req, &resolved),
             "GetMonitoringSubscription" => self.get_monitoring_subscription(&resolved),
             "DeleteMonitoringSubscription" => self.delete_monitoring_subscription(&resolved),
+            "CreateStreamingDistribution" => self.create_streaming_distribution(&req, false),
+            "CreateStreamingDistributionWithTags" => self.create_streaming_distribution(&req, true),
+            "GetStreamingDistribution" => self.get_streaming_distribution(&resolved),
+            "GetStreamingDistributionConfig" => self.get_streaming_distribution_config(&resolved),
+            "UpdateStreamingDistribution" => self.update_streaming_distribution(&req, &resolved),
+            "DeleteStreamingDistribution" => self.delete_streaming_distribution(&req, &resolved),
+            "ListStreamingDistributions" => self.list_streaming_distributions(&req),
             other => Err(aws_error(
                 StatusCode::NOT_IMPLEMENTED,
                 "InvalidAction",

--- a/crates/fakecloud-cloudfront/src/state.rs
+++ b/crates/fakecloud-cloudfront/src/state.rs
@@ -16,6 +16,7 @@ use crate::policies::{
     StoredCachePolicy, StoredContinuousDeploymentPolicy, StoredOriginAccessControl,
     StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
 };
+use crate::streaming::StoredStreamingDistribution;
 
 pub type SharedCloudFrontState = Arc<RwLock<CloudFrontAccounts>>;
 
@@ -60,6 +61,7 @@ pub struct AccountState {
     pub origin_access_identities: HashMap<String, StoredOriginAccessIdentity>,
     /// Per-distribution monitoring subscription, keyed by distribution id.
     pub monitoring_subscriptions: HashMap<String, StoredMonitoringSubscription>,
+    pub streaming_distributions: HashMap<String, StoredStreamingDistribution>,
 }
 
 impl CloudFrontAccounts {

--- a/crates/fakecloud-cloudfront/src/streaming.rs
+++ b/crates/fakecloud-cloudfront/src/streaming.rs
@@ -1,0 +1,94 @@
+//! Data types for CloudFront Batch 4 resources: Streaming Distributions
+//! (legacy RTMP), Field-Level Encryption, Realtime Log Configs.
+//!
+//! Batch 4 ships Streaming Distributions; Field-Level Encryption and
+//! Realtime Log Configs land in subsequent batches as they're independent
+//! resource families.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+fn skip_if_none<T>(x: &Option<T>) -> bool {
+    x.is_none()
+}
+
+// ─── Streaming Distribution (legacy RTMP) ─────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StreamingDistributionConfig {
+    pub caller_reference: String,
+    pub s3_origin: S3Origin,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub aliases: Option<StreamingAliases>,
+    pub comment: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub logging: Option<StreamingLoggingConfig>,
+    pub trusted_signers: TrustedSigners,
+    pub price_class: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct S3Origin {
+    pub domain_name: String,
+    pub origin_access_identity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StreamingAliases {
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<AliasItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct AliasItems {
+    #[serde(default, rename = "CNAME")]
+    pub cname: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StreamingLoggingConfig {
+    pub enabled: bool,
+    pub bucket: String,
+    pub prefix: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct TrustedSigners {
+    pub enabled: bool,
+    pub quantity: i32,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub items: Option<AwsAccountItems>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct AwsAccountItems {
+    #[serde(default, rename = "AwsAccountNumber")]
+    pub aws_account_number: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub struct StreamingDistributionConfigWithTags {
+    pub streaming_distribution_config: StreamingDistributionConfig,
+    pub tags: crate::model::Tags,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredStreamingDistribution {
+    pub id: String,
+    pub arn: String,
+    pub status: String,
+    pub last_modified_time: DateTime<Utc>,
+    pub domain_name: String,
+    pub etag: String,
+    pub config: StreamingDistributionConfig,
+}

--- a/crates/fakecloud-cloudfront/src/streaming_service.rs
+++ b/crates/fakecloud-cloudfront/src/streaming_service.rs
@@ -1,0 +1,427 @@
+//! Handlers for CloudFront Streaming Distributions (legacy RTMP).
+
+use chrono::Utc;
+use http::header::{ETAG, LOCATION};
+use http::{HeaderMap, HeaderValue, StatusCode};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::policies::{
+    not_found, precondition_failed, require_if_match, rfc3339, route_id, xml_with_etag,
+};
+use crate::router::Route;
+use crate::service::{
+    aws_error, esc, generate_etag, invalid_argument, xml_response, CloudFrontService,
+    DEFAULT_ACCOUNT,
+};
+use crate::state::Tag;
+use crate::streaming::{
+    StoredStreamingDistribution, StreamingDistributionConfig, StreamingDistributionConfigWithTags,
+};
+use crate::xml_io;
+
+const NS: &str = crate::NAMESPACE;
+const XML_DECL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>"#;
+
+impl CloudFrontService {
+    pub(crate) fn create_streaming_distribution(
+        &self,
+        req: &AwsRequest,
+        with_tags: bool,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let (config, tags) = if with_tags {
+            let parsed: StreamingDistributionConfigWithTags = xml_io::from_xml_root(&req.body)
+                .map_err(|e| {
+                    invalid_argument(format!(
+                        "invalid StreamingDistributionConfigWithTags XML: {e}"
+                    ))
+                })?;
+            let tags = parsed
+                .tags
+                .items
+                .map(|i| {
+                    i.tag
+                        .into_iter()
+                        .map(|t| Tag {
+                            key: t.key,
+                            value: t.value,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            (parsed.streaming_distribution_config, tags)
+        } else {
+            let parsed: StreamingDistributionConfig =
+                xml_io::from_xml_root(&req.body).map_err(|e| {
+                    invalid_argument(format!("invalid StreamingDistributionConfig XML: {e}"))
+                })?;
+            (parsed, Vec::new())
+        };
+        if config.caller_reference.is_empty() {
+            return Err(invalid_argument("CallerReference is required"));
+        }
+
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default();
+
+        if let Some(existing) = account
+            .streaming_distributions
+            .values()
+            .find(|d| d.config.caller_reference == config.caller_reference)
+        {
+            return Err(aws_error(
+                StatusCode::CONFLICT,
+                "StreamingDistributionAlreadyExists",
+                format!(
+                    "Streaming distribution with same CallerReference exists: {}",
+                    existing.id
+                ),
+            ));
+        }
+
+        let id = generate_streaming_id();
+        let now = Utc::now();
+        let etag = generate_etag();
+        let domain = format!("{}.cloudfront.net", id.to_lowercase());
+        let arn = format!(
+            "arn:aws:cloudfront::{}:streaming-distribution/{}",
+            DEFAULT_ACCOUNT, id
+        );
+
+        let stored = StoredStreamingDistribution {
+            id: id.clone(),
+            arn: arn.clone(),
+            status: "Deployed".to_string(),
+            last_modified_time: now,
+            domain_name: domain,
+            etag: etag.clone(),
+            config,
+        };
+        account
+            .streaming_distributions
+            .insert(id.clone(), stored.clone());
+        if !tags.is_empty() {
+            account.tags.insert(arn.clone(), tags);
+        }
+        drop(state);
+
+        let body = render_streaming_distribution(&stored);
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = HeaderValue::from_str(&etag) {
+            headers.insert(ETAG, v);
+        }
+        if let Ok(v) = HeaderValue::from_str(&stored.arn) {
+            headers.insert(LOCATION, v);
+        }
+        Ok(xml_response(StatusCode::CREATED, body, headers))
+    }
+
+    pub(crate) fn get_streaming_distribution(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "StreamingDistribution")?;
+        let state = self.state.read();
+        let d = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.streaming_distributions.get(&id).cloned())
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        drop(state);
+        let body = render_streaming_distribution(&d);
+        Ok(xml_with_etag(StatusCode::OK, body, &d.etag, None))
+    }
+
+    pub(crate) fn get_streaming_distribution_config(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "StreamingDistribution")?;
+        let state = self.state.read();
+        let d = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.streaming_distributions.get(&id).cloned())
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        drop(state);
+        let body = render_streaming_distribution_config(&d.config);
+        Ok(xml_with_etag(StatusCode::OK, body, &d.etag, None))
+    }
+
+    pub(crate) fn update_streaming_distribution(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "StreamingDistribution")?;
+        let if_match = require_if_match(req)?;
+        let cfg: StreamingDistributionConfig = xml_io::from_xml_root(&req.body).map_err(|e| {
+            invalid_argument(format!("invalid StreamingDistributionConfig XML: {e}"))
+        })?;
+        if cfg.caller_reference.is_empty() {
+            return Err(invalid_argument("CallerReference is required"));
+        }
+
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        let d = account
+            .streaming_distributions
+            .get_mut(&id)
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        if d.etag != if_match {
+            return Err(precondition_failed());
+        }
+        if d.config.caller_reference != cfg.caller_reference {
+            return Err(invalid_argument(
+                "CallerReference cannot change on UpdateStreamingDistribution",
+            ));
+        }
+        d.config = cfg;
+        d.etag = generate_etag();
+        d.last_modified_time = Utc::now();
+        let snap = d.clone();
+        drop(state);
+        let body = render_streaming_distribution(&snap);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn delete_streaming_distribution(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "StreamingDistribution")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        let d = account
+            .streaming_distributions
+            .get(&id)
+            .ok_or_else(|| not_found("StreamingDistribution", &id))?;
+        if d.etag != if_match {
+            return Err(precondition_failed());
+        }
+        if d.config.enabled {
+            return Err(aws_error(
+                StatusCode::PRECONDITION_FAILED,
+                "StreamingDistributionNotDisabled",
+                "StreamingDistribution must be disabled before deletion",
+            ));
+        }
+        account.streaming_distributions.remove(&id);
+        drop(state);
+        Ok(crate::policies::empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_streaming_distributions(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredStreamingDistribution> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.streaming_distributions.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let mut body = String::with_capacity(512);
+        body.push_str(XML_DECL);
+        body.push_str(&format!("<StreamingDistributionList xmlns=\"{NS}\">"));
+        body.push_str("<Marker></Marker>");
+        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str("<IsTruncated>false</IsTruncated>");
+        body.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+        body.push_str("<Items>");
+        for d in &items {
+            body.push_str("<StreamingDistributionSummary>");
+            push_summary_inner(&mut body, d);
+            body.push_str("</StreamingDistributionSummary>");
+        }
+        body.push_str("</Items>");
+        body.push_str("</StreamingDistributionList>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+fn generate_streaming_id() -> String {
+    let raw = Uuid::new_v4().simple().to_string().to_uppercase();
+    format!("S{}", &raw[..13])
+}
+
+fn render_streaming_distribution(d: &StoredStreamingDistribution) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<StreamingDistribution xmlns=\"{NS}\">"));
+    out.push_str(&format!("<Id>{}</Id>", esc(&d.id)));
+    out.push_str(&format!("<ARN>{}</ARN>", esc(&d.arn)));
+    out.push_str(&format!("<Status>{}</Status>", esc(&d.status)));
+    out.push_str(&format!(
+        "<LastModifiedTime>{}</LastModifiedTime>",
+        rfc3339(&d.last_modified_time)
+    ));
+    out.push_str(&format!("<DomainName>{}</DomainName>", esc(&d.domain_name)));
+    out.push_str(&render_active_trusted_signers(&d.config));
+    out.push_str(&serialize_config_inner(&d.config));
+    out.push_str("</StreamingDistribution>");
+    out
+}
+
+fn render_streaming_distribution_config(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<StreamingDistributionConfig xmlns=\"{NS}\">"));
+    out.push_str(&serialize_config_body(cfg));
+    out.push_str("</StreamingDistributionConfig>");
+    out
+}
+
+fn push_summary_inner(out: &mut String, d: &StoredStreamingDistribution) {
+    out.push_str(&format!("<Id>{}</Id>", esc(&d.id)));
+    out.push_str(&format!("<ARN>{}</ARN>", esc(&d.arn)));
+    out.push_str(&format!("<Status>{}</Status>", esc(&d.status)));
+    out.push_str(&format!(
+        "<LastModifiedTime>{}</LastModifiedTime>",
+        rfc3339(&d.last_modified_time)
+    ));
+    out.push_str(&format!("<DomainName>{}</DomainName>", esc(&d.domain_name)));
+    // S3Origin
+    out.push_str("<S3Origin>");
+    out.push_str(&format!(
+        "<DomainName>{}</DomainName>",
+        esc(&d.config.s3_origin.domain_name)
+    ));
+    out.push_str(&format!(
+        "<OriginAccessIdentity>{}</OriginAccessIdentity>",
+        esc(&d.config.s3_origin.origin_access_identity)
+    ));
+    out.push_str("</S3Origin>");
+    out.push_str(&render_aliases(&d.config));
+    out.push_str(&render_trusted_signers(&d.config));
+    out.push_str(&format!("<Comment>{}</Comment>", esc(&d.config.comment)));
+    out.push_str(&format!(
+        "<PriceClass>{}</PriceClass>",
+        esc(&d.config.price_class)
+    ));
+    out.push_str(&format!("<Enabled>{}</Enabled>", d.config.enabled));
+}
+
+fn serialize_config_inner(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str("<StreamingDistributionConfig>");
+    out.push_str(&serialize_config_body(cfg));
+    out.push_str("</StreamingDistributionConfig>");
+    out
+}
+
+fn serialize_config_body(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(&format!(
+        "<CallerReference>{}</CallerReference>",
+        esc(&cfg.caller_reference)
+    ));
+    out.push_str("<S3Origin>");
+    out.push_str(&format!(
+        "<DomainName>{}</DomainName>",
+        esc(&cfg.s3_origin.domain_name)
+    ));
+    out.push_str(&format!(
+        "<OriginAccessIdentity>{}</OriginAccessIdentity>",
+        esc(&cfg.s3_origin.origin_access_identity)
+    ));
+    out.push_str("</S3Origin>");
+    out.push_str(&render_aliases(cfg));
+    out.push_str(&format!("<Comment>{}</Comment>", esc(&cfg.comment)));
+    if let Some(log) = &cfg.logging {
+        out.push_str("<Logging>");
+        out.push_str(&format!("<Enabled>{}</Enabled>", log.enabled));
+        out.push_str(&format!("<Bucket>{}</Bucket>", esc(&log.bucket)));
+        out.push_str(&format!("<Prefix>{}</Prefix>", esc(&log.prefix)));
+        out.push_str("</Logging>");
+    }
+    out.push_str(&render_trusted_signers(cfg));
+    out.push_str(&format!(
+        "<PriceClass>{}</PriceClass>",
+        esc(&cfg.price_class)
+    ));
+    out.push_str(&format!("<Enabled>{}</Enabled>", cfg.enabled));
+    out
+}
+
+fn render_aliases(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(64);
+    let (qty, items) = match &cfg.aliases {
+        Some(a) => (a.quantity, a.items.clone()),
+        None => (0, None),
+    };
+    out.push_str("<Aliases>");
+    out.push_str(&format!("<Quantity>{}</Quantity>", qty));
+    if let Some(it) = items {
+        out.push_str("<Items>");
+        for c in &it.cname {
+            out.push_str(&format!("<CNAME>{}</CNAME>", esc(c)));
+        }
+        out.push_str("</Items>");
+    }
+    out.push_str("</Aliases>");
+    out
+}
+
+fn render_trusted_signers(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(64);
+    out.push_str("<TrustedSigners>");
+    out.push_str(&format!(
+        "<Enabled>{}</Enabled>",
+        cfg.trusted_signers.enabled
+    ));
+    out.push_str(&format!(
+        "<Quantity>{}</Quantity>",
+        cfg.trusted_signers.quantity
+    ));
+    if let Some(it) = &cfg.trusted_signers.items {
+        out.push_str("<Items>");
+        for a in &it.aws_account_number {
+            out.push_str(&format!("<AwsAccountNumber>{}</AwsAccountNumber>", esc(a)));
+        }
+        out.push_str("</Items>");
+    }
+    out.push_str("</TrustedSigners>");
+    out
+}
+
+fn render_active_trusted_signers(cfg: &StreamingDistributionConfig) -> String {
+    let mut out = String::with_capacity(64);
+    out.push_str("<ActiveTrustedSigners>");
+    out.push_str(&format!(
+        "<Enabled>{}</Enabled>",
+        cfg.trusted_signers.enabled
+    ));
+    out.push_str(&format!(
+        "<Quantity>{}</Quantity>",
+        cfg.trusted_signers.quantity
+    ));
+    if let Some(it) = &cfg.trusted_signers.items {
+        out.push_str("<Items>");
+        for a in &it.aws_account_number {
+            out.push_str("<Signer>");
+            out.push_str(&format!("<AwsAccountNumber>{}</AwsAccountNumber>", esc(a)));
+            out.push_str("</Signer>");
+        }
+        out.push_str("</Items>");
+    }
+    out.push_str("</ActiveTrustedSigners>");
+    out
+}

--- a/crates/fakecloud-cloudfront/src/streaming_service.rs
+++ b/crates/fakecloud-cloudfront/src/streaming_service.rs
@@ -218,7 +218,11 @@ impl CloudFrontService {
                 "StreamingDistribution must be disabled before deletion",
             ));
         }
+        let arn = d.arn.clone();
         account.streaming_distributions.remove(&id);
+        // Tags are keyed by ARN — drop them too so ListTagsForResource
+        // doesn't return tags for a deleted resource.
+        account.tags.remove(&arn);
         drop(state);
         Ok(crate::policies::empty(StatusCode::NO_CONTENT))
     }

--- a/crates/fakecloud-conformance/tests/cloudfront_streaming.rs
+++ b/crates/fakecloud-conformance/tests/cloudfront_streaming.rs
@@ -1,0 +1,161 @@
+//! CloudFront Batch 4 conformance tests: legacy Streaming Distributions.
+#![allow(deprecated)]
+
+mod helpers;
+
+use aws_sdk_cloudfront::types::{
+    PriceClass, S3Origin, StreamingDistributionConfig, StreamingDistributionConfigWithTags, Tag,
+    Tags, TrustedSigners,
+};
+use fakecloud_conformance_macros::test_action;
+use helpers::TestServer;
+
+fn streaming_cfg(caller_ref: &str, enabled: bool) -> StreamingDistributionConfig {
+    StreamingDistributionConfig::builder()
+        .caller_reference(caller_ref)
+        .s3_origin(
+            S3Origin::builder()
+                .domain_name("origin.example.com.s3.amazonaws.com")
+                .origin_access_identity("")
+                .build()
+                .unwrap(),
+        )
+        .comment("conf streaming")
+        .price_class(PriceClass::PriceClassAll)
+        .enabled(enabled)
+        .trusted_signers(
+            TrustedSigners::builder()
+                .enabled(false)
+                .quantity(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+#[test_action("cloudfront", "CreateStreamingDistribution", checksum = "05c28ba1")]
+#[tokio::test]
+async fn cf_create_streaming() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("conf-sd-1", true))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "CreateStreamingDistributionWithTags",
+    checksum = "8213fb25"
+)]
+#[tokio::test]
+async fn cf_create_streaming_with_tags() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_streaming_distribution_with_tags()
+        .streaming_distribution_config_with_tags(
+            StreamingDistributionConfigWithTags::builder()
+                .streaming_distribution_config(streaming_cfg("conf-sd-tags", true))
+                .tags(
+                    Tags::builder()
+                        .items(Tag::builder().key("env").value("conf").build().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetStreamingDistribution", checksum = "f93c8468")]
+#[tokio::test]
+async fn cf_get_streaming() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let c = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("conf-sd-2", true))
+        .send()
+        .await
+        .unwrap();
+    let id = c.streaming_distribution().unwrap().id().to_string();
+    cf.get_streaming_distribution()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetStreamingDistributionConfig", checksum = "7fd6122b")]
+#[tokio::test]
+async fn cf_get_streaming_config() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let c = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("conf-sd-3", true))
+        .send()
+        .await
+        .unwrap();
+    let id = c.streaming_distribution().unwrap().id().to_string();
+    cf.get_streaming_distribution_config()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateStreamingDistribution", checksum = "93bc7366")]
+#[tokio::test]
+async fn cf_update_streaming() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let c = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("conf-sd-4", true))
+        .send()
+        .await
+        .unwrap();
+    let id = c.streaming_distribution().unwrap().id().to_string();
+    let etag = c.e_tag().unwrap().to_string();
+    cf.update_streaming_distribution()
+        .id(&id)
+        .if_match(&etag)
+        .streaming_distribution_config(streaming_cfg("conf-sd-4", false))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteStreamingDistribution", checksum = "303045d4")]
+#[tokio::test]
+async fn cf_delete_streaming() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let c = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("conf-sd-5", false))
+        .send()
+        .await
+        .unwrap();
+    let id = c.streaming_distribution().unwrap().id().to_string();
+    let etag = c.e_tag().unwrap().to_string();
+    cf.delete_streaming_distribution()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListStreamingDistributions", checksum = "b109420c")]
+#[tokio::test]
+async fn cf_list_streaming() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_streaming_distributions().send().await.unwrap();
+}

--- a/crates/fakecloud-e2e/tests/cloudfront_streaming.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_streaming.rs
@@ -135,3 +135,57 @@ async fn list_streaming_distributions_includes_created() {
         "list should contain at least one streaming distribution"
     );
 }
+
+#[tokio::test]
+async fn delete_streaming_distribution_clears_tags() {
+    use aws_sdk_cloudfront::types::{
+        StreamingDistributionConfigWithTags, Tag as SdkTag, Tags as SdkTags,
+    };
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let create = cf
+        .create_streaming_distribution_with_tags()
+        .streaming_distribution_config_with_tags(
+            StreamingDistributionConfigWithTags::builder()
+                .streaming_distribution_config(streaming_cfg("e2e-sd-tagcleanup", false))
+                .tags(
+                    SdkTags::builder()
+                        .items(SdkTag::builder().key("env").value("e2e").build().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let dist = create.streaming_distribution().unwrap();
+    let id = dist.id().to_string();
+    let arn = dist.arn().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+
+    // Confirm tags exist via ListTagsForResource.
+    let tags = cf
+        .list_tags_for_resource()
+        .resource(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().unwrap().items().len(), 1);
+
+    cf.delete_streaming_distribution()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+
+    // After delete, tags must be gone.
+    let tags = cf
+        .list_tags_for_resource()
+        .resource(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags.tags().unwrap().items().len(), 0);
+}

--- a/crates/fakecloud-e2e/tests/cloudfront_streaming.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_streaming.rs
@@ -1,0 +1,137 @@
+//! CloudFront Batch 4 E2E: legacy Streaming Distributions (RTMP).
+#![allow(deprecated)]
+
+mod helpers;
+
+use aws_sdk_cloudfront::types::{
+    PriceClass, S3Origin, StreamingDistributionConfig, TrustedSigners,
+};
+use helpers::TestServer;
+
+fn streaming_cfg(caller_ref: &str, enabled: bool) -> StreamingDistributionConfig {
+    StreamingDistributionConfig::builder()
+        .caller_reference(caller_ref)
+        .s3_origin(
+            S3Origin::builder()
+                .domain_name("origin.example.com.s3.amazonaws.com")
+                .origin_access_identity("")
+                .build()
+                .unwrap(),
+        )
+        .comment("e2e streaming")
+        .price_class(PriceClass::PriceClassAll)
+        .enabled(enabled)
+        .trusted_signers(
+            TrustedSigners::builder()
+                .enabled(false)
+                .quantity(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn streaming_distribution_lifecycle() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let create = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("e2e-sd-1", true))
+        .send()
+        .await
+        .expect("create");
+    let dist = create.streaming_distribution().expect("dist");
+    let id = dist.id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    assert!(dist.domain_name().ends_with(".cloudfront.net"));
+    assert!(dist.arn().contains(":streaming-distribution/"));
+
+    let _ = cf
+        .get_streaming_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get");
+
+    let _ = cf
+        .get_streaming_distribution_config()
+        .id(&id)
+        .send()
+        .await
+        .expect("getconfig");
+
+    // Disable then delete (DeleteStreamingDistribution requires Enabled=false).
+    let upd = cf
+        .update_streaming_distribution()
+        .id(&id)
+        .if_match(&etag)
+        .streaming_distribution_config(streaming_cfg("e2e-sd-1", false))
+        .send()
+        .await
+        .expect("update");
+    let new_etag = upd.e_tag().unwrap().to_string();
+
+    cf.delete_streaming_distribution()
+        .id(&id)
+        .if_match(&new_etag)
+        .send()
+        .await
+        .expect("delete");
+}
+
+#[tokio::test]
+async fn delete_enabled_streaming_distribution_is_rejected() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let create = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("e2e-sd-2", true))
+        .send()
+        .await
+        .unwrap();
+    let id = create.streaming_distribution().unwrap().id().to_string();
+    let etag = create.e_tag().unwrap().to_string();
+    let res = cf
+        .delete_streaming_distribution()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await;
+    assert!(res.is_err(), "deleting enabled streaming dist must fail");
+}
+
+#[tokio::test]
+async fn duplicate_streaming_caller_reference_is_rejected() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("e2e-sd-dup", true))
+        .send()
+        .await
+        .unwrap();
+    let res = cf
+        .create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("e2e-sd-dup", true))
+        .send()
+        .await;
+    assert!(res.is_err(), "duplicate CallerReference must be rejected");
+}
+
+#[tokio::test]
+async fn list_streaming_distributions_includes_created() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_streaming_distribution()
+        .streaming_distribution_config(streaming_cfg("e2e-sd-list", true))
+        .send()
+        .await
+        .unwrap();
+    let list = cf.list_streaming_distributions().send().await.unwrap();
+    assert!(
+        list.streaming_distribution_list().unwrap().quantity() >= 1,
+        "list should contain at least one streaming distribution"
+    );
+}

--- a/website/content/docs/services/_index.md
+++ b/website/content/docs/services/_index.md
@@ -7,7 +7,7 @@ template = "docs.html"
 page_template = "docs-page.html"
 +++
 
-fakecloud implements 28 AWS services with 2,141 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
+fakecloud implements 28 AWS services with 2,148 total operations, all at 100% Smithy conformance. Per-service feature matrices and gotchas live on individual service pages — use the sidebar to navigate.
 
 | Service                | Ops | Notes                                                                  |
 | ---------------------- | --- | ---------------------------------------------------------------------- |
@@ -38,6 +38,6 @@ fakecloud implements 28 AWS services with 2,141 total operations, all at 100% Sm
 | ECR                    |  58 | Full API — OCI v2 push/pull, lifecycle eval, scanning, pull-through cache, registry templates, real cosign signature verification |
 | ECS                    |  60 | Full API — clusters, real Fargate-style task execution via Docker, services + rolling deployments, task sets, container instances, ECS Exec, awslogs -> Logs, secrets injection, task role credentials |
 | Elastic Load Balancing v2 |  51 | Full control plane — ALB/NLB/GWLB CRUD, target groups + targets + real health probes, listeners + rules + certificates, attributes, capacity reservations, **mTLS trust stores + revocations**, resource policies, SSL policies, tags. **In-process HTTP data plane for ALBs** — per-LB TCP bind, rule matching, forward / fixed-response / redirect, sticky sessions |
-| CloudFront                |  93 | Distributions (full CRUD + ETag/If-Match concurrency + WithTags + copy + by-X listings), invalidations, web ACL associate/disassociate, alias associate, tags. Origin Access Controls + Cache/Origin Request/Response Headers/Continuous Deployment policies. **CloudFront Functions (incl. Publish/Test), Public Keys, Key Groups, Key Value Stores, Origin Access Identities (legacy)** — full CRUD; per-distribution **Monitoring Subscriptions** (Create/Get/Delete; AWS has no Update for this resource). Full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
+| CloudFront                | 100 | Distributions, invalidations, tagging, by-X listings, web ACL/alias association. OAC + Cache/OriginRequest/ResponseHeaders/ContinuousDeployment policies. CloudFront Functions, Public Keys, Key Groups, Key Value Stores, Origin Access Identities (legacy), Monitoring Subscriptions. **Streaming Distributions (legacy RTMP) — full CRUD + WithTags + ETag/If-Match concurrency, `StreamingDistributionNotDisabled` enforced before delete.** Full `DistributionConfig` round-trip incl. origins, cache behaviors, custom error responses, viewer certificates, geo restrictions |
 
 Detailed per-service pages are coming. If you need specifics on a service today, the conformance baseline at [`conformance-baseline.json`](https://github.com/faiscadev/fakecloud/blob/main/conformance-baseline.json) lists every operation fakecloud handles, and the AWS Smithy models in [`aws-models/`](https://github.com/faiscadev/fakecloud/tree/main/aws-models) are the authoritative source of truth.

--- a/website/content/docs/services/cloudfront.md
+++ b/website/content/docs/services/cloudfront.md
@@ -4,9 +4,9 @@ description = "CloudFront control plane — distributions, invalidations, web AC
 weight = 24
 +++
 
-fakecloud implements CloudFront's REST-XML control plane focused on the operations real applications and Terraform stacks rely on: distribution lifecycle, invalidations, alias and web ACL association, tags, the full policy resource surface (OAC + Cache/OriginRequest/ResponseHeaders/ContinuousDeployment), CloudFront Functions, public keys + key groups, key value stores, legacy origin access identities, and per-distribution monitoring subscriptions. 93 operations.
+fakecloud implements CloudFront's REST-XML control plane focused on the operations real applications and Terraform stacks rely on: distribution lifecycle, invalidations, alias and web ACL association, tags, the full policy resource surface (OAC + Cache/OriginRequest/ResponseHeaders/ContinuousDeployment), CloudFront Functions, public keys + key groups, key value stores, legacy origin access identities, per-distribution monitoring subscriptions, and the legacy RTMP streaming distributions. 100 operations.
 
-**Status: Batches 1-3 shipped.** Streaming distributions, field-level encryption, real-time log config, VPC origins, anycast IP lists, trust stores, distribution tenants, and connection functions/groups are still pending across subsequent batches.
+**Status: Batches 1-4 shipped.** Field-level encryption, real-time log config, VPC origins, anycast IP lists, trust stores, distribution tenants, and connection functions/groups are still pending across subsequent batches.
 
 ## Supported today
 
@@ -25,6 +25,7 @@ fakecloud implements CloudFront's REST-XML control plane focused on the operatio
 - **Key Value Stores** — `CreateKeyValueStore` (with optional `ImportSource`), `DescribeKeyValueStore`, `UpdateKeyValueStore`, `DeleteKeyValueStore`, `ListKeyValueStores`.
 - **Legacy Origin Access Identities** — `CreateCloudFrontOriginAccessIdentity`, `Get`, `GetConfig`, `Update`, `Delete`, `List`.
 - **Monitoring Subscriptions** — `CreateMonitoringSubscription`, `GetMonitoringSubscription`, `DeleteMonitoringSubscription` keyed by distribution id.
+- **Streaming Distributions (legacy RTMP)** — `CreateStreamingDistribution`, `CreateStreamingDistributionWithTags`, `GetStreamingDistribution`, `GetStreamingDistributionConfig`, `UpdateStreamingDistribution`, `DeleteStreamingDistribution`, `ListStreamingDistributions`. ETag/If-Match concurrency. `DeleteStreamingDistribution` enforces the AWS rule that the distribution must be `Enabled = false` before deletion (`StreamingDistributionNotDisabled`).
 
 ### Concurrency semantics
 
@@ -78,11 +79,10 @@ aws --endpoint-url http://localhost:4566 cloudfront list-invalidations --distrib
 
 | Surface                                | Status                  |
 |----------------------------------------|-------------------------|
-| Field-Level Encryption                 | Batch 4                 |
-| Real-time Log Config                   | Batch 4                 |
-| Streaming Distributions (legacy RTMP)  | Batch 4                 |
-| VPC Origins + Anycast IP Lists         | Batch 5                 |
-| Trust Stores + Distribution Tenants    | Batch 5                 |
-| Connection Functions / Groups          | Batch 5                 |
+| Field-Level Encryption                 | Batch 5                 |
+| Real-time Log Config                   | Batch 5                 |
+| VPC Origins + Anycast IP Lists         | Batch 6                 |
+| Trust Stores + Distribution Tenants    | Batch 6                 |
+| Connection Functions / Groups          | Batch 6                 |
 
 There is no edge data plane: requests against a CloudFront distribution domain are not actually proxied to origins. Use ELBv2's in-process data plane for HTTP request matching tests today.


### PR DESCRIPTION
## Summary
- Streaming Distributions: `Create`, `CreateWithTags`, `Get`, `GetConfig`, `Update`, `Delete`, `List`
- ETag/If-Match concurrency, `CallerReference` uniqueness on create
- `DeleteStreamingDistribution` enforces `StreamingDistributionNotDisabled` (matches AWS)
- **+7 ops** (cloudfront 93 -> 100, total 2,141 -> 2,148)

## Test plan
- [x] `cargo test -p fakecloud-e2e --test cloudfront_streaming` — 4 lifecycle tests pass
- [x] `FAKECLOUD_RUN_CONFORMANCE=1 cargo test -p fakecloud-conformance --test cloudfront_streaming` — 7 conformance tests pass
- [x] `cargo run -p fakecloud-conformance -- audit` — cloudfront 101/101 covered
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] README + website docs synced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for CloudFront Streaming Distributions (legacy RTMP), including CRUD and tagging, with AWS-accurate concurrency and delete rules. CloudFront now has 100 ops (project total 2,148), and docs are updated.

- **New Features**
  - Streaming Distributions: Create, CreateWithTags, Get, GetConfig, Update, Delete, List.
  - Concurrency: ETag/If-Match required on update/delete; `CallerReference` must be unique on create.
  - Delete rule: reject delete when `Enabled=true` (`StreamingDistributionNotDisabled`), matching AWS.

- **Bug Fixes**
  - `DeleteStreamingDistribution` now clears tags for the distribution ARN to prevent orphaned tags in `ListTagsForResource`.

<sup>Written for commit b9e42cd5be9edea56a40df3079cbd6a233614a85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

