### PR TITLE
fix(rds): vendor mysql UDF plugin API in fakecloud_udf.c

### DIFF
--- a/crates/fakecloud-rds/assets/mariadb/Dockerfile
+++ b/crates/fakecloud-rds/assets/mariadb/Dockerfile
@@ -9,9 +9,13 @@ ARG MARIADB_VERSION=10.11
 FROM mariadb:${MARIADB_VERSION}
 
 USER root
+# UDF plugin API structs are vendored inline in fakecloud_udf.c so we
+# only need a C compiler + libcurl headers. Keeping the dep set
+# symmetric with the mysql Dockerfile means a single source of truth
+# for the build rule.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        gcc make libcurl4-openssl-dev libmariadb-dev libc6-dev ca-certificates curl \
+        gcc make libcurl4-openssl-dev libc6-dev ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY fakecloud_udf.c /tmp/fakecloud_udf.c
@@ -19,19 +23,19 @@ COPY fakecloud-bootstrap.sh /usr/local/bin/fakecloud-bootstrap.sh
 COPY 99-fakecloud-bootstrap.sql.tmpl /tmp/99-fakecloud-bootstrap.sql.tmpl
 RUN chmod +x /usr/local/bin/fakecloud-bootstrap.sh
 
-# MariaDB ships mysql_config-style headers via libmariadb-dev. The
-# plugin dir lives at /usr/lib/mysql/plugin (or under the mariadb
-# tree on some images); honor whatever mysql_config reports first.
-RUN PLUGIN_DIR="$(mariadb_config --plugindir 2>/dev/null \
-        || mysql_config --plugindir 2>/dev/null \
-        || echo /usr/lib/mysql/plugin)" \
-    && mkdir -p "$PLUGIN_DIR" \
-    && CFLAGS="$(mariadb_config --cflags 2>/dev/null \
-        || mysql_config --cflags 2>/dev/null \
-        || echo -I/usr/include/mariadb)" \
-    && gcc -O2 -fPIC -shared $CFLAGS -o "$PLUGIN_DIR/fakecloud_udf.so" \
-        /tmp/fakecloud_udf.c -lcurl -lpthread \
-    && rm /tmp/fakecloud_udf.c
+# Compile the UDF and drop it into the server's plugin dir. Mariadb
+# images use /usr/lib/mysql/plugin on Debian; probe a few common
+# locations for forward compatibility.
+RUN set -eux; \
+    PLUGIN_DIR=""; \
+    for d in /usr/lib/mysql/plugin /usr/lib/x86_64-linux-gnu/mariadb19/plugin /usr/lib/aarch64-linux-gnu/mariadb19/plugin /usr/lib64/mysql/plugin; do \
+        if [ -d "$d" ]; then PLUGIN_DIR="$d"; break; fi; \
+    done; \
+    : "${PLUGIN_DIR:=/usr/lib/mysql/plugin}"; \
+    mkdir -p "$PLUGIN_DIR"; \
+    gcc -O2 -fPIC -shared -o "$PLUGIN_DIR/fakecloud_udf.so" \
+        /tmp/fakecloud_udf.c -lcurl -lpthread; \
+    rm /tmp/fakecloud_udf.c
 
 ENTRYPOINT ["fakecloud-bootstrap.sh"]
 CMD ["mariadbd"]

