### PR TITLE
fix(rds): unblock fakecloud-mysql/mariadb image builds

### DIFF
--- a/.github/workflows/docker-rds-images.yml
+++ b/.github/workflows/docker-rds-images.yml
@@ -43,8 +43,9 @@ jobs:
           - { engine: postgres, version: "14", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "15", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "16", build_arg: "PG_VERSION" }
-          # MySQL majors.
-          - { engine: mysql, version: "5.7", build_arg: "MYSQL_VERSION" }
+          # MySQL majors. 5.7 is excluded — Oracle ended community
+          # support in October 2023 and the image base no longer ships
+          # the build deps we'd need to compile the UDF.
           - { engine: mysql, version: "8.0", build_arg: "MYSQL_VERSION" }
           # MariaDB majors.
           - { engine: mariadb, version: "10.6", build_arg: "MARIADB_VERSION" }
@@ -123,7 +124,6 @@ jobs:
           - { engine: postgres, version: "14" }
           - { engine: postgres, version: "15" }
           - { engine: postgres, version: "16" }
-          - { engine: mysql, version: "5.7" }
           - { engine: mysql, version: "8.0" }
           - { engine: mariadb, version: "10.6" }
           - { engine: mariadb, version: "10.11" }

--- a/crates/fakecloud-rds/assets/mariadb/fakecloud_udf.c
+++ b/crates/fakecloud-rds/assets/mariadb/fakecloud_udf.c
@@ -24,6 +24,7 @@
 #include <mysql.h>
 #include <curl/curl.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -14,15 +14,24 @@ ARG MYSQL_VERSION=8.0
 FROM mysql:${MYSQL_VERSION}
 
 USER root
-RUN microdnf install -y \
-        gcc \
-        make \
-        libcurl-devel \
-        glibc-devel \
-    || ( apt-get update \
-         && apt-get install -y --no-install-recommends \
-            gcc make libcurl4-openssl-dev libc6-dev ca-certificates curl \
-         && rm -rf /var/lib/apt/lists/* )
+# mysql 8.0+ defaults to an Oracle Linux base with `microdnf`; older
+# tags + the `*-debian` variants ship apt. Pick whichever is present.
+RUN set -eux; \
+    if command -v microdnf >/dev/null 2>&1; then \
+        microdnf install -y --enablerepo=ol8_codeready_builder \
+            gcc make libcurl-devel glibc-devel pkgconf-pkg-config \
+        || microdnf install -y \
+            gcc make libcurl-devel glibc-devel pkgconf-pkg-config; \
+        microdnf clean all; \
+    elif command -v apt-get >/dev/null 2>&1; then \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+            gcc make libcurl4-openssl-dev libc6-dev ca-certificates pkg-config; \
+        rm -rf /var/lib/apt/lists/*; \
+    else \
+        echo "no supported package manager found in base image" >&2; \
+        exit 1; \
+    fi
 
 # UDF source + bootstrap SQL.
 COPY fakecloud_udf.c /tmp/fakecloud_udf.c

--- a/crates/fakecloud-rds/assets/mysql/fakecloud_udf.c
+++ b/crates/fakecloud-rds/assets/mysql/fakecloud_udf.c
@@ -24,6 +24,7 @@
 #include <mysql.h>
 #include <curl/curl.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/crates/fakecloud-rds/src/runtime.rs
+++ b/crates/fakecloud-rds/src/runtime.rs
@@ -134,11 +134,12 @@ impl RdsRuntime {
                 (image, "5432", env_vars, Some(major_version.to_string()))
             }
             "mysql" => {
-                let major_version = if engine_version.starts_with("5.7") {
-                    "5.7"
-                } else {
-                    "8.0"
-                };
+                // 5.7 was dropped after Oracle community support ended
+                // (Oct 2023) — the image base no longer ships the build
+                // deps we need for the UDF. Any 5.7.* engine version
+                // resolves to 8.0.
+                let _ = engine_version;
+                let major_version = "8.0";
                 let image = self.ensure_mysql_image(major_version).await?;
                 let env_vars = vec![
                     format!("MYSQL_ROOT_PASSWORD={password}"),


### PR DESCRIPTION
## Summary

PR #810 left the new MySQL/MariaDB image-build matrix red. Fix three issues caught on the first post-merge run:

- `fakecloud_udf.c` used bare `bool` without `<stdbool.h>`. Add the include.
- `mysql:8.0` base is Oracle Linux 8 with `microdnf` (not apt). Switch the package install to a real `if`/`elif` shell branch and opt into `ol8_codeready_builder` for libcurl-devel.
- Drop `mysql 5.7` from the matrix (community support ended Oct 2023; image base no longer ships our build deps). Runtime now resolves any `5.7*` engine version to 8.0.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] `docker-rds-images.yml` PR run all green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks MySQL/MariaDB image builds. Fixes UDF headers, makes the MySQL Dockerfile OS-aware, and removes unsupported MySQL 5.7 (runtime now resolves 5.7.* to 8.0).

- **Bug Fixes**
  - Add `<stdbool.h>` to MySQL and MariaDB UDF sources.
  - Update MySQL Dockerfile to branch on `microdnf` vs `apt-get`, enable `ol8_codeready_builder`, and install `pkgconf-pkg-config`/`pkg-config`.
  - Drop MySQL 5.7 from CI matrix and map any `5.7.*` engine request to `8.0` at runtime.

<sup>Written for commit 9842d2b306b349d9508be4f7a2b09cfdfc597029. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/811?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

