### PR TITLE
refactor(iam): use core paginate() helper in paginated_tags_response

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use http::StatusCode;
 
+use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 // NOTE: The shared validation helpers use ValidationException error codes, but real IAM
 // typically returns InvalidInput or ValidationError for input validation failures. This is
@@ -1238,20 +1239,15 @@ fn paginated_tags_response(
     )?;
     validate_optional_range_i64("maxItems", max_items_i64, 1, 1000)?;
     let max_items: usize = max_items_i64.unwrap_or(100) as usize;
-    let offset: usize = req
-        .query_params
-        .get("Marker")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0);
 
-    let offset = offset.min(tags.len());
-    let page = &tags[offset..tags.len().min(offset + max_items)];
-    let is_truncated = offset + max_items < tags.len();
-    let members = tags_xml(page);
-    let marker = if is_truncated {
-        format!("<Marker>{}</Marker>", offset + max_items)
-    } else {
-        String::new()
+    let next_token = req.query_params.get("Marker").map(|s| s.as_str());
+    let (page, next_marker) = paginate(tags, next_token, max_items);
+
+    let is_truncated = next_marker.is_some();
+    let members = tags_xml(&page);
+    let marker = match &next_marker {
+        Some(m) => format!("<Marker>{m}</Marker>"),
+        None => String::new(),
     };
 
     Ok(format!(


### PR DESCRIPTION
## Summary

The audit's §3 Inconsistencies flagged IAM as having a bespoke 'paginated_tags_response' that doesn't go through the workspace 'fakecloud_core::pagination::paginate()' helper. PR #830 swept other services; this finishes the IAM holdout.

The bespoke logic used 'offset + max_items < tags.len()' as its is_truncated check while the canonical helper checks 'page.len() > max_results' (after slicing). Both produce identical output when paging through, but using the shared helper eliminates the divergence and inherits the zero-page short-circuit fix from PR #830.

## Test plan

- [x] cargo build -p fakecloud-iam
- [x] cargo test -p fakecloud-iam (378 passed)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors IAM tag pagination to use the shared `fakecloud_core::pagination::paginate()` helper. This aligns behavior with other services and fixes the zero-page edge case.

- **Refactors**
  - Replace custom offset/marker logic in `paginated_tags_response` with `paginate(tags, next_token, max_items)`.
  - Build the response from the returned `page` and `next_marker` (emit `<Marker>` only when present).

<sup>Written for commit 52242e75190a62d9942d68f5f70b3fe88bc71c6a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/849?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

