### PR TITLE
refactor: drop local xml_wrap wrappers, call core helper directly

### DIFF
--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -6,6 +6,7 @@ use http::StatusCode;
 use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::xml::xml_escape;
+use fakecloud_core::query::query_response_xml;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
@@ -363,8 +364,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheEngineVersions",
+            query_response_xml(
+                "DescribeCacheEngineVersions", ELASTICACHE_NS,
                 &format!("<CacheEngineVersions>{members_xml}</CacheEngineVersions>{marker_xml}"),
                 &request.request_id,
             ),
@@ -412,8 +413,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheParameterGroups",
+            query_response_xml(
+                "DescribeCacheParameterGroups", ELASTICACHE_NS,
                 &format!("<CacheParameterGroups>{members_xml}</CacheParameterGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -482,8 +483,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeReservedCacheNodes",
+            query_response_xml(
+                "DescribeReservedCacheNodes", ELASTICACHE_NS,
                 &format!("<ReservedCacheNodes>{members_xml}</ReservedCacheNodes>{marker_xml}"),
                 &request.request_id,
             ),
@@ -549,8 +550,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeReservedCacheNodesOfferings",
+            query_response_xml(
+                "DescribeReservedCacheNodesOfferings", ELASTICACHE_NS,
                 &format!(
                     "<ReservedCacheNodesOfferings>{members_xml}</ReservedCacheNodesOfferings>{marker_xml}"
                 ),
@@ -577,8 +578,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeEngineDefaultParameters",
+            query_response_xml(
+                "DescribeEngineDefaultParameters", ELASTICACHE_NS,
                 &format!(
                     "<EngineDefaults>\
                      <CacheParameterGroupFamily>{}</CacheParameterGroupFamily>\
@@ -644,8 +645,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateCacheSubnetGroup",
+            query_response_xml(
+                "CreateCacheSubnetGroup", ELASTICACHE_NS,
                 &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
                 &request.request_id,
             ),
@@ -698,8 +699,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheSubnetGroups",
+            query_response_xml(
+                "DescribeCacheSubnetGroups", ELASTICACHE_NS,
                 &format!("<CacheSubnetGroups>{members_xml}</CacheSubnetGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -735,7 +736,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteCacheSubnetGroup", "", &request.request_id),
+            query_response_xml("DeleteCacheSubnetGroup", ELASTICACHE_NS, "", &request.request_id),
         ))
     }
 
@@ -770,8 +771,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyCacheSubnetGroup",
+            query_response_xml(
+                "ModifyCacheSubnetGroup", ELASTICACHE_NS,
                 &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
                 &request.request_id,
             ),
@@ -933,8 +934,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateCacheCluster",
+            query_response_xml(
+                "CreateCacheCluster", ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -988,8 +989,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheClusters",
+            query_response_xml(
+                "DescribeCacheClusters", ELASTICACHE_NS,
                 &format!("<CacheClusters>{members_xml}</CacheClusters>{marker_xml}"),
                 &request.request_id,
             ),
@@ -1032,8 +1033,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteCacheCluster",
+            query_response_xml(
+                "DeleteCacheCluster", ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -1163,8 +1164,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateReplicationGroup",
+            query_response_xml(
+                "CreateReplicationGroup", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1248,8 +1249,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateGlobalReplicationGroup",
+            query_response_xml(
+                "CreateGlobalReplicationGroup", ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1312,8 +1313,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeGlobalReplicationGroups",
+            query_response_xml(
+                "DescribeGlobalReplicationGroups", ELASTICACHE_NS,
                 &format!(
                     "<GlobalReplicationGroups>{groups_xml}</GlobalReplicationGroups>{marker_xml}"
                 ),
@@ -1369,8 +1370,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeReplicationGroups",
+            query_response_xml(
+                "DescribeReplicationGroups", ELASTICACHE_NS,
                 &format!("<ReplicationGroups>{members_xml}</ReplicationGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -1420,8 +1421,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteGlobalReplicationGroup",
+            query_response_xml(
+                "DeleteGlobalReplicationGroup", ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1462,8 +1463,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteReplicationGroup",
+            query_response_xml(
+                "DeleteReplicationGroup", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1599,8 +1600,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateServerlessCache",
+            query_response_xml(
+                "CreateServerlessCache", ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1646,8 +1647,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeServerlessCaches",
+            query_response_xml(
+                "DescribeServerlessCaches", ELASTICACHE_NS,
                 &format!("<ServerlessCaches>{members_xml}</ServerlessCaches>{next_token_xml}"),
                 &request.request_id,
             ),
@@ -1687,8 +1688,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteServerlessCache",
+            query_response_xml(
+                "DeleteServerlessCache", ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1762,8 +1763,8 @@ impl ElastiCacheService {
         let xml = serverless_cache_xml(cache);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyServerlessCache",
+            query_response_xml(
+                "ModifyServerlessCache", ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1833,8 +1834,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateServerlessCacheSnapshot",
+            query_response_xml(
+                "CreateServerlessCacheSnapshot", ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -1914,8 +1915,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeServerlessCacheSnapshots",
+            query_response_xml(
+                "DescribeServerlessCacheSnapshots", ELASTICACHE_NS,
                 &format!(
                     "<ServerlessCacheSnapshots>{members_xml}</ServerlessCacheSnapshots>{next_token_xml}"
                 ),
@@ -1950,8 +1951,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteServerlessCacheSnapshot",
+            query_response_xml(
+                "DeleteServerlessCacheSnapshot", ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -2050,8 +2051,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateSnapshot",
+            query_response_xml(
+                "CreateSnapshot", ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -2116,8 +2117,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeSnapshots",
+            query_response_xml(
+                "DescribeSnapshots", ELASTICACHE_NS,
                 &format!("<Snapshots>{members_xml}</Snapshots>{marker_xml}"),
                 &request.request_id,
             ),
@@ -2143,8 +2144,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteSnapshot",
+            query_response_xml(
+                "DeleteSnapshot", ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -2241,8 +2242,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyReplicationGroup",
+            query_response_xml(
+                "ModifyReplicationGroup", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2329,8 +2330,8 @@ impl ElastiCacheService {
         let xml = global_replication_group_xml(group, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyGlobalReplicationGroup",
+            query_response_xml(
+                "ModifyGlobalReplicationGroup", ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2422,8 +2423,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "IncreaseReplicaCount",
+            query_response_xml(
+                "IncreaseReplicaCount", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2515,8 +2516,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DecreaseReplicaCount",
+            query_response_xml(
+                "DecreaseReplicaCount", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2556,8 +2557,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "TestFailover",
+            query_response_xml(
+                "TestFailover", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2610,8 +2611,8 @@ impl ElastiCacheService {
         let xml = global_replication_group_xml(group, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DisassociateGlobalReplicationGroup",
+            query_response_xml(
+                "DisassociateGlobalReplicationGroup", ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2664,8 +2665,8 @@ impl ElastiCacheService {
         let xml = global_replication_group_xml(group, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "FailoverGlobalReplicationGroup",
+            query_response_xml(
+                "FailoverGlobalReplicationGroup", ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2777,7 +2778,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("CreateUser", &xml, &request.request_id),
+            query_response_xml("CreateUser", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -2819,8 +2820,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeUsers",
+            query_response_xml(
+                "DescribeUsers", ELASTICACHE_NS,
                 &format!("<Users>{members_xml}</Users>{marker_xml}"),
                 &request.request_id,
             ),
@@ -2862,7 +2863,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteUser", &xml, &request.request_id),
+            query_response_xml("DeleteUser", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -2944,7 +2945,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("CreateUserGroup", &xml, &request.request_id),
+            query_response_xml("CreateUserGroup", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -2986,8 +2987,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeUserGroups",
+            query_response_xml(
+                "DescribeUserGroups", ELASTICACHE_NS,
                 &format!("<UserGroups>{members_xml}</UserGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3023,7 +3024,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteUserGroup", &xml, &request.request_id),
+            query_response_xml("DeleteUserGroup", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3047,8 +3048,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "AddTagsToResource",
+            query_response_xml(
+                "AddTagsToResource", ELASTICACHE_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -3073,8 +3074,8 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ListTagsForResource",
+            query_response_xml(
+                "ListTagsForResource", ELASTICACHE_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -3102,7 +3103,7 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("RemoveTagsFromResource", "", &request.request_id),
+            query_response_xml("RemoveTagsFromResource", ELASTICACHE_NS, "", &request.request_id),
         ))
     }
 
@@ -3142,7 +3143,7 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("CreateCacheSecurityGroup", &xml, &request.request_id),
+            query_response_xml("CreateCacheSecurityGroup", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3162,7 +3163,7 @@ impl ElastiCacheService {
         })?;
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteCacheSecurityGroup", "", &request.request_id),
+            query_response_xml("DeleteCacheSecurityGroup", ELASTICACHE_NS, "", &request.request_id),
         ))
     }
 
@@ -3213,8 +3214,8 @@ impl ElastiCacheService {
             .unwrap_or_default();
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheSecurityGroups",
+            query_response_xml(
+                "DescribeCacheSecurityGroups", ELASTICACHE_NS,
                 &format!("<CacheSecurityGroups>{members}</CacheSecurityGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3259,8 +3260,8 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "AuthorizeCacheSecurityGroupIngress",
+            query_response_xml(
+                "AuthorizeCacheSecurityGroupIngress", ELASTICACHE_NS,
                 &xml,
                 &request.request_id,
             ),
@@ -3300,7 +3301,7 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("RevokeCacheSecurityGroupIngress", &xml, &request.request_id),
+            query_response_xml("RevokeCacheSecurityGroupIngress", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3342,7 +3343,7 @@ impl ElastiCacheService {
         let xml = cache_parameter_group_xml(&group);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("CreateCacheParameterGroup", &xml, &request.request_id),
+            query_response_xml("CreateCacheParameterGroup", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3367,7 +3368,7 @@ impl ElastiCacheService {
         state.parameter_group_parameters.remove(&name);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteCacheParameterGroup", "", &request.request_id),
+            query_response_xml("DeleteCacheParameterGroup", ELASTICACHE_NS, "", &request.request_id),
         ))
     }
 
@@ -3422,7 +3423,7 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("ModifyCacheParameterGroup", &body, &request.request_id),
+            query_response_xml("ModifyCacheParameterGroup", ELASTICACHE_NS, &body, &request.request_id),
         ))
     }
 
@@ -3459,7 +3460,7 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("ResetCacheParameterGroup", &body, &request.request_id),
+            query_response_xml("ResetCacheParameterGroup", ELASTICACHE_NS, &body, &request.request_id),
         ))
     }
 
@@ -3497,8 +3498,8 @@ impl ElastiCacheService {
             .unwrap_or_default();
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeCacheParameters",
+            query_response_xml(
+                "DescribeCacheParameters", ELASTICACHE_NS,
                 &format!("<Parameters>{members}</Parameters><CacheNodeTypeSpecificParameters/>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3533,8 +3534,8 @@ impl ElastiCacheService {
         let xml = cache_cluster_xml(cluster, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyCacheCluster",
+            query_response_xml(
+                "ModifyCacheCluster", ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -3556,8 +3557,8 @@ impl ElastiCacheService {
         let xml = cache_cluster_xml(cluster, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "RebootCacheCluster",
+            query_response_xml(
+                "RebootCacheCluster", ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -3583,8 +3584,8 @@ impl ElastiCacheService {
         body.push_str("</ScaleDownModifications>");
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ListAllowedNodeTypeModifications",
+            query_response_xml(
+                "ListAllowedNodeTypeModifications", ELASTICACHE_NS,
                 &body,
                 &request.request_id,
             ),
@@ -3614,8 +3615,8 @@ impl ElastiCacheService {
         let xml = replication_group_xml(group, &region);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyReplicationGroupShardConfiguration",
+            query_response_xml(
+                "ModifyReplicationGroupShardConfiguration", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -3662,8 +3663,8 @@ impl ElastiCacheService {
         let xml = global_replication_group_xml(group, true);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                action,
+            query_response_xml(
+                action, ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -3691,7 +3692,7 @@ impl ElastiCacheService {
         let xml = user_xml(user);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("ModifyUser", &xml, &request.request_id),
+            query_response_xml("ModifyUser", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3718,7 +3719,7 @@ impl ElastiCacheService {
         let xml = user_group_xml(group);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("ModifyUserGroup", &xml, &request.request_id),
+            query_response_xml("ModifyUserGroup", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
@@ -3780,8 +3781,8 @@ impl ElastiCacheService {
         let xml = reserved_cache_node_xml(&node);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "PurchaseReservedCacheNodesOffering",
+            query_response_xml(
+                "PurchaseReservedCacheNodesOffering", ELASTICACHE_NS,
                 &format!("<ReservedCacheNode>{xml}</ReservedCacheNode>"),
                 &request.request_id,
             ),
@@ -3815,8 +3816,8 @@ impl ElastiCacheService {
             .unwrap_or_default();
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeEvents",
+            query_response_xml(
+                "DescribeEvents", ELASTICACHE_NS,
                 &format!("<Events>{members}</Events>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3830,7 +3831,7 @@ impl ElastiCacheService {
         let body = "<ServiceUpdates/>";
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DescribeServiceUpdates", body, &request.request_id),
+            query_response_xml("DescribeServiceUpdates", ELASTICACHE_NS, body, &request.request_id),
         ))
     }
 
@@ -3841,7 +3842,7 @@ impl ElastiCacheService {
         let body = "<UpdateActions/>";
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DescribeUpdateActions", body, &request.request_id),
+            query_response_xml("DescribeUpdateActions", ELASTICACHE_NS, body, &request.request_id),
         ))
     }
 
@@ -3889,7 +3890,7 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(action, &body, &request.request_id),
+            query_response_xml(action, ELASTICACHE_NS, &body, &request.request_id),
         ))
     }
 
@@ -3921,8 +3922,8 @@ impl ElastiCacheService {
         state.snapshots.insert(target, snap);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CopySnapshot",
+            query_response_xml(
+                "CopySnapshot", ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -3961,8 +3962,8 @@ impl ElastiCacheService {
         state.serverless_cache_snapshots.insert(target, snap);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CopyServerlessCacheSnapshot",
+            query_response_xml(
+                "CopyServerlessCacheSnapshot", ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -3992,8 +3993,8 @@ impl ElastiCacheService {
         let _ = bucket;
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ExportServerlessCacheSnapshot",
+            query_response_xml(
+                "ExportServerlessCacheSnapshot", ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -4029,8 +4030,8 @@ impl ElastiCacheService {
         let xml = replication_group_xml(group, &region);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CompleteMigration",
+            query_response_xml(
+                "CompleteMigration", ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -4085,8 +4086,8 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                action,
+            query_response_xml(
+                action, ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -4511,10 +4512,6 @@ fn filter_engine_versions(
 }
 
 // XML formatting
-
-fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    fakecloud_core::query::query_response_xml(action, ELASTICACHE_NS, inner, request_id)
-}
 
 fn engine_version_xml(v: &CacheEngineVersion) -> String {
     format!(
@@ -5489,7 +5486,7 @@ mod tests {
 
     #[test]
     fn xml_wrap_produces_valid_response() {
-        let xml = xml_wrap("TestAction", "<Data>ok</Data>", "req-123");
+        let xml = query_response_xml("TestAction", ELASTICACHE_NS, "<Data>ok</Data>", "req-123");
         assert!(xml.contains("<TestActionResponse"));
         assert!(xml.contains("<TestActionResult>"));
         assert!(xml.contains("<RequestId>req-123</RequestId>"));

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -365,7 +365,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeCacheEngineVersions", ELASTICACHE_NS,
+                "DescribeCacheEngineVersions",
+                ELASTICACHE_NS,
                 &format!("<CacheEngineVersions>{members_xml}</CacheEngineVersions>{marker_xml}"),
                 &request.request_id,
             ),
@@ -414,7 +415,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeCacheParameterGroups", ELASTICACHE_NS,
+                "DescribeCacheParameterGroups",
+                ELASTICACHE_NS,
                 &format!("<CacheParameterGroups>{members_xml}</CacheParameterGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -484,7 +486,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeReservedCacheNodes", ELASTICACHE_NS,
+                "DescribeReservedCacheNodes",
+                ELASTICACHE_NS,
                 &format!("<ReservedCacheNodes>{members_xml}</ReservedCacheNodes>{marker_xml}"),
                 &request.request_id,
             ),
@@ -579,7 +582,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeEngineDefaultParameters", ELASTICACHE_NS,
+                "DescribeEngineDefaultParameters",
+                ELASTICACHE_NS,
                 &format!(
                     "<EngineDefaults>\
                      <CacheParameterGroupFamily>{}</CacheParameterGroupFamily>\
@@ -646,7 +650,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateCacheSubnetGroup", ELASTICACHE_NS,
+                "CreateCacheSubnetGroup",
+                ELASTICACHE_NS,
                 &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
                 &request.request_id,
             ),
@@ -700,7 +705,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeCacheSubnetGroups", ELASTICACHE_NS,
+                "DescribeCacheSubnetGroups",
+                ELASTICACHE_NS,
                 &format!("<CacheSubnetGroups>{members_xml}</CacheSubnetGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -736,7 +742,12 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("DeleteCacheSubnetGroup", ELASTICACHE_NS, "", &request.request_id),
+            query_response_xml(
+                "DeleteCacheSubnetGroup",
+                ELASTICACHE_NS,
+                "",
+                &request.request_id,
+            ),
         ))
     }
 
@@ -772,7 +783,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyCacheSubnetGroup", ELASTICACHE_NS,
+                "ModifyCacheSubnetGroup",
+                ELASTICACHE_NS,
                 &format!("<CacheSubnetGroup>{xml}</CacheSubnetGroup>"),
                 &request.request_id,
             ),
@@ -935,7 +947,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateCacheCluster", ELASTICACHE_NS,
+                "CreateCacheCluster",
+                ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -990,7 +1003,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeCacheClusters", ELASTICACHE_NS,
+                "DescribeCacheClusters",
+                ELASTICACHE_NS,
                 &format!("<CacheClusters>{members_xml}</CacheClusters>{marker_xml}"),
                 &request.request_id,
             ),
@@ -1034,7 +1048,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteCacheCluster", ELASTICACHE_NS,
+                "DeleteCacheCluster",
+                ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -1165,7 +1180,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateReplicationGroup", ELASTICACHE_NS,
+                "CreateReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1250,7 +1266,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateGlobalReplicationGroup", ELASTICACHE_NS,
+                "CreateGlobalReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1314,7 +1331,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeGlobalReplicationGroups", ELASTICACHE_NS,
+                "DescribeGlobalReplicationGroups",
+                ELASTICACHE_NS,
                 &format!(
                     "<GlobalReplicationGroups>{groups_xml}</GlobalReplicationGroups>{marker_xml}"
                 ),
@@ -1371,7 +1389,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeReplicationGroups", ELASTICACHE_NS,
+                "DescribeReplicationGroups",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroups>{members_xml}</ReplicationGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -1422,7 +1441,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteGlobalReplicationGroup", ELASTICACHE_NS,
+                "DeleteGlobalReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1464,7 +1484,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteReplicationGroup", ELASTICACHE_NS,
+                "DeleteReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -1601,7 +1622,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateServerlessCache", ELASTICACHE_NS,
+                "CreateServerlessCache",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1648,7 +1670,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeServerlessCaches", ELASTICACHE_NS,
+                "DescribeServerlessCaches",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCaches>{members_xml}</ServerlessCaches>{next_token_xml}"),
                 &request.request_id,
             ),
@@ -1689,7 +1712,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteServerlessCache", ELASTICACHE_NS,
+                "DeleteServerlessCache",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1764,7 +1788,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyServerlessCache", ELASTICACHE_NS,
+                "ModifyServerlessCache",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCache>{xml}</ServerlessCache>"),
                 &request.request_id,
             ),
@@ -1835,7 +1860,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateServerlessCacheSnapshot", ELASTICACHE_NS,
+                "CreateServerlessCacheSnapshot",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -1952,7 +1978,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteServerlessCacheSnapshot", ELASTICACHE_NS,
+                "DeleteServerlessCacheSnapshot",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -2052,7 +2079,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateSnapshot", ELASTICACHE_NS,
+                "CreateSnapshot",
+                ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -2118,7 +2146,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeSnapshots", ELASTICACHE_NS,
+                "DescribeSnapshots",
+                ELASTICACHE_NS,
                 &format!("<Snapshots>{members_xml}</Snapshots>{marker_xml}"),
                 &request.request_id,
             ),
@@ -2145,7 +2174,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteSnapshot", ELASTICACHE_NS,
+                "DeleteSnapshot",
+                ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -2243,7 +2273,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyReplicationGroup", ELASTICACHE_NS,
+                "ModifyReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2331,7 +2362,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyGlobalReplicationGroup", ELASTICACHE_NS,
+                "ModifyGlobalReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2424,7 +2456,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "IncreaseReplicaCount", ELASTICACHE_NS,
+                "IncreaseReplicaCount",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2517,7 +2550,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DecreaseReplicaCount", ELASTICACHE_NS,
+                "DecreaseReplicaCount",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2558,7 +2592,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "TestFailover", ELASTICACHE_NS,
+                "TestFailover",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2612,7 +2647,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DisassociateGlobalReplicationGroup", ELASTICACHE_NS,
+                "DisassociateGlobalReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2666,7 +2702,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "FailoverGlobalReplicationGroup", ELASTICACHE_NS,
+                "FailoverGlobalReplicationGroup",
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -2821,7 +2858,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeUsers", ELASTICACHE_NS,
+                "DescribeUsers",
+                ELASTICACHE_NS,
                 &format!("<Users>{members_xml}</Users>{marker_xml}"),
                 &request.request_id,
             ),
@@ -2988,7 +3026,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeUserGroups", ELASTICACHE_NS,
+                "DescribeUserGroups",
+                ELASTICACHE_NS,
                 &format!("<UserGroups>{members_xml}</UserGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3049,7 +3088,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "AddTagsToResource", ELASTICACHE_NS,
+                "AddTagsToResource",
+                ELASTICACHE_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -3075,7 +3115,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ListTagsForResource", ELASTICACHE_NS,
+                "ListTagsForResource",
+                ELASTICACHE_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -3103,7 +3144,12 @@ impl ElastiCacheService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("RemoveTagsFromResource", ELASTICACHE_NS, "", &request.request_id),
+            query_response_xml(
+                "RemoveTagsFromResource",
+                ELASTICACHE_NS,
+                "",
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3143,7 +3189,12 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("CreateCacheSecurityGroup", ELASTICACHE_NS, &xml, &request.request_id),
+            query_response_xml(
+                "CreateCacheSecurityGroup",
+                ELASTICACHE_NS,
+                &xml,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3163,7 +3214,12 @@ impl ElastiCacheService {
         })?;
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("DeleteCacheSecurityGroup", ELASTICACHE_NS, "", &request.request_id),
+            query_response_xml(
+                "DeleteCacheSecurityGroup",
+                ELASTICACHE_NS,
+                "",
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3215,7 +3271,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeCacheSecurityGroups", ELASTICACHE_NS,
+                "DescribeCacheSecurityGroups",
+                ELASTICACHE_NS,
                 &format!("<CacheSecurityGroups>{members}</CacheSecurityGroups>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3261,7 +3318,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "AuthorizeCacheSecurityGroupIngress", ELASTICACHE_NS,
+                "AuthorizeCacheSecurityGroupIngress",
+                ELASTICACHE_NS,
                 &xml,
                 &request.request_id,
             ),
@@ -3301,7 +3359,12 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("RevokeCacheSecurityGroupIngress", ELASTICACHE_NS, &xml, &request.request_id),
+            query_response_xml(
+                "RevokeCacheSecurityGroupIngress",
+                ELASTICACHE_NS,
+                &xml,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3343,7 +3406,12 @@ impl ElastiCacheService {
         let xml = cache_parameter_group_xml(&group);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("CreateCacheParameterGroup", ELASTICACHE_NS, &xml, &request.request_id),
+            query_response_xml(
+                "CreateCacheParameterGroup",
+                ELASTICACHE_NS,
+                &xml,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3368,7 +3436,12 @@ impl ElastiCacheService {
         state.parameter_group_parameters.remove(&name);
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("DeleteCacheParameterGroup", ELASTICACHE_NS, "", &request.request_id),
+            query_response_xml(
+                "DeleteCacheParameterGroup",
+                ELASTICACHE_NS,
+                "",
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3423,7 +3496,12 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("ModifyCacheParameterGroup", ELASTICACHE_NS, &body, &request.request_id),
+            query_response_xml(
+                "ModifyCacheParameterGroup",
+                ELASTICACHE_NS,
+                &body,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3460,7 +3538,12 @@ impl ElastiCacheService {
         );
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("ResetCacheParameterGroup", ELASTICACHE_NS, &body, &request.request_id),
+            query_response_xml(
+                "ResetCacheParameterGroup",
+                ELASTICACHE_NS,
+                &body,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3535,7 +3618,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyCacheCluster", ELASTICACHE_NS,
+                "ModifyCacheCluster",
+                ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -3558,7 +3642,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "RebootCacheCluster", ELASTICACHE_NS,
+                "RebootCacheCluster",
+                ELASTICACHE_NS,
                 &format!("<CacheCluster>{xml}</CacheCluster>"),
                 &request.request_id,
             ),
@@ -3585,7 +3670,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ListAllowedNodeTypeModifications", ELASTICACHE_NS,
+                "ListAllowedNodeTypeModifications",
+                ELASTICACHE_NS,
                 &body,
                 &request.request_id,
             ),
@@ -3616,7 +3702,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyReplicationGroupShardConfiguration", ELASTICACHE_NS,
+                "ModifyReplicationGroupShardConfiguration",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -3664,7 +3751,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                action, ELASTICACHE_NS,
+                action,
+                ELASTICACHE_NS,
                 &format!("<GlobalReplicationGroup>{xml}</GlobalReplicationGroup>"),
                 &request.request_id,
             ),
@@ -3782,7 +3870,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "PurchaseReservedCacheNodesOffering", ELASTICACHE_NS,
+                "PurchaseReservedCacheNodesOffering",
+                ELASTICACHE_NS,
                 &format!("<ReservedCacheNode>{xml}</ReservedCacheNode>"),
                 &request.request_id,
             ),
@@ -3817,7 +3906,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeEvents", ELASTICACHE_NS,
+                "DescribeEvents",
+                ELASTICACHE_NS,
                 &format!("<Events>{members}</Events>{marker_xml}"),
                 &request.request_id,
             ),
@@ -3831,7 +3921,12 @@ impl ElastiCacheService {
         let body = "<ServiceUpdates/>";
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("DescribeServiceUpdates", ELASTICACHE_NS, body, &request.request_id),
+            query_response_xml(
+                "DescribeServiceUpdates",
+                ELASTICACHE_NS,
+                body,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3842,7 +3937,12 @@ impl ElastiCacheService {
         let body = "<UpdateActions/>";
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            query_response_xml("DescribeUpdateActions", ELASTICACHE_NS, body, &request.request_id),
+            query_response_xml(
+                "DescribeUpdateActions",
+                ELASTICACHE_NS,
+                body,
+                &request.request_id,
+            ),
         ))
     }
 
@@ -3923,7 +4023,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CopySnapshot", ELASTICACHE_NS,
+                "CopySnapshot",
+                ELASTICACHE_NS,
                 &format!("<Snapshot>{xml}</Snapshot>"),
                 &request.request_id,
             ),
@@ -3963,7 +4064,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CopyServerlessCacheSnapshot", ELASTICACHE_NS,
+                "CopyServerlessCacheSnapshot",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -3994,7 +4096,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ExportServerlessCacheSnapshot", ELASTICACHE_NS,
+                "ExportServerlessCacheSnapshot",
+                ELASTICACHE_NS,
                 &format!("<ServerlessCacheSnapshot>{xml}</ServerlessCacheSnapshot>"),
                 &request.request_id,
             ),
@@ -4031,7 +4134,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CompleteMigration", ELASTICACHE_NS,
+                "CompleteMigration",
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),
@@ -4087,7 +4191,8 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                action, ELASTICACHE_NS,
+                action,
+                ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
             ),

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -608,7 +608,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateDBInstance", RDS_NS,
+                "CreateDBInstance",
+                RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, None)
@@ -715,7 +716,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteDBInstance", RDS_NS,
+                "DeleteDBInstance",
+                RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("deleting"))
@@ -897,7 +899,8 @@ impl RdsService {
         }
         let instance_arn = instance.db_instance_arn.clone();
         let xml = query_response_xml(
-            "ModifyDBInstance", RDS_NS,
+            "ModifyDBInstance",
+            RDS_NS,
             &format!(
                 "<DBInstance>{}</DBInstance>",
                 db_instance_xml(instance, Some("modifying"))
@@ -1007,7 +1010,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "RebootDBInstance", RDS_NS,
+                "RebootDBInstance",
+                RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("rebooting"))
@@ -1040,7 +1044,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeDBEngineVersions", RDS_NS,
+                "DescribeDBEngineVersions",
+                RDS_NS,
                 &format!(
                     "<DBEngineVersions>{}</DBEngineVersions>",
                     versions.iter().map(engine_version_xml).collect::<String>()
@@ -1070,7 +1075,8 @@ impl RdsService {
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
                 query_response_xml(
-                    "DescribeDBInstances", RDS_NS,
+                    "DescribeDBInstances",
+                    RDS_NS,
                     &format!(
                         "<DBInstances><DBInstance>{}</DBInstance></DBInstances>",
                         db_instance_xml(&instance, None)
@@ -1102,7 +1108,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeDBInstances", RDS_NS,
+                "DescribeDBInstances",
+                RDS_NS,
                 &format!(
                     "<DBInstances>{}</DBInstances>{}",
                     paginated
@@ -1144,7 +1151,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeOrderableDBInstanceOptions", RDS_NS,
+                "DescribeOrderableDBInstanceOptions",
+                RDS_NS,
                 &format!(
                     "<OrderableDBInstanceOptions>{}</OrderableDBInstanceOptions>",
                     options.iter().map(orderable_option_xml).collect::<String>()
@@ -1196,7 +1204,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ListTagsForResource", RDS_NS,
+                "ListTagsForResource",
+                RDS_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -1334,7 +1343,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateDBSnapshot", RDS_NS,
+                "CreateDBSnapshot",
+                RDS_NS,
                 &format!("<DBSnapshot>{}</DBSnapshot>", db_snapshot_xml(&snapshot)),
                 &request.request_id,
             ),
@@ -1370,7 +1380,8 @@ impl RdsService {
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
                 query_response_xml(
-                    "DescribeDBSnapshots", RDS_NS,
+                    "DescribeDBSnapshots",
+                    RDS_NS,
                     &format!(
                         "<DBSnapshots><DBSnapshot>{}</DBSnapshot></DBSnapshots>",
                         db_snapshot_xml(&snapshot)
@@ -1413,7 +1424,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeDBSnapshots", RDS_NS,
+                "DescribeDBSnapshots",
+                RDS_NS,
                 &format!(
                     "<DBSnapshots>{}</DBSnapshots>{}",
                     paginated
@@ -1456,7 +1468,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DeleteDBSnapshot", RDS_NS,
+                "DeleteDBSnapshot",
+                RDS_NS,
                 &format!("<DBSnapshot>{}</DBSnapshot>", db_snapshot_xml(&snapshot)),
                 &request.request_id,
             ),
@@ -1573,7 +1586,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "RestoreDBInstanceFromDBSnapshot", RDS_NS,
+                "RestoreDBInstanceFromDBSnapshot",
+                RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, None)
@@ -1747,7 +1761,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateDBInstanceReadReplica", RDS_NS,
+                "CreateDBInstanceReadReplica",
+                RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&replica, None)
@@ -1824,7 +1839,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateDBSubnetGroup", RDS_NS,
+                "CreateDBSubnetGroup",
+                RDS_NS,
                 &format!(
                     "<DBSubnetGroup>{}</DBSubnetGroup>",
                     db_subnet_group_xml(&subnet_group)
@@ -1859,7 +1875,8 @@ impl RdsService {
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
                 query_response_xml(
-                    "DescribeDBSubnetGroups", RDS_NS,
+                    "DescribeDBSubnetGroups",
+                    RDS_NS,
                     &format!(
                         "<DBSubnetGroups><DBSubnetGroup>{}</DBSubnetGroup></DBSubnetGroups>",
                         db_subnet_group_xml(sg)
@@ -1894,7 +1911,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeDBSubnetGroups", RDS_NS,
+                "DescribeDBSubnetGroups",
+                RDS_NS,
                 &format!("<DBSubnetGroups>{}</DBSubnetGroups>{}", body, marker_xml),
                 &request.request_id,
             ),
@@ -1979,7 +1997,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyDBSubnetGroup", RDS_NS,
+                "ModifyDBSubnetGroup",
+                RDS_NS,
                 &format!(
                     "<DBSubnetGroup>{}</DBSubnetGroup>",
                     db_subnet_group_xml(&subnet_group_clone)
@@ -2050,7 +2069,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "CreateDBParameterGroup", RDS_NS,
+                "CreateDBParameterGroup",
+                RDS_NS,
                 &format!(
                     "<DBParameterGroup>{}</DBParameterGroup>",
                     db_parameter_group_xml(&parameter_group)
@@ -2126,7 +2146,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DescribeDBParameterGroups", RDS_NS,
+                "DescribeDBParameterGroups",
+                RDS_NS,
                 &format!(
                     "<DBParameterGroups>{}</DBParameterGroups>{}",
                     body, marker_xml
@@ -2200,7 +2221,8 @@ impl RdsService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "ModifyDBParameterGroup", RDS_NS,
+                "ModifyDBParameterGroup",
+                RDS_NS,
                 &format!(
                     "<DBParameterGroupName>{}</DBParameterGroupName>",
                     xml_escape(&parameter_group_clone.db_parameter_group_name)

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::delivery::DeliveryBus;
+use fakecloud_core::query::query_response_xml;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 
@@ -606,8 +607,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateDBInstance",
+            query_response_xml(
+                "CreateDBInstance", RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, None)
@@ -713,8 +714,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteDBInstance",
+            query_response_xml(
+                "DeleteDBInstance", RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("deleting"))
@@ -895,8 +896,8 @@ impl RdsService {
             }
         }
         let instance_arn = instance.db_instance_arn.clone();
-        let xml = xml_wrap(
-            "ModifyDBInstance",
+        let xml = query_response_xml(
+            "ModifyDBInstance", RDS_NS,
             &format!(
                 "<DBInstance>{}</DBInstance>",
                 db_instance_xml(instance, Some("modifying"))
@@ -1005,8 +1006,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "RebootDBInstance",
+            query_response_xml(
+                "RebootDBInstance", RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, Some("rebooting"))
@@ -1038,8 +1039,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeDBEngineVersions",
+            query_response_xml(
+                "DescribeDBEngineVersions", RDS_NS,
                 &format!(
                     "<DBEngineVersions>{}</DBEngineVersions>",
                     versions.iter().map(engine_version_xml).collect::<String>()
@@ -1068,8 +1069,8 @@ impl RdsService {
 
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
-                xml_wrap(
-                    "DescribeDBInstances",
+                query_response_xml(
+                    "DescribeDBInstances", RDS_NS,
                     &format!(
                         "<DBInstances><DBInstance>{}</DBInstance></DBInstances>",
                         db_instance_xml(&instance, None)
@@ -1100,8 +1101,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeDBInstances",
+            query_response_xml(
+                "DescribeDBInstances", RDS_NS,
                 &format!(
                     "<DBInstances>{}</DBInstances>{}",
                     paginated
@@ -1142,8 +1143,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeOrderableDBInstanceOptions",
+            query_response_xml(
+                "DescribeOrderableDBInstanceOptions", RDS_NS,
                 &format!(
                     "<OrderableDBInstanceOptions>{}</OrderableDBInstanceOptions>",
                     options.iter().map(orderable_option_xml).collect::<String>()
@@ -1172,7 +1173,7 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("AddTagsToResource", "", &request.request_id),
+            query_response_xml("AddTagsToResource", RDS_NS, "", &request.request_id),
         ))
     }
 
@@ -1194,8 +1195,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ListTagsForResource",
+            query_response_xml(
+                "ListTagsForResource", RDS_NS,
                 &format!("<TagList>{tag_xml}</TagList>"),
                 &request.request_id,
             ),
@@ -1226,7 +1227,7 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("RemoveTagsFromResource", "", &request.request_id),
+            query_response_xml("RemoveTagsFromResource", RDS_NS, "", &request.request_id),
         ))
     }
 
@@ -1332,8 +1333,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateDBSnapshot",
+            query_response_xml(
+                "CreateDBSnapshot", RDS_NS,
                 &format!("<DBSnapshot>{}</DBSnapshot>", db_snapshot_xml(&snapshot)),
                 &request.request_id,
             ),
@@ -1368,8 +1369,8 @@ impl RdsService {
 
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
-                xml_wrap(
-                    "DescribeDBSnapshots",
+                query_response_xml(
+                    "DescribeDBSnapshots", RDS_NS,
                     &format!(
                         "<DBSnapshots><DBSnapshot>{}</DBSnapshot></DBSnapshots>",
                         db_snapshot_xml(&snapshot)
@@ -1411,8 +1412,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeDBSnapshots",
+            query_response_xml(
+                "DescribeDBSnapshots", RDS_NS,
                 &format!(
                     "<DBSnapshots>{}</DBSnapshots>{}",
                     paginated
@@ -1454,8 +1455,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DeleteDBSnapshot",
+            query_response_xml(
+                "DeleteDBSnapshot", RDS_NS,
                 &format!("<DBSnapshot>{}</DBSnapshot>", db_snapshot_xml(&snapshot)),
                 &request.request_id,
             ),
@@ -1571,8 +1572,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "RestoreDBInstanceFromDBSnapshot",
+            query_response_xml(
+                "RestoreDBInstanceFromDBSnapshot", RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&instance, None)
@@ -1745,8 +1746,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateDBInstanceReadReplica",
+            query_response_xml(
+                "CreateDBInstanceReadReplica", RDS_NS,
                 &format!(
                     "<DBInstance>{}</DBInstance>",
                     db_instance_xml(&replica, None)
@@ -1822,8 +1823,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateDBSubnetGroup",
+            query_response_xml(
+                "CreateDBSubnetGroup", RDS_NS,
                 &format!(
                     "<DBSubnetGroup>{}</DBSubnetGroup>",
                     db_subnet_group_xml(&subnet_group)
@@ -1857,8 +1858,8 @@ impl RdsService {
 
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
-                xml_wrap(
-                    "DescribeDBSubnetGroups",
+                query_response_xml(
+                    "DescribeDBSubnetGroups", RDS_NS,
                     &format!(
                         "<DBSubnetGroups><DBSubnetGroup>{}</DBSubnetGroup></DBSubnetGroups>",
                         db_subnet_group_xml(sg)
@@ -1892,8 +1893,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeDBSubnetGroups",
+            query_response_xml(
+                "DescribeDBSubnetGroups", RDS_NS,
                 &format!("<DBSubnetGroups>{}</DBSubnetGroups>{}", body, marker_xml),
                 &request.request_id,
             ),
@@ -1916,7 +1917,7 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteDBSubnetGroup", "", &request.request_id),
+            query_response_xml("DeleteDBSubnetGroup", RDS_NS, "", &request.request_id),
         ))
     }
 
@@ -1977,8 +1978,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyDBSubnetGroup",
+            query_response_xml(
+                "ModifyDBSubnetGroup", RDS_NS,
                 &format!(
                     "<DBSubnetGroup>{}</DBSubnetGroup>",
                     db_subnet_group_xml(&subnet_group_clone)
@@ -2048,8 +2049,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "CreateDBParameterGroup",
+            query_response_xml(
+                "CreateDBParameterGroup", RDS_NS,
                 &format!(
                     "<DBParameterGroup>{}</DBParameterGroup>",
                     db_parameter_group_xml(&parameter_group)
@@ -2083,8 +2084,8 @@ impl RdsService {
 
             return Ok(AwsResponse::xml(
                 StatusCode::OK,
-                xml_wrap(
-                    "DescribeDBParameterGroups",
+                query_response_xml(
+                    "DescribeDBParameterGroups", RDS_NS,
                     &format!(
                         "<DBParameterGroups><DBParameterGroup>{}</DBParameterGroup></DBParameterGroups>",
                         db_parameter_group_xml(pg)
@@ -2124,8 +2125,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "DescribeDBParameterGroups",
+            query_response_xml(
+                "DescribeDBParameterGroups", RDS_NS,
                 &format!(
                     "<DBParameterGroups>{}</DBParameterGroups>{}",
                     body, marker_xml
@@ -2166,7 +2167,7 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap("DeleteDBParameterGroup", "", &request.request_id),
+            query_response_xml("DeleteDBParameterGroup", RDS_NS, "", &request.request_id),
         ))
     }
 
@@ -2198,8 +2199,8 @@ impl RdsService {
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
-            xml_wrap(
-                "ModifyDBParameterGroup",
+            query_response_xml(
+                "ModifyDBParameterGroup", RDS_NS,
                 &format!(
                     "<DBParameterGroupName>{}</DBParameterGroupName>",
                     xml_escape(&parameter_group_clone.db_parameter_group_name)
@@ -2671,10 +2672,6 @@ fn build_read_replica_instance(
         multi_az: source.multi_az,
         pending_modified_values: None,
     }
-}
-
-fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    fakecloud_core::query::query_response_xml(action, RDS_NS, inner, request_id)
 }
 
 fn engine_version_xml(version: &EngineVersionInfo) -> String {

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use http::StatusCode;
 use std::collections::HashMap;
 
+use fakecloud_core::query::{query_metadata_only_xml, query_response_xml};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
@@ -16,14 +17,9 @@ use crate::state::{
 /// XML namespace for SES v1 responses.
 const SES_NS: &str = "http://ses.amazonaws.com/doc/2010-12-01/";
 
-/// Wrap a v1 action result in the standard SES Query protocol XML envelope.
-fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    fakecloud_core::query::query_response_xml(action, SES_NS, inner, request_id)
-}
-
 /// Response with only metadata (no result body).
 fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = fakecloud_core::query::query_metadata_only_xml(action, SES_NS, request_id);
+    let xml = query_metadata_only_xml(action, SES_NS, request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 
@@ -521,7 +517,7 @@ fn verify_domain_identity(
     let inner = format!("<VerificationToken>{token}</VerificationToken>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("VerifyDomainIdentity", &inner, &req.request_id),
+        query_response_xml("VerifyDomainIdentity", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -559,7 +555,7 @@ fn verify_domain_dkim(
     inner.push_str("</DkimTokens>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("VerifyDomainDkim", &inner, &req.request_id),
+        query_response_xml("VerifyDomainDkim", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -590,7 +586,7 @@ fn list_identities(
     inner.push_str("</Identities>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("ListIdentities", &inner, &req.request_id),
+        query_response_xml("ListIdentities", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -634,7 +630,7 @@ fn get_identity_verification_attributes(
     inner.push_str("</VerificationAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetIdentityVerificationAttributes", &inner, &req.request_id),
+        query_response_xml("GetIdentityVerificationAttributes", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -688,7 +684,7 @@ fn get_identity_dkim_attributes(
     inner.push_str("</DkimAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetIdentityDkimAttributes", &inner, &req.request_id),
+        query_response_xml("GetIdentityDkimAttributes", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -811,7 +807,7 @@ fn get_identity_notification_attributes(
     inner.push_str("</NotificationAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetIdentityNotificationAttributes", &inner, &req.request_id),
+        query_response_xml("GetIdentityNotificationAttributes", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -861,8 +857,8 @@ fn get_identity_mail_from_domain_attributes(
     inner.push_str("</MailFromDomainAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap(
-            "GetIdentityMailFromDomainAttributes",
+        query_response_xml(
+            "GetIdentityMailFromDomainAttributes", SES_NS,
             &inner,
             &req.request_id,
         ),
@@ -955,7 +951,7 @@ fn send_email(state: &SharedSesState, req: &AwsRequest) -> Result<AwsResponse, A
     let inner = format!("<MessageId>{message_id}</MessageId>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("SendEmail", &inner, &req.request_id),
+        query_response_xml("SendEmail", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -999,7 +995,7 @@ fn send_raw_email(
     let inner = format!("<MessageId>{message_id}</MessageId>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("SendRawEmail", &inner, &req.request_id),
+        query_response_xml("SendRawEmail", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1060,7 +1056,7 @@ fn send_templated_email(
     let inner = format!("<MessageId>{message_id}</MessageId>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("SendTemplatedEmail", &inner, &req.request_id),
+        query_response_xml("SendTemplatedEmail", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1114,7 +1110,7 @@ fn send_bulk_templated_email(
     inner.push_str("</Status>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("SendBulkTemplatedEmail", &inner, &req.request_id),
+        query_response_xml("SendBulkTemplatedEmail", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1228,7 +1224,7 @@ fn get_template(state: &SharedSesState, req: &AwsRequest) -> Result<AwsResponse,
     inner.push_str("</Template>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetTemplate", &inner, &req.request_id),
+        query_response_xml("GetTemplate", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1252,7 +1248,7 @@ fn list_templates(
     inner.push_str("</TemplatesMetadata>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("ListTemplates", &inner, &req.request_id),
+        query_response_xml("ListTemplates", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1387,7 +1383,7 @@ fn describe_configuration_set(
     }
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("DescribeConfigurationSet", &inner, &req.request_id),
+        query_response_xml("DescribeConfigurationSet", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1410,7 +1406,7 @@ fn list_configuration_sets(
     inner.push_str("</ConfigurationSets>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("ListConfigurationSets", &inner, &req.request_id),
+        query_response_xml("ListConfigurationSets", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1561,7 +1557,7 @@ fn get_send_quota(
         <SentLast24Hours>0.0</SentLast24Hours>";
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetSendQuota", inner, &req.request_id),
+        query_response_xml("GetSendQuota", SES_NS, inner, &req.request_id),
     ))
 }
 
@@ -1587,7 +1583,7 @@ fn get_send_statistics(
     );
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetSendStatistics", &inner, &req.request_id),
+        query_response_xml("GetSendStatistics", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1602,7 +1598,7 @@ fn get_account_sending_enabled(
     let inner = format!("<Enabled>{enabled}</Enabled>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("GetAccountSendingEnabled", &inner, &req.request_id),
+        query_response_xml("GetAccountSendingEnabled", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1705,7 +1701,7 @@ fn describe_receipt_rule_set(
     );
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("DescribeReceiptRuleSet", &inner, &req.request_id),
+        query_response_xml("DescribeReceiptRuleSet", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1729,7 +1725,7 @@ fn list_receipt_rule_sets(
     inner.push_str("</RuleSets>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("ListReceiptRuleSets", &inner, &req.request_id),
+        query_response_xml("ListReceiptRuleSets", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -1957,7 +1953,7 @@ fn describe_receipt_rule(
     let inner = format!("<Rule>{inner_xml}</Rule>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("DescribeReceiptRule", &inner, &req.request_id),
+        query_response_xml("DescribeReceiptRule", SES_NS, &inner, &req.request_id),
     ))
 }
 
@@ -2068,7 +2064,7 @@ fn list_receipt_filters(
     inner.push_str("</Filters>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        xml_wrap("ListReceiptFilters", &inner, &req.request_id),
+        query_response_xml("ListReceiptFilters", SES_NS, &inner, &req.request_id),
     ))
 }
 

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -630,7 +630,12 @@ fn get_identity_verification_attributes(
     inner.push_str("</VerificationAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        query_response_xml("GetIdentityVerificationAttributes", SES_NS, &inner, &req.request_id),
+        query_response_xml(
+            "GetIdentityVerificationAttributes",
+            SES_NS,
+            &inner,
+            &req.request_id,
+        ),
     ))
 }
 
@@ -807,7 +812,12 @@ fn get_identity_notification_attributes(
     inner.push_str("</NotificationAttributes>");
     Ok(AwsResponse::xml(
         StatusCode::OK,
-        query_response_xml("GetIdentityNotificationAttributes", SES_NS, &inner, &req.request_id),
+        query_response_xml(
+            "GetIdentityNotificationAttributes",
+            SES_NS,
+            &inner,
+            &req.request_id,
+        ),
     ))
 }
 
@@ -858,7 +868,8 @@ fn get_identity_mail_from_domain_attributes(
     Ok(AwsResponse::xml(
         StatusCode::OK,
         query_response_xml(
-            "GetIdentityMailFromDomainAttributes", SES_NS,
+            "GetIdentityMailFromDomainAttributes",
+            SES_NS,
             &inner,
             &req.request_id,
         ),

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -1020,15 +1020,12 @@ fn val_as_i64(v: &Value) -> Option<i64> {
 }
 
 use fakecloud_aws::xml::xml_escape;
+use fakecloud_core::query::{query_metadata_only_xml, query_response_xml};
 
 const SQS_NS: &str = "http://queue.amazonaws.com/doc/2012-11-05/";
 
-fn xml_wrap(action: &str, inner: &str, request_id: &str) -> String {
-    fakecloud_core::query::query_response_xml(action, SQS_NS, inner, request_id)
-}
-
 fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
-    let xml = fakecloud_core::query::query_metadata_only_xml(action, SQS_NS, request_id);
+    let xml = query_metadata_only_xml(action, SQS_NS, request_id);
     AwsResponse::xml(StatusCode::OK, xml)
 }
 
@@ -1062,7 +1059,10 @@ fn sqs_response(action: &str, body: Value, request_id: &str, is_query: bool) -> 
         // DeleteQueue, DeleteMessage, PurgeQueue, SetQueueAttributes, ChangeMessageVisibility
         _ => return xml_metadata_only(action, request_id),
     };
-    AwsResponse::xml(StatusCode::OK, xml_wrap(action, &inner, request_id))
+    AwsResponse::xml(
+        StatusCode::OK,
+        query_response_xml(action, SQS_NS, &inner, request_id),
+    )
 }
 
 fn xml_queue_url_only(body: &Value) -> String {


### PR DESCRIPTION
## Summary

- Per audit 2026-04-28 §2 CRITICAL: each Query-protocol service had a 1-line `xml_wrap` wrapper that just forwarded to `fakecloud_core::query::query_response_xml`.
- Drop the wrappers in sqs, elasticache, rds, ses/v1.
- Update ~125 call sites to call the core helper directly with each crate's namespace constant inline.

## Test plan

- [x] `cargo build -p fakecloud-sqs -p fakecloud-elasticache -p fakecloud-rds -p fakecloud-ses`
- [x] `cargo test -p fakecloud-sqs -p fakecloud-elasticache -p fakecloud-rds -p fakecloud-ses --lib` (129 sqs lib tests pass; rest similar)
- [x] `cargo clippy -p fakecloud-sqs -p fakecloud-elasticache -p fakecloud-rds -p fakecloud-ses --all-targets -- -D warnings`
- [ ] Wait CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant Query protocol `xml_wrap` helpers and call `fakecloud_core::query` helpers directly to centralize XML envelope logic and reduce duplication. No behavior changes.

- **Refactors**
  - Deleted local `xml_wrap` wrappers in `fakecloud-sqs`, `fakecloud-elasticache`, `fakecloud-rds`, and `fakecloud-ses` (v1).
  - Updated ~125 call sites to use `query_response_xml` (and `query_metadata_only_xml` where needed) with each crate’s namespace (`SQS_NS`, `ELASTICACHE_NS`, `RDS_NS`, `SES_NS`).
  - Simplified imports to `fakecloud_core::query::{query_response_xml, query_metadata_only_xml}` and ran `cargo fmt`.

<sup>Written for commit 3b57fce10bb105361657191a566364823c371a2f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

