### PR TITLE
refactor(bedrock): centralize JSON response builder + drop infallible unwraps

### DIFF
--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -69,9 +69,9 @@ pub fn start_async_invoke(
     s.async_invocations
         .insert(invocation_arn.clone(), invocation);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::OK,
-        serde_json::to_string(&json!({ "invocationArn": invocation_arn })).unwrap(),
+        json!({ "invocationArn": invocation_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -46,9 +46,9 @@ pub fn create_automated_reasoning_policy(
     s.automated_reasoning_policies
         .insert(policy_arn.clone(), policy);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "policyArn": policy_arn })).unwrap(),
+        json!({ "policyArn": policy_arn }),
     ))
 }
 
@@ -220,13 +220,12 @@ pub fn create_automated_reasoning_policy_version(
     policy.versions.push(version_str.clone());
     policy.updated_at = Utc::now();
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({
+        json!({
             "policyArn": policy.policy_arn,
             "version": version_str,
-        }))
-        .unwrap(),
+        }),
     ))
 }
 
@@ -308,9 +307,9 @@ pub fn create_automated_reasoning_policy_test_case(
     s.automated_reasoning_test_cases
         .insert((policy_arn, test_case_id.clone()), tc);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "testCaseId": test_case_id })).unwrap(),
+        json!({ "testCaseId": test_case_id }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -69,9 +69,9 @@ pub fn start_build_workflow(
     s.ar_build_workflows
         .insert((policy_arn, workflow_id.clone()), workflow);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "buildWorkflowId": workflow_id })).unwrap(),
+        json!({ "buildWorkflowId": workflow_id }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -40,9 +40,9 @@ pub fn create_custom_model_deployment(
     s.custom_model_deployments
         .insert(deployment_arn.clone(), deployment);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "customModelDeploymentArn": deployment_arn })).unwrap(),
+        json!({ "customModelDeploymentArn": deployment_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/custom_models.rs
+++ b/crates/fakecloud-bedrock/src/custom_models.rs
@@ -35,9 +35,9 @@ pub fn create_custom_model(
     let s = accts.get_or_create(&req.account_id);
     s.custom_models.insert(model_arn.clone(), model);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "modelArn": model_arn })).unwrap(),
