### PR TITLE
refactor: replace inline arn:aws format!() with Arn helper in production code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,6 +2786,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-logs",
  "fakecloud-persistence",

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use fakecloud_aws::arn::Arn;
+use fakecloud_aws::arn::{partition_for, Arn};
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -835,6 +835,7 @@ fn synth_scalable_target_arn(account_id: &str, region: &str) -> String {
         account_id,
         &format!("scalable-target/{id}"),
     )
+    .with_partition(partition_for(region))
     .to_string()
 }
 

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -9,6 +9,7 @@ use parking_lot::RwLock;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -828,7 +829,13 @@ fn synth_scalable_target_arn(account_id: &str, region: &str) -> String {
     };
     let id = Uuid::new_v4().simple().to_string();
     let id = &id[..10];
-    format!("arn:aws:application-autoscaling:{region}:{account_id}:scalable-target/{id}")
+    Arn::new(
+        "application-autoscaling",
+        region,
+        account_id,
+        &format!("scalable-target/{id}"),
+    )
+    .to_string()
 }
 
 fn synth_policy_arn(

--- a/crates/fakecloud-aws/src/arn.rs
+++ b/crates/fakecloud-aws/src/arn.rs
@@ -47,6 +47,23 @@ impl Arn {
     }
 }
 
+/// Map an AWS region name to its partition. Mirrors the AWS SDK's
+/// region-to-partition lookup so synthesized ARNs in cn/gov-cloud
+/// regions emit the correct partition prefix.
+pub fn partition_for(region: &str) -> &'static str {
+    if region.starts_with("cn-") {
+        "aws-cn"
+    } else if region.starts_with("us-gov-") {
+        "aws-us-gov"
+    } else if region.starts_with("us-iso-") {
+        "aws-iso"
+    } else if region.starts_with("us-isob-") {
+        "aws-iso-b"
+    } else {
+        "aws"
+    }
+}
+
 impl fmt::Display for Arn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -109,5 +126,16 @@ mod tests {
     fn with_partition_overrides() {
         let arn = Arn::new("sqs", "cn-north-1", "123", "q").with_partition("aws-cn");
         assert_eq!(arn.to_string(), "arn:aws-cn:sqs:cn-north-1:123:q");
+    }
+
+    #[test]
+    fn partition_for_region() {
+        assert_eq!(partition_for("us-east-1"), "aws");
+        assert_eq!(partition_for("eu-west-1"), "aws");
+        assert_eq!(partition_for("cn-north-1"), "aws-cn");
+        assert_eq!(partition_for("cn-northwest-1"), "aws-cn");
+        assert_eq!(partition_for("us-gov-west-1"), "aws-us-gov");
+        assert_eq!(partition_for("us-iso-east-1"), "aws-iso");
+        assert_eq!(partition_for("us-isob-east-1"), "aws-iso-b");
     }
 }

--- a/crates/fakecloud-aws/src/arn.rs
+++ b/crates/fakecloud-aws/src/arn.rs
@@ -27,6 +27,24 @@ impl Arn {
     pub fn global(service: &str, account_id: &str, resource: &str) -> Self {
         Self::new(service, "", account_id, resource)
     }
+
+    /// Create an S3 ARN — no region, no account.
+    /// Format: `arn:aws:s3:::resource`.
+    pub fn s3(resource: &str) -> Self {
+        Self {
+            partition: "aws".to_string(),
+            service: "s3".to_string(),
+            region: String::new(),
+            account_id: String::new(),
+            resource: resource.to_string(),
+        }
+    }
+
+    /// Override the partition (default `aws`). Use for `aws-cn` / `aws-us-gov`.
+    pub fn with_partition(mut self, partition: &str) -> Self {
+        self.partition = partition.to_string();
+        self
+    }
 }
 
 impl fmt::Display for Arn {
@@ -77,5 +95,19 @@ mod tests {
     fn global_arn() {
         let arn = Arn::global("iam", "123456789012", "user/admin");
         assert_eq!(arn.to_string(), "arn:aws:iam::123456789012:user/admin");
+    }
+
+    #[test]
+    fn s3_arn() {
+        let arn = Arn::s3("my-bucket");
+        assert_eq!(arn.to_string(), "arn:aws:s3:::my-bucket");
+        let object = Arn::s3("my-bucket/key.txt");
+        assert_eq!(object.to_string(), "arn:aws:s3:::my-bucket/key.txt");
+    }
+
+    #[test]
+    fn with_partition_overrides() {
+        let arn = Arn::new("sqs", "cn-north-1", "123", "q").with_partition("aws-cn");
+        assert_eq!(arn.to_string(), "arn:aws-cn:sqs:cn-north-1:123:q");
     }
 }

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-logs = { workspace = true }
 fakecloud-persistence = { workspace = true }

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -6,6 +6,7 @@ use http::StatusCode;
 use serde_json::{json, Map, Value};
 use tokio::sync::Mutex as AsyncMutex;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
@@ -954,11 +955,9 @@ impl EcsService {
             runtime_platform: body.get("runtimePlatform").cloned(),
             requires_attributes: Vec::new(),
             registered_at: Utc::now(),
-            registered_by: request
-                .principal
-                .as_ref()
-                .map(|p| p.arn.clone())
-                .or(Some(format!("arn:aws:iam::{}:root", state.account_id))),
+            registered_by: request.principal.as_ref().map(|p| p.arn.clone()).or(Some(
+                Arn::global("iam", &state.account_id, "root").to_string(),
+            )),
             deregistered_at: None,
             tags: tags.clone(),
             enable_fault_injection: body.get("enableFaultInjection").and_then(|v| v.as_bool()),
@@ -1468,7 +1467,7 @@ impl EcsService {
         let principal_arn = opt_str(&body, "principalArn")
             .map(String::from)
             .or_else(|| request.principal.as_ref().map(|p| p.arn.clone()))
-            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+            .unwrap_or_else(|| Arn::global("iam", &request.account_id, "root").to_string());
         let account = request.account_id.clone();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
@@ -1503,7 +1502,7 @@ impl EcsService {
             "setting": {
                 "name": name,
                 "value": value,
-                "principalArn": format!("arn:aws:iam::{}:root", state.account_id),
+                "principalArn": Arn::global("iam", &state.account_id, "root").to_string(),
             }
         })))
     }
