### PR TITLE
fix(rds): apt-get upgrade base packages to clear stale CVE patches

### DIFF
--- a/crates/fakecloud-rds/assets/mariadb/Dockerfile
+++ b/crates/fakecloud-rds/assets/mariadb/Dockerfile
@@ -26,6 +26,7 @@ RUN chmod 0755 /usr/local/bin/gosu
 # symmetric with the mysql Dockerfile means a single source of truth
 # for the build rule.
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         gcc make libcurl4-openssl-dev libc6-dev ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/fakecloud-rds/assets/mysql/Dockerfile
+++ b/crates/fakecloud-rds/assets/mysql/Dockerfile
@@ -52,6 +52,7 @@ RUN set -eux; \
         microdnf clean all; \
     elif command -v apt-get >/dev/null 2>&1; then \
         apt-get update; \
+        apt-get upgrade -y --no-install-recommends; \
         apt-get install -y --no-install-recommends \
             gcc make libcurl4-openssl-dev libc6-dev ca-certificates; \
         rm -rf /var/lib/apt/lists/*; \

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -24,7 +24,13 @@ ARG PG_VERSION
 COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
 RUN chmod 0755 /usr/local/bin/gosu
 
+# `apt-get upgrade` pulls in patched OS packages (openssl, glibc, dirmngr…)
+# which sometimes lag behind on the upstream `postgres:<major>` tag —
+# Trivy flags those as HIGH/CRITICAL even when fixes are available in
+# the same Debian release. Running upgrade keeps the published image
+# clean against the latest debian13 security DB at build time.
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         postgresql-plpython3-${PG_VERSION} \
         ca-certificates \


### PR DESCRIPTION
## Summary
- Second supply-chain validation (run 25063842355) flagged 35 HIGH/CRITICAL CVEs against postgres:13 only — openssl 3.5.1, glibc 2.41-12, dirmngr 2.4.7-21+b3 — all with fixes already in Debian 13.
- The upstream `postgres:<major>` tag refresh cadence can lag the security DB by a cycle, so an in-build `apt-get upgrade` pulls the patched packages directly instead of waiting on Docker Inc to re-publish.
- Same change applied to mysql + mariadb Dockerfiles so a future drift on those base tags does not block the next release.

## Test plan
- [ ] PR CI green (paths-filtered dry-run build for all 8 engine×version × 2 arch combos)
- [ ] Cubic clean
- [ ] After merge: re-run `workflow_dispatch` on `RDS support images`, confirm all 8 scans exit 0
- [ ] Then proceed to v0.13.2 release tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `apt-get upgrade` in RDS base Dockerfiles to pull patched Debian packages and clear stale CVE findings. Fixes Trivy HIGH/CRITICAL issues on `postgres:13` and prevents future drift for `mysql` and `mariadb`.

- **Bug Fixes**
  - Added `apt-get upgrade -y --no-install-recommends` before installs in `postgres`, `mysql`, and `mariadb` Dockerfiles.
  - Addresses Trivy findings on `postgres:13` (`openssl 3.5.1`, `glibc 2.41-12`, `dirmngr 2.4.7-21+b3`) by pulling Debian 13 patched packages at build time.

<sup>Written for commit 2c78144302ec66a23df5852d7a25c0b88d3e89ad. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/824?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

