### PR TITLE
ci(e2e): run partition check parallel to test jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,7 @@ jobs:
 
   e2e:
     name: E2E ${{ matrix.name }}
-    needs: [changes, e2e-build, e2e-partition-check]
+    needs: [changes, e2e-build]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- `e2e-partition-check` takes ~10m and was gating every `e2e` matrix job via `needs:`
- It still runs as a top-level job and still fails the workflow on drift, so gating just adds wall time without adding safety
- Drop it from `e2e.needs:` so partition jobs start as soon as `e2e-build` finishes

## Test plan
- [ ] CI: `e2e-partition-check` and `e2e (*)` jobs start in parallel
- [ ] Workflow still fails red if partition coverage drift introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `e2e-partition-check` in parallel with the `e2e` matrix jobs by removing it from `e2e.needs`, so partitions start right after `e2e-build`. This reduces wall time without reducing safety, since the partition check still runs as a top-level job and fails the workflow on drift.

<sup>Written for commit ac09b0a13a1b64f5fa01c258fe45d79fe5e01cdc. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/825?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

