### PR TITLE
fix: harden tfacc parent() unwrap and bedrock streaming infallible serializations

### DIFF
--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -97,9 +97,9 @@ pub(crate) fn build_invoke_stream_response(model_id: &str, response_text: &str) 
             }
         });
         let payload = serde_json::to_vec(
-            &json!({ "bytes": base64_encode(&serde_json::to_vec(&chunk).unwrap()) }),
+            &json!({ "bytes": base64_encode(&serde_json::to_vec(&chunk).expect("serde_json::Value serialization is infallible")) }),
         )
-        .unwrap();
+        .expect("serde_json::Value serialization is infallible");
         body.extend(encode_event("chunk", "application/json", &payload));
     } else {
         // Generic: single chunk with the full response
@@ -107,9 +107,9 @@ pub(crate) fn build_invoke_stream_response(model_id: &str, response_text: &str) 
             "outputText": response_text
         });
         let payload = serde_json::to_vec(
-            &json!({ "bytes": base64_encode(&serde_json::to_vec(&chunk).unwrap()) }),
+            &json!({ "bytes": base64_encode(&serde_json::to_vec(&chunk).expect("serde_json::Value serialization is infallible")) }),
         )
-        .unwrap();
+        .expect("serde_json::Value serialization is infallible");
         body.extend(encode_event("chunk", "application/json", &payload));
     }
 
@@ -122,12 +122,14 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
 
     // messageStart event
     let start = json!({ "role": "assistant" });
-    let payload = serde_json::to_vec(&json!({ "messageStart": start })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "messageStart": start }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event("messageStart", "application/json", &payload));
 
     // contentBlockStart event
     let block_start = json!({ "contentBlockIndex": 0, "start": {} });
-    let payload = serde_json::to_vec(&json!({ "contentBlockStart": block_start })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "contentBlockStart": block_start }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event(
         "contentBlockStart",
         "application/json",
@@ -141,7 +143,8 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
             "text": response_text
         }
     });
-    let payload = serde_json::to_vec(&json!({ "contentBlockDelta": delta })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "contentBlockDelta": delta }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event(
         "contentBlockDelta",
         "application/json",
@@ -150,7 +153,8 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
 
     // contentBlockStop event
     let block_stop = json!({ "contentBlockIndex": 0 });
-    let payload = serde_json::to_vec(&json!({ "contentBlockStop": block_stop })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "contentBlockStop": block_stop }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event(
         "contentBlockStop",
         "application/json",
@@ -161,7 +165,8 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
     let stop = json!({
         "stopReason": "end_turn"
     });
-    let payload = serde_json::to_vec(&json!({ "messageStop": stop })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "messageStop": stop }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event("messageStop", "application/json", &payload));
 
     // metadata event
@@ -175,7 +180,8 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
             "latencyMs": 100
         }
     });
-    let payload = serde_json::to_vec(&json!({ "metadata": metadata })).unwrap();
+    let payload = serde_json::to_vec(&json!({ "metadata": metadata }))
+        .expect("serde_json::Value serialization is infallible");
     body.extend(encode_event("metadata", "application/json", &payload));
 
     body

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -63,7 +63,13 @@ pub fn require_toolchain() {
 pub fn setup_provider_source() -> std::io::Result<PathBuf> {
     let target = provider_dir();
     if !target.exists() {
-        std::fs::create_dir_all(target.parent().unwrap())?;
+        let parent = target.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("provider_dir() has no parent: {}", target.display()),
+            )
+        })?;
+        std::fs::create_dir_all(parent)?;
         let status = Command::new("git")
             .args([
                 "clone",


### PR DESCRIPTION
## Summary

Two MEDIUM findings from the 2026-04-28 audit (§5 Error Handling):

- 'tfacc/src/lib.rs:66': 'std::fs::create_dir_all(target.parent().unwrap())' panics if target is root. Now returns an io::Error.
- 'bedrock/src/streaming.rs': 10 '.unwrap()' calls on infallible 'serde_json::to_vec()' of 'json!()' values. Same pattern as PR #832 (Bedrock builders) and PR #833 (Step Functions). Switched to '.expect()' with descriptive message.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened error handling in `fakecloud-tfacc` and made `fakecloud-bedrock` streaming serialization explicit to avoid panics and improve error messages. Addresses two MEDIUM findings from the 2026-04-28 audit.

- **Bug Fixes**
  - `fakecloud-tfacc`: Guard `target.parent()` in `setup_provider_source()`; return an `io::Error` if missing (root path) and create the parent dir safely.
  - `fakecloud-bedrock`: Replace 10 `.unwrap()` calls on `serde_json` `to_vec(json!(...))` with `.expect("serde_json::Value serialization is infallible")` in streaming responses for clearer diagnostics.

<sup>Written for commit eac793bae297b80f57d2ce6f126c4d905efe2f1a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

