### PR TITLE
chore: drop synthetic dead-code anchors and unused type imports

### DIFF
--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -7,8 +7,6 @@
 
 #![allow(dead_code, unused_imports)]
 
-use std::path::PathBuf;
-
 pub use fakecloud_testkit::{data_path_for, run_until_exit, CliOutput, TestServer};
 
 /// Decompress gzipped data.
@@ -18,13 +16,6 @@ pub fn gunzip(data: &[u8]) -> Vec<u8> {
     let mut result = Vec::new();
     decoder.read_to_end(&mut result).unwrap();
     result
-}
-
-/// Re-exported for historical reasons. Some test helpers construct a
-/// `PathBuf` from a `tempfile::TempDir` through this shim.
-#[allow(dead_code)]
-pub fn _path_buf_shim(p: PathBuf) -> PathBuf {
-    p
 }
 
 /// Poll DescribeDBInstances until the instance reports

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -3557,5 +3557,4 @@ mod tests {
         assert!(!wildcard_match("exact", "exactly"));
         assert!(!wildcard_match("a*b*c", "a-b"));
     }
-
 }

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -3397,7 +3397,6 @@ mod tests {
     use super::{evaluate_lifecycle_policy, wildcard_match};
     use crate::state::{Image, Repository};
     use chrono::Utc;
-    use std::collections::BTreeMap;
 
     fn repo_with_images(entries: &[(&str, &[&str], i64)]) -> Repository {
         // entries: (digest, tags, minutes_ago_pushed)
@@ -3559,9 +3558,4 @@ mod tests {
         assert!(!wildcard_match("a*b*c", "a-b"));
     }
 
-    // Suppress clippy::no_effect for BTreeMap usage anchor in this mod.
-    #[allow(dead_code)]
-    fn _anchor_btree() -> BTreeMap<String, String> {
-        BTreeMap::new()
-    }
 }

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -22,7 +22,7 @@ use parking_lot::RwLock;
 use tempfile::TempDir;
 use tokio::process::Command;
 
-use crate::state::{LifecycleEvent, SharedEcsState, Task};
+use crate::state::{LifecycleEvent, SharedEcsState};
 
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
@@ -636,10 +636,6 @@ fn snapshot_task(state: &SharedEcsState, account_id: &str, task_id: &str) -> Opt
         ),
     })
 }
-
-/// Unused silencer: keep `Task` in scope for future snapshot extensions.
-#[allow(dead_code)]
-fn _task_type_anchor(_t: &Task) {}
 
 fn cli_works(cli: &str) -> bool {
     std::process::Command::new(cli)


### PR DESCRIPTION
## Summary
Three places held \`#[allow(dead_code)]\` on functions whose only purpose was to keep an otherwise-unused type or import in scope:

- \`crates/fakecloud-ecs/src/runtime.rs:642\` — \`_task_type_anchor(_t: &Task)\` paired with \`use crate::state::{..., Task};\`. \`Task\` wasn't referenced elsewhere in the module (only \`TaskSnapshot\` was). Dropped both.
- \`crates/fakecloud-ecr/src/service.rs:3563\` — \`_anchor_btree() -> BTreeMap<String, String>\` in the test mod paired with \`use std::collections::BTreeMap;\`. Test mod doesn't construct any BTreeMap outside the anchor. Dropped both.
- \`crates/fakecloud-e2e/tests/helpers/mod.rs:26\` — \`_path_buf_shim\` "re-exported for historical reasons" but no callers in the e2e suite. Dropped along with the \`PathBuf\` import.

Per audit: when \`#[allow(dead_code)]\` suppresses code that exists only to silence its own dead-code warning, deleting the code is the fix; the suppression itself was the smell.

## Deferred (separate PRs)
Other markers in [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §4 each need separate judgment:
- \`fakecloud-iam/src/credential_resolver.rs:62\` — \`_assert_impl\` is *actually* invoked from a \`const _: fn() = ||\` static type-check; clippy doesn't see it. Suppression is necessary.
- \`fakecloud-elbv2/src/service.rs:217-221\` — \`SubnetMapping\` fields parsed from the request but not yet read. Wire up vs delete decision belongs with whoever finishes ELBv2 dataplane.
- \`fakecloud-s3/src/service/mod.rs:1429\` — \`S3_SUPPORTED_ACTIONS\` doc-inventory const. Promote to a doc comment or delete.
- Scheduler/conformance type-check stubs (\`scheduler/{simulation,ticker,service,delivery}.rs\`, \`conformance/application_autoscaling.rs:417\`) — each silences a specific unused-import. Per-file fix.

## Test plan
- [x] \`cargo build -p fakecloud-ecs -p fakecloud-ecr\`
- [x] \`cargo build --tests -p fakecloud-e2e --test cognito\` (verifies helpers/mod.rs still compiles for one e2e test)
- [x] \`cargo clippy -p fakecloud-ecs -p fakecloud-ecr --all-targets -- -D warnings\`
- [ ] Full CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed synthetic dead-code anchors and unused type imports in `fakecloud-ecs`, `fakecloud-ecr`, and `fakecloud-e2e`. No behavior changes; also cleaned up a stray blank line in `fakecloud-ecr` tests.

- **Refactors**
  - `crates/fakecloud-ecs/src/runtime.rs`: removed `_task_type_anchor` and the unused `Task` import.
  - `crates/fakecloud-ecr/src/service.rs` (tests): removed `_anchor_btree`, the unused `BTreeMap` import, and a trailing blank line.
  - `crates/fakecloud-e2e/tests/helpers/mod.rs`: removed unused `_path_buf_shim` and the `PathBuf` import.

<sup>Written for commit cb2b1a436d00e738ebaa8f7f8199de16af634c58. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/836?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

