### PR TITLE
fix(rds): forward fmt + SDK e2e poll fixes from PR #808

### DIFF
--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1773,9 +1773,7 @@ async fn main() {
                                     let stuck: Vec<String> = state
                                         .instances
                                         .iter()
-                                        .filter(|(_, inst)| {
-                                            inst.db_instance_status == "creating"
-                                        })
+                                        .filter(|(_, inst)| inst.db_instance_status == "creating")
                                         .map(|(id, _)| id.clone())
                                         .collect();
                                     for id in &stuck {

--- a/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
+++ b/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
@@ -329,7 +329,7 @@ class E2ETest {
 
     // ── RDS ────────────────────────────────────────────────────────
     @Test
-    void rdsGetInstancesReturnsManagedInstances() {
+    void rdsGetInstancesReturnsManagedInstances() throws Exception {
         RdsClient rds = configure(RdsClient.builder()).build();
         rds.createDBInstance(CreateDbInstanceRequest.builder()
                 .dbInstanceIdentifier("java-rds-db")
@@ -341,6 +341,19 @@ class E2ETest {
                 .masterUserPassword("secret123")
                 .dbName("appdb")
                 .build());
+
+        // CreateDBInstance returns a `creating` placeholder; poll until
+        // the container is up so the introspection endpoint reports the
+        // populated host_port / container_id.
+        long deadline = System.currentTimeMillis() + 240_000;
+        while (System.currentTimeMillis() < deadline) {
+            var desc = rds.describeDBInstances(b -> b.dbInstanceIdentifier("java-rds-db"));
+            if (!desc.dbInstances().isEmpty()
+                    && "available".equals(desc.dbInstances().get(0).dbInstanceStatusAsString())) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
 
         var instance = fc.rds().getInstances().instances().stream()
                 .filter(i -> "java-rds-db".equals(i.dbInstanceIdentifier()))

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -111,6 +111,8 @@ def test_health(fc: FakeCloudSync, fakecloud_url: str) -> None:
 
 
 def test_rds_instances(fc: FakeCloudSync, fakecloud_url: str) -> None:
+    import time
+
     rds = boto3.client("rds", **_boto_kwargs(fakecloud_url))
     rds.create_db_instance(
         DBInstanceIdentifier="py-sdk-rds-db",
@@ -122,6 +124,19 @@ def test_rds_instances(fc: FakeCloudSync, fakecloud_url: str) -> None:
         MasterUserPassword="secret123",
         DBName="appdb",
     )
+
+    # CreateDBInstance returns a `creating` placeholder; poll until the
+    # container is up so the introspection endpoint reports the populated
+    # container_id and host_port.
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        desc = rds.describe_db_instances(DBInstanceIdentifier="py-sdk-rds-db")
+        if (
+            desc["DBInstances"]
+            and desc["DBInstances"][0]["DBInstanceStatus"] == "available"
+        ):
+            break
+        time.sleep(1)
 
     result = fc.rds.get_instances()
     instance = next(


### PR DESCRIPTION
## Summary

PR #808 auto-merged before its trailing fmt + SDK e2e fix commits landed. Forward both:

- `cargo fmt` collapse on the persistence-load creating-instance scrub.
- Java + Python SDK e2e tests now poll DescribeDBInstances until `available` before asserting populated container_id/host_port (CreateDBInstance now returns a `creating` placeholder per #808).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Java + Python SDK e2e in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards missed fixes from PR #808: formats the RDS creating-instance scrub and updates SDK e2e tests to wait for instances to be ready before asserting container fields.

- **Bug Fixes**
  - Java and Python SDK e2e: after `CreateDBInstance` (now returns a `creating` placeholder), poll `DescribeDBInstances` up to 4 minutes until status `available`, then assert `container_id` and `host_port`.

- **Refactors**
  - Apply `cargo fmt` collapse in the RDS creating-instance scrub filter closure.

<sup>Written for commit 18e751c618ca6fee9d2a65cab20cbef3af364379. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/809?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

