### PR TITLE
feat(cloudfront): implement DistributionTenant + ConnectionFunction ops

### DIFF
--- a/crates/fakecloud-cloudfront/src/cfunctions.rs
+++ b/crates/fakecloud-cloudfront/src/cfunctions.rs
@@ -1,0 +1,23 @@
+// CloudFront ConnectionFunction data types. Connection Functions are
+// edge functions that run on the connection-handling path (different
+// from regular CloudFront Functions which run on viewer requests).
+// Same lifecycle as Functions: create -> publish -> attached to
+// distributions.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredConnectionFunction {
+    pub id: String,
+    pub name: String,
+    pub arn: String,
+    pub stage: String,
+    pub status: String,
+    pub runtime: String,
+    pub comment: String,
+    pub code: Vec<u8>,
+    pub etag: String,
+    pub created_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+}

--- a/crates/fakecloud-cloudfront/src/cfunctions_service.rs
+++ b/crates/fakecloud-cloudfront/src/cfunctions_service.rs
@@ -1,0 +1,329 @@
+// Handlers for CloudFront ConnectionFunction ops (8 ops). Mirrors the
+// regular CloudFront Functions lifecycle: create -> describe/get ->
+// update -> publish -> attach. Code blob is base64-encoded on the
+// wire, returned raw for GetConnectionFunction.
+
+use base64::Engine;
+use chrono::Utc;
+use http::header::ETAG;
+use http::{HeaderMap, StatusCode};
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError, ResponseBody};
+
+use crate::cfunctions::StoredConnectionFunction;
+use crate::policies::{
+    not_found, precondition_failed, require_if_match, rfc3339, route_id, xml_with_etag,
+};
+use crate::router::Route;
+use crate::service::{
+    aws_error, esc, generate_id_with_prefix, invalid_argument, xml_response, CloudFrontService,
+    DEFAULT_ACCOUNT,
+};
+use crate::xml_io;
+
+const NS: &str = crate::NAMESPACE;
+const XML_DECL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>"#;
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct CreateConnectionFunctionRequest {
+    pub name: String,
+    pub connection_function_config: ConnectionFunctionConfigInput,
+    pub connection_function_code: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct UpdateConnectionFunctionRequest {
+    pub connection_function_config: ConnectionFunctionConfigInput,
+    pub connection_function_code: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ConnectionFunctionConfigInput {
+    pub comment: String,
+    pub runtime: String,
+}
+
+impl CloudFrontService {
+    pub(crate) fn create_connection_function(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let parsed: CreateConnectionFunctionRequest =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid CreateConnectionFunctionRequest XML: {e}"))
+            })?;
+        if parsed.name.is_empty() {
+            return Err(invalid_argument("Name is required"));
+        }
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default();
+        if account.connection_functions.contains_key(&parsed.name) {
+            return Err(aws_error(
+                StatusCode::CONFLICT,
+                "EntityAlreadyExists",
+                format!("ConnectionFunction {} already exists", parsed.name),
+            ));
+        }
+        let now = Utc::now();
+        let etag = generate_id_with_prefix("E");
+        let id = generate_id_with_prefix("CF");
+        let arn = format!(
+            "arn:aws:cloudfront::{}:connection-function/{}",
+            DEFAULT_ACCOUNT, parsed.name
+        );
+        let code = base64::engine::general_purpose::STANDARD
+            .decode(parsed.connection_function_code.trim())
+            .unwrap_or_else(|_| parsed.connection_function_code.into_bytes());
+        let stored = StoredConnectionFunction {
+            id,
+            name: parsed.name.clone(),
+            arn,
+            stage: "DEVELOPMENT".to_string(),
+            status: "UNPUBLISHED".to_string(),
+            runtime: parsed.connection_function_config.runtime,
+            comment: parsed.connection_function_config.comment,
+            code,
+            etag: etag.clone(),
+            created_time: now,
+            last_modified_time: now,
+        };
+        account
+            .connection_functions
+            .insert(parsed.name.clone(), stored.clone());
+        drop(state);
+        let body = render_connection_function_summary(&stored, true);
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, None))
+    }
+
+    pub(crate) fn describe_connection_function(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let state = self.state.read();
+        let f = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.connection_functions.get(&name).cloned())
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        drop(state);
+        let body = render_connection_function_summary(&f, true);
+        Ok(xml_with_etag(StatusCode::OK, body, &f.etag, None))
+    }
+
+    pub(crate) fn get_connection_function(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let state = self.state.read();
+        let f = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.connection_functions.get(&name).cloned())
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        drop(state);
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = http::HeaderValue::from_str(&f.etag) {
+            headers.insert(ETAG, v);
+        }
+        Ok(AwsResponse {
+            status: StatusCode::OK,
+            headers,
+            content_type: "application/octet-stream".to_string(),
+            body: ResponseBody::Bytes(bytes::Bytes::from(f.code.clone())),
+        })
+    }
+
+    pub(crate) fn update_connection_function(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let if_match = require_if_match(req)?;
+        let parsed: UpdateConnectionFunctionRequest =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid UpdateConnectionFunctionRequest XML: {e}"))
+            })?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        let f = account
+            .connection_functions
+            .get_mut(&name)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        if f.etag != if_match {
+            return Err(precondition_failed());
+        }
+        f.runtime = parsed.connection_function_config.runtime;
+        f.comment = parsed.connection_function_config.comment;
+        f.code = base64::engine::general_purpose::STANDARD
+            .decode(parsed.connection_function_code.trim())
+            .unwrap_or_else(|_| parsed.connection_function_code.into_bytes());
+        f.etag = generate_id_with_prefix("E");
+        f.last_modified_time = Utc::now();
+        f.status = "UNPUBLISHED".to_string();
+        f.stage = "DEVELOPMENT".to_string();
+        let snap = f.clone();
+        drop(state);
+        let body = render_connection_function_summary(&snap, true);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn delete_connection_function(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        let f = account
+            .connection_functions
+            .get(&name)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        if f.etag != if_match {
+            return Err(precondition_failed());
+        }
+        account.connection_functions.remove(&name);
+        drop(state);
+        Ok(crate::policies::empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_connection_functions(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredConnectionFunction> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.connection_functions.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        items.sort_by(|a, b| a.name.cmp(&b.name));
+        let mut body = String::with_capacity(512);
+        body.push_str(XML_DECL);
+        body.push_str(&format!("<ListConnectionFunctionsResult xmlns=\"{NS}\">"));
+        body.push_str("<NextMarker></NextMarker>");
+        body.push_str("<ConnectionFunctions>");
+        for f in &items {
+            body.push_str(&render_connection_function_summary_inner(f));
+        }
+        body.push_str("</ConnectionFunctions>");
+        body.push_str("</ListConnectionFunctionsResult>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+
+    pub(crate) fn publish_connection_function(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        let f = account
+            .connection_functions
+            .get_mut(&name)
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        if f.etag != if_match {
+            return Err(precondition_failed());
+        }
+        f.status = "DEPLOYED".to_string();
+        f.stage = "LIVE".to_string();
+        f.last_modified_time = Utc::now();
+        let snap = f.clone();
+        drop(state);
+        let body = render_connection_function_summary(&snap, true);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn test_connection_function(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = route_id(route, "ConnectionFunction")?;
+        let if_match = require_if_match(req)?;
+        let state = self.state.read();
+        let f = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.connection_functions.get(&name).cloned())
+            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+        drop(state);
+        if f.etag != if_match {
+            return Err(precondition_failed());
+        }
+        let mut body = String::with_capacity(512);
+        body.push_str(XML_DECL);
+        body.push_str(&format!("<ConnectionFunctionTestResult xmlns=\"{NS}\">"));
+        body.push_str(&render_connection_function_summary_inner(&f));
+        body.push_str("<ComputeUtilization>0</ComputeUtilization>");
+        body.push_str("<ConnectionFunctionExecutionLogs></ConnectionFunctionExecutionLogs>");
+        body.push_str("<ConnectionFunctionErrorMessage></ConnectionFunctionErrorMessage>");
+        body.push_str("<ConnectionFunctionOutput>{}</ConnectionFunctionOutput>");
+        body.push_str("</ConnectionFunctionTestResult>");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+fn render_connection_function_summary(f: &StoredConnectionFunction, with_decl: bool) -> String {
+    let mut out = String::with_capacity(512);
+    if with_decl {
+        out.push_str(XML_DECL);
+    }
+    out.push_str(&format!("<ConnectionFunctionSummary xmlns=\"{NS}\">"));
+    push_summary_body(&mut out, f);
+    out.push_str("</ConnectionFunctionSummary>");
+    out
+}
+
+fn render_connection_function_summary_inner(f: &StoredConnectionFunction) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str("<ConnectionFunctionSummary>");
+    push_summary_body(&mut out, f);
+    out.push_str("</ConnectionFunctionSummary>");
+    out
+}
+
+fn push_summary_body(out: &mut String, f: &StoredConnectionFunction) {
+    out.push_str(&format!("<Name>{}</Name>", esc(&f.name)));
+    out.push_str(&format!("<Id>{}</Id>", esc(&f.id)));
+    out.push_str(&format!("<Status>{}</Status>", esc(&f.status)));
+    out.push_str(&format!(
+        "<ConnectionFunctionArn>{}</ConnectionFunctionArn>",
+        esc(&f.arn)
+    ));
+    out.push_str(&format!("<Stage>{}</Stage>", esc(&f.stage)));
+    out.push_str(&format!(
+        "<CreatedTime>{}</CreatedTime>",
+        rfc3339(&f.created_time)
+    ));
+    out.push_str(&format!(
+        "<LastModifiedTime>{}</LastModifiedTime>",
+        rfc3339(&f.last_modified_time)
+    ));
+    out.push_str("<ConnectionFunctionConfig>");
+    out.push_str(&format!("<Comment>{}</Comment>", esc(&f.comment)));
+    out.push_str(&format!("<Runtime>{}</Runtime>", esc(&f.runtime)));
+    out.push_str("</ConnectionFunctionConfig>");
+}

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -5,6 +5,8 @@
 //! `cloudfront`; the service is global so callers always sign for
 //! `us-east-1`.
 
+pub mod cfunctions;
+pub mod cfunctions_service;
 pub mod extras;
 pub mod extras2;
 pub mod extras2_service;
@@ -21,6 +23,8 @@ pub(crate) mod service;
 pub(crate) mod state;
 pub mod streaming;
 pub mod streaming_service;
+pub mod tenants;
+pub mod tenants_service;
 pub mod xml_io;
 
 pub const API_VERSION: &str = "2020-05-31";

--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -171,6 +171,26 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "VerifyDnsConfiguration",
     "GetManagedCertificateDetails",
     "UpdateDistributionWithStagingConfig",
+    "CreateDistributionTenant",
+    "GetDistributionTenant",
+    "GetDistributionTenantByDomain",
+    "UpdateDistributionTenant",
+    "DeleteDistributionTenant",
+    "ListDistributionTenants",
+    "ListDistributionTenantsByCustomization",
+    "AssociateDistributionTenantWebACL",
+    "DisassociateDistributionTenantWebACL",
+    "CreateInvalidationForDistributionTenant",
+    "GetInvalidationForDistributionTenant",
+    "ListInvalidationsForDistributionTenant",
+    "CreateConnectionFunction",
+    "GetConnectionFunction",
+    "DescribeConnectionFunction",
+    "UpdateConnectionFunction",
+    "DeleteConnectionFunction",
+    "ListConnectionFunctions",
+    "PublishConnectionFunction",
+    "TestConnectionFunction",
 ];
 
 pub struct CloudFrontService {
@@ -383,6 +403,38 @@ impl AwsService for CloudFrontService {
             "UpdateDistributionWithStagingConfig" => {
                 self.update_distribution_with_staging_config(&req, &resolved)
             }
+            "CreateDistributionTenant" => self.create_distribution_tenant(&req),
+            "GetDistributionTenant" => self.get_distribution_tenant(&resolved),
+            "GetDistributionTenantByDomain" => self.get_distribution_tenant_by_domain(&req),
+            "UpdateDistributionTenant" => self.update_distribution_tenant(&req, &resolved),
+            "DeleteDistributionTenant" => self.delete_distribution_tenant(&req, &resolved),
+            "ListDistributionTenants" => self.list_distribution_tenants(&req),
+            "ListDistributionTenantsByCustomization" => {
+                self.list_distribution_tenants_by_customization(&req)
+            }
+            "AssociateDistributionTenantWebACL" => {
+                self.associate_distribution_tenant_web_acl(&req, &resolved)
+            }
+            "DisassociateDistributionTenantWebACL" => {
+                self.disassociate_distribution_tenant_web_acl(&req, &resolved)
+            }
+            "CreateInvalidationForDistributionTenant" => {
+                self.create_invalidation_for_distribution_tenant(&req, &resolved)
+            }
+            "GetInvalidationForDistributionTenant" => {
+                self.get_invalidation_for_distribution_tenant(&resolved)
+            }
+            "ListInvalidationsForDistributionTenant" => {
+                self.list_invalidations_for_distribution_tenant(&resolved)
+            }
+            "CreateConnectionFunction" => self.create_connection_function(&req),
+            "GetConnectionFunction" => self.get_connection_function(&resolved),
+            "DescribeConnectionFunction" => self.describe_connection_function(&resolved),
+            "UpdateConnectionFunction" => self.update_connection_function(&req, &resolved),
+            "DeleteConnectionFunction" => self.delete_connection_function(&req, &resolved),
+            "ListConnectionFunctions" => self.list_connection_functions(&req),
+            "PublishConnectionFunction" => self.publish_connection_function(&req, &resolved),
+            "TestConnectionFunction" => self.test_connection_function(&req, &resolved),
             other => Err(aws_error(
                 StatusCode::NOT_IMPLEMENTED,
                 "InvalidAction",

--- a/crates/fakecloud-cloudfront/src/state.rs
+++ b/crates/fakecloud-cloudfront/src/state.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
+use crate::cfunctions::StoredConnectionFunction;
 use crate::extras::{StoredAnycastIpList, StoredResourcePolicy, StoredTrustStore, StoredVpcOrigin};
 use crate::extras2::StoredConnectionGroup;
 use crate::fle::{
@@ -22,6 +23,7 @@ use crate::policies::{
     StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
 };
 use crate::streaming::StoredStreamingDistribution;
+use crate::tenants::{StoredDistributionTenant, StoredTenantInvalidation};
 
 pub type SharedCloudFrontState = Arc<RwLock<CloudFrontAccounts>>;
 
@@ -77,6 +79,9 @@ pub struct AccountState {
     /// Resource policies keyed by resource ARN.
     pub resource_policies: BTreeMap<String, StoredResourcePolicy>,
     pub connection_groups: BTreeMap<String, StoredConnectionGroup>,
+    pub distribution_tenants: BTreeMap<String, StoredDistributionTenant>,
+    pub tenant_invalidations: BTreeMap<String, StoredTenantInvalidation>,
+    pub connection_functions: BTreeMap<String, StoredConnectionFunction>,
 }
 
 impl CloudFrontAccounts {

--- a/crates/fakecloud-cloudfront/src/tenants.rs
+++ b/crates/fakecloud-cloudfront/src/tenants.rs
@@ -1,0 +1,34 @@
+// CloudFront DistributionTenant data types — multi-tenant distribution
+// service that lets callers carve a base distribution into per-tenant
+// configurations (custom domains, certs, parameter overrides). Wire
+// protocol mirrors the parent Distribution: REST-XML with ETag-based
+// concurrency control.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredDistributionTenant {
+    pub id: String,
+    pub arn: String,
+    pub name: String,
+    pub distribution_id: String,
+    pub domains: Vec<String>,
+    pub connection_group_id: Option<String>,
+    pub web_acl_arn: Option<String>,
+    pub enabled: bool,
+    pub status: String,
+    pub etag: String,
+    pub created_time: DateTime<Utc>,
+    pub last_modified_time: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredTenantInvalidation {
+    pub id: String,
+    pub tenant_id: String,
+    pub status: String,
+    pub create_time: DateTime<Utc>,
+    pub paths: Vec<String>,
+    pub caller_reference: String,
+}

--- a/crates/fakecloud-cloudfront/src/tenants_service.rs
+++ b/crates/fakecloud-cloudfront/src/tenants_service.rs
@@ -1,0 +1,620 @@
+// Handlers for CloudFront DistributionTenant ops (12 ops). Same
+// REST-XML conventions as Distribution: ETag-based concurrency,
+// IDs prefixed with `dt-`, ARNs under `arn:aws:cloudfront::`.
+
+use chrono::Utc;
+use http::header::LOCATION;
+use http::{HeaderMap, StatusCode};
+use uuid::Uuid;
+
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::policies::{
+    not_found, precondition_failed, require_if_match, rfc3339, route_id, xml_with_etag,
+};
+use crate::router::Route;
+use crate::service::{
+    aws_error, esc, generate_id_with_prefix, invalid_argument, xml_response, CloudFrontService,
+    DEFAULT_ACCOUNT,
+};
+use crate::tenants::{StoredDistributionTenant, StoredTenantInvalidation};
+use crate::xml_io;
+
+const NS: &str = crate::NAMESPACE;
+const XML_DECL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>"#;
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct CreateDistributionTenantRequest {
+    pub distribution_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub domains: Option<DomainItems>,
+    #[serde(default)]
+    pub connection_group_id: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct UpdateDistributionTenantRequest {
+    #[serde(default)]
+    pub distribution_id: Option<String>,
+    #[serde(default)]
+    pub domains: Option<DomainItems>,
+    #[serde(default)]
+    pub connection_group_id: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct DomainItems {
+    #[serde(default, rename = "member")]
+    pub members: Vec<DomainItem>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DomainItem {
+    pub domain: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct AssociateWebAclRequest {
+    #[serde(rename = "WebACLArn")]
+    pub web_acl_arn: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InvalidationBatchRequest {
+    pub paths: PathsItems,
+    pub caller_reference: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct PathsItems {
+    #[serde(default)]
+    pub items: Option<PathItems>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct PathItems {
+    #[serde(default, rename = "Path")]
+    pub path: Vec<String>,
+}
+
+impl CloudFrontService {
+    pub(crate) fn create_distribution_tenant(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let parsed: CreateDistributionTenantRequest =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid CreateDistributionTenantRequest XML: {e}"))
+            })?;
+        if parsed.distribution_id.is_empty() {
+            return Err(invalid_argument("DistributionId is required"));
+        }
+        if parsed.name.is_empty() {
+            return Err(invalid_argument("Name is required"));
+        }
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .entry(DEFAULT_ACCOUNT.to_string())
+            .or_default();
+        if account
+            .distribution_tenants
+            .values()
+            .any(|t| t.name == parsed.name)
+        {
+            return Err(aws_error(
+                StatusCode::CONFLICT,
+                "EntityAlreadyExists",
+                format!("DistributionTenant {} already exists", parsed.name),
+            ));
+        }
+        let id = generate_tenant_id();
+        let arn = format!(
+            "arn:aws:cloudfront::{}:distribution-tenant/{}",
+            DEFAULT_ACCOUNT, id
+        );
+        let etag = generate_id_with_prefix("E");
+        let now = Utc::now();
+        let domains = parsed
+            .domains
+            .map(|d| d.members.into_iter().map(|i| i.domain).collect())
+            .unwrap_or_default();
+        let stored = StoredDistributionTenant {
+            id: id.clone(),
+            arn,
+            name: parsed.name,
+            distribution_id: parsed.distribution_id,
+            domains,
+            connection_group_id: parsed.connection_group_id,
+            web_acl_arn: None,
+            enabled: parsed.enabled.unwrap_or(true),
+            status: "Deployed".to_string(),
+            etag: etag.clone(),
+            created_time: now,
+            last_modified_time: now,
+        };
+        account
+            .distribution_tenants
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_distribution_tenant(&stored);
+        Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
+    }
+
+    pub(crate) fn get_distribution_tenant(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "DistributionTenant")?;
+        let state = self.state.read();
+        let t = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| a.distribution_tenants.get(&id).cloned())
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        drop(state);
+        let body = render_distribution_tenant(&t);
+        Ok(xml_with_etag(StatusCode::OK, body, &t.etag, None))
+    }
+
+    pub(crate) fn get_distribution_tenant_by_domain(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let domain = req
+            .query_params
+            .get("domain")
+            .or_else(|| req.query_params.get("Domain"))
+            .cloned()
+            .ok_or_else(|| invalid_argument("Domain query parameter is required"))?;
+        let state = self.state.read();
+        let t = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .and_then(|a| {
+                a.distribution_tenants
+                    .values()
+                    .find(|t| t.domains.iter().any(|d| d == &domain))
+                    .cloned()
+            })
+            .ok_or_else(|| not_found("DistributionTenant", &domain))?;
+        drop(state);
+        let body = render_distribution_tenant(&t);
+        Ok(xml_with_etag(StatusCode::OK, body, &t.etag, None))
+    }
+
+    pub(crate) fn update_distribution_tenant(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "DistributionTenant")?;
+        let if_match = require_if_match(req)?;
+        let parsed: UpdateDistributionTenantRequest =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid UpdateDistributionTenantRequest XML: {e}"))
+            })?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        let t = account
+            .distribution_tenants
+            .get_mut(&id)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        if t.etag != if_match {
+            return Err(precondition_failed());
+        }
+        if let Some(d) = parsed.distribution_id {
+            t.distribution_id = d;
+        }
+        if let Some(d) = parsed.domains {
+            t.domains = d.members.into_iter().map(|i| i.domain).collect();
+        }
+        if let Some(c) = parsed.connection_group_id {
+            t.connection_group_id = Some(c);
+        }
+        if let Some(e) = parsed.enabled {
+            t.enabled = e;
+        }
+        t.etag = generate_id_with_prefix("E");
+        t.last_modified_time = Utc::now();
+        let snap = t.clone();
+        drop(state);
+        let body = render_distribution_tenant(&snap);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn delete_distribution_tenant(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "DistributionTenant")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        let t = account
+            .distribution_tenants
+            .get(&id)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        if t.etag != if_match {
+            return Err(precondition_failed());
+        }
+        if t.enabled {
+            return Err(aws_error(
+                StatusCode::PRECONDITION_FAILED,
+                "ResourceInUse",
+                "DistributionTenant must be disabled before delete",
+            ));
+        }
+        let arn = t.arn.clone();
+        account.distribution_tenants.remove(&id);
+        account
+            .tenant_invalidations
+            .retain(|_, inv| inv.tenant_id != id);
+        account.tags.remove(&arn);
+        drop(state);
+        Ok(crate::policies::empty(StatusCode::NO_CONTENT))
+    }
+
+    pub(crate) fn list_distribution_tenants(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredDistributionTenant> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.distribution_tenants.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+        let body = render_tenant_list(&items, "ListDistributionTenantsResult");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+
+    pub(crate) fn list_distribution_tenants_by_customization(
+        &self,
+        _req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let state = self.state.read();
+        let mut items: Vec<StoredDistributionTenant> = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .map(|a| a.distribution_tenants.values().cloned().collect())
+            .unwrap_or_default();
+        drop(state);
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+        let body = render_tenant_list(&items, "ListDistributionTenantsByCustomizationResult");
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+
+    pub(crate) fn associate_distribution_tenant_web_acl(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "DistributionTenant")?;
+        let if_match = require_if_match(req)?;
+        let parsed: AssociateWebAclRequest = xml_io::from_xml_root(&req.body).map_err(|e| {
+            invalid_argument(format!(
+                "invalid AssociateDistributionTenantWebACLRequest XML: {e}"
+            ))
+        })?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        let t = account
+            .distribution_tenants
+            .get_mut(&id)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        if t.etag != if_match {
+            return Err(precondition_failed());
+        }
+        t.web_acl_arn = Some(parsed.web_acl_arn);
+        t.etag = generate_id_with_prefix("E");
+        t.last_modified_time = Utc::now();
+        let snap = t.clone();
+        drop(state);
+        let body = render_associate_web_acl(&snap);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn disassociate_distribution_tenant_web_acl(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let id = route_id(route, "DistributionTenant")?;
+        let if_match = require_if_match(req)?;
+        let mut state = self.state.write();
+        let account = state
+            .accounts
+            .get_mut(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        let t = account
+            .distribution_tenants
+            .get_mut(&id)
+            .ok_or_else(|| not_found("DistributionTenant", &id))?;
+        if t.etag != if_match {
+            return Err(precondition_failed());
+        }
+        t.web_acl_arn = None;
+        t.etag = generate_id_with_prefix("E");
+        t.last_modified_time = Utc::now();
+        let snap = t.clone();
+        drop(state);
+        let body = render_disassociate_web_acl(&snap);
+        Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
+    }
+
+    pub(crate) fn create_invalidation_for_distribution_tenant(
+        &self,
+        req: &AwsRequest,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let tenant_id = route_id(route, "DistributionTenant")?;
+        let parsed: InvalidationBatchRequest = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid InvalidationBatch XML: {e}")))?;
+        if parsed.caller_reference.is_empty() {
+            return Err(invalid_argument("CallerReference is required"));
+        }
+        let paths = parsed.paths.items.map(|i| i.path).unwrap_or_default();
+        if paths.is_empty() {
+            return Err(invalid_argument(
+                "InvalidationBatch.Paths must be non-empty",
+            ));
+        }
+        let mut state = self.state.write();
+        let account = state.entry(DEFAULT_ACCOUNT);
+        if !account.distribution_tenants.contains_key(&tenant_id) {
+            return Err(not_found("DistributionTenant", &tenant_id));
+        }
+        let id = generate_invalidation_id();
+        let stored = StoredTenantInvalidation {
+            id: id.clone(),
+            tenant_id: tenant_id.clone(),
+            status: "Completed".to_string(),
+            create_time: Utc::now(),
+            paths,
+            caller_reference: parsed.caller_reference,
+        };
+        account
+            .tenant_invalidations
+            .insert(id.clone(), stored.clone());
+        drop(state);
+        let body = render_tenant_invalidation(&stored);
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = http::HeaderValue::from_str(&format!(
+            "/2020-05-31/distribution-tenant/{tenant_id}/invalidation/{}",
+            stored.id
+        )) {
+            headers.insert(LOCATION, v);
+        }
+        Ok(xml_response(StatusCode::CREATED, body, headers))
+    }
+
+    pub(crate) fn get_invalidation_for_distribution_tenant(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let tenant_id = route
+            .id
+            .as_deref()
+            .ok_or_else(|| invalid_argument("missing distribution tenant id"))?;
+        let inv_id = route
+            .second_id
+            .as_deref()
+            .ok_or_else(|| invalid_argument("missing invalidation id"))?;
+        let state = self.state.read();
+        let account = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("Invalidation", inv_id))?;
+        if !account.distribution_tenants.contains_key(tenant_id) {
+            return Err(not_found("DistributionTenant", tenant_id));
+        }
+        let inv = account
+            .tenant_invalidations
+            .get(inv_id)
+            .filter(|i| i.tenant_id == tenant_id)
+            .ok_or_else(|| not_found("Invalidation", inv_id))?
+            .clone();
+        drop(state);
+        let body = render_tenant_invalidation(&inv);
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+
+    pub(crate) fn list_invalidations_for_distribution_tenant(
+        &self,
+        route: &Route,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let tenant_id = route
+            .id
+            .as_deref()
+            .ok_or_else(|| invalid_argument("missing distribution tenant id"))?;
+        let state = self.state.read();
+        let account = state
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .ok_or_else(|| not_found("DistributionTenant", tenant_id))?;
+        if !account.distribution_tenants.contains_key(tenant_id) {
+            return Err(not_found("DistributionTenant", tenant_id));
+        }
+        let mut items: Vec<&StoredTenantInvalidation> = account
+            .tenant_invalidations
+            .values()
+            .filter(|i| i.tenant_id == tenant_id)
+            .collect();
+        items.sort_by_key(|a| a.create_time);
+        let body = render_tenant_invalidation_list(&items);
+        drop(state);
+        Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+fn generate_tenant_id() -> String {
+    let raw = Uuid::new_v4().simple().to_string().to_uppercase();
+    format!("DT{}", &raw[..12])
+}
+
+fn generate_invalidation_id() -> String {
+    let raw = Uuid::new_v4().simple().to_string().to_uppercase();
+    format!("I{}", &raw[..13])
+}
+
+fn render_distribution_tenant(t: &StoredDistributionTenant) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<DistributionTenant xmlns=\"{NS}\">"));
+    push_tenant_inner(&mut out, t);
+    out.push_str("</DistributionTenant>");
+    out
+}
+
+fn push_tenant_inner(out: &mut String, t: &StoredDistributionTenant) {
+    out.push_str(&format!("<Id>{}</Id>", esc(&t.id)));
+    out.push_str(&format!(
+        "<DistributionId>{}</DistributionId>",
+        esc(&t.distribution_id)
+    ));
+    out.push_str(&format!("<Name>{}</Name>", esc(&t.name)));
+    out.push_str(&format!("<Arn>{}</Arn>", esc(&t.arn)));
+    out.push_str(&format!("<Status>{}</Status>", esc(&t.status)));
+    out.push_str(&format!("<Enabled>{}</Enabled>", t.enabled));
+    out.push_str(&format!(
+        "<CreatedTime>{}</CreatedTime>",
+        rfc3339(&t.created_time)
+    ));
+    out.push_str(&format!(
+        "<LastModifiedTime>{}</LastModifiedTime>",
+        rfc3339(&t.last_modified_time)
+    ));
+    if let Some(c) = &t.connection_group_id {
+        out.push_str(&format!(
+            "<ConnectionGroupId>{}</ConnectionGroupId>",
+            esc(c)
+        ));
+    }
+    out.push_str("<Domains>");
+    for d in &t.domains {
+        out.push_str("<DomainResult>");
+        out.push_str(&format!("<Domain>{}</Domain>", esc(d)));
+        out.push_str("<Status>active</Status>");
+        out.push_str("</DomainResult>");
+    }
+    out.push_str("</Domains>");
+}
+
+fn render_tenant_list(items: &[StoredDistributionTenant], wrapper: &str) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<{wrapper} xmlns=\"{NS}\">"));
+    out.push_str("<NextMarker></NextMarker>");
+    out.push_str("<DistributionTenantList>");
+    for t in items {
+        out.push_str("<DistributionTenantSummary>");
+        push_tenant_inner(&mut out, t);
+        out.push_str("</DistributionTenantSummary>");
+    }
+    out.push_str("</DistributionTenantList>");
+    out.push_str(&format!("</{wrapper}>"));
+    out
+}
+
+fn render_associate_web_acl(t: &StoredDistributionTenant) -> String {
+    let mut out = String::with_capacity(256);
+    out.push_str(XML_DECL);
+    out.push_str(&format!(
+        "<AssociateDistributionTenantWebACLResult xmlns=\"{NS}\">"
+    ));
+    out.push_str(&format!("<Id>{}</Id>", esc(&t.id)));
+    if let Some(arn) = &t.web_acl_arn {
+        out.push_str(&format!("<WebACLArn>{}</WebACLArn>", esc(arn)));
+    }
+    out.push_str("</AssociateDistributionTenantWebACLResult>");
+    out
+}
+
+fn render_disassociate_web_acl(t: &StoredDistributionTenant) -> String {
+    let mut out = String::with_capacity(256);
+    out.push_str(XML_DECL);
+    out.push_str(&format!(
+        "<DisassociateDistributionTenantWebACLResult xmlns=\"{NS}\">"
+    ));
+    out.push_str(&format!("<Id>{}</Id>", esc(&t.id)));
+    out.push_str("</DisassociateDistributionTenantWebACLResult>");
+    out
+}
+
+fn render_tenant_invalidation(inv: &StoredTenantInvalidation) -> String {
+    let mut out = String::with_capacity(512);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<Invalidation xmlns=\"{NS}\">"));
+    out.push_str(&format!("<Id>{}</Id>", esc(&inv.id)));
+    out.push_str(&format!("<Status>{}</Status>", esc(&inv.status)));
+    out.push_str(&format!(
+        "<CreateTime>{}</CreateTime>",
+        rfc3339(&inv.create_time)
+    ));
+    out.push_str("<InvalidationBatch>");
+    out.push_str(&format!(
+        "<CallerReference>{}</CallerReference>",
+        esc(&inv.caller_reference)
+    ));
+    out.push_str("<Paths>");
+    out.push_str(&format!("<Quantity>{}</Quantity>", inv.paths.len()));
+    out.push_str("<Items>");
+    for p in &inv.paths {
+        out.push_str(&format!("<Path>{}</Path>", esc(p)));
+    }
+    out.push_str("</Items>");
+    out.push_str("</Paths>");
+    out.push_str("</InvalidationBatch>");
+    out.push_str("</Invalidation>");
+    out
+}
+
+fn render_tenant_invalidation_list(items: &[&StoredTenantInvalidation]) -> String {
+    let mut out = String::with_capacity(1024);
+    out.push_str(XML_DECL);
+    out.push_str(&format!("<InvalidationList xmlns=\"{NS}\">"));
+    out.push_str("<Marker></Marker>");
+    out.push_str("<MaxItems>100</MaxItems>");
+    out.push_str("<IsTruncated>false</IsTruncated>");
+    out.push_str(&format!("<Quantity>{}</Quantity>", items.len()));
+    if !items.is_empty() {
+        out.push_str("<Items>");
+        for inv in items {
+            out.push_str("<InvalidationSummary>");
+            out.push_str(&format!("<Id>{}</Id>", esc(&inv.id)));
+            out.push_str(&format!(
+                "<CreateTime>{}</CreateTime>",
+                rfc3339(&inv.create_time)
+            ));
+            out.push_str(&format!("<Status>{}</Status>", esc(&inv.status)));
+            out.push_str("</InvalidationSummary>");
+        }
+        out.push_str("</Items>");
+    }
+    out.push_str("</InvalidationList>");
+    out
+}

--- a/crates/fakecloud-conformance/tests/cloudfront_extras2.rs
+++ b/crates/fakecloud-conformance/tests/cloudfront_extras2.rs
@@ -264,3 +264,391 @@ async fn cf_update_distribution_with_staging_config() {
         .await
         .unwrap();
 }
+
+// ─── Distribution Tenants ────────────────────────────────────────────
+
+async fn create_tenant(cf: &aws_sdk_cloudfront::Client, name: &str) -> (String, String) {
+    let resp = cf
+        .create_distribution_tenant()
+        .distribution_id("E1234")
+        .name(name)
+        .enabled(true)
+        .send()
+        .await
+        .unwrap();
+    let id = resp
+        .distribution_tenant()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    let etag = resp.e_tag().unwrap().to_string();
+    (id, etag)
+}
+
+#[test_action("cloudfront", "CreateDistributionTenant", checksum = "5727cf8f")]
+#[tokio::test]
+async fn cf_create_distribution_tenant() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    create_tenant(&cf, "conf-tenant-1").await;
+}
+
+#[test_action("cloudfront", "GetDistributionTenant", checksum = "e5f7687a")]
+#[tokio::test]
+async fn cf_get_distribution_tenant() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, _) = create_tenant(&cf, "conf-tenant-2").await;
+    cf.get_distribution_tenant()
+        .identifier(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "GetDistributionTenantByDomain", checksum = "8d02c083")]
+#[tokio::test]
+async fn cf_get_distribution_tenant_by_domain() {
+    use aws_sdk_cloudfront::types::DomainItem;
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.create_distribution_tenant()
+        .distribution_id("E1234")
+        .name("conf-tenant-3")
+        .domains(
+            DomainItem::builder()
+                .domain("docs.example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    cf.get_distribution_tenant_by_domain()
+        .domain("docs.example.com")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateDistributionTenant", checksum = "8b0efe18")]
+#[tokio::test]
+async fn cf_update_distribution_tenant() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, etag) = create_tenant(&cf, "conf-tenant-4").await;
+    cf.update_distribution_tenant()
+        .id(&id)
+        .if_match(&etag)
+        .enabled(false)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteDistributionTenant", checksum = "7e831b6b")]
+#[tokio::test]
+async fn cf_delete_distribution_tenant() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let resp = cf
+        .create_distribution_tenant()
+        .distribution_id("E1234")
+        .name("conf-tenant-5")
+        .enabled(false)
+        .send()
+        .await
+        .unwrap();
+    let id = resp
+        .distribution_tenant()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    let etag = resp.e_tag().unwrap().to_string();
+    cf.delete_distribution_tenant()
+        .id(&id)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListDistributionTenants", checksum = "7518eabb")]
+#[tokio::test]
+async fn cf_list_distribution_tenants() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distribution_tenants().send().await.unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListDistributionTenantsByCustomization",
+    checksum = "178df5d9"
+)]
+#[tokio::test]
+async fn cf_list_distribution_tenants_by_customization() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_distribution_tenants_by_customization()
+        .web_acl_arn("arn:aws:wafv2::000000000000:global/webacl/example/abc")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "AssociateDistributionTenantWebACL",
+    checksum = "c23f80f5"
+)]
+#[tokio::test]
+async fn cf_associate_distribution_tenant_web_acl() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, etag) = create_tenant(&cf, "conf-tenant-6").await;
+    cf.associate_distribution_tenant_web_acl()
+        .id(&id)
+        .if_match(&etag)
+        .web_acl_arn("arn:aws:wafv2::000000000000:global/webacl/example/abc")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "DisassociateDistributionTenantWebACL",
+    checksum = "837fc3ab"
+)]
+#[tokio::test]
+async fn cf_disassociate_distribution_tenant_web_acl() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, etag) = create_tenant(&cf, "conf-tenant-7").await;
+    let assoc = cf
+        .associate_distribution_tenant_web_acl()
+        .id(&id)
+        .if_match(&etag)
+        .web_acl_arn("arn:aws:wafv2::000000000000:global/webacl/example/abc")
+        .send()
+        .await
+        .unwrap();
+    let etag2 = assoc.e_tag().unwrap().to_string();
+    cf.disassociate_distribution_tenant_web_acl()
+        .id(&id)
+        .if_match(&etag2)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "CreateInvalidationForDistributionTenant",
+    checksum = "f22b2e6d"
+)]
+#[tokio::test]
+async fn cf_create_invalidation_for_distribution_tenant() {
+    use aws_sdk_cloudfront::types::{InvalidationBatch, Paths};
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, _) = create_tenant(&cf, "conf-tenant-8").await;
+    cf.create_invalidation_for_distribution_tenant()
+        .id(&id)
+        .invalidation_batch(
+            InvalidationBatch::builder()
+                .caller_reference("conf-1")
+                .paths(Paths::builder().quantity(1).items("/*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "GetInvalidationForDistributionTenant",
+    checksum = "fc7cd4e9"
+)]
+#[tokio::test]
+async fn cf_get_invalidation_for_distribution_tenant() {
+    use aws_sdk_cloudfront::types::{InvalidationBatch, Paths};
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, _) = create_tenant(&cf, "conf-tenant-9").await;
+    let inv = cf
+        .create_invalidation_for_distribution_tenant()
+        .id(&id)
+        .invalidation_batch(
+            InvalidationBatch::builder()
+                .caller_reference("conf-2")
+                .paths(Paths::builder().quantity(1).items("/*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let inv_id = inv.invalidation().unwrap().id().to_string();
+    cf.get_invalidation_for_distribution_tenant()
+        .distribution_tenant_id(&id)
+        .id(&inv_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action(
+    "cloudfront",
+    "ListInvalidationsForDistributionTenant",
+    checksum = "604db2e3"
+)]
+#[tokio::test]
+async fn cf_list_invalidations_for_distribution_tenant() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (id, _) = create_tenant(&cf, "conf-tenant-10").await;
+    cf.list_invalidations_for_distribution_tenant()
+        .id(&id)
+        .send()
+        .await
+        .unwrap();
+}
+
+// ─── Connection Functions ────────────────────────────────────────────
+
+async fn create_cf_func(cf: &aws_sdk_cloudfront::Client, name: &str) -> (String, String) {
+    use aws_sdk_cloudfront::primitives::Blob;
+    use aws_sdk_cloudfront::types::{FunctionConfig, FunctionRuntime};
+    let resp = cf
+        .create_connection_function()
+        .name(name)
+        .connection_function_config(
+            FunctionConfig::builder()
+                .comment("conf")
+                .runtime(FunctionRuntime::CloudfrontJs20)
+                .build()
+                .unwrap(),
+        )
+        .connection_function_code(Blob::new(b"function handler() {}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+    let etag = resp.e_tag().unwrap().to_string();
+    (name.to_string(), etag)
+}
+
+#[test_action("cloudfront", "CreateConnectionFunction", checksum = "e7154db7")]
+#[tokio::test]
+async fn cf_create_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    create_cf_func(&cf, "conf-cfn-1").await;
+}
+
+#[test_action("cloudfront", "GetConnectionFunction", checksum = "6546786b")]
+#[tokio::test]
+async fn cf_get_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, _) = create_cf_func(&cf, "conf-cfn-2").await;
+    cf.get_connection_function()
+        .identifier(&name)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DescribeConnectionFunction", checksum = "75c8c4c9")]
+#[tokio::test]
+async fn cf_describe_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, _) = create_cf_func(&cf, "conf-cfn-3").await;
+    cf.describe_connection_function()
+        .identifier(&name)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "UpdateConnectionFunction", checksum = "224e25ea")]
+#[tokio::test]
+async fn cf_update_connection_function() {
+    use aws_sdk_cloudfront::primitives::Blob;
+    use aws_sdk_cloudfront::types::{FunctionConfig, FunctionRuntime};
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, etag) = create_cf_func(&cf, "conf-cfn-4").await;
+    cf.update_connection_function()
+        .id(&name)
+        .if_match(&etag)
+        .connection_function_config(
+            FunctionConfig::builder()
+                .comment("updated")
+                .runtime(FunctionRuntime::CloudfrontJs20)
+                .build()
+                .unwrap(),
+        )
+        .connection_function_code(Blob::new(b"function handler2() {}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "DeleteConnectionFunction", checksum = "c0df295e")]
+#[tokio::test]
+async fn cf_delete_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, etag) = create_cf_func(&cf, "conf-cfn-5").await;
+    cf.delete_connection_function()
+        .id(&name)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "ListConnectionFunctions", checksum = "65b39c33")]
+#[tokio::test]
+async fn cf_list_connection_functions() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    cf.list_connection_functions().send().await.unwrap();
+}
+
+#[test_action("cloudfront", "PublishConnectionFunction", checksum = "ba4441f7")]
+#[tokio::test]
+async fn cf_publish_connection_function() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, etag) = create_cf_func(&cf, "conf-cfn-6").await;
+    cf.publish_connection_function()
+        .id(&name)
+        .if_match(&etag)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_action("cloudfront", "TestConnectionFunction", checksum = "f38011e0")]
+#[tokio::test]
+async fn cf_test_connection_function() {
+    use aws_sdk_cloudfront::primitives::Blob;
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+    let (name, etag) = create_cf_func(&cf, "conf-cfn-7").await;
+    cf.test_connection_function()
+        .id(&name)
+        .if_match(&etag)
+        .connection_object(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary
- Adds 20 new CloudFront operations covering the late-2025 multi-tenant distribution and edge connection-function primitives
- DistributionTenant (12 ops): Create/Get/GetByDomain/Update/Delete/List, ListByCustomization, Associate/DisassociateWebACL, CreateInvalidation/GetInvalidation/ListInvalidations
- ConnectionFunction (8 ops): Create/Get/Describe/Update/Delete/List, Publish/Test
- State, dispatcher, supported actions, conformance tests all wired up

## Test plan
- [x] All 31 cloudfront_extras2 conformance tests green (12 DT + 8 CF newly added, 11 existing unchanged)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CloudFront `DistributionTenant` and `ConnectionFunction` in `fakecloud-cloudfront`, adding 20 REST-XML ops with ETag concurrency and full state/dispatcher wiring. All new conformance tests pass; no changes to existing behavior.

- **New Features**
  - DistributionTenant (12 ops): create/get/get-by-domain/update/delete/list, list-by-customization, associate/disassociate WebACL, create/get/list invalidations. Uses REST-XML with ETag checks; IDs like `DT…`, proper ARNs; exposes domain results and timestamps.
  - ConnectionFunction (8 ops): create/get/describe/update/delete/list/publish/test. Accepts base64 code on input, returns raw bytes for get; tracks stage/status (DEVELOPMENT/LIVE) and updates ETags.
  - Service wiring: adds supported actions, routes, and state maps; new modules `tenants`, `tenants_service`, `cfunctions`, `cfunctions_service`.
  - Tests: expands `cloudfront_extras2` with coverage for all new ops; lints and formatting clean.

<sup>Written for commit 58aa725529358a49a1cdffb0dc600c085bbbf12b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

