### PR TITLE
feat(ecs): implement Daemon + ExpressGatewayService 2026 ops

### DIFF
--- a/crates/fakecloud-conformance/tests/ecs.rs
+++ b/crates/fakecloud-conformance/tests/ecs.rs
@@ -1534,3 +1534,343 @@ async fn ecs_describe_service_revisions() {
         .unwrap();
     resp.service_revisions();
 }
+
+// ── Daemon + ExpressGatewayService conformance (2026 ops) ───────────────
+
+async fn create_default_cluster(client: &aws_sdk_ecs::Client) {
+    client
+        .create_cluster()
+        .cluster_name("default")
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn register_daemon_td_arn(client: &aws_sdk_ecs::Client, family: &str) -> String {
+    use aws_sdk_ecs::types::DaemonContainerDefinition;
+    let container = DaemonContainerDefinition::builder()
+        .name("agent")
+        .image("nginx:latest")
+        .build()
+        .unwrap();
+    let resp = client
+        .register_daemon_task_definition()
+        .family(family)
+        .container_definitions(container)
+        .send()
+        .await
+        .unwrap();
+    resp.daemon_task_definition_arn().unwrap().to_string()
+}
+
+#[test_action("ecs", "RegisterDaemonTaskDefinition", checksum = "d0a5705c")]
+#[tokio::test]
+async fn ecs_register_daemon_task_definition() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    let arn = register_daemon_td_arn(&client, "daemon-conf-register").await;
+    assert!(arn.contains(":daemon-task-definition/"));
+}
+
+#[test_action("ecs", "DescribeDaemonTaskDefinition", checksum = "ae657c0d")]
+#[tokio::test]
+async fn ecs_describe_daemon_task_definition() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    let arn = register_daemon_td_arn(&client, "daemon-conf-desc").await;
+    let resp = client
+        .describe_daemon_task_definition()
+        .daemon_task_definition(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.daemon_task_definition().is_some());
+}
+
+#[test_action("ecs", "DeleteDaemonTaskDefinition", checksum = "cbd6b909")]
+#[tokio::test]
+async fn ecs_delete_daemon_task_definition() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    let arn = register_daemon_td_arn(&client, "daemon-conf-del").await;
+    let resp = client
+        .delete_daemon_task_definition()
+        .daemon_task_definition(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.daemon_task_definition_arn().is_some());
+}
+
+#[test_action("ecs", "ListDaemonTaskDefinitions", checksum = "b6ebee95")]
+#[tokio::test]
+async fn ecs_list_daemon_task_definitions() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    register_daemon_td_arn(&client, "daemon-conf-list").await;
+    let resp = client.list_daemon_task_definitions().send().await.unwrap();
+    assert!(!resp.daemon_task_definitions().is_empty());
+}
+
+async fn create_daemon_with_arn(client: &aws_sdk_ecs::Client, name: &str) -> String {
+    let arn = register_daemon_td_arn(client, name).await;
+    let resp = client
+        .create_daemon()
+        .daemon_name(name)
+        .daemon_task_definition_arn(arn)
+        .capacity_provider_arns("FARGATE")
+        .send()
+        .await
+        .unwrap();
+    resp.daemon_arn().unwrap().to_string()
+}
+
+#[test_action("ecs", "CreateDaemon", checksum = "8b96e9bf")]
+#[tokio::test]
+async fn ecs_create_daemon() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let arn = create_daemon_with_arn(&client, "conf-create").await;
+    assert!(arn.contains(":daemon/"));
+}
+
+#[test_action("ecs", "DescribeDaemon", checksum = "af1141c6")]
+#[tokio::test]
+async fn ecs_describe_daemon() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let arn = create_daemon_with_arn(&client, "conf-desc-d").await;
+    let resp = client
+        .describe_daemon()
+        .daemon_arn(arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.daemon().is_some());
+}
+
+#[test_action("ecs", "UpdateDaemon", checksum = "87f1f95b")]
+#[tokio::test]
+async fn ecs_update_daemon() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let arn = create_daemon_with_arn(&client, "conf-upd").await;
+    let new_td = register_daemon_td_arn(&client, "conf-upd").await;
+    let resp = client
+        .update_daemon()
+        .daemon_arn(arn)
+        .daemon_task_definition_arn(new_td)
+        .capacity_provider_arns("FARGATE")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.daemon_arn().is_some());
+}
+
+#[test_action("ecs", "DeleteDaemon", checksum = "b10fefb1")]
+#[tokio::test]
+async fn ecs_delete_daemon() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let arn = create_daemon_with_arn(&client, "conf-del-d").await;
+    let resp = client.delete_daemon().daemon_arn(arn).send().await.unwrap();
+    assert!(resp.daemon_arn().is_some());
+}
+
+#[test_action("ecs", "ListDaemons", checksum = "7f97207d")]
+#[tokio::test]
+async fn ecs_list_daemons() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    create_daemon_with_arn(&client, "conf-list-d").await;
+    let resp = client.list_daemons().send().await.unwrap();
+    assert!(!resp.daemon_summaries_list().is_empty());
+}
+
+async fn create_daemon_get_deployment(
+    client: &aws_sdk_ecs::Client,
+    name: &str,
+) -> (String, String) {
+    let td = register_daemon_td_arn(client, name).await;
+    let resp = client
+        .create_daemon()
+        .daemon_name(name)
+        .daemon_task_definition_arn(td)
+        .capacity_provider_arns("FARGATE")
+        .send()
+        .await
+        .unwrap();
+    (
+        resp.daemon_arn().unwrap().to_string(),
+        resp.deployment_arn().unwrap().to_string(),
+    )
+}
+
+#[test_action("ecs", "DescribeDaemonDeployments", checksum = "d0f1127a")]
+#[tokio::test]
+async fn ecs_describe_daemon_deployments() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let (_d, dep) = create_daemon_get_deployment(&client, "conf-desc-deps").await;
+    let resp = client
+        .describe_daemon_deployments()
+        .daemon_deployment_arns(dep)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.daemon_deployments().is_empty());
+}
+
+#[test_action("ecs", "ListDaemonDeployments", checksum = "842a7d48")]
+#[tokio::test]
+async fn ecs_list_daemon_deployments() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let (d_arn, _) = create_daemon_get_deployment(&client, "conf-list-deps").await;
+    let resp = client
+        .list_daemon_deployments()
+        .daemon_arn(d_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.daemon_deployments().is_empty());
+}
+
+#[test_action("ecs", "DescribeDaemonRevisions", checksum = "4eb9e0f0")]
+#[tokio::test]
+async fn ecs_describe_daemon_revisions() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let (_d, dep) = create_daemon_get_deployment(&client, "conf-desc-revs").await;
+    let resp = client
+        .describe_daemon_revisions()
+        .daemon_revision_arns(dep)
+        .send()
+        .await
+        .unwrap();
+    assert!(!resp.daemon_revisions().is_empty());
+}
+
+fn primary_eg_container() -> aws_sdk_ecs::types::ExpressGatewayContainer {
+    aws_sdk_ecs::types::ExpressGatewayContainer::builder()
+        .image("nginx:latest")
+        .build()
+        .unwrap()
+}
+
+#[test_action("ecs", "CreateExpressGatewayService", checksum = "af2d07b8")]
+#[tokio::test]
+async fn ecs_create_express_gateway_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let resp = client
+        .create_express_gateway_service()
+        .execution_role_arn("arn:aws:iam::000000000000:role/execution")
+        .infrastructure_role_arn("arn:aws:iam::000000000000:role/infra")
+        .service_name("eg-conf-create")
+        .primary_container(primary_eg_container())
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service().is_some());
+}
+
+#[test_action("ecs", "DescribeExpressGatewayService", checksum = "a9f14d47")]
+#[tokio::test]
+async fn ecs_describe_express_gateway_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let created = client
+        .create_express_gateway_service()
+        .execution_role_arn("arn:aws:iam::000000000000:role/execution")
+        .infrastructure_role_arn("arn:aws:iam::000000000000:role/infra")
+        .service_name("eg-conf-desc")
+        .primary_container(primary_eg_container())
+        .send()
+        .await
+        .unwrap();
+    let eg_arn = created
+        .service()
+        .unwrap()
+        .service_arn()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .describe_express_gateway_service()
+        .service_arn(eg_arn.clone())
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service().is_some());
+}
+
+#[test_action("ecs", "UpdateExpressGatewayService", checksum = "e7d45f06")]
+#[tokio::test]
+async fn ecs_update_express_gateway_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let created = client
+        .create_express_gateway_service()
+        .execution_role_arn("arn:aws:iam::000000000000:role/execution")
+        .infrastructure_role_arn("arn:aws:iam::000000000000:role/infra")
+        .service_name("eg-conf-upd")
+        .primary_container(primary_eg_container())
+        .send()
+        .await
+        .unwrap();
+    let eg_arn = created
+        .service()
+        .unwrap()
+        .service_arn()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .update_express_gateway_service()
+        .service_arn(eg_arn.clone())
+        .cpu("512")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service().is_some());
+}
+
+#[test_action("ecs", "DeleteExpressGatewayService", checksum = "d9132bdf")]
+#[tokio::test]
+async fn ecs_delete_express_gateway_service() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    create_default_cluster(&client).await;
+    let created = client
+        .create_express_gateway_service()
+        .execution_role_arn("arn:aws:iam::000000000000:role/execution")
+        .infrastructure_role_arn("arn:aws:iam::000000000000:role/infra")
+        .service_name("eg-conf-del")
+        .primary_container(primary_eg_container())
+        .send()
+        .await
+        .unwrap();
+    let eg_arn = created
+        .service()
+        .unwrap()
+        .service_arn()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .delete_express_gateway_service()
+        .service_arn(eg_arn.clone())
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.service().is_some());
+}

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -40,6 +40,14 @@ pub(crate) fn is_mutating(action: &str) -> bool {
             | "SubmitTaskStateChange"
             | "SubmitAttachmentStateChanges"
             | "StopServiceDeployment"
+            | "RegisterDaemonTaskDefinition"
+            | "DeleteDaemonTaskDefinition"
+            | "CreateDaemon"
+            | "UpdateDaemon"
+            | "DeleteDaemon"
+            | "CreateExpressGatewayService"
+            | "UpdateExpressGatewayService"
+            | "DeleteExpressGatewayService"
     )
 }
 

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -77,6 +77,22 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ListServiceDeployments",
     "DescribeServiceDeployments",
     "DescribeServiceRevisions",
