### PR TITLE
release(v0.13.1): aws_lambda extension + prebuilt postgres images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.13.0"
+version = "0.13.1"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -93,39 +93,39 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.0" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.0" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.0" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.0" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.0" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.0" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.0" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.0" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.0" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.0" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.0" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.0" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.0" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.0" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.0" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.0" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.0" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.0" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.0" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.0" }
-fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.0" }
-fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.0" }
-fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.0" }
-fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.0" }
-fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.0" }
-fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.0" }
-fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.0" }
-fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.0" }
-fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.0" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.0" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.0" }
-fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.0" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.0" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.0" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.0" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.0" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.1" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.1" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.1" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.1" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.1" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.1" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.1" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.1" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.1" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.1" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.1" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.1" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.1" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.1" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.1" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.1" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.1" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.1" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.1" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.1" }
+fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.1" }
+fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.1" }
+fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.1" }
+fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.1" }
+fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.1" }
+fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.1" }
+fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.1" }
+fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.1" }
+fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.1" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.1" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.1" }
+fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.1" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.1" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.1" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.1" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.1" }

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.13.0"
+version = "0.13.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.12.0",
+      "version": "0.13.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Follow-up release on the v0.13.0 train shipping two infra additions that
landed after the v0.13.0 cut:

- **RDS PostgreSQL `aws_lambda` extension** (#802) — SQL inside
  fakecloud-managed PostgreSQL DB instances can now invoke fakecloud
  Lambda functions, matching AWS RDS / Aurora and LocalStack's
  documented surface. Plpython3u UDF posts to a new
  `/_fakecloud/rds/lambda-invoke` bridge that resolves the function
  ARN against the fakecloud Lambda service.
- **Prebuilt `fakecloud-postgres` images** (#803, #804) — published
  per release tag for pg13/14/15/16 on linux/amd64 + linux/arm64 to
  `ghcr.io/faiscadev/fakecloud-postgres:<major>-<version>`. Runtime is
  pull-first (inspect -> pull -> local build) so first-time
  `CreateDBInstance` skips the ~60s `apt install plpython3u` build.
  Local build stays as the offline / unreleased fallback.

The publish path was validated end-to-end via a workflow_dispatch
dev-tag run before this bump — multi-arch manifests confirmed for all
four majors. Cutting v0.13.1 fires the real release pipeline:
`docker-rds-images.yml` publishes the four `:<major>-0.13.1` + rolling
`:<major>` tags, and `release.yml` publishes the SDKs + crates.

## Test plan

- [x] `cargo build --workspace` clean at 0.13.1
- [x] Multi-arch manifest verified for `:16-dev-<sha>` (amd64 + arm64)
- [x] Multi-arch manifest verified for `:13/14/15-dev-<sha>` (amd64 + arm64)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.13.1`, watch `docker-rds-images.yml` publish
      `:<major>-0.13.1` + `:<major>` for all four majors
- [ ] After merge: watch `release.yml` publish npm / PyPI / Maven / crates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RDS PostgreSQL `aws_lambda` support so SQL can invoke fakecloud Lambda, and switches RDS to prebuilt `fakecloud-postgres` images for faster first-time DB setup.

- New Features
  - RDS PostgreSQL `aws_lambda`: SQL can call fakecloud Lambda via a plpython3u UDF that posts to `/_fakecloud/rds/lambda-invoke`.
  - Prebuilt images: Publish `ghcr.io/faiscadev/fakecloud-postgres:<major>-<version>` for pg13–16 on linux/amd64 and linux/arm64; runtime pulls first to skip the ~60s local build, with local build as fallback.

- Dependencies
  - Bump workspace crates and SDKs to 0.13.1 (Cargo, npm, PyPI, Maven, Java).

<sup>Written for commit 4ec03b8e930faa3e561b08ca5c9cb2ca3b3d51b4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/805?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