+        json!({ "modelArn": model_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -67,9 +67,9 @@ pub fn create_model_customization_job(
     let s = accts.get_or_create(&req.account_id);
     s.customization_jobs.insert(job_arn.clone(), job);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+        json!({ "jobArn": job_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -44,9 +44,9 @@ pub fn create_evaluation_job(
     let s = accts.get_or_create(&req.account_id);
     s.evaluation_jobs.insert(job_arn.clone(), job);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+        json!({ "jobArn": job_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -58,15 +58,14 @@ pub fn create_guardrail(
     let s = accts.get_or_create(&req.account_id);
     s.guardrails.insert(guardrail_id.clone(), guardrail);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({
+        json!({
             "guardrailId": guardrail_id,
             "guardrailArn": guardrail_arn,
             "version": "DRAFT",
             "createdAt": now.to_rfc3339(),
-        }))
-        .unwrap(),
+        }),
     ))
 }
 
@@ -283,13 +282,12 @@ pub fn create_guardrail_version(
     let key = (guardrail_id.to_string(), version_str.clone());
     s.guardrail_versions.insert(key, version);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({
+        json!({
             "guardrailId": guardrail_id,
             "version": version_str,
-        }))
-        .unwrap(),
+        }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -55,9 +55,9 @@ pub fn create_inference_profile(
 
     s.inference_profiles.insert(profile_arn.clone(), profile);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "inferenceProfileArn": profile_arn })).unwrap(),
+        json!({ "inferenceProfileArn": profile_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -40,9 +40,9 @@ pub fn create_model_invocation_job(
     let s = accts.get_or_create(&req.account_id);
     s.model_invocation_jobs.insert(job_arn.clone(), job);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+        json!({ "jobArn": job_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -48,11 +48,17 @@ pub fn invoke_model(
     }
 
     let mut headers = http::HeaderMap::new();
-    headers.insert("x-amzn-bedrock-input-token-count", "10".parse().unwrap());
-    headers.insert("x-amzn-bedrock-output-token-count", "20".parse().unwrap());
+    headers.insert(
+        "x-amzn-bedrock-input-token-count",
+        http::HeaderValue::from_static("10"),
+    );
+    headers.insert(
+        "x-amzn-bedrock-output-token-count",
+        http::HeaderValue::from_static("20"),
+    );
     headers.insert(
         "x-amzn-bedrock-performanceconfig-latency",
-        "standard".parse().unwrap(),
+        http::HeaderValue::from_static("standard"),
     );
 
     Ok(AwsResponse {
@@ -177,7 +183,7 @@ fn anthropic_response(model_id: &str, _input: &Value) -> String {
             "output_tokens": 20
         }
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
@@ -188,7 +194,7 @@ fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
             "embedding": embedding,
             "inputTextTokenCount": 10
         }))
-        .unwrap();
+        .expect("serde_json::Value serialization is infallible");
     }
 
     serde_json::to_string(&json!({
@@ -201,7 +207,7 @@ fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
             }
         ]
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 fn meta_llama_response(_input: &Value) -> String {
@@ -213,7 +219,7 @@ fn meta_llama_response(_input: &Value) -> String {
         "generation_token_count": 20,
         "prompt_token_count": 10
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 fn cohere_response(_input: &Value) -> String {
@@ -228,7 +234,7 @@ fn cohere_response(_input: &Value) -> String {
         ],
         "prompt": ""
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 fn mistral_response(_input: &Value) -> String {
@@ -240,14 +246,14 @@ fn mistral_response(_input: &Value) -> String {
             }
         ]
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 fn generic_response(_input: &Value) -> String {
     serde_json::to_string(&json!({
         "output": "This is a test response from the emulated model."
     }))
-    .unwrap()
+    .expect("serde_json::Value serialization is infallible")
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -50,9 +50,9 @@ pub fn create_marketplace_model_endpoint(
     s.marketplace_endpoints
         .insert(endpoint_arn.clone(), endpoint);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "marketplaceModelEndpointArn": endpoint_arn })).unwrap(),
+        json!({ "marketplaceModelEndpointArn": endpoint_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/model_copy.rs
+++ b/crates/fakecloud-bedrock/src/model_copy.rs
@@ -38,9 +38,9 @@ pub fn create_model_copy_job(
     let s = accts.get_or_create(&req.account_id);
     s.model_copy_jobs.insert(job_arn.clone(), job);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+        json!({ "jobArn": job_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -55,9 +55,9 @@ pub fn create_model_import_job(
     s.imported_models
         .insert(imported_model_arn.clone(), imported_model);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "jobArn": job_arn })).unwrap(),
+        json!({ "jobArn": job_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -39,9 +39,9 @@ pub fn create_prompt_router(
     let s = accts.get_or_create(&req.account_id);
     s.prompt_routers.insert(router_arn.clone(), router);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({ "promptRouterArn": router_arn })).unwrap(),
+        json!({ "promptRouterArn": router_arn }),
     ))
 }
 

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -77,12 +77,11 @@ pub fn create_provisioned_model_throughput(
     s.provisioned_throughputs
         .insert(provisioned_model_id, throughput);
 
-    Ok(AwsResponse::json(
+    Ok(AwsResponse::json_value(
         StatusCode::CREATED,
-        serde_json::to_string(&json!({
+        json!({
             "provisionedModelArn": provisioned_model_arn,
-        }))
-        .unwrap(),
+        }),
     ))
 }
 

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -380,9 +380,21 @@ impl AwsResponse {
         }
     }
 
+    /// Build a JSON response from a `serde_json::Value` with an explicit status.
+    ///
+    /// Serialization of an in-memory `Value` cannot fail — it has no cycles and
+    /// no custom serializers — so the inner `to_vec` is documented as infallible
+    /// rather than left as a bare `unwrap()`.
+    pub fn json_value(status: StatusCode, value: serde_json::Value) -> Self {
+        Self::json(
+            status,
+            serde_json::to_vec(&value).expect("serde_json::Value serialization is infallible"),
+        )
+    }
+
     /// Convenience constructor for a 200 OK JSON response from a `serde_json::Value`.
     pub fn ok_json(value: serde_json::Value) -> Self {
-        Self::json(StatusCode::OK, serde_json::to_vec(&value).unwrap())
+        Self::json_value(StatusCode::OK, value)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add \`AwsResponse::json_value(status, Value)\` to fakecloud-core; reworks the existing \`ok_json\` constructor to delegate. Documents in one place that serializing an in-memory \`Value\` is infallible.
- Migrate 17 Bedrock response-builder sites that previously wrote \`AwsResponse::json(STATUS, serde_json::to_string(&json!(...)).unwrap())\` to the new helper.
- Convert the 7 model-emulator string builders in \`invoke.rs\` (which return \`String\`, not \`AwsResponse\`) from \`.unwrap()\` to \`.expect("serde_json::Value serialization is infallible")\` so the panic-by-construction is documented.
- Replace 3 static-string \`.parse().unwrap()\` HeaderValue calls in invoke.rs with \`HeaderValue::from_static\`.

Closes [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §5 CRITICAL ("Bedrock-wide pattern: \`serde_json::to_string(&json!(...)).unwrap()\`") and §2 MEDIUM (Bedrock invoke header parses).

## Test plan
- [x] \`cargo build -p fakecloud-bedrock -p fakecloud-core\`
- [x] \`cargo clippy -p fakecloud-bedrock -p fakecloud-core --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-bedrock -p fakecloud-core --lib\` — 178 core, all bedrock unit tests pass
- [ ] Full CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Bedrock JSON response construction via `AwsResponse::json_value(status, Value)` and removes infallible `unwrap()`s. This reduces duplication and makes panic-by-construction explicit.

- **Refactors**
  - Added `AwsResponse::json_value` to `fakecloud-core`; `ok_json` now delegates to it.
  - Migrated 17 `fakecloud-bedrock` call sites from `AwsResponse::json(..., serde_json::to_string(...).unwrap())` to `json_value(...)`.
  - Cleaned up `invoke.rs`: replace `.unwrap()` on `serde_json::to_string` with `.expect("serde_json::Value serialization is infallible")` and use `HeaderValue::from_static` for static headers.
  - Addresses audit report 2026-04-28 §5 (JSON unwraps) and §2 (header parses).

<sup>Written for commit 641b943526b7121c8b037e4451b12e391069fbda. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/832?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

