### PR TITLE
release(v0.13.2): supply-chain hardening for prebuilt RDS images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.13.1"
+version = "0.13.2"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -93,39 +93,39 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.1" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.1" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.1" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.1" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.1" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.1" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.1" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.1" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.1" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.1" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.1" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.1" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.1" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.1" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.1" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.1" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.1" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.1" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.1" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.1" }
-fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.1" }
-fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.1" }
-fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.1" }
-fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.1" }
-fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.1" }
-fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.1" }
-fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.1" }
-fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.1" }
-fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.1" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.1" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.1" }
-fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.1" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.1" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.1" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.1" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.1" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.2" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.2" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.2" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.2" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.2" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.2" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.2" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.2" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.2" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.2" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.2" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.2" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.2" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.2" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.2" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.2" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.2" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.2" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.2" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.2" }
+fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.2" }
+fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.2" }
+fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.2" }
+fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.2" }
+fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.2" }
+fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.2" }
+fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.2" }
+fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.2" }
+fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.2" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.2" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.2" }
+fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.2" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.2" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.2" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.2" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.2" }

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.13.1"
+version = "0.13.2"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.13.1"
+version = "0.13.2"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Workspace + SDK version bump 0.13.1 -> 0.13.2 (Cargo, npm, PyPI, Maven, Go via tag).
- Validates Trivy + cosign supply-chain pipeline shipped in #814: gosu rebuilt from source, mysqlsh stripped, `apt-get upgrade` baked in.
- Validation `workflow_dispatch` against main published 8 dev-tagged images (postgres 13/14/15/16, mysql 8.0, mariadb 10.6/10.11/11.4) × linux/amd64 + linux/arm64. Trivy: 0 CRITICAL/HIGH on all 8. `cosign verify` against GitHub OIDC issuer succeeds.
- Bundles the v0.13.2 train: aws_s3 PG extension, async CreateDBInstance, MySQL/MariaDB Aurora lambda bridge + prebuilt mysql/mariadb images on ghcr.io, mariadb 11.4 wired through engine validator.

## Test plan
- [ ] CI green on PR
- [ ] Cubic clean
- [ ] After merge: tag v0.13.2 against the merge commit; release workflow publishes to crates.io / npm / PyPI / Maven / ghcr / GitHub Releases
- [ ] First post-tag `RDS support images` run on `v0.13.2` ref publishes pinned `<engine>:<major>-0.13.2` tags + rolling `<major>` tags + cosign signs each; Trivy gates on CRITICAL/HIGH

## Note on current main CI state
- `E2E general-1` red on a pre-existing regression: `ecs_task_resolves_secretsmanager_secret` returns empty captured logs (not introduced by this bump; passes locally). To be tracked in a follow-up.
- Conformance went red on a runner disk-full flake on the latest main commit (rerun-able).
- Release workflow (`release.yml`) excludes E2E + conformance + tfacc + parity, so the publish path is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.13.2 hardens prebuilt Postgres/MySQL/MariaDB RDS images with Trivy scans and `cosign` signing, and bumps workspace/SDK versions. It also adds faster async DB instance creation and new engine/extension support.

- **New Features**
  - Supply-chain hardened prebuilt images: rebuilt `gosu`, removed `mysqlsh`, and baked in `apt-get upgrade`. Trivy finds 0 CRITICAL/HIGH; `cosign` verify passes. Validated on Postgres 13–16, MySQL 8.0, and MariaDB 10.6/10.11/11.4 for linux/amd64 and linux/arm64.
  - `CreateDBInstance` is now async for faster returns.
  - Added Postgres `aws_s3` extension; added MySQL/MariaDB Aurora lambda bridge; wired in MariaDB 11.4.

- **Dependencies**
  - Bumped all workspace and SDK versions to `0.13.2` (`Cargo`, `npm`, `PyPI`, Maven).
  - Updated GitHub `trivy-action` to `v0.36.0`.

<sup>Written for commit 5956a1587b9f3ff45f84061b0a7b1a5461599992. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/826?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

