### PR TITLE
fix(s3): route virtual-hosted PUT object through streaming dispatch

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -686,7 +686,15 @@ fn streaming_route(
     // URL (AWSAccessKeyId + Signature + Expires query parameters).
     if method == http::Method::PUT {
         let after = path.trim_start_matches('/');
-        if !after.contains('/') {
+        // Path-style PutObject is `PUT /<bucket>/<key>` (path contains a
+        // slash); virtual-hosted-style is `PUT /<key>` with the bucket
+        // in the Host header. For virtual-hosted, accept any non-empty
+        // path so the key flows through the streaming dispatch — the
+        // Host parser already routed this request to S3.
+        let virtual_hosted_s3 = protocol::parse_routing_host_from_headers(headers)
+            .filter(|h| h.service == "s3" && h.bucket.is_some())
+            .is_some();
+        if after.is_empty() || (!virtual_hosted_s3 && !after.contains('/')) {
             return None;
         }
         let header_s3 = headers


### PR DESCRIPTION
## Summary

Fixes the regression introduced when the buffered S3 PutObject fallback was removed in #785. Virtual-hosted-style PUT (path `/<key>`, bucket in Host header) was falling through to the buffered branch because `streaming_route` only accepted path-style PUTs. The service then rejected the request with `400 MalformedRequestBody: PutObject requires a streaming request body`.

`streaming_route` now also matches when the Host header parses as a virtual-hosted-style S3 bucket, with any non-empty path. Path-style still requires a slash so `PUT /bucket` (CreateBucket) is unaffected.

## What was broken

E2E `host_routing::s3_virtual_hosted_put_get_delete` failing on every main run since #785 merged. Same root cause for the sibling virtual-hosted PUT/GET tests across modern AWS, legacy global, and dash-separated host shapes.

## Test plan

- [x] `cargo test -p fakecloud-e2e --test host_routing` - 14/14 pass
- [x] `cargo test -p fakecloud-core --lib` - 170 pass
- [x] `cargo test -p fakecloud-s3 --lib` - 280 pass
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes virtual-hosted S3 PutObject requests that were rejected after the buffered fallback was removed. `PUT /<key>` (bucket in Host) is now routed through streaming dispatch to avoid `MalformedRequestBody`.

- **Bug Fixes**
  - `streaming_route` now matches virtual-hosted-style PUT when the Host parses as S3 with a bucket and the path is non-empty; request bodies are streamed.
  - Path-style rules unchanged; `PUT /bucket` (CreateBucket) remains unaffected.

<sup>Written for commit 0ce58a3933fbc61f08560f8b4dbec5f6636298f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

