### PR TITLE
fix(lambda): accept ARN, partial ARN, qualified names in URL paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ dependencies = [
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -68,6 +68,63 @@ async fn lambda_create_get_delete_function() {
 }
 
 #[tokio::test]
+async fn lambda_get_function_accepts_arn_partial_arn_and_qualifier() {
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("arn-target")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Full ARN — what the VS Code AWS Toolkit sends.
+    let resp = client
+        .get_function()
+        .function_name("arn:aws:lambda:us-east-1:123456789012:function:arn-target")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.configuration().unwrap().function_name().unwrap(),
+        "arn-target"
+    );
+
+    // Partial ARN.
+    let resp = client
+        .get_function()
+        .function_name("123456789012:function:arn-target")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.configuration().unwrap().function_name().unwrap(),
+        "arn-target"
+    );
+
+    // Bare name with version qualifier.
+    let resp = client
+        .get_function()
+        .function_name("arn-target:1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.configuration().unwrap().function_name().unwrap(),
+        "arn-target"
+    );
+}
+
+#[tokio::test]
 async fn lambda_list_functions() {
     let server = TestServer::start().await;
     let client = server.lambda_client().await;

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { workspace = true }
 tracing = { workspace = true }
 zip = { workspace = true }
 tempfile = { workspace = true }
+percent-encoding = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -17,6 +17,124 @@ use crate::state::{
     LAMBDA_SNAPSHOT_SCHEMA_VERSION,
 };
 
+/// Lambda actions whose URL `resource_name` slot is a `FunctionName`
+/// (and therefore accepts ARN / partial ARN / `name:qualifier` forms).
+/// Layer / event-source-mapping / code-signing-config actions key off
+/// other resource identifiers and are excluded.
+pub(crate) fn action_takes_function_name(action: &str) -> bool {
+    matches!(
+        action,
+        "GetFunction"
+            | "DeleteFunction"
+            | "Invoke"
+            | "InvokeAsync"
+            | "InvokeWithResponseStream"
+            | "PublishVersion"
+            | "ListVersionsByFunction"
+            | "AddPermission"
+            | "RemovePermission"
+            | "GetPolicy"
+            | "GetFunctionConfiguration"
+            | "UpdateFunctionConfiguration"
+            | "UpdateFunctionCode"
+            | "GetFunctionConcurrency"
+            | "PutFunctionConcurrency"
+            | "DeleteFunctionConcurrency"
+            | "PutProvisionedConcurrencyConfig"
+            | "GetProvisionedConcurrencyConfig"
+            | "DeleteProvisionedConcurrencyConfig"
+            | "ListProvisionedConcurrencyConfigs"
+            | "PutFunctionEventInvokeConfig"
+            | "UpdateFunctionEventInvokeConfig"
+            | "GetFunctionEventInvokeConfig"
+            | "DeleteFunctionEventInvokeConfig"
+            | "ListFunctionEventInvokeConfigs"
+            | "CreateFunctionUrlConfig"
+            | "UpdateFunctionUrlConfig"
+            | "GetFunctionUrlConfig"
+            | "DeleteFunctionUrlConfig"
+            | "ListFunctionUrlConfigs"
+            | "PutFunctionCodeSigningConfig"
+            | "GetFunctionCodeSigningConfig"
+            | "DeleteFunctionCodeSigningConfig"
+            | "GetFunctionScalingConfig"
+            | "PutFunctionRecursionConfig"
+            | "GetFunctionRecursionConfig"
+            | "CreateAlias"
+            | "GetAlias"
+            | "ListAliases"
+            | "UpdateAlias"
+            | "DeleteAlias"
+    )
+}
+
+/// Strip an ARN, partial ARN, or trailing `:qualifier` from a Lambda
+/// `FunctionName` input down to the bare function name used as the
+/// state map key. AWS Lambda accepts four forms in URL path slots and
+/// API params:
+///
+///   - `MyFunction`
+///   - `MyFunction:Qualifier`
+///   - `123456789012:function:MyFunction[:Qualifier]`           (partial ARN)
+///   - `arn:aws:lambda:REGION:ACCOUNT:function:MyFunction[:Qualifier]`
+///
+/// Inputs that don't match any of those structures are returned
+/// unchanged. The qualifier (version or alias) is dropped because most
+/// callers look up the function by name and resolve qualifier
+/// separately.
+pub(crate) fn normalize_function_name(input: &str) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+
+    // SDKs URL-encode `:` in path segments, so `arn:aws:lambda:...`
+    // arrives as `arn%3Aaws%3Alambda%3A...`. Decode first; legitimate
+    // function names contain no percent-encoded characters, so this is
+    // safe for the bare-name path too.
+    let decoded = percent_encoding::percent_decode_str(input)
+        .decode_utf8_lossy()
+        .into_owned();
+    let input = decoded.as_str();
+
+    // Full ARN: arn:aws:lambda:REGION:ACCOUNT:function:NAME[:QUALIFIER]
+    if let Some(rest) = input.strip_prefix("arn:aws:lambda:") {
+        let parts: Vec<&str> = rest.splitn(5, ':').collect();
+        // parts: [region, account, "function", name, qualifier?]
+        if parts.len() >= 4 && parts[2] == "function" && !parts[3].is_empty() {
+            return parts[3].to_string();
+        }
+        return input.to_string();
+    }
+
+    // Partial ARN: ACCOUNT:function:NAME[:QUALIFIER]
+    let parts: Vec<&str> = input.splitn(4, ':').collect();
+    if parts.len() >= 3 && parts[1] == "function" && parts[0].chars().all(|c| c.is_ascii_digit()) {
+        if !parts[2].is_empty() {
+            return parts[2].to_string();
+        }
+        return input.to_string();
+    }
+
+    // Bare name with qualifier: NAME:QUALIFIER. Only apply when the
+    // input contains exactly one colon and the name part is a valid
+    // Lambda function-name token, so malformed ARNs (e.g. wrong service
+    // or wrong format) fall through unchanged rather than getting their
+    // first colon-segment returned.
+    if input.matches(':').count() == 1 {
+        if let Some((name, _qualifier)) = input.split_once(':') {
+            if !name.is_empty() && name.chars().all(is_function_name_char) {
+                return name.to_string();
+            }
+        }
+    }
+
+    input.to_string()
+}
+
+fn is_function_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
+}
+
 /// All fields of a `CreateFunction` request, already parsed and
 /// defaulted. The code zip (if any) is eagerly base64-decoded so the
 /// caller can hash it without doing the decode again.