--- a/crates/fakecloud-rds/assets/mariadb/fakecloud_udf.c
+++ b/crates/fakecloud-rds/assets/mariadb/fakecloud_udf.c
@@ -21,12 +21,50 @@
  *          'plugin_dir'`) and `CREATE FUNCTION`.
  */
 
-#include <mysql.h>
 #include <curl/curl.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+
+/*
+ * Minimal vendored UDF API. The mysql.h plugin headers ship in
+ * `mysql-community-devel` / `libmysqlclient-dev` / `libmariadb-dev`,
+ * which are absent or repo-gated on the upstream mysql:8.0 image
+ * (the official Dockerfile removes the community release repo). The
+ * struct layout below has been ABI-stable across MySQL 5.6 -> 8.x
+ * and MariaDB 10.x/11.x — the server casts our exported symbols to
+ * these shapes regardless of how we obtained them, so vendoring is
+ * safe and avoids a brittle external repo dependency at build time.
+ */
+enum Item_result {
+    INVALID_RESULT = -1,
+    STRING_RESULT = 0,
+    REAL_RESULT,
+    INT_RESULT,
+    ROW_RESULT,
+    DECIMAL_RESULT
+};
+
+typedef struct st_udf_args {
+    unsigned int arg_count;
+    enum Item_result *arg_type;
+    char **args;
+    unsigned long *lengths;
+    char *maybe_null;
+    char **attributes;
+    unsigned long *attribute_lengths;
+    void *extension;
+} UDF_ARGS;
+
+typedef struct st_udf_init {
+    char maybe_null;
+    unsigned int decimals;
+    unsigned long max_length;
+    char *ptr;
+    char const_item;
+    void *extension;
+} UDF_INIT;
 
 /* ── shared helpers ─────────────────────────────────────────────────── */
 

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -14,23 +14,19 @@ ARG MYSQL_VERSION=8.0
 FROM mysql:${MYSQL_VERSION}
 
 USER root
-# mysql 8.0+ defaults to an Oracle Linux base with `microdnf`; older
-# tags + the `*-debian` variants ship apt. Pick whichever is present.
-# We need build deps (gcc/make), libcurl headers, and the MySQL UDF
-# header (`mysql.h`) — the latter ships in `mysql-community-devel`,
-# which the image's enabled `mysql-tools-community` repo already
-# provides.
+# UDF needs only gcc + libcurl headers; mysql plugin API structs are
+# vendored inline in fakecloud_udf.c (the upstream mysql:8.0 image
+# strips its community release repo so `mysql-community-devel` is not
+# installable, and adding it back hard-codes a brittle URL).
 RUN set -eux; \
     if command -v microdnf >/dev/null 2>&1; then \
         microdnf install -y \
-            gcc make libcurl-devel glibc-devel pkgconf-pkg-config \
-            mysql-community-devel; \
+            gcc make libcurl-devel glibc-devel; \
         microdnf clean all; \
     elif command -v apt-get >/dev/null 2>&1; then \
         apt-get update; \
         apt-get install -y --no-install-recommends \
-            gcc make libcurl4-openssl-dev libmysqlclient-dev libc6-dev \
-            ca-certificates pkg-config; \
+            gcc make libcurl4-openssl-dev libc6-dev ca-certificates; \
         rm -rf /var/lib/apt/lists/*; \
     else \
         echo "no supported package manager found in base image" >&2; \
@@ -43,15 +39,19 @@ COPY fakecloud-bootstrap.sh /usr/local/bin/fakecloud-bootstrap.sh
 COPY 99-fakecloud-bootstrap.sql.tmpl /tmp/99-fakecloud-bootstrap.sql.tmpl
 RUN chmod +x /usr/local/bin/fakecloud-bootstrap.sh
 
-# Compile the UDF against the running MySQL's plugin headers and drop
-# it into the standard plugin dir. The runtime image ships
-# mysql_config (or pkg-config + libmysqlclient-dev when on Debian).
-RUN PLUGIN_DIR="$(mysql_config --plugindir 2>/dev/null || echo /usr/lib/mysql/plugin)" \
-    && mkdir -p "$PLUGIN_DIR" \
-    && CFLAGS="$(mysql_config --cflags 2>/dev/null || echo -I/usr/include/mysql)" \
-    && gcc -O2 -fPIC -shared $CFLAGS -o "$PLUGIN_DIR/fakecloud_udf.so" \
-        /tmp/fakecloud_udf.c -lcurl -lpthread \
-    && rm /tmp/fakecloud_udf.c
+# Compile the UDF and drop it into the server's plugin dir. We probe
+# common locations because Oracle Linux ships /usr/lib64/mysql/plugin
+# while Debian-based mysql images use /usr/lib/mysql/plugin.
+RUN set -eux; \
+    PLUGIN_DIR=""; \
+    for d in /usr/lib64/mysql/plugin /usr/lib/mysql/plugin /usr/lib/x86_64-linux-gnu/mysql/plugin; do \
+        if [ -d "$d" ]; then PLUGIN_DIR="$d"; break; fi; \
+    done; \
+    : "${PLUGIN_DIR:=/usr/lib/mysql/plugin}"; \
+    mkdir -p "$PLUGIN_DIR"; \
+    gcc -O2 -fPIC -shared -o "$PLUGIN_DIR/fakecloud_udf.so" \
+        /tmp/fakecloud_udf.c -lcurl -lpthread; \
+    rm /tmp/fakecloud_udf.c
 
 # The bootstrap shell script substitutes FAKECLOUD_* env vars into the
 # template SQL and drops the result into /docker-entrypoint-initdb.d/

--- a/crates/fakecloud-rds/assets/mysql/fakecloud_udf.c
+++ b/crates/fakecloud-rds/assets/mysql/fakecloud_udf.c
@@ -21,12 +21,50 @@
  *          'plugin_dir'`) and `CREATE FUNCTION`.
  */
 
