### PR TITLE
refactor: standardize state collections on BTreeMap (application-autoscaling, wafv2)

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/state.rs
+++ b/crates/fakecloud-application-autoscaling/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for Application Auto Scaling.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -11,7 +11,7 @@ pub type SharedApplicationAutoScalingState = Arc<RwLock<ApplicationAutoScalingAc
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ApplicationAutoScalingAccounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl ApplicationAutoScalingAccounts {
@@ -23,15 +23,15 @@ impl ApplicationAutoScalingAccounts {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension).
-    pub scalable_targets: HashMap<TargetKey, ScalableTarget>,
+    pub scalable_targets: BTreeMap<TargetKey, ScalableTarget>,
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension, PolicyName).
-    pub scaling_policies: HashMap<PolicyKey, ScalingPolicy>,
+    pub scaling_policies: BTreeMap<PolicyKey, ScalingPolicy>,
     /// Keyed by (ServiceNamespace, ResourceId, ScalableDimension, ScheduledActionName).
-    pub scheduled_actions: HashMap<ScheduledKey, ScheduledAction>,
+    pub scheduled_actions: BTreeMap<ScheduledKey, ScheduledAction>,
     /// Scaling activities, newest first.
     pub scaling_activities: Vec<ScalingActivity>,
     /// Tags keyed by ARN.
-    pub tags: HashMap<String, HashMap<String, String>>,
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
 }
 
 pub type TargetKey = (String, String, String);

--- a/crates/fakecloud-wafv2/src/service.rs
+++ b/crates/fakecloud-wafv2/src/service.rs
@@ -1,6 +1,6 @@
 //! WAF v2 JSON 1.1 service.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -1778,8 +1778,8 @@ fn parse_string_list(value: Option<&Value>) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn parse_tags(value: Option<&Value>) -> Result<HashMap<String, String>, AwsServiceError> {
-    let mut out = HashMap::new();
+fn parse_tags(value: Option<&Value>) -> Result<BTreeMap<String, String>, AwsServiceError> {
+    let mut out = BTreeMap::new();
     let Some(arr) = value.and_then(Value::as_array) else {
         return Ok(out);
     };
@@ -1799,7 +1799,7 @@ fn parse_tags(value: Option<&Value>) -> Result<HashMap<String, String>, AwsServi
     Ok(out)
 }
 
-fn parse_custom_response_bodies(value: Option<&Value>) -> HashMap<String, Value> {
+fn parse_custom_response_bodies(value: Option<&Value>) -> BTreeMap<String, Value> {
     value
         .and_then(Value::as_object)
         .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())

--- a/crates/fakecloud-wafv2/src/state.rs
+++ b/crates/fakecloud-wafv2/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory state for WAF v2.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -12,7 +12,7 @@ pub type SharedWafv2State = Arc<RwLock<Wafv2Accounts>>;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Wafv2Accounts {
-    pub accounts: HashMap<String, AccountState>,
+    pub accounts: BTreeMap<String, AccountState>,
 }
 
 impl Wafv2Accounts {
@@ -24,23 +24,23 @@ impl Wafv2Accounts {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AccountState {
     /// Keyed by (scope, name).
-    pub web_acls: HashMap<ScopedKey, WebAcl>,
+    pub web_acls: BTreeMap<ScopedKey, WebAcl>,
     /// Keyed by (scope, name).
-    pub rule_groups: HashMap<ScopedKey, RuleGroup>,
+    pub rule_groups: BTreeMap<ScopedKey, RuleGroup>,
     /// Keyed by (scope, name).
-    pub ip_sets: HashMap<ScopedKey, IpSet>,
+    pub ip_sets: BTreeMap<ScopedKey, IpSet>,
     /// Keyed by (scope, name).
-    pub regex_pattern_sets: HashMap<ScopedKey, RegexPatternSet>,
+    pub regex_pattern_sets: BTreeMap<ScopedKey, RegexPatternSet>,
     /// API key tokens keyed by token string.
-    pub api_keys: HashMap<String, ApiKey>,
+    pub api_keys: BTreeMap<String, ApiKey>,
     /// LoggingConfiguration keyed by ResourceArn (WebACL ARN).
-    pub logging_configs: HashMap<String, Value>,
+    pub logging_configs: BTreeMap<String, Value>,
     /// IAM-style permission policies keyed by RuleGroup ARN.
-    pub permission_policies: HashMap<String, String>,
+    pub permission_policies: BTreeMap<String, String>,
     /// WebACL ARN keyed by associated ResourceArn (ALB / APIGW / Cognito UP / etc).
-    pub associations: HashMap<String, String>,
+    pub associations: BTreeMap<String, String>,
     /// Tags keyed by ARN.
-    pub tags: HashMap<String, HashMap<String, String>>,
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
 }
 
 pub type ScopedKey = (String, String);
@@ -58,7 +58,7 @@ pub struct WebAcl {
     pub capacity: i64,
     pub lock_token: String,
     pub label_namespace: String,
-    pub custom_response_bodies: HashMap<String, Value>,
+    pub custom_response_bodies: BTreeMap<String, Value>,
     pub captcha_config: Option<Value>,
     pub challenge_config: Option<Value>,
     pub token_domains: Vec<String>,
@@ -85,7 +85,7 @@ pub struct RuleGroup {
     pub visibility_config: Value,
     pub lock_token: String,
     pub label_namespace: String,
-    pub custom_response_bodies: HashMap<String, Value>,
+    pub custom_response_bodies: BTreeMap<String, Value>,
     pub available_labels: Vec<Value>,
     pub consumed_labels: Vec<Value>,
     pub created_time: DateTime<Utc>,


### PR DESCRIPTION
## Summary

Audit batch 12 continued. Same conversion as #850 (ACM) and #851 (athena/route53/cloudfront).

- application-autoscaling: scalable_targets, scaling_policies, scheduled_actions, tags
- wafv2: web_acls, ip_sets, regex_pattern_sets, rule_groups, managed_rule_groups, logging_configurations

KMS, secretsmanager, and cloudformation were attempted but reverted — cross-crate friction (KMS<->IAM trait signatures, secretsmanager<->KMS hook taking HashMap, cloudformation/resource_provisioner constructing types from other crates that still expect HashMap). Those need per-crate attention or a tags-helper widening pass first.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest -P ci -p fakecloud-conformance: 55/55 wafv2, 7/7 application-autoscaling pass
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized in-memory state maps on `BTreeMap` for deterministic ordering in `fakecloud-application-autoscaling` and `fakecloud-wafv2`. This covers resource collections, tags, and related parsers.

- **Refactors**
  - `fakecloud-application-autoscaling`: moved accounts and state collections (scalable_targets, scaling_policies, scheduled_actions, tags) to `BTreeMap`.
  - `fakecloud-wafv2`: moved accounts and state collections (web_acls, rule_groups, ip_sets, regex_pattern_sets, api_keys, logging_configs, permission_policies, associations, tags) to `BTreeMap`; updated `custom_response_bodies` and parsing helpers for tags/response bodies to return `BTreeMap`.

<sup>Written for commit fa0c63d644c3ac8e81b4211ced2987e14f94d3ff. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/852?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

