### PR TITLE
refactor(core): extract optional/required_param helpers taking HashMap

### DIFF
--- a/crates/fakecloud-core/src/query.rs
+++ b/crates/fakecloud-core/src/query.rs
@@ -1,5 +1,7 @@
 //! Shared helpers for AWS Query protocol services (SQS, SNS, ElastiCache, RDS, SES v1, IAM).
 
+use std::collections::HashMap;
+
 use http::StatusCode;
 
 use crate::service::{AwsRequest, AwsServiceError};
@@ -34,27 +36,40 @@ pub fn query_metadata_only_xml(action: &str, namespace: &str, request_id: &str) 
     )
 }
 
-/// Extract an optional query parameter from an `AwsRequest`.
+/// Extract an optional parameter from a query parameter map.
 ///
 /// Returns `None` if the parameter is missing or empty.
-pub fn optional_query_param(req: &AwsRequest, name: &str) -> Option<String> {
-    req.query_params
+pub fn optional_param(params: &HashMap<String, String>, name: &str) -> Option<String> {
+    params
         .get(name)
         .cloned()
         .filter(|value| !value.is_empty())
 }
 
-/// Extract a required query parameter from an `AwsRequest`.
+/// Extract a required parameter from a query parameter map.
 ///
 /// Returns `MissingParameter` error if the parameter is missing or empty.
-pub fn required_query_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
-    optional_query_param(req, name).ok_or_else(|| {
+pub fn required_param(
+    params: &HashMap<String, String>,
+    name: &str,
+) -> Result<String, AwsServiceError> {
+    optional_param(params, name).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "MissingParameter",
             format!("The request must contain the parameter {name}."),
         )
     })
+}
+
+/// Extract an optional query parameter from an `AwsRequest`.
+pub fn optional_query_param(req: &AwsRequest, name: &str) -> Option<String> {
+    optional_param(&req.query_params, name)
+}
+
+/// Extract a required query parameter from an `AwsRequest`.
+pub fn required_query_param(req: &AwsRequest, name: &str) -> Result<String, AwsServiceError> {
+    required_param(&req.query_params, name)
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-core/src/query.rs
+++ b/crates/fakecloud-core/src/query.rs
@@ -40,10 +40,7 @@ pub fn query_metadata_only_xml(action: &str, namespace: &str, request_id: &str) 
 ///
 /// Returns `None` if the parameter is missing or empty.
 pub fn optional_param(params: &HashMap<String, String>, name: &str) -> Option<String> {
-    params
-        .get(name)
-        .cloned()
-        .filter(|value| !value.is_empty())
+    params.get(name).cloned().filter(|value| !value.is_empty())
 }
 
 /// Extract a required parameter from a query parameter map.

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -1142,13 +1142,7 @@ fn required_param(
     params: &std::collections::HashMap<String, String>,
     name: &str,
 ) -> Result<String, AwsServiceError> {
-    params.get(name).cloned().ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "MissingParameter",
-            format!("The request must contain the parameter {name}"),
-        )
-    })
+    fakecloud_core::query::required_param(params, name)
 }
 
 /// Resolve the calling user when UserName is not provided.


### PR DESCRIPTION
## Summary
- Add \`fakecloud_core::query::optional_param\` / \`required_param\` accepting \`&HashMap<String, String>\` directly.
- Existing \`optional_query_param\` / \`required_query_param\` (taking \`&AwsRequest\`) now delegate to the new helpers.
- IAM's bespoke \`required_param\` (with the same MissingParameter error code) now delegates to core. ~150 call sites untouched.
- ElastiCache and RDS already wrap the request-shaped helpers; SES v1 keeps its borrowed-&str variant intentionally to avoid clones across 50+ call sites.

Closes the optional/required_param adoption gap from [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §2 HIGH.

## Test plan
- [x] \`cargo build -p fakecloud-core -p fakecloud-iam -p fakecloud-elasticache -p fakecloud-rds\`
- [x] \`cargo clippy -p fakecloud-core -p fakecloud-iam --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-core --lib\` (178 pass)
- [x] \`cargo test -p fakecloud-iam --lib\` (378 pass — covers all 6 IAM submodules using the helper)
- [ ] Full CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized query parameter extraction by adding map-based helpers in `fakecloud-core` and routing IAM to use them. This removes a bespoke IAM helper and keeps behavior unchanged.

- **Refactors**
  - Added `fakecloud_core::query::{optional_param, required_param}` for `&HashMap<String, String>`; formatted `query.rs` (no behavior change).
  - Updated `optional_query_param` and `required_query_param` to delegate to the new helpers.
  - Switched IAM’s local `required_param` to call `fakecloud_core::query::required_param` (same `MissingParameter` behavior).
  - No changes to ElastiCache/RDS call sites; SES v1 keeps its borrowed-`&str` helper to avoid clones.

<sup>Written for commit 2ee4ddab6435e42e7554cfed3e37eda1a15ff069. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/831?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

