### PR TITLE
refactor: standardize state collections on BTreeMap (athena, route53, cloudfront)

### DIFF
--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -1874,8 +1874,8 @@ fn parse_string_list(value: Option<&Value>) -> Vec<String> {
 
 fn parse_tags(
     value: Option<&Value>,
-) -> Result<std::collections::HashMap<String, String>, AwsServiceError> {
-    let mut out = std::collections::HashMap::new();
+) -> Result<std::collections::BTreeMap<String, String>, AwsServiceError> {
+    let mut out = std::collections::BTreeMap::new();
     let Some(arr) = value.and_then(Value::as_array) else {
         return Ok(out);
     };

--- a/crates/fakecloud-athena/src/state.rs
+++ b/crates/fakecloud-athena/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for Athena.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -12,7 +12,7 @@ pub type SharedAthenaState = Arc<RwLock<AthenaAccounts>>;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AthenaAccounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl AthenaAccounts {
@@ -23,17 +23,17 @@ impl AthenaAccounts {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
-    pub work_groups: HashMap<String, WorkGroup>,
-    pub data_catalogs: HashMap<String, DataCatalog>,
-    pub named_queries: HashMap<String, NamedQuery>,
-    pub prepared_statements: HashMap<(String, String), PreparedStatement>,
-    pub query_executions: HashMap<String, QueryExecution>,
-    pub notebooks: HashMap<String, Notebook>,
-    pub sessions: HashMap<String, Session>,
-    pub calculations: HashMap<String, Calculation>,
-    pub capacity_reservations: HashMap<String, CapacityReservation>,
+    pub work_groups: BTreeMap<String, WorkGroup>,
+    pub data_catalogs: BTreeMap<String, DataCatalog>,
+    pub named_queries: BTreeMap<String, NamedQuery>,
+    pub prepared_statements: BTreeMap<(String, String), PreparedStatement>,
+    pub query_executions: BTreeMap<String, QueryExecution>,
+    pub notebooks: BTreeMap<String, Notebook>,
+    pub sessions: BTreeMap<String, Session>,
+    pub calculations: BTreeMap<String, Calculation>,
+    pub capacity_reservations: BTreeMap<String, CapacityReservation>,
     pub capacity_assignment_config: Option<CapacityAssignmentConfiguration>,
-    pub tags: HashMap<String, HashMap<String, String>>,
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
     pub initialized: bool,
 }
 
@@ -59,7 +59,7 @@ impl AccountState {
             name: "AwsDataCatalog".to_string(),
             description: Some("Default AWS data catalog".to_string()),
             cat_type: "GLUE".to_string(),
-            parameters: HashMap::new(),
+            parameters: BTreeMap::new(),
             status: "CREATE_COMPLETE".to_string(),
             connection_type: None,
             error: None,
@@ -84,7 +84,7 @@ pub struct DataCatalog {
     pub name: String,
     pub description: Option<String>,
     pub cat_type: String,
-    pub parameters: HashMap<String, String>,
+    pub parameters: BTreeMap<String, String>,
     pub status: String,
     pub connection_type: Option<String>,
     pub error: Option<String>,

--- a/crates/fakecloud-cloudfront/src/state.rs
+++ b/crates/fakecloud-cloudfront/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for CloudFront resources.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -27,7 +27,7 @@ pub type SharedCloudFrontState = Arc<RwLock<CloudFrontAccounts>>;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CloudFrontAccounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl CloudFrontAccounts {
@@ -50,33 +50,33 @@ impl CloudFrontAccounts {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
-    pub distributions: HashMap<String, StoredDistribution>,
-    pub invalidations: HashMap<String, StoredInvalidation>,
+    pub distributions: BTreeMap<String, StoredDistribution>,
+    pub invalidations: BTreeMap<String, StoredInvalidation>,
     /// Tags keyed by ARN.
-    pub tags: HashMap<String, Vec<Tag>>,
-    pub origin_access_controls: HashMap<String, StoredOriginAccessControl>,
-    pub cache_policies: HashMap<String, StoredCachePolicy>,
-    pub origin_request_policies: HashMap<String, StoredOriginRequestPolicy>,
-    pub response_headers_policies: HashMap<String, StoredResponseHeadersPolicy>,
-    pub continuous_deployment_policies: HashMap<String, StoredContinuousDeploymentPolicy>,
-    pub functions: HashMap<String, StoredFunction>,
-    pub public_keys: HashMap<String, StoredPublicKey>,
-    pub key_groups: HashMap<String, StoredKeyGroup>,
-    pub key_value_stores: HashMap<String, StoredKeyValueStore>,
-    pub origin_access_identities: HashMap<String, StoredOriginAccessIdentity>,
+    pub tags: BTreeMap<String, Vec<Tag>>,
+    pub origin_access_controls: BTreeMap<String, StoredOriginAccessControl>,
+    pub cache_policies: BTreeMap<String, StoredCachePolicy>,
+    pub origin_request_policies: BTreeMap<String, StoredOriginRequestPolicy>,
+    pub response_headers_policies: BTreeMap<String, StoredResponseHeadersPolicy>,
+    pub continuous_deployment_policies: BTreeMap<String, StoredContinuousDeploymentPolicy>,
+    pub functions: BTreeMap<String, StoredFunction>,
+    pub public_keys: BTreeMap<String, StoredPublicKey>,
+    pub key_groups: BTreeMap<String, StoredKeyGroup>,
+    pub key_value_stores: BTreeMap<String, StoredKeyValueStore>,
+    pub origin_access_identities: BTreeMap<String, StoredOriginAccessIdentity>,
     /// Per-distribution monitoring subscription, keyed by distribution id.
-    pub monitoring_subscriptions: HashMap<String, StoredMonitoringSubscription>,
-    pub streaming_distributions: HashMap<String, StoredStreamingDistribution>,
-    pub field_level_encryptions: HashMap<String, StoredFieldLevelEncryption>,
-    pub field_level_encryption_profiles: HashMap<String, StoredFieldLevelEncryptionProfile>,
+    pub monitoring_subscriptions: BTreeMap<String, StoredMonitoringSubscription>,
+    pub streaming_distributions: BTreeMap<String, StoredStreamingDistribution>,
+    pub field_level_encryptions: BTreeMap<String, StoredFieldLevelEncryption>,
+    pub field_level_encryption_profiles: BTreeMap<String, StoredFieldLevelEncryptionProfile>,
     /// Realtime log configs keyed by ARN.
-    pub realtime_log_configs: HashMap<String, StoredRealtimeLogConfig>,
-    pub vpc_origins: HashMap<String, StoredVpcOrigin>,
-    pub anycast_ip_lists: HashMap<String, StoredAnycastIpList>,
-    pub trust_stores: HashMap<String, StoredTrustStore>,
+    pub realtime_log_configs: BTreeMap<String, StoredRealtimeLogConfig>,
+    pub vpc_origins: BTreeMap<String, StoredVpcOrigin>,
+    pub anycast_ip_lists: BTreeMap<String, StoredAnycastIpList>,
+    pub trust_stores: BTreeMap<String, StoredTrustStore>,
     /// Resource policies keyed by resource ARN.
-    pub resource_policies: HashMap<String, StoredResourcePolicy>,
-    pub connection_groups: HashMap<String, StoredConnectionGroup>,
+    pub resource_policies: BTreeMap<String, StoredResourcePolicy>,
+    pub connection_groups: BTreeMap<String, StoredConnectionGroup>,
 }
 
 impl CloudFrontAccounts {

--- a/crates/fakecloud-route53/src/service.rs
+++ b/crates/fakecloud-route53/src/service.rs
@@ -1,6 +1,6 @@
 //! Route 53 REST-XML service implementation.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1398,8 +1398,8 @@ impl Route53Service {
             .unwrap_or(100);
         let state = self.state.read();
         // Group by policy id; emit only the latest version of each.
-        let mut latest: HashMap<String, StoredTrafficPolicy> = HashMap::new();
-        let mut counts: HashMap<String, i64> = HashMap::new();
+        let mut latest: BTreeMap<String, StoredTrafficPolicy> = BTreeMap::new();
+        let mut counts: BTreeMap<String, i64> = BTreeMap::new();
         if let Some(account) = state.accounts.get(DEFAULT_ACCOUNT) {
             for p in account.traffic_policies.values() {
                 let entry = latest.entry(p.id.clone()).or_insert_with(|| p.clone());
@@ -2323,7 +2323,7 @@ impl Route53Service {
             arn: arn.clone(),
             version: 1,
             caller_reference: cfg.caller_reference,
-            locations: HashMap::new(),
+            locations: BTreeMap::new(),
         };
         account.cidr_collections.insert(id.clone(), stored.clone());
         drop(state);
@@ -3978,7 +3978,7 @@ impl Route53Service {
         }
         let state = self.state.read();
         let account = state.accounts.get(DEFAULT_ACCOUNT);
-        let mut sets: Vec<(String, HashMap<String, String>)> = Vec::new();
+        let mut sets: Vec<(String, BTreeMap<String, String>)> = Vec::new();
         for id in &cfg.resource_ids.resource_id {
             if let Some(a) = account {
                 if !tag_target_exists(a, &res_type, id) {
@@ -4091,7 +4091,7 @@ fn push_resource_tag_set(
     out: &mut String,
     res_type: &str,
     res_id: &str,
-    bag: &HashMap<String, String>,
+    bag: &BTreeMap<String, String>,
 ) {
     out.push_str("<ResourceTagSet>");
     out.push_str(&format!("<ResourceType>{}</ResourceType>", esc(res_type)));

--- a/crates/fakecloud-route53/src/state.rs
+++ b/crates/fakecloud-route53/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for Route 53 resources.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -13,7 +13,7 @@ pub type SharedRoute53State = Arc<RwLock<Route53Accounts>>;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Route53Accounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl Route53Accounts {
@@ -36,27 +36,27 @@ impl Route53Accounts {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
-    pub hosted_zones: HashMap<String, StoredHostedZone>,
-    pub changes: HashMap<String, StoredChange>,
-    pub health_checks: HashMap<String, StoredHealthCheck>,
+    pub hosted_zones: BTreeMap<String, StoredHostedZone>,
+    pub changes: BTreeMap<String, StoredChange>,
+    pub health_checks: BTreeMap<String, StoredHealthCheck>,
     /// Keyed by `(traffic_policy_id, version)`. Each `CreateTrafficPolicyVersion`
     /// inserts a new entry alongside the existing versions.
-    pub traffic_policies: HashMap<(String, i64), StoredTrafficPolicy>,
-    pub traffic_policy_instances: HashMap<String, StoredTrafficPolicyInstance>,
+    pub traffic_policies: BTreeMap<(String, i64), StoredTrafficPolicy>,
+    pub traffic_policy_instances: BTreeMap<String, StoredTrafficPolicyInstance>,
     /// Per-zone DNSSEC `ServeSignature` status (SIGNING / NOT_SIGNING). Absent
     /// entries are treated as NOT_SIGNING.
-    pub dnssec_status: HashMap<String, String>,
+    pub dnssec_status: BTreeMap<String, String>,
     /// Keyed by `(hosted_zone_id, ksk_name)`.
-    pub key_signing_keys: HashMap<(String, String), StoredKeySigningKey>,
-    pub query_logging_configs: HashMap<String, StoredQueryLoggingConfig>,
-    pub cidr_collections: HashMap<String, StoredCidrCollection>,
-    pub reusable_delegation_sets: HashMap<String, StoredReusableDelegationSet>,
+    pub key_signing_keys: BTreeMap<(String, String), StoredKeySigningKey>,
+    pub query_logging_configs: BTreeMap<String, StoredQueryLoggingConfig>,
+    pub cidr_collections: BTreeMap<String, StoredCidrCollection>,
+    pub reusable_delegation_sets: BTreeMap<String, StoredReusableDelegationSet>,
     /// Per-zone authorized cross-account VPCs that may be associated next.
-    pub vpc_authorizations: HashMap<String, Vec<VPC>>,
+    pub vpc_authorizations: BTreeMap<String, Vec<VPC>>,
     /// Tag bag keyed by `(resource_type, resource_id)`. Both supported
     /// resource types ("healthcheck", "hostedzone") share the bag; the
     /// resource-type discriminator is in the key tuple.
-    pub tags: HashMap<(String, String), HashMap<String, String>>,
+    pub tags: BTreeMap<(String, String), BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,7 +143,7 @@ pub struct StoredCidrCollection {
     pub version: i64,
     pub caller_reference: String,
     /// Maps location name -> sorted list of CIDR blocks.
-    pub locations: HashMap<String, Vec<String>>,
+    pub locations: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Audit batch 12 continued. Same conversion as #850 (ACM PoC), applied to three more small services.

- athena: workgroups, tags, query executions, sessions
- route53: hosted zones, record sets, traffic policies, CIDR collections, locations, tag bags
- cloudfront: distributions, invalidations, OAIs, OACs, key groups, public keys, policies (response/cache/origin), monitoring subscriptions, etc.

Behavior change: deterministic sorted-by-key iteration replaces insertion-random HashMap. ListXxx pagination becomes stable across runs.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest -P ci -p fakecloud-conformance: 70/70 athena, 60/60 cloudfront pass
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized in-memory state collections on BTreeMap across `fakecloud-athena`, `fakecloud-route53`, and `fakecloud-cloudfront` for deterministic, key-sorted iteration. This stabilizes List* pagination across runs and better matches AWS behavior.

- **Refactors**
  - Athena: workgroups, query executions, sessions, tags.
  - Route53: hosted zones, record sets, traffic policies, CIDR collections/locations, tag bags.
  - CloudFront: distributions, invalidations, OAIs/OACs, key groups, public keys, cache/origin/response policies, monitoring subscriptions.

<sup>Written for commit be60ec4bdc6739fc45d3458bb30a94ac4c55d6b3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/851?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