+    "RegisterDaemonTaskDefinition",
+    "DescribeDaemonTaskDefinition",
+    "DeleteDaemonTaskDefinition",
+    "ListDaemonTaskDefinitions",
+    "CreateDaemon",
+    "DescribeDaemon",
+    "UpdateDaemon",
+    "DeleteDaemon",
+    "ListDaemons",
+    "DescribeDaemonDeployments",
+    "ListDaemonDeployments",
+    "DescribeDaemonRevisions",
+    "CreateExpressGatewayService",
+    "DescribeExpressGatewayService",
+    "UpdateExpressGatewayService",
+    "DeleteExpressGatewayService",
 ];
 
 pub struct EcsService {
@@ -226,6 +242,22 @@ impl AwsService for EcsService {
             "ListServiceDeployments" => self.list_service_deployments(&request),
             "DescribeServiceDeployments" => self.describe_service_deployments(&request),
             "DescribeServiceRevisions" => self.describe_service_revisions(&request),
+            "RegisterDaemonTaskDefinition" => self.register_daemon_task_definition(&request),
+            "DescribeDaemonTaskDefinition" => self.describe_daemon_task_definition(&request),
+            "DeleteDaemonTaskDefinition" => self.delete_daemon_task_definition(&request),
+            "ListDaemonTaskDefinitions" => self.list_daemon_task_definitions(&request),
+            "CreateDaemon" => self.create_daemon(&request),
+            "DescribeDaemon" => self.describe_daemon(&request),
+            "UpdateDaemon" => self.update_daemon(&request),
+            "DeleteDaemon" => self.delete_daemon(&request),
+            "ListDaemons" => self.list_daemons(&request),
+            "DescribeDaemonDeployments" => self.describe_daemon_deployments(&request),
+            "ListDaemonDeployments" => self.list_daemon_deployments(&request),
+            "DescribeDaemonRevisions" => self.describe_daemon_revisions(&request),
+            "CreateExpressGatewayService" => self.create_express_gateway_service(&request),
+            "DescribeExpressGatewayService" => self.describe_express_gateway_service(&request),
+            "UpdateExpressGatewayService" => self.update_express_gateway_service(&request),
+            "DeleteExpressGatewayService" => self.delete_express_gateway_service(&request),
             _ => Err(AwsServiceError::action_not_implemented(
                 "ecs",
                 &request.action,
@@ -278,6 +310,12 @@ mod service_services_resource;
 
 #[path = "service_container_instances_etc.rs"]
 mod service_container_instances_etc;
+
+#[path = "service_daemons.rs"]
+mod service_daemons;
+
+#[path = "service_express_gateway.rs"]
+mod service_express_gateway;
 
 #[path = "helpers.rs"]
 mod helpers;

--- a/crates/fakecloud-ecs/src/service_daemons.rs
+++ b/crates/fakecloud-ecs/src/service_daemons.rs
@@ -1,0 +1,769 @@
+// Daemon and DaemonTaskDefinition operations.
+//
+// AWS shipped Daemon services (DaemonSet-style scheduling, one task per
+// matching capacity provider) and a dedicated DaemonTaskDefinition
+// shape in late 2025. Implemented here against the same dispatcher
+// pattern as Service / TaskDefinition.
+
+#![allow(clippy::too_many_arguments)]
+
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+
+use fakecloud_core::pagination::paginate;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use super::*;
+use crate::state::{Daemon, DaemonDeployment, DaemonTaskDefinition};
+
+impl EcsService {
+    pub(super) fn register_daemon_task_definition(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let family = req_str(&body, "family")?.to_string();
+        let containers = body
+            .get("containerDefinitions")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ClientException",
+                    "containerDefinitions is required",
+                )
+            })?
+            .clone();
+        let task_role_arn = body
+            .get("taskRoleArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let execution_role_arn = body
+            .get("executionRoleArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let cpu = body.get("cpu").and_then(|v| v.as_str()).map(String::from);
+        let memory = body
+            .get("memory")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let volumes = body
+            .get("volumes")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let tags = parse_tags(&body);
+
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+        let revision = s.allocate_daemon_revision(&family);
+        let arn = s.daemon_task_definition_arn(&family, revision);
+
+        let def = DaemonTaskDefinition {
+            family: family.clone(),
+            revision,
+            task_definition_arn: arn.clone(),
+            status: "ACTIVE".to_string(),
+            container_definitions: containers,
+            task_role_arn,
+            execution_role_arn,
+            cpu,
+            memory,
+            volumes,
+            registered_at: Utc::now(),
+            deregistered_at: None,
+            tags,
+        };
+
+        s.daemon_task_definitions
+            .entry(family.clone())
+            .or_default()
+            .insert(revision, def.clone());
+
+        let arn_clone = def.task_definition_arn.clone();
+        Ok(AwsResponse::ok_json(json!({
+            "daemonTaskDefinitionArn": arn_clone,
+        })))
+    }
+
+    pub(super) fn describe_daemon_task_definition(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let identifier = req_str(&body, "daemonTaskDefinition")?.to_string();
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let def = lookup_daemon_task_definition(&s, &identifier).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Daemon task definition {} not found", identifier),
+            )
+        })?;
+        Ok(AwsResponse::ok_json(json!({
+            "daemonTaskDefinition": daemon_task_definition_json(&def),
+        })))
+    }
+
+    pub(super) fn delete_daemon_task_definition(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let identifier = req_str(&body, "daemonTaskDefinition")?.to_string();
+        let mut accounts = self.state.write();
+        let s = accounts.get_or_create(&request.account_id);
+        let arn = if let Some(def) = lookup_daemon_task_definition_mut(s, &identifier) {
+            def.status = "DELETE_IN_PROGRESS".to_string();
+            def.deregistered_at = Some(Utc::now());
+            def.task_definition_arn.clone()
+        } else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Daemon task definition {} not found", identifier),
+            ));
+        };
+        Ok(AwsResponse::ok_json(json!({
+            "daemonTaskDefinitionArn": arn,
+        })))
+    }
+
+    pub(super) fn list_daemon_task_definitions(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let family_prefix = body
+            .get("familyPrefix")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let status_filter = body
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ACTIVE")
+            .to_string();
+        let max_results = body
+            .get("maxResults")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(100) as usize;
+        let next_token = body
+            .get("nextToken")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let mut summaries: Vec<DaemonTaskDefinition> = Vec::new();
+        for (family, revisions) in &s.daemon_task_definitions {
+            if let Some(prefix) = &family_prefix {
+                if !family.starts_with(prefix) {
+                    continue;
+                }
+            }
+            for def in revisions.values() {
+                if def.status == status_filter {
+                    summaries.push(def.clone());
+                }
+            }
+        }
+        summaries.sort_by(|a, b| a.task_definition_arn.cmp(&b.task_definition_arn));
+
+        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        let json_page: Vec<Value> = page
+            .iter()
+            .map(daemon_task_definition_summary_json)
+            .collect();
+        Ok(AwsResponse::ok_json(json!({
+            "daemonTaskDefinitions": json_page,
+            "nextToken": token,
+        })))
+    }
+
+    pub(super) fn create_daemon(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let daemon_name = req_str(&body, "daemonName")?.to_string();
+        let task_definition_arn = req_str(&body, "daemonTaskDefinitionArn")?.to_string();
+        let cluster_input = body.get("clusterArn").and_then(|v| v.as_str());
+        let capacity_provider_arns: Vec<String> = body
+            .get("capacityProviderArns")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ClientException",
+                    "capacityProviderArns is required",
+                )
+            })?
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect();
+
+        let deployment_configuration = body.get("deploymentConfiguration").cloned();
+        let propagate_tags = body
+            .get("propagateTags")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let enable_ecs_managed_tags = body
+            .get("enableECSManagedTags")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let enable_execute_command = body
+            .get("enableExecuteCommand")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let client_token = body
+            .get("clientToken")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let tags = parse_tags(&body);
+
+        let now = Utc::now();
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+        let cluster_name = cluster_arn_to_name(cluster_input.unwrap_or("default"));
+        let cluster_arn = s.cluster_arn(&cluster_name);
+
+        if !s.clusters.contains_key(&cluster_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClusterNotFoundException",
+                format!("Cluster {} not found", cluster_name),
+            ));
+        }
+
+        let key = EcsState::daemon_key(&cluster_name, &daemon_name);
+        if s.daemons.contains_key(&key) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!(
+                    "Daemon {} already exists in cluster {}",
+                    daemon_name, cluster_name
+                ),
+            ));
+        }
+
+        let daemon_arn = s.daemon_arn(&cluster_name, &daemon_name);
+        let deployment_id = uuid::Uuid::new_v4().to_string();
+        let deployment_arn = s.daemon_deployment_arn(&daemon_name, &deployment_id);
+
+        let deployment = DaemonDeployment {
+            deployment_arn: deployment_arn.clone(),
+            daemon_arn: daemon_arn.clone(),
+            daemon_name: daemon_name.clone(),
+            cluster_arn: cluster_arn.clone(),
+            task_definition_arn: task_definition_arn.clone(),
+            status: "PRIMARY".to_string(),
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+        };
+
+        let daemon = Daemon {
+            daemon_name: daemon_name.clone(),
+            daemon_arn: daemon_arn.clone(),
+            cluster_arn,
+            cluster_name,
+            daemon_task_definition_arn: task_definition_arn.clone(),
+            status: "ACTIVE".to_string(),
+            deployment_arn: deployment_arn.clone(),
+            created_at: now,
+            updated_at: now,
+            capacity_provider_arns,
+            deployment_configuration,
+            propagate_tags,
+            enable_ecs_managed_tags,
+            enable_execute_command,
+            client_token,
+            tags,
+            deployment_history: vec![deployment_arn.clone()],
+        };
+
+        s.daemons.insert(key, daemon);
+        s.daemon_deployments
+            .insert(deployment_arn.clone(), deployment);
+
+        Ok(AwsResponse::ok_json(json!({
+            "daemonArn": daemon_arn,
+            "status": "ACTIVE",
+            "createdAt": now.timestamp() as f64 + now.timestamp_subsec_micros() as f64 / 1_000_000.0,
+            "deploymentArn": deployment_arn,
+        })))
+    }
+
+    pub(super) fn describe_daemon(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let daemon_arn = req_str(&body, "daemonArn")?.to_string();
+
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+
+        let daemon = lookup_daemon_by_arn(&s, &daemon_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Daemon {} not found", daemon_arn),
+            )
+        })?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "daemon": daemon_json(&daemon),
+        })))
+    }
+
+    pub(super) fn update_daemon(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let daemon_arn = req_str(&body, "daemonArn")?.to_string();
+        let new_task_def = Some(req_str(&body, "daemonTaskDefinitionArn")?.to_string());
+        let new_caps: Option<Vec<String>> = body
+            .get("capacityProviderArns")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(String::from))
+                    .collect()
+            });
+
+        let now = Utc::now();
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+
+        let key = lookup_daemon_key_by_arn(s, &daemon_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Daemon {} not found", daemon_arn),
+            )
+        })?;
+
+        // Mint a new deployment if task definition changed.
+        let mut new_deployment_arn: Option<String> = None;
+        if let Some(td_arn) = new_task_def.clone() {
+            let daemon_name = s
+                .daemons
+                .get(&key)
+                .map(|d| d.daemon_name.clone())
+                .unwrap_or_default();
+            let cluster_arn = s
+                .daemons
+                .get(&key)
+                .map(|d| d.cluster_arn.clone())
+                .unwrap_or_default();
+            let daemon_arn = s
+                .daemons
+                .get(&key)
+                .map(|d| d.daemon_arn.clone())
+                .unwrap_or_default();
+            let deployment_id = uuid::Uuid::new_v4().to_string();
+            let deployment_arn = s.daemon_deployment_arn(&daemon_name, &deployment_id);
+            let revision = s
+                .daemons
+                .get(&key)
+                .map(|d| d.deployment_history.len() as i64 + 1)
+                .unwrap_or(1);
+            let deployment = DaemonDeployment {
+                deployment_arn: deployment_arn.clone(),
+                daemon_arn,
+                daemon_name,
+                cluster_arn,
+                task_definition_arn: td_arn,
+                status: "PRIMARY".to_string(),
+                revision,
+                created_at: now,
+                updated_at: now,
+            };
+            s.daemon_deployments
+                .insert(deployment_arn.clone(), deployment);
+            new_deployment_arn = Some(deployment_arn);
+        }
+
+        let daemon = s.daemons.get_mut(&key).unwrap();
+        if let Some(td) = new_task_def {
+            daemon.daemon_task_definition_arn = td;
+        }
+        if let Some(caps) = new_caps {
+            daemon.capacity_provider_arns = caps;
+        }
+        if let Some(dep_arn) = new_deployment_arn {
+            daemon.deployment_arn = dep_arn.clone();
+            daemon.deployment_history.push(dep_arn);
+        }
+        daemon.updated_at = now;
+
+        let snapshot = daemon.clone();
+        Ok(AwsResponse::ok_json(json!({
+            "daemonArn": snapshot.daemon_arn,
+            "status": snapshot.status,
+            "createdAt": snapshot.created_at.timestamp() as f64
+                + snapshot.created_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+            "updatedAt": snapshot.updated_at.timestamp() as f64
+                + snapshot.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+            "deploymentArn": snapshot.deployment_arn,
+        })))
+    }
+
+    pub(super) fn delete_daemon(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let daemon_arn = req_str(&body, "daemonArn")?.to_string();
+
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+
+        let key = lookup_daemon_key_by_arn(s, &daemon_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Daemon {} not found", daemon_arn),
+            )
+        })?;
+        let mut daemon = s.daemons.remove(&key).unwrap();
+        daemon.status = "DRAINING".to_string();
+        daemon.updated_at = Utc::now();
+        Ok(AwsResponse::ok_json(json!({
+            "daemonArn": daemon.daemon_arn,
+            "status": daemon.status,
+            "createdAt": daemon.created_at.timestamp() as f64
+                + daemon.created_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+            "updatedAt": daemon.updated_at.timestamp() as f64
+                + daemon.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+            "deploymentArn": daemon.deployment_arn,
+        })))
+    }
+
+    pub(super) fn list_daemons(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let cluster_input = body.get("clusterArn").and_then(|v| v.as_str());
+        let max_results = body
+            .get("maxResults")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(100) as usize;
+        let next_token = body
+            .get("nextToken")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let cluster_name = cluster_input.map(cluster_arn_to_name);
+
+        let mut summaries: Vec<Value> = Vec::new();
+        for daemon in s.daemons.values() {
+            if let Some(target) = &cluster_name {
+                if &daemon.cluster_name != target {
+                    continue;
+                }
+            }
+            summaries.push(json!({
+                "daemonArn": daemon.daemon_arn,
+                "daemonName": daemon.daemon_name,
+                "clusterArn": daemon.cluster_arn,
+                "status": daemon.status,
+                "deploymentArn": daemon.deployment_arn,
+            }));
+        }
+        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        Ok(AwsResponse::ok_json(json!({
+            "daemonSummariesList": page,
+            "nextToken": token,
+        })))
+    }
+
+    pub(super) fn describe_daemon_deployments(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let arns: Vec<String> = body
+            .get("daemonDeploymentArns")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let mut found = Vec::new();
+        let mut failures = Vec::new();
+        for arn in arns {
+            if let Some(d) = s.daemon_deployments.get(&arn) {
+                found.push(daemon_deployment_json(d));
+            } else {
+                failures.push(json!({
+                    "arn": arn,
+                    "reason": "MISSING",
+                }));
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({
+            "daemonDeployments": found,
+            "failures": failures,
+        })))
+    }
+
+    pub(super) fn list_daemon_deployments(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let daemon_filter = body
+            .get("daemonArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let cluster_input: Option<&str> = None;
+        let max_results = body
+            .get("maxResults")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(100) as usize;
+        let next_token = body
+            .get("nextToken")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let cluster_name = cluster_input.map(cluster_arn_to_name);
+
+        let mut summaries: Vec<Value> = Vec::new();
+        for d in s.daemon_deployments.values() {
+            if let Some(target) = &cluster_name {
+                let dc = cluster_arn_to_name(&d.cluster_arn);
+                if &dc != target {
+                    continue;
+                }
+            }
+            if let Some(filter) = &daemon_filter {
+                if &d.daemon_name != filter && &d.daemon_arn != filter {
+                    continue;
+                }
+            }
+            summaries.push(daemon_deployment_json(d));
+        }
+        let (page, token) = paginate(&summaries, next_token.as_deref(), max_results);
+        Ok(AwsResponse::ok_json(json!({
+            "daemonDeployments": page,
+            "nextToken": token,
+        })))
+    }
+
+    pub(super) fn describe_daemon_revisions(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let arns: Vec<String> = body
+            .get("daemonRevisionArns")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+
+        let mut revisions = Vec::new();
+        let mut failures = Vec::new();
+        for arn in arns {
+            if let Some(d) = s.daemon_deployments.get(&arn) {
+                revisions.push(daemon_deployment_json(d));
+            } else {
+                failures.push(json!({"arn": arn, "reason": "MISSING"}));
+            }
+        }
+
+        Ok(AwsResponse::ok_json(json!({
+            "daemonRevisions": revisions,
+            "failures": failures,
+        })))
+    }
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────
+
+fn cluster_arn_to_name(arn_or_name: &str) -> String {
+    if let Some(idx) = arn_or_name.rfind('/') {
+        arn_or_name[idx + 1..].to_string()
+    } else {
+        arn_or_name.to_string()
+    }
+}
+
+fn lookup_daemon_by_arn(s: &crate::state::EcsState, arn: &str) -> Option<Daemon> {
+    s.daemons.values().find(|d| d.daemon_arn == arn).cloned()
+}
+
+fn lookup_daemon_key_by_arn(s: &crate::state::EcsState, arn: &str) -> Option<String> {
+    for (k, d) in &s.daemons {
+        if d.daemon_arn == arn {
+            return Some(k.clone());
+        }
+    }
+    None
+}
+
+fn lookup_daemon_task_definition(
+    s: &crate::state::EcsState,
+    identifier: &str,
+) -> Option<DaemonTaskDefinition> {
+    if let Some((family, revision)) = parse_family_revision(identifier) {
+        return s
+            .daemon_task_definitions
+            .get(&family)
+            .and_then(|m| m.get(&revision))
+            .cloned();
+    }
+    s.daemon_task_definitions
+        .values()
+        .flat_map(|m| m.values())
+        .find(|d| d.task_definition_arn == identifier)
+        .cloned()
+}
+
+fn lookup_daemon_task_definition_mut<'a>(
+    s: &'a mut crate::state::EcsState,
+    identifier: &str,
+) -> Option<&'a mut DaemonTaskDefinition> {
+    if let Some((family, revision)) = parse_family_revision(identifier) {
+        return s
+            .daemon_task_definitions
+            .get_mut(&family)
+            .and_then(|m| m.get_mut(&revision));
+    }
+    for m in s.daemon_task_definitions.values_mut() {
+        for d in m.values_mut() {
+            if d.task_definition_arn == identifier {
+                return Some(d);
+            }
+        }
+    }
+    None
+}
+
+/// Parse `family:revision` (or its trailing form within an ARN) into
+/// `(family, revision)`. Returns None if the input is just a family
+/// or otherwise malformed.
+fn parse_family_revision(s: &str) -> Option<(String, i32)> {
+    let (head, rev_str) = s.rsplit_once(':')?;
+    let rev: i32 = rev_str.parse().ok()?;
+    let family = match head.rsplit_once('/') {
+        Some((_, f)) => f,
+        None => head,
+    };
+    Some((family.to_string(), rev))
+}
+
+fn daemon_task_definition_json(d: &DaemonTaskDefinition) -> Value {
+    json!({
+        "family": d.family,
+        "revision": d.revision,
+        "taskDefinitionArn": d.task_definition_arn,
+        "status": d.status,
+        "containerDefinitions": d.container_definitions,
+        "taskRoleArn": d.task_role_arn,
+        "executionRoleArn": d.execution_role_arn,
+        "cpu": d.cpu,
+        "memory": d.memory,
+        "volumes": d.volumes,
+        "registeredAt": d.registered_at.timestamp() as f64
+            + d.registered_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "deregisteredAt": d.deregistered_at.map(|t|
+            t.timestamp() as f64 + t.timestamp_subsec_micros() as f64 / 1_000_000.0),
+        "tags": d.tags.iter().map(|t| json!({"key": t.key, "value": t.value})).collect::<Vec<_>>(),
+    })
+}
+
+fn daemon_task_definition_summary_json(d: &DaemonTaskDefinition) -> Value {
+    json!({
+        "arn": d.task_definition_arn,
+        "registeredAt": d.registered_at.timestamp() as f64
+            + d.registered_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "deleteRequestedAt": d.deregistered_at.map(|t|
+            t.timestamp() as f64 + t.timestamp_subsec_micros() as f64 / 1_000_000.0),
+        "status": d.status,
+    })
+}
+
+fn daemon_json(d: &Daemon) -> Value {
+    json!({
+        "daemonName": d.daemon_name,
+        "daemonArn": d.daemon_arn,
+        "clusterArn": d.cluster_arn,
+        "daemonTaskDefinitionArn": d.daemon_task_definition_arn,
+        "status": d.status,
+        "deploymentArn": d.deployment_arn,
+        "createdAt": d.created_at.timestamp() as f64
+            + d.created_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "updatedAt": d.updated_at.timestamp() as f64
+            + d.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "capacityProviderArns": d.capacity_provider_arns,
+        "deploymentConfiguration": d.deployment_configuration,
+        "propagateTags": d.propagate_tags,
+        "enableECSManagedTags": d.enable_ecs_managed_tags,
+        "enableExecuteCommand": d.enable_execute_command,
+        "tags": d.tags.iter().map(|t| json!({"key": t.key, "value": t.value})).collect::<Vec<_>>(),
+    })
+}
+
+fn daemon_deployment_json(d: &DaemonDeployment) -> Value {
+    json!({
+        "deploymentArn": d.deployment_arn,
+        "daemonArn": d.daemon_arn,
+        "daemonName": d.daemon_name,
+        "clusterArn": d.cluster_arn,
+        "taskDefinitionArn": d.task_definition_arn,
+        "status": d.status,
+        "revision": d.revision,
+        "createdAt": d.created_at.timestamp() as f64
+            + d.created_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "updatedAt": d.updated_at.timestamp() as f64
+            + d.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+    })
+}

