### PR TITLE
refactor: convert cognito/elasticache/ses/eventbridge state to BTreeMap

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -542,7 +542,7 @@ impl ResourceProvisioner {
             managed_by: None,
             created_by: None,
             targets: Vec::new(),
-            tags: HashMap::new(),
+            tags: std::collections::BTreeMap::new(),
             last_fired: None,
         };
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1063,7 +1063,7 @@ mod tests {
                     description: None,
                     kms_key_identifier: None,
                     dead_letter_config: None,
-                    tags: HashMap::new(),
+                    tags: std::collections::BTreeMap::new(),
                 },
             );
         }

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -1624,11 +1624,11 @@ impl CognitoService {
                 password: Some(password.to_string()),
                 temporary_password: None,
                 confirmation_code: None,
-                attribute_verification_codes: HashMap::new(),
+                attribute_verification_codes: BTreeMap::new(),
                 mfa_preferences: None,
                 totp_secret: None,
                 totp_verified: false,
-                devices: HashMap::new(),
+                devices: BTreeMap::new(),
                 linked_providers: Vec::new(),
             };
 

--- a/crates/fakecloud-cognito/src/service/groups.rs
+++ b/crates/fakecloud-cognito/src/service/groups.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -172,7 +172,7 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
-        let empty = std::collections::HashMap::new();
+        let empty = std::collections::BTreeMap::new();
         let pool_groups = state.groups.get(pool_id).unwrap_or(&empty);
 
         let mut groups: Vec<&Group> = pool_groups.values().collect();
@@ -342,7 +342,7 @@ impl CognitoService {
             ));
         }
 
-        let empty_user_groups: HashMap<String, Vec<String>> = HashMap::new();
+        let empty_user_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
         let empty_group_list: Vec<String> = Vec::new();
         let user_group_names = state
             .user_groups
@@ -351,7 +351,7 @@ impl CognitoService {
             .get(username)
             .unwrap_or(&empty_group_list);
 
-        let empty_groups: HashMap<String, Group> = HashMap::new();
+        let empty_groups: BTreeMap<String, Group> = BTreeMap::new();
         let pool_groups = state.groups.get(pool_id).unwrap_or(&empty_groups);
 
         // Collect and sort groups by creation date
@@ -418,7 +418,7 @@ impl CognitoService {
             ));
         }
 
-        let empty_user_groups: HashMap<String, Vec<String>> = HashMap::new();
+        let empty_user_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
         let pool_user_groups = state.user_groups.get(pool_id).unwrap_or(&empty_user_groups);
 
         // Find all usernames that belong to this group
@@ -429,7 +429,7 @@ impl CognitoService {
             .collect();
         usernames_in_group.sort();
 
-        let empty_users = std::collections::HashMap::new();
+        let empty_users = std::collections::BTreeMap::new();
         let pool_users = state.users.get(pool_id).unwrap_or(&empty_users);
 
         // Sort by creation date for consistent pagination

--- a/crates/fakecloud-cognito/src/service/identity_providers.rs
+++ b/crates/fakecloud-cognito/src/service/identity_providers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -202,7 +202,7 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
-        let empty = HashMap::new();
+        let empty = BTreeMap::new();
         let pool_providers = state.identity_providers.get(pool_id).unwrap_or(&empty);
 
         let mut providers: Vec<&IdentityProvider> = pool_providers.values().collect();
@@ -257,7 +257,7 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
-        let empty = HashMap::new();
+        let empty = BTreeMap::new();
         let pool_providers = state.identity_providers.get(pool_id).unwrap_or(&empty);
 
         let idp = pool_providers

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -365,7 +365,7 @@ impl CognitoService {
             })?;
 
         let now = Utc::now();
-        let mut device_attributes = HashMap::new();
+        let mut device_attributes = BTreeMap::new();
         if let Some(name) = device_name {
             device_attributes.insert("device_name".to_string(), name.to_string());
         }
@@ -711,7 +711,7 @@ impl CognitoService {
         let body = req.json_body();
         let resource_arn = require_str(&body, "ResourceArn")?;
 
-        let tags: HashMap<String, String> = body["Tags"]
+        let tags: BTreeMap<String, String> = body["Tags"]
             .as_object()
             .map(|m| {
                 m.iter()

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -10,7 +10,7 @@ mod resource_servers;
 mod user_pools;
 mod users;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -949,8 +949,8 @@ fn parse_admin_create_user_config(val: &Value) -> Option<AdminCreateUserConfig> 
     })
 }
 