-#include <mysql.h>
 #include <curl/curl.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+
+/*
+ * Minimal vendored UDF API. The mysql.h plugin headers ship in
+ * `mysql-community-devel` / `libmysqlclient-dev` / `libmariadb-dev`,
+ * which are absent or repo-gated on the upstream mysql:8.0 image
+ * (the official Dockerfile removes the community release repo). The
+ * struct layout below has been ABI-stable across MySQL 5.6 -> 8.x
+ * and MariaDB 10.x/11.x — the server casts our exported symbols to
+ * these shapes regardless of how we obtained them, so vendoring is
+ * safe and avoids a brittle external repo dependency at build time.
+ */
+enum Item_result {
+    INVALID_RESULT = -1,
+    STRING_RESULT = 0,
+    REAL_RESULT,
+    INT_RESULT,
+    ROW_RESULT,
+    DECIMAL_RESULT
+};
+
+typedef struct st_udf_args {
+    unsigned int arg_count;
+    enum Item_result *arg_type;
+    char **args;
+    unsigned long *lengths;
+    char *maybe_null;
+    char **attributes;
+    unsigned long *attribute_lengths;
+    void *extension;
+} UDF_ARGS;
+
+typedef struct st_udf_init {
+    char maybe_null;
+    unsigned int decimals;
+    unsigned long max_length;
+    char *ptr;
+    char const_item;
+    void *extension;
+} UDF_INIT;
 
 /* ── shared helpers ─────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Vendor minimal `UDF_INIT`/`UDF_ARGS`/`Item_result` definitions inline in `fakecloud_udf.c`, dropping the `#include <mysql.h>` requirement.
- Remove `mysql-community-devel` / `libmysqlclient-dev` / `libmariadb-dev` from both Dockerfiles — only `gcc` + `libcurl-devel` remain.
- Probe plugin dir from a known list instead of relying on `mysql_config`.

## Why
PR #812 added `mysql-community-devel` to fix `mysql.h: not found`, but the upstream `mysql:8.0` image's Dockerfile strips its community release repo after install — `microdnf install mysql-community-devel` returns `No package matches`. Re-adding the repo would hard-code a brittle Oracle URL.

The UDF plugin API surface we touch is tiny and ABI-stable across MySQL 5.6 -> 8.x and MariaDB 10.x/11.x. Vendoring is safer than depending on a repo definition Oracle removed.

## Test plan
- [ ] CI `RDS support images` workflow builds `fakecloud-mysql:8.0` on linux/amd64 and linux/arm64.
- [ ] Same for `fakecloud-mariadb` 10.6, 10.11, 11.4.
- [ ] Postgres images unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendor minimal MySQL UDF structs inline in both `mysql/fakecloud_udf.c` and `mariadb/fakecloud_udf.c` to drop the `mysql.h` dependency and fix UDF builds on `mysql:8.0` and MariaDB. Dockerfiles now compile the UDF with only gcc + libcurl and probe plugin directories without `mysql_config`.

- **Bug Fixes**
  - Inline `UDF_INIT`/`UDF_ARGS`/`Item_result` in both UDF sources and remove the include.
  - Probe common plugin dirs across OL and Debian paths (fallback to `/usr/lib/mysql/plugin`).
  - Build the UDF without `mysql_config` flags.

- **Dependencies**
  - Remove `mysql-community-devel`, `libmysqlclient-dev`, `libmariadb-dev`.
  - Keep only `gcc`, `make`, libcurl headers (`libcurl-devel`/`libcurl4-openssl-dev`), and libc headers.

<sup>Written for commit dd18ac9a648b8ca338419356a47ca64f73a259c0. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/813?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

