### PR TITLE
ci(rds): rebuild gosu + strip mysqlsh to clear Trivy CVE findings

### DIFF
--- a/crates/fakecloud-rds/assets/mariadb/Dockerfile
+++ b/crates/fakecloud-rds/assets/mariadb/Dockerfile
@@ -5,13 +5,16 @@
 # tries to pull that tag first and falls back to building from this
 # Dockerfile locally when the pull fails.
 
+# MARIADB_VERSION must sit before the first FROM so its substitution is
+# available across all stages.
+ARG MARIADB_VERSION=10.11
+
 # Rebuild gosu from source with current Go to eliminate upstream
 # mariadb image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
 FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
 RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
 
-ARG MARIADB_VERSION=10.11
 FROM mariadb:${MARIADB_VERSION}
 
 USER root

--- a/crates/fakecloud-rds/assets/mariadb/Dockerfile
+++ b/crates/fakecloud-rds/assets/mariadb/Dockerfile
@@ -5,10 +5,19 @@
 # tries to pull that tag first and falls back to building from this
 # Dockerfile locally when the pull fails.
 
+# Rebuild gosu from source with current Go to eliminate upstream
+# mariadb image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
+FROM golang:1.25-bookworm AS gosu-builder
+ENV CGO_ENABLED=0
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+
 ARG MARIADB_VERSION=10.11
 FROM mariadb:${MARIADB_VERSION}
 
 USER root
+
+COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
+RUN chmod 0755 /usr/local/bin/gosu
 # UDF plugin API structs are vendored inline in fakecloud_udf.c so we
 # only need a C compiler + libcurl headers. Keeping the dep set
 # symmetric with the mysql Dockerfile means a single source of truth

--- a/crates/fakecloud-rds/assets/mariadb/Dockerfile
+++ b/crates/fakecloud-rds/assets/mariadb/Dockerfile
@@ -13,7 +13,7 @@ ARG MARIADB_VERSION=10.11
 # mariadb image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
 FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
-RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v0.0.0-20250923190938-6456aaa0f3c8
 
 FROM mariadb:${MARIADB_VERSION}
 

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -10,10 +10,34 @@
 # procedures so SQL inside an RDS-managed MySQL instance can invoke
 # fakecloud Lambda functions.
 
+# Rebuild gosu from source with current Go to eliminate upstream
+# mysql:8.0 image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
+FROM golang:1.25-bookworm AS gosu-builder
+ENV CGO_ENABLED=0
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+
 ARG MYSQL_VERSION=8.0
 FROM mysql:${MYSQL_VERSION}
 
 USER root
+
+COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
+RUN chmod 0755 /usr/local/bin/gosu
+
+# Strip the bundled `mysql-shell` (mysqlsh) tooling. We drive the
+# server over the wire from Rust (`mysql_async`); mysqlsh is never
+# invoked, but its vendored Python site-packages bring pyOpenSSL +
+# other libraries that Trivy flags as CVEs we cannot fix without
+# a coordinated upstream re-release.
+RUN set -eux; \
+    if command -v microdnf >/dev/null 2>&1; then \
+        microdnf remove -y mysql-shell || true; \
+        microdnf clean all; \
+    elif command -v apt-get >/dev/null 2>&1; then \
+        apt-get remove -y --purge mysql-shell || true; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi; \
+    rm -rf /usr/lib/mysqlsh /usr/bin/mysqlsh
 # UDF needs only gcc + libcurl headers; mysql plugin API structs are
 # vendored inline in fakecloud_udf.c (the upstream mysql:8.0 image
 # strips its community release repo so `mysql-community-devel` is not

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -10,13 +10,16 @@
 # procedures so SQL inside an RDS-managed MySQL instance can invoke
 # fakecloud Lambda functions.
 
+# MYSQL_VERSION must sit before the first FROM so its substitution is
+# available across all stages.
+ARG MYSQL_VERSION=8.0
+
 # Rebuild gosu from source with current Go to eliminate upstream
 # mysql:8.0 image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
 FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
 RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
 
-ARG MYSQL_VERSION=8.0
 FROM mysql:${MYSQL_VERSION}
 
 USER root

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -18,7 +18,7 @@ ARG MYSQL_VERSION=8.0
 # mysql:8.0 image's bundled go1.24.6 stdlib CVEs in /usr/local/bin/gosu.
 FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
-RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v0.0.0-20250923190938-6456aaa0f3c8
 
 FROM mysql:${MYSQL_VERSION}
 

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -4,6 +4,11 @@
 # (plus a rolling :<major> tag). RdsRuntime::ensure_postgres_image
 # tries to pull that tag first and falls back to building from this
 # Dockerfile locally when the pull fails (dev / unreleased / airgapped).
+# PG_VERSION must sit before the first FROM so its substitution is
+# available across all stages. Inside each stage it has to be
+# re-declared (Dockerfile spec) for `RUN`/`COPY` references to expand.
+ARG PG_VERSION=16
+
 # Rebuild `gosu` from source with current Go to eliminate the upstream
 # postgres image's bundled `/usr/local/bin/gosu` Go-stdlib CVEs (Trivy
 # flags 8 HIGH + 1 CRITICAL on go1.24.6 stdlib at scan time). gosu
@@ -13,7 +18,6 @@ FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
 RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
 
-ARG PG_VERSION=16
 FROM postgres:${PG_VERSION}
 ARG PG_VERSION
 

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -16,7 +16,7 @@ ARG PG_VERSION=16
 # on every image build means we control the stdlib version baked in.
 FROM golang:1.25-bookworm AS gosu-builder
 ENV CGO_ENABLED=0
-RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v0.0.0-20250923190938-6456aaa0f3c8
 
 FROM postgres:${PG_VERSION}
 ARG PG_VERSION

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -4,9 +4,21 @@
 # (plus a rolling :<major> tag). RdsRuntime::ensure_postgres_image
 # tries to pull that tag first and falls back to building from this
 # Dockerfile locally when the pull fails (dev / unreleased / airgapped).
+# Rebuild `gosu` from source with current Go to eliminate the upstream
+# postgres image's bundled `/usr/local/bin/gosu` Go-stdlib CVEs (Trivy
+# flags 8 HIGH + 1 CRITICAL on go1.24.6 stdlib at scan time). gosu
+# upstream is rarely re-released; pinning the source version + rebuilding
+# on every image build means we control the stdlib version baked in.
+FROM golang:1.25-bookworm AS gosu-builder
+ENV CGO_ENABLED=0
+RUN go install -ldflags='-s -w' github.com/tianon/gosu@v1.17
+
 ARG PG_VERSION=16
 FROM postgres:${PG_VERSION}
 ARG PG_VERSION
+
+COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
+RUN chmod 0755 /usr/local/bin/gosu
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Validation `workflow_dispatch` against the supply-chain pipeline (run 25058211125) confirmed builds + manifest merge + cosign signing all work end-to-end. Trivy scan caught two classes of upstream-base-image CVEs that would block any future `v*` tag publish:
  - `gosu` in postgres/mysql/mariadb statically linked against go1.24.6 stdlib (8 HIGH + 1 CRITICAL).
  - `mysqlsh`'s vendored Python in mysql:8.0 ships pyOpenSSL 25.3.0 (1 HIGH).
- Fix: add a tiny `golang:1.25-bookworm` builder stage that compiles `gosu@v1.17` fresh and copies it over the upstream binary; remove the unused `mysql-shell` package + `/usr/lib/mysqlsh` from the mysql image (we drive the server over the wire from `mysql_async`, mysqlsh is never invoked).

## Test plan
- [ ] CI green on PR (paths-filtered dry-run build for all 8 engine×version × 2 arch combos)
- [ ] Cubic clean
- [ ] After merge: re-run `workflow_dispatch` on `RDS support images`, confirm Trivy scan exits 0 and cosign signing still succeeds
- [ ] Then proceed to v0.13.2 release tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds `gosu` from source, removes `mysql-shell`, and fixes Dockerfile `ARG` scoping to clear Trivy CVEs in Postgres/MySQL/MariaDB images and unblock release builds.

- **Bug Fixes**
  - Rebuilt `gosu` in a `golang:1.25-bookworm` stage and overwrote `/usr/local/bin/gosu` in all engines; hoisted version `ARG`s above the first `FROM`; pinned `gosu` via a Go module pseudo-version for the 1.19 commit to avoid tag resolution issues.
  - Removed `mysql-shell` and `/usr/lib/mysqlsh` from the MySQL image to drop vulnerable pyOpenSSL; `mysqlsh` is not used by our runtime.

<sup>Written for commit 82de3fe6ac62b166c422d3c49171b891ee8b8aa3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/823?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