-fn parse_tags(val: &Value) -> std::collections::HashMap<String, String> {
-    let mut tags = std::collections::HashMap::new();
+fn parse_tags(val: &Value) -> std::collections::BTreeMap<String, String> {
+    let mut tags = std::collections::BTreeMap::new();
     if let Some(obj) = val.as_object() {
         for (k, v) in obj {
             if let Some(s) = v.as_str() {
@@ -1062,7 +1062,7 @@ fn validate_provider_type(provider_type: &str) -> Result<(), AwsServiceError> {
     Ok(())
 }
 
-fn parse_string_map(val: &Value) -> HashMap<String, String> {
+fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
     val.as_object()
         .map(|obj| {
             obj.iter()
@@ -2022,11 +2022,11 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
-            attribute_verification_codes: HashMap::new(),
+            attribute_verification_codes: BTreeMap::new(),
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
-            devices: HashMap::new(),
+            devices: BTreeMap::new(),
             linked_providers: Vec::new(),
         };
 
@@ -2056,11 +2056,11 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
-            attribute_verification_codes: HashMap::new(),
+            attribute_verification_codes: BTreeMap::new(),
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
-            devices: HashMap::new(),
+            devices: BTreeMap::new(),
             linked_providers: Vec::new(),
         };
 
@@ -2087,11 +2087,11 @@ mod tests {
             password: None,
             temporary_password: None,
             confirmation_code: None,
-            attribute_verification_codes: HashMap::new(),
+            attribute_verification_codes: BTreeMap::new(),
             mfa_preferences: None,
             totp_secret: None,
             totp_verified: false,
-            devices: HashMap::new(),
+            devices: BTreeMap::new(),
             linked_providers: Vec::new(),
         };
 
@@ -3531,7 +3531,7 @@ mod tests {
                 "dev-key-1".to_string(),
                 Device {
                     device_key: "dev-key-1".to_string(),
-                    device_attributes: HashMap::new(),
+                    device_attributes: BTreeMap::new(),
                     device_create_date: Utc::now(),
                     device_last_modified_date: Utc::now(),
                     device_last_authenticated_date: None,

--- a/crates/fakecloud-cognito/src/service/resource_servers.rs
+++ b/crates/fakecloud-cognito/src/service/resource_servers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use http::StatusCode;
 use serde_json::{json, Value};
@@ -174,7 +174,7 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
-        let empty = HashMap::new();
+        let empty = BTreeMap::new();
         let pool_servers = state.resource_servers.get(pool_id).unwrap_or(&empty);
 
         let mut servers: Vec<&ResourceServer> = pool_servers.values().collect();

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -92,11 +92,11 @@ impl CognitoService {
                 password: None,
                 temporary_password,
                 confirmation_code: None,
-                attribute_verification_codes: HashMap::new(),
+                attribute_verification_codes: BTreeMap::new(),
                 mfa_preferences: None,
                 totp_secret: None,
                 totp_verified: false,
-                devices: HashMap::new(),
+                devices: BTreeMap::new(),
                 linked_providers: Vec::new(),
             };
 
@@ -547,7 +547,7 @@ impl CognitoService {
         // Validate pool exists
         ensure_user_pool_exists(state, pool_id)?;
 
-        let empty = std::collections::HashMap::new();
+        let empty = std::collections::BTreeMap::new();
         let pool_users = state.users.get(pool_id).unwrap_or(&empty);
 
         // Sort users by creation date for consistent pagination

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -30,63 +30,63 @@ pub struct CognitoState {
     pub account_id: String,
     pub region: String,
     #[serde(default)]
-    pub user_pools: HashMap<String, UserPool>,
+    pub user_pools: BTreeMap<String, UserPool>,
     #[serde(default)]
-    pub user_pool_clients: HashMap<String, UserPoolClient>,
+    pub user_pool_clients: BTreeMap<String, UserPoolClient>,
     /// pool_id -> (username -> User)
     #[serde(default)]
-    pub users: HashMap<String, HashMap<String, User>>,
+    pub users: BTreeMap<String, BTreeMap<String, User>>,
     /// refresh_token -> RefreshTokenData
     #[serde(default)]
-    pub refresh_tokens: HashMap<String, RefreshTokenData>,
+    pub refresh_tokens: BTreeMap<String, RefreshTokenData>,
     /// session_token -> SessionData
     #[serde(default)]
-    pub sessions: HashMap<String, SessionData>,
+    pub sessions: BTreeMap<String, SessionData>,
     /// access_token -> AccessTokenData
     #[serde(default)]
-    pub access_tokens: HashMap<String, AccessTokenData>,
+    pub access_tokens: BTreeMap<String, AccessTokenData>,
     /// pool_id -> (group_name -> Group)
     #[serde(default)]
-    pub groups: HashMap<String, HashMap<String, Group>>,
+    pub groups: BTreeMap<String, BTreeMap<String, Group>>,
     /// pool_id -> (username -> [group_names])
     #[serde(default)]
-    pub user_groups: HashMap<String, HashMap<String, Vec<String>>>,
+    pub user_groups: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     /// pool_id -> (provider_name -> IdentityProvider)
     #[serde(default)]
-    pub identity_providers: HashMap<String, HashMap<String, IdentityProvider>>,
+    pub identity_providers: BTreeMap<String, BTreeMap<String, IdentityProvider>>,
     /// pool_id -> (identifier -> ResourceServer)
     #[serde(default)]
-    pub resource_servers: HashMap<String, HashMap<String, ResourceServer>>,
+    pub resource_servers: BTreeMap<String, BTreeMap<String, ResourceServer>>,
     /// domain -> UserPoolDomain
     #[serde(default)]
-    pub domains: HashMap<String, UserPoolDomain>,
+    pub domains: BTreeMap<String, UserPoolDomain>,
     /// resource_arn -> tags
     #[serde(default)]
-    pub tags: HashMap<String, HashMap<String, String>>,
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
     /// pool_id -> (job_id -> UserImportJob)
     #[serde(default)]
-    pub import_jobs: HashMap<String, HashMap<String, UserImportJob>>,
+    pub import_jobs: BTreeMap<String, BTreeMap<String, UserImportJob>>,
     /// Auth events for introspection — not persisted across restarts.
     #[serde(default, skip)]
     pub auth_events: Vec<AuthEvent>,
     /// (pool_id, client_id|"") -> UICustomization JSON
     #[serde(default)]
-    pub ui_customizations: HashMap<String, serde_json::Value>,
+    pub ui_customizations: BTreeMap<String, serde_json::Value>,
     /// pool_id -> LogDeliveryConfiguration JSON
     #[serde(default)]
-    pub log_delivery_configs: HashMap<String, serde_json::Value>,
+    pub log_delivery_configs: BTreeMap<String, serde_json::Value>,
     /// (pool_id, client_id|"") -> RiskConfiguration JSON
     #[serde(default)]
-    pub risk_configurations: HashMap<String, serde_json::Value>,
+    pub risk_configurations: BTreeMap<String, serde_json::Value>,
     /// branding_id -> ManagedLoginBranding JSON
     #[serde(default)]
-    pub managed_login_brandings: HashMap<String, serde_json::Value>,
+    pub managed_login_brandings: BTreeMap<String, serde_json::Value>,
     /// terms_id -> Terms JSON
     #[serde(default)]
-    pub terms: HashMap<String, serde_json::Value>,
+    pub terms: BTreeMap<String, serde_json::Value>,
     /// (pool_id:username) -> WebAuthn credentials
     #[serde(default)]
-    pub webauthn_credentials: HashMap<String, Vec<WebAuthnCredential>>,
+    pub webauthn_credentials: BTreeMap<String, Vec<WebAuthnCredential>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -124,26 +124,26 @@ impl CognitoState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            user_pools: HashMap::new(),
-            user_pool_clients: HashMap::new(),
-            users: HashMap::new(),
-            refresh_tokens: HashMap::new(),
-            sessions: HashMap::new(),
-            access_tokens: HashMap::new(),
-            groups: HashMap::new(),
-            user_groups: HashMap::new(),
-            identity_providers: HashMap::new(),
-            resource_servers: HashMap::new(),
-            domains: HashMap::new(),
-            tags: HashMap::new(),
-            import_jobs: HashMap::new(),
+            user_pools: BTreeMap::new(),
+            user_pool_clients: BTreeMap::new(),
+            users: BTreeMap::new(),
+            refresh_tokens: BTreeMap::new(),
+            sessions: BTreeMap::new(),
+            access_tokens: BTreeMap::new(),
+            groups: BTreeMap::new(),
+            user_groups: BTreeMap::new(),
+            identity_providers: BTreeMap::new(),
+            resource_servers: BTreeMap::new(),
+            domains: BTreeMap::new(),
+            tags: BTreeMap::new(),
+            import_jobs: BTreeMap::new(),
             auth_events: Vec::new(),
-            ui_customizations: HashMap::new(),
-            log_delivery_configs: HashMap::new(),
-            risk_configurations: HashMap::new(),
-            managed_login_brandings: HashMap::new(),
-            terms: HashMap::new(),
-            webauthn_credentials: HashMap::new(),
+            ui_customizations: BTreeMap::new(),
+            log_delivery_configs: BTreeMap::new(),
+            risk_configurations: BTreeMap::new(),
+            managed_login_brandings: BTreeMap::new(),
+            terms: BTreeMap::new(),
+            webauthn_credentials: BTreeMap::new(),
         }
     }
 
@@ -226,7 +226,7 @@ pub struct UserPool {
     pub email_configuration: Option<EmailConfiguration>,
     pub sms_configuration: Option<SmsConfiguration>,
     pub admin_create_user_config: Option<AdminCreateUserConfig>,
-    pub user_pool_tags: HashMap<String, String>,
+    pub user_pool_tags: BTreeMap<String, String>,
     pub account_recovery_setting: Option<AccountRecoverySetting>,
     pub deletion_protection: Option<String>,
     pub estimated_number_of_users: i64,
@@ -410,11 +410,11 @@ pub struct User {
     pub temporary_password: Option<String>,
     pub confirmation_code: Option<String>,
     /// attribute_name -> verification_code (for GetUserAttributeVerificationCode / VerifyUserAttribute)
-    pub attribute_verification_codes: HashMap<String, String>,
+    pub attribute_verification_codes: BTreeMap<String, String>,
     pub mfa_preferences: Option<MfaPreferences>,
     pub totp_secret: Option<String>,
     pub totp_verified: bool,
-    pub devices: HashMap<String, Device>,
+    pub devices: BTreeMap<String, Device>,
     pub linked_providers: Vec<LinkedProvider>,
 }
 
@@ -448,8 +448,8 @@ pub struct IdentityProvider {
     pub user_pool_id: String,
     pub provider_name: String,
     pub provider_type: String,
-    pub provider_details: HashMap<String, String>,
-    pub attribute_mapping: HashMap<String, String>,
+    pub provider_details: BTreeMap<String, String>,
+    pub attribute_mapping: BTreeMap<String, String>,
     pub idp_identifiers: Vec<String>,
     pub creation_date: DateTime<Utc>,
     pub last_modified_date: DateTime<Utc>,
@@ -486,7 +486,7 @@ pub struct CustomDomainConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Device {
     pub device_key: String,
-    pub device_attributes: HashMap<String, String>,
+    pub device_attributes: BTreeMap<String, String>,
     pub device_create_date: DateTime<Utc>,
     pub device_last_modified_date: DateTime<Utc>,
     pub device_last_authenticated_date: Option<DateTime<Utc>>,
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn reset_clears_state() {
         let mut state = CognitoState::new("123456789012", "us-east-1");
-        state.tags.insert("arn".to_string(), HashMap::new());
+        state.tags.insert("arn".to_string(), BTreeMap::new());
         state.reset();
         assert!(state.tags.is_empty());
     }

--- a/crates/fakecloud-cognito/src/triggers.rs
+++ b/crates/fakecloud-cognito/src/triggers.rs
@@ -751,7 +751,7 @@ mod tests {
                     email_configuration: None,
                     sms_configuration: None,
                     admin_create_user_config: None,
-                    user_pool_tags: std::collections::HashMap::new(),
+                    user_pool_tags: std::collections::BTreeMap::new(),
                     account_recovery_setting: None,
                     deletion_protection: None,
                     estimated_number_of_users: 0,

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use fakecloud_aws::arn::Arn;
@@ -347,30 +347,30 @@ pub struct ElastiCacheState {
     pub account_id: String,
     pub region: String,
     pub parameter_groups: Vec<CacheParameterGroup>,
-    pub subnet_groups: HashMap<String, CacheSubnetGroup>,
-    pub reserved_cache_nodes: HashMap<String, ReservedCacheNode>,
+    pub subnet_groups: BTreeMap<String, CacheSubnetGroup>,
+    pub reserved_cache_nodes: BTreeMap<String, ReservedCacheNode>,
     pub reserved_cache_nodes_offerings: Vec<ReservedCacheNodesOffering>,
-    pub cache_clusters: HashMap<String, CacheCluster>,
-    pub replication_groups: HashMap<String, ReplicationGroup>,
-    pub global_replication_groups: HashMap<String, GlobalReplicationGroup>,
-    pub users: HashMap<String, ElastiCacheUser>,
-    pub user_groups: HashMap<String, ElastiCacheUserGroup>,
-    pub snapshots: HashMap<String, CacheSnapshot>,
-    pub serverless_caches: HashMap<String, ServerlessCache>,
-    pub serverless_cache_snapshots: HashMap<String, ServerlessCacheSnapshot>,
-    pub tags: HashMap<String, Vec<(String, String)>>,
+    pub cache_clusters: BTreeMap<String, CacheCluster>,
+    pub replication_groups: BTreeMap<String, ReplicationGroup>,
+    pub global_replication_groups: BTreeMap<String, GlobalReplicationGroup>,
+    pub users: BTreeMap<String, ElastiCacheUser>,
+    pub user_groups: BTreeMap<String, ElastiCacheUserGroup>,
+    pub snapshots: BTreeMap<String, CacheSnapshot>,
+    pub serverless_caches: BTreeMap<String, ServerlessCache>,
+    pub serverless_cache_snapshots: BTreeMap<String, ServerlessCacheSnapshot>,
+    pub tags: BTreeMap<String, Vec<(String, String)>>,
     in_progress_cache_cluster_ids: HashSet<String>,
     in_progress_replication_group_ids: HashSet<String>,
     in_progress_serverless_cache_names: HashSet<String>,
     #[serde(default)]
-    pub security_groups: HashMap<String, CacheSecurityGroup>,
+    pub security_groups: BTreeMap<String, CacheSecurityGroup>,
     #[serde(default)]
-    pub parameter_group_parameters: HashMap<String, Vec<CacheParameter>>,
+    pub parameter_group_parameters: BTreeMap<String, Vec<CacheParameter>>,
     #[serde(default)]
     pub events: Vec<CacheEvent>,
     /// Active migrations keyed by replication group id.
     #[serde(default)]
-    pub migrations: HashMap<String, Migration>,
+    pub migrations: BTreeMap<String, Migration>,
 }
 
 impl ElastiCacheState {
@@ -378,7 +378,7 @@ impl ElastiCacheState {
         let parameter_groups = default_parameter_groups(account_id, region);
         let subnet_groups = default_subnet_groups(account_id, region);
         let users = default_users(account_id, region);
-        let mut tags: HashMap<String, Vec<(String, String)>> = subnet_groups
+        let mut tags: BTreeMap<String, Vec<(String, String)>> = subnet_groups
             .values()
             .map(|g| (g.arn.clone(), Vec::new()))
             .collect();
@@ -390,24 +390,24 @@ impl ElastiCacheState {
             region: region.to_string(),
             parameter_groups,
             subnet_groups,
-            reserved_cache_nodes: HashMap::new(),
+            reserved_cache_nodes: BTreeMap::new(),
             reserved_cache_nodes_offerings: default_reserved_cache_nodes_offerings(),
-            cache_clusters: HashMap::new(),
-            replication_groups: HashMap::new(),
-            global_replication_groups: HashMap::new(),
+            cache_clusters: BTreeMap::new(),
+            replication_groups: BTreeMap::new(),
+            global_replication_groups: BTreeMap::new(),
             users,
-            user_groups: HashMap::new(),
-            snapshots: HashMap::new(),
-            serverless_caches: HashMap::new(),
-            serverless_cache_snapshots: HashMap::new(),
+            user_groups: BTreeMap::new(),
+            snapshots: BTreeMap::new(),
+            serverless_caches: BTreeMap::new(),
+            serverless_cache_snapshots: BTreeMap::new(),
             tags,
             in_progress_cache_cluster_ids: HashSet::new(),
             in_progress_replication_group_ids: HashSet::new(),
             in_progress_serverless_cache_names: HashSet::new(),
-            security_groups: HashMap::new(),
-            parameter_group_parameters: HashMap::new(),
+            security_groups: BTreeMap::new(),
+            parameter_group_parameters: BTreeMap::new(),
             events: Vec::new(),
-            migrations: HashMap::new(),
+            migrations: BTreeMap::new(),
         }
     }
 
@@ -647,7 +647,7 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
     ]
 }
 
-fn default_subnet_groups(account_id: &str, region: &str) -> HashMap<String, CacheSubnetGroup> {
+fn default_subnet_groups(account_id: &str, region: &str) -> BTreeMap<String, CacheSubnetGroup> {
     let default_group = CacheSubnetGroup {
         cache_subnet_group_name: "default".to_string(),
         cache_subnet_group_description: "Default CacheSubnetGroup".to_string(),
@@ -655,7 +655,7 @@ fn default_subnet_groups(account_id: &str, region: &str) -> HashMap<String, Cach
         subnet_ids: vec!["subnet-00000000".to_string()],
         arn: Arn::new("elasticache", region, account_id, "subnetgroup:default").to_string(),
     };
-    let mut map = HashMap::new();
+    let mut map = BTreeMap::new();
     map.insert("default".to_string(), default_group);
     map
 }
@@ -752,8 +752,8 @@ pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter
     }
 }
 
-fn default_users(account_id: &str, region: &str) -> HashMap<String, ElastiCacheUser> {
-    let mut map = HashMap::new();
+fn default_users(account_id: &str, region: &str) -> BTreeMap<String, ElastiCacheUser> {
+    let mut map = BTreeMap::new();
     map.insert(
         "default".to_string(),
         ElastiCacheUser {

--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -137,6 +137,7 @@ mod tests {
     use crate::state::{EventRule, EventTarget as EbTarget, SharedEventBridgeState};
     use fakecloud_core::delivery::{SnsDelivery, SqsDelivery};
     use parking_lot::RwLock;
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
 
     #[derive(Default)]
@@ -203,7 +204,7 @@ mod tests {
                 input_transformer: None,
                 sqs_parameters: None,
             }],
-            tags: HashMap::new(),
+            tags: BTreeMap::new(),
             last_fired: None,
         }
     }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -344,6 +344,7 @@ impl Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn parse_rate_minutes() {
@@ -547,7 +548,7 @@ mod tests {
                     input_transformer: None,
                     sqs_parameters: None,
                 }],
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
                 last_fired: None,
             }
         }

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use tokio::sync::Mutex as AsyncMutex;
@@ -328,8 +328,8 @@ impl AwsService for EventBridgeService {
     }
 }
 
-fn parse_tags(body: &Value) -> HashMap<String, String> {
-    let mut tags = HashMap::new();
+fn parse_tags(body: &Value) -> BTreeMap<String, String> {
+    let mut tags = BTreeMap::new();
     if let Some(arr) = body["Tags"].as_array() {
         for tag in arr {
             if let (Some(key), Some(val)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
@@ -2390,7 +2390,7 @@ impl EventBridgeService {
             managed_by: Some("prod.vhs.events.aws.internal".to_string()),
             created_by: Some(state.account_id.clone()),
             targets: vec![archive_target],
-            tags: HashMap::new(),
+            tags: BTreeMap::new(),
             last_fired: None,
         };
         let key = (bus_name, rule_name);
@@ -3499,7 +3499,7 @@ impl EventBridgeService {
 fn find_tags_mut<'a>(
     state: &'a mut crate::state::EventBridgeState,
     arn: &str,
-) -> Result<&'a mut HashMap<String, String>, AwsServiceError> {
+) -> Result<&'a mut BTreeMap<String, String>, AwsServiceError> {
     // Check buses
     for bus in state.buses.values_mut() {
         if bus.arn == arn {
@@ -3540,7 +3540,7 @@ fn find_tags_mut<'a>(
 fn find_tags<'a>(
     state: &'a crate::state::EventBridgeState,
     arn: &str,
-) -> Result<&'a HashMap<String, String>, AwsServiceError> {
+) -> Result<&'a BTreeMap<String, String>, AwsServiceError> {
     for bus in state.buses.values() {
         if bus.arn == arn {
             return Ok(&bus.tags);

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -222,6 +222,7 @@ mod tests {
     use super::*;
     use crate::state::EventRule;
     use parking_lot::RwLock;
+    use std::collections::BTreeMap;
 
     fn make_state() -> SharedEventBridgeState {
         Arc::new(RwLock::new(
@@ -253,7 +254,7 @@ mod tests {
                 managed_by: None,
                 created_by: None,
                 targets,
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
                 last_fired: None,
             },
         );

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -3,14 +3,14 @@ use fakecloud_aws::arn::Arn;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventBus {
     pub name: String,
     pub arn: String,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     pub policy: Option<Value>,
     pub description: Option<String>,
     pub kms_key_identifier: Option<String>,
@@ -32,7 +32,7 @@ pub struct EventRule {
     pub managed_by: Option<String>,
     pub created_by: Option<String>,
     pub targets: Vec<EventTarget>,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     pub last_fired: Option<DateTime<Utc>>,
 }
 
@@ -172,10 +172,10 @@ pub struct StepFunctionExecution {
 mod rule_map_serde {
     use super::{EventRule, RuleKey};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     pub fn serialize<S: Serializer>(
-        map: &HashMap<RuleKey, EventRule>,
+        map: &BTreeMap<RuleKey, EventRule>,
         s: S,
     ) -> Result<S::Ok, S::Error> {
         let entries: Vec<(&String, &String, &EventRule)> = map
@@ -187,7 +187,7 @@ mod rule_map_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         d: D,
-    ) -> Result<HashMap<RuleKey, EventRule>, D::Error> {
+    ) -> Result<BTreeMap<RuleKey, EventRule>, D::Error> {
         let entries: Vec<(String, String, EventRule)> = Vec::deserialize(d)?;
         Ok(entries
             .into_iter()
@@ -200,18 +200,18 @@ mod rule_map_serde {
 pub struct EventBridgeState {
     pub account_id: String,
     pub region: String,
-    pub buses: HashMap<String, EventBus>,
+    pub buses: BTreeMap<String, EventBus>,
     #[serde(with = "rule_map_serde")]
-    pub rules: HashMap<RuleKey, EventRule>,
+    pub rules: BTreeMap<RuleKey, EventRule>,
     pub events: Vec<PutEvent>,
-    pub archives: HashMap<String, Archive>,
-    pub connections: HashMap<String, Connection>,
-    pub api_destinations: HashMap<String, ApiDestination>,
-    pub replays: HashMap<String, Replay>,
+    pub archives: BTreeMap<String, Archive>,
+    pub connections: BTreeMap<String, Connection>,
+    pub api_destinations: BTreeMap<String, ApiDestination>,
+    pub replays: BTreeMap<String, Replay>,
     /// Partner event sources: name -> PartnerEventSource
-    pub partner_event_sources: HashMap<String, PartnerEventSource>,
+    pub partner_event_sources: BTreeMap<String, PartnerEventSource>,
     /// Endpoints: name -> Endpoint
-    pub endpoints: HashMap<String, Endpoint>,
+    pub endpoints: BTreeMap<String, Endpoint>,
     /// Recorded Lambda invocations (stub deliveries).
     pub lambda_invocations: Vec<LambdaInvocation>,
     /// Recorded CloudWatch Logs deliveries (stub deliveries).
@@ -225,13 +225,13 @@ impl EventBridgeState {
         let now = Utc::now();
         let default_bus_arn =
             Arn::new("events", region, account_id, "event-bus/default").to_string();
-        let mut buses = HashMap::new();
+        let mut buses = BTreeMap::new();
         buses.insert(
             "default".to_string(),
             EventBus {
                 name: "default".to_string(),
                 arn: default_bus_arn,
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
                 policy: None,
                 description: None,
                 kms_key_identifier: None,
@@ -245,14 +245,14 @@ impl EventBridgeState {
             account_id: account_id.to_string(),
             region: region.to_string(),
             buses,
-            rules: HashMap::new(),
+            rules: BTreeMap::new(),
             events: Vec::new(),
-            archives: HashMap::new(),
-            connections: HashMap::new(),
-            api_destinations: HashMap::new(),
-            replays: HashMap::new(),
-            partner_event_sources: HashMap::new(),
-            endpoints: HashMap::new(),
+            archives: BTreeMap::new(),
+            connections: BTreeMap::new(),
+            api_destinations: BTreeMap::new(),
+            replays: BTreeMap::new(),
+            partner_event_sources: BTreeMap::new(),
+            endpoints: BTreeMap::new(),
             lambda_invocations: Vec::new(),
             log_deliveries: Vec::new(),
             step_function_executions: Vec::new(),
@@ -291,7 +291,7 @@ impl EventBridgeState {
             EventBus {
                 name: "default".to_string(),
                 arn: default_bus_arn,
-                tags: HashMap::new(),
+                tags: BTreeMap::new(),
                 policy: None,
                 description: None,
                 kms_key_identifier: None,

--- a/crates/fakecloud-ses/src/service/contact_lists.rs
+++ b/crates/fakecloud-ses/src/service/contact_lists.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -52,7 +52,7 @@ impl SesV2Service {
                 last_updated_at: now,
             },
         );
-        state.contacts.insert(name, HashMap::new());
+        state.contacts.insert(name, BTreeMap::new());
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -312,50 +312,50 @@ pub struct SesState {
     pub account_id: String,
     pub region: String,
     #[serde(default)]
-    pub identities: HashMap<String, EmailIdentity>,
+    pub identities: BTreeMap<String, EmailIdentity>,
     #[serde(default)]
-    pub configuration_sets: HashMap<String, ConfigurationSet>,
+    pub configuration_sets: BTreeMap<String, ConfigurationSet>,
     #[serde(default)]
-    pub templates: HashMap<String, EmailTemplate>,
+    pub templates: BTreeMap<String, EmailTemplate>,
     #[serde(default, skip_serializing)]
     pub sent_emails: Vec<SentEmail>,
-    pub contact_lists: HashMap<String, ContactList>,
-    pub contacts: HashMap<String, HashMap<String, Contact>>,
+    pub contact_lists: BTreeMap<String, ContactList>,
+    pub contacts: BTreeMap<String, BTreeMap<String, Contact>>,
     /// Tags keyed by resource ARN, value is key→value tag map.
-    pub tags: HashMap<String, HashMap<String, String>>,
+    pub tags: BTreeMap<String, BTreeMap<String, String>>,
     /// Suppression list: email → suppressed destination info.
-    pub suppressed_destinations: HashMap<String, SuppressedDestination>,
+    pub suppressed_destinations: BTreeMap<String, SuppressedDestination>,
     /// Event destinations: config set name → list of event destinations.
-    pub event_destinations: HashMap<String, Vec<EventDestination>>,
+    pub event_destinations: BTreeMap<String, Vec<EventDestination>>,
     /// Identity policies: identity name → policy name → policy JSON document.
-    pub identity_policies: HashMap<String, HashMap<String, String>>,
+    pub identity_policies: BTreeMap<String, BTreeMap<String, String>>,
     /// Custom verification email templates: template name → template.
-    pub custom_verification_email_templates: HashMap<String, CustomVerificationEmailTemplate>,
+    pub custom_verification_email_templates: BTreeMap<String, CustomVerificationEmailTemplate>,
     /// Dedicated IP pools: pool name → pool.
-    pub dedicated_ip_pools: HashMap<String, DedicatedIpPool>,
+    pub dedicated_ip_pools: BTreeMap<String, DedicatedIpPool>,
     /// Dedicated IPs: IP address → dedicated IP info.
-    pub dedicated_ips: HashMap<String, DedicatedIp>,
+    pub dedicated_ips: BTreeMap<String, DedicatedIp>,
     /// Multi-region endpoints: endpoint name → endpoint.
-    pub multi_region_endpoints: HashMap<String, MultiRegionEndpoint>,
+    pub multi_region_endpoints: BTreeMap<String, MultiRegionEndpoint>,
     /// Account-level settings (sending, suppression, VDM, details).
     pub account_settings: AccountSettings,
     /// Import jobs: job_id → ImportJob.
-    pub import_jobs: HashMap<String, ImportJob>,
+    pub import_jobs: BTreeMap<String, ImportJob>,
     /// Export jobs: job_id → ExportJob.
-    pub export_jobs: HashMap<String, ExportJob>,
+    pub export_jobs: BTreeMap<String, ExportJob>,
     /// Tenants: tenant_name → Tenant.
-    pub tenants: HashMap<String, Tenant>,
+    pub tenants: BTreeMap<String, Tenant>,
     /// Tenant resource associations: tenant_name → Vec<resource_arn>.
-    pub tenant_resource_associations: HashMap<String, Vec<TenantResourceAssociation>>,
+    pub tenant_resource_associations: BTreeMap<String, Vec<TenantResourceAssociation>>,
     /// Reputation entities: "type/reference" → ReputationEntity.
-    pub reputation_entities: HashMap<String, ReputationEntityState>,
+    pub reputation_entities: BTreeMap<String, ReputationEntityState>,
     // ── SES v1 Receipt Rule state ──
     /// Receipt rule sets: name → rule set.
-    pub receipt_rule_sets: HashMap<String, ReceiptRuleSet>,
+    pub receipt_rule_sets: BTreeMap<String, ReceiptRuleSet>,
     /// Which rule set is active (by name).
     pub active_receipt_rule_set: Option<String>,
     /// Receipt filters: name → filter.
-    pub receipt_filters: HashMap<String, ReceiptFilter>,
+    pub receipt_filters: BTreeMap<String, ReceiptFilter>,
     /// Inbound emails processed by the introspection endpoint.
     #[serde(default, skip_serializing)]
     pub inbound_emails: Vec<InboundEmail>,
@@ -364,7 +364,7 @@ pub struct SesState {
     pub deliverability_dashboard: DeliverabilityDashboard,
     /// Deliverability test reports keyed by ReportId.
     #[serde(default)]
-    pub deliverability_test_reports: HashMap<String, DeliverabilityTestReport>,
+    pub deliverability_test_reports: BTreeMap<String, DeliverabilityTestReport>,
     /// VDM recommendations (read-only, lazily seeded once on first read).
     #[serde(default)]
     pub vdm_recommendations: Vec<VdmRecommendation>,
@@ -423,20 +423,20 @@ impl SesState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            identities: HashMap::new(),
-            configuration_sets: HashMap::new(),
-            templates: HashMap::new(),
+            identities: BTreeMap::new(),
+            configuration_sets: BTreeMap::new(),
+            templates: BTreeMap::new(),
             sent_emails: Vec::new(),
-            contact_lists: HashMap::new(),
-            contacts: HashMap::new(),
-            tags: HashMap::new(),
-            suppressed_destinations: HashMap::new(),
-            event_destinations: HashMap::new(),
-            identity_policies: HashMap::new(),
-            custom_verification_email_templates: HashMap::new(),
-            dedicated_ip_pools: HashMap::new(),
-            dedicated_ips: HashMap::new(),
-            multi_region_endpoints: HashMap::new(),
+            contact_lists: BTreeMap::new(),
+            contacts: BTreeMap::new(),
+            tags: BTreeMap::new(),
+            suppressed_destinations: BTreeMap::new(),
+            event_destinations: BTreeMap::new(),
+            identity_policies: BTreeMap::new(),
+            custom_verification_email_templates: BTreeMap::new(),
+            dedicated_ip_pools: BTreeMap::new(),
+            dedicated_ips: BTreeMap::new(),
+            multi_region_endpoints: BTreeMap::new(),
             account_settings: AccountSettings {
                 sending_enabled: true,
                 dedicated_ip_auto_warmup_enabled: false,
@@ -444,17 +444,17 @@ impl SesState {
                 vdm_attributes: None,
                 details: None,
             },
-            import_jobs: HashMap::new(),
-            export_jobs: HashMap::new(),
-            tenants: HashMap::new(),
-            tenant_resource_associations: HashMap::new(),
-            reputation_entities: HashMap::new(),
-            receipt_rule_sets: HashMap::new(),
+            import_jobs: BTreeMap::new(),
+            export_jobs: BTreeMap::new(),
+            tenants: BTreeMap::new(),
+            tenant_resource_associations: BTreeMap::new(),
+            reputation_entities: BTreeMap::new(),
+            receipt_rule_sets: BTreeMap::new(),
             active_receipt_rule_set: None,
-            receipt_filters: HashMap::new(),
+            receipt_filters: BTreeMap::new(),
             inbound_emails: Vec::new(),
             deliverability_dashboard: DeliverabilityDashboard::default(),
-            deliverability_test_reports: HashMap::new(),
+            deliverability_test_reports: BTreeMap::new(),
             vdm_recommendations: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

Phase E batch 4 (per audit 2026-04-28 §3): switch state.rs `HashMap` → `BTreeMap` for 4 more services so list-resource pagination has deterministic order.

- **cognito**: pools, users, groups, resource_servers, identity_providers, triggers
- **elasticache**: cache_clusters, parameter_groups, subnet_groups, replication_groups, snapshots
- **ses**: identities, configuration_sets, templates, contact_lists, contacts, suppression
- **eventbridge**: event_buses, rules, targets, archives, replays, connections, api_destinations

`AwsRequest.query_params` keeps HashMap (foreign field). SqsDelivery / EventBridgeDelivery trait methods keep `&HashMap` signatures (recorder impls in tests).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p fakecloud-cognito -p fakecloud-elasticache -p fakecloud-ses -p fakecloud-eventbridge --lib` (290 + 177 + 193 + 190 tests pass)
- [x] `cargo clippy -p ... --all-targets -- -D warnings`
- [ ] CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor service state from `HashMap` to `BTreeMap` across Cognito, ElastiCache, SES, and EventBridge to make list/pagination order deterministic.

- **Refactors**
  - Converted state/service maps to `BTreeMap` across Cognito (pools, users, groups, resource servers, identity providers, triggers), ElastiCache (clusters, parameter/subnet groups, replication groups, snapshots), SES (identities, configuration sets, templates, contact lists, contacts, suppression), and EventBridge (buses, rules, targets, archives, replays, connections, API destinations).
  - Updated tags, device attributes, and helper parsers (e.g., parse_tags, parse_string_map) and default/seed builders to use `BTreeMap`. Kept `AwsRequest.query_params` as `HashMap` and preserved `SqsDelivery`/`EventBridgeDelivery` trait method signatures using `&HashMap`.

- **Bug Fixes**
  - CloudFormation EventBridge resources now use `BTreeMap` for `tags` to match cross-crate types.

<sup>Written for commit 621e27173f50a822eede9d5f3670f4ff9021d64b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/865?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

