### PR TITLE
refactor(bedrock): demote internal pub fn to pub(crate) across the crate

### DIFF
--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{AsyncInvocation, SharedBedrockState};
 
-pub fn start_async_invoke(
+pub(crate) fn start_async_invoke(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -75,7 +75,7 @@ pub fn start_async_invoke(
     ))
 }
 
-pub fn get_async_invoke(
+pub(crate) fn get_async_invoke(
     state: &SharedBedrockState,
     req: &AwsRequest,
     invocation_id: &str,
@@ -103,7 +103,7 @@ pub fn get_async_invoke(
     Ok(AwsResponse::ok_json(invocation_to_json(invocation)))
 }
 
-pub fn list_async_invokes(
+pub(crate) fn list_async_invokes(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-bedrock/src/automated_reasoning.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning.rs
@@ -9,7 +9,7 @@ use crate::state::{AutomatedReasoningPolicy, AutomatedReasoningTestCase, SharedB
 
 // Policy CRUD
 
-pub fn create_automated_reasoning_policy(
+pub(crate) fn create_automated_reasoning_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -52,7 +52,7 @@ pub fn create_automated_reasoning_policy(
     ))
 }
 
-pub fn get_automated_reasoning_policy(
+pub(crate) fn get_automated_reasoning_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -71,7 +71,7 @@ pub fn get_automated_reasoning_policy(
     Ok(AwsResponse::ok_json(policy_to_json(policy)))
 }
 
-pub fn list_automated_reasoning_policies(
+pub(crate) fn list_automated_reasoning_policies(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -127,7 +127,7 @@ pub fn list_automated_reasoning_policies(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_automated_reasoning_policy(
+pub(crate) fn update_automated_reasoning_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -164,7 +164,7 @@ pub fn update_automated_reasoning_policy(
     Ok(AwsResponse::ok_json(policy_to_json(policy)))
 }
 
-pub fn delete_automated_reasoning_policy(
+pub(crate) fn delete_automated_reasoning_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -191,7 +191,7 @@ pub fn delete_automated_reasoning_policy(
 
 // Policy versions
 
-pub fn create_automated_reasoning_policy_version(
+pub(crate) fn create_automated_reasoning_policy_version(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -229,7 +229,7 @@ pub fn create_automated_reasoning_policy_version(
     ))
 }
 
-pub fn export_automated_reasoning_policy_version(
+pub(crate) fn export_automated_reasoning_policy_version(
     state: &SharedBedrockState,
     identifier: &str,
     req: &AwsRequest,
@@ -265,7 +265,7 @@ pub fn export_automated_reasoning_policy_version(
 
 // Test cases
 
-pub fn create_automated_reasoning_policy_test_case(
+pub(crate) fn create_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -313,7 +313,7 @@ pub fn create_automated_reasoning_policy_test_case(
     ))
 }
 
-pub fn get_automated_reasoning_policy_test_case(
+pub(crate) fn get_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -346,7 +346,7 @@ pub fn get_automated_reasoning_policy_test_case(
     Ok(AwsResponse::ok_json(test_case_to_json(tc)))
 }
 
-pub fn list_automated_reasoning_policy_test_cases(
+pub(crate) fn list_automated_reasoning_policy_test_cases(
     state: &SharedBedrockState,
     policy_identifier: &str,
     req: &AwsRequest,
@@ -415,7 +415,7 @@ pub fn list_automated_reasoning_policy_test_cases(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_automated_reasoning_policy_test_case(
+pub(crate) fn update_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -462,7 +462,7 @@ pub fn update_automated_reasoning_policy_test_case(
     Ok(AwsResponse::ok_json(test_case_to_json(tc)))
 }
 
-pub fn delete_automated_reasoning_policy_test_case(
+pub(crate) fn delete_automated_reasoning_policy_test_case(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,

--- a/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
+++ b/crates/fakecloud-bedrock/src/automated_reasoning_workflows.rs
@@ -45,7 +45,7 @@ fn workflow_to_json(w: &AutomatedReasoningBuildWorkflow) -> Value {
     })
 }
 
-pub fn start_build_workflow(
+pub(crate) fn start_build_workflow(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -75,7 +75,7 @@ pub fn start_build_workflow(
     ))
 }
 
-pub fn get_build_workflow(
+pub(crate) fn get_build_workflow(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -100,7 +100,7 @@ pub fn get_build_workflow(
     Ok(AwsResponse::ok_json(workflow_to_json(workflow)))
 }
 
-pub fn list_build_workflows(
+pub(crate) fn list_build_workflows(
     state: &SharedBedrockState,
     policy_identifier: &str,
     req: &AwsRequest,
@@ -153,7 +153,7 @@ pub fn list_build_workflows(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn cancel_build_workflow(
+pub(crate) fn cancel_build_workflow(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -180,7 +180,7 @@ pub fn cancel_build_workflow(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn delete_build_workflow(
+pub(crate) fn delete_build_workflow(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -208,7 +208,7 @@ pub fn delete_build_workflow(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn get_build_workflow_result_assets(
+pub(crate) fn get_build_workflow_result_assets(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -233,7 +233,7 @@ pub fn get_build_workflow_result_assets(
     Ok(AwsResponse::ok_json(json!({ "assets": [] })))
 }
 
-pub fn start_test_workflow(
+pub(crate) fn start_test_workflow(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -262,7 +262,7 @@ pub fn start_test_workflow(
     ))
 }
 
-pub fn get_test_result(
+pub(crate) fn get_test_result(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -303,7 +303,7 @@ pub fn get_test_result(
     Ok(AwsResponse::ok_json(result))
 }
 
-pub fn list_test_results(
+pub(crate) fn list_test_results(
     state: &SharedBedrockState,
     policy_identifier: &str,
     workflow_id: &str,
@@ -368,7 +368,7 @@ pub fn list_test_results(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn get_annotations(
+pub(crate) fn get_annotations(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -399,7 +399,7 @@ pub fn get_annotations(
     Ok(AwsResponse::ok_json(annotations))
 }
 
-pub fn update_annotations(
+pub(crate) fn update_annotations(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,
@@ -427,7 +427,7 @@ pub fn update_annotations(
     Ok(AwsResponse::ok_json(body.clone()))
 }
 
-pub fn get_next_scenario(
+pub(crate) fn get_next_scenario(
     state: &SharedBedrockState,
     req: &AwsRequest,
     policy_identifier: &str,

--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::state::SharedBedrockState;
 
 /// Handle the Converse API — unified conversation format across all models.
-pub fn converse(
+pub(crate) fn converse(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,

--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{CustomModelDeployment, SharedBedrockState};
 
-pub fn create_custom_model_deployment(
+pub(crate) fn create_custom_model_deployment(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -46,7 +46,7 @@ pub fn create_custom_model_deployment(
     ))
 }
 
-pub fn get_custom_model_deployment(
+pub(crate) fn get_custom_model_deployment(
     state: &SharedBedrockState,
     req: &AwsRequest,
     deployment_identifier: &str,
@@ -59,7 +59,7 @@ pub fn get_custom_model_deployment(
     Ok(AwsResponse::ok_json(deployment_to_json(deployment)))
 }
 
-pub fn list_custom_model_deployments(
+pub(crate) fn list_custom_model_deployments(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -104,7 +104,7 @@ pub fn list_custom_model_deployments(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_custom_model_deployment(
+pub(crate) fn update_custom_model_deployment(
     state: &SharedBedrockState,
     req: &AwsRequest,
     deployment_identifier: &str,
@@ -129,7 +129,7 @@ pub fn update_custom_model_deployment(
     ))
 }
 
-pub fn delete_custom_model_deployment(
+pub(crate) fn delete_custom_model_deployment(
     state: &SharedBedrockState,
     req: &AwsRequest,
     deployment_identifier: &str,

--- a/crates/fakecloud-bedrock/src/custom_models.rs
+++ b/crates/fakecloud-bedrock/src/custom_models.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{CustomModel, SharedBedrockState};
 
-pub fn create_custom_model(
+pub(crate) fn create_custom_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -41,7 +41,7 @@ pub fn create_custom_model(
     ))
 }
 
-pub fn get_custom_model(
+pub(crate) fn get_custom_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_identifier: &str,
@@ -74,7 +74,7 @@ pub fn get_custom_model(
     })))
 }
 
-pub fn list_custom_models(
+pub(crate) fn list_custom_models(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -126,7 +126,7 @@ pub fn list_custom_models(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_custom_model(
+pub(crate) fn delete_custom_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_identifier: &str,

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
-pub fn create_model_customization_job(
+pub(crate) fn create_model_customization_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -73,7 +73,7 @@ pub fn create_model_customization_job(
     ))
 }
 
-pub fn get_model_customization_job(
+pub(crate) fn get_model_customization_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,
@@ -120,7 +120,7 @@ pub fn get_model_customization_job(
     })))
 }
 
-pub fn list_model_customization_jobs(
+pub(crate) fn list_model_customization_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -175,7 +175,7 @@ pub fn list_model_customization_jobs(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn stop_model_customization_job(
+pub(crate) fn stop_model_customization_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,

--- a/crates/fakecloud-bedrock/src/enforced_guardrails.rs
+++ b/crates/fakecloud-bedrock/src/enforced_guardrails.rs
@@ -6,7 +6,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
-pub fn put_enforced_guardrail_configuration(
+pub(crate) fn put_enforced_guardrail_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -23,7 +23,7 @@ pub fn put_enforced_guardrail_configuration(
     })))
 }
 
-pub fn list_enforced_guardrails_configuration(
+pub(crate) fn list_enforced_guardrails_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -74,7 +74,7 @@ pub fn list_enforced_guardrails_configuration(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_enforced_guardrail_configuration(
+pub(crate) fn delete_enforced_guardrail_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
     config_id: &str,

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{EvaluationJob, SharedBedrockState};
 
-pub fn create_evaluation_job(
+pub(crate) fn create_evaluation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -50,7 +50,7 @@ pub fn create_evaluation_job(
     ))
 }
 
-pub fn get_evaluation_job(
+pub(crate) fn get_evaluation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,
@@ -75,7 +75,7 @@ pub fn get_evaluation_job(
     })))
 }
 
-pub fn list_evaluation_jobs(
+pub(crate) fn list_evaluation_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -128,7 +128,7 @@ pub fn list_evaluation_jobs(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn stop_evaluation_job(
+pub(crate) fn stop_evaluation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,
@@ -155,7 +155,7 @@ pub fn stop_evaluation_job(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn batch_delete_evaluation_job(
+pub(crate) fn batch_delete_evaluation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,

--- a/crates/fakecloud-bedrock/src/faults.rs
+++ b/crates/fakecloud-bedrock/src/faults.rs
@@ -9,7 +9,7 @@ use crate::state::{FaultRule, ModelInvocation, SharedBedrockState};
 /// pair. Decrements the rule's remaining count; removes the rule when it hits
 /// zero. Returns the rule as it looked *before* decrementing so callers can see
 /// the intended error type/message/status.
-pub fn take_matching_fault(
+pub(crate) fn take_matching_fault(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,
@@ -36,13 +36,13 @@ pub fn take_matching_fault(
 }
 
 /// Convert a queued fault rule into an `AwsServiceError` for the caller to return.
-pub fn fault_to_error(fault: &FaultRule) -> AwsServiceError {
+pub(crate) fn fault_to_error(fault: &FaultRule) -> AwsServiceError {
     let status = StatusCode::from_u16(fault.http_status).unwrap_or(StatusCode::BAD_REQUEST);
     AwsServiceError::aws_error(status, &fault.error_type, &fault.message)
 }
 
 /// Record an invocation that was rejected by an injected fault.
-pub fn record_faulted_invocation(
+pub(crate) fn record_faulted_invocation(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,

--- a/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
+++ b/crates/fakecloud-bedrock/src/foundation_model_agreements.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{FoundationModelAgreement, SharedBedrockState};
 
-pub fn create_foundation_model_agreement(
+pub(crate) fn create_foundation_model_agreement(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -38,7 +38,7 @@ pub fn create_foundation_model_agreement(
     })))
 }
 
-pub fn delete_foundation_model_agreement(
+pub(crate) fn delete_foundation_model_agreement(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -72,7 +72,7 @@ pub fn delete_foundation_model_agreement(
     }
 }
 
-pub fn list_foundation_model_agreement_offers(
+pub(crate) fn list_foundation_model_agreement_offers(
     _state: &SharedBedrockState,
     _req: &AwsRequest,
     model_id: &str,
@@ -83,7 +83,7 @@ pub fn list_foundation_model_agreement_offers(
     })))
 }
 
-pub fn get_foundation_model_availability(
+pub(crate) fn get_foundation_model_availability(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,
@@ -104,7 +104,7 @@ pub fn get_foundation_model_availability(
     })))
 }
 
-pub fn get_use_case_for_model_access(
+pub(crate) fn get_use_case_for_model_access(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -118,7 +118,7 @@ pub fn get_use_case_for_model_access(
     })))
 }
 
-pub fn put_use_case_for_model_access(
+pub(crate) fn put_use_case_for_model_access(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,

--- a/crates/fakecloud-bedrock/src/guardrails.rs
+++ b/crates/fakecloud-bedrock/src/guardrails.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{Guardrail, GuardrailVersion, SharedBedrockState};
 
-pub fn create_guardrail(
+pub(crate) fn create_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -69,7 +69,7 @@ pub fn create_guardrail(
     ))
 }
 
-pub fn get_guardrail(
+pub(crate) fn get_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
     guardrail_id: &str,
@@ -107,7 +107,7 @@ pub fn get_guardrail(
     Ok(AwsResponse::ok_json(guardrail_to_json(guardrail)))
 }
 
-pub fn list_guardrails(
+pub(crate) fn list_guardrails(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -163,7 +163,7 @@ pub fn list_guardrails(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_guardrail(
+pub(crate) fn update_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
     guardrail_id: &str,
@@ -216,7 +216,7 @@ pub fn update_guardrail(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_guardrail(
+pub(crate) fn delete_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
     guardrail_id: &str,
@@ -237,7 +237,7 @@ pub fn delete_guardrail(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn create_guardrail_version(
+pub(crate) fn create_guardrail_version(
     state: &SharedBedrockState,
     req: &AwsRequest,
     guardrail_id: &str,
@@ -292,7 +292,7 @@ pub fn create_guardrail_version(
 }
 
 /// Handle the ApplyGuardrail API — evaluate content against a guardrail.
-pub fn apply_guardrail(
+pub(crate) fn apply_guardrail(
     state: &SharedBedrockState,
     req: &AwsRequest,
     guardrail_id: &str,
@@ -405,7 +405,7 @@ pub struct GuardrailView<'a> {
 }
 
 impl<'a> GuardrailView<'a> {
-    pub fn from_guardrail(g: &'a Guardrail) -> Self {
+    pub(crate) fn from_guardrail(g: &'a Guardrail) -> Self {
         Self {
             word_policy: g.word_policy.as_ref(),
             topic_policy: g.topic_policy.as_ref(),
@@ -415,7 +415,7 @@ impl<'a> GuardrailView<'a> {
         }
     }
 
-    pub fn from_version(gv: &'a GuardrailVersion) -> Self {
+    pub(crate) fn from_version(gv: &'a GuardrailVersion) -> Self {
         Self {
             word_policy: gv.word_policy.as_ref(),
             topic_policy: gv.topic_policy.as_ref(),
@@ -428,7 +428,14 @@ impl<'a> GuardrailView<'a> {
 
 /// Evaluate content against a guardrail's configured policies.
 /// Returns a list of assessment results.
-pub fn evaluate_content(guardrail: &Guardrail, text: &str) -> Vec<Value> {
+///
+/// This is a test convenience around `evaluate_content_view` that takes a
+/// `Guardrail` directly. The operational call path uses
+/// `evaluate_content_view` with a `GuardrailView` built from a versioned
+/// guardrail. Compiled out of release builds via `cfg(test)` because the
+/// non-versioned form is only useful in unit tests.
+#[cfg(test)]
+fn evaluate_content(guardrail: &Guardrail, text: &str) -> Vec<Value> {
     evaluate_content_view(&GuardrailView::from_guardrail(guardrail), text)
 }
 

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{InferenceProfile, SharedBedrockState};
 
-pub fn create_inference_profile(
+pub(crate) fn create_inference_profile(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -61,7 +61,7 @@ pub fn create_inference_profile(
     ))
 }
 
-pub fn get_inference_profile(
+pub(crate) fn get_inference_profile(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -98,7 +98,7 @@ pub fn get_inference_profile(
     })))
 }
 
-pub fn list_inference_profiles(
+pub(crate) fn list_inference_profiles(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -153,7 +153,7 @@ pub fn list_inference_profiles(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_inference_profile(
+pub(crate) fn delete_inference_profile(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{ModelInvocationJob, SharedBedrockState};
 
-pub fn create_model_invocation_job(
+pub(crate) fn create_model_invocation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -46,7 +46,7 @@ pub fn create_model_invocation_job(
     ))
 }
 
-pub fn get_model_invocation_job(
+pub(crate) fn get_model_invocation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,
@@ -74,7 +74,7 @@ pub fn get_model_invocation_job(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn list_model_invocation_jobs(
+pub(crate) fn list_model_invocation_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -128,7 +128,7 @@ pub fn list_model_invocation_jobs(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn stop_model_invocation_job(
+pub(crate) fn stop_model_invocation_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -8,7 +8,7 @@ use crate::state::SharedBedrockState;
 
 /// Invoke a model and return a provider-specific canned response.
 /// If a custom response has been configured via simulation endpoint, use that instead.
-pub fn invoke_model(
+pub(crate) fn invoke_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,
@@ -70,7 +70,7 @@ pub fn invoke_model(
 }
 
 /// Count tokens for the given input text (rough approximation).
-pub fn count_tokens(
+pub(crate) fn count_tokens(
     _state: &SharedBedrockState,
     _req: &AwsRequest,
     model_id: &str,

--- a/crates/fakecloud-bedrock/src/logging.rs
+++ b/crates/fakecloud-bedrock/src/logging.rs
@@ -5,7 +5,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
-pub fn put_model_invocation_logging_configuration(
+pub(crate) fn put_model_invocation_logging_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -39,7 +39,7 @@ pub fn put_model_invocation_logging_configuration(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn get_model_invocation_logging_configuration(
+pub(crate) fn get_model_invocation_logging_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -67,7 +67,7 @@ pub fn get_model_invocation_logging_configuration(
     }
 }
 
-pub fn delete_model_invocation_logging_configuration(
+pub(crate) fn delete_model_invocation_logging_configuration(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-bedrock/src/marketplace.rs
+++ b/crates/fakecloud-bedrock/src/marketplace.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{MarketplaceModelEndpoint, SharedBedrockState};
 
-pub fn create_marketplace_model_endpoint(
+pub(crate) fn create_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -56,7 +56,7 @@ pub fn create_marketplace_model_endpoint(
     ))
 }
 
-pub fn get_marketplace_model_endpoint(
+pub(crate) fn get_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -93,7 +93,7 @@ pub fn get_marketplace_model_endpoint(
     })))
 }
 
-pub fn list_marketplace_model_endpoints(
+pub(crate) fn list_marketplace_model_endpoints(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -147,7 +147,7 @@ pub fn list_marketplace_model_endpoints(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_marketplace_model_endpoint(
+pub(crate) fn update_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -196,7 +196,7 @@ pub fn update_marketplace_model_endpoint(
     })))
 }
 
-pub fn delete_marketplace_model_endpoint(
+pub(crate) fn delete_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -227,7 +227,7 @@ pub fn delete_marketplace_model_endpoint(
     }
 }
 
-pub fn register_marketplace_model_endpoint(
+pub(crate) fn register_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -272,7 +272,7 @@ pub fn register_marketplace_model_endpoint(
     })))
 }
 
-pub fn deregister_marketplace_model_endpoint(
+pub(crate) fn deregister_marketplace_model_endpoint(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,

--- a/crates/fakecloud-bedrock/src/model_copy.rs
+++ b/crates/fakecloud-bedrock/src/model_copy.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{ModelCopyJob, SharedBedrockState};
 
-pub fn create_model_copy_job(
+pub(crate) fn create_model_copy_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -44,7 +44,7 @@ pub fn create_model_copy_job(
     ))
 }
 
-pub fn get_model_copy_job(
+pub(crate) fn get_model_copy_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_arn: &str,
@@ -78,7 +78,7 @@ pub fn get_model_copy_job(
     })))
 }
 
-pub fn list_model_copy_jobs(
+pub(crate) fn list_model_copy_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {

--- a/crates/fakecloud-bedrock/src/model_import.rs
+++ b/crates/fakecloud-bedrock/src/model_import.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{ImportedModel, ModelImportJob, SharedBedrockState};
 
-pub fn create_model_import_job(
+pub(crate) fn create_model_import_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -61,7 +61,7 @@ pub fn create_model_import_job(
     ))
 }
 
-pub fn get_model_import_job(
+pub(crate) fn get_model_import_job(
     state: &SharedBedrockState,
     req: &AwsRequest,
     job_identifier: &str,
@@ -98,7 +98,7 @@ pub fn get_model_import_job(
     })))
 }
 
-pub fn list_model_import_jobs(
+pub(crate) fn list_model_import_jobs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -153,7 +153,7 @@ pub fn list_model_import_jobs(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn get_imported_model(
+pub(crate) fn get_imported_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_identifier: &str,
@@ -187,7 +187,7 @@ pub fn get_imported_model(
     })))
 }
 
-pub fn list_imported_models(
+pub(crate) fn list_imported_models(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -238,7 +238,7 @@ pub fn list_imported_models(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_imported_model(
+pub(crate) fn delete_imported_model(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_identifier: &str,

--- a/crates/fakecloud-bedrock/src/models.rs
+++ b/crates/fakecloud-bedrock/src/models.rs
@@ -14,7 +14,7 @@ pub struct FoundationModel {
 }
 
 impl FoundationModel {
-    pub fn to_summary_json(&self) -> Value {
+    pub(crate) fn to_summary_json(&self) -> Value {
         json!({
             "modelId": self.model_id,
             "modelName": self.model_name,
@@ -30,7 +30,7 @@ impl FoundationModel {
         })
     }
 
-    pub fn to_detail_json(&self, region: &str, account_id: &str) -> Value {
+    pub(crate) fn to_detail_json(&self, region: &str, account_id: &str) -> Value {
         let arn = format!(
             "arn:aws:bedrock:{}::foundation-model/{}",
             region, self.model_id
@@ -230,7 +230,7 @@ pub static FOUNDATION_MODELS: &[FoundationModel] = &[
 ];
 
 /// Find a foundation model by its model ID.
-pub fn find_model(model_id: &str) -> Option<&'static FoundationModel> {
+pub(crate) fn find_model(model_id: &str) -> Option<&'static FoundationModel> {
     FOUNDATION_MODELS.iter().find(|m| m.model_id == model_id)
 }
 

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -9,7 +9,7 @@ use crate::state::{ResponseRule, SharedBedrockState};
 /// Handles both InvokeModel (provider-specific shapes) and Converse bodies.
 /// Returns an empty string when nothing recognizable is found, so a rule
 /// with `prompt_contains = ""` matches any call.
-pub fn extract_prompt_text(model_id: &str, body: &[u8]) -> String {
+pub(crate) fn extract_prompt_text(model_id: &str, body: &[u8]) -> String {
     let Ok(value): Result<Value, _> = serde_json::from_slice(body) else {
         return String::new();
     };
@@ -68,7 +68,7 @@ pub fn extract_prompt_text(model_id: &str, body: &[u8]) -> String {
 
 /// Return the first rule whose `prompt_contains` filter matches the current prompt.
 /// A rule with `prompt_contains = None` or an empty string matches anything.
-pub fn match_rule<'a>(rules: &'a [ResponseRule], prompt: &str) -> Option<&'a ResponseRule> {
+pub(crate) fn match_rule<'a>(rules: &'a [ResponseRule], prompt: &str) -> Option<&'a ResponseRule> {
     rules.iter().find(|rule| match &rule.prompt_contains {
         None => true,
         Some(needle) if needle.is_empty() => true,
@@ -79,7 +79,7 @@ pub fn match_rule<'a>(rules: &'a [ResponseRule], prompt: &str) -> Option<&'a Res
 /// Resolve the response body a runtime call should use, applying
 /// rule-based overrides first, then the legacy single-response override.
 /// Returns `None` when neither is configured — caller falls back to canned.
-pub fn resolve_override(
+pub(crate) fn resolve_override(
     state: &SharedBedrockState,
     req: &AwsRequest,
     model_id: &str,

--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{PromptRouter, SharedBedrockState};
 
-pub fn create_prompt_router(
+pub(crate) fn create_prompt_router(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -45,7 +45,7 @@ pub fn create_prompt_router(
     ))
 }
 
-pub fn get_prompt_router(
+pub(crate) fn get_prompt_router(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,
@@ -84,7 +84,7 @@ pub fn get_prompt_router(
     })))
 }
 
-pub fn list_prompt_routers(
+pub(crate) fn list_prompt_routers(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -139,7 +139,7 @@ pub fn list_prompt_routers(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn delete_prompt_router(
+pub(crate) fn delete_prompt_router(
     state: &SharedBedrockState,
     req: &AwsRequest,
     identifier: &str,

--- a/crates/fakecloud-bedrock/src/resource_policies.rs
+++ b/crates/fakecloud-bedrock/src/resource_policies.rs
@@ -6,7 +6,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::SharedBedrockState;
 
-pub fn put_resource_policy(
+pub(crate) fn put_resource_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -40,7 +40,7 @@ pub fn put_resource_policy(
     })))
 }
 
-pub fn get_resource_policy(
+pub(crate) fn get_resource_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     resource_arn: &str,
@@ -73,7 +73,7 @@ pub fn get_resource_policy(
     })))
 }
 
-pub fn delete_resource_policy(
+pub(crate) fn delete_resource_policy(
     state: &SharedBedrockState,
     req: &AwsRequest,
     resource_arn: &str,

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -29,7 +29,7 @@ mod tuple2_map_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::collections::HashMap;
 
-    pub fn serialize<V: Serialize, S: Serializer>(
+    pub(crate) fn serialize<V: Serialize, S: Serializer>(
         map: &HashMap<(String, String), V>,
         s: S,
     ) -> Result<S::Ok, S::Error> {
@@ -38,7 +38,7 @@ mod tuple2_map_serde {
         entries.serialize(s)
     }
 
-    pub fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
+    pub(crate) fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
         d: D,
     ) -> Result<HashMap<(String, String), V>, D::Error> {
         let entries: Vec<(String, String, V)> = Vec::deserialize(d)?;
@@ -52,7 +52,7 @@ mod tuple3_map_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::collections::HashMap;
 
-    pub fn serialize<V: Serialize, S: Serializer>(
+    pub(crate) fn serialize<V: Serialize, S: Serializer>(
         map: &HashMap<(String, String, String), V>,
         s: S,
     ) -> Result<S::Ok, S::Error> {
@@ -61,7 +61,7 @@ mod tuple3_map_serde {
         entries.serialize(s)
     }
 
-    pub fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
+    pub(crate) fn deserialize<'de, V: Deserialize<'de>, D: Deserializer<'de>>(
         d: D,
     ) -> Result<HashMap<(String, String, String), V>, D::Error> {
         let entries: Vec<(String, String, String, V)> = Vec::deserialize(d)?;

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 /// The event stream binary format:
 ///   [total_byte_length:4] [headers_byte_length:4] [prelude_crc:4]
 ///   [headers:*] [payload:*] [message_crc:4]
-pub fn encode_event(event_type: &str, content_type: &str, payload: &[u8]) -> Vec<u8> {
+pub(crate) fn encode_event(event_type: &str, content_type: &str, payload: &[u8]) -> Vec<u8> {
     let headers = encode_headers(event_type, content_type);
     let headers_len = headers.len() as u32;
 
@@ -81,7 +81,7 @@ fn crc32(data: &[u8]) -> u32 {
 
 /// Build the complete event stream body for InvokeModelWithResponseStream.
 /// Returns the full body as a single chunk containing all events.
-pub fn build_invoke_stream_response(model_id: &str, response_text: &str) -> Vec<u8> {
+pub(crate) fn build_invoke_stream_response(model_id: &str, response_text: &str) -> Vec<u8> {
     let mut body = Vec::new();
 
     // For Anthropic models, emit message_start, content_block_start, content_block_delta,
@@ -117,7 +117,7 @@ pub fn build_invoke_stream_response(model_id: &str, response_text: &str) -> Vec<
 }
 
 /// Build the complete event stream body for ConverseStream.
-pub fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
+pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
     let mut body = Vec::new();
 
     // messageStart event
@@ -187,13 +187,13 @@ fn base64_encode(data: &[u8]) -> String {
 }
 
 /// Wrap response text for non-streaming provider fallback
-pub fn default_stream_text() -> &'static str {
+pub(crate) fn default_stream_text() -> &'static str {
     "This is a test response from the emulated model."
 }
 
 /// Generate the canned response text, checking for prompt-conditional and
 /// legacy custom overrides for the given call.
-pub fn get_response_text(
+pub(crate) fn get_response_text(
     state: &crate::state::SharedBedrockState,
     req: &fakecloud_core::service::AwsRequest,
     model_id: &str,

--- a/crates/fakecloud-bedrock/src/throughput.rs
+++ b/crates/fakecloud-bedrock/src/throughput.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{ProvisionedThroughput, SharedBedrockState};
 
-pub fn create_provisioned_model_throughput(
+pub(crate) fn create_provisioned_model_throughput(
     state: &SharedBedrockState,
     req: &AwsRequest,
     body: &Value,
@@ -85,7 +85,7 @@ pub fn create_provisioned_model_throughput(
     ))
 }
 
-pub fn get_provisioned_model_throughput(
+pub(crate) fn get_provisioned_model_throughput(
     state: &SharedBedrockState,
     req: &AwsRequest,
     provisioned_model_id: &str,
@@ -98,7 +98,7 @@ pub fn get_provisioned_model_throughput(
     Ok(AwsResponse::ok_json(throughput_to_json(throughput)))
 }
 
-pub fn list_provisioned_model_throughputs(
+pub(crate) fn list_provisioned_model_throughputs(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
@@ -156,7 +156,7 @@ pub fn list_provisioned_model_throughputs(
     Ok(AwsResponse::ok_json(resp))
 }
 
-pub fn update_provisioned_model_throughput(
+pub(crate) fn update_provisioned_model_throughput(
     state: &SharedBedrockState,
     req: &AwsRequest,
     provisioned_model_id: &str,
@@ -178,7 +178,7 @@ pub fn update_provisioned_model_throughput(
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
 }
 
-pub fn delete_provisioned_model_throughput(
+pub(crate) fn delete_provisioned_model_throughput(
     state: &SharedBedrockState,
     req: &AwsRequest,
     provisioned_model_id: &str,


### PR DESCRIPTION
## Summary
Bedrock had ~125 \`pub fn\` declarations across 26 source files. Cross-crate consumers (fakecloud-server, conformance, e2e tests) only call into the crate via type names — \`SharedBedrockState\`, \`BedrockState\`, \`BedrockSnapshot\`, \`ResponseRule\`, \`FaultRule\` — and via the \`AwsService\` trait. No external caller invokes a free function or service method directly except for:
- \`BedrockService::with_snapshot_store\` (server's persistence wiring)
- \`BedrockState::reset\` (server's reset handler)

Both stay \`pub\`. Everything else demotes to \`pub(crate)\`. Constructors named \`build\`/\`builder\`/\`new\`/\`default\` are preserved as \`pub\` since downstream code may rely on the conventional construction API on builders.

\`evaluate_content\` (a test convenience around \`evaluate_content_view\` in guardrails.rs) is gated behind \`cfg(test)\` and dropped from the crate surface entirely — it had no non-test callers.

Closes [audit report 2026-04-28](https://github.com/faiscadev/fakecloud/blob/main/.claude/audit-reports/2026-04-28.md) §7 HIGH "fakecloud-bedrock over-exports (116 pub fn)" — the count was 128, now ~10 (mostly type constructors).

## Future work
The audit also flags every service crate's \`pub mod state; pub mod service;\` (§7 HIGH) and the analogous overexposure in non-Bedrock crates. Those need per-service judgment about which constructors and types are genuinely cross-crate; tracked separately.

## Test plan
- [x] \`cargo build\` (full workspace, 0 errors)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo test -p fakecloud-bedrock --lib\` (332 tests pass)
- [ ] Full CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink `fakecloud-bedrock` public API by demoting internal `pub fn`s to `pub(crate)`, aligning visibility with actual usage and the audit’s over-export finding. No changes expected for consumers; documented entry points remain public.

- **Refactors**
  - Demoted ~125 functions across 26 files to `pub(crate)`.
  - Kept `BedrockService::with_snapshot_store` and `BedrockState::reset` as `pub`.
  - Preserved `build`/`builder`/`new`/`default` constructors as `pub`.
  - Gated `evaluate_content` behind `cfg(test)`; removed from release surface.

<sup>Written for commit 808af5ea8fa9439d6fd871418ea4d7e3da883af2. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/838?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

