### PR TITLE
refactor(arn): replace inline format!("arn:aws:...") with Arn helper in prod

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
 use crate::state::{
@@ -781,7 +782,7 @@ fn synth_certificate_arn(account_id: &str, region: &str) -> String {
         region
     };
     let id = Uuid::new_v4();
-    format!("arn:aws:acm:{region}:{account_id}:certificate/{id}")
+    Arn::new("acm", region, account_id, &format!("certificate/{id}")).to_string()
 }
 
 fn synth_serial(arn: &str) -> String {

--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -1859,7 +1859,13 @@ fn capacity_reservation_arn(account_id: &str, region: &str, name: &str) -> Strin
     } else {
         region
     };
-    Arn::new("athena", region, account_id, &format!("capacity-reservation/{name}")).to_string()
+    Arn::new(
+        "athena",
+        region,
+        account_id,
+        &format!("capacity-reservation/{name}"),
+    )
+    .to_string()
 }
 
 fn parse_string_list(value: Option<&Value>) -> Vec<String> {

--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -9,6 +9,7 @@ use parking_lot::RwLock;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -1840,7 +1841,7 @@ fn workgroup_arn(account_id: &str, region: &str, name: &str) -> String {
     } else {
         region
     };
-    format!("arn:aws:athena:{region}:{account_id}:workgroup/{name}")
+    Arn::new("athena", region, account_id, &format!("workgroup/{name}")).to_string()
 }
 
 fn datacatalog_arn(account_id: &str, region: &str, name: &str) -> String {
@@ -1849,7 +1850,7 @@ fn datacatalog_arn(account_id: &str, region: &str, name: &str) -> String {
     } else {
         region
     };
-    format!("arn:aws:athena:{region}:{account_id}:datacatalog/{name}")
+    Arn::new("athena", region, account_id, &format!("datacatalog/{name}")).to_string()
 }
 
 fn capacity_reservation_arn(account_id: &str, region: &str, name: &str) -> String {
@@ -1858,7 +1859,7 @@ fn capacity_reservation_arn(account_id: &str, region: &str, name: &str) -> Strin
     } else {
         region
     };
