### PR TITLE
ci: strip full debuginfo from test profile to fix linker OOM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,3 +129,8 @@ fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.
 fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.2" }
 fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.2" }
 fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.2" }
+
+# Drop full DWARF on test binaries to keep `ld` under the GitHub runner's
+# ~7 GB RAM budget. Backtraces still show file:line.
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
## Summary

Stabilize CI runner flakes (2/3) — fix `cargo nextest run` linker OOM.

Default `[profile.test]` emits full DWARF, which on the workspace's E2E test binaries spiked `ld` past the default GitHub runner's ~7 GB free RAM and killed it with \`collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped\`. Pattern hit E2E lambda-runtime + lambda-container-clis partitions repeatedly across PRs #823, #824, #826.

Fix: set \`[profile.test] debug = \"line-tables-only\"\` in the workspace \`Cargo.toml\`. line-tables-only keeps file:line in backtraces (so panics still point at source lines) but drops per-symbol type and variable DWARF, which is what blows up linker memory. No effect on \`dev\`/\`release\`.

Verified locally: \`cargo check --workspace --tests\` succeeds.

Sibling PRs: #827 (nextest retries + disk diagnostics) and a follow-up for ECS task failure diagnostics.

## Test plan

- [ ] CI runs green first try on this PR
- [ ] No new linker OOM in any partition
- [ ] If a test panics, the failure message still includes file:line (verify post-merge by inspecting any next failed E2E run)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI linker OOM by setting `[profile.test] debug = "line-tables-only"` in the workspace `Cargo.toml`. Backtraces still show file:line, `cargo nextest run` no longer exhausts RAM on the default GitHub runner, and `dev`/`release` are unchanged.

<sup>Written for commit df66de629a77a36cf5ffb2e141172058a807eb47. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/828?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

