### PR TITLE
release(v0.13.3): bump workspace + SDK versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.13.2"
+version = "0.13.3"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
@@ -93,42 +93,42 @@ regex = "1"
 tokio-postgres = "0.7"
 
 # Internal crates
-fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.2" }
-fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.2" }
-fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.2" }
-fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.2" }
-fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.2" }
-fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.2" }
-fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.2" }
-fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.2" }
-fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.2" }
-fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.2" }
-fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.2" }
-fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.2" }
-fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.2" }
-fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.2" }
-fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.2" }
-fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.2" }
-fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.2" }
-fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.2" }
-fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.2" }
-fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.2" }
-fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.2" }
-fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.2" }
-fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.2" }
-fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.2" }
-fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.2" }
-fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.2" }
-fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.2" }
-fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.2" }
-fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.2" }
-fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.2" }
-fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.2" }
-fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.2" }
-fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.2" }
-fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.2" }
-fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.2" }
-fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.2" }
+fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.3" }
+fakecloud-aws = { path = "crates/fakecloud-aws", version = "0.13.3" }
+fakecloud-sqs = { path = "crates/fakecloud-sqs", version = "0.13.3" }
+fakecloud-sns = { path = "crates/fakecloud-sns", version = "0.13.3" }
+fakecloud-eventbridge = { path = "crates/fakecloud-eventbridge", version = "0.13.3" }
+fakecloud-iam = { path = "crates/fakecloud-iam", version = "0.13.3" }
+fakecloud-organizations = { path = "crates/fakecloud-organizations", version = "0.13.3" }
+fakecloud-ssm = { path = "crates/fakecloud-ssm", version = "0.13.3" }
+fakecloud-s3 = { path = "crates/fakecloud-s3", version = "0.13.3" }
+fakecloud-dynamodb = { path = "crates/fakecloud-dynamodb", version = "0.13.3" }
+fakecloud-lambda = { path = "crates/fakecloud-lambda", version = "0.13.3" }
+fakecloud-secretsmanager = { path = "crates/fakecloud-secretsmanager", version = "0.13.3" }
+fakecloud-logs = { path = "crates/fakecloud-logs", version = "0.13.3" }
+fakecloud-kms = { path = "crates/fakecloud-kms", version = "0.13.3" }
+fakecloud-cloudformation = { path = "crates/fakecloud-cloudformation", version = "0.13.3" }
+fakecloud-ses = { path = "crates/fakecloud-ses", version = "0.13.3" }
+fakecloud-cognito = { path = "crates/fakecloud-cognito", version = "0.13.3" }
+fakecloud-kinesis = { path = "crates/fakecloud-kinesis", version = "0.13.3" }
+fakecloud-rds = { path = "crates/fakecloud-rds", version = "0.13.3" }
+fakecloud-elasticache = { path = "crates/fakecloud-elasticache", version = "0.13.3" }
+fakecloud-ecr = { path = "crates/fakecloud-ecr", version = "0.13.3" }
+fakecloud-ecs = { path = "crates/fakecloud-ecs", version = "0.13.3" }
+fakecloud-elbv2 = { path = "crates/fakecloud-elbv2", version = "0.13.3" }
+fakecloud-cloudfront = { path = "crates/fakecloud-cloudfront", version = "0.13.3" }
+fakecloud-route53 = { path = "crates/fakecloud-route53", version = "0.13.3" }
+fakecloud-acm = { path = "crates/fakecloud-acm", version = "0.13.3" }
+fakecloud-application-autoscaling = { path = "crates/fakecloud-application-autoscaling", version = "0.13.3" }
+fakecloud-wafv2 = { path = "crates/fakecloud-wafv2", version = "0.13.3" }
+fakecloud-athena = { path = "crates/fakecloud-athena", version = "0.13.3" }
+fakecloud-stepfunctions = { path = "crates/fakecloud-stepfunctions", version = "0.13.3" }
+fakecloud-scheduler = { path = "crates/fakecloud-scheduler", version = "0.13.3" }
+fakecloud-apigateway = { path = "crates/fakecloud-apigateway", version = "0.13.3" }
+fakecloud-apigatewayv2 = { path = "crates/fakecloud-apigatewayv2", version = "0.13.3" }
+fakecloud-bedrock = { path = "crates/fakecloud-bedrock", version = "0.13.3" }
+fakecloud-sdk = { path = "crates/fakecloud-sdk", version = "0.13.3" }
+fakecloud-persistence = { path = "crates/fakecloud-persistence", version = "0.13.3" }
 
 # Drop full DWARF on test binaries to keep `ld` under the GitHub runner's
 # ~7 GB RAM budget. Backtraces still show file:line.

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.13.2"
+version = "0.13.3"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.13.2"
+version = "0.13.3"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.13.2 -> 0.13.3 across the workspace and language SDKs (TS / Python / Java). Tag will be cut after merge.

Includes #862, which fixes #853 (Lambda layers attached to functions and mounted into /opt at invoke).

## Test plan

- [x] cargo build --workspace clean
- [x] cargo update -w to sync lockfile
- [ ] CI green on this PR
- [ ] After merge, tag v0.13.3 to trigger release workflow (binaries, crates.io, npm, PyPI, Maven Central, Packagist, Go module tag)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.13.3 across the workspace and SDKs. Includes the Lambda layers fix for correct mounting at runtime.

- **Bug Fixes**
  - Lambda layers are now attached to functions and mounted at `/opt` on invoke (fixes #853).

- **Dependencies**
  - Bump all Rust workspace crates to 0.13.3.
  - Bump SDKs to 0.13.3: `fakecloud` (TypeScript), `fakecloud` (Python), and the Java SDK.

<sup>Written for commit d74661b21d0d581ed4af41d0373ee1b5d1fe26ad. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/864?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

