### PR TITLE
test(e2e): add wait_until poll helper, convert eventbridge fixed sleeps

### DIFF
--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -205,13 +205,8 @@ async fn eb_schedule_fires_to_sqs() {
         .unwrap();
 
     // Poll SQS until scheduler delivers at least one message (rate(1 second))
-    let messages = helpers::sqs_receive_at_least(
-        &sqs,
-        queue_url,
-        1,
-        std::time::Duration::from_secs(10),
-    )
-    .await;
+    let messages =
+        helpers::sqs_receive_at_least(&sqs, queue_url, 1, std::time::Duration::from_secs(10)).await;
     assert!(
         !messages.is_empty(),
         "expected at least one scheduled event message in SQS"

--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -204,19 +204,14 @@ async fn eb_schedule_fires_to_sqs() {
         .await
         .unwrap();
 
-    // Wait for the scheduler to fire at least once
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-    // Receive messages from SQS
-    let resp = sqs
-        .receive_message()
-        .queue_url(queue_url)
-        .max_number_of_messages(10)
-        .send()
-        .await
-        .unwrap();
-
-    let messages = resp.messages();
+    // Poll SQS until scheduler delivers at least one message (rate(1 second))
+    let messages = helpers::sqs_receive_at_least(
+        &sqs,
+        queue_url,
+        1,
+        std::time::Duration::from_secs(10),
+    )
+    .await;
     assert!(
         !messages.is_empty(),
         "expected at least one scheduled event message in SQS"
@@ -972,8 +967,23 @@ async fn eventbridge_archive_replay_delivers_events() {
     // Purge the queue
     let _ = sqs.purge_queue().queue_url(&queue_url).send().await;
 
-    // Small delay for purge to take effect
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Wait for purge to take effect by polling until the queue is empty
+    let purged = helpers::wait_until(std::time::Duration::from_secs(5), || async {
+        let resp = sqs
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        if resp.messages().is_empty() {
+            Some(())
+        } else {
+            None
+        }
+    })
+    .await;
+    assert!(purged.is_some(), "queue did not drain after purge");
 
     // Start replay
     let replay_resp = eb
@@ -1337,22 +1347,22 @@ async fn eb_rule_starts_stepfunctions_execution() {
         .await
         .unwrap();
 
-    // Give the async execution a moment to start
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // Verify execution was started
-    let executions = sfn
-        .list_executions()
-        .state_machine_arn(sm_arn)
-        .send()
-        .await
-        .expect("list executions");
-
-    assert_eq!(
-        executions.executions().len(),
-        1,
-        "expected 1 execution started by EventBridge rule"
-    );
+    // Poll until the EventBridge rule triggers a Step Functions execution
+    let executions = helpers::wait_until(std::time::Duration::from_secs(10), || async {
+        let resp = sfn
+            .list_executions()
+            .state_machine_arn(sm_arn)
+            .send()
+            .await
+            .ok()?;
+        if resp.executions().len() == 1 {
+            Some(resp)
+        } else {
+            None
+        }
+    })
+    .await
+    .expect("expected 1 execution started by EventBridge rule");
     let exec = &executions.executions()[0];
     assert_eq!(
         exec.status(),

--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -41,6 +41,31 @@ pub async fn sqs_receive_at_least(
     all
 }
 
+/// Poll `probe` every 50ms until it returns `Some(value)` or the deadline
+/// elapses. Returns `Some(value)` on first match or `None` on timeout. The
+/// caller asserts on the returned `Option` so the failure message reflects
+/// the test's intent rather than a generic timeout panic.
+///
+/// Use this in place of `tokio::time::sleep(fixed)` followed by a one-shot
+/// assertion: a fixed sleep is either too short (flake under CI load) or too
+/// long (wastes wall clock). Polling adapts to actual readiness.
+pub async fn wait_until<F, Fut, T>(deadline: std::time::Duration, mut probe: F) -> Option<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let until = std::time::Instant::now() + deadline;
+    loop {
+        if let Some(v) = probe().await {
+            return Some(v);
+        }
+        if std::time::Instant::now() >= until {
+            return None;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
 /// Decompress gzipped data.
 pub fn gunzip(data: &[u8]) -> Vec<u8> {
     use std::io::Read;


### PR DESCRIPTION
## Summary

Per audit 2026-04-28 §6 HIGH: hardcoded sleeps cause CI flake.

- Add a generic `wait_until` poll helper in `tests/helpers/mod.rs` alongside the existing `sqs_receive_at_least` helper.
- Convert three high-value blind-wait sites in `tests/eventbridge.rs`:
  - `eb_schedule_fires_to_sqs`: 3s blind wait → poll SQS via helper
  - replay test: 200ms purge wait → poll until queue drains
  - sfn-target test: 500ms execution-start wait → poll `list_executions`
- Other fixed sleeps (SQS msg TTL waits, scheduler-rate elapsed waits) stay as-is — they are time-bounded by feature semantics, not by async readiness, and can't be converted to polling without changing test semantics.

## Test plan

- [x] `cargo build -p fakecloud-e2e --tests`
- [x] `cargo clippy -p fakecloud-e2e --tests -- -D warnings`
- [ ] CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced brittle fixed sleeps in EventBridge e2e tests with polling to reduce CI flakiness and speed up runs. Added a `wait_until` helper, updated three tests to poll SQS and Step Functions readiness, and ran `cargo fmt`.

- **New Features**
  - Added `wait_until` poll helper (50ms interval, deadline-based) in test helpers.

- **Bug Fixes**
  - Converted three blind waits to polling: schedule→SQS delivery, queue purge drain, and Step Functions execution start.
  - Left intentional time-based waits (SQS TTL, schedule rate) unchanged.

<sup>Written for commit 406710711908dee8b2ef2c24962a9530655eb8ad. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

