### PR TITLE
refactor(bedrock): combine validation and mutation in customization stop_job

### DIFF
--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -183,12 +183,16 @@ pub fn stop_model_customization_job(
     let mut accts = state.write();
     let s = accts.get_or_create(&req.account_id);
 
-    // Find the key first to avoid double mutable borrow
-    let key = s
+    let job = s
         .customization_jobs
-        .iter()
-        .find(|(k, j)| *k == job_identifier || j.job_name == job_identifier)
-        .map(|(k, _)| k.clone())
+        .iter_mut()
+        .find_map(|(k, j)| {
+            if *k == job_identifier || j.job_name == job_identifier {
+                Some(j)
+            } else {
+                None
+            }
+        })
         .ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -196,8 +200,6 @@ pub fn stop_model_customization_job(
                 format!("Model customization job {job_identifier} not found"),
             )
         })?;
-
-    let job = s.customization_jobs.get_mut(&key).unwrap();
 
     if job.status != "InProgress" {
         return Err(AwsServiceError::aws_error(


### PR DESCRIPTION
## Summary
\`stop_model_customization_job\` did the lookup twice — once via \`.iter().find()\` to clone the matching key (so the immutable borrow could drop), then via \`.get_mut(&key).unwrap()\` to acquire the mutable reference. The unwrap was safe by construction but the original comment "Find the key first to avoid double mutable borrow" documented that the second borrow had to trust the first lookup.

Replace with a single \`iter_mut().find_map(...)\` that returns the mutable reference directly. No separate key clone, no unwrap, validation and mutation happen in one fallible expression.

Per [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §5 CRITICAL "get-mut-after-validate".

## Cleanup vs audit list
The audit also referenced \`automated_reasoning.rs\`, \`evaluation.rs\`, \`invocation_jobs.rs\`, \`throughput.rs\`, \`marketplace.rs\`, \`custom_model_deployments.rs\` for the same pattern. After recent refactors, \`grep -rn ".get_mut(.*).*.unwrap()" crates/fakecloud-bedrock/src/\` returns only the customization.rs site (plus one in async_invoke.rs that's a test fixture, not operational code). Audit list was stale.

## Test plan
- [x] \`cargo build -p fakecloud-bedrock\`
- [x] \`cargo clippy -p fakecloud-bedrock --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-bedrock --lib customization\` (9 unit tests, all pass — \`stop_job_transitions_status\`, \`stop_job_not_in_progress_conflicts\`, \`stop_job_unknown_not_found\` cover both happy and error paths)
- [ ] Full CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combine validation and mutation in `stop_model_customization_job` via a single mutable lookup. This removes the key clone and `unwrap`, avoids double-borrow, and addresses the audit item “get-mut-after-validate” for customization jobs.

- **Refactors**
  - Use `iter_mut().find_map(...)` to return the mutable job directly; no separate key lookup or `unwrap`.
  - Removed the last `get_mut(&key).unwrap()` in `crates/fakecloud-bedrock/src/customization.rs`; other files are already clean.

<sup>Written for commit c24b90c28141905739af6de657678dbaa13f12b6. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/837?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

