### PR TITLE
refactor(e2e): replace fixed-sleep SES->SQS waits with polling helper

### DIFF
--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -11,6 +11,38 @@ use std::path::PathBuf;
 
 pub use fakecloud_testkit::{data_path_for, run_until_exit, CliOutput, TestServer};
 
+/// Poll SQS ReceiveMessage until at least `n` messages have been collected
+/// across one or more calls, or the deadline elapses. Returns whatever was
+/// gathered so the caller's assertion can produce a useful failure message.
+///
+/// Useful when an upstream system (SES → SNS → SQS, EventBridge → SQS, etc.)
+/// publishes asynchronously and a fixed sleep would either be too short under
+/// CI load or wastefully long under local development.
+pub async fn sqs_receive_at_least(
+    sqs: &aws_sdk_sqs::Client,
+    queue_url: &str,
+    n: usize,
+    deadline: std::time::Duration,
+) -> Vec<aws_sdk_sqs::types::Message> {
+    let until = std::time::Instant::now() + deadline;
+    let mut all: Vec<aws_sdk_sqs::types::Message> = Vec::new();
+    while std::time::Instant::now() < until {
+        let resp = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(10)
+            .send()
+            .await
+            .unwrap();
+        all.extend(resp.messages().to_vec());
+        if all.len() >= n {
+            return all;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    all
+}
+
 /// Decompress gzipped data.
 pub fn gunzip(data: &[u8]) -> Vec<u8> {
     use std::io::Read;

--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -2366,27 +2366,18 @@ async fn ses_event_fanout_sns_destination() {
         .unwrap();
 
     // 5. Receive messages from SQS — should have at least 2 (Send + Delivery)
-    // Give a tiny delay for delivery
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let msgs =
+        helpers::sqs_receive_at_least(&sqs, &queue_url, 2, std::time::Duration::from_secs(3)).await;
 
-    let msgs = sqs
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(10)
-        .send()
-        .await
-        .unwrap();
-
-    // We expect 2 messages: one for Send, one for Delivery
     assert!(
-        msgs.messages().len() >= 2,
+        msgs.len() >= 2,
         "Expected at least 2 SNS notifications (Send + Delivery), got {}",
-        msgs.messages().len()
+        msgs.len()
     );
 
     // Parse SNS envelopes and check the event payloads
     let mut event_types: Vec<String> = Vec::new();
-    for msg in msgs.messages() {
+    for msg in &msgs {
         let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
         let inner: serde_json::Value =
             serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
@@ -2507,25 +2498,17 @@ async fn ses_event_fanout_bounce_simulator() {
         .await
         .unwrap();
 
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let msgs =
+        helpers::sqs_receive_at_least(&sqs, &queue_url, 2, std::time::Duration::from_secs(3)).await;
 
-    let msgs = sqs
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(10)
-        .send()
-        .await
-        .unwrap();
-
-    // Should have Send + Bounce events
     assert!(
-        msgs.messages().len() >= 2,
+        msgs.len() >= 2,
         "Expected at least 2 messages (Send + Bounce), got {}",
-        msgs.messages().len()
+        msgs.len()
     );
 
     let mut event_types: Vec<String> = Vec::new();
-    for msg in msgs.messages() {
+    for msg in &msgs {
         let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
         let inner: serde_json::Value =
             serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
@@ -2535,7 +2518,7 @@ async fn ses_event_fanout_bounce_simulator() {
     assert!(event_types.contains(&"Send".to_string()));
 
     // Verify the bounce event has correct structure
-    for msg in msgs.messages() {
+    for msg in &msgs {
         let envelope: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
         let inner: serde_json::Value =
             serde_json::from_str(envelope["Message"].as_str().unwrap()).unwrap();
@@ -2720,25 +2703,18 @@ async fn ses_event_fanout_eventbridge_destination() {
         .await
         .unwrap();
 
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
     // Check SQS for EventBridge-delivered events
-    let msgs = sqs
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(10)
-        .send()
-        .await
-        .unwrap();
+    let msgs =
+        helpers::sqs_receive_at_least(&sqs, &queue_url, 2, std::time::Duration::from_secs(3)).await;
 
     assert!(
-        msgs.messages().len() >= 2,
+        msgs.len() >= 2,
         "Expected at least 2 EventBridge->SQS messages, got {}",
-        msgs.messages().len()
+        msgs.len()
     );
 
     // Verify the event structure
-    for msg in msgs.messages() {
+    for msg in &msgs {
         let event: serde_json::Value = serde_json::from_str(msg.body().unwrap()).unwrap();
         assert_eq!(event["source"], "aws.ses");
         assert_eq!(event["detail-type"], "SES Email Sending");


### PR DESCRIPTION
## Summary
- Add \`helpers::sqs_receive_at_least(client, queue_url, n, deadline)\` to the e2e test helpers — polls SQS receive_message in a loop, accumulates messages across calls, returns whatever was collected when the deadline elapses.
- Replace 3 fixed \`tokio::time::sleep(Duration::from_millis(100))\` waits in \`crates/fakecloud-e2e/tests/ses.rs\` (Send/Delivery, Send/Bounce, and EventBridge fanout) with a 3-second polled wait.
- Real AWS typically delivers SES→SNS→SQS in well under a second; the longer ceiling absorbs slow CI without slowing the local case.

Other sleeps in the [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §6 HIGH list either live inside existing polling loops (\`conformance/rds.rs:588\`, \`e2e/cloudformation.rs:550\`, \`conformance/stepfunctions.rs:253\`) or are timing fixtures simulating delayed producers (\`e2e/sqs.rs:502\` sends after 500ms to test long-poll receive). Those are intentionally left alone.

## Test plan
- [x] \`cargo build --tests -p fakecloud-e2e\`
- [x] \`cargo clippy --tests -p fakecloud-e2e -- -D warnings\`
- [ ] Full E2E suite green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fixed 100ms waits in SES fanout e2e tests with a polling helper to make SQS message assertions reliable in CI. Added `helpers::sqs_receive_at_least` to poll and accumulate messages with a 3s ceiling.

- **Refactors**
  - Added `helpers::sqs_receive_at_least(client, queue_url, n, deadline)` that loops `receive_message`, accumulates results, and returns what it collected by the deadline.
  - Updated three tests in `ses.rs` (Send+Delivery, Send+Bounce, EventBridge) to require ≥2 messages using a 3s poll.

<sup>Written for commit 95002c83149f547812ea919e2c007d5b6aeeca8d. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/834?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

