### PR TITLE
chore: purge remaining #[allow(dead_code)] markers

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -222,18 +222,6 @@ fn check_enum(body: &Value, name: &str, allowed: &[&str]) -> Result<(), AwsServi
     Ok(())
 }
 
-/// Require a non-empty path-derived resource id. Empty ids come from
-/// probe variants that omit a `{param}` from the URI (rendering e.g.
-/// `/v2/tags/` or `/v2/portals/`); treat them as missing rather than
-/// silently succeeding.
-#[allow(dead_code)]
-fn non_empty<'a>(s: Option<&'a str>, name: &str) -> Result<&'a str, AwsServiceError> {
-    match s {
-        Some(v) if !v.is_empty() => Ok(v),
-        _ => Err(missing(name)),
-    }
-}
-
 /// An id segment is "valid" iff it's non-empty and not a literal
 /// placeholder (`{Name}` or URL-encoded `%7BName%7D`). Probe variants
 /// that omit a required label leave the template token behind; treating

--- a/crates/fakecloud-conformance/tests/application_autoscaling.rs
+++ b/crates/fakecloud-conformance/tests/application_autoscaling.rs
@@ -5,7 +5,7 @@ mod helpers;
 use aws_sdk_applicationautoscaling::primitives::DateTime as AwsDateTime;
 use aws_sdk_applicationautoscaling::types::{
     PolicyType, ScalableDimension, ScalableTargetAction, ServiceNamespace,
-    StepScalingPolicyConfiguration, SuspendedState,
+    StepScalingPolicyConfiguration,
 };
 use fakecloud_conformance_macros::test_action;
 use helpers::TestServer;
@@ -411,9 +411,4 @@ async fn aas_untag_resource() {
         .send()
         .await
         .unwrap();
-}
-
-#[allow(dead_code)]
-fn _suspended_state_compiles() -> SuspendedState {
-    SuspendedState::builder().build()
 }

--- a/crates/fakecloud-e2e/tests/ecr_lifecycle.rs
+++ b/crates/fakecloud-e2e/tests/ecr_lifecycle.rs
@@ -4,7 +4,6 @@
 
 mod helpers;
 
-use aws_sdk_ecr::primitives::Blob;
 use helpers::TestServer;
 
 async fn create_repo(ecr: &aws_sdk_ecr::Client, name: &str) {
@@ -206,7 +205,3 @@ async fn lifecycle_policy_roundtrips() {
         serde_json::Value::String("days".into())
     );
 }
-
-/// Unused silencer for the `Blob` import — ensures rustc doesn't warn.
-#[allow(dead_code)]
-fn _blob_import_anchor(_b: Blob) {}

--- a/crates/fakecloud-e2e/tests/ecs_account_settings_arn.rs
+++ b/crates/fakecloud-e2e/tests/ecs_account_settings_arn.rs
@@ -9,7 +9,7 @@
 
 mod helpers;
 
-use aws_sdk_ecs::types::{ContainerDefinition, SettingName, SettingType};
+use aws_sdk_ecs::types::{ContainerDefinition, SettingName};
 use helpers::TestServer;
 
 async fn register_noop_task_def(client: &aws_sdk_ecs::Client, family: &str) {
@@ -156,7 +156,3 @@ async fn account_setting_default_list_reflects_writes() {
         .expect("taskLongArnFormat in effective settings");
     assert_eq!(found.value(), Some("disabled"));
 }
-
-// Silences clippy about unused import when this test module lives alone.
-#[allow(dead_code)]
-fn _setting_type_anchor(_t: SettingType) {}

--- a/crates/fakecloud-e2e/tests/ecs_task_role_secrets.rs
+++ b/crates/fakecloud-e2e/tests/ecs_task_role_secrets.rs
@@ -11,7 +11,6 @@
 
 mod helpers;
 
-use std::collections::HashMap;
 use std::time::Duration;
 
 use aws_sdk_ecs::types::{ContainerDefinition, Secret};
@@ -354,10 +353,4 @@ async fn ecs_task_with_missing_secret_fails_fast() {
         Some("TaskFailedToStart"),
         "expected TaskFailedToStart; got {stop_code:?}"
     );
-}
-
-// Keep the unused helpers::helpers module import alive.
-#[allow(dead_code)]
-fn _unused_hashmap_import() {
-    let _: HashMap<String, String> = HashMap::new();
 }

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -29,7 +29,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
-use crate::router::{pattern_matches, select_actions};
+use crate::router::select_actions;
 use crate::state::{Action, Listener, LoadBalancer, Rule, SharedElbv2State, TargetGroup};
 
 const ENV_DISABLE: &str = "FAKECLOUD_ELBV2_DISABLE_DATAPLANE";
