### PR TITLE
feat(rds): add aws_s3 postgres extension (table_import / query_export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Other install options (Cargo, Docker, Docker Compose, source) are documented at 
 | SES (v2 + v1 inbound)  | 110 | Sending, templates, DKIM, **real receipt rule execution**              |
 | Cognito User Pools     | 122 | Pools, clients, MFA, identity providers, full auth flows; verification email -> SES, SMS -> SNS, all 12 Lambda triggers |
 | Kinesis                |  39 | Streams, records, shard iterators, retention                           |
-| RDS                    | 163 | Real Postgres, MySQL, MariaDB, Oracle, SQL Server, Db2 via Docker; lifecycle ops emit `aws.rds` EventBridge events; PostgreSQL `aws_lambda` extension invokes fakecloud Lambda functions from SQL |
+| RDS                    | 163 | Real Postgres, MySQL, MariaDB, Oracle, SQL Server, Db2 via Docker; lifecycle ops emit `aws.rds` EventBridge events; PostgreSQL `aws_lambda` + `aws_s3` extensions invoke fakecloud Lambda and import/export S3 objects from SQL |
 | ElastiCache            |  75 | Real Redis, Valkey, Memcached via Docker                               |
 | Step Functions         |  37 | Full ASL interpreter, Lambda/SQS/SNS/EventBridge/DynamoDB tasks        |
 | API Gateway v1         | 124 | REST APIs, resources, methods, integrations (`MOCK`/`HTTP`/`HTTP_PROXY`/`AWS_PROXY` Lambda), deployments, stages, API keys, usage plans, authorizers, models, request validators, VPC links, domain names, base path mappings, client certs, gateway responses, docs, tags |
@@ -119,7 +119,7 @@ Full guides: [fakecloud.dev/docs/guides](https://fakecloud.dev/docs/guides).
 | Cognito User Pools  | 122 operations                                     | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES v2              | Full send + templates + DKIM + suppression         | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | SES inbound email   | Real receipt rule action execution                 | [Stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
-| RDS                 | 163 operations, PostgreSQL/MySQL/MariaDB/Oracle/SQL Server/Db2 via Docker, PostgreSQL `aws_lambda` extension | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
+| RDS                 | 163 operations, PostgreSQL/MySQL/MariaDB/Oracle/SQL Server/Db2 via Docker, PostgreSQL `aws_lambda` + `aws_s3` extensions | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | ElastiCache         | 75 operations, Redis, Valkey, and Memcached via Docker | [Paid only](https://docs.localstack.cloud/references/licensing/)           |
 | API Gateway v1      | 124 operations — REST APIs incl. real Lambda proxy data plane | [Paid only](https://docs.localstack.cloud/references/licensing/)               |
 | API Gateway v2      | 103 operations — HTTP APIs + developer portals     | [Paid only](https://docs.localstack.cloud/references/licensing/)               |

--- a/crates/fakecloud-e2e/tests/rds_aws_s3.rs
+++ b/crates/fakecloud-e2e/tests/rds_aws_s3.rs
@@ -1,0 +1,160 @@
+//! End-to-end test for the RDS PostgreSQL `aws_s3` extension.
+//!
+//! Drives the round trip: put a CSV in S3, create a Postgres DB
+//! instance, `CREATE EXTENSION aws_s3 CASCADE`, import the CSV into a
+//! table, then export a query back into S3 and read it from the bucket.
+
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use helpers::TestServer;
+use tokio_postgres::NoTls;
+
+async fn connect_with_retry(
+    host: &str,
+    port: i32,
+    user: &str,
+    password: &str,
+    dbname: &str,
+) -> tokio_postgres::Client {
+    let connection_string =
+        format!("host={host} port={port} user={user} password={password} dbname={dbname}");
+    let mut last_error = None;
+    for _ in 0..30 {
+        match tokio_postgres::connect(&connection_string, NoTls).await {
+            Ok((client, connection)) => {
+                tokio::spawn(async move {
+                    let _ = connection.await;
+                });
+                return client;
+            }
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+        }
+    }
+    panic!(
+        "could not connect to postgres at {}:{}: {:?}",
+        host, port, last_error
+    );
+}
+
+#[tokio::test]
+async fn aws_s3_extension_import_export_round_trip() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    let rds = server.rds_client().await;
+
+    // 1. Bucket + CSV input.
+    s3.create_bucket()
+        .bucket("aws-s3-ext")
+        .send()
+        .await
+        .expect("create bucket");
+    let csv = b"1,alice\n2,bob\n3,carol\n";
+    s3.put_object()
+        .bucket("aws-s3-ext")
+        .key("input.csv")
+        .body(ByteStream::from_static(csv))
+        .send()
+        .await
+        .expect("put input.csv");
+
+    // 2. Postgres instance — reuses the lazy fakecloud-postgres image
+    //    that the aws_lambda e2e already exercises, so this run is fast
+    //    when ordered after the lambda test on the same runner.
+    let create = rds
+        .create_db_instance()
+        .db_instance_identifier("aws-s3-ext-db")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create postgres instance");
+    let endpoint = create
+        .db_instance()
+        .and_then(|i| i.endpoint())
+        .expect("endpoint");
+    let host = endpoint.address().expect("address").to_string();
+    let port = endpoint.port().expect("port");
+
+    let client = connect_with_retry(&host, port, "admin", "secret123", "appdb").await;
+    client
+        .simple_query("CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE")
+        .await
+        .expect("load aws_s3 extension");
+    client
+        .simple_query("CREATE TABLE people (id int, name text)")
+        .await
+        .expect("create table");
+
+    // 3. table_import_from_s3 (positional + composite overloads).
+    let row = client
+        .query_one(
+            "SELECT rows_imported, bytes_processed FROM aws_s3.table_import_from_s3(\
+                'people', '', 'format csv', 'aws-s3-ext', 'input.csv', 'us-east-1')",
+            &[],
+        )
+        .await
+        .expect("import csv");
+    let rows_imported: i64 = row.get(0);
+    let bytes_processed: i64 = row.get(1);
+    assert_eq!(rows_imported, 3);
+    assert_eq!(bytes_processed, csv.len() as i64);
+
+    let count_row = client
+        .query_one("SELECT count(*)::int FROM people", &[])
+        .await
+        .unwrap();
+    let count: i32 = count_row.get(0);
+    assert_eq!(count, 3);
+
+    let composite_row = client
+        .query_one(
+            "SELECT rows_imported FROM aws_s3.table_import_from_s3(\
+                'people', '', 'format csv', \
+                aws_commons.create_s3_uri('aws-s3-ext', 'input.csv', 'us-east-1'))",
+            &[],
+        )
+        .await
+        .expect("import via composite uri");
+    let rows: i64 = composite_row.get(0);
+    assert_eq!(rows, 3);
+
+    // 4. query_export_to_s3.
+    let export_row = client
+        .query_one(
+            "SELECT rows_uploaded, files_uploaded FROM aws_s3.query_export_to_s3(\
+                'SELECT id, name FROM people ORDER BY id LIMIT 2', \
+                aws_commons.create_s3_uri('aws-s3-ext', 'export.csv', 'us-east-1'), \
+                'format csv')",
+            &[],
+        )
+        .await
+        .expect("export query");
+    let rows_uploaded: i64 = export_row.get(0);
+    let files_uploaded: i64 = export_row.get(1);
+    assert_eq!(rows_uploaded, 2);
+    assert_eq!(files_uploaded, 1);
+
+    let exported = s3
+        .get_object()
+        .bucket("aws-s3-ext")
+        .key("export.csv")
+        .send()
+        .await
+        .expect("get export.csv");
+    let body = exported.body.collect().await.expect("collect").into_bytes();
+    let body_str = std::str::from_utf8(&body).unwrap();
+    assert!(
+        body_str.contains("1,alice") && body_str.contains("2,bob"),
+        "exported csv missing rows: {body_str}"
+    );
+    assert!(!body_str.contains("3,carol"));
+}

--- a/crates/fakecloud-e2e/tests/rds_aws_s3.rs
+++ b/crates/fakecloud-e2e/tests/rds_aws_s3.rs
@@ -115,19 +115,9 @@ async fn aws_s3_extension_import_export_round_trip() {
     let count: i32 = count_row.get(0);
     assert_eq!(count, 3);
 
-    let composite_row = client
-        .query_one(
-            "SELECT rows_imported FROM aws_s3.table_import_from_s3(\
-                'people', '', 'format csv', \
-                aws_commons.create_s3_uri('aws-s3-ext', 'input.csv', 'us-east-1'))",
-            &[],
-        )
-        .await
-        .expect("import via composite uri");
-    let rows: i64 = composite_row.get(0);
-    assert_eq!(rows, 3);
-
-    // 4. query_export_to_s3.
+    // 4. query_export_to_s3 — runs against the deterministic 3-row state
+    //    before we exercise the composite-typed import overload (which
+    //    appends a second copy of the CSV into the same table).
     let export_row = client
         .query_one(
             "SELECT rows_uploaded, files_uploaded FROM aws_s3.query_export_to_s3(\
@@ -143,6 +133,24 @@ async fn aws_s3_extension_import_export_round_trip() {
     assert_eq!(rows_uploaded, 2);
     assert_eq!(files_uploaded, 1);
 
+    // 5. Composite-typed import overload — into a fresh scratch table so
+    //    the export above stays deterministic.
+    client
+        .simple_query("CREATE TABLE people_scratch (id int, name text)")
+        .await
+        .expect("create scratch table");
+    let composite_row = client
+        .query_one(
+            "SELECT rows_imported FROM aws_s3.table_import_from_s3(\
+                'people_scratch', '', 'format csv', \
+                aws_commons.create_s3_uri('aws-s3-ext', 'input.csv', 'us-east-1'))",
+            &[],
+        )
+        .await
+        .expect("import via composite uri");
+    let rows: i64 = composite_row.get(0);
+    assert_eq!(rows, 3);
+
     let exported = s3
         .get_object()
         .bucket("aws-s3-ext")
@@ -157,4 +165,11 @@ async fn aws_s3_extension_import_export_round_trip() {
         "exported csv missing rows: {body_str}"
     );
     assert!(!body_str.contains("3,carol"));
+
+    let scratch_count_row = client
+        .query_one("SELECT count(*)::int FROM people_scratch", &[])
+        .await
+        .unwrap();
+    let scratch_count: i32 = scratch_count_row.get(0);
+    assert_eq!(scratch_count, 3);
 }

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY aws_commons.control aws_commons--1.0.sql \
+COPY aws_commons.control aws_commons--1.1.sql aws_commons--1.0--1.1.sql \
      aws_lambda.control aws_lambda--1.0.sql \
+     aws_s3.control aws_s3--1.0.sql \
      /usr/share/postgresql/${PG_VERSION}/extension/

--- a/crates/fakecloud-rds/assets/postgres/aws_commons--1.0--1.1.sql
+++ b/crates/fakecloud-rds/assets/postgres/aws_commons--1.0--1.1.sql
@@ -1,0 +1,29 @@
+-- aws_commons 1.0 -> 1.1 upgrade (fakecloud)
+-- Adds the `_s3_uri_1` composite type and `create_s3_uri()` constructor
+-- consumed by the aws_s3 extension. Loaded automatically by
+-- `ALTER EXTENSION aws_commons UPDATE` for users that already have 1.0.
+
+\echo Use "ALTER EXTENSION aws_commons UPDATE TO '1.1'" to load this file. \quit
+
+CREATE TYPE aws_commons._s3_uri_1 AS (
+    bucket text,
+    file_path text,
+    region text
+);
+
+CREATE FUNCTION aws_commons.create_s3_uri(
+    bucket text,
+    file_path text,
+    region text DEFAULT NULL
+) RETURNS aws_commons._s3_uri_1
+LANGUAGE plpgsql IMMUTABLE
+AS $$
+DECLARE
+    result aws_commons._s3_uri_1;
+BEGIN
+    result.bucket := bucket;
+    result.file_path := file_path;
+    result.region := region;
+    RETURN result;
+END;
+$$;

--- a/crates/fakecloud-rds/assets/postgres/aws_commons--1.1.sql
+++ b/crates/fakecloud-rds/assets/postgres/aws_commons--1.1.sql
@@ -1,4 +1,4 @@
--- aws_commons extension v1.0 (fakecloud)
+-- aws_commons extension v1.1 (fakecloud)
 -- Provides composite types and helpers used by aws_lambda and aws_s3 RDS extensions.
 
 \echo Use "CREATE EXTENSION aws_commons" to load this file. \quit
@@ -18,6 +18,29 @@ DECLARE
     result aws_commons._lambda_function_arn_1;
 BEGIN
     result.function_name := function_name;
+    result.region := region;
+    RETURN result;
+END;
+$$;
+
+CREATE TYPE aws_commons._s3_uri_1 AS (
+    bucket text,
+    file_path text,
+    region text
+);
+
+CREATE FUNCTION aws_commons.create_s3_uri(
+    bucket text,
+    file_path text,
+    region text DEFAULT NULL
+) RETURNS aws_commons._s3_uri_1
+LANGUAGE plpgsql IMMUTABLE
+AS $$
+DECLARE
+    result aws_commons._s3_uri_1;
+BEGIN
+    result.bucket := bucket;
+    result.file_path := file_path;
     result.region := region;
     RETURN result;
 END;

--- a/crates/fakecloud-rds/assets/postgres/aws_commons.control
+++ b/crates/fakecloud-rds/assets/postgres/aws_commons.control
@@ -1,4 +1,4 @@
 comment = 'AWS commons types and helpers (fakecloud)'
-default_version = '1.0'
+default_version = '1.1'
 relocatable = false
 schema = 'aws_commons'

--- a/crates/fakecloud-rds/assets/postgres/aws_s3--1.0.sql
+++ b/crates/fakecloud-rds/assets/postgres/aws_s3--1.0.sql
@@ -1,0 +1,259 @@
+-- aws_s3 extension v1.0 (fakecloud)
+-- Imports objects from a fakecloud S3 bucket into postgres tables
+-- (`table_import_from_s3`) and exports query results back into S3
+-- (`query_export_to_s3`). Talks to fakecloud over the bridge endpoints
+-- /_fakecloud/rds/s3-import and /_fakecloud/rds/s3-export.
+
+\echo Use "CREATE EXTENSION aws_s3 CASCADE" to load this file. \quit
+
+-- Internal helper: GET <bucket>/<key> via the bridge, write the body
+-- to a temp file, return the temp path and total bytes.
+CREATE FUNCTION aws_s3._fetch_object(
+    bucket text,
+    file_path text,
+    region text
+) RETURNS TABLE(temp_path text, bytes_processed bigint)
+LANGUAGE plpython3u
+AS $$
+import base64
+import json
+import os
+import tempfile
+import urllib.request
+import urllib.error
+
+endpoint = os.environ.get('FAKECLOUD_ENDPOINT')
+if not endpoint:
+    plpy.error('aws_s3: FAKECLOUD_ENDPOINT not set on the database container')
+account_id = os.environ.get('FAKECLOUD_ACCOUNT_ID', '000000000000')
+default_region = os.environ.get('FAKECLOUD_REGION', 'us-east-1')
+
+body = json.dumps({
+    'bucket': bucket,
+    'key': file_path,
+    'region': region or default_region,
+}).encode('utf-8')
+
+req = urllib.request.Request(
+    endpoint.rstrip('/') + '/_fakecloud/rds/s3-import',
+    data=body,
+    headers={
+        'Content-Type': 'application/json',
+        'X-Fakecloud-Account-Id': account_id,
+    },
+    method='POST',
+)
+try:
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        raw = resp.read()
+except urllib.error.HTTPError as e:
+    detail = e.read().decode('utf-8', errors='replace')
+    plpy.error('aws_s3: s3-import bridge returned {}: {}'.format(e.code, detail))
+except Exception as e:
+    plpy.error('aws_s3: s3-import bridge call failed: {}'.format(e))
+
+parsed = json.loads(raw)
+data = base64.b64decode(parsed['body_b64'])
+
+fd, path = tempfile.mkstemp(prefix='aws_s3_', suffix='.dat', dir='/tmp')
+try:
+    with os.fdopen(fd, 'wb') as fh:
+        fh.write(data)
+except Exception:
+    os.unlink(path)
+    raise
+
+return [(path, len(data))]
+$$;
+
+CREATE FUNCTION aws_s3.table_import_from_s3(
+    table_name text,
+    column_list text,
+    options text,
+    bucket text,
+    file_path text,
+    region text DEFAULT NULL
+) RETURNS TABLE(rows_imported bigint, file_compression text, bytes_processed bigint)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    fetched record;
+    column_clause text;
+    options_clause text;
+    copy_sql text;
+    inserted_rows bigint;
+BEGIN
+    SELECT * INTO fetched FROM aws_s3._fetch_object(bucket, file_path, region);
+
+    IF column_list IS NOT NULL AND length(trim(column_list)) > 0 THEN
+        column_clause := format(' (%s)', column_list);
+    ELSE
+        column_clause := '';
+    END IF;
+
+    IF options IS NOT NULL AND length(trim(options)) > 0 THEN
+        options_clause := format(' WITH (%s)', options);
+    ELSE
+        options_clause := '';
+    END IF;
+
+    copy_sql := format(
+        'COPY %s%s FROM %L%s',
+        table_name,
+        column_clause,
+        fetched.temp_path,
+        options_clause
+    );
+
+    BEGIN
+        EXECUTE copy_sql;
+        GET DIAGNOSTICS inserted_rows = ROW_COUNT;
+    EXCEPTION WHEN OTHERS THEN
+        PERFORM aws_s3._cleanup_temp(fetched.temp_path);
+        RAISE;
+    END;
+
+    PERFORM aws_s3._cleanup_temp(fetched.temp_path);
+    RETURN QUERY SELECT inserted_rows, ''::text, fetched.bytes_processed;
+END;
+$$;
+
+CREATE FUNCTION aws_s3.table_import_from_s3(
+    table_name text,
+    column_list text,
+    options text,
+    s3_info aws_commons._s3_uri_1
+) RETURNS TABLE(rows_imported bigint, file_compression text, bytes_processed bigint)
+LANGUAGE SQL
+AS $$
+    SELECT * FROM aws_s3.table_import_from_s3(
+        table_name,
+        column_list,
+        options,
+        (s3_info).bucket,
+        (s3_info).file_path,
+        (s3_info).region
+    );
+$$;
+
+CREATE FUNCTION aws_s3._cleanup_temp(path text) RETURNS void
+LANGUAGE plpython3u
+AS $$
+import os
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+$$;
+
+-- Internal helper: read a temp file produced by `COPY ... TO`, base64
+-- encode it, and PUT it through the bridge to the target bucket/key.
+CREATE FUNCTION aws_s3._upload_object(
+    bucket text,
+    file_path text,
+    region text,
+    temp_path text
+) RETURNS TABLE(rows_uploaded bigint, files_uploaded bigint, bytes_uploaded bigint)
+LANGUAGE plpython3u
+AS $$
+import base64
+import json
+import os
+import urllib.request
+import urllib.error
+
+endpoint = os.environ.get('FAKECLOUD_ENDPOINT')
+if not endpoint:
+    plpy.error('aws_s3: FAKECLOUD_ENDPOINT not set on the database container')
+account_id = os.environ.get('FAKECLOUD_ACCOUNT_ID', '000000000000')
+default_region = os.environ.get('FAKECLOUD_REGION', 'us-east-1')
+
+with open(temp_path, 'rb') as fh:
+    raw = fh.read()
+
+body = json.dumps({
+    'bucket': bucket,
+    'key': file_path,
+    'region': region or default_region,
+    'body_b64': base64.b64encode(raw).decode('ascii'),
+}).encode('utf-8')
+
+req = urllib.request.Request(
+    endpoint.rstrip('/') + '/_fakecloud/rds/s3-export',
+    data=body,
+    headers={
+        'Content-Type': 'application/json',
+        'X-Fakecloud-Account-Id': account_id,
+    },
+    method='POST',
+)
+try:
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        parsed = json.loads(resp.read())
+except urllib.error.HTTPError as e:
+    detail = e.read().decode('utf-8', errors='replace')
+    plpy.error('aws_s3: s3-export bridge returned {}: {}'.format(e.code, detail))
+except Exception as e:
+    plpy.error('aws_s3: s3-export bridge call failed: {}'.format(e))
+
+# rows_uploaded is filled by the SQL caller from GET DIAGNOSTICS; the
+# bridge only knows bytes. files_uploaded is always 1 (single PutObject).
+return [(0, 1, int(parsed.get('bytes_uploaded', len(raw))))]
+$$;
+
+CREATE FUNCTION aws_s3.query_export_to_s3(
+    query text,
+    bucket text,
+    file_path text,
+    region text DEFAULT NULL,
+    options text DEFAULT NULL
+) RETURNS TABLE(rows_uploaded bigint, files_uploaded bigint, bytes_uploaded bigint)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    options_clause text;
+    copy_sql text;
+    temp_path text;
+    exported_rows bigint;
+    upload record;
+BEGIN
+    IF options IS NOT NULL AND length(trim(options)) > 0 THEN
+        options_clause := format(' WITH (%s)', options);
+    ELSE
+        options_clause := '';
+    END IF;
+
+    -- Use a stable, unique path so we can pass it to COPY (which needs a
+    -- string literal) and then read it back from plpython3u.
+    temp_path := format('/tmp/aws_s3_export_%s.dat', floor(random() * 1e12)::bigint);
+    copy_sql := format('COPY (%s) TO %L%s', query, temp_path, options_clause);
+
+    BEGIN
+        EXECUTE copy_sql;
+        GET DIAGNOSTICS exported_rows = ROW_COUNT;
+        SELECT * INTO upload FROM aws_s3._upload_object(bucket, file_path, region, temp_path);
+    EXCEPTION WHEN OTHERS THEN
+        PERFORM aws_s3._cleanup_temp(temp_path);
+        RAISE;
+    END;
+
+    PERFORM aws_s3._cleanup_temp(temp_path);
+    RETURN QUERY SELECT exported_rows, upload.files_uploaded, upload.bytes_uploaded;
+END;
+$$;
+
+CREATE FUNCTION aws_s3.query_export_to_s3(
+    query text,
+    s3_info aws_commons._s3_uri_1,
+    options text DEFAULT NULL
+) RETURNS TABLE(rows_uploaded bigint, files_uploaded bigint, bytes_uploaded bigint)
+LANGUAGE SQL
+AS $$
+    SELECT * FROM aws_s3.query_export_to_s3(
+        query,
+        (s3_info).bucket,
+        (s3_info).file_path,
+        (s3_info).region,
+        options
+    );
+$$;

--- a/crates/fakecloud-rds/assets/postgres/aws_s3.control
+++ b/crates/fakecloud-rds/assets/postgres/aws_s3.control
@@ -1,0 +1,5 @@
+comment = 'AWS S3 import/export from PostgreSQL (fakecloud)'
+default_version = '1.0'
+relocatable = false
+schema = 'aws_s3'
+requires = 'plpython3u, aws_commons'

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -7,9 +7,12 @@ use tokio_postgres::NoTls;
 
 const POSTGRES_DOCKERFILE: &str = include_str!("../assets/postgres/Dockerfile");
 const AWS_COMMONS_CONTROL: &str = include_str!("../assets/postgres/aws_commons.control");
-const AWS_COMMONS_SQL: &str = include_str!("../assets/postgres/aws_commons--1.0.sql");
+const AWS_COMMONS_SQL: &str = include_str!("../assets/postgres/aws_commons--1.1.sql");
+const AWS_COMMONS_UPGRADE_SQL: &str = include_str!("../assets/postgres/aws_commons--1.0--1.1.sql");
 const AWS_LAMBDA_CONTROL: &str = include_str!("../assets/postgres/aws_lambda.control");
 const AWS_LAMBDA_SQL: &str = include_str!("../assets/postgres/aws_lambda--1.0.sql");
+const AWS_S3_CONTROL: &str = include_str!("../assets/postgres/aws_s3.control");
+const AWS_S3_SQL: &str = include_str!("../assets/postgres/aws_s3--1.0.sql");
 
 /// Default registry that hosts the prebuilt postgres images. CI publishes
 /// to `ghcr.io/faiscadev/fakecloud-postgres:<major>-<version>` on each
@@ -685,12 +688,15 @@ impl RdsRuntime {
     ) -> Result<(), RuntimeError> {
         let build_dir =
             tempfile::tempdir().map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
-        let assets: [(&str, &str); 5] = [
+        let assets: [(&str, &str); 8] = [
             ("Dockerfile", POSTGRES_DOCKERFILE),
             ("aws_commons.control", AWS_COMMONS_CONTROL),
-            ("aws_commons--1.0.sql", AWS_COMMONS_SQL),
+            ("aws_commons--1.1.sql", AWS_COMMONS_SQL),
+            ("aws_commons--1.0--1.1.sql", AWS_COMMONS_UPGRADE_SQL),
             ("aws_lambda.control", AWS_LAMBDA_CONTROL),
             ("aws_lambda--1.0.sql", AWS_LAMBDA_SQL),
+            ("aws_s3.control", AWS_S3_CONTROL),
+            ("aws_s3--1.0.sql", AWS_S3_SQL),
         ];
         for (name, contents) in assets {
             tokio::fs::write(build_dir.path().join(name), contents)

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -324,6 +324,48 @@ pub struct RdsLambdaInvokeResponse {
     pub log_result: Option<String>,
 }
 
+// ── RDS aws_s3 extension bridge ─────────────────────────────────────
+
+/// Request body for `POST /_fakecloud/rds/s3-import`. The endpoint is
+/// the bridge that the PostgreSQL `aws_s3` extension calls into to
+/// fetch an object from a fakecloud bucket. Body is returned base64
+/// encoded so JSON transport stays text-only.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RdsS3ImportRequest {
+    pub bucket: String,
+    pub key: String,
+    pub region: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RdsS3ImportResponse {
+    pub bucket: String,
+    pub key: String,
+    pub body_b64: String,
+    pub bytes_processed: i64,
+}
+
+/// Request body for `POST /_fakecloud/rds/s3-export`. Bridge equivalent
+/// of an S3 PutObject driven from inside the DB container.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RdsS3ExportRequest {
+    pub bucket: String,
+    pub key: String,
+    pub region: Option<String>,
+    pub body_b64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RdsS3ExportResponse {
+    pub bucket: String,
+    pub key: String,
+    pub bytes_uploaded: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FireRuleTarget {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -549,6 +549,7 @@ async fn main() {
     let sqs_introspection_state = sqs_state.clone();
     let eb_introspection_state = eb_state.clone();
     let s3_introspection_state = s3_state.clone();
+    let rds_bridge_s3_state = s3_state.clone();
     let rds_introspection_state = rds_state.clone();
     let elasticache_introspection_state = elasticache_state.clone();
     let ecr_introspection_state = ecr_state.clone();
@@ -3577,6 +3578,144 @@ async fn main() {
                                 })),
                             ),
                         }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/rds/s3-import",
+            axum::routing::post({
+                let s3 = rds_bridge_s3_state.clone();
+                move |headers: axum::http::HeaderMap,
+                      axum::Json(body): axum::Json<types::RdsS3ImportRequest>| {
+                    let s3 = s3.clone();
+                    async move {
+                        let account_id = headers
+                            .get("x-fakecloud-account-id")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("000000000000")
+                            .to_string();
+                        let bytes = {
+                            let mas = s3.read();
+                            let state = mas.get(&account_id).unwrap_or_else(|| mas.default_ref());
+                            let Some(bucket) = state.buckets.get(&body.bucket) else {
+                                return (
+                                    axum::http::StatusCode::NOT_FOUND,
+                                    axum::Json(serde_json::json!({
+                                        "error": "NoSuchBucket",
+                                        "bucket": body.bucket,
+                                    })),
+                                );
+                            };
+                            let Some(object) = bucket.objects.get(&body.key) else {
+                                return (
+                                    axum::http::StatusCode::NOT_FOUND,
+                                    axum::Json(serde_json::json!({
+                                        "error": "NoSuchKey",
+                                        "bucket": body.bucket,
+                                        "key": body.key,
+                                    })),
+                                );
+                            };
+                            match state.read_body(&object.body) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    return (
+                                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                        axum::Json(serde_json::json!({
+                                            "error": "ReadBodyFailed",
+                                            "message": e.to_string(),
+                                        })),
+                                    );
+                                }
+                            }
+                        };
+                        let len = bytes.len() as i64;
+                        let resp = types::RdsS3ImportResponse {
+                            bucket: body.bucket,
+                            key: body.key,
+                            body_b64: base64::Engine::encode(
+                                &base64::engine::general_purpose::STANDARD,
+                                &bytes,
+                            ),
+                            bytes_processed: len,
+                        };
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::to_value(resp).unwrap()),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/rds/s3-export",
+            axum::routing::post({
+                let s3 = rds_bridge_s3_state;
+                move |headers: axum::http::HeaderMap,
+                      axum::Json(body): axum::Json<types::RdsS3ExportRequest>| {
+                    let s3 = s3.clone();
+                    async move {
+                        let account_id = headers
+                            .get("x-fakecloud-account-id")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("000000000000")
+                            .to_string();
+                        let bytes = match base64::Engine::decode(
+                            &base64::engine::general_purpose::STANDARD,
+                            body.body_b64.as_bytes(),
+                        ) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                return (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    axum::Json(serde_json::json!({
+                                        "error": "InvalidBase64",
+                                        "message": e.to_string(),
+                                    })),
+                                );
+                            }
+                        };
+                        let bytes_uploaded = bytes.len() as i64;
+                        let now = chrono::Utc::now();
+                        let etag = {
+                            use md5::{Digest, Md5};
+                            format!("\"{:x}\"", Md5::digest(&bytes))
+                        };
+                        let body_bytes = bytes::Bytes::from(bytes);
+                        {
+                            let mut mas = s3.write();
+                            let state = mas.get_or_create(&account_id);
+                            let Some(bucket) = state.buckets.get_mut(&body.bucket) else {
+                                return (
+                                    axum::http::StatusCode::NOT_FOUND,
+                                    axum::Json(serde_json::json!({
+                                        "error": "NoSuchBucket",
+                                        "bucket": body.bucket,
+                                    })),
+                                );
+                            };
+                            let object = fakecloud_s3::state::S3Object {
+                                key: body.key.clone(),
+                                body: fakecloud_s3::state::memory_body(body_bytes),
+                                content_type: "application/octet-stream".to_string(),
+                                etag,
+                                size: bytes_uploaded as u64,
+                                last_modified: now,
+                                storage_class: "STANDARD".to_string(),
+                                ..Default::default()
+                            };
+                            bucket.objects.insert(body.key.clone(), object);
+                        }
+                        let resp = types::RdsS3ExportResponse {
+                            bucket: body.bucket,
+                            key: body.key,
+                            bytes_uploaded,
+                        };
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::to_value(resp).unwrap()),
+                        )
                     }
                 }
             }),

--- a/website/content/docs/services/rds.md
+++ b/website/content/docs/services/rds.md
@@ -23,6 +23,7 @@ fakecloud implements **163 of 163** RDS operations at 100% Smithy conformance. D
 - **License models** — tracking
 - **EventBridge events** — lifecycle ops emit `aws.rds` events on the `default` bus, deliverable to SQS, SNS, Lambda, etc. via standard EB rules
 - **PostgreSQL `aws_lambda` extension** — call fakecloud Lambda functions from inside RDS PostgreSQL via `CREATE EXTENSION aws_lambda CASCADE` and `aws_lambda.invoke(...)` (subset of the AWS RDS extension surface; see below)
+- **PostgreSQL `aws_s3` extension** — import objects from fakecloud S3 into tables (`aws_s3.table_import_from_s3`) and export query results back to S3 (`aws_s3.query_export_to_s3`); see below
 
 ## EventBridge integration
 
@@ -55,6 +56,7 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses.
 
 - `GET /_fakecloud/rds/instances` — list fakecloud-managed DB instances with runtime metadata (container id, host port)
 - `POST /_fakecloud/rds/lambda-invoke` — internal bridge used by the PostgreSQL `aws_lambda` extension to invoke fakecloud Lambda functions from inside the DB container
+- `POST /_fakecloud/rds/s3-import` / `POST /_fakecloud/rds/s3-export` — internal bridges used by the PostgreSQL `aws_s3` extension to read/write fakecloud S3 objects from inside the DB container
 
 ## PostgreSQL `aws_lambda` extension
 
@@ -83,6 +85,41 @@ The first time you create a PostgreSQL DB instance, fakecloud lazily builds a `f
 
 Inside the container, the extension's `plpython3u` body POSTs to `http://host.docker.internal:<server_port>/_fakecloud/rds/lambda-invoke`, which routes through fakecloud's standard Lambda invocation path.
 
+## PostgreSQL `aws_s3` extension
+
+Matches the AWS RDS extension of the same name. Lets SQL running inside an RDS-managed PostgreSQL instance read objects from fakecloud S3 directly into tables and write query results back as objects:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE;
+
+-- Import a CSV file into a table
+SELECT * FROM aws_s3.table_import_from_s3(
+    'people',
+    '',                           -- column list (empty = all columns)
+    'format csv',                 -- COPY options
+    aws_commons.create_s3_uri('my-bucket', 'people.csv', 'us-east-1')
+);
+
+-- Export a query result back to S3
+SELECT * FROM aws_s3.query_export_to_s3(
+    'SELECT id, name FROM people ORDER BY id',
+    aws_commons.create_s3_uri('my-bucket', 'export.csv', 'us-east-1'),
+    'format csv'
+);
+```
+
+Implemented function signatures (subset of the AWS RDS S3 import/export API):
+
+- `aws_s3.table_import_from_s3(table_name text, column_list text, options text, bucket text, file_path text, region text DEFAULT NULL)` -> returns `(rows_imported bigint, file_compression text, bytes_processed bigint)`
+- `aws_s3.table_import_from_s3(table_name text, column_list text, options text, s3_info aws_commons._s3_uri_1)` (composite-typed overload)
+- `aws_s3.query_export_to_s3(query text, bucket text, file_path text, region text DEFAULT NULL, options text DEFAULT NULL)` -> returns `(rows_uploaded bigint, files_uploaded bigint, bytes_uploaded bigint)`
+- `aws_s3.query_export_to_s3(query text, s3_info aws_commons._s3_uri_1, options text DEFAULT NULL)` (composite-typed overload)
+- `aws_commons.create_s3_uri(bucket text, file_path text, region text DEFAULT NULL)` -> composite of `(bucket, file_path, region)`
+
+The `options` argument is forwarded verbatim into the underlying postgres `COPY` `WITH (...)` clause (`format csv`, `header true`, `delimiter ','`, etc.). `file_compression` is always returned empty — fakecloud does not autodetect compression on import; pre-decompress objects before calling.
+
+The bridges (`/_fakecloud/rds/s3-import`, `/_fakecloud/rds/s3-export`) read and write the in-memory S3 state of the same fakecloud server, so any object that's visible to a `GetObject`/`PutObject` call against fakecloud is reachable from `aws_s3`.
+
 ## How the Docker integration works
 
 When you call `CreateDBInstance` for PostgreSQL/MySQL/MariaDB/Oracle/SQL Server/Db2, fakecloud starts a real Docker container running the upstream image for that engine and version, waits for it to be ready, and reports the mapped host port. Your application connects to that port like it would connect to any database.
@@ -93,7 +130,7 @@ When you call `CreateDBInstance` for PostgreSQL/MySQL/MariaDB/Oracle/SQL Server/
 
 | Engine | Image | Port | Wait probe |
 |--------|-------|------|------------|
-| `postgres` | `ghcr.io/faiscadev/fakecloud-postgres:<major>-<fakecloud-version>` (prebuilt with `plpython3u` + the `aws_lambda` and `aws_commons` extensions on top of `postgres:<major>`; falls back to a local build if the pull fails) | 5432 | `tokio-postgres` ping |
+| `postgres` | `ghcr.io/faiscadev/fakecloud-postgres:<major>-<fakecloud-version>` (prebuilt with `plpython3u` + the `aws_commons`, `aws_lambda`, and `aws_s3` extensions on top of `postgres:<major>`; falls back to a local build if the pull fails) | 5432 | `tokio-postgres` ping |
 | `mysql` | `mysql:<major>` | 3306 | `mysql_async` ping |
 | `mariadb` | `mariadb:<major>` | 3306 | `mysql_async` ping |
 | `oracle-ee` / `oracle-se2` (+`-cdb`) | `gvenzl/oracle-free:23-slim` | 1521 | log marker `DATABASE IS READY TO USE!` + TCP probe |

--- a/website/content/local-rds.md
+++ b/website/content/local-rds.md
@@ -16,7 +16,7 @@ Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud
 ## Why fakecloud for RDS
 
 - **163 RDS operations** at 100% conformance — DB instances, snapshots, read replicas, parameter groups, subnet groups, engine/version discovery, tagging, upgrades.
-- **Real database engines.** fakecloud pulls real PostgreSQL / MySQL / MariaDB / Oracle / SQL Server / Db2 Docker images and runs them as the RDS instance. Your SQL schema, indexes, triggers, and extensions all work because they are real engines. PostgreSQL uses a prebuilt `ghcr.io/faiscadev/fakecloud-postgres:<major>` image that bakes in `plpython3u` and the AWS RDS `aws_lambda` extension.
+- **Real database engines.** fakecloud pulls real PostgreSQL / MySQL / MariaDB / Oracle / SQL Server / Db2 Docker images and runs them as the RDS instance. Your SQL schema, indexes, triggers, and extensions all work because they are real engines. PostgreSQL uses a prebuilt `ghcr.io/faiscadev/fakecloud-postgres:<major>` image that bakes in `plpython3u` and the AWS RDS `aws_lambda` and `aws_s3` extensions.
 - **Endpoint works.** `DescribeDBInstances` returns a real connectable host. Your application connects with the usual PostgreSQL / MySQL / Oracle / SQL Server / Db2 driver.
 - **Paid on LocalStack; free here.** RDS has always been LocalStack Pro-only.
 - **No account, no auth token, no paid tier.** AGPL-3.0.


### PR DESCRIPTION
## Summary

- Add Aurora-postgres-compatible `aws_s3` extension: `aws_s3.table_import_from_s3` and `aws_s3.query_export_to_s3` (positional + `aws_commons._s3_uri_1` composite overloads).
- Bump `aws_commons` to 1.1 with the `_s3_uri_1` type and `create_s3_uri()` constructor, plus a 1.0->1.1 upgrade script.
- Two new bridge endpoints (`/_fakecloud/rds/s3-import`, `/_fakecloud/rds/s3-export`) wired straight into the in-memory S3 state.
- Bake the new extension files into the prebuilt `fakecloud-postgres` image.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-rds`
- [ ] `cargo test -p fakecloud-e2e --test rds_aws_s3` (Docker required — runs in CI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the RDS PostgreSQL `aws_s3` extension so SQL can import from and export to S3. Also adds server bridges and upgrades `aws_commons` to 1.1; the extensions are baked into the prebuilt `fakecloud-postgres` image.

- **New Features**
  - `aws_s3.table_import_from_s3` and `aws_s3.query_export_to_s3` (positional and `aws_commons._s3_uri_1` overloads via `aws_commons.create_s3_uri()`).
  - New bridges: `/_fakecloud/rds/s3-import` and `/_fakecloud/rds/s3-export` (read/write in-memory S3).
  - Prebuilt image now includes `aws_commons` 1.1, `aws_lambda`, and `aws_s3`.
  - E2E test covers S3 → table import → query export → S3, uses a scratch table for the composite import to keep the export deterministic; docs and README updated.

- **Migration**
  - If you have `aws_commons` 1.0 installed, run: `ALTER EXTENSION aws_commons UPDATE TO '1.1'` before using `aws_s3`.

<sup>Written for commit 3880c77797ebcc8b7f7e5b5afe41dff2d9ad53ce. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/806?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

