### PR TITLE
refactor(stepfunctions): replace unwrap_or_default with expect on infallible Value serialization

### DIFF
--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -49,7 +49,7 @@ pub async fn execute_state_machine(
         "ExecutionStarted",
         0,
         json!({
-            "input": serde_json::to_string(&raw_input).unwrap_or_default(),
+            "input": serde_json::to_string(&raw_input).expect("serde_json::Value serialization is infallible"),
             "roleArn": "arn:aws:iam::123456789012:role/execution-role"
         }),
     );
@@ -308,7 +308,7 @@ fn run_pass_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -321,7 +321,7 @@ fn run_pass_state(
         entered_event_id,
         json!({
             "name": name,
-            "output": serde_json::to_string(&result).unwrap_or_default(),
+            "output": serde_json::to_string(&result).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -342,7 +342,7 @@ fn run_succeed_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -368,7 +368,7 @@ fn run_succeed_state(
         0,
         json!({
             "name": name,
-            "output": serde_json::to_string(&output).unwrap_or_default(),
+            "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -395,7 +395,7 @@ fn run_fail_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -416,7 +416,7 @@ fn run_choice_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -436,7 +436,7 @@ fn run_choice_state(
                 entered_event_id,
                 json!({
                     "name": name,
-                    "output": serde_json::to_string(&input).unwrap_or_default(),
+                    "output": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
                 }),
             );
             Advance::Next(next, input)
@@ -462,7 +462,7 @@ async fn run_wait_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -475,7 +475,7 @@ async fn run_wait_state(
         entered_event_id,
         json!({
             "name": name,
-            "output": serde_json::to_string(&input).unwrap_or_default(),
+            "output": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -499,7 +499,7 @@ async fn run_task_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -523,7 +523,7 @@ async fn run_task_state(
                 entered_event_id,
                 json!({
                     "name": name,
-                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                    "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
                 }),
             );
             advance_from_next(state_def, output)
@@ -549,7 +549,7 @@ async fn run_parallel_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -572,7 +572,7 @@ async fn run_parallel_state(
                 entered_event_id,
                 json!({
                     "name": name,
-                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                    "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
                 }),
             );
             advance_from_next(state_def, output)
@@ -598,7 +598,7 @@ async fn run_map_state(
         0,
         json!({
             "name": name,
-            "input": serde_json::to_string(&input).unwrap_or_default(),
+            "input": serde_json::to_string(&input).expect("serde_json::Value serialization is infallible"),
         }),
     );
 
@@ -621,7 +621,7 @@ async fn run_map_state(
                 entered_event_id,
                 json!({
                     "name": name,
-                    "output": serde_json::to_string(&output).unwrap_or_default(),
+                    "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
                 }),
             );
             advance_from_next(state_def, output)
@@ -751,7 +751,7 @@ async fn execute_task_state(
             json!({
                 "resource": resource,
                 "region": "us-east-1",
-                "parameters": serde_json::to_string(&task_input).unwrap_or_default(),
+                "parameters": serde_json::to_string(&task_input).expect("serde_json::Value serialization is infallible"),
             }),
         );
 
@@ -783,7 +783,7 @@ async fn execute_task_state(
                     entered_event_id,
                     json!({
                         "resource": resource,
-                        "output": serde_json::to_string(&result).unwrap_or_default(),
+                        "output": serde_json::to_string(&result).expect("serde_json::Value serialization is infallible"),
                     }),
                 );
 
@@ -1155,7 +1155,8 @@ fn invoke_sqs_send_message(
         .map(|s| s.to_string())
         .unwrap_or_else(|| {
             // If MessageBody is not a string, serialize the value
-            serde_json::to_string(&input["MessageBody"]).unwrap_or_default()
+            serde_json::to_string(&input["MessageBody"])
+                .expect("serde_json::Value serialization is infallible")
         });
 
     // Convert QueueUrl to ARN format for the delivery bus
@@ -1193,7 +1194,10 @@ fn invoke_sns_publish(
     let message = input["Message"]
         .as_str()
         .map(|s| s.to_string())
-        .unwrap_or_else(|| serde_json::to_string(&input["Message"]).unwrap_or_default());
+        .unwrap_or_else(|| {
+            serde_json::to_string(&input["Message"])
+                .expect("serde_json::Value serialization is infallible")
+        });
 
     let subject = input["Subject"].as_str();
 
@@ -1233,7 +1237,10 @@ fn invoke_eventbridge_put_events(
         let detail = entry["Detail"]
             .as_str()
             .map(|s| s.to_string())
-            .unwrap_or_else(|| serde_json::to_string(&entry["Detail"]).unwrap_or("{}".to_string()));
+            .unwrap_or_else(|| {
+                serde_json::to_string(&entry["Detail"])
+                    .expect("serde_json::Value serialization is infallible")
+            });
         let bus_name = entry["EventBusName"].as_str().unwrap_or("default");
 
         delivery.put_event_to_eventbridge(source, detail_type, &detail, bus_name);
@@ -1803,7 +1810,8 @@ async fn invoke_lambda_direct(
         )
     })?;
 
-    let payload = serde_json::to_string(input).unwrap_or_default();
+    let payload =
+        serde_json::to_string(input).expect("serde_json::Value serialization is infallible");
 
     let invoke_future = delivery.invoke_lambda(function_arn, &payload);
 
@@ -1871,7 +1879,8 @@ async fn invoke_activity(
         uuid::Uuid::new_v4().simple(),
     );
     let now = chrono::Utc::now();
-    let input_str = serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
+    let input_str =
+        serde_json::to_string(input).expect("serde_json::Value serialization is infallible");
     {
         let mut accounts = shared_state.write();
         let state = accounts.get_or_create(&activity_account);
@@ -2066,7 +2075,8 @@ fn succeed_execution(state: &SharedStepFunctionsState, execution_arn: &str, outp
         }
     }
 
-    let output_str = serde_json::to_string(output).unwrap_or_default();
+    let output_str =
+        serde_json::to_string(output).expect("serde_json::Value serialization is infallible");
 
     add_event(
         state,


### PR DESCRIPTION
## Summary
- Replace 22 \`serde_json::to_string(&value).unwrap_or_default()\` calls in \`crates/fakecloud-stepfunctions/src/interpreter.rs\` with \`.expect("serde_json::Value serialization is infallible")\`.
- Same fix for two \`unwrap_or_else(|_| "{}".to_string())\` and \`unwrap_or("{}".to_string())\` fallbacks at lines 1236 (EventBridge entry serialization) and 1874 (activity input serialization).
- Behavior unchanged: \`serde_json::Value\` cannot fail to serialize, so the default branches were unreachable. The audit's concern was that the empty-string fallback could silently corrupt execution history — that's now expressed as a documented invariant rather than a hidden one.

Closes [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §5 HIGH ("Step Functions interpreter: \`unwrap_or_default()\` masks errors").

## Test plan
- [x] \`cargo build -p fakecloud-stepfunctions\`
- [x] \`cargo clippy -p fakecloud-stepfunctions --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-stepfunctions --lib\` — 137 unit tests pass
- [ ] Full CI green (E2E and conformance suites for Step Functions cover real execution paths)
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fallbacks during `serde_json::Value` serialization in the Step Functions interpreter with `.expect(...)` to make the invariant explicit and remove unreachable defaults. No behavior changes; eliminates silent empty-string/{} fallbacks in logs and addresses the audit concern.

- **Refactors**
  - Replaced 22 `serde_json::to_string(&value).unwrap_or_default()` calls with `.expect("serde_json::Value serialization is infallible")` in `crates/fakecloud-stepfunctions/src/interpreter.rs`.
  - Replaced two `"{}"` fallbacks in EventBridge entry and activity input serialization with `.expect(...)`.
  - Clarifies invariants and surfaces unexpected failures instead of masking them.

<sup>Written for commit fb0703d912d4f3bfeb8e8adb60d8820f1f2dfadc. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/833?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

