### PR TITLE
ci: add nextest retries + disk diagnostics

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,4 @@ fail-fast = false
 failure-output = "immediate-final"
 status-level = "fail"
 final-status-level = "slow"
+retries = 2

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,16 +44,34 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@b3bd89dcd46d5f3d508436e1bf794284c155bbcc # nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Disk diagnostics before build
+        run: df -h
 
       - name: Build server
         run: cargo build --bin fakecloud
 
       - name: Run conformance integration tests
         run: cargo nextest run -P ci -p fakecloud-conformance --tests
+
+      - name: Disk diagnostics after tests
+        if: always()
+        run: df -h
 
       - name: Build conformance tool
         run: cargo build -p fakecloud-conformance

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,6 +143,15 @@ jobs:
       - name: Mark fakecloud binary executable
         run: chmod +x target/debug/fakecloud
 
+      - name: Disk diagnostics before nextest
+        run: |
+          echo "=== df -h ==="
+          df -h
+          echo "=== target dir ==="
+          du -sh target 2>/dev/null || true
+          echo "=== ~/.cargo ==="
+          du -sh ~/.cargo 2>/dev/null || true
+
       - name: Run nextest partition
         run: |
           cmd=(cargo nextest run -P ci -p fakecloud-e2e -E "$NEXTEST_FILTER")
@@ -150,6 +159,14 @@ jobs:
             cmd+=(--partition "$NEXTEST_PARTITION")
           fi
           "${cmd[@]}"
+
+      - name: Disk diagnostics after nextest
+        if: always()
+        run: |
+          echo "=== df -h ==="
+          df -h
+          echo "=== target dir ==="
+          du -sh target 2>/dev/null || true
 
       - name: Prune container state after tests
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -167,6 +167,8 @@ jobs:
           df -h
           echo "=== target dir ==="
           du -sh target 2>/dev/null || true
+          echo "=== ~/.cargo ==="
+          du -sh ~/.cargo 2>/dev/null || true
 
       - name: Prune container state after tests
         if: always()

--- a/.github/workflows/tfacc.yml
+++ b/.github/workflows/tfacc.yml
@@ -76,6 +76,17 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.tfacc-matrix.outputs.shards) }}
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -110,8 +121,15 @@ jobs:
       - name: Mark fakecloud binary executable
         run: chmod +x target/debug/fakecloud
 
+      - name: Disk diagnostics before tests
+        run: df -h
+
       - name: Run ${{ matrix.name }} acceptance tests
         run: cargo test -p fakecloud-tfacc --test acc ${{ matrix.test_fn }} -- --nocapture
+
+      - name: Disk diagnostics after tests
+        if: always()
+        run: df -h
 
       - name: Upload failing go test output
         if: failure()


### PR DESCRIPTION
## Summary

Stabilize CI runner flakes (1/3) — auto-retry transient failures and surface disk-full reasons.

- Add `retries = 2` to the workspace `[profile.ci]` nextest config so transient infra hiccups (slow docker pulls, fleeting network) auto-retry inside the same job. Avoids forcing a full workflow rerun for a single flaky test. Both fakecloud-e2e and fakecloud-conformance inherit this from `.config/nextest.toml` at the workspace root.
- Emit `df -h`, `du -sh target`, and `du -sh ~/.cargo` before and after \`cargo nextest run\` in every E2E partition job, so when a runner does fill up, the job log shows where the space went instead of leaving the failure visible only in the runner \`_diag\` log.
- Add the same \`Free disk space\` (jlumbroso) step to \`conformance.yml\` that \`e2e.yml\` already uses, plus pre/post \`df -h\`. Conformance currently has no disk reclamation and is hitting the same disk-full pattern as E2E lambda-runtime jobs.

Part of an autonomous flake-stabilization sweep. Sibling PRs follow for linker OOM (test-profile debuginfo) and ECS task failure diagnostics.

## Test plan

- [ ] CI runs green first try on this PR
- [ ] Disk diagnostics output is visible in the E2E + conformance job logs
- [ ] No \`continue-on-error: true\` introduced anywhere

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CI by enabling `nextest` retries and adding disk diagnostics to E2E, conformance, and `tfacc` workflows. Reduces flaky reruns and surfaces disk-full issues in job logs.

- **New Features**
  - Set `retries = 2` in `[profile.ci]` `nextest` at the workspace root; inherited by `fakecloud-e2e` and `fakecloud-conformance`.
  - Emit `df -h`, `du -sh target`, and `du -sh ~/.cargo` before and after `cargo nextest run` in E2E partitions.
  - Add `Free disk space` step (`jlumbroso/free-disk-space`) and pre/post `df -h` to `conformance.yml` and `tfacc.yml`.

<sup>Written for commit a0ca11ef943c8554413e800f0141b936d065af57. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/827?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

