### PR TITLE
fix(sdk-java): use dbInstanceStatus() in e2e poll

### DIFF
--- a/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
+++ b/sdks/java/src/test/java/dev/fakecloud/E2ETest.java
@@ -349,7 +349,7 @@ class E2ETest {
         while (System.currentTimeMillis() < deadline) {
             var desc = rds.describeDBInstances(b -> b.dbInstanceIdentifier("java-rds-db"));
             if (!desc.dbInstances().isEmpty()
-                    && "available".equals(desc.dbInstances().get(0).dbInstanceStatusAsString())) {
+                    && "available".equals(desc.dbInstances().get(0).dbInstanceStatus())) {
                 break;
             }
             Thread.sleep(1000);


### PR DESCRIPTION
## Summary
PR #809 added a `DescribeDBInstances` poll loop in the Java SDK e2e and called `dbInstanceStatusAsString()`, but AWS SDK v2 only generates `*AsString()` accessors for enum-typed Smithy fields. `DBInstance.dbInstanceStatus` is a plain `String`, so the bare accessor is correct and the enum-style name fails compilation.

## Test plan
- [ ] `./gradlew test` in `sdks/java` compiles and runs.
- [ ] CI Java SDK `build-and-test` job passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Java SDK e2e RDS poll to use dbInstanceStatus() (a String) instead of dbInstanceStatusAsString(). This restores compilation and correctly checks for "available".

<sup>Written for commit 67ef31d629c198c8e5c27c65f8950b7aaee2dbb7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/815?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