@@ -1617,6 +1735,16 @@ impl AwsService for LambdaService {
             )
         })?;
 
+        // Normalize FunctionName-bearing resource slots: AWS Lambda accepts
+        // bare name, name:qualifier, partial ARN, and full ARN in any URL
+        // slot that names a function. Layer / event-source-mapping resource
+        // names go through different routes and are left as-is.
+        let resource_name = if action_takes_function_name(action) {
+            resource_name.map(|s| normalize_function_name(&s))
+        } else {
+            resource_name
+        };
+
         let mutates = matches!(
             action,
             "CreateFunction"
@@ -1951,6 +2079,140 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[test]
+    fn normalize_function_name_bare_name_passes_through() {
+        assert_eq!(normalize_function_name("MyFunction"), "MyFunction");
+    }
+
+    #[test]
+    fn normalize_function_name_strips_qualifier_from_bare_name() {
+        assert_eq!(normalize_function_name("MyFunction:PROD"), "MyFunction");
+        assert_eq!(normalize_function_name("MyFunction:1"), "MyFunction");
+    }
+
+    #[test]
+    fn normalize_function_name_strips_full_arn() {
+        assert_eq!(
+            normalize_function_name("arn:aws:lambda:us-east-1:123456789012:function:MyFunction"),
+            "MyFunction"
+        );
+    }
+
+    #[test]
+    fn normalize_function_name_strips_qualified_full_arn() {
+        assert_eq!(
+            normalize_function_name(
+                "arn:aws:lambda:us-east-1:123456789012:function:MyFunction:PROD"
+            ),
+            "MyFunction"
+        );
+    }
+
+    #[test]
+    fn normalize_function_name_strips_partial_arn() {
+        assert_eq!(
+            normalize_function_name("123456789012:function:MyFunction"),
+            "MyFunction"
+        );
+        assert_eq!(
+            normalize_function_name("123456789012:function:MyFunction:1"),
+            "MyFunction"
+        );
+    }
+
+    #[test]
+    fn normalize_function_name_leaves_malformed_arn_alone() {
+        // wrong service in ARN — multiple colons, no lambda prefix → unchanged
+        let s = "arn:aws:s3:us-east-1:123456789012:function:Foo";
+        assert_eq!(normalize_function_name(s), s);
+        // partial ARN with non-numeric account-shaped prefix → unchanged
+        let s2 = "abc:function:Foo";
+        assert_eq!(normalize_function_name(s2), s2);
+    }
+
+    #[test]
+    fn normalize_function_name_empty() {
+        assert_eq!(normalize_function_name(""), "");
+    }
+
+    #[test]
+    fn normalize_function_name_decodes_percent_encoded_arn() {
+        // SDKs URL-encode `:` in path segments. The toolkit / aws-sdk-lambda
+        // wire form for `arn:aws:lambda:...` is `arn%3Aaws%3Alambda%3A...`.
+        let encoded = "arn%3Aaws%3Alambda%3Aus-east-1%3A123456789012%3Afunction%3AMyFunc";
+        assert_eq!(normalize_function_name(encoded), "MyFunc");
+    }
+
+    #[tokio::test]
+    async fn get_function_accepts_full_arn() {
+        let svc = LambdaService::new(make_state());
+        // Seed a function via CreateFunction
+        let create_body = json!({
+            "FunctionName": "MyFunc",
+            "Runtime": "nodejs20.x",
+            "Role": "arn:aws:iam::123456789012:role/lambda-role",
+            "Handler": "index.handler",
+            "Code": {"ZipFile": ""},
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/2015-03-31/functions", &create_body);
+        svc.handle(req).await.expect("create function");
+
+        // GetFunction by full ARN
+        let req = make_request(
+            Method::GET,
+            "/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:MyFunc",
+            "",
+        );
+        let resp = svc.handle(req).await.expect("get function by ARN");
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn get_function_accepts_partial_arn() {
+        let svc = LambdaService::new(make_state());
+        let create_body = json!({
+            "FunctionName": "MyFunc",
+            "Runtime": "nodejs20.x",
+            "Role": "arn:aws:iam::123456789012:role/lambda-role",
+            "Handler": "index.handler",
+            "Code": {"ZipFile": ""},
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/2015-03-31/functions", &create_body);
+        svc.handle(req).await.expect("create function");
+
+        let req = make_request(
+            Method::GET,
+            "/2015-03-31/functions/123456789012:function:MyFunc",
+            "",
+        );
+        let resp = svc.handle(req).await.expect("get function by partial ARN");
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn get_function_accepts_name_with_qualifier() {
+        let svc = LambdaService::new(make_state());
+        let create_body = json!({
+            "FunctionName": "MyFunc",
+            "Runtime": "nodejs20.x",
+            "Role": "arn:aws:iam::123456789012:role/lambda-role",
+            "Handler": "index.handler",
+            "Code": {"ZipFile": ""},
+        })
+        .to_string();
+        let req = make_request(Method::POST, "/2015-03-31/functions", &create_body);
+        svc.handle(req).await.expect("create function");
+
+        let req = make_request(Method::GET, "/2015-03-31/functions/MyFunc:1", "");
+        let resp = svc
+            .handle(req)
+            .await
+            .expect("get function by name:qualifier");
+        assert_eq!(resp.status, StatusCode::OK);
     }
 
     #[test]

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -65,6 +65,9 @@ pub(crate) fn action_takes_function_name(action: &str) -> bool {
             | "ListAliases"
             | "UpdateAlias"
             | "DeleteAlias"
+            | "PutRuntimeManagementConfig"
+            | "GetRuntimeManagementConfig"
+            | "ListDurableExecutionsByFunction"
     )
 }
 


### PR DESCRIPTION
## Summary

Closes #817.

The VS Code AWS Toolkit calls `GetFunction` with a fully-qualified function ARN. Real AWS Lambda accepts ARN, partial ARN (`ACCOUNT:function:NAME`), and `name:qualifier` in any URL slot that names a function. fakecloud was looking up the raw URL segment in the in-memory map keyed by short name, so every toolkit request returned 404 and the Lambda explorer in the IDE showed nothing.

- New `normalize_function_name` helper strips full ARN, partial ARN, and trailing `:qualifier` down to the bare name. Percent-decodes first since SDKs URL-encode `:` in path segments (`arn%3A...`).
- Applied at dispatch: `handle()` normalizes the resource name for every action that takes a `FunctionName` (Get/Delete/Invoke/aliases/concurrency/URL config/event invoke config/recursion config/versions/policy/scaling). Layer and event-source-mapping routes are untouched.

## Test plan

- [x] 8 unit tests for the normalizer (bare name, qualifier strip, full ARN, qualified full ARN, partial ARN, malformed ARN passthrough, empty, percent-encoded ARN)
- [x] 3 unit tests exercising `LambdaService::handle` end-to-end with full ARN, partial ARN, and `name:qualifier`
- [x] 1 e2e test via `aws-sdk-lambda` calling `GetFunction` with all three forms — same code path the VS Code toolkit hits
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] VS Code AWS Toolkit smoke test against running fakecloud (manual, post-merge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept full ARNs, partial ARNs, and name:qualifier in Lambda function URL paths to match AWS behavior. This fixes GetFunction 404s from the VS Code AWS Toolkit so functions appear in the IDE.

- **Bug Fixes**
  - Added a normalizer that percent-decodes and strips full/partial ARNs and trailing qualifiers to the bare function name.
  - Applied at dispatch to all actions that take `FunctionName`, including runtime management and durable-executions routes; layer and event-source-mapping routes are unchanged.

- **Dependencies**
  - Added `percent-encoding` for URL-decoding path segments.

<sup>Written for commit 55daeeb9c53b94c117c7171546c126ccef42eec1. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/822?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