@@ -1514,7 +1513,7 @@ impl EcsService {
         let principal_arn = opt_str(&body, "principalArn")
             .map(String::from)
             .or_else(|| request.principal.as_ref().map(|p| p.arn.clone()))
-            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+            .unwrap_or_else(|| Arn::global("iam", &request.account_id, "root").to_string());
         let account = request.account_id.clone();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
@@ -1546,7 +1545,7 @@ impl EcsService {
         let Some(state) = accounts.get(&account) else {
             return Ok(AwsResponse::ok_json(json!({"settings": []})));
         };
-        let root_arn = format!("arn:aws:iam::{}:root", state.account_id);
+        let root_arn = Arn::global("iam", &state.account_id, "root").to_string();
         let mut settings: Vec<Value> = Vec::new();
 
         if effective_only {
@@ -2195,7 +2194,7 @@ impl EcsService {
             .principal
             .as_ref()
             .map(|p| p.arn.clone())
-            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+            .unwrap_or_else(|| Arn::global("iam", &request.account_id, "root").to_string());
 
         let (service_json, spawn_task_ids) = {
             let mut accounts = self.state.write();
@@ -2313,7 +2312,7 @@ impl EcsService {
             .principal
             .as_ref()
             .map(|p| p.arn.clone())
-            .unwrap_or_else(|| format!("arn:aws:iam::{}:root", request.account_id));
+            .unwrap_or_else(|| Arn::global("iam", &request.account_id, "root").to_string());
         let runtime = self.runtime.clone();
 
         let (service_json, spawn_ids, stop_ids) = {

--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -3,6 +3,7 @@ use base64::Engine as _;
 use http::{HeaderMap, StatusCode};
 
 use bytes::Bytes;
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::persistence::bucket_meta_snapshot;
@@ -299,7 +300,7 @@ impl S3Service {
         headers.insert("location", format!("/{bucket}").parse().unwrap());
         headers.insert(
             "x-amz-bucket-arn",
-            format!("arn:aws:s3:::{bucket}").parse().unwrap(),
+            Arn::s3(bucket).to_string().parse().unwrap(),
         );
         Ok(AwsResponse {
             status: StatusCode::OK,

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Timelike, Utc};
 use http::{HeaderMap, Method, StatusCode};
 use md5::{Digest, Md5};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_kms::state::SharedKmsState;
@@ -125,7 +126,7 @@ impl S3Service {
             return Ok(bytes::Bytes::copy_from_slice(plaintext));
         };
         let key = kms_key_id.filter(|k| !k.is_empty()).unwrap_or("aws/s3");
-        let bucket_arn = format!("arn:aws:s3:::{bucket}");
+        let bucket_arn = Arn::s3(bucket).to_string();
         let mut ctx = std::collections::HashMap::new();
         ctx.insert("aws:s3:arn".to_string(), bucket_arn);
         match hook.encrypt(account_id, region, key, plaintext, "s3.amazonaws.com", ctx) {
@@ -165,7 +166,7 @@ impl S3Service {
             Ok(s) => s,
             Err(_) => return Ok(bytes::Bytes::copy_from_slice(ciphertext)),
         };
-        let bucket_arn = format!("arn:aws:s3:::{bucket}");
+        let bucket_arn = Arn::s3(bucket).to_string();
         let mut ctx = std::collections::HashMap::new();
         ctx.insert("aws:s3:arn".to_string(), bucket_arn);
         match hook.decrypt(account_id, envelope, "s3.amazonaws.com", ctx) {
@@ -1457,12 +1458,12 @@ fn s3_resource_for(action: &'static str, bucket: Option<&str>, key: Option<&str>
     };
     if OBJECT_ACTIONS.contains(&action) {
         match key {
-            Some(k) if !k.is_empty() => format!("arn:aws:s3:::{}/{}", bucket, k),
-            _ => format!("arn:aws:s3:::{}/*", bucket),
+            Some(k) if !k.is_empty() => Arn::s3(&format!("{bucket}/{k}")).to_string(),
+            _ => Arn::s3(&format!("{bucket}/*")).to_string(),
         }
     } else {
         // Bucket-level actions (ListObjectsV2, GetBucketTagging, ...).
-        format!("arn:aws:s3:::{}", bucket)
+        Arn::s3(bucket).to_string()
     }
 }
 

--- a/crates/fakecloud-s3/src/service/notifications.rs
+++ b/crates/fakecloud-s3/src/service/notifications.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::delivery::DeliveryBus;
 
 use crate::state::{S3NotificationEvent, SharedS3State};
@@ -400,7 +401,7 @@ pub(crate) fn build_s3_event_notification(
             "s3": {
                 "bucket": {
                     "name": bucket_name,
-                    "arn": format!("arn:aws:s3:::{}", bucket_name)
+                    "arn": Arn::s3(bucket_name).to_string()
                 },
                 "object": {
                     "key": key,

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_sdk::types;
 
 // Make pub so main.rs can construct it
@@ -491,7 +492,7 @@ pub(crate) fn create_admin_in_account(
             .replace('-', "")
             .to_uppercase()[..16]
     );
-    let arn = format!("arn:aws:iam::{}:user/{}", account_id, user_name);
+    let arn = Arn::global("iam", account_id, &format!("user/{user_name}")).to_string();
     let akid = format!(
         "FKIA{}",
         &uuid::Uuid::new_v4()

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -487,7 +487,7 @@ impl SsmService {
 
         let value = version.secret_string.as_deref().unwrap_or("").to_string();
 
-        let arn = format!("arn:aws:ssm:{region}:{}:parameter{}", account_id, raw_name);
+        let arn = Arn::new("ssm", region, account_id, &format!("parameter{raw_name}")).to_string();
 
         Ok(AwsResponse::ok_json(json!({
             "Parameter": {


### PR DESCRIPTION
## Summary

Audit batch 7 partial. Extends fakecloud-aws Arn API and sweeps production-code inline ARN formats.

New Arn methods:
- 'Arn::s3(resource)' — no-region/no-account S3 form ('arn:aws:s3:::resource')
- 'Arn::with_partition(p)' — override partition for aws-cn / aws-us-gov

Production-code sweep (~12 sites):
- s3: bucket_arn lookups, x-amz-bucket-arn header, s3_resource_for classifier, notification event payload
- ecs: 6 sites of 'arn:aws:iam::{account}:root' principal ARN
- ssm: GetParameter ARN
- application-autoscaling: scalable-target ARN
- server/reset: admin user ARN

Test-code ARN formats (mod tests blocks, test helpers/builders) intentionally left alone — they don't affect production wire shape and converting them is noisier than the value justifies.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt
- [x] new Arn helper unit tests (s3 + with_partition)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized ARN construction across production by switching to the `Arn` helper and fixed partition handling so ARNs match real AWS in cn/gov/iso regions. Added S3 and partition helpers in `fakecloud-aws`.

- **New Features**
  - `Arn::s3(resource)` for `arn:aws:s3:::...` (no region/account).
  - `Arn::with_partition(partition)` to override `aws`.
  - `partition_for(region)` maps to `aws`, `aws-cn`, `aws-us-gov`, `aws-iso`, `aws-iso-b`.

- **Refactors**
  - Replaced `format!("arn:aws:...")` with `Arn` in production:
    - `s3`: bucket ARN header, KMS context, resource classifier, event payloads.
    - `ecs`: default `iam::account:root` principal.
    - `ssm`: `GetParameter` ARN.
    - `application-autoscaling`: scalable-target ARN (now uses `partition_for(region)`).
    - `server/reset`: admin user ARN.
  - Added `fakecloud-aws` to `fakecloud-ecs`. Test-only code unchanged.

<sup>Written for commit 942eb0fb9a2f3721d8ab3e15b2686f6da6300fb7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/843?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

