### PR TITLE
test(rds): wait for db instance available before chaining ops

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -91,6 +91,8 @@ async fn rds_describe_db_instances() {
         .await
         .unwrap();
 
+    wait_for_db_instance_available(&client, "conf-rds-db").await;
+
     let response = client
         .describe_db_instances()
         .db_instance_identifier("conf-rds-db")
@@ -540,7 +542,7 @@ async fn create_instance_with_deletion_protection(
     db_instance_identifier: &str,
     deletion_protection: bool,
 ) -> aws_sdk_rds::operation::create_db_instance::CreateDbInstanceOutput {
-    client
+    let response = client
         .create_db_instance()
         .db_instance_identifier(db_instance_identifier)
         .allocated_storage(20)
@@ -553,7 +555,52 @@ async fn create_instance_with_deletion_protection(
         .db_name("appdb")
         .send()
         .await
-        .unwrap()
+        .unwrap();
+    wait_for_db_instance_available(client, db_instance_identifier).await;
+    response
+}
+
+/// CreateDBInstance returns immediately with status="creating" and the
+/// real postgres container starts in a background task. Tests that
+/// chain operations on the instance (snapshot, modify, reboot, etc.)
+/// need it to reach "available" first or the followup either errors or
+/// observes intermediate state. Polls DescribeDBInstances every 250ms
+/// for up to 60s.
+async fn wait_for_db_instance_available(
+    client: &aws_sdk_rds::Client,
+    db_instance_identifier: &str,
+) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        let response = client
+            .describe_db_instances()
+            .db_instance_identifier(db_instance_identifier)
+            .send()
+            .await
+            .unwrap_or_else(|err| {
+                panic!("describe_db_instances during wait failed: {err:?}");
+            });
+        let status = response
+            .db_instances()
+            .first()
+            .and_then(|i| i.db_instance_status())
+            .unwrap_or("")
+            .to_string();
+        if status == "available" {
+            return;
+        }
+        if status == "failed" {
+            panic!(
+                "db instance {db_instance_identifier} entered status `failed` while waiting for available"
+            );
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for db instance {db_instance_identifier} to reach available (last status: {status})"
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
 }
 
 #[test_action("rds", "CreateDBSubnetGroup", checksum = "1b1b06a3")]
@@ -873,6 +920,8 @@ async fn rds_delete_db_instance_with_final_snapshot() {
         .await
         .unwrap();
 
+    wait_for_db_instance_available(&client, "conf-rds-final").await;
+
     // Delete with final snapshot
     let response = client
         .delete_db_instance()
@@ -981,6 +1030,8 @@ async fn rds_describe_db_snapshots_pagination() {
         .send()
         .await
         .unwrap();
+
+    wait_for_db_instance_available(&client, "conf-snap-paginate").await;
 
     // Create 3 snapshots
     for i in 1..=3 {


### PR DESCRIPTION
## Summary
Conformance has been failing on main since the async CreateDBInstance work landed (\`v0.13.1 deferred RDS shipped\`, 2026-04-28). \`CreateDBInstance\` returns immediately with \`status=\"creating\"\` and the real postgres container starts in a background task, but 10 RDS conformance tests were running follow-up ops (snapshot, reboot, modify, replica, restore, delete-with-final-snapshot) against a still-\`creating\` instance and either erroring or observing intermediate state.

Adds \`wait_for_db_instance_available\` polling helper and wires it into the \`create_instance\` test helper plus the three inline-create tests so all chained ops see an \`available\` instance.

## Test plan
- [x] All 10 affected tests now have a wait barrier before the followup op:
  - \`rds_describe_db_instances\`
  - \`rds_create_db_snapshot\`
  - \`rds_describe_db_snapshots\`
  - \`rds_delete_db_snapshot\`
  - \`rds_describe_db_snapshots_pagination\`
  - \`rds_reboot_db_instance\`
  - \`rds_modify_db_instance_with_apply_immediately_false\`
  - \`rds_create_db_instance_read_replica\`
  - \`rds_restore_db_instance_from_db_snapshot\`
  - \`rds_delete_db_instance_with_final_snapshot\`
- [x] Tests that intentionally observe \`creating\` (\`rds_create_db_instance\`) bypass the helper and stay unaffected.
- [x] Tests that observe \`modifying\` / \`deleting\` (\`rds_modify_db_instance\`, \`rds_delete_db_instance\`) still pass — they go through the wait helper, then the next op produces the expected transitional state.
- [ ] CI conformance job green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RDS conformance failures by waiting for a DB instance to be "available" before chaining follow-up operations in tests.

- **Bug Fixes**
  - Added `wait_for_db_instance_available` helper (polls every 250ms, 60s timeout via `DescribeDBInstances`).
  - Wired into the create-instance test helper and added inline waits in tests that create instances directly, so snapshot, reboot, modify, replica, restore, and delete-with-final-snapshot run against an available instance.
  - Tests that assert "creating", "modifying", or "deleting" states remain unchanged.

<sup>Written for commit 5f7c3eb6ce47006989f0b0cb0640a9d45935aa62. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/821?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

