### PR TITLE
fix(rds): install mysql.h headers in fakecloud-mysql image

### DIFF
--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -16,17 +16,21 @@ FROM mysql:${MYSQL_VERSION}
 USER root
 # mysql 8.0+ defaults to an Oracle Linux base with `microdnf`; older
 # tags + the `*-debian` variants ship apt. Pick whichever is present.
+# We need build deps (gcc/make), libcurl headers, and the MySQL UDF
+# header (`mysql.h`) — the latter ships in `mysql-community-devel`,
+# which the image's enabled `mysql-tools-community` repo already
+# provides.
 RUN set -eux; \
     if command -v microdnf >/dev/null 2>&1; then \
-        microdnf install -y --enablerepo=ol8_codeready_builder \
+        microdnf install -y \
             gcc make libcurl-devel glibc-devel pkgconf-pkg-config \
-        || microdnf install -y \
-            gcc make libcurl-devel glibc-devel pkgconf-pkg-config; \
+            mysql-community-devel; \
         microdnf clean all; \
     elif command -v apt-get >/dev/null 2>&1; then \
         apt-get update; \
         apt-get install -y --no-install-recommends \
-            gcc make libcurl4-openssl-dev libc6-dev ca-certificates pkg-config; \
+            gcc make libcurl4-openssl-dev libmysqlclient-dev libc6-dev \
+            ca-certificates pkg-config; \
         rm -rf /var/lib/apt/lists/*; \
     else \
         echo "no supported package manager found in base image" >&2; \


### PR DESCRIPTION
## Summary

Stack of fixes on top of #811 to actually unbreak the `fakecloud-mysql` image build:

- mysql:8.0 base is Oracle Linux 8 with `microdnf`, but the image doesn't ship the UDF dev headers (`mysql.h`) by default. Add `mysql-community-devel` to the install list — the image's enabled `mysql-tools-community` repo carries it.
- Add `libmysqlclient-dev` to the Debian fallback for symmetry.
- Drop the `ol8_codeready_builder` repo flag — the install works without it now that we have the right repo set.

Mariadb builds went green on #811 already. This unblocks the remaining 2 mysql 8.0 jobs.

## Test plan

- [ ] `docker-rds-images.yml` PR run all green (postgres + mysql + mariadb)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `fakecloud-mysql` image build by installing the missing MySQL UDF headers (`mysql.h`). Unblocks the remaining MySQL 8.0 jobs.

- **Bug Fixes**
  - Add `mysql-community-devel` to `microdnf` installs on `mysql:8.0`.
  - Add `libmysqlclient-dev` to the Debian path.
  - Remove the `ol8_codeready_builder` repo flag.

<sup>Written for commit 01b0159035ee701b7fca10fc0d3f3ee4ee806291. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/812?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

