### PR TITLE
test(rds): force postgres image rebuild for aws_s3 e2e

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_aws_s3.rs
+++ b/crates/fakecloud-e2e/tests/rds_aws_s3.rs
@@ -42,7 +42,12 @@ async fn connect_with_retry(
 
 #[tokio::test]
 async fn aws_s3_extension_import_export_round_trip() {
-    let server = TestServer::start().await;
+    // Force the postgres image to be (re)built locally so the aws_s3
+    // extension files baked into this commit are present. The published
+    // `fakecloud-postgres:<major>-<release>` image only ships extensions
+    // that existed at the corresponding release tag; this test runs on
+    // pre-release commits that add aws_s3 before the next tag goes out.
+    let server = TestServer::start_with_env(&[("FAKECLOUD_REBUILD_POSTGRES_IMAGE", "1")]).await;
     let s3 = server.s3_client().await;
     let rds = server.rds_client().await;
 


### PR DESCRIPTION
## Summary

PR #806 merged the aws_s3 extension but the e2e test fails on CI because the runtime's pull-first path returns `fakecloud-postgres:16-0.13.1` (last published image) which lacks the new aws_s3 extension files.

Set `FAKECLOUD_REBUILD_POSTGRES_IMAGE=1` for the new test so it always builds locally from the embedded assets at HEAD. Goes away naturally once v0.13.2 publishes the image with aws_s3 baked in.

## Test plan

- [x] `cargo check -p fakecloud-e2e --tests`
- [ ] `cargo test -p fakecloud-e2e --test rds_aws_s3` (Docker required — runs in CI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a local rebuild of the Postgres image in the `rds_aws_s3` e2e test so the `aws_s3` extension is available and the test passes in CI. Sets `FAKECLOUD_REBUILD_POSTGRES_IMAGE=1` to bypass the pull-first path that currently returns `fakecloud-postgres:16-0.13.1`; this can be removed once v0.13.2 publishes the updated image.

<sup>Written for commit b1a4f1afdadbffc2460f5d9ba52596230a005928. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/807?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

