### PR TITLE
refactor(application-autoscaling): use Arn helper for service-linked role ARN

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -890,7 +890,12 @@ fn default_service_linked_role(account_id: &str, namespace: &str) -> String {
         "kafka" => "KafkaCluster",
         _ => "ApplicationAutoScaling_Default",
     };
-    format!("arn:aws:iam::{account_id}:role/aws-service-role/applicationautoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_{suffix}")
+    Arn::global(
+        "iam",
+        account_id,
+        &format!("role/aws-service-role/applicationautoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_{suffix}"),
+    )
+    .to_string()
 }
 
 fn synth_forecast(start: DateTime<Utc>, end: DateTime<Utc>) -> Vec<(DateTime<Utc>, i32)> {


### PR DESCRIPTION
## Summary

Audit batch 7 final follow-up. The synth_role_arn site for IAM service-linked roles now uses Arn::global() like other production sites.

Other ARN format!() sites that surveyed as production turned out to be inside #[cfg(test)] mod blocks (test helpers/fixtures), so they're left untouched — the audit's intent was to clean production code paths.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `Arn::global()` to build the IAM service-linked role ARN in `fakecloud-application-autoscaling`, replacing manual string formatting for consistency across production code.

- **Refactors**
  - Replaced `format!()` with `Arn::global()` in `default_service_linked_role`.
  - Left test-only `format!()` helpers unchanged.

<sup>Written for commit e4a17ff8ff28eeb1b2de56ebae5d0b44c7d5f8fa. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/846?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