--- a/crates/fakecloud-ecs/src/service_express_gateway.rs
+++ b/crates/fakecloud-ecs/src/service_express_gateway.rs
@@ -1,0 +1,270 @@
+// 2026 Express Gateway service ops. Express Gateway is a serverless
+// container service with built-in load balancing and autoscaling. The
+// CRUD ops here record the spec; runtime semantics (scheduling tasks,
+// load-balancing requests) are intentionally not modeled — the
+// fakecloud control plane only round-trips configuration.
+
+#![allow(clippy::too_many_arguments)]
+
+use chrono::Utc;
+use http::StatusCode;
+use serde_json::{json, Value};
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use super::*;
+use crate::state::ExpressGatewayService;
+
+impl EcsService {
+    pub(super) fn create_express_gateway_service(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let execution_role_arn = req_str(&body, "executionRoleArn")?.to_string();
+        let infrastructure_role_arn = req_str(&body, "infrastructureRoleArn")?.to_string();
+        let primary_container = body.get("primaryContainer").cloned().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                "primaryContainer is required",
+            )
+        })?;
+        let service_name = body
+            .get("serviceName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("eg-{}", uuid::Uuid::new_v4()));
+
+        let task_role_arn = body
+            .get("taskRoleArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let network_configuration = body.get("networkConfiguration").cloned();
+        let health_check_path = body
+            .get("healthCheckPath")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let cpu = body.get("cpu").and_then(|v| v.as_str()).map(String::from);
+        let memory = body
+            .get("memory")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let scaling_target = body.get("scalingTarget").cloned();
+        let tags = parse_tags(&body);
+        let cluster_input = body.get("cluster").and_then(|v| v.as_str());
+
+        let now = Utc::now();
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+        let cluster_name = cluster_arn_to_name(cluster_input.unwrap_or("default"));
+
+        if !s.clusters.contains_key(&cluster_name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClusterNotFoundException",
+                format!("Cluster {} not found", cluster_name),
+            ));
+        }
+
+        let key = EcsState::express_gateway_key(&cluster_name, &service_name);
+        if s.express_gateway_services.contains_key(&key) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!(
+                    "Express Gateway service {} already exists in cluster {}",
+                    service_name, cluster_name
+                ),
+            ));
+        }
+
+        let service_arn = s.express_gateway_arn(&cluster_name, &service_name);
+        let cluster_arn = s.cluster_arn(&cluster_name);
+
+        let svc = ExpressGatewayService {
+            service_name: service_name.clone(),
+            service_arn: service_arn.clone(),
+            cluster_arn,
+            cluster_name,
+            status: "ACTIVE".to_string(),
+            execution_role_arn,
+            infrastructure_role_arn,
+            task_role_arn,
+            primary_container,
+            network_configuration,
+            health_check_path,
+            cpu,
+            memory,
+            scaling_target,
+            created_at: now,
+            updated_at: now,
+            tags,
+        };
+        s.express_gateway_services.insert(key, svc.clone());
+
+        Ok(AwsResponse::ok_json(json!({
+            "service": express_gateway_service_json(&svc),
+        })))
+    }
+
+    pub(super) fn describe_express_gateway_service(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let identifier = req_str(&body, "serviceArn")?.to_string();
+
+        let accounts = self.state.read();
+        let s = accounts
+            .get(&request.account_id)
+            .cloned()
+            .unwrap_or_else(|| accounts.default_ref().clone());
+        let svc = lookup_express_gateway_by_arn(&s, &identifier).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Express Gateway service {} not found", identifier),
+            )
+        })?;
+        Ok(AwsResponse::ok_json(json!({
+            "service": express_gateway_service_json(&svc),
+        })))
+    }
+
+    pub(super) fn update_express_gateway_service(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let identifier = req_str(&body, "serviceArn")?.to_string();
+
+        let now = Utc::now();
+
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+        let key = lookup_express_gateway_key_by_arn(s, &identifier).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Express Gateway service {} not found", identifier),
+            )
+        })?;
+
+        let svc = s.express_gateway_services.get_mut(&key).unwrap();
+        if let Some(v) = body.get("primaryContainer").cloned() {
+            svc.primary_container = v;
+        }
+        if let Some(v) = body.get("taskRoleArn").and_then(|v| v.as_str()) {
+            svc.task_role_arn = Some(v.to_string());
+        }
+        if let Some(v) = body.get("networkConfiguration").cloned() {
+            svc.network_configuration = Some(v);
+        }
+        if let Some(v) = body.get("healthCheckPath").and_then(|v| v.as_str()) {
+            svc.health_check_path = Some(v.to_string());
+        }
+        if let Some(v) = body.get("cpu").and_then(|v| v.as_str()) {
+            svc.cpu = Some(v.to_string());
+        }
+        if let Some(v) = body.get("memory").and_then(|v| v.as_str()) {
+            svc.memory = Some(v.to_string());
+        }
+        if let Some(v) = body.get("scalingTarget").cloned() {
+            svc.scaling_target = Some(v);
+        }
+        svc.updated_at = now;
+
+        let snapshot = svc.clone();
+        Ok(AwsResponse::ok_json(json!({
+            "service": express_gateway_service_json(&snapshot),
+        })))
+    }
+
+    pub(super) fn delete_express_gateway_service(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = request.json_body();
+        let identifier = req_str(&body, "serviceArn")?.to_string();
+
+        let mut accounts = self.state.write();
+        let account_id = request.account_id.clone();
+        let s = accounts.get_or_create(&account_id);
+        let key = lookup_express_gateway_key_by_arn(s, &identifier).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ClientException",
+                format!("Express Gateway service {} not found", identifier),
+            )
+        })?;
+        let mut svc = s.express_gateway_services.remove(&key).unwrap();
+        svc.status = "DRAINING".to_string();
+        svc.updated_at = Utc::now();
+        Ok(AwsResponse::ok_json(json!({
+            "service": express_gateway_service_json(&svc),
+        })))
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn cluster_arn_to_name(arn_or_name: &str) -> String {
+    if let Some(idx) = arn_or_name.rfind('/') {
+        arn_or_name[idx + 1..].to_string()
+    } else {
+        arn_or_name.to_string()
+    }
+}
+
+fn lookup_express_gateway_by_arn(
+    s: &crate::state::EcsState,
+    arn: &str,
+) -> Option<ExpressGatewayService> {
+    s.express_gateway_services
+        .values()
+        .find(|svc| svc.service_arn == arn)
+        .cloned()
+}
+
+fn lookup_express_gateway_key_by_arn(s: &crate::state::EcsState, arn: &str) -> Option<String> {
+    for (k, svc) in &s.express_gateway_services {
+        if svc.service_arn == arn {
+            return Some(k.clone());
+        }
+    }
+    None
+}
+
+fn express_gateway_service_json(s: &ExpressGatewayService) -> Value {
+    let active_configuration = json!({
+        "serviceRevisionArn": format!("{}:1", s.service_arn),
+        "executionRoleArn": s.execution_role_arn,
+        "taskRoleArn": s.task_role_arn,
+        "cpu": s.cpu,
+        "memory": s.memory,
+        "networkConfiguration": s.network_configuration,
+        "healthCheckPath": s.health_check_path,
+        "primaryContainer": s.primary_container,
+        "scalingTarget": s.scaling_target,
+    });
+    json!({
+        "cluster": s.cluster_name,
+        "serviceName": s.service_name,
+        "serviceArn": s.service_arn,
+        "infrastructureRoleArn": s.infrastructure_role_arn,
+        "status": {
+            "statusCode": s.status,
+            "statusReason": Value::Null,
+        },
+        "currentDeployment": Value::Null,
+        "activeConfigurations": [active_configuration],
+        "createdAt": s.created_at.timestamp() as f64
+            + s.created_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "updatedAt": s.updated_at.timestamp() as f64
+            + s.updated_at.timestamp_subsec_micros() as f64 / 1_000_000.0,
+        "tags": s.tags.iter().map(|t| json!({"key": t.key, "value": t.value})).collect::<Vec<_>>(),
+    })
+}

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -72,6 +72,28 @@ pub struct EcsState {
     /// Task sets keyed by `cluster/service/task-set-id`.
     #[serde(default)]
     pub task_sets: BTreeMap<String, TaskSet>,
+    /// Daemon task definitions keyed by `family` -> `revision` -> definition.
+    /// Same shape as `task_definitions` but isolated since daemon defs use
+    /// the dedicated `RegisterDaemonTaskDefinition` op and have their own
+    /// revision counter.
+    #[serde(default)]
+    pub daemon_task_definitions: BTreeMap<String, BTreeMap<i32, DaemonTaskDefinition>>,
+    /// Per-family monotonic revision counter for daemon task defs.
+    #[serde(default)]
+    pub next_daemon_revision: BTreeMap<String, i32>,
+    /// Daemons keyed by `cluster/daemon-name`. Daemons are cluster-scoped
+    /// and run one task per matching capacity provider per AWS spec.
+    #[serde(default)]
+    pub daemons: BTreeMap<String, Daemon>,
+    /// Daemon deployment history keyed by deployment ARN. Each
+    /// CreateDaemon / UpdateDaemon mints a new deployment record.
+    #[serde(default)]
+    pub daemon_deployments: BTreeMap<String, DaemonDeployment>,
+    /// Express Gateway services keyed by `cluster/service-name`. The
+    /// 2026 Express Gateway feature is a serverless container service
+    /// with built-in load balancing and autoscaling.
+    #[serde(default)]
+    pub express_gateway_services: BTreeMap<String, ExpressGatewayService>,
 }
 
 impl EcsState {
@@ -91,6 +113,11 @@ impl EcsState {
             attributes: BTreeMap::new(),
             capacity_providers: BTreeMap::new(),
             task_sets: BTreeMap::new(),
+            daemon_task_definitions: BTreeMap::new(),
+            next_daemon_revision: BTreeMap::new(),
+            daemons: BTreeMap::new(),
+            daemon_deployments: BTreeMap::new(),
+            express_gateway_services: BTreeMap::new(),
         }
     }
 