@@ -46,8 +46,6 @@ pub fn dataplane_enabled() -> bool {
 /// Per-LB listener handle. Held in the supervisor map so that a LB
 /// removal can drop the JoinHandle and free the OS port.
 struct BoundListener {
-    #[allow(dead_code)]
-    port: u16,
     handle: JoinHandle<()>,
 }
 
@@ -163,7 +161,7 @@ async fn reconcile(dp: &DataPlane, bindings: &mut HashMap<String, BoundListener>
                 let handle = tokio::spawn(async move {
                     accept_loop(dp2, arn2, listener).await;
                 });
-                bindings.insert(arn.clone(), BoundListener { port, handle });
+                bindings.insert(arn.clone(), BoundListener { handle });
                 trace!(arn = %arn, port, "ELBv2 data plane: bound listener");
             }
             Err(e) => {
@@ -760,11 +758,4 @@ fn extract_cookie<'a>(cookies: &'a str, name: &str) -> Option<&'a str> {
 fn short_id() -> String {
     let id = Uuid::new_v4();
     id.simple().to_string()[0..16].to_string()
-}
-
-// Suppress unused import warning when feature combinations don't
-// need this path matcher in release builds.
-#[allow(dead_code)]
-fn _path_matches(p: &str, s: &str) -> bool {
-    pattern_matches(p, s)
 }

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -214,12 +214,6 @@ fn parse_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
 struct SubnetMapping {
     subnet_id: Option<String>,
     allocation_id: Option<String>,
-    #[allow(dead_code)]
-    private_ipv4_address: Option<String>,
-    #[allow(dead_code)]
-    ipv6_address: Option<String>,
-    #[allow(dead_code)]
-    source_nat_ipv6_prefix: Option<String>,
 }
 
 fn parse_subnet_mappings(req: &AwsRequest) -> Vec<SubnetMapping> {
@@ -231,31 +225,12 @@ fn parse_subnet_mappings(req: &AwsRequest) -> Vec<SubnetMapping> {
             .query_params
             .get(&format!("{prefix}.AllocationId"))
             .cloned();
-        let private_ipv4 = req
-            .query_params
-            .get(&format!("{prefix}.PrivateIPv4Address"))
-            .cloned();
-        let ipv6 = req
-            .query_params
-            .get(&format!("{prefix}.IPv6Address"))
-            .cloned();
-        let source_nat_ipv6_prefix = req
-            .query_params
-            .get(&format!("{prefix}.SourceNatIpv6Prefix"))
-            .cloned();
-        if subnet_id.is_none()
-            && allocation_id.is_none()
-            && private_ipv4.is_none()
-            && ipv6.is_none()
-        {
+        if subnet_id.is_none() && allocation_id.is_none() {
             break;
         }
         out.push(SubnetMapping {
             subnet_id,
             allocation_id,
-            private_ipv4_address: private_ipv4,
-            ipv6_address: ipv6,
-            source_nat_ipv6_prefix,
         });
     }
     out

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -57,9 +57,6 @@ impl CredentialResolver for IamCredentialResolver {
     }
 }
 
-// Prevent rustc from warning on the unused import when the module is
-// included via `lib.rs` without tests referencing it.
-#[allow(dead_code)]
 fn _assert_impl<T: CredentialResolver>() {}
 const _: fn() = || {
     _assert_impl::<IamCredentialResolver>();

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -1803,14 +1803,6 @@ impl ConfigKind {
             ConfigKind::Metrics => "ListMetricsConfigurationsResult",
         }
     }
-    #[allow(dead_code)]
-    fn member(&self) -> &'static str {
-        match self {
-            ConfigKind::Analytics => "AnalyticsConfiguration",
-            ConfigKind::IntelligentTiering => "IntelligentTieringConfiguration",
-            ConfigKind::Metrics => "MetricsConfiguration",
-        }
-    }
     fn subresource(&self) -> BucketSubresource {
         match self {
             ConfigKind::Analytics => BucketSubresource::Analytics,

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -49,7 +49,6 @@ pub struct S3Service {
     delivery: Arc<DeliveryBus>,
     kms_state: Option<SharedKmsState>,
     pub(crate) kms_hook: Option<Arc<dyn fakecloud_core::delivery::KmsHook>>,
-    #[allow(dead_code)]
     store: Arc<dyn S3Store>,
 }
 
@@ -1420,89 +1419,6 @@ fn s3_detect_action(
         _ => None,
     }
 }
-
-/// Full list of S3 actions whose resource ARNs are classified by
-/// [`s3_resource_for`]. Not referenced at runtime (S3's action name is
-/// derived from method + path in [`s3_detect_action`]), but kept as a
-/// documented inventory so future work can easily enumerate the
-/// enforcement surface.
-#[allow(dead_code)]
-const S3_SUPPORTED_ACTIONS: &[&str] = &[
-    "ListBuckets",
-    "CreateBucket",
-    "DeleteBucket",
-    "HeadBucket",
-    "GetBucketLocation",
-    "PutObject",
-    "GetObject",
-    "DeleteObject",
-    "HeadObject",
-    "CopyObject",
-    "DeleteObjects",
-    "ListObjectsV2",
-    "ListObjects",
-    "ListObjectVersions",
-    "GetObjectAttributes",
-    "RestoreObject",
-    "PutObjectTagging",
-    "GetObjectTagging",
-    "DeleteObjectTagging",
-    "PutObjectAcl",
-    "GetObjectAcl",
-    "PutObjectRetention",
-    "GetObjectRetention",
-    "PutObjectLegalHold",
-    "GetObjectLegalHold",
-    "PutBucketTagging",
-    "GetBucketTagging",
-    "DeleteBucketTagging",
-    "PutBucketAcl",
-    "GetBucketAcl",
-    "PutBucketVersioning",
-    "GetBucketVersioning",
-    "PutBucketCors",
-    "GetBucketCors",
-    "DeleteBucketCors",
-    "PutBucketNotificationConfiguration",
-    "GetBucketNotificationConfiguration",
-    "PutBucketWebsite",
-    "GetBucketWebsite",
-    "DeleteBucketWebsite",
-    "PutBucketAccelerateConfiguration",
-    "GetBucketAccelerateConfiguration",
-    "PutPublicAccessBlock",
-    "GetPublicAccessBlock",
-    "DeletePublicAccessBlock",
-    "PutBucketEncryption",
-    "GetBucketEncryption",
-    "DeleteBucketEncryption",
-    "PutBucketLifecycleConfiguration",
-    "GetBucketLifecycleConfiguration",
-    "DeleteBucketLifecycle",
-    "PutBucketLogging",
-    "GetBucketLogging",
-    "PutBucketPolicy",
-    "GetBucketPolicy",
-    "DeleteBucketPolicy",
-    "PutObjectLockConfiguration",
-    "GetObjectLockConfiguration",
-    "PutBucketReplication",
-    "GetBucketReplication",
-    "DeleteBucketReplication",
-    "PutBucketOwnershipControls",
-    "GetBucketOwnershipControls",
-    "DeleteBucketOwnershipControls",
-    "PutBucketInventoryConfiguration",
-    "GetBucketInventoryConfiguration",
-    "DeleteBucketInventoryConfiguration",
-    "CreateMultipartUpload",
-    "UploadPart",
-    "UploadPartCopy",
-    "CompleteMultipartUpload",
-    "AbortMultipartUpload",
-    "ListParts",
-    "ListMultipartUploads",
-];
 
 /// Build the S3 resource ARN for an action. Returns `*` for
 /// `ListBuckets` (account-scoped), a bucket ARN for bucket-level

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -218,7 +218,6 @@ mod tests {
     use crate::state::{DeadLetterConfig, FlexibleTimeWindow, Schedule, Target};
     use chrono::Utc;
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     type RecordedCall = (String, String, HashMap<String, SqsMessageAttribute>);
@@ -454,11 +453,5 @@ mod tests {
         let sched = make_schedule("arn:aws:ec2:us-east-1:1:instance/foo", None, None);
         assert!(deliver_target(&bus, &sched).is_ok());
         assert!(recorder.calls.lock().unwrap().is_empty());
-    }
-
-    // Silence unused warning on AtomicUsize import when we expand later.
-    #[allow(dead_code)]
-    fn _placeholder(_: AtomicUsize) {
-        let _ = Ordering::SeqCst;
     }
 }

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -1087,11 +1087,6 @@ fn group_name_from_tag_arn(arn: &str) -> Result<String, AwsServiceError> {
     }
 }
 
-// Silence unused-import warnings for Arc in case refactors move
-// state handling around.
-#[allow(dead_code)]
-fn _type_check(_: Arc<()>) {}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-scheduler/src/simulation.rs
+++ b/crates/fakecloud-scheduler/src/simulation.rs
@@ -135,9 +135,7 @@ pub fn list_all_schedules(state: &SharedSchedulerState) -> Vec<ScheduleRow> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{
-        FlexibleTimeWindow, Schedule, SchedulerState, SharedSchedulerState, Target,
-    };
+    use crate::state::{FlexibleTimeWindow, Schedule, SharedSchedulerState, Target};
     use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
     use parking_lot::RwLock;
     use std::collections::HashMap;
@@ -289,8 +287,4 @@ mod tests {
         assert_eq!(rows[0].name, "a");
         assert_eq!(rows[1].name, "b");
     }
-
-    // Silence unused-import warning.
-    #[allow(dead_code)]
-    fn _type_check(_: SchedulerState) {}
 }

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -204,13 +204,11 @@ fn is_due_with_dedup(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{
-        FlexibleTimeWindow, Schedule, SchedulerState, SharedSchedulerState, Target,
-    };
+    use crate::state::{FlexibleTimeWindow, Schedule, SharedSchedulerState, Target};
     use chrono::Utc;
     use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
     use parking_lot::RwLock;
-    use std::collections::{HashMap, VecDeque};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Mutex;
 
@@ -442,8 +440,4 @@ mod tests {
         ticker.tick(&mut cron);
         assert!(rec.calls.lock().unwrap().is_empty());
     }
-
-    // Silence unused-import warning.
-    #[allow(dead_code)]
-    fn _unused(_: VecDeque<()>, _: SchedulerState) {}
 }


