### PR TITLE
refactor(acm): standardize state collections on BTreeMap

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -1,6 +1,6 @@
 //! ACM (Certificate Manager) JSON 1.1 service.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -791,8 +791,8 @@ fn synth_serial(arn: &str) -> String {
     hex::encode(&digest[..16])
 }
 
-fn parse_tags(value: Option<&Value>) -> Result<HashMap<String, String>, AwsServiceError> {
-    let mut out = HashMap::new();
+fn parse_tags(value: Option<&Value>) -> Result<BTreeMap<String, String>, AwsServiceError> {
+    let mut out = BTreeMap::new();
     let Some(arr) = value.and_then(Value::as_array) else {
         return Ok(out);
     };

--- a/crates/fakecloud-acm/src/state.rs
+++ b/crates/fakecloud-acm/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for ACM certificates.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -11,7 +11,7 @@ pub type SharedAcmState = Arc<RwLock<AcmAccounts>>;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AcmAccounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl AcmAccounts {
@@ -23,7 +23,7 @@ impl AcmAccounts {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by full certificate ARN.
-    pub certificates: HashMap<String, StoredCertificate>,
+    pub certificates: BTreeMap<String, StoredCertificate>,
     pub account_config: AccountConfig,
 }
 
@@ -64,7 +64,7 @@ pub struct StoredCertificate {
     pub renewal_eligibility: String,
     pub managed_by: Option<String>,
     pub certificate_authority_arn: Option<String>,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     pub in_use_by: Vec<String>,
 }
 


### PR DESCRIPTION
## Summary

First service in the audit batch 12 'BTreeMap for state collections' sweep. ACM picked as proof-of-concept since it's the smallest service.

Three HashMap -> BTreeMap conversions in 'AcmAccounts', 'AccountState.certificates', 'StoredCertificate.tags', plus the 'parse_tags()' helper return type.

Behavior change: iteration is now sorted-by-key instead of random. ListCertificates pagination becomes deterministic across runs, which more closely matches real AWS behavior than insertion-random HashMap.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest run -P ci -p fakecloud-conformance --tests acm (17 ACM tests pass)
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized ACM state collections on BTreeMap to make iteration order deterministic. This stabilizes ListCertificates pagination across runs and better matches AWS behavior.

- **Refactors**
  - Swapped `HashMap` to `BTreeMap` for `AcmAccounts.accounts`, `AccountState.certificates`, and `StoredCertificate.tags`.
  - Updated `parse_tags()` to return a `BTreeMap`.

<sup>Written for commit 375be87f530853bf02d2546480756d8c10e0e7f9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/850?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

