### PR TITLE
refactor: convert iam/kms/sqs state to BTreeMap

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -115,7 +115,7 @@ impl ResourceProvisioner {
         );
 
         let is_fifo = queue_name.ends_with(".fifo");
-        let mut attributes = HashMap::new();
+        let mut attributes = std::collections::BTreeMap::new();
         if let Some(obj) = props.as_object() {
             for (k, v) in obj {
                 if k != "QueueName" {
@@ -137,12 +137,12 @@ impl ResourceProvisioner {
             inflight: Vec::new(),
             attributes,
             is_fifo,
-            dedup_cache: HashMap::new(),
+            dedup_cache: std::collections::BTreeMap::new(),
             redrive_policy: None,
-            tags: HashMap::new(),
+            tags: std::collections::BTreeMap::new(),
             next_sequence_number: 0,
             permission_labels: Vec::new(),
-            receipt_handle_map: HashMap::new(),
+            receipt_handle_map: std::collections::BTreeMap::new(),
         };
 
         state
@@ -1063,7 +1063,7 @@ mod tests {
                     description: None,
                     kms_key_identifier: None,
                     dead_letter_config: None,
-                    tags: HashMap::new(),
+                    tags: std::collections::BTreeMap::new(),
                 },
             );
         }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1063,7 +1063,7 @@ mod tests {
                     description: None,
                     kms_key_identifier: None,
                     dead_letter_config: None,
-                    tags: std::collections::BTreeMap::new(),
+                    tags: HashMap::new(),
                 },
             );
         }

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -47,7 +47,7 @@ impl CredentialResolver for IamCredentialResolver {
                         account_id: lookup.account_id,
                         principal_type,
                         source_identity: None,
-                        tags: lookup.principal_tags,
+                        tags: lookup.principal_tags.map(|m| m.into_iter().collect()),
                     },
                     session_policies: lookup.session_policies,
                 });

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -1686,7 +1686,7 @@ mod tests {
                 permissions_boundary: None,
             },
         );
-        let mut inline = std::collections::HashMap::new();
+        let mut inline = std::collections::BTreeMap::new();
         inline.insert(
             "AllowGet".to_string(),
             r#"{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#
@@ -1742,7 +1742,7 @@ mod tests {
                 permissions_boundary: None,
             },
         );
-        let mut inline = std::collections::HashMap::new();
+        let mut inline = std::collections::BTreeMap::new();
         inline.insert(
             "AllowGet".to_string(),
             r#"{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#
@@ -1812,7 +1812,7 @@ mod tests {
                 path: "/".into(),
                 created_at: Utc::now(),
                 members: vec!["alice".into()],
-                inline_policies: std::collections::HashMap::new(),
+                inline_policies: std::collections::BTreeMap::new(),
                 attached_policies: vec![policy_arn],
             },
         );

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -45,7 +45,7 @@ impl IamService {
             path,
             created_at: Utc::now(),
             members: Vec::new(),
-            inline_policies: std::collections::HashMap::new(),
+            inline_policies: std::collections::BTreeMap::new(),
             attached_policies: Vec::new(),
         };
 

