### PR TITLE
fix(kms): emit valid IssuingAccount ARN in ListGrants/ListRetirableGrants

### DIFF
--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -2330,7 +2330,7 @@ impl KmsService {
                     true
                 }
             })
-            .map(grant_to_json)
+            .map(|g| grant_to_json(g, &req.account_id))
             .collect();
 
         Ok(AwsResponse::json(
@@ -2372,7 +2372,7 @@ impl KmsService {
                     .as_deref()
                     .is_some_and(|rp| rp == retiring_principal)
             })
-            .map(grant_to_json)
+            .map(|g| grant_to_json(g, &req.account_id))
             .collect();
 
         let start = if let Some(m) = marker {
@@ -3517,13 +3517,13 @@ fn fmt_enum_set(items: &[String]) -> String {
     format!("[{}]", inner.join(", "))
 }
 
-fn grant_to_json(grant: &KmsGrant) -> Value {
+fn grant_to_json(grant: &KmsGrant, account_id: &str) -> Value {
     let mut v = json!({
         "KeyId": grant.key_id,
         "GrantId": grant.grant_id,
         "GranteePrincipal": grant.grantee_principal,
         "Operations": grant.operations,
-        "IssuingAccount": format!("arn:aws:iam::root"),
+        "IssuingAccount": fakecloud_aws::arn::Arn::global("iam", account_id, "root").to_string(),
         "CreationDate": grant.creation_date,
     });
 


### PR DESCRIPTION
## Summary

grant_to_json hard-coded 'arn:aws:iam::root' — only 5 ARN parts (missing account_id). Real KMS returns 'arn:aws:iam::ACCOUNT:root'.

Discovered during the batch 7 ARN sweep. The other ARN sites in that file were inside #[cfg(test)] mod blocks; this one is a real production bug — clients parsing the IssuingAccount field as an ARN would have rejected the malformed value.

Threads req.account_id into grant_to_json and uses Arn::global("iam", account, "root") to build the principal.

## Test plan

- [x] cargo build -p fakecloud-kms
- [x] cargo test -p fakecloud-kms (134 passed)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes KMS ListGrants/ListRetirableGrants to emit a valid IssuingAccount ARN that includes the account ID, matching AWS KMS. Prevents clients that validate ARNs from rejecting responses.

- **Bug Fixes**
  - Threaded `req.account_id` into `grant_to_json`.
  - Built IssuingAccount with `fakecloud_aws::arn::Arn::global("iam", account_id, "root")`.
  - Updated both list handlers to pass account ID instead of using `.map(grant_to_json)` directly.

<sup>Written for commit 3444b3840d5d5d22417dce511134d1add93b016f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/847?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