### PR DESCRIPTION
## Summary

Audit batch 8c finish. Closes the gap from PR #836 (3 of 21 markers) — all remaining `#[allow(dead_code)]` markers gone.

For each marker: deleted dead code, OR unwrapped the suppression where it was redundant.

- elbv2: drop unused `BoundListener.port` + 3 `SubnetMapping` fields (CIDR/IPv6/IPv6 prefix)
- scheduler: delete 4 type-anchor closures across delivery/service/simulation/ticker
- e2e tests (ecr_lifecycle, ecs_account_settings_arn, ecs_task_role_secrets): delete unused-import anchor fns and drop now-unused imports (`Blob`, `SettingType`, `HashMap`)
- conformance/application_autoscaling: drop `SuspendedState` anchor + import
- s3/service/mod: delete `S3_SUPPORTED_ACTIONS` inventory const (zero callers); remove redundant allow on `store` field (it's actually used)
- s3/service/config: drop unused `ConfigKind::member()`
- apigatewayv2/extras: drop unused `non_empty()`
- iam/credential_resolver: remove redundant allow on `_assert_impl` (already exercised by `const _`)

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt
- [x] zero remaining `#[allow(dead_code)]` markers in crates/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove all remaining #[allow(dead_code)] markers by deleting unused code and unwrapping redundant allows. Cleans up multiple crates and tests with no behavior changes.

- **Refactors**
  - `fakecloud-elbv2`: removed `BoundListener.port`; trimmed unused `SubnetMapping` fields; dropped unused path matcher import/anchor.
  - `fakecloud-s3`: deleted `S3_SUPPORTED_ACTIONS` const; removed `ConfigKind::member()`; dropped redundant allow on `store`.
  - `fakecloud-scheduler`: removed type-anchor helpers and unused test imports across delivery/service/simulation/ticker.
  - `fakecloud-apigatewayv2`: deleted unused `non_empty()`.
  - `fakecloud-iam`: removed redundant allow on `_assert_impl`.
  - Tests: removed unused-import anchors and now-unused imports in ECR/ECS; dropped conformance `SuspendedState` anchor.

<sup>Written for commit 7ff0c8c3bfbc47ad1da8f2d9cd744bcdfa9220cd. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/840?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