-    format!("arn:aws:athena:{region}:{account_id}:capacity-reservation/{name}")
+    Arn::new("athena", region, account_id, &format!("capacity-reservation/{name}")).to_string()
 }
 
 fn parse_string_list(value: Option<&Value>) -> Vec<String> {

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -2365,7 +2365,7 @@ impl EventBridgeService {
         // Build the archive target with InputTransformer
         let archive_target = EventTarget {
             id: name.clone(),
-            arn: format!("arn:aws:events:{}:::", req.region),
+            arn: Arn::new("events", &req.region, "", "").to_string(),
             input: None,
             input_path: None,
             input_transformer: Some(json!({

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::LambdaService;
@@ -1217,7 +1218,7 @@ impl LambdaService {
             .runtime_management
             .insert(format!("{function_name}:{qualifier}"), cfg.clone());
         ok(json!({
-            "FunctionArn": format!("arn:aws:lambda:{}:{}:function:{}:{}", state.region, state.account_id, function_name, qualifier),
+            "FunctionArn": Arn::new("lambda", &state.region, &state.account_id, &format!("function:{function_name}:{qualifier}")).to_string(),
             "UpdateRuntimeOn": cfg.update_runtime_on,
             "RuntimeVersionArn": cfg.runtime_version_arn,
         }))

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -14,6 +14,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
@@ -119,7 +120,7 @@ impl RdsService {
             // ── DB Clusters ──
             "CreateDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").ok_or_else(|| missing("DBClusterIdentifier"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster:{id}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
                 let entry = json!({
                     "DBClusterIdentifier": id, "DBClusterArn": arn,
                     "Status": "available", "Engine": get_param(req, "Engine").unwrap_or_else(|| "aurora-postgresql".to_string()),
@@ -135,7 +136,7 @@ impl RdsService {
             }
             "DeleteDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").ok_or_else(|| missing("DBClusterIdentifier"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster:{id}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 if let Some(m) = state.extras.get_mut("clusters") { m.remove(&id); }
@@ -143,7 +144,7 @@ impl RdsService {
             }
             "ModifyDBCluster" | "RebootDBCluster" | "StartDBCluster" | "StopDBCluster" | "FailoverDBCluster" | "BacktrackDBCluster" | "PromoteReadReplicaDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").unwrap_or_else(|| "default".to_string());
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster:{id}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
                 Ok(xml_response(action.as_str(), db_cluster_xml(&id, &arn), &rid))
             }
             "DescribeDBClusters" => {
@@ -160,7 +161,7 @@ impl RdsService {
             "CreateDBClusterSnapshot" | "CopyDBClusterSnapshot" => {
                 let id = get_param(req, "DBClusterSnapshotIdentifier").or_else(|| get_param(req, "TargetDBClusterSnapshotIdentifier"))
                     .ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster-snapshot:{id}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster-snapshot:{id}")).to_string();
                 let cluster = get_param(req, "DBClusterIdentifier").unwrap_or_else(|| "default".to_string());
                 let entry = json!({"DBClusterSnapshotIdentifier": id, "DBClusterSnapshotArn": arn, "DBClusterIdentifier": cluster, "Status": "available"});
                 let mut accounts = write_state!();
@@ -170,7 +171,7 @@ impl RdsService {
             }
             "DeleteDBClusterSnapshot" => {
                 let id = get_param(req, "DBClusterSnapshotIdentifier").ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster-snapshot:{id}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster-snapshot:{id}")).to_string();
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 if let Some(m) = state.extras.get_mut("cluster_snapshots") { m.remove(&id); }
@@ -189,7 +190,7 @@ impl RdsService {
             "CreateDBClusterParameterGroup" | "CopyDBClusterParameterGroup" => {
                 let name = get_param(req, "DBClusterParameterGroupName").or_else(|| get_param(req, "TargetDBClusterParameterGroupIdentifier"))
                     .ok_or_else(|| missing("DBClusterParameterGroupName"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:cluster-pg:{name}");
+                let arn = Arn::new("rds", region, &aid, &format!("cluster-pg:{name}")).to_string();
                 let family = get_param(req, "DBParameterGroupFamily").unwrap_or_else(|| "aurora-postgresql15".to_string());
                 let entry = json!({"DBClusterParameterGroupName": name, "DBClusterParameterGroupArn": arn, "DBParameterGroupFamily": family, "Description": get_param(req, "Description").unwrap_or_default()});
                 let mut accounts = write_state!();
@@ -240,7 +241,7 @@ impl RdsService {
             // ── DB Proxies ──
             "CreateDBProxy" => {
                 let name = get_param(req, "DBProxyName").ok_or_else(|| missing("DBProxyName"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:db-proxy:{name}");
+                let arn = Arn::new("rds", region, &aid, &format!("db-proxy:{name}")).to_string();
                 let entry = json!({"DBProxyName": name, "DBProxyArn": arn, "Status": "available", "EngineFamily": get_param(req, "EngineFamily").unwrap_or_else(|| "POSTGRESQL".to_string())});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
@@ -301,7 +302,7 @@ impl RdsService {
             "CreateOptionGroup" | "CopyOptionGroup" => {
                 let name = get_param(req, "OptionGroupName").or_else(|| get_param(req, "TargetOptionGroupIdentifier"))
                     .ok_or_else(|| missing("OptionGroupName"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:og:{name}");
+                let arn = Arn::new("rds", region, &aid, &format!("og:{name}")).to_string();
                 let entry = json!({"OptionGroupName": name, "OptionGroupArn": arn, "EngineName": get_param(req, "EngineName").unwrap_or_else(|| "mysql".to_string()), "MajorEngineVersion": get_param(req, "MajorEngineVersion").unwrap_or_else(|| "8.0".to_string())});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
@@ -345,7 +346,7 @@ impl RdsService {
             // ── Global clusters ──
             "CreateGlobalCluster" => {
                 let id = get_param(req, "GlobalClusterIdentifier").ok_or_else(|| missing("GlobalClusterIdentifier"))?;
-                let arn = format!("arn:aws:rds::{aid}:global-cluster:{id}");
+                let arn = Arn::global("rds", &aid, &format!("global-cluster:{id}")).to_string();
                 let entry = json!({"GlobalClusterIdentifier": id, "GlobalClusterArn": arn, "Status": "available"});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
@@ -365,7 +366,7 @@ impl RdsService {
             // ── Integrations ──
             "CreateIntegration" => {
                 let name = get_param(req, "IntegrationName").ok_or_else(|| missing("IntegrationName"))?;
-                let arn = format!("arn:aws:rds:{region}:{aid}:integration:{name}");
+                let arn = Arn::new("rds", region, &aid, &format!("integration:{name}")).to_string();
                 let entry = json!({"IntegrationName": name, "IntegrationArn": arn, "Status": "active"});
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
@@ -478,7 +479,7 @@ impl RdsService {
                             .get(&aid)
                             .and_then(|s| s.instances.get(&id).map(|i| i.db_instance_arn.clone()))
                             .unwrap_or_else(|| {
-                                format!("arn:aws:rds:{region}:{aid}:db:{id}")
+                                Arn::new("rds", region, &aid, &format!("db:{id}")).to_string()
                             })
                     };
                     self.emit_event(

--- a/crates/fakecloud-scheduler/src/simulation.rs
+++ b/crates/fakecloud-scheduler/src/simulation.rs
@@ -100,7 +100,7 @@ pub fn fire_schedule_response(
 ) -> Result<FireScheduleResponse, String> {
     let target_arn = fire_once(state, delivery, account_id, group, name)?;
     Ok(FireScheduleResponse {
-        schedule_arn: format!("arn:aws:scheduler:{region}:{account_id}:schedule/{group}/{name}"),
+        schedule_arn: crate::state::schedule_arn(region, account_id, group, name),
         target_arn,
     })
 }

--- a/crates/fakecloud-scheduler/src/state.rs
+++ b/crates/fakecloud-scheduler/src/state.rs
@@ -204,13 +204,25 @@ pub struct SchedulerSnapshot {
 /// Build an EventBridge Scheduler schedule ARN.
 /// Format: `arn:aws:scheduler:<region>:<account>:schedule/<group>/<name>`.
 pub fn schedule_arn(region: &str, account_id: &str, group: &str, name: &str) -> String {
-    Arn::new("scheduler", region, account_id, &format!("schedule/{group}/{name}")).to_string()
+    Arn::new(
+        "scheduler",
+        region,
+        account_id,
+        &format!("schedule/{group}/{name}"),
+    )
+    .to_string()
 }
 
 /// Build a schedule-group ARN.
 /// Format: `arn:aws:scheduler:<region>:<account>:schedule-group/<group>`.
 pub fn group_arn(region: &str, account_id: &str, group: &str) -> String {
-    Arn::new("scheduler", region, account_id, &format!("schedule-group/{group}")).to_string()
+    Arn::new(
+        "scheduler",
+        region,
+        account_id,
+        &format!("schedule-group/{group}"),
+    )
+    .to_string()
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-scheduler/src/state.rs
+++ b/crates/fakecloud-scheduler/src/state.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::multi_account::{AccountState, MultiAccountState};
 
 /// Default schedule group name, auto-created for every account and
@@ -203,13 +204,13 @@ pub struct SchedulerSnapshot {
 /// Build an EventBridge Scheduler schedule ARN.
 /// Format: `arn:aws:scheduler:<region>:<account>:schedule/<group>/<name>`.
 pub fn schedule_arn(region: &str, account_id: &str, group: &str, name: &str) -> String {
-    format!("arn:aws:scheduler:{region}:{account_id}:schedule/{group}/{name}")
+    Arn::new("scheduler", region, account_id, &format!("schedule/{group}/{name}")).to_string()
 }
 
 /// Build a schedule-group ARN.
 /// Format: `arn:aws:scheduler:<region>:<account>:schedule-group/<group>`.
 pub fn group_arn(region: &str, account_id: &str, group: &str) -> String {
-    format!("arn:aws:scheduler:{region}:{account_id}:schedule-group/{group}")
+    Arn::new("scheduler", region, account_id, &format!("schedule-group/{group}")).to_string()
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-wafv2/src/service.rs
+++ b/crates/fakecloud-wafv2/src/service.rs
@@ -11,6 +11,7 @@ use parking_lot::RwLock;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
@@ -1441,7 +1442,7 @@ impl Wafv2Service {
             .to_string();
         Ok(AwsResponse::ok_json(json!({
             "VersionName": version,
-            "SnsTopicArn": format!("arn:aws:sns:us-east-1::{vendor}-{name}-notifications"),
+            "SnsTopicArn": Arn::new("sns", "us-east-1", "", &format!("{vendor}-{name}-notifications")).to_string(),
             "Capacity": 50,
             "Rules": managed_rule_summaries(&vendor, &name),
             "LabelNamespace": format!("awswaf:managed:{vendor}:{name}:"),
@@ -1463,11 +1464,11 @@ impl Wafv2Service {
             "ManagedRuleSet": {
                 "Name": name,
                 "Id": id,
-                "ARN": format!("arn:aws:wafv2:{}:{}:managedruleset/{name}/{id}", req.region, req.account_id),
+                "ARN": Arn::new("wafv2", &req.region, &req.account_id, &format!("managedruleset/{name}/{id}")).to_string(),
                 "Description": format!("Managed rule set {name}"),
                 "PublishedVersions": {
                     "Version_1.0": {
-                        "AssociatedRuleGroupArn": format!("arn:aws:wafv2:{}:aws:managedrulegroup/{name}", req.region),
+                        "AssociatedRuleGroupArn": Arn::new("wafv2", &req.region, "aws", &format!("managedrulegroup/{name}")).to_string(),
                         "Capacity": 50,
                         "ForecastedLifetime": 90,
                         "PublishTimestamp": Utc::now().timestamp() as f64,
@@ -1764,7 +1765,13 @@ fn synth_arn(
     } else {
         (region, region)
     };
-    format!("arn:aws:wafv2:{region_in_arn}:{account_id}:{scope_seg}/{kind}/{name}/{id}")
+    Arn::new(
+        "wafv2",
+        region_in_arn,
+        account_id,
+        &format!("{scope_seg}/{kind}/{name}/{id}"),
+    )
+    .to_string()
 }
 
 fn parse_string_list(value: Option<&Value>) -> Vec<String> {


### PR DESCRIPTION
## Summary

Per audit 2026-04-28 §2 HIGH (104 inline ARN format strings vs 22 `Arn::new` adopters):

- Sweep operational sites in 8 crates so prod ARN strings flow through the central `Arn` builder.
- After this PR, every `src/*.rs` non-test ARN goes through `Arn::new` / `Arn::global` / `schedule_arn` helper.
- Inline `format!(\"arn:aws:...\")` calls remaining are all in `#[cfg(test)]` fixtures — cosmetic, separate concern.

Crates touched:
- rds extras: 11 cluster/snapshot/proxy/og/integration/global-cluster ARNs
- athena: workgroup/datacatalog/capacity-reservation ARN builders
- acm: certificate ARN builder
- wafv2: managedruleset/managedrulegroup/SNS notification ARNs
- lambda extras: runtime-management FunctionArn
- eventbridge service: archive target placeholder ARN
- scheduler simulation: route through state::schedule_arn helper
- scheduler state: schedule + group ARN builders use Arn::new

## Test plan

- [x] `cargo build -p fakecloud-{rds,acm,athena,wafv2,lambda,eventbridge,scheduler}`
- [x] `cargo clippy -p fakecloud-{rds,acm,athena,wafv2,lambda,eventbridge,scheduler} --all-targets -- -D warnings`
- [x] `cargo test -p ...`
- [ ] CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced inline ARN string formats with the `Arn` helper across seven crates. Centralizes and standardizes prod ARNs with no behavior change.

- **Refactors**
  - `fakecloud-rds`: clusters, cluster snapshots, cluster parameter groups, DB proxies, option groups, integrations, global clusters (`Arn::global`), and event fallback instance ARNs now use `Arn`.
  - `fakecloud-athena`: workgroup, datacatalog, and capacity-reservation ARNs use `Arn`.
  - `fakecloud-acm`: certificate ARNs use `Arn`.
  - `fakecloud-wafv2`: managed rule set ARNs, associated managed rule group ARNs, SNS topic ARNs, and `synth_arn` now use `Arn`.
  - `fakecloud-lambda`: runtime management `FunctionArn` uses `Arn`.
  - `fakecloud-eventbridge`: archive target placeholder ARN uses `Arn`.
  - `fakecloud-scheduler`: `schedule_arn` and `group_arn` use `Arn`; simulation routes through these helpers.
  - Inline `format!("arn:aws:...")` remains only in tests.

<sup>Written for commit d076315d6350702524beda54937ba0ea9f545b7a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/859?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

