### PR TITLE
refactor(kinesis): standardize state collections on BTreeMap

### DIFF
--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -86,7 +86,7 @@ mod tests {
     use super::*;
     use crate::state::{KinesisShard, KinesisState, KinesisStream, SharedKinesisState};
     use parking_lot::RwLock;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     fn make_stream(name: &str, shard_count: usize) -> KinesisStream {
         let shards = (0..shard_count)
@@ -112,7 +112,7 @@ mod tests {
             key_id: None,
             shard_count: shard_count as i32,
             open_shard_count: shard_count as i32,
-            tags: HashMap::new(),
+            tags: BTreeMap::new(),
             shards,
             next_shard_index: shard_count as i32,
             enhanced_metrics: Vec::new(),

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -272,7 +272,7 @@ impl KinesisService {
             key_id: None,
             shard_count,
             open_shard_count: shard_count,
-            tags: std::collections::HashMap::new(),
+            tags: std::collections::BTreeMap::new(),
             shards: build_stream_shards(shard_count),
             next_shard_index: shard_count,
             enhanced_metrics: Vec::new(),
@@ -1885,7 +1885,6 @@ fn expired_iterator() -> AwsServiceError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -1902,7 +1901,7 @@ mod tests {
             account_id: "123456789012".to_string(),
             request_id: "req-1".to_string(),
             headers: HeaderMap::new(),
-            query_params: HashMap::new(),
+            query_params: std::collections::HashMap::new(),
             body: Bytes::from(serde_json::to_vec(&body).unwrap()),
             body_stream: parking_lot::Mutex::new(None),
             path_segments: Vec::new(),

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
@@ -18,11 +18,11 @@ impl fakecloud_core::multi_account::AccountState for KinesisState {
 pub struct KinesisState {
     pub account_id: String,
     pub region: String,
-    pub streams: HashMap<String, KinesisStream>,
-    pub iterators: HashMap<String, ShardIteratorLease>,
-    pub lambda_checkpoints: HashMap<String, usize>,
-    pub consumers: HashMap<String, KinesisConsumer>,
-    pub resource_policies: HashMap<String, String>,
+    pub streams: BTreeMap<String, KinesisStream>,
+    pub iterators: BTreeMap<String, ShardIteratorLease>,
+    pub lambda_checkpoints: BTreeMap<String, usize>,
+    pub consumers: BTreeMap<String, KinesisConsumer>,
+    pub resource_policies: BTreeMap<String, String>,
     pub shard_limit: i32,
     pub on_demand_stream_count_limit: i32,
     pub billing_commitment_status: String,
@@ -40,7 +40,7 @@ pub struct KinesisStream {
     pub key_id: Option<String>,
     pub shard_count: i32,
     pub open_shard_count: i32,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     pub shards: Vec<KinesisShard>,
     pub next_shard_index: i32,
     pub enhanced_metrics: Vec<String>,
@@ -91,11 +91,11 @@ impl KinesisState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            streams: HashMap::new(),
-            iterators: HashMap::new(),
-            lambda_checkpoints: HashMap::new(),
-            consumers: HashMap::new(),
-            resource_policies: HashMap::new(),
+            streams: BTreeMap::new(),
+            iterators: BTreeMap::new(),
+            lambda_checkpoints: BTreeMap::new(),
+            consumers: BTreeMap::new(),
+            resource_policies: BTreeMap::new(),
             shard_limit: 500,
             on_demand_stream_count_limit: 50,
             billing_commitment_status: "DISABLED".to_string(),


### PR DESCRIPTION
## Summary

Audit batch 12 continued. Same conversion as #850 (ACM), #851 (athena/route53/cloudfront), #852 (application-autoscaling/wafv2).

kinesis: streams, iterators, lambda_checkpoints, consumers — both state and service/delivery follow-up.

SQS/SNS/Scheduler/StepFunctions were attempted in this batch but reverted: they implement cross-crate traits (SqsDelivery, IamCondition::resource_tags_for) whose signatures take HashMap. Migrating those needs either a fakecloud_core tags-helper widening or a coordinated trait update first.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest -P ci -p fakecloud-conformance --tests kinesis_: 21/21 pass
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Kinesis state collections on `BTreeMap` to ensure deterministic ordering and consistent behavior. Updates are scoped to `fakecloud-kinesis`; conformance tests for Kinesis remain 21/21 passing.

- **Refactors**
  - Replaced `HashMap` with `BTreeMap` for streams, iterators, lambda checkpoints, consumers, resource policies, and stream `tags`.
  - Updated defaults and tests in `delivery.rs` and `service.rs` to use `BTreeMap`.
  - Scope is Kinesis only; other services remain on `HashMap` due to cross-crate trait constraints.

<sup>Written for commit 518ca352b089f735c6c37b691c6f36536d705e0b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/854?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