@@ -107,6 +134,11 @@ impl EcsState {
         self.attributes.clear();
         self.capacity_providers.clear();
         self.task_sets.clear();
+        self.daemon_task_definitions.clear();
+        self.next_daemon_revision.clear();
+        self.daemons.clear();
+        self.daemon_deployments.clear();
+        self.express_gateway_services.clear();
     }
 
     /// Services are uniquely identified by `(cluster, name)` within an
@@ -587,6 +619,162 @@ pub struct TaskSet {
     pub capacity_provider_strategy: Vec<Value>,
     #[serde(default)]
     pub tags: Vec<TagEntry>,
+}
+
+/// Daemon task definition. Same structural shape as a regular
+/// TaskDefinition but registered via `RegisterDaemonTaskDefinition` and
+/// kept in a separate per-family revision counter.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DaemonTaskDefinition {
+    pub family: String,
+    pub revision: i32,
+    pub task_definition_arn: String,
+    pub status: String,
+    pub container_definitions: Vec<Value>,
+    pub task_role_arn: Option<String>,
+    pub execution_role_arn: Option<String>,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    #[serde(default)]
+    pub volumes: Vec<Value>,
+    pub registered_at: DateTime<Utc>,
+    pub deregistered_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub tags: Vec<TagEntry>,
+}
+
+/// Daemon resource. Daemons run one task per matching capacity
+/// provider in the cluster. Modeled after the ECS Service struct
+/// since the lifecycle / status / deployment story is parallel.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Daemon {
+    pub daemon_name: String,
+    pub daemon_arn: String,
+    pub cluster_arn: String,
+    pub cluster_name: String,
+    pub daemon_task_definition_arn: String,
+    pub status: String,
+    pub deployment_arn: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub capacity_provider_arns: Vec<String>,
+    pub deployment_configuration: Option<Value>,
+    pub propagate_tags: Option<String>,
+    pub enable_ecs_managed_tags: bool,
+    pub enable_execute_command: bool,
+    pub client_token: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<TagEntry>,
+    /// Revision history of deployment ARNs in chronological order.
+    #[serde(default)]
+    pub deployment_history: Vec<String>,
+}
+
+/// Single deployment record. Created on every CreateDaemon /
+/// UpdateDaemon and retained so DescribeDaemonDeployments and
+/// DescribeDaemonRevisions have something to return.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DaemonDeployment {
+    pub deployment_arn: String,
+    pub daemon_arn: String,
+    pub daemon_name: String,
+    pub cluster_arn: String,
+    pub task_definition_arn: String,
+    pub status: String,
+    pub revision: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// 2026 Express Gateway service — serverless container service with
+/// integrated load balancing, health checks, and autoscaling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExpressGatewayService {
+    pub service_name: String,
+    pub service_arn: String,
+    pub cluster_arn: String,
+    pub cluster_name: String,
+    pub status: String,
+    pub execution_role_arn: String,
+    pub infrastructure_role_arn: String,
+    pub task_role_arn: Option<String>,
+    pub primary_container: Value,
+    pub network_configuration: Option<Value>,
+    pub health_check_path: Option<String>,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub scaling_target: Option<Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub tags: Vec<TagEntry>,
+}
+
+impl EcsState {
+    /// Composite key for daemon storage (`cluster_name/daemon_name`).
+    pub fn daemon_key(cluster: &str, name: &str) -> String {
+        format!("{}/{}", cluster, name)
+    }
+
+    /// Composite key for express-gateway storage (`cluster_name/service_name`).
+    pub fn express_gateway_key(cluster: &str, name: &str) -> String {
+        format!("{}/{}", cluster, name)
+    }
+
+    /// Allocate the next monotonic revision for a daemon task family.
+    pub fn allocate_daemon_revision(&mut self, family: &str) -> i32 {
+        let entry = self
+            .next_daemon_revision
+            .entry(family.to_string())
+            .or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Build a daemon ARN for a (cluster, name) pair under this account/region.
+    pub fn daemon_arn(&self, cluster: &str, name: &str) -> String {
+        fakecloud_aws::arn::Arn::new(
+            "ecs",
+            &self.region,
+            &self.account_id,
+            &format!("daemon/{}/{}", cluster, name),
+        )
+        .to_string()
+    }
+
+    /// Build an express-gateway service ARN.
+    pub fn express_gateway_arn(&self, cluster: &str, name: &str) -> String {
+        fakecloud_aws::arn::Arn::new(
+            "ecs",
+            &self.region,
+            &self.account_id,
+            &format!("express-gateway-service/{}/{}", cluster, name),
+        )
+        .to_string()
+    }
+
+    /// Build a daemon task definition ARN for a `family:revision` pair.
+    pub fn daemon_task_definition_arn(&self, family: &str, revision: i32) -> String {
+        fakecloud_aws::arn::Arn::new(
+            "ecs",
+            &self.region,
+            &self.account_id,
+            &format!("daemon-task-definition/{}:{}", family, revision),
+        )
+        .to_string()
+    }
+
+    /// Build a daemon deployment ARN.
+    pub fn daemon_deployment_arn(&self, daemon_name: &str, deployment_id: &str) -> String {
+        fakecloud_aws::arn::Arn::new(
+            "ecs",
+            &self.region,
+            &self.account_id,
+            &format!("daemon-deployment/{}/{}", daemon_name, deployment_id),
+        )
+        .to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds 16 new ECS operations covering the late-2025 Daemon (DaemonSet-style scheduling) and Express Gateway service primitives
- Daemon: Register/Describe/Delete/List DaemonTaskDefinition, Create/Describe/Update/Delete/List Daemon, Describe/List DaemonDeployments, DescribeDaemonRevisions
- Express Gateway: Create/Describe/Update/Delete ExpressGatewayService
- State, dispatcher, mutating-action list, helpers, conformance tests all wired up

## Test plan
- [x] All 76 ECS conformance tests green (12 daemon + 4 EG newly added, 60 existing unchanged)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 2026 ECS Daemon and Express Gateway APIs, enabling DaemonSet-style scheduling primitives and Express Gateway service CRUD. Updates state and routing, with all conformance tests passing.

- **New Features**
  - Daemon task definitions: Register, Describe, Delete, List.
  - Daemon lifecycle: Create, Describe, Update, Delete, List; plus Describe/List deployments and Describe revisions.
  - Express Gateway service: Create, Describe, Update, Delete.
  - State and dispatcher wired up, mutating-action list updated; 76 ECS conformance tests green (12 Daemon, 4 Express Gateway, 60 existing).

<sup>Written for commit 3e12362361b2a43e0f8acffe2b0d9b57a960f4ac. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/884?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

