### PR TITLE
refactor: convert organizations/scheduler/secretsmanager state to BTreeMap

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -3,7 +3,7 @@
 //! Wire protocol: AWS Query (form-encoded request, XML response). Endpoint
 //! prefix `elasticloadbalancing`, SigV4 service `elasticloadbalancing`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -592,7 +592,7 @@ impl Elbv2Service {
             ),
             ipv4_ipam_pool_id: optional_query_param(req, "IpamPools.Ipv4IpamPoolId"),
             tags,
-            attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
             minimum_capacity_units: optional_query_param(
                 req,
                 "MinimumLoadBalancerCapacity.CapacityUnits",
@@ -1426,7 +1426,7 @@ impl Elbv2Service {
             alpn_policy,
             mutual_authentication: parse_mutual_authentication(req),
             tags,
-            attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
         };
         let listener_xml = render_listener_xml(&listener);
         st.listeners.insert(arn, listener);
@@ -1913,7 +1913,7 @@ impl Elbv2Service {
             total_revoked_entries: 0,
             created_time: Utc::now(),
             ca_certificates_bundle: Some(format!("s3://{bucket}/{key}").into_bytes()),
-            revocations: HashMap::new(),
+            revocations: BTreeMap::new(),
             next_revocation_id: 1,
             tags,
         };
@@ -2231,8 +2231,8 @@ fn trust_store_not_found(arn: &str) -> AwsServiceError {
     )
 }
 
