### PR TITLE
test(e2e): replace 3 standalone hardcoded sleeps with bounded polling

### DIFF
--- a/crates/fakecloud-e2e/tests/cross_service.rs
+++ b/crates/fakecloud-e2e/tests/cross_service.rs
@@ -676,25 +676,31 @@ async fn kinesis_lambda_event_source_mapping() {
         .await
         .unwrap();
 
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-    let invocations = get_lambda_invocations(server.endpoint()).await;
+    // Poll for the Kinesis-shaped Lambda invocation rather than sleeping
+    // a fixed duration. Bounded by a 10s deadline.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let (invocations, inv) = loop {
+        let invocations = get_lambda_invocations(server.endpoint()).await;
+        let inv_list = invocations["invocations"].as_array().unwrap().clone();
+        let kinesis_inv = inv_list.iter().rev().find(|inv| {
+            inv["payload"]
+                .as_str()
+                .unwrap_or("")
+                .contains("\"eventSource\":\"aws:kinesis\"")
+        });
+        if let Some(inv) = kinesis_inv {
+            break (invocations, inv.clone());
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("expected a Kinesis-shaped Lambda invocation within 10s");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
     let inv_list = invocations["invocations"].as_array().unwrap();
     assert!(
         !inv_list.is_empty(),
         "expected at least one Lambda invocation"
     );
-
-    let inv = inv_list
-        .iter()
-        .rev()
-        .find(|inv| {
-            inv["payload"]
-                .as_str()
-                .unwrap_or("")
-                .contains("\"eventSource\":\"aws:kinesis\"")
-        })
-        .expect("expected a Kinesis-shaped Lambda invocation payload");
     assert!(inv["functionArn"]
         .as_str()
         .unwrap()

--- a/crates/fakecloud-e2e/tests/scheduler.rs
+++ b/crates/fakecloud-e2e/tests/scheduler.rs
@@ -337,14 +337,19 @@ async fn scheduler_at_one_shot_delete_removes_schedule_after_fire() {
         .expect("one-shot should fire within 10s");
     assert_eq!(msg.body.unwrap(), "{\"one\":\"shot\"}");
 
-    // Give the ticker a beat to apply the DELETE post-fire action.
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    let err = sched
-        .get_schedule()
-        .name("once-delete")
-        .send()
-        .await
-        .expect_err("schedule should be deleted after firing");
+    // Poll for the DELETE post-fire action to take effect rather than
+    // sleeping a fixed duration. Still bounded by a 10s deadline.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let err = loop {
+        let result = sched.get_schedule().name("once-delete").send().await;
+        if let Err(e) = result {
+            break e;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("schedule was not deleted within 10s after firing");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
     assert!(format!("{err:?}").contains("ResourceNotFound"));
 }
 

--- a/crates/fakecloud-e2e/tests/scheduler_introspection.rs
+++ b/crates/fakecloud-e2e/tests/scheduler_introspection.rs
@@ -95,16 +95,23 @@ async fn fire_schedule_endpoint_triggers_sqs_delivery() {
         .await
         .unwrap();
 
-    // Wait a tick so the first-bootstrap auto-fire goes to the queue,
-    // then drain it.
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    sqs.receive_message()
-        .queue_url(&q_url)
-        .max_number_of_messages(10)
-        .wait_time_seconds(1)
-        .send()
-        .await
-        .unwrap();
+    // Drain any first-bootstrap auto-fire from the queue. Long-polls
+    // up to 1s per round so the bootstrap message has time to land,
+    // then loops until the queue stays empty for one round.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let resp = sqs
+            .receive_message()
+            .queue_url(&q_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(1)
+            .send()
+            .await
+            .unwrap();
+        if resp.messages().is_empty() || std::time::Instant::now() >= deadline {
+            break;
+        }
+    }
 
     // Now drive the introspection endpoint.
     let resp = reqwest::Client::new()


### PR DESCRIPTION
## Summary

Audit batch 6 finish (partial). Converts the standalone 'sleep N then assume done' patterns to bounded polling loops.

- scheduler_introspection bootstrap drain: long-poll loop until queue empty
- scheduler one-shot DELETE: poll get_schedule for ResourceNotFound
- cross_service Kinesis->Lambda: poll get_lambda_invocations for the kinesis-shaped event

Each loop has a 10s deadline so a stuck system fails the test instead of hanging.

Sleeps left as-is:
- Inside polling loops (the sleep IS the retry interval)
- Wall-clock-dependent (SQS message retention expiration, idempotency redelivery windows)

## Test plan

- [x] cargo build -p fakecloud-e2e --tests
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace three hardcoded sleeps in e2e tests with bounded polling loops (10s deadlines) to reduce flakiness and fail fast instead of hanging. Other wall-clock dependent sleeps remain by design.

- **Refactors**
  - Scheduler introspection: drain bootstrap queue via 1s long-poll loop until empty (max 10s).
  - Scheduler one-shot DELETE: poll get_schedule() until ResourceNotFound (max 10s).
  - Kinesis→Lambda: poll get_lambda_invocations() until a Kinesis-shaped invocation is observed (max 10s).

<sup>Written for commit 190ee5659803560fcf9b575e9a4168f9e4597b94. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/844?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

