### PR TITLE
refactor: standardize state collections on BTreeMap (ecr, elbv2)

### DIFF
--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -42,7 +42,7 @@ pub struct EcrState {
     pub replication_configuration: Option<ReplicationConfiguration>,
     /// Account setting flags keyed by setting name (e.g.,
     /// `BASIC_SCAN_TYPE_VERSION`, `REGISTRY_POLICY_SCOPE`).
-    pub account_settings: HashMap<String, String>,
+    pub account_settings: BTreeMap<String, String>,
     /// Layer upload state machine keyed by `uploadId`. Each entry is
     /// tied to a specific repository.
     #[serde(default)]
@@ -71,7 +71,7 @@ impl EcrState {
             registry_policy: None,
             registry_scanning_configuration: RegistryScanningConfiguration::default(),
             replication_configuration: None,
-            account_settings: HashMap::new(),
+            account_settings: BTreeMap::new(),
             layer_uploads: BTreeMap::new(),
             pull_time_exclusions: BTreeMap::new(),
             pull_through_cache_rules: BTreeMap::new(),

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -11,7 +11,7 @@
 //! TLS termination, mTLS, and raw NLB TCP are intentionally next-
 //! batch work items. The data-plane doc page enumerates the gap.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -60,9 +60,9 @@ impl Drop for BoundListener {
 struct DataPlane {
     state: SharedElbv2State,
     /// Round-robin index per target group ARN (mod target count).
-    rr_counters: Arc<Mutex<HashMap<String, usize>>>,
+    rr_counters: Arc<Mutex<BTreeMap<String, usize>>>,
     /// Sticky-session map: `AWSALB` cookie value -> `tg_arn|target_id|target_port`.
-    sticky_targets: Arc<Mutex<HashMap<String, String>>>,
+    sticky_targets: Arc<Mutex<BTreeMap<String, String>>>,
     upstream: reqwest::Client,
 }
 
@@ -87,15 +87,15 @@ pub fn spawn_dataplane(state: SharedElbv2State) {
     };
     let dp = DataPlane {
         state,
-        rr_counters: Arc::new(Mutex::new(HashMap::new())),
-        sticky_targets: Arc::new(Mutex::new(HashMap::new())),
+        rr_counters: Arc::new(Mutex::new(BTreeMap::new())),
+        sticky_targets: Arc::new(Mutex::new(BTreeMap::new())),
         upstream,
     };
     tokio::spawn(supervisor_loop(dp));
 }
 
 async fn supervisor_loop(dp: DataPlane) {
-    let mut bindings: HashMap<String, BoundListener> = HashMap::new();
+    let mut bindings: BTreeMap<String, BoundListener> = BTreeMap::new();
     let mut tick = tokio::time::interval(Duration::from_secs(SUPERVISOR_TICK_SECS));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
@@ -104,7 +104,7 @@ async fn supervisor_loop(dp: DataPlane) {
     }
 }
 
-async fn reconcile(dp: &DataPlane, bindings: &mut HashMap<String, BoundListener>) {
+async fn reconcile(dp: &DataPlane, bindings: &mut BTreeMap<String, BoundListener>) {
     // 1. Snapshot the set of ALBs that need a listener and their schemes.
     let want: Vec<(String, String)> = {
         let accs = dp.state.read();
@@ -304,7 +304,7 @@ async fn handle_request(
 struct LbSnapshot {
     listeners: Vec<Listener>,
     rules: Vec<Rule>,
-    target_groups: HashMap<String, TargetGroup>,
+    target_groups: BTreeMap<String, TargetGroup>,
 }
 
 impl LbSnapshot {
@@ -350,7 +350,7 @@ fn snapshot(dp: &DataPlane, lb_arn: &str) -> Option<LbSnapshot> {
                 .filter(|r| listener_arns.contains(&r.listener_arn))
                 .cloned()
                 .collect();
-            let target_groups: HashMap<String, TargetGroup> = st
+            let target_groups: BTreeMap<String, TargetGroup> = st
                 .target_groups
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -639,7 +639,7 @@ async fn forward_action(
 }
 
 fn round_robin_pick(
-    counters: &Arc<Mutex<HashMap<String, usize>>>,
+    counters: &Arc<Mutex<BTreeMap<String, usize>>>,
     tg_arn: &str,
     n: usize,
 ) -> usize {
@@ -654,7 +654,7 @@ fn round_robin_pick(
 }
 
 fn pick_weighted(
-    counters: &Arc<Mutex<HashMap<String, usize>>>,
+    counters: &Arc<Mutex<BTreeMap<String, usize>>>,
     key: &str,
     target_groups: &[(String, i32)],
     total_weight: usize,

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -3,7 +3,7 @@
 //! Wire protocol: AWS Query (form-encoded request, XML response). Endpoint
 //! prefix `elasticloadbalancing`, SigV4 service `elasticloadbalancing`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -592,7 +592,7 @@ impl Elbv2Service {
             ),
             ipv4_ipam_pool_id: optional_query_param(req, "IpamPools.Ipv4IpamPoolId"),
             tags,
-            attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
             minimum_capacity_units: optional_query_param(
                 req,
                 "MinimumLoadBalancerCapacity.CapacityUnits",
@@ -1426,7 +1426,7 @@ impl Elbv2Service {
             alpn_policy,
             mutual_authentication: parse_mutual_authentication(req),
             tags,
-            attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
         };
         let listener_xml = render_listener_xml(&listener);
         st.listeners.insert(arn, listener);
@@ -1913,7 +1913,7 @@ impl Elbv2Service {
             total_revoked_entries: 0,
             created_time: Utc::now(),
             ca_certificates_bundle: Some(format!("s3://{bucket}/{key}").into_bytes()),
-            revocations: HashMap::new(),
+            revocations: BTreeMap::new(),
             next_revocation_id: 1,
             tags,
         };
@@ -2231,8 +2231,8 @@ fn trust_store_not_found(arn: &str) -> AwsServiceError {
     )
 }
 
-fn default_lb_attributes(lb_type: &str) -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn default_lb_attributes(lb_type: &str) -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert("idle_timeout.timeout_seconds".to_string(), "60".to_string());
     m.insert(
         "deletion_protection.enabled".to_string(),
@@ -2259,7 +2259,10 @@ fn default_lb_attributes(lb_type: &str) -> HashMap<String, String> {
     m
 }
 
-fn merge_lb_attributes(lb_type: &str, stored: &HashMap<String, String>) -> HashMap<String, String> {
+fn merge_lb_attributes(
+    lb_type: &str,
+    stored: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
     let mut m = default_lb_attributes(lb_type);
     for (k, v) in stored {
         m.insert(k.clone(), v.clone());
@@ -2877,7 +2880,7 @@ fn parse_attributes(req: &AwsRequest) -> Vec<(String, String)> {
     out
 }
 
-fn render_attributes_xml(attrs: &HashMap<String, String>) -> String {
+fn render_attributes_xml(attrs: &BTreeMap<String, String>) -> String {
     let entries = attrs
         .iter()
         .map(|(k, v)| {
@@ -2891,8 +2894,8 @@ fn render_attributes_xml(attrs: &HashMap<String, String>) -> String {
     format!("<Attributes>{entries}</Attributes>")
 }
 
-fn default_target_group_attributes() -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn default_target_group_attributes() -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert(
         "deregistration_delay.timeout_seconds".to_string(),
         "300".to_string(),
@@ -2987,7 +2990,7 @@ mod tests {
     use parking_lot::RwLock;
 
     fn req(action: &str, params: &[(&str, &str)]) -> AwsRequest {
-        let mut q = HashMap::new();
+        let mut q = std::collections::HashMap::new();
         for (k, v) in params {
             q.insert((*k).to_string(), (*v).to_string());
         }

--- a/crates/fakecloud-elbv2/src/state.rs
+++ b/crates/fakecloud-elbv2/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +9,7 @@ pub type SharedElbv2State = Arc<RwLock<Elbv2Accounts>>;
 
 #[derive(Default)]
 pub struct Elbv2Accounts {
-    accounts: HashMap<String, Elbv2State>,
+    accounts: BTreeMap<String, Elbv2State>,
 }
 
 impl Elbv2Accounts {
@@ -39,24 +39,24 @@ impl Elbv2Accounts {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Elbv2State {
     pub account_id: String,
-    pub load_balancers: HashMap<String, LoadBalancer>,
-    pub target_groups: HashMap<String, TargetGroup>,
-    pub listeners: HashMap<String, Listener>,
-    pub rules: HashMap<String, Rule>,
-    pub trust_stores: HashMap<String, TrustStore>,
-    pub resource_policies: HashMap<String, String>,
+    pub load_balancers: BTreeMap<String, LoadBalancer>,
+    pub target_groups: BTreeMap<String, TargetGroup>,
+    pub listeners: BTreeMap<String, Listener>,
+    pub rules: BTreeMap<String, Rule>,
+    pub trust_stores: BTreeMap<String, TrustStore>,
+    pub resource_policies: BTreeMap<String, String>,
 }
 
 impl Elbv2State {
     pub fn new(account_id: &str) -> Self {
         Self {
             account_id: account_id.to_string(),
-            load_balancers: HashMap::new(),
-            target_groups: HashMap::new(),
-            listeners: HashMap::new(),
-            rules: HashMap::new(),
-            trust_stores: HashMap::new(),
-            resource_policies: HashMap::new(),
+            load_balancers: BTreeMap::new(),
+            target_groups: BTreeMap::new(),
+            listeners: BTreeMap::new(),
+            rules: BTreeMap::new(),
+            trust_stores: BTreeMap::new(),
+            resource_policies: BTreeMap::new(),
         }
     }
 }
@@ -81,7 +81,7 @@ pub struct LoadBalancer {
     pub enable_prefix_for_ipv6_source_nat: Option<String>,
     pub ipv4_ipam_pool_id: Option<String>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
     pub minimum_capacity_units: Option<i32>,
     /// In-process data plane TCP port assigned by the OS once the
     /// data plane supervisor binds a listener for this LB. `None`
@@ -140,7 +140,7 @@ pub struct TargetGroup {
     pub load_balancer_arns: Vec<String>,
     pub targets: Vec<TargetDescription>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
     pub created_time: DateTime<Utc>,
 }
 
@@ -197,7 +197,7 @@ pub struct Listener {
     pub alpn_policy: Vec<String>,
     pub mutual_authentication: Option<MutualAuthentication>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -301,7 +301,7 @@ pub struct TrustStore {
     pub total_revoked_entries: i64,
     pub created_time: DateTime<Utc>,
     pub ca_certificates_bundle: Option<Vec<u8>>,
-    pub revocations: HashMap<i64, TrustStoreRevocation>,
+    pub revocations: BTreeMap<i64, TrustStoreRevocation>,
     pub next_revocation_id: i64,
     pub tags: Vec<Tag>,
 }


### PR DESCRIPTION
## Summary

Audit batch 12 continued. Same conversion pattern as #850, #851, #852, #854.

- ecr: repos, image manifests, scan results, lifecycle policies
- elbv2: load balancers, listeners, target groups, target health, rules, trust stores

apigateway/apigatewayv2 attempted but reverted — helpers pass through 'AwsRequest.query_params' (foreign HashMap field) and same-type internal copies, creating many call-site mismatches that need per-call manual conversion. Same for eventbridge (cross-crate 'send_to_sqs' signature takes HashMap).

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest -P ci -p fakecloud-conformance: 58/58 ecr_, 51/51 elbv2 pass
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized state collections on `BTreeMap` in `fakecloud-ecr` and `fakecloud-elbv2` to get deterministic ordering and stable serialization. ELBv2 dataplane now also uses `BTreeMap`; all ECR (58/58) and ELBv2 (51/51) conformance tests pass.

- **Refactors**
  - `fakecloud-ecr`: `EcrState.account_settings` switched to `BTreeMap` with updated defaults.
  - `fakecloud-elbv2`: state maps (`load_balancers`, `target_groups`, `listeners`, `rules`, `trust_stores`, `resource_policies`) and resource `attributes`/`revocations` moved to `BTreeMap`.
  - Dataplane: `rr_counters`, `sticky_targets`, and listener `bindings` now `BTreeMap`; snapshot and RR helpers updated.
  - Attribute helpers now accept/return `BTreeMap` (default/merge/render).
  - No changes for `apigateway`/`apigatewayv2` and `eventbridge` due to external `HashMap`-typed interfaces like `AwsRequest.query_params` and `send_to_sqs`.

<sup>Written for commit cdec162384970b997f5e8b7bd6ef1c66cf57d72f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