-fn default_lb_attributes(lb_type: &str) -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn default_lb_attributes(lb_type: &str) -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert("idle_timeout.timeout_seconds".to_string(), "60".to_string());
     m.insert(
         "deletion_protection.enabled".to_string(),
@@ -2259,7 +2259,10 @@ fn default_lb_attributes(lb_type: &str) -> HashMap<String, String> {
     m
 }
 
-fn merge_lb_attributes(lb_type: &str, stored: &HashMap<String, String>) -> HashMap<String, String> {
+fn merge_lb_attributes(
+    lb_type: &str,
+    stored: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
     let mut m = default_lb_attributes(lb_type);
     for (k, v) in stored {
         m.insert(k.clone(), v.clone());
@@ -2877,7 +2880,7 @@ fn parse_attributes(req: &AwsRequest) -> Vec<(String, String)> {
     out
 }
 
-fn render_attributes_xml(attrs: &HashMap<String, String>) -> String {
+fn render_attributes_xml(attrs: &BTreeMap<String, String>) -> String {
     let entries = attrs
         .iter()
         .map(|(k, v)| {
@@ -2891,8 +2894,8 @@ fn render_attributes_xml(attrs: &HashMap<String, String>) -> String {
     format!("<Attributes>{entries}</Attributes>")
 }
 
-fn default_target_group_attributes() -> HashMap<String, String> {
-    let mut m = HashMap::new();
+fn default_target_group_attributes() -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
     m.insert(
         "deregistration_delay.timeout_seconds".to_string(),
         "300".to_string(),
@@ -2985,6 +2988,7 @@ mod tests {
     use bytes::Bytes;
     use http::HeaderMap;
     use parking_lot::RwLock;
+    use std::collections::HashMap;
 
     fn req(action: &str, params: &[(&str, &str)]) -> AwsRequest {
         let mut q = HashMap::new();

--- a/crates/fakecloud-elbv2/src/state.rs
+++ b/crates/fakecloud-elbv2/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +9,7 @@ pub type SharedElbv2State = Arc<RwLock<Elbv2Accounts>>;
 
 #[derive(Default)]
 pub struct Elbv2Accounts {
-    accounts: HashMap<String, Elbv2State>,
+    accounts: BTreeMap<String, Elbv2State>,
 }
 
 impl Elbv2Accounts {
@@ -39,24 +39,24 @@ impl Elbv2Accounts {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Elbv2State {
     pub account_id: String,
-    pub load_balancers: HashMap<String, LoadBalancer>,
-    pub target_groups: HashMap<String, TargetGroup>,
-    pub listeners: HashMap<String, Listener>,
-    pub rules: HashMap<String, Rule>,
-    pub trust_stores: HashMap<String, TrustStore>,
-    pub resource_policies: HashMap<String, String>,
+    pub load_balancers: BTreeMap<String, LoadBalancer>,
+    pub target_groups: BTreeMap<String, TargetGroup>,
+    pub listeners: BTreeMap<String, Listener>,
+    pub rules: BTreeMap<String, Rule>,
+    pub trust_stores: BTreeMap<String, TrustStore>,
+    pub resource_policies: BTreeMap<String, String>,
 }
 
 impl Elbv2State {
     pub fn new(account_id: &str) -> Self {
         Self {
             account_id: account_id.to_string(),
-            load_balancers: HashMap::new(),
-            target_groups: HashMap::new(),
-            listeners: HashMap::new(),
-            rules: HashMap::new(),
-            trust_stores: HashMap::new(),
-            resource_policies: HashMap::new(),
+            load_balancers: BTreeMap::new(),
+            target_groups: BTreeMap::new(),
+            listeners: BTreeMap::new(),
+            rules: BTreeMap::new(),
+            trust_stores: BTreeMap::new(),
+            resource_policies: BTreeMap::new(),
         }
     }
 }
@@ -81,7 +81,7 @@ pub struct LoadBalancer {
     pub enable_prefix_for_ipv6_source_nat: Option<String>,
     pub ipv4_ipam_pool_id: Option<String>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
     pub minimum_capacity_units: Option<i32>,
     /// In-process data plane TCP port assigned by the OS once the
     /// data plane supervisor binds a listener for this LB. `None`
@@ -140,7 +140,7 @@ pub struct TargetGroup {
     pub load_balancer_arns: Vec<String>,
     pub targets: Vec<TargetDescription>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
     pub created_time: DateTime<Utc>,
 }
 
@@ -197,7 +197,7 @@ pub struct Listener {
     pub alpn_policy: Vec<String>,
     pub mutual_authentication: Option<MutualAuthentication>,
     pub tags: Vec<Tag>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -301,7 +301,7 @@ pub struct TrustStore {
     pub total_revoked_entries: i64,
     pub created_time: DateTime<Utc>,
     pub ca_certificates_bundle: Option<Vec<u8>>,
-    pub revocations: HashMap<i64, TrustStoreRevocation>,
+    pub revocations: BTreeMap<i64, TrustStoreRevocation>,
     pub next_revocation_id: i64,
     pub tags: Vec<Tag>,
 }

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -37,11 +37,11 @@ pub struct OrganizationState {
     pub root_arn: String,
     pub root_name: String,
     pub created_at: DateTime<Utc>,
-    pub ous: HashMap<String, OrganizationalUnit>,
-    pub accounts: HashMap<String, MemberAccount>,
-    pub policies: HashMap<String, Policy>,
+    pub ous: BTreeMap<String, OrganizationalUnit>,
+    pub accounts: BTreeMap<String, MemberAccount>,
+    pub policies: BTreeMap<String, Policy>,
     /// target_id -> attached policy ids. Targets are root id, OU id, or account id.
-    pub attachments: HashMap<String, HashSet<String>>,
+    pub attachments: BTreeMap<String, HashSet<String>>,
 }
 
 impl OrganizationState {
@@ -66,7 +66,7 @@ impl OrganizationState {
             management_account_id, org_id, management_account_id
         );
 
-        let mut policies = HashMap::new();
+        let mut policies = BTreeMap::new();
         policies.insert(
             FULL_AWS_ACCESS_POLICY_ID.to_string(),
             Policy {
@@ -83,13 +83,13 @@ impl OrganizationState {
             },
         );
 
-        let mut attachments: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut attachments: BTreeMap<String, HashSet<String>> = BTreeMap::new();
         attachments
             .entry(root_id.clone())
             .or_default()
             .insert(FULL_AWS_ACCESS_POLICY_ID.to_string());
 
-        let mut accounts = HashMap::new();
+        let mut accounts = BTreeMap::new();
         accounts.insert(
             management_account_id.to_string(),
             MemberAccount {
@@ -115,7 +115,7 @@ impl OrganizationState {
             root_arn,
             root_name: "Root".to_string(),
             created_at: now,
-            ous: HashMap::new(),
+            ous: BTreeMap::new(),
             accounts,
             policies,
             attachments,

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -12,7 +12,7 @@
 
 use http::StatusCode;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
@@ -75,9 +75,9 @@ where
 }
 
 fn store<'a>(
-    extras: &'a mut HashMap<String, HashMap<String, Value>>,
+    extras: &'a mut BTreeMap<String, BTreeMap<String, Value>>,
     category: &str,
-) -> &'a mut HashMap<String, Value> {
+) -> &'a mut BTreeMap<String, Value> {
     extras.entry(category.to_string()).or_default()
 }
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -2038,7 +2038,7 @@ impl RdsService {
             db_parameter_group_arn,
             db_parameter_group_family,
             description,
-            parameters: std::collections::HashMap::new(),
+            parameters: std::collections::BTreeMap::new(),
             tags,
         };
 

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
@@ -180,11 +180,11 @@ impl fmt::Debug for DbSnapshot {
 pub struct RdsState {
     pub account_id: String,
     pub region: String,
-    pub instances: HashMap<String, DbInstance>,
+    pub instances: BTreeMap<String, DbInstance>,
     pub in_progress_instance_ids: HashSet<String>,
-    pub snapshots: HashMap<String, DbSnapshot>,
-    pub subnet_groups: HashMap<String, DbSubnetGroup>,
-    pub parameter_groups: HashMap<String, DbParameterGroup>,
+    pub snapshots: BTreeMap<String, DbSnapshot>,
+    pub subnet_groups: BTreeMap<String, DbSubnetGroup>,
+    pub parameter_groups: BTreeMap<String, DbParameterGroup>,
     /// Generic stores keyed by category (clusters, cluster_snapshots,
     /// cluster_param_groups, proxies, proxy_endpoints, security_groups,
     /// option_groups, event_subscriptions, global_clusters, integrations,
@@ -192,7 +192,7 @@ pub struct RdsState {
     /// export_tasks, etc.) so the extras handlers can persist state
     /// without proliferating per-category fields.
     #[serde(default)]
-    pub extras: HashMap<String, HashMap<String, serde_json::Value>>,
+    pub extras: BTreeMap<String, BTreeMap<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -233,7 +233,7 @@ pub struct DbParameterGroup {
     pub db_parameter_group_arn: String,
     pub db_parameter_group_family: String,
     pub description: String,
-    pub parameters: HashMap<String, String>,
+    pub parameters: BTreeMap<String, String>,
     pub tags: Vec<RdsTag>,
 }
 
@@ -242,12 +242,12 @@ impl RdsState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            instances: HashMap::new(),
+            instances: BTreeMap::new(),
             in_progress_instance_ids: HashSet::new(),
-            snapshots: HashMap::new(),
-            subnet_groups: HashMap::new(),
+            snapshots: BTreeMap::new(),
+            subnet_groups: BTreeMap::new(),
             parameter_groups: default_parameter_groups(account_id, region),
-            extras: HashMap::new(),
+            extras: BTreeMap::new(),
         }
     }
 
@@ -453,8 +453,8 @@ pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
 pub fn default_parameter_groups(
     account_id: &str,
     region: &str,
-) -> HashMap<String, DbParameterGroup> {
-    let mut groups = HashMap::new();
+) -> BTreeMap<String, DbParameterGroup> {
+    let mut groups = BTreeMap::new();
 
     let families = vec![
         ("postgres16", "Default parameter group for postgres16"),
@@ -533,7 +533,7 @@ pub fn default_parameter_groups(
             .to_string(),
             db_parameter_group_family: family.to_string(),
             description: description.to_string(),
-            parameters: HashMap::new(),
+            parameters: BTreeMap::new(),
             tags: Vec::new(),
         };
         groups.insert(group_name, group);

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -382,7 +382,7 @@ impl SchedulerService {
             ));
         }
 
-        let mut tags = HashMap::new();
+        let mut tags = BTreeMap::new();
         if let Err(field) =
             fakecloud_core::tags::apply_tags(&mut tags, &body, "Tags", "Key", "Value")
         {
@@ -715,7 +715,10 @@ impl AwsService for SchedulerService {
         let accounts = self.state.read();
         let account_id = arn_account_id(resource_arn)?;
         let state = accounts.get(&account_id)?;
-        state.groups.get(&group_name).map(|g| g.tags.clone())
+        state
+            .groups
+            .get(&group_name)
+            .map(|g| g.tags.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     }
 
     fn request_tags_from(

--- a/crates/fakecloud-scheduler/src/state.rs
+++ b/crates/fakecloud-scheduler/src/state.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use fakecloud_core::multi_account::{AccountState, MultiAccountState};
@@ -91,7 +91,7 @@ pub struct ScheduleGroup {
     pub state: String, // ACTIVE | DELETING
     pub creation_date: DateTime<Utc>,
     pub last_modification_date: DateTime<Utc>,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
 }
 
 /// Composite key: (group_name, schedule_name). Schedules are unique
@@ -103,23 +103,23 @@ pub struct SchedulerState {
     pub account_id: String,
     pub region: String,
     #[serde(default)]
-    pub groups: HashMap<String, ScheduleGroup>,
+    pub groups: BTreeMap<String, ScheduleGroup>,
     // JSON can't represent a tuple-keyed map, so we (de)serialize
     // schedules as a flat Vec<Schedule> and rebuild the in-memory
     // `(group, name)` index on read. Pre-refactor versions silently
     // dropped the entire map during save — the regression that broke
     // schedule-survives-restart.
     #[serde(default, with = "schedules_vec_serde")]
-    pub schedules: HashMap<ScheduleKey, Schedule>,
+    pub schedules: BTreeMap<ScheduleKey, Schedule>,
 }
 
 mod schedules_vec_serde {
     use super::{Schedule, ScheduleKey};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     pub fn serialize<S: Serializer>(
-        schedules: &HashMap<ScheduleKey, Schedule>,
+        schedules: &BTreeMap<ScheduleKey, Schedule>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let mut sorted: Vec<&Schedule> = schedules.values().collect();
@@ -133,7 +133,7 @@ mod schedules_vec_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<HashMap<ScheduleKey, Schedule>, D::Error> {
+    ) -> Result<BTreeMap<ScheduleKey, Schedule>, D::Error> {
         let v: Vec<Schedule> = Vec::deserialize(deserializer)?;
         Ok(v.into_iter()
             .map(|s| ((s.group_name.clone(), s.name.clone()), s))
@@ -144,7 +144,7 @@ mod schedules_vec_serde {
 impl SchedulerState {
     pub fn new(account_id: &str, region: &str) -> Self {
         let now = Utc::now();
-        let mut groups = HashMap::new();
+        let mut groups = BTreeMap::new();
         groups.insert(
             DEFAULT_GROUP.to_string(),
             ScheduleGroup {
@@ -153,14 +153,14 @@ impl SchedulerState {
                 state: "ACTIVE".to_string(),
                 creation_date: now,
                 last_modification_date: now,
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
             },
         );
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
             groups,
-            schedules: HashMap::new(),
+            schedules: BTreeMap::new(),
         }
     }
 
@@ -176,7 +176,7 @@ impl SchedulerState {
                 state: "ACTIVE".to_string(),
                 creation_date: now,
                 last_modification_date: now,
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
             },
         );
     }
@@ -271,7 +271,7 @@ mod tests {
                 state: "ACTIVE".to_string(),
                 creation_date: Utc::now(),
                 last_modification_date: Utc::now(),
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
             },
         );
         s.reset();

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -185,7 +185,7 @@ mod tests {
     use crate::state::*;
     use chrono::Duration;
     use parking_lot::RwLock;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     fn make_state() -> SharedSecretsManagerState {
@@ -208,7 +208,7 @@ mod tests {
         let last_rotated = last_rotated_ago_days.map(|d| now - Duration::days(d));
         let version_id = "v1".to_string();
 
-        let mut versions = HashMap::new();
+        let mut versions = BTreeMap::new();
         versions.insert(
             version_id.clone(),
             SecretVersion {

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -48,7 +48,7 @@ enum VersionIdempotency {
 /// string — callers compute this via the KMS hook before invoking so
 /// the comparison happens on plaintext, not on stored ciphertext.
 fn check_secret_version_idempotency(
-    versions: &HashMap<String, SecretVersion>,
+    versions: &BTreeMap<String, SecretVersion>,
     version_id: &str,
     existing_plaintext: Option<String>,
     secret_string: &Option<String>,
@@ -297,11 +297,11 @@ impl SecretsManagerService {
                 stages: vec!["AWSCURRENT".to_string()],
                 created_at: now,
             };
-            let mut versions = std::collections::HashMap::new();
+            let mut versions = std::collections::BTreeMap::new();
             versions.insert(vid.clone(), version);
             (versions, Some(vid.clone()), Some(vid))
         } else {
-            (std::collections::HashMap::new(), None, None)
+            (std::collections::BTreeMap::new(), None, None)
         };
 
         let tags_ever_set = !input.tags.is_empty();
@@ -2399,7 +2399,7 @@ mod tests {
     use bytes::Bytes;
     use http::{HeaderMap, Method};
     use parking_lot::RwLock;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
 
     fn make_state() -> SharedSecretsManagerState {
@@ -4419,7 +4419,7 @@ mod tests {
 
     #[test]
     fn test_check_version_idempotency() {
-        let mut versions = HashMap::new();
+        let mut versions = BTreeMap::new();
         versions.insert(
             "v1".to_string(),
             SecretVersion {
@@ -4497,7 +4497,7 @@ mod tests {
             arn: "arn".to_string(),
             description: None,
             kms_key_id: None,
-            versions: HashMap::new(),
+            versions: BTreeMap::new(),
             current_version_id: None,
             tags: vec![],
             tags_ever_set: false,
@@ -4523,7 +4523,7 @@ mod tests {
             arn: "arn".to_string(),
             description: None,
             kms_key_id: None,
-            versions: HashMap::new(),
+            versions: BTreeMap::new(),
             current_version_id: None,
             tags: vec![("env".to_string(), "production".to_string())],
             tags_ever_set: true,
@@ -4549,7 +4549,7 @@ mod tests {
             arn: "arn".to_string(),
             description: Some("important database".to_string()),
             kms_key_id: None,
-            versions: HashMap::new(),
+            versions: BTreeMap::new(),
             current_version_id: None,
             tags: vec![("team".to_string(), "backend".to_string())],
             tags_ever_set: true,

--- a/crates/fakecloud-secretsmanager/src/state.rs
+++ b/crates/fakecloud-secretsmanager/src/state.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -9,7 +9,7 @@ pub struct Secret {
     pub arn: String,
     pub description: Option<String>,
     pub kms_key_id: Option<String>,
-    pub versions: HashMap<String, SecretVersion>,
+    pub versions: BTreeMap<String, SecretVersion>,
     pub current_version_id: Option<String>,
     pub tags: Vec<(String, String)>,
     pub tags_ever_set: bool,
@@ -43,7 +43,7 @@ pub struct SecretVersion {
 pub struct SecretsManagerState {
     pub account_id: String,
     pub region: String,
-    pub secrets: HashMap<String, Secret>,
+    pub secrets: BTreeMap<String, Secret>,
 }
 
 impl SecretsManagerState {
@@ -51,7 +51,7 @@ impl SecretsManagerState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            secrets: HashMap::new(),
+            secrets: BTreeMap::new(),
         }
     }
 
@@ -104,7 +104,7 @@ mod tests {
                 arn: "arn".to_string(),
                 description: None,
                 kms_key_id: None,
-                versions: HashMap::new(),
+                versions: BTreeMap::new(),
                 current_version_id: None,
                 tags: vec![],
                 tags_ever_set: false,


### PR DESCRIPTION
## Summary

Phase E batch 1 (per audit 2026-04-28 §3): switch state.rs `HashMap` usage to `BTreeMap` so list-resource pagination has deterministic order without `sort()` at the response layer.

- **organizations**: 9 `HashMap` fields → `BTreeMap` (orgs/accounts/policies/units)
- **scheduler**: schedules + groups maps → `BTreeMap`; tags `HashMap` → `BTreeMap`; `resource_tags_for` now converts `BTreeMap` → `HashMap` at the `AwsService` trait boundary (the trait still returns `HashMap`)
- **secretsmanager**: secrets + version maps → `BTreeMap` (state, service, rotation)

Stacks on top of #860 (core tag helper widening — needed so `apply_tags`/`tags_to_json` accept BTreeMap).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p fakecloud-organizations -p fakecloud-secretsmanager -p fakecloud-scheduler --lib`
- [x] `cargo clippy -p fakecloud-organizations -p fakecloud-secretsmanager -p fakecloud-scheduler --all-targets -- -D warnings`
- [ ] CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor internal state maps to `BTreeMap` in `fakecloud-organizations`, `fakecloud-scheduler`, `fakecloud-secretsmanager`, `fakecloud-elbv2`, and `fakecloud-rds` to make list and pagination order deterministic without sorting. External APIs stay the same; `AwsService` still returns `HashMap`.

- **Refactors**
  - `fakecloud-organizations`: `ous`, `accounts`, `policies`, and `attachments` now use `BTreeMap`.
  - `fakecloud-scheduler`: `groups` and `schedules` use `BTreeMap`; tag maps use `BTreeMap`; `resource_tags_for` converts to `HashMap` at the `AwsService` boundary.
  - `fakecloud-secretsmanager`: `secrets` and `versions` use `BTreeMap` across state, service, and rotation.
  - `fakecloud-elbv2`: state maps use `BTreeMap`; attributes and trust store `revocations` use `BTreeMap`.
  - `fakecloud-rds`: state maps use `BTreeMap`; parameter groups/parameters and `extras` nested maps use `BTreeMap`.

<sup>Written for commit b63daec98a3f095c538c93556711f887d4e708de. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/861?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