--- a/crates/fakecloud-iam/src/policy_evaluator.rs
+++ b/crates/fakecloud-iam/src/policy_evaluator.rs
@@ -213,7 +213,7 @@ mod tests {
             .user_inline_policies
             .insert(
                 "alice".into(),
-                std::collections::HashMap::from([(
+                std::collections::BTreeMap::from([(
                     "AllowGet".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#
                         .into(),
@@ -242,7 +242,7 @@ mod tests {
         let state = setup();
         state.write().get_or_create("123456789012").user_inline_policies.insert(
             "alice".into(),
-            std::collections::HashMap::from([
+            std::collections::BTreeMap::from([
                 (
                     "AllowAll".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
@@ -322,7 +322,7 @@ mod tests {
             let s = mas.get_or_create("123456789012");
             s.user_inline_policies.insert(
                 "alice".into(),
-                std::collections::HashMap::from([(
+                std::collections::BTreeMap::from([(
                     "AllowAll".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
                 )]),
@@ -366,7 +366,7 @@ mod tests {
             let s = mas.get_or_create("123456789012");
             s.user_inline_policies.insert(
                 "alice".into(),
-                std::collections::HashMap::from([(
+                std::collections::BTreeMap::from([(
                     "AllowAll".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
                 )]),
@@ -402,7 +402,7 @@ mod tests {
             let s = mas.get_or_create("123456789012");
             s.user_inline_policies.insert(
                 "alice".into(),
-                std::collections::HashMap::from([(
+                std::collections::BTreeMap::from([(
                     "AllowAll".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
                 )]),
@@ -451,7 +451,7 @@ mod tests {
             );
             s.role_inline_policies.insert(
                 "AWSServiceRoleForLambda".into(),
-                std::collections::HashMap::from([(
+                std::collections::BTreeMap::from([(
                     "AllowAll".into(),
                     r#"{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.into(),
                 )]),

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fakecloud_core::multi_account::{AccountState, MultiAccountState};
 
@@ -69,9 +69,9 @@ pub struct IamGroup {
     pub arn: String,
     pub path: String,
     pub created_at: DateTime<Utc>,
-    pub members: Vec<String>,                     // user names
-    pub inline_policies: HashMap<String, String>, // policy_name -> document
-    pub attached_policies: Vec<String>,           // policy ARNs
+    pub members: Vec<String>,                      // user names
+    pub inline_policies: BTreeMap<String, String>, // policy_name -> document
+    pub attached_policies: Vec<String>,            // policy ARNs
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -238,12 +238,12 @@ pub struct SecretLookup {
     pub session_policies: Vec<String>,
     /// Tags on the principal (IAM user or assumed role) for
     /// `aws:PrincipalTag/<key>` condition evaluation.
-    pub principal_tags: Option<HashMap<String, String>>,
+    pub principal_tags: Option<BTreeMap<String, String>>,
 }
 
-/// Convert a `Vec<Tag>` to a `HashMap<String, String>`.
+/// Convert a `Vec<Tag>` to a `BTreeMap<String, String>`.
 /// Returns `None` when the input is empty (no tags to evaluate).
-pub fn tags_to_hashmap(tags: &[Tag]) -> Option<HashMap<String, String>> {
+pub fn tags_to_hashmap(tags: &[Tag]) -> Option<BTreeMap<String, String>> {
     if tags.is_empty() {
         return None;
     }
@@ -275,44 +275,44 @@ pub struct AccessKeyLastUsed {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IamState {
     pub account_id: String,
-    pub users: HashMap<String, IamUser>,
-    pub access_keys: HashMap<String, Vec<IamAccessKey>>, // username -> keys
-    pub roles: HashMap<String, IamRole>,
-    pub policies: HashMap<String, IamPolicy>, // arn -> policy
-    pub role_policies: HashMap<String, Vec<String>>, // role_name -> managed policy arns
-    pub role_inline_policies: HashMap<String, HashMap<String, String>>, // role_name -> {policy_name -> doc}
-    pub user_policies: HashMap<String, Vec<String>>, // user_name -> managed policy arns
-    pub user_inline_policies: HashMap<String, HashMap<String, String>>, // user_name -> {policy_name -> doc}
-    pub groups: HashMap<String, IamGroup>,
-    pub instance_profiles: HashMap<String, IamInstanceProfile>,
-    pub login_profiles: HashMap<String, LoginProfile>,
-    pub saml_providers: HashMap<String, SamlProvider>, // arn -> provider
-    pub oidc_providers: HashMap<String, OidcProvider>, // arn -> provider
-    pub server_certificates: HashMap<String, ServerCertificate>, // name -> cert
-    pub signing_certificates: HashMap<String, Vec<SigningCertificate>>, // user_name -> certs
+    pub users: BTreeMap<String, IamUser>,
+    pub access_keys: BTreeMap<String, Vec<IamAccessKey>>, // username -> keys
+    pub roles: BTreeMap<String, IamRole>,
+    pub policies: BTreeMap<String, IamPolicy>, // arn -> policy
+    pub role_policies: BTreeMap<String, Vec<String>>, // role_name -> managed policy arns
+    pub role_inline_policies: BTreeMap<String, BTreeMap<String, String>>, // role_name -> {policy_name -> doc}
+    pub user_policies: BTreeMap<String, Vec<String>>, // user_name -> managed policy arns
+    pub user_inline_policies: BTreeMap<String, BTreeMap<String, String>>, // user_name -> {policy_name -> doc}
+    pub groups: BTreeMap<String, IamGroup>,
+    pub instance_profiles: BTreeMap<String, IamInstanceProfile>,
+    pub login_profiles: BTreeMap<String, LoginProfile>,
+    pub saml_providers: BTreeMap<String, SamlProvider>, // arn -> provider
+    pub oidc_providers: BTreeMap<String, OidcProvider>, // arn -> provider
+    pub server_certificates: BTreeMap<String, ServerCertificate>, // name -> cert
+    pub signing_certificates: BTreeMap<String, Vec<SigningCertificate>>, // user_name -> certs
     pub account_aliases: Vec<String>,
     pub account_password_policy: Option<AccountPasswordPolicy>,
-    pub virtual_mfa_devices: HashMap<String, VirtualMfaDevice>, // serial_number -> device
-    pub service_linked_role_deletions: HashMap<String, ServiceLinkedRoleDeletion>,
+    pub virtual_mfa_devices: BTreeMap<String, VirtualMfaDevice>, // serial_number -> device
+    pub service_linked_role_deletions: BTreeMap<String, ServiceLinkedRoleDeletion>,
     /// Maps access key ID to the identity that should be returned by GetCallerIdentity.
-    pub credential_identities: HashMap<String, CredentialIdentity>,
+    pub credential_identities: BTreeMap<String, CredentialIdentity>,
     /// Temporary credentials issued by STS, keyed by access key ID. Includes
     /// the secret access key and session token — required for SigV4
     /// verification and IAM enforcement. Expired entries are purged lazily on
     /// lookup.
-    pub sts_temp_credentials: HashMap<String, StsTempCredential>,
+    pub sts_temp_credentials: BTreeMap<String, StsTempCredential>,
     pub credential_report_generated: bool,
-    pub ssh_public_keys: HashMap<String, Vec<SshPublicKey>>, // user_name -> keys
-    pub access_key_last_used: HashMap<String, AccessKeyLastUsed>,
+    pub ssh_public_keys: BTreeMap<String, Vec<SshPublicKey>>, // user_name -> keys
+    pub access_key_last_used: BTreeMap<String, AccessKeyLastUsed>,
     /// Per-user service-specific credentials (Codecommit/Keyspaces).
     #[serde(default)]
-    pub service_specific_credentials: HashMap<String, Vec<ServiceSpecificCredential>>, // user -> creds
+    pub service_specific_credentials: BTreeMap<String, Vec<ServiceSpecificCredential>>, // user -> creds
     /// Active delegation requests keyed by id.
     #[serde(default)]
-    pub delegation_requests: HashMap<String, DelegationRequest>,
+    pub delegation_requests: BTreeMap<String, DelegationRequest>,
     /// Per-resource-arn tag map for SAML/Server cert/MFA device tags.
     #[serde(default)]
-    pub extra_tags: HashMap<String, Vec<(String, String)>>,
+    pub extra_tags: BTreeMap<String, Vec<(String, String)>>,
     /// Organizations integration toggles.
     #[serde(default)]
     pub organizations_root_credentials_management: bool,
@@ -323,10 +323,10 @@ pub struct IamState {
     pub outbound_web_identity_federation: Option<OutboundWebIdentityFederation>,
     /// Generated ServiceLastAccessed jobs keyed by job id.
     #[serde(default)]
-    pub service_last_accessed_jobs: HashMap<String, ServiceLastAccessedJob>,
+    pub service_last_accessed_jobs: BTreeMap<String, ServiceLastAccessedJob>,
     /// Organizations access reports keyed by job id.
     #[serde(default)]
-    pub organizations_access_reports: HashMap<String, OrganizationsAccessReport>,
+    pub organizations_access_reports: BTreeMap<String, OrganizationsAccessReport>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -377,38 +377,38 @@ impl IamState {
     pub fn new(account_id: &str) -> Self {
         Self {
             account_id: account_id.to_string(),
-            users: HashMap::new(),
-            access_keys: HashMap::new(),
-            roles: HashMap::new(),
-            policies: HashMap::new(),
-            role_policies: HashMap::new(),
-            role_inline_policies: HashMap::new(),
-            user_policies: HashMap::new(),
-            user_inline_policies: HashMap::new(),
-            groups: HashMap::new(),
-            instance_profiles: HashMap::new(),
-            login_profiles: HashMap::new(),
-            saml_providers: HashMap::new(),
-            oidc_providers: HashMap::new(),
-            server_certificates: HashMap::new(),
-            signing_certificates: HashMap::new(),
+            users: BTreeMap::new(),
+            access_keys: BTreeMap::new(),
+            roles: BTreeMap::new(),
+            policies: BTreeMap::new(),
+            role_policies: BTreeMap::new(),
+            role_inline_policies: BTreeMap::new(),
+            user_policies: BTreeMap::new(),
+            user_inline_policies: BTreeMap::new(),
+            groups: BTreeMap::new(),
+            instance_profiles: BTreeMap::new(),
+            login_profiles: BTreeMap::new(),
+            saml_providers: BTreeMap::new(),
+            oidc_providers: BTreeMap::new(),
+            server_certificates: BTreeMap::new(),
+            signing_certificates: BTreeMap::new(),
             account_aliases: Vec::new(),
             account_password_policy: None,
-            virtual_mfa_devices: HashMap::new(),
-            service_linked_role_deletions: HashMap::new(),
-            credential_identities: HashMap::new(),
-            sts_temp_credentials: HashMap::new(),
+            virtual_mfa_devices: BTreeMap::new(),
+            service_linked_role_deletions: BTreeMap::new(),
+            credential_identities: BTreeMap::new(),
+            sts_temp_credentials: BTreeMap::new(),
             credential_report_generated: false,
-            ssh_public_keys: HashMap::new(),
-            access_key_last_used: HashMap::new(),
-            service_specific_credentials: HashMap::new(),
-            delegation_requests: HashMap::new(),
-            extra_tags: HashMap::new(),
+            ssh_public_keys: BTreeMap::new(),
+            access_key_last_used: BTreeMap::new(),
+            service_specific_credentials: BTreeMap::new(),
+            delegation_requests: BTreeMap::new(),
+            extra_tags: BTreeMap::new(),
             organizations_root_credentials_management: false,
             organizations_root_sessions: false,
             outbound_web_identity_federation: None,
-            service_last_accessed_jobs: HashMap::new(),
-            organizations_access_reports: HashMap::new(),
+            service_last_accessed_jobs: BTreeMap::new(),
+            organizations_access_reports: BTreeMap::new(),
         }
     }
 
@@ -514,7 +514,7 @@ impl IamState {
     /// Resolve role tags from an assumed-role principal ARN.
     /// ARN format: `arn:aws:sts::<account>:assumed-role/<role-name>/<session>`
     /// Looks up the role by name and returns its tags.
-    fn resolve_role_tags(&self, principal_arn: &str) -> Option<HashMap<String, String>> {
+    fn resolve_role_tags(&self, principal_arn: &str) -> Option<BTreeMap<String, String>> {
         // assumed-role ARNs: arn:aws:sts::<account>:assumed-role/<role>/<session>
         let parts: Vec<&str> = principal_arn.split(':').collect();
         if parts.len() < 6 {

--- a/crates/fakecloud-kms/src/hook.rs
+++ b/crates/fakecloud-kms/src/hook.rs
@@ -17,7 +17,7 @@
 //! Encryption context, key policy enforcement, and KMS-managed key
 //! rotation come in follow-up PRs.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -316,7 +316,7 @@ fn provision_aws_managed_key(
         key_manager: "AWS".to_string(),
         key_state: "Enabled".to_string(),
         deletion_date: None,
-        tags: HashMap::new(),
+        tags: BTreeMap::new(),
         policy,
         key_rotation_enabled: true,
         origin: "AWS_KMS".to_string(),

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -402,7 +402,12 @@ impl AwsService for KmsService {
         let accounts = self.state.read();
         let state = accounts.get(&account_id)?;
         let key = state.keys.get(key_id)?;
-        Some(key.tags.clone())
+        Some(
+            key.tags
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
     }
 
     fn request_tags_from(
@@ -540,7 +545,7 @@ struct CreateKeyInput {
     origin: String,
     multi_region: bool,
     policy: Option<String>,
-    tags: HashMap<String, String>,
+    tags: BTreeMap<String, String>,
 }
 
 impl CreateKeyInput {
@@ -586,7 +591,7 @@ impl CreateKeyInput {
             ));
         }
 
-        let tags: HashMap<String, String> = body["Tags"]
+        let tags: BTreeMap<String, String> = body["Tags"]
             .as_array()
             .map(|arr| {
                 arr.iter()

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -15,10 +15,10 @@ impl fakecloud_core::multi_account::AccountState for KmsState {
 pub struct KmsState {
     pub account_id: String,
     pub region: String,
-    pub keys: HashMap<String, KmsKey>,
-    pub aliases: HashMap<String, KmsAlias>,
+    pub keys: BTreeMap<String, KmsKey>,
+    pub aliases: BTreeMap<String, KmsAlias>,
     pub grants: Vec<KmsGrant>,
-    pub custom_key_stores: HashMap<String, CustomKeyStore>,
+    pub custom_key_stores: BTreeMap<String, CustomKeyStore>,
     /// Per-account master key bytes (32 bytes for AES-256-GCM) used to
     /// wrap plaintext in the AWS-shaped ciphertext blob format. Generated
     /// lazily on first encrypt and persisted alongside the rest of the
@@ -41,10 +41,10 @@ impl KmsState {
         Self {
             account_id: account_id.to_string(),
             region: region.to_string(),
-            keys: HashMap::new(),
-            aliases: HashMap::new(),
+            keys: BTreeMap::new(),
+            aliases: BTreeMap::new(),
             grants: Vec::new(),
-            custom_key_stores: HashMap::new(),
+            custom_key_stores: BTreeMap::new(),
             master_key_bytes: default_master_key_bytes(),
         }
     }
@@ -70,7 +70,7 @@ pub struct KmsKey {
     pub key_manager: String,
     pub key_state: String,
     pub deletion_date: Option<f64>,
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     pub policy: String,
     pub key_rotation_enabled: bool,
     pub origin: String,

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -526,7 +526,7 @@ pub(crate) fn create_admin_in_account(
     );
     state.user_inline_policies.insert(
         user_name.to_string(),
-        std::collections::HashMap::from([(
+        std::collections::BTreeMap::from([(
             "fakecloud-admin".to_string(),
             r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#.to_string(),
         )]),

--- a/crates/fakecloud-sqs/src/delivery.rs
+++ b/crates/fakecloud-sqs/src/delivery.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use base64::Engine;
 use chrono::Utc;
@@ -105,7 +105,7 @@ impl SqsDelivery for SqsDeliveryImpl {
             None
         };
 
-        let sqs_attrs: HashMap<String, MessageAttribute> = message_attributes
+        let sqs_attrs: BTreeMap<String, MessageAttribute> = message_attributes
             .iter()
             .map(|(k, v)| {
                 (
@@ -128,7 +128,7 @@ impl SqsDelivery for SqsDeliveryImpl {
             md5_of_body: crate::service::md5_hex(message_body),
             body: message_body.to_string(),
             sent_timestamp: now.timestamp_millis(),
-            attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
             message_attributes: sqs_attrs,
             visible_at: None,
             receive_count: 0,
@@ -158,7 +158,7 @@ mod tests {
     const ENDPOINT: &str = "http://localhost:4566";
 
     fn make_queue(name: &str, is_fifo: bool, content_based_dedup: bool) -> SqsQueue {
-        let mut attributes = HashMap::new();
+        let mut attributes = BTreeMap::new();
         if content_based_dedup {
             attributes.insert("ContentBasedDeduplication".to_string(), "true".to_string());
         }
@@ -171,12 +171,12 @@ mod tests {
             inflight: Vec::new(),
             attributes,
             is_fifo,
-            dedup_cache: HashMap::new(),
+            dedup_cache: BTreeMap::new(),
             redrive_policy: None,
-            tags: HashMap::new(),
+            tags: BTreeMap::new(),
             next_sequence_number: 0,
             permission_labels: Vec::new(),
-            receipt_handle_map: HashMap::new(),
+            receipt_handle_map: BTreeMap::new(),
         }
     }
 

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 use md5::Md5;
 use serde_json::{json, Value};
 use sha2::Sha256;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
@@ -23,7 +23,7 @@ use crate::state::{
 /// documented ranges; we return the same error code/message the real
 /// service does.
 fn validate_create_queue_attributes(
-    attrs: &HashMap<String, String>,
+    attrs: &BTreeMap<String, String>,
 ) -> Result<(), AwsServiceError> {
     if let Some(ds) = attrs.get("DelaySeconds") {
         match ds.parse::<i64>() {
@@ -300,7 +300,7 @@ fn process_batch_send_entry(
         md5_of_body: md5_hex(&message_body),
         body: stored_body_override.unwrap_or(message_body),
         sent_timestamp: cfg.now.timestamp_millis(),
-        attributes: HashMap::new(),
+        attributes: BTreeMap::new(),
         message_attributes,
         visible_at,
         receive_count: 0,
@@ -699,7 +699,13 @@ impl AwsService for SqsService {
         let state = _accts.get(account_id)?;
         let queue_url = state.name_to_url.get(queue_name)?;
         let queue = state.queues.get(queue_url)?;
-        Some(queue.tags.clone())
+        Some(
+            queue
+                .tags
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
     }
 
     fn request_tags_from(
@@ -1339,7 +1345,7 @@ impl SqsService {
             ));
         }
 
-        let mut new_attributes = HashMap::new();
+        let mut new_attributes = BTreeMap::new();
         if let Some(attrs) = body["Attributes"].as_object() {
             for (k, v) in attrs {
                 if let Some(s) = v.as_str() {
@@ -1388,7 +1394,7 @@ impl SqsService {
 
         let queue_url = format!("{}/{}/{}", state.endpoint, state.account_id, queue_name);
 
-        let mut attributes = HashMap::new();
+        let mut attributes = BTreeMap::new();
         // Default attributes (real AWS SQS defaults).
         attributes.insert("VisibilityTimeout".to_string(), "30".to_string());
         attributes.insert("DelaySeconds".to_string(), "0".to_string());
@@ -1456,7 +1462,7 @@ impl SqsService {
         // string is what GetQueueAttributes returns and round-trips clean.
 
         // Parse tags
-        let mut tags = HashMap::new();
+        let mut tags = BTreeMap::new();
         if let Some(tags_obj) = body["tags"].as_object() {
             for (k, v) in tags_obj {
                 if let Some(s) = v.as_str() {
@@ -1491,12 +1497,12 @@ impl SqsService {
             inflight: Vec::new(),
             attributes,
             is_fifo,
-            dedup_cache: HashMap::new(),
+            dedup_cache: BTreeMap::new(),
             redrive_policy,
             tags,
             next_sequence_number: 0,
             permission_labels: Vec::new(),
-            receipt_handle_map: HashMap::new(),
+            receipt_handle_map: BTreeMap::new(),
         };
 
         state.name_to_url.insert(queue_name, queue_url.clone());
@@ -3655,10 +3661,10 @@ fn format_receive_response(
             }
 
             // Filter message attributes
-            let filtered_attrs: HashMap<String, &MessageAttribute> =
+            let filtered_attrs: BTreeMap<String, &MessageAttribute> =
                 if let Some(names) = msg_attr_names {
                     if names.is_empty() {
-                        HashMap::new()
+                        BTreeMap::new()
                     } else if names.iter().any(|n| n == "All" || n == ".*") {
                         m.message_attributes
                             .iter()
@@ -3680,7 +3686,7 @@ fn format_receive_response(
                             .collect()
                     }
                 } else {
-                    HashMap::new()
+                    BTreeMap::new()
                 };
 
             if !filtered_attrs.is_empty() {
@@ -3718,8 +3724,8 @@ fn format_receive_response(
     sqs_response("ReceiveMessage", body, request_id, is_query)
 }
 
-fn parse_message_attributes(body: &Value) -> HashMap<String, MessageAttribute> {
-    let mut result = HashMap::new();
+fn parse_message_attributes(body: &Value) -> BTreeMap<String, MessageAttribute> {
+    let mut result = BTreeMap::new();
     if let Some(attrs) = body["MessageAttributes"].as_object() {
         for (name, val) in attrs {
             let data_type = val["DataType"].as_str().unwrap_or("String").to_string();
@@ -3781,7 +3787,7 @@ fn parse_message_attributes(body: &Value) -> HashMap<String, MessageAttribute> {
 
 /// Validate message attribute names and data types
 fn validate_message_attributes(
-    attrs: &HashMap<String, MessageAttribute>,
+    attrs: &BTreeMap<String, MessageAttribute>,
 ) -> Result<(), AwsServiceError> {
     for (name, attr) in attrs {
         // Validate attribute name
@@ -3828,7 +3834,7 @@ fn is_valid_queue_name(name: &str) -> bool {
 /// AWS sorts attributes by name, then for each: encode name length (4 bytes BE),
 /// name bytes, data type length (4 bytes BE), data type bytes,
 /// then transport type (1=String, 2=Binary) and value length + value bytes.
-fn md5_of_message_attributes(attrs: &HashMap<String, MessageAttribute>) -> String {
+fn md5_of_message_attributes(attrs: &BTreeMap<String, MessageAttribute>) -> String {
     use md5::Digest;
     let mut sorted: Vec<(&String, &MessageAttribute)> = attrs.iter().collect();
     sorted.sort_by_key(|(k, _)| k.as_str());
@@ -3865,7 +3871,7 @@ fn md5_of_message_attributes(attrs: &HashMap<String, MessageAttribute>) -> Strin
 }
 
 /// Same as md5_of_message_attributes but works with borrowed references
-fn md5_of_message_attributes_from_refs(attrs: &HashMap<String, &MessageAttribute>) -> String {
+fn md5_of_message_attributes_from_refs(attrs: &BTreeMap<String, &MessageAttribute>) -> String {
     use md5::Digest;
     let mut sorted: Vec<(&String, &&MessageAttribute)> = attrs.iter().collect();
     sorted.sort_by_key(|(k, _)| k.as_str());
@@ -3977,8 +3983,8 @@ fn find_message_id_for_receipt(
 }
 
 /// Parse MessageSystemAttributes (e.g., AWSTraceHeader) from the request body.
-fn parse_message_system_attributes(body: &Value) -> HashMap<String, String> {
-    let mut result = HashMap::new();
+fn parse_message_system_attributes(body: &Value) -> BTreeMap<String, String> {
+    let mut result = BTreeMap::new();
 
     // JSON protocol
     if let Some(attrs) = body["MessageSystemAttributes"].as_object() {

--- a/crates/fakecloud-sqs/src/simulation.rs
+++ b/crates/fakecloud-sqs/src/simulation.rs
@@ -129,7 +129,7 @@ mod tests {
     use chrono::Duration;
     use fakecloud_core::multi_account::MultiAccountState;
     use parking_lot::RwLock;
-    use std::collections::{HashMap, VecDeque};
+    use std::collections::{BTreeMap, VecDeque};
     use std::sync::Arc;
 
     fn make_state() -> SharedSqsState {
@@ -147,8 +147,8 @@ mod tests {
             body: body.to_string(),
             md5_of_body: String::new(),
             sent_timestamp: 0,
-            attributes: HashMap::new(),
-            message_attributes: HashMap::new(),
+            attributes: BTreeMap::new(),
+            message_attributes: BTreeMap::new(),
             visible_at: None,
             receive_count,
             message_group_id: None,
@@ -163,7 +163,7 @@ mod tests {
         let s = accts.default_mut();
         let url = format!("http://localhost:4566/123456789012/{name}");
         let arn = format!("arn:aws:sqs:us-east-1:123456789012:{name}");
-        let mut attrs = HashMap::new();
+        let mut attrs = BTreeMap::new();
         if let Some(r) = retention {
             attrs.insert("MessageRetentionPeriod".to_string(), r.to_string());
         }
@@ -176,12 +176,12 @@ mod tests {
             inflight: Vec::new(),
             attributes: attrs,
             is_fifo: false,
-            dedup_cache: HashMap::new(),
+            dedup_cache: BTreeMap::new(),
             redrive_policy: None,
-            tags: HashMap::new(),
+            tags: BTreeMap::new(),
             next_sequence_number: 0,
             permission_labels: Vec::new(),
-            receipt_handle_map: HashMap::new(),
+            receipt_handle_map: BTreeMap::new(),
         };
         s.queues.insert(url.clone(), queue);
         s.name_to_url.insert(name.to_string(), url.clone());

--- a/crates/fakecloud-sqs/src/state.rs
+++ b/crates/fakecloud-sqs/src/state.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -19,8 +19,8 @@ pub struct SqsMessage {
     pub body: String,
     pub md5_of_body: String,
     pub sent_timestamp: i64,
-    pub attributes: HashMap<String, String>,
-    pub message_attributes: HashMap<String, MessageAttribute>,
+    pub attributes: BTreeMap<String, String>,
+    pub message_attributes: BTreeMap<String, MessageAttribute>,
     /// When this message becomes visible again (after ReceiveMessage)
     pub visible_at: Option<DateTime<Utc>>,
     pub receive_count: u32,
@@ -48,20 +48,20 @@ pub struct SqsQueue {
     pub created_at: DateTime<Utc>,
     pub messages: VecDeque<SqsMessage>,
     pub inflight: Vec<SqsMessage>,
-    pub attributes: HashMap<String, String>,
+    pub attributes: BTreeMap<String, String>,
     pub is_fifo: bool,
     /// For FIFO dedup: dedup_id -> expiry
-    pub dedup_cache: HashMap<String, DateTime<Utc>>,
+    pub dedup_cache: BTreeMap<String, DateTime<Utc>>,
     /// DLQ redrive policy
     pub redrive_policy: Option<RedrivePolicy>,
     /// Queue tags (key -> value)
-    pub tags: HashMap<String, String>,
+    pub tags: BTreeMap<String, String>,
     /// FIFO: next sequence number counter
     pub next_sequence_number: u64,
     /// Permission labels stored on the queue
     pub permission_labels: Vec<String>,
     /// Tracks message_id -> list of all receipt handles ever issued for that message
-    pub receipt_handle_map: HashMap<String, Vec<String>>,
+    pub receipt_handle_map: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -113,8 +113,8 @@ pub struct SqsState {
     pub account_id: String,
     pub region: String,
     pub endpoint: String,
-    pub queues: HashMap<String, SqsQueue>, // queue_url -> queue
-    pub name_to_url: HashMap<String, String>, // queue_name -> queue_url
+    pub queues: BTreeMap<String, SqsQueue>, // queue_url -> queue
+    pub name_to_url: BTreeMap<String, String>, // queue_name -> queue_url
     #[serde(default)]
     pub message_move_tasks: Vec<MessageMoveTask>,
 }
@@ -125,8 +125,8 @@ impl SqsState {
             account_id: account_id.to_string(),
             region: region.to_string(),
             endpoint: endpoint.to_string(),
-            queues: HashMap::new(),
-            name_to_url: HashMap::new(),
+            queues: BTreeMap::new(),
+            name_to_url: BTreeMap::new(),
             message_move_tasks: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

Phase E batch 5 (per audit 2026-04-28 §3): switch state.rs `HashMap` → `BTreeMap` for 3 more services so list-resource pagination has deterministic order.

- **iam**: state + service + evaluator + policy_evaluator + credential_resolver maps → BTreeMap (users, roles, groups, policies, inline_policies, principal_tags). Trait boundary `resource_tags_for` keeps `Option<HashMap<String,String>>` return.
- **kms**: state + service + hook maps → BTreeMap (keys, aliases, grants, tags). `resource_tags_for` converts at trait boundary.
- **sqs**: state + service + delivery + simulation maps → BTreeMap (queues, attributes, dedup_cache, receipt_handle_map, tags, message_attributes). `SqsDelivery::deliver_to_queue` trait sig stays `&HashMap<String, String>`; test fixtures use HashMap.

Server `reset.rs` `user_inline_policies` initial insert switches to `BTreeMap::from`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p fakecloud-iam -p fakecloud-kms -p fakecloud-sqs --lib` (378 + 134 + 129 tests pass)
- [x] `cargo clippy -p fakecloud-iam -p fakecloud-kms -p fakecloud-sqs --all-targets -- -D warnings`
- [ ] CI green + Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch internal maps from HashMap to BTreeMap in IAM, KMS, and SQS to make list/pagination order deterministic. External request/response shapes stay the same by converting at service boundaries.

- **Refactors**
  - `fakecloud-iam`: State maps (users, roles, groups, policies, inline/managed policies, principal tags) now use BTreeMap; evaluators and service updated; convert to HashMap at trait boundaries.
  - `fakecloud-kms`: Keys, aliases, custom key stores, and tags moved to BTreeMap; trait boundary returns still convert to HashMap.
  - `fakecloud-sqs`: Queues, attributes, tags, message_attributes, dedup_cache, and receipt_handle_map use BTreeMap; delivery trait unchanged; helpers/tests adjusted.
  - CloudFormation: SQS provisioner initializes BTreeMap fields; EventBridge EventBus tags stay HashMap to match unchanged state. `fakecloud-server` reset uses BTreeMap for inline policies.

<sup>Written for commit 4b0c91e1c5a4fee47fd3233f97506e4ed27fec2c. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/866?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

