### PR TITLE
refactor: continue Arn helper sweep in production code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
  "http 1.4.0",

--- a/crates/fakecloud-apigatewayv2/Cargo.toml
+++ b/crates/fakecloud-apigatewayv2/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -6,6 +6,7 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::ApiGatewayV2Service;
@@ -296,7 +297,7 @@ impl ApiGatewayV2Service {
                 let state = accounts.get_or_create(aid);
                 let mut entry = json!({
                     "DomainName": name,
-                    "DomainNameArn": format!("arn:aws:apigateway:us-east-1::/domainnames/{}", name),
+                    "DomainNameArn": Arn::new("apigateway", "us-east-1", "", &format!("/domainnames/{name}")).to_string(),
                     "DomainNameConfigurations": body.get("DomainNameConfigurations").cloned().unwrap_or(json!([])),
                     "ApiMappingSelectionExpression": "$request.basepath",
                     "RoutingMode": "API_MAPPING_ONLY",
@@ -1277,7 +1278,7 @@ impl ApiGatewayV2Service {
                 }
                 json!({
                     id_field: id,
-                    "PortalArn": format!("arn:aws:apigateway:us-east-1::/portals/{}", id),
+                    "PortalArn": Arn::new("apigateway", "us-east-1", "", &format!("/portals/{id}")).to_string(),
                     "LastModified": now,
                     "LastPublished": now,
                     "LastPublishedDescription": "",
@@ -1293,7 +1294,7 @@ impl ApiGatewayV2Service {
             }
             "portal_products" => json!({
                 id_field: id,
-                "PortalProductArn": format!("arn:aws:apigateway:us-east-1::/portalproducts/{}", id),
+                "PortalProductArn": Arn::new("apigateway", "us-east-1", "", &format!("/portalproducts/{id}")).to_string(),
                 "LastModified": now,
                 "Description": input.get("Description").and_then(|x| x.as_str()).unwrap_or(""),
                 "DisplayName": input.get("DisplayName").and_then(|x| x.as_str()).unwrap_or(&id),

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -14,6 +14,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
@@ -105,8 +106,20 @@ impl CloudFormationService {
             "CreateChangeSet" => {
                 let stack_name = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
                 let cs_name = params.get("ChangeSetName").ok_or_else(|| missing("ChangeSetName"))?.clone();
-                let id = format!("arn:aws:cloudformation:us-east-1:{aid}:changeSet/{cs_name}/{}", rand_id());
-                let stack_id = format!("arn:aws:cloudformation:us-east-1:{aid}:stack/{stack_name}/{}", rand_id());
+                let id = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("changeSet/{cs_name}/{}", rand_id()),
+                )
+                .to_string();
+                let stack_id = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("stack/{stack_name}/{}", rand_id()),
+                )
+                .to_string();
                 let entry = json!({
                     "Id": id,
                     "ChangeSetName": cs_name,
@@ -295,12 +308,26 @@ impl CloudFormationService {
 
             // ── Types / extensions ──
             "ActivateType" => {
-                let arn = format!("arn:aws:cloudformation:us-east-1:{aid}:type/resource/{}", rand_id());
+                let arn = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("type/resource/{}", rand_id()),
+                )
+                .to_string();
                 Ok(xml_response("ActivateType", format!("    <Arn>{}</Arn>", xml_escape(&arn)), &rid))
             }
             "DeactivateType" => Ok(xml_response("DeactivateType", String::new(), &rid)),
             "DescribeType" => {
-                let arn = params.get("Arn").cloned().unwrap_or_else(|| format!("arn:aws:cloudformation:us-east-1:{aid}:type/resource/Default"));
+                let arn = params.get("Arn").cloned().unwrap_or_else(|| {
+                    Arn::new(
+                        "cloudformation",
+                        "us-east-1",
+                        &aid,
+                        "type/resource/Default",
+                    )
+                    .to_string()
+                });
                 let inner = format!(
                     "    <Arn>{}</Arn>\n    <Type>RESOURCE</Type>\n    <TypeName>AWS::Custom::Type</TypeName>",
                     xml_escape(&arn),
@@ -329,16 +356,34 @@ impl CloudFormationService {
                 &rid,
             )),
             "SetTypeConfiguration" => {
-                let arn = format!("arn:aws:cloudformation:us-east-1:{aid}:type-config/{}", rand_id());
+                let arn = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("type-config/{}", rand_id()),
+                )
+                .to_string();
                 Ok(xml_response("SetTypeConfiguration", format!("    <ConfigurationArn>{}</ConfigurationArn>", xml_escape(&arn)), &rid))
             }
             "SetTypeDefaultVersion" => Ok(xml_response("SetTypeDefaultVersion", String::new(), &rid)),
             "TestType" => {
-                let arn = format!("arn:aws:cloudformation:us-east-1:{aid}:type/resource/{}", rand_id());
+                let arn = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("type/resource/{}", rand_id()),
+                )
+                .to_string();
                 Ok(xml_response("TestType", format!("    <TypeVersionArn>{}</TypeVersionArn>", xml_escape(&arn)), &rid))
             }
             "PublishType" => {
-                let arn = format!("arn:aws:cloudformation:us-east-1:{aid}:type/resource/{}", rand_id());
+                let arn = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("type/resource/{}", rand_id()),
+                )
+                .to_string();
                 Ok(xml_response("PublishType", format!("    <PublicTypeArn>{}</PublicTypeArn>", xml_escape(&arn)), &rid))
             }
             "RegisterPublisher" => {
@@ -357,7 +402,13 @@ impl CloudFormationService {
             // ── Generated templates ──
             "CreateGeneratedTemplate" => {
                 let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
-                let id = format!("arn:aws:cloudformation:us-east-1:{aid}:generatedtemplate/{}", rand_id());
+                let id = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("generatedtemplate/{}", rand_id()),
+                )
+                .to_string();
                 let entry = json!({"GeneratedTemplateId": id.clone(), "Name": name.clone(), "Status": "COMPLETE"});
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
@@ -366,7 +417,13 @@ impl CloudFormationService {
             }
             "UpdateGeneratedTemplate" => {
                 let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
-                let id = format!("arn:aws:cloudformation:us-east-1:{aid}:generatedtemplate/{name}");
+                let id = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("generatedtemplate/{name}"),
+                )
+                .to_string();
                 Ok(xml_response("UpdateGeneratedTemplate", format!("    <GeneratedTemplateId>{}</GeneratedTemplateId>", xml_escape(&id)), &rid))
             }
             "DescribeGeneratedTemplate" => {
@@ -393,7 +450,13 @@ impl CloudFormationService {
 
             // ── Resource scans ──
             "StartResourceScan" => {
-                let id = format!("arn:aws:cloudformation:us-east-1:{aid}:resourceScan/{}", rand_id());
+                let id = Arn::new(
+                    "cloudformation",
+                    "us-east-1",
+                    &aid,
+                    &format!("resourceScan/{}", rand_id()),
+                )
+                .to_string();
                 Ok(xml_response("StartResourceScan", format!("    <ResourceScanId>{}</ResourceScanId>", xml_escape(&id)), &rid))
             }
             "DescribeResourceScan" => {

--- a/crates/fakecloud-cloudfront/src/extras_service.rs
+++ b/crates/fakecloud-cloudfront/src/extras_service.rs
@@ -4,6 +4,7 @@
 use chrono::Utc;
 use http::{HeaderMap, StatusCode};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::extras::{
@@ -59,7 +60,8 @@ impl CloudFrontService {
         let id = generate_id_with_prefix("VO");
         let etag = generate_id_with_prefix("E");
         let now = Utc::now();
-        let arn = format!("arn:aws:cloudfront::{}:vpc-origin/{}", DEFAULT_ACCOUNT, id);
+        let arn =
+            Arn::global("cloudfront", DEFAULT_ACCOUNT, &format!("vpc-origin/{id}")).to_string();
         let stored = StoredVpcOrigin {
             id: id.clone(),
             arn,
@@ -399,7 +401,8 @@ impl CloudFrontService {
             ));
         }
         let id = generate_id_with_prefix("TS");
-        let arn = format!("arn:aws:cloudfront::{}:trust-store/{}", DEFAULT_ACCOUNT, id);
+        let arn =
+            Arn::global("cloudfront", DEFAULT_ACCOUNT, &format!("trust-store/{id}")).to_string();
         let etag = generate_id_with_prefix("E");
         let stored = StoredTrustStore {
             id: id.clone(),

--- a/crates/fakecloud-route53/src/service.rs
+++ b/crates/fakecloud-route53/src/service.rs
@@ -10,6 +10,7 @@ use http::{HeaderMap, StatusCode};
 use parking_lot::RwLock;
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError, ResponseBody};
 
 use crate::model::{
@@ -2314,7 +2315,8 @@ impl Route53Service {
             ));
         }
         let id = Uuid::new_v4().to_string();
-        let arn = format!("arn:aws:route53::{}:cidrcollection/{}", DEFAULT_ACCOUNT, id);
+        let arn =
+            Arn::global("route53", DEFAULT_ACCOUNT, &format!("cidrcollection/{id}")).to_string();
         let stored = StoredCidrCollection {
             id: id.clone(),
             name: cfg.name,


### PR DESCRIPTION
## Summary

Audit batch 7 continued. Follow-on to PR #843. More production-code 'format!(\"arn:aws:...\")' sites converted to fakecloud-aws Arn helper.

- cloudfront/extras_service: vpc-origin, trust-store
- route53/service: cidrcollection
- cloudformation/extras: changeSet, stack, type/resource, type-config, generatedtemplate, resourceScan (8 sites)
- apigatewayv2/extras: domainnames, portals, portalproducts (and adds fakecloud-aws workspace dep)

Doc-comment ARN samples and test-helper builders left as-is — those are documentation/test fixtures, not runtime ARNs.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced inline ARN strings with the centralized `Arn` helper across multiple services to standardize construction and reduce string mistakes. No behavior changes.

- **Refactors**
  - Switched to `Arn` in CloudFront (vpc-origin, trust-store).
  - Switched to `Arn` in Route53 (cidrcollection).
  - Switched to `Arn` in CloudFormation (changeSet, stack, type/resource, type-config, generatedtemplate, resourceScan).
  - Switched to `Arn` in API Gateway v2 (domainnames, portals, portalproducts).
  - Left doc-comment samples and test builders unchanged.

- **Dependencies**
  - Added `fakecloud-aws` to `fakecloud-apigatewayv2`.

<sup>Written for commit 32a5997fce4d8ee5dda1c4f53a97dfef66919529. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

