### PR TITLE
fix(lambda): attach layers to functions and mount /opt at invoke (#853)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda_layers.rs
+++ b/crates/fakecloud-e2e/tests/lambda_layers.rs
@@ -1,0 +1,270 @@
+//! Lambda layer attachment + runtime mount.
+//!
+//! Reproduces the bug from issue #853: `Layers` field on
+//! Create/UpdateFunctionConfiguration was silently dropped, so layer
+//! modules were not on `sys.path` when the function executed.
+//!
+//! Wire round-trip is asserted unconditionally. The actual `import`
+//! check is gated on Docker since it boots a Python Lambda container.
+
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{FunctionCode, LayerVersionContentInput, Runtime};
+use helpers::TestServer;
+use sha2::{Digest, Sha256};
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+    for (name, content) in entries {
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn b64_sha256(bytes: &[u8]) -> String {
+    use base64::Engine;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    base64::engine::general_purpose::STANDARD.encode(hasher.finalize())
+}
+
+#[tokio::test]
+async fn publish_layer_returns_real_content_metadata_and_downloadable_location() {
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+
+    let zip = make_zip(&[("python/greeter.py", b"def greet():\n    return 'hi'\n")]);
+    let expected_sha = b64_sha256(&zip);
+    let expected_size = zip.len() as i64;
+
+    let pub_resp = lambda
+        .publish_layer_version()
+        .layer_name("greeter")
+        .content(
+            LayerVersionContentInput::builder()
+                .zip_file(Blob::new(zip.clone()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let content = pub_resp.content().expect("Content set on publish response");
+    assert_eq!(content.code_sha256(), Some(expected_sha.as_str()));
+    assert_eq!(content.code_size(), expected_size);
+    let location = content
+        .location()
+        .expect("Location set on publish response");
+    assert!(location.contains("/_fakecloud/lambda/layer-content/"));
+
+    // Location must be a real URL that streams the original ZIP.
+    let bytes = reqwest::get(location)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(bytes.as_ref(), zip.as_slice());
+
+    // GetLayerVersion mirrors the publish payload.
+    let get_resp = lambda
+        .get_layer_version()
+        .layer_name("greeter")
+        .version_number(1)
+        .send()
+        .await
+        .unwrap();
+    let g_content = get_resp
+        .content()
+        .expect("Content set on GetLayerVersion response");
+    assert_eq!(g_content.code_sha256(), Some(expected_sha.as_str()));
+    assert_eq!(g_content.code_size(), expected_size);
+}
+
+#[tokio::test]
+async fn create_and_update_function_round_trips_layers() {
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+
+    let layer_a = make_zip(&[("python/a.py", b"def a():\n    return 1\n")]);
+    let layer_b = make_zip(&[("python/b.py", b"def b():\n    return 2\n")]);
+
+    let arn_a = lambda
+        .publish_layer_version()
+        .layer_name("layer-a")
+        .content(
+            LayerVersionContentInput::builder()
+                .zip_file(Blob::new(layer_a.clone()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .layer_version_arn()
+        .unwrap()
+        .to_string();
+    let arn_b = lambda
+        .publish_layer_version()
+        .layer_name("layer-b")
+        .content(
+            LayerVersionContentInput::builder()
+                .zip_file(Blob::new(layer_b.clone()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap()
+        .layer_version_arn()
+        .unwrap()
+        .to_string();
+
+    let handler_zip = make_zip(&[("index.py", b"def handler(e, c):\n    return {}\n")]);
+    let create = lambda
+        .create_function()
+        .function_name("layered-fn")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .code(
+            FunctionCode::builder()
+                .zip_file(Blob::new(handler_zip))
+                .build(),
+        )
+        .layers(arn_a.clone())
+        .layers(arn_b.clone())
+        .send()
+        .await
+        .unwrap();
+    let layers = create.layers();
+    assert_eq!(layers.len(), 2);
+    assert_eq!(layers[0].arn(), Some(arn_a.as_str()));
+    assert_eq!(layers[0].code_size(), layer_a.len() as i64);
+    assert_eq!(layers[1].arn(), Some(arn_b.as_str()));
+    assert_eq!(layers[1].code_size(), layer_b.len() as i64);
+
+    let cfg = lambda
+        .get_function_configuration()
+        .function_name("layered-fn")
+        .send()
+        .await
+        .unwrap();
+    let g_layers = cfg.layers();
+    assert_eq!(g_layers.len(), 2);
+    assert_eq!(g_layers[0].arn(), Some(arn_a.as_str()));
+    assert_eq!(g_layers[1].arn(), Some(arn_b.as_str()));
+
+    // Replace with reversed order — assert order preserved
+    let updated = lambda
+        .update_function_configuration()
+        .function_name("layered-fn")
+        .layers(arn_b.clone())
+        .layers(arn_a.clone())
+        .send()
+        .await
+        .unwrap();
+    let u_layers = updated.layers();
+    assert_eq!(u_layers.len(), 2);
+    assert_eq!(u_layers[0].arn(), Some(arn_b.as_str()));
+    assert_eq!(u_layers[1].arn(), Some(arn_a.as_str()));
+
+    // Empty list detaches all layers
+    let detached = lambda
+        .update_function_configuration()
+        .function_name("layered-fn")
+        .set_layers(Some(vec![]))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        detached.layers().is_empty(),
+        "Layers should be empty after explicit reset"
+    );
+}
+
+#[tokio::test]
+async fn invoke_python_function_imports_module_from_attached_layer() {
+    if !docker_available() {
+        eprintln!("docker required for Lambda execution; skipping");
+        return;
+    }
+    let server = TestServer::start().await;
+    let lambda = server.lambda_client().await;
+
+    // Layer ZIP places `greeter.py` under `python/`, the Python-runtime
+    // path AWS base images add to `sys.path` for `/opt`.
+    let layer_zip = make_zip(&[(
+        "python/greeter.py",
+        b"def greet():\n    return 'hello-from-layer'\n",
+    )]);
+    let layer_arn = lambda
+        .publish_layer_version()
+        .layer_name("invoke-greeter")
+        .content(
+            LayerVersionContentInput::builder()
+                .zip_file(Blob::new(layer_zip))
+                .build(),
+        )
+        .compatible_runtimes(Runtime::Python312)
+        .send()
+        .await
+        .unwrap()
+        .layer_version_arn()
+        .unwrap()
+        .to_string();
+
+    let handler_src = b"\
+import greeter
+def handler(event, context):
+    return {'msg': greeter.greet()}
+";
+    let handler_zip = make_zip(&[("index.py", handler_src)]);
+    lambda
+        .create_function()
+        .function_name("layered-invoke")
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .code(
+            FunctionCode::builder()
+                .zip_file(Blob::new(handler_zip))
+                .build(),
+        )
+        .layers(layer_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = lambda
+        .invoke()
+        .function_name("layered-invoke")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+    let payload = String::from_utf8(resp.payload().unwrap().as_ref().to_vec()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(
+        parsed.get("msg").and_then(|v| v.as_str()),
+        Some("hello-from-layer"),
+        "function response: {payload}"
+    );
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -4045,13 +4045,30 @@ pub fn invoke_lambda_async(
     let payload = payload.as_bytes().to_vec();
 
     tokio::spawn(async move {
-        let func = {
+        let resolved = {
             let accounts = lambda_state.read();
             let state = accounts.default_ref();
-            state.functions.get(&func_name).cloned()
+            state.functions.get(&func_name).cloned().map(|func| {
+                let mut layer_zips: Vec<Vec<u8>> = Vec::with_capacity(func.layers.len());
+                for attached in &func.layers {
+                    if let Some(bytes) = fakecloud_lambda::extras::parse_layer_version_arn(
+                        &attached.arn,
+                    )
+                    .and_then(|(acct, name, ver)| {
+                        accounts
+                            .get(&acct)
+                            .and_then(|s| s.layers.get(&name))
+                            .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                            .and_then(|v| v.code_zip.clone())
+                    }) {
+                        layer_zips.push(bytes);
+                    }
+                }
+                (func, layer_zips)
+            })
         };
-        let func = match func {
-            Some(f) => f,
+        let (func, layer_zips) = match resolved {
+            Some(pair) => pair,
             None => {
                 tracing::warn!(
                     function = %func_name,
@@ -4060,7 +4077,7 @@ pub fn invoke_lambda_async(
                 return;
             }
         };
-        match runtime.invoke(&func, &payload).await {
+        match runtime.invoke(&func, &payload, &layer_zips).await {
             Ok(_) => {
                 tracing::info!(function = %func_name, "EventBridge Lambda invocation succeeded");
             }

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -6,15 +6,40 @@
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::LambdaService;
 use crate::state::{
-    AccountSettings, CapacityProvider, CodeSigningConfig, DurableExecution, EventInvokeConfig,
-    FunctionAlias, FunctionScalingConfig, FunctionUrlConfig, LambdaState, Layer, LayerVersion,
-    ProvisionedConcurrencyConfig, RuntimeManagementConfig,
+    AccountSettings, AttachedLayer, CapacityProvider, CodeSigningConfig, DurableExecution,
+    EventInvokeConfig, FunctionAlias, FunctionScalingConfig, FunctionUrlConfig, LambdaState, Layer,
+    LayerVersion, ProvisionedConcurrencyConfig, RuntimeManagementConfig,
 };
+
+/// Resolve a layer-version ARN to its current `CodeSize` from the
+/// multi-account state. Returns 0 when the ARN is unparseable, when the
+/// referenced account/layer/version is unknown, or when the version was
+/// published without ZIP content (legacy snapshots).
+pub(crate) fn resolve_layer_attachments(
+    accounts: &fakecloud_core::multi_account::MultiAccountState<LambdaState>,
+    arns: Vec<String>,
+) -> Vec<AttachedLayer> {
+    arns.into_iter()
+        .map(|arn| {
+            let code_size = parse_layer_version_arn(&arn)
+                .and_then(|(acct, name, ver)| {
+                    accounts
+                        .get(&acct)
+                        .and_then(|s| s.layers.get(&name))
+                        .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                        .map(|v| v.code_size)
+                })
+                .unwrap_or(0);
+            AttachedLayer { arn, code_size }
+        })
+        .collect()
+}
 
 fn missing(name: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
@@ -42,6 +67,40 @@ fn empty() -> Result<AwsResponse, AwsServiceError> {
 
 fn body(req: &AwsRequest) -> Value {
     serde_json::from_slice(&req.body).unwrap_or_else(|_| Value::Object(Default::default()))
+}
+
+/// Build a fakecloud-hosted download URL for a layer version's ZIP. The URL
+/// is reachable on the same authority the SDK used for the original
+/// request, so test harnesses get a working `Location` they can `GET`
+/// directly instead of the placeholder AWS clients otherwise see.
+fn layer_content_url(req: &AwsRequest, account_id: &str, layer_name: &str, version: i64) -> String {
+    let host = req
+        .headers
+        .get(http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost");
+    let scheme = req
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("http");
+    format!(
+        "{scheme}://{host}/_fakecloud/lambda/layer-content/{account_id}/{layer_name}/{version}.zip"
+    )
+}
+
+/// AWS layer-version ARN: `arn:aws:lambda:<region>:<account>:layer:<name>:<version>`.
+/// Returns `(account_id, layer_name, version)`. Used to resolve cross-account
+/// layer references attached to a function.
+pub fn parse_layer_version_arn(arn: &str) -> Option<(String, String, i64)> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() != 8 || parts[0] != "arn" || parts[2] != "lambda" || parts[5] != "layer" {
+        return None;
+    }
+    let account = parts[4].to_string();
+    let name = parts[6].to_string();
+    let version: i64 = parts[7].parse().ok()?;
+    Some((account, name, version))
 }
 
 fn parse_qualifier(req: &AwsRequest) -> String {
@@ -219,6 +278,15 @@ impl LambdaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = body(req);
         let mut accounts = self.state.write();
+        // Pre-resolve layer attachments before re-borrowing accounts mutably
+        // for the function. Layer ARNs may live in sibling accounts.
+        let layer_attachments: Option<Vec<AttachedLayer>> = body["Layers"].as_array().map(|arr| {
+            let arns: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            resolve_layer_attachments(&accounts, arns)
+        });
         let state = accounts.get_or_create(&req.account_id);
         let func = state
             .functions
@@ -238,6 +306,9 @@ impl LambdaService {
         }
         if let Some(desc) = body["Description"].as_str() {
             func.description = desc.to_string();
+        }
+        if let Some(attachments) = layer_attachments {
+            func.layers = attachments;
         }
         func.last_modified = Utc::now();
         ok(self.function_config_json(func))
@@ -434,8 +505,36 @@ impl LambdaService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = body(req);
+        let zip_bytes: Option<Vec<u8>> = match body["Content"]["ZipFile"].as_str() {
+            Some(b64) => Some(
+                base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).map_err(
+                    |_| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterValueException",
+                            "Could not decode Content.ZipFile: invalid base64",
+                        )
+                    },
+                )?,
+            ),
+            None => None,
+        };
+        let (code_sha256, code_size) = match zip_bytes.as_deref() {
+            Some(bytes) => {
+                let mut hasher = Sha256::new();
+                hasher.update(bytes);
+                let digest = hasher.finalize();
+                (
+                    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, digest),
+                    bytes.len() as i64,
+                )
+            }
+            None => (String::new(), 0),
+        };
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        let account_id = state.account_id.clone();
         let layer = state
             .layers
             .entry(layer_name.to_string())
@@ -457,6 +556,7 @@ impl LambdaService {
                     .collect()
             })
             .unwrap_or_default();
+        let layer_arn = layer.layer_arn.clone();
         let lv = LayerVersion {
             version: next_version,
             layer_version_arn: version_arn.clone(),
@@ -465,16 +565,25 @@ impl LambdaService {
             compatible_runtimes: runtimes,
             license_info: body["LicenseInfo"].as_str().unwrap_or("").to_string(),
             policy: None,
+            code_zip: zip_bytes,
+            code_sha256: code_sha256.clone(),
+            code_size,
         };
         layer.versions.push(lv.clone());
+        let location = layer_content_url(req, &account_id, layer_name, next_version);
         ok(json!({
-            "LayerArn": layer.layer_arn,
+            "LayerArn": layer_arn,
             "LayerVersionArn": version_arn,
             "Version": next_version,
             "Description": lv.description,
             "CreatedDate": lv.created_date.format("%Y-%m-%dT%H:%M:%S.%3fZ").to_string(),
             "CompatibleRuntimes": lv.compatible_runtimes,
             "LicenseInfo": lv.license_info,
+            "Content": {
+                "Location": location,
+                "CodeSha256": code_sha256,
+                "CodeSize": code_size,
+            },
         }))
     }
 
@@ -540,6 +649,7 @@ impl LambdaService {
             .and_then(|s| s.parse().ok())
             .ok_or_else(|| missing("VersionNumber"))?;
         let region = self.region_for(&req.account_id);
+        let location = layer_content_url(req, &req.account_id, &layer_name, version);
         self.with_state_read(&req.account_id, &region, |state| {
             state
                 .layers
@@ -554,9 +664,9 @@ impl LambdaService {
                         "CompatibleRuntimes": v.compatible_runtimes,
                         "LicenseInfo": v.license_info,
                         "Content": {
-                            "Location": "https://example.com/layer.zip",
-                            "CodeSha256": "",
-                            "CodeSize": 0,
+                            "Location": location,
+                            "CodeSha256": v.code_sha256,
+                            "CodeSize": v.code_size,
                         },
                     }))
                 })
@@ -571,15 +681,11 @@ impl LambdaService {
             .or_else(|| req.query_params.get("find"))
             .cloned()
             .unwrap_or_default();
-        // arn:aws:lambda:region:account:layer:name:version
-        let parts: Vec<&str> = arn.rsplitn(3, ':').collect();
-        if parts.len() < 3 {
-            return Err(missing("Arn"));
-        }
-        let version: i64 = parts[0].parse().map_err(|_| missing("Arn"))?;
-        let layer_name = parts[1].to_string();
-        let region = self.region_for(&req.account_id);
-        self.with_state_read(&req.account_id, &region, |state| {
+        let (account_id, layer_name, version) =
+            parse_layer_version_arn(&arn).ok_or_else(|| missing("Arn"))?;
+        let region = self.region_for(&account_id);
+        let location = layer_content_url(req, &account_id, &layer_name, version);
+        self.with_state_read(&account_id, &region, |state| {
             state
                 .layers
                 .get(&layer_name)
@@ -592,6 +698,11 @@ impl LambdaService {
                         "CreatedDate": v.created_date.format("%Y-%m-%dT%H:%M:%S.%3fZ").to_string(),
                         "CompatibleRuntimes": v.compatible_runtimes,
                         "LicenseInfo": v.license_info,
+                        "Content": {
+                            "Location": location,
+                            "CodeSha256": v.code_sha256,
+                            "CodeSize": v.code_size,
+                        },
                     }))
                 })
                 .unwrap_or_else(|| Err(not_found("LayerVersion", &arn)))

--- a/crates/fakecloud-lambda/src/resource_policy.rs
+++ b/crates/fakecloud-lambda/src/resource_policy.rs
@@ -120,6 +120,7 @@ mod tests {
             code_zip: None,
             image_uri: None,
             policy: policy.map(str::to_string),
+            layers: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use parking_lot::RwLock;
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
 use crate::state::LambdaFunction;
@@ -14,7 +15,29 @@ struct WarmContainer {
     container_id: String,
     host_port: u16,
     last_used: RwLock<Instant>,
-    code_sha256: String,
+    /// Combined fingerprint of the function's code SHA-256 plus the
+    /// SHA-256 of every attached layer's ZIP bytes, joined in attach
+    /// order. Layers mutate `/opt`, so a layer change invalidates the
+    /// warm container even when the function code is unchanged.
+    deploy_id: String,
+}
+
+/// Compute the warm-container key for a function with its current layer
+/// set. Stable across calls — layer ARNs are immutable in AWS, so the
+/// hash of their bytes is the right cache key.
+fn deploy_id_for(func: &LambdaFunction, layers: &[Vec<u8>]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(func.code_sha256.as_bytes());
+    for bytes in layers {
+        let mut layer_hasher = Sha256::new();
+        layer_hasher.update(bytes);
+        hasher.update(b":");
+        hasher.update(layer_hasher.finalize());
+    }
+    base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        hasher.finalize(),
+    )
 }
 
 /// Docker/Podman-based Lambda execution engine.
@@ -109,11 +132,15 @@ impl ContainerRuntime {
         &self.cli
     }
 
-    /// Invoke a Lambda function, starting a container if needed.
+    /// Invoke a Lambda function, starting a container if needed. Layer
+    /// ZIPs are extracted into `/opt` of the runtime sandbox; AWS base
+    /// images already include `/opt/python`, `/opt/nodejs/node_modules`,
+    /// `/opt/lib`, and `/opt/bin` on the right import paths.
     pub async fn invoke(
         &self,
         func: &LambdaFunction,
         payload: &[u8],
+        layers: &[Vec<u8>],
     ) -> Result<Vec<u8>, RuntimeError> {
         // Zip-based functions need code bytes; image-based functions have
         // everything baked into the image. Defer the zip check until we
@@ -123,11 +150,13 @@ impl ContainerRuntime {
             return Err(RuntimeError::NoCodeZip(func.function_name.clone()));
         }
 
-        // Check for warm container with matching code
+        let deploy_id = deploy_id_for(func, layers);
+
+        // Check for warm container with matching deploy fingerprint
         let port = {
             let containers = self.containers.read();
             if let Some(container) = containers.get(&func.function_name) {
-                if container.code_sha256 == func.code_sha256 {
+                if container.deploy_id == deploy_id {
                     *container.last_used.write() = Instant::now();
                     Some(container.host_port)
                 } else {
@@ -156,7 +185,7 @@ impl ContainerRuntime {
                     let containers = self.containers.read();
                     containers
                         .get(&func.function_name)
-                        .filter(|c| c.code_sha256 == func.code_sha256)
+                        .filter(|c| c.deploy_id == deploy_id)
                         .map(|c| {
                             *c.last_used.write() = Instant::now();
                             c.host_port
@@ -167,13 +196,14 @@ impl ContainerRuntime {
                 } else {
                     self.stop_container(&func.function_name).await;
                     let container = if is_image {
-                        self.start_image_container(func).await?
+                        self.start_image_container(func, layers, &deploy_id).await?
                     } else {
                         let zip_bytes = func
                             .code_zip
                             .as_ref()
                             .ok_or_else(|| RuntimeError::NoCodeZip(func.function_name.clone()))?;
-                        self.start_container(func, zip_bytes).await?
+                        self.start_container(func, zip_bytes, layers, &deploy_id)
+                            .await?
                     };
                     let p = container.host_port;
                     self.containers
@@ -215,6 +245,8 @@ impl ContainerRuntime {
     async fn start_image_container(
         &self,
         func: &LambdaFunction,
+        layers: &[Vec<u8>],
+        deploy_id: &str,
     ) -> Result<WarmContainer, RuntimeError> {
         let image = func.image_uri.as_deref().ok_or_else(|| {
             RuntimeError::ContainerStartFailed("PackageType=Image function has no ImageUri".into())
@@ -292,6 +324,11 @@ impl ContainerRuntime {
         }
         let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
+        if let Err(e) = self.copy_layers_into(&container_id, layers).await {
+            let _ = self.remove_container(&container_id).await;
+            return Err(e);
+        }
+
         let start_result = tokio::process::Command::new(&self.cli)
             .args(["start", &container_id])
             .output()
@@ -353,7 +390,7 @@ impl ContainerRuntime {
             container_id,
             host_port: port,
             last_used: RwLock::new(Instant::now()),
-            code_sha256: func.code_sha256.clone(),
+            deploy_id: deploy_id.to_string(),
         })
     }
 
@@ -361,6 +398,8 @@ impl ContainerRuntime {
         &self,
         func: &LambdaFunction,
         zip_bytes: &[u8],
+        layers: &[Vec<u8>],
+        deploy_id: &str,
     ) -> Result<WarmContainer, RuntimeError> {
         let image = runtime_to_image(&func.runtime)
             .ok_or_else(|| RuntimeError::UnsupportedRuntime(func.runtime.clone()))?;
@@ -453,6 +492,11 @@ impl ContainerRuntime {
             }
         }
 
+        if let Err(e) = self.copy_layers_into(&container_id, layers).await {
+            let _ = self.remove_container(&container_id).await;
+            return Err(e);
+        }
+
         // TempDir is dropped here — code now lives inside the container
 
         // Step 3: docker start
@@ -523,8 +567,51 @@ impl ContainerRuntime {
             container_id,
             host_port: port,
             last_used: RwLock::new(Instant::now()),
-            code_sha256: func.code_sha256.clone(),
+            deploy_id: deploy_id.to_string(),
         })
+    }
+
+    /// Extract each layer ZIP into a shared temp directory and `docker cp`
+    /// it into `/opt/` of the target container. Layer ZIPs include
+    /// language-specific subpaths (`python/`, `nodejs/`, `java/`, `lib/`,
+    /// `bin/`) that AWS base images already wire onto the runtime's
+    /// import paths, so plain extraction at the temp root produces the
+    /// correct on-disk layout. Empty `layers` is a no-op.
+    async fn copy_layers_into(
+        &self,
+        container_id: &str,
+        layers: &[Vec<u8>],
+    ) -> Result<(), RuntimeError> {
+        if layers.is_empty() {
+            return Ok(());
+        }
+        let layers_dir =
+            TempDir::new().map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))?;
+        let layers_path = layers_dir.path().to_path_buf();
+        let layers_owned: Vec<Vec<u8>> = layers.to_vec();
+        tokio::task::spawn_blocking(move || {
+            for bytes in &layers_owned {
+                extract_zip(bytes, &layers_path)?;
+            }
+            Ok::<_, RuntimeError>(())
+        })
+        .await
+        .map_err(|e| RuntimeError::ZipExtractionFailed(e.to_string()))??;
+
+        let cp_result = tokio::process::Command::new(&self.cli)
+            .arg("cp")
+            .arg(format!("{}/.", layers_dir.path().display()))
+            .arg(format!("{}:/opt", container_id))
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !cp_result.status.success() {
+            let stderr = String::from_utf8_lossy(&cp_result.stderr);
+            return Err(RuntimeError::ContainerStartFailed(format!(
+                "docker cp layers to /opt failed: {stderr}"
+            )));
+        }
+        Ok(())
     }
 
     /// Remove a container (stop + rm, since we don't use --rm with docker create).

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -156,6 +156,7 @@ struct CreateFunctionInput {
     code_zip: Option<Vec<u8>>,
     code_fallback: Vec<u8>,
     image_uri: Option<String>,
+    layer_arns: Vec<String>,
 }
 
 impl CreateFunctionInput {
@@ -237,6 +238,15 @@ impl CreateFunctionInput {
             ));
         }
 
+        let layer_arns: Vec<String> = body["Layers"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(Self {
             function_name,
             runtime: body["Runtime"].as_str().unwrap_or("python3.12").to_string(),
@@ -255,6 +265,7 @@ impl CreateFunctionInput {
             code_zip,
             code_fallback,
             image_uri,
+            layer_arns,
         })
     }
 }
@@ -876,6 +887,10 @@ impl LambdaService {
         }
 
         let mut accounts = self.state.write();
+        // Pre-resolve layer attachments before re-borrowing accounts mutably.
+        // Layer ARNs may live in sibling accounts.
+        let layer_attachments =
+            crate::extras::resolve_layer_attachments(&accounts, input.layer_arns.clone());
         let state = accounts.get_or_create(&req.account_id);
 
         if state.functions.contains_key(&input.function_name) {
@@ -921,6 +936,7 @@ impl LambdaService {
             code_zip: input.code_zip,
             image_uri: input.image_uri,
             policy: None,
+            layers: layer_attachments,
         };
 
         let response = self.function_config_json(&func);
@@ -1030,11 +1046,11 @@ impl LambdaService {
         account_id: &str,
         invocation_type: InvocationType,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let func = {
+        let (func, layer_zips) = {
             let accounts = self.state.read();
             let empty = LambdaState::new(account_id, "");
             let state = accounts.get(account_id).unwrap_or(&empty);
-            state.functions.get(function_name).cloned().ok_or_else(|| {
+            let func = state.functions.get(function_name).cloned().ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::NOT_FOUND,
                     "ResourceNotFoundException",
@@ -1043,7 +1059,32 @@ impl LambdaService {
                         state.region, state.account_id, function_name
                     ),
                 )
-            })?
+            })?;
+            // Resolve attached layer ARNs to ZIP bytes under the same read
+            // lock. Layers may live in sibling accounts (cross-account
+            // attach is legal in AWS); fall back to no bytes for unknown
+            // ARNs and warn — invoke proceeds without that layer.
+            let mut layer_zips: Vec<Vec<u8>> = Vec::with_capacity(func.layers.len());
+            for attached in &func.layers {
+                let bytes = crate::extras::parse_layer_version_arn(&attached.arn).and_then(
+                    |(acct, name, ver)| {
+                        accounts
+                            .get(&acct)
+                            .and_then(|s| s.layers.get(&name))
+                            .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                            .and_then(|v| v.code_zip.clone())
+                    },
+                );
+                match bytes {
+                    Some(b) => layer_zips.push(b),
+                    None => tracing::warn!(
+                        function = %function_name,
+                        layer_arn = %attached.arn,
+                        "attached layer not resolvable; skipping /opt mount for this layer"
+                    ),
+                }
+            }
+            (func, layer_zips)
         };
 
         if func.code_zip.is_none() {
@@ -1080,8 +1121,12 @@ impl LambdaService {
                 let bus = self.delivery_bus.clone();
                 let destination_config = self.lookup_destination_config(&func, account_id);
                 let function_arn = func.function_arn.clone();
+                let layer_zips_async = layer_zips.clone();
                 tokio::spawn(async move {
-                    let result = match runtime.invoke(&func_clone, &payload_vec).await {
+                    let result = match runtime
+                        .invoke(&func_clone, &payload_vec, &layer_zips_async)
+                        .await
+                    {
                         Ok(bytes) => {
                             // Lambda runtime returns 200 even on uncaught
                             // function errors; the body has errorMessage /
@@ -1127,7 +1172,7 @@ impl LambdaService {
                 Ok(resp)
             }
             InvocationType::RequestResponse | InvocationType::DryRun => {
-                match runtime.invoke(&func, payload).await {
+                match runtime.invoke(&func, payload, &layer_zips).await {
                     Ok(response_bytes) => {
                         let mut resp = AwsResponse::json(StatusCode::OK, response_bytes);
                         resp.headers.insert(
@@ -1442,6 +1487,13 @@ impl LambdaService {
                 "ImageUri": uri,
                 "ResolvedImageUri": uri,
             });
+        }
+        if !func.layers.is_empty() {
+            config["Layers"] = json!(func
+                .layers
+                .iter()
+                .map(|l| json!({"Arn": l.arn, "CodeSize": l.code_size}))
+                .collect::<Vec<_>>());
         }
         config
     }

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -37,6 +37,22 @@ pub struct LambdaFunction {
     /// `RemovePermission` leaves at least `{"Statement":[]}` behind,
     /// matching AWS behavior.
     pub policy: Option<String>,
+    /// Layer versions attached to this function, in attach order. AWS
+    /// extracts each layer's content into `/opt` of the runtime sandbox at
+    /// invoke time; fakecloud's container runtime mirrors that via
+    /// `docker cp`. `code_size` is captured at attach time from the
+    /// referenced `LayerVersion` so `GetFunctionConfiguration` can echo it
+    /// without a second state lookup; layer versions are immutable so the
+    /// cached size never goes stale.
+    #[serde(default)]
+    pub layers: Vec<AttachedLayer>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachedLayer {
+    pub arn: String,
+    #[serde(default)]
+    pub code_size: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -171,6 +187,14 @@ pub struct LayerVersion {
     pub compatible_runtimes: Vec<String>,
     pub license_info: String,
     pub policy: Option<String>,
+    /// Raw ZIP bytes from `Content.ZipFile` on `PublishLayerVersion`.
+    /// `None` only on legacy snapshots predating layer storage.
+    #[serde(default)]
+    pub code_zip: Option<Vec<u8>>,
+    #[serde(default)]
+    pub code_sha256: String,
+    #[serde(default)]
+    pub code_size: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -49,11 +49,32 @@ impl LambdaDelivery for LambdaDeliveryImpl {
             }
         };
 
-        let func = {
+        let (func, layer_zips) = {
             let accounts = self.lambda_state.read();
-            accounts
+            match accounts
                 .get(&account_id)
                 .and_then(|state| state.functions.get(&function_name).cloned())
+            {
+                Some(func) => {
+                    let mut layer_zips: Vec<Vec<u8>> = Vec::with_capacity(func.layers.len());
+                    for attached in &func.layers {
+                        if let Some(bytes) =
+                            fakecloud_lambda::extras::parse_layer_version_arn(&attached.arn)
+                                .and_then(|(acct, name, ver)| {
+                                    accounts
+                                        .get(&acct)
+                                        .and_then(|s| s.layers.get(&name))
+                                        .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                                        .and_then(|v| v.code_zip.clone())
+                                })
+                        {
+                            layer_zips.push(bytes);
+                        }
+                    }
+                    (Some(func), layer_zips)
+                }
+                None => (None, Vec::new()),
+            }
         };
 
         let runtime = self.runtime.clone();
@@ -84,7 +105,7 @@ impl LambdaDelivery for LambdaDeliveryImpl {
                 ));
             }
             runtime
-                .invoke(&func, payload.as_bytes())
+                .invoke(&func, payload.as_bytes(), &layer_zips)
                 .await
                 .map_err(|e| format!("Lambda invocation failed: {e}"))
         })

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -569,6 +569,7 @@ async fn main() {
     let lambda_sim_warm_state = lambda_state.clone();
     let lambda_sim_warm_runtime = container_runtime.clone();
     let lambda_sim_evict_runtime = container_runtime.clone();
+    let lambda_layer_content_state = lambda_state.clone();
     let sns_sim_pending_state = sns_state.clone();
     let sns_sim_confirm_state = sns_state.clone();
 
@@ -4321,6 +4322,47 @@ async fn main() {
                         false
                     };
                     axum::Json(types::EvictContainerResponse { evicted })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/lambda/layer-content/{account_id}/{layer_name}/{file}",
+            axum::routing::get({
+                let ls = lambda_layer_content_state;
+                move |axum::extract::Path((account_id, layer_name, file)): axum::extract::Path<(String, String, String)>| {
+                    let ls = ls.clone();
+                    async move {
+                        let version: Option<i64> = file
+                            .strip_suffix(".zip")
+                            .and_then(|v| v.parse().ok());
+                        let Some(version) = version else {
+                            return (
+                                axum::http::StatusCode::NOT_FOUND,
+                                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                                axum::body::Bytes::from_static(b"layer version not found"),
+                            );
+                        };
+                        let bytes_opt: Option<Vec<u8>> = {
+                            let accounts = ls.read();
+                            accounts
+                                .get(&account_id)
+                                .and_then(|s| s.layers.get(&layer_name))
+                                .and_then(|l| l.versions.iter().find(|v| v.version == version))
+                                .and_then(|v| v.code_zip.clone())
+                        };
+                        match bytes_opt {
+                            Some(bytes) => (
+                                axum::http::StatusCode::OK,
+                                [(axum::http::header::CONTENT_TYPE, "application/zip")],
+                                axum::body::Bytes::from(bytes),
+                            ),
+                            None => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                                axum::body::Bytes::from_static(b"layer version not found"),
+                            ),
+                        }
+                    }
                 }
             }),
         )

--- a/website/content/docs/services/lambda.md
+++ b/website/content/docs/services/lambda.md
@@ -12,7 +12,7 @@ fakecloud implements **85 of 85** Lambda operations at 100% Smithy conformance. 
 - **Real code execution** — functions run in Docker containers with the official AWS Lambda runtime images
 - **23 runtimes** — Node.js (16/18/20/22/24), Python (3.8/3.9/3.10/3.11/3.12/3.13/3.14), Java (11/17/21/25), Go (1.x), Ruby (3.3/3.4), .NET (8/10), `provided.al2`, `provided.al2023`
 - **Event source mappings** — SQS, Kinesis, DynamoDB Streams polling loops with **`FilterCriteria`** (EventBridge-style JSON pattern, exists/prefix/suffix/equals-ignore-case/anything-but/numeric operators, SQS body decode), **`StartingPosition`** (`TRIM_HORIZON` / `LATEST` / `AT_TIMESTAMP` for Kinesis, `TRIM_HORIZON` / `LATEST` for DDB Streams), **`MaximumBatchingWindowInSeconds`** (SQS), and **`FunctionResponseTypes=[ReportBatchItemFailures]`** for SQS partial-batch failure semantics
-- **Layers** — create, publish, attach to functions
+- **Layers** — create, publish, attach to functions; layer ZIP content is extracted into `/opt` of the runtime container at invoke time, so Python `import`, Node `require`, and `LD_LIBRARY_PATH` lookups resolve against attached layers exactly as on real AWS
 - **Environment variables** — passed to the container
 - **Aliases and versions** — publish, point aliases at versions
 - **Concurrency controls** — reserved concurrency (recorded, not enforced)
@@ -29,6 +29,7 @@ REST. Path-based routing for invoke operations, JSON for control plane.
 - `GET /_fakecloud/lambda/invocations` — list all Lambda invocations with input/output/errors
 - `GET /_fakecloud/lambda/warm-containers` — list currently warm containers
 - `POST /_fakecloud/lambda/{function-name}/evict-container` — force a cold start on the next invoke
+- `GET /_fakecloud/lambda/layer-content/{account-id}/{layer-name}/{version}.zip` — download the raw layer ZIP. Returned as the `Content.Location` from `PublishLayerVersion` and `GetLayerVersion`, so AWS SDK / Terraform clients that re-download a layer get the actual bytes
 
 ## Event source mapping example: FilterCriteria + partial batch failure
 


### PR DESCRIPTION
## Summary

Fixes #853. Layers are now real:

- `CreateFunction` / `UpdateFunctionConfiguration` parse and persist `Layers`; `GetFunctionConfiguration` emits the `Layers` reference list.
- `PublishLayerVersion` stores `Content.ZipFile`, returns real `CodeSha256` / `CodeSize`. `GetLayerVersion` mirrors them.
- `ContainerRuntime::invoke` `docker cp`s every attached layer's contents into `/opt/` of the runtime container, so Python `import`, Node `require`, etc. resolve against layers exactly as on real AWS. Warm-container key now includes layer fingerprint, so layer changes invalidate the cache.
- New `/_fakecloud/lambda/layer-content/{account}/{name}/{version}.zip` route streams the stored ZIP, returned as the `Content.Location` from layer reads — replaces the previous `https://example.com/layer.zip` placeholder.
- Cross-account layer ARNs supported (resolution via `MultiAccountState::get`).
- Lambda docs updated.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-lambda` — 75 tests pass
- [x] `cargo test -p fakecloud-conformance --test lambda lambda_layer_lifecycle` — pass (existing recordings unchanged)
- [x] New E2E `crates/fakecloud-e2e/tests/lambda_layers.rs`:
  - `publish_layer_returns_real_content_metadata_and_downloadable_location` — pass (no Docker)
  - `create_and_update_function_round_trips_layers` — pass (no Docker)
  - `invoke_python_function_imports_module_from_attached_layer` — Docker-gated; verifies an attached layer's `python/greeter.py` imports successfully at invoke

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Lambda Layers fully functional: persist and expose layer attachments and content, and mount layer files into /opt at invoke so imports work like AWS. Fixes #853.

- **Bug Fixes**
  - Parse and persist `Layers` on create/update; `GetFunctionConfiguration` now returns `Layers` with `{ Arn, CodeSize }`.
  - Extract attached layer ZIPs into `/opt` at invoke; warm-container cache key now includes a layer fingerprint to invalidate on layer changes.

- **New Features**
  - `PublishLayerVersion` stores `Content.ZipFile` and returns real `Content.Location`, `CodeSha256`, and `CodeSize`; `GetLayerVersion` and `GetLayerVersionByArn` mirror them.
  - New route `/_fakecloud/lambda/layer-content/{account-id}/{layer-name}/{version}.zip` streams the stored ZIP (used as `Content.Location`).
  - Support cross-account layer ARNs when attaching to functions.
  - `fakecloud-lambda` runtime mounts layers; `fakecloud-eventbridge` and `fakecloud-server` pass layer bytes on invoke. Docs updated; E2E adds a Python import test.

<sup>Written for commit 6e85409d2c6aebbdfc7bb0d392059906a3cf78fe. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/862?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

