### PR TITLE
feat(conformance): @examples deep-diff strategy

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,138 @@
 {
-  "variants_passed": 80073,
-  "total_variants": 81489,
+  "variants_passed": 81439,
+  "total_variants": 82013,
   "per_service": {
-    "cloudformation": {
-      "passed": 3420,
-      "total": 3420
-    },
-    "athena": {
-      "passed": 2320,
-      "total": 2320
-    },
-    "apigatewayv2": {
-      "passed": 2769,
-      "total": 2769
-    },
-    "route53": {
-      "passed": 2388,
-      "total": 2388
-    },
-    "ses": {
-      "passed": 2858,
-      "total": 2858
+    "secretsmanager": {
+      "passed": 872,
+      "total": 874
     },
     "iam": {
-      "passed": 5962,
-      "total": 5962
+      "passed": 5998,
+      "total": 5998
     },
-    "scheduler": {
-      "passed": 460,
-      "total": 491
-    },
-    "ecs": {
-      "passed": 1733,
-      "total": 2327
-    },
-    "elasticloadbalancing": {
-      "passed": 1560,
-      "total": 1560
-    },
-    "cloudfront": {
-      "passed": 3576,
-      "total": 4103
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "rds": {
-      "passed": 5376,
-      "total": 5376
-    },
-    "states": {
-      "passed": 1256,
-      "total": 1292
-    },
-    "sts": {
-      "passed": 438,
-      "total": 438
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "dynamodb": {
-      "passed": 2123,
-      "total": 2123
-    },
-    "bedrock": {
-      "passed": 3591,
-      "total": 3591
+    "lambda": {
+      "passed": 3388,
+      "total": 3388
     },
     "logs": {
       "passed": 3911,
       "total": 3911
     },
-    "apigatewayv1": {
-      "passed": 3134,
-      "total": 3362
+    "sns": {
+      "passed": 1027,
+      "total": 1027
     },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 852
+    "ssm": {
+      "passed": 5305,
+      "total": 5305
     },
-    "kms": {
-      "passed": 2196,
-      "total": 2196
+    "states": {
+      "passed": 1256,
+      "total": 1292
+    },
+    "route53": {
+      "passed": 2400,
+      "total": 2400
     },
     "wafv2": {
       "passed": 2141,
       "total": 2141
     },
-    "cognito-idp": {
-      "passed": 4479,
-      "total": 4479
+    "cloudfront": {
+      "passed": 4115,
+      "total": 4115
     },
-    "lambda": {
-      "passed": 3347,
-      "total": 3347
+    "sts": {
+      "passed": 448,
+      "total": 448
     },
-    "s3": {
-      "passed": 3620,
-      "total": 3620
+    "ecs": {
+      "passed": 2126,
+      "total": 2401
     },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
+    "ses": {
+      "passed": 2859,
+      "total": 2859
+    },
+    "elasticloadbalancing": {
+      "passed": 1587,
+      "total": 1587
     },
     "events": {
       "passed": 2108,
       "total": 2108
     },
-    "application-autoscaling": {
-      "passed": 944,
-      "total": 944
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
+    },
+    "scheduler": {
+      "passed": 460,
+      "total": 491
+    },
+    "rds": {
+      "passed": 5497,
+      "total": 5497
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "bedrock": {
+      "passed": 3593,
+      "total": 3593
     },
     "ecr": {
-      "passed": 1789,
-      "total": 1789
+      "passed": 1804,
+      "total": 1805
+    },
+    "apigatewayv2": {
+      "passed": 2769,
+      "total": 2769
+    },
+    "dynamodb": {
+      "passed": 2133,
+      "total": 2133
+    },
+    "athena": {
+      "passed": 2320,
+      "total": 2320
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
+    "cloudformation": {
+      "passed": 3430,
+      "total": 3430
+    },
+    "kms": {
+      "passed": 2231,
+      "total": 2231
+    },
+    "bedrock-runtime": {
+      "passed": 412,
+      "total": 412
+    },
+    "s3": {
+      "passed": 3662,
+      "total": 3662
+    },
+    "apigatewayv1": {
+      "passed": 3134,
+      "total": 3362
+    },
+    "application-autoscaling": {
+      "passed": 951,
+      "total": 951
     },
     "elasticache": {
-      "passed": 2219,
-      "total": 2219
-    },
-    "ssm": {
-      "passed": 5303,
-      "total": 5303
+      "passed": 2258,
+      "total": 2258
     },
     "acm": {
       "passed": 601,
       "total": 601
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
     }
   }
 }

--- a/crates/fakecloud-conformance/README.md
+++ b/crates/fakecloud-conformance/README.md
@@ -16,9 +16,9 @@ We wanted an oracle outside the loop. AWS publishes Smithy models for every serv
 
 AWS's Smithy JSON models for each service are committed to [`aws-models/`](../../aws-models/) (e.g. `s3.json`, `dynamodb.json`, `lambda.json`). `smithy.rs` parses them into a `ServiceModel` with shapes, operations, traits (`@length`, `@range`, `@required`, `@enum`, `@examples`), and error definitions.
 
-### 2. Generate inputs with six orthogonal strategies
+### 2. Generate inputs with seven orthogonal strategies
 
-For every operation, [`generators/`](./src/generators/) produces test variants using six independent strategies. Each one targets a different class of bug:
+For every operation, [`generators/`](./src/generators/) produces test variants using seven independent strategies. Each one targets a different class of bug:
 
 | Strategy | What it generates | What it catches |
 |---|---|---|
@@ -26,8 +26,9 @@ For every operation, [`generators/`](./src/generators/) produces test variants u
 | **Enum exhaustion** (`enum_exhaust.rs`) | One variant per valid enum value for every enum field | Unhandled enum branches, stale enum lists, default-case fallthrough |
 | **Optionals permutation** (`optionals.rs`) | Required-only, required+each-optional, all-fields | Mis-flagged required fields, crashes on absent optionals |
 | **Property-based** (`proptest_gen.rs`) | 20 randomized inputs per operation, drawn from each field's type and constraints | Panics on adversarial-but-valid input, parser fragility |
-| **Model examples** (`examples.rs`) | The `@examples` trait from the Smithy model itself — AWS's own canonical inputs and outputs | Divergence from AWS's documented examples |
+| **Model examples** (`examples.rs`) | The `@examples` trait from the Smithy model itself — AWS's own canonical inputs | Divergence from AWS's documented examples |
 | **Negative** (`negative.rs`) | Missing required fields, out-of-range values, invalid enums, wrong types | Validation gaps, silent-pass bugs, 500s that should be 400s |
+| **Examples diff** (`examples_diff.rs`) | The `@examples` trait's documented *output* — diffs every leaf field/JSON-type against the live response | Optional-in-Smithy fields that AWS's own examples document, but fakecloud doesn't return |
 
 A single operation typically produces anywhere from a dozen to several hundred variants. Across all 33 services the baseline is **80,074 / 81,489 variants passing (98.3%)** — see [`conformance-baseline.json`](../../conformance-baseline.json) for the per-service breakdown.
 

--- a/crates/fakecloud-conformance/src/generators/boundary.rs
+++ b/crates/fakecloud-conformance/src/generators/boundary.rs
@@ -55,6 +55,7 @@ pub fn generate(
                         strategy: Strategy::Boundary,
                         input,
                         expectation: Expectation::Success,
+                        expected_output: None,
                     });
                 }
                 if let Some(max) = merged.length_max {
@@ -71,6 +72,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                 }
@@ -87,6 +89,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                 }
@@ -109,6 +112,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                 }
@@ -130,6 +134,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                     if let Some(max) = merged.range_max {
@@ -143,6 +148,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                     if let (Some(min), Some(max)) = (merged.range_min, merged.range_max) {
@@ -156,6 +162,7 @@ pub fn generate(
                             strategy: Strategy::Boundary,
                             input,
                             expectation: Expectation::Success,
+                            expected_output: None,
                         });
                     }
                 }

--- a/crates/fakecloud-conformance/src/generators/enum_exhaust.rs
+++ b/crates/fakecloud-conformance/src/generators/enum_exhaust.rs
@@ -48,6 +48,7 @@ pub fn generate(
                     strategy: Strategy::EnumExhaust,
                     input,
                     expectation: Expectation::Success,
+                    expected_output: None,
                 }
             })
             .collect();
@@ -74,6 +75,7 @@ pub fn generate(
                 strategy: Strategy::EnumExhaust,
                 input,
                 expectation: Expectation::Success,
+                expected_output: None,
             });
         }
     } else {
@@ -89,6 +91,7 @@ pub fn generate(
                     strategy: Strategy::EnumExhaust,
                     input,
                     expectation: Expectation::Success,
+                    expected_output: None,
                 });
             }
         }

--- a/crates/fakecloud-conformance/src/generators/examples.rs
+++ b/crates/fakecloud-conformance/src/generators/examples.rs
@@ -23,6 +23,7 @@ pub fn generate(traits: &ShapeTraits) -> Vec<TestVariant> {
             strategy: Strategy::Examples,
             input: example.input.clone(),
             expectation: Expectation::Success,
+            expected_output: None,
         })
         .collect()
 }

--- a/crates/fakecloud-conformance/src/generators/examples_diff.rs
+++ b/crates/fakecloud-conformance/src/generators/examples_diff.rs
@@ -1,0 +1,92 @@
+//! Strategy 7: documented `@examples` output diff.
+//!
+//! AWS commits canonical request/response pairs to its Smithy models via
+//! the `smithy.api#examples` trait. The existing `examples` strategy sends
+//! the documented input. This strategy reuses the same input but additionally
+//! carries the documented `output` so the probe layer can deep-diff the
+//! live response against AWS's own answer.
+//!
+//! The diff is structural, not value-equality: every leaf path that exists
+//! in the documented output must also exist (with matching JSON type) in
+//! the live response. Placeholder string values like `"examplebucket"` are
+//! intentionally not compared. This catches "field is optional in Smithy
+//! but AWS always emits it" bugs (#816 — `BucketRegion` on `ListBuckets`).
+
+use super::{Expectation, Strategy, TestVariant};
+use crate::smithy::ShapeTraits;
+use serde_json::Value;
+
+pub fn generate(traits: &ShapeTraits) -> Vec<TestVariant> {
+    traits
+        .examples
+        .iter()
+        .enumerate()
+        .filter(|(_, ex)| !is_empty_output(&ex.output))
+        .map(|(i, example)| TestVariant {
+            name: format!(
+                "examples_diff_{}_{}",
+                i,
+                example
+                    .title
+                    .replace(' ', "_")
+                    .replace(|c: char| !c.is_alphanumeric() && c != '_', "")
+            ),
+            strategy: Strategy::ExamplesDiff,
+            input: example.input.clone(),
+            expectation: Expectation::Success,
+            expected_output: Some(example.output.clone()),
+        })
+        .collect()
+}
+
+/// `@examples` entries with no documented output (or with `output: {}`)
+/// give the diff nothing to assert against. Skip them so we don't pad the
+/// variant count with empty checks.
+fn is_empty_output(output: &Value) -> bool {
+    match output {
+        Value::Null => true,
+        Value::Object(map) => map.is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::smithy::OperationExample;
+    use serde_json::json;
+
+    fn traits_with_examples(examples: Vec<OperationExample>) -> ShapeTraits {
+        ShapeTraits {
+            examples,
+            ..ShapeTraits::default()
+        }
+    }
+
+    #[test]
+    fn skips_empty_output_examples() {
+        let traits = traits_with_examples(vec![OperationExample {
+            title: "no documented output".to_string(),
+            input: json!({"Bucket": "x"}),
+            output: json!({}),
+        }]);
+        assert!(generate(&traits).is_empty());
+    }
+
+    #[test]
+    fn carries_documented_output() {
+        let traits = traits_with_examples(vec![OperationExample {
+            title: "List my buckets".to_string(),
+            input: json!({}),
+            output: json!({
+                "Buckets": [{"Name": "examplebucket", "BucketRegion": "us-east-1"}],
+                "Owner": {"ID": "123"}
+            }),
+        }]);
+        let variants = generate(&traits);
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0].strategy, Strategy::ExamplesDiff);
+        let expected = variants[0].expected_output.as_ref().unwrap();
+        assert_eq!(expected["Buckets"][0]["BucketRegion"], "us-east-1");
+    }
+}

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -1,6 +1,7 @@
 pub mod boundary;
 pub mod enum_exhaust;
 pub mod examples;
+pub mod examples_diff;
 pub mod negative;
 pub mod optionals;
 pub mod proptest_gen;
@@ -21,6 +22,12 @@ pub struct TestVariant {
     pub input: Value,
     /// Whether this variant is expected to succeed or return a specific error.
     pub expectation: Expectation,
+    /// Documented response body from the operation's `@examples` trait.
+    /// When `Some`, the harness deep-diffs the live response against this
+    /// value: every leaf field present here must also be present (with
+    /// matching JSON type) in the actual response. Catches "optional in
+    /// Smithy but AWS always emits" bugs (see #816).
+    pub expected_output: Option<Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,6 +44,8 @@ pub enum Strategy {
     Examples,
     /// Strategy 6: Negative testing
     Negative,
+    /// Strategy 7: Documented `@examples` output diff against live response
+    ExamplesDiff,
 }
 
 impl std::fmt::Display for Strategy {
@@ -48,6 +57,7 @@ impl std::fmt::Display for Strategy {
             Strategy::Proptest => write!(f, "proptest"),
             Strategy::Examples => write!(f, "examples"),
             Strategy::Negative => write!(f, "negative"),
+            Strategy::ExamplesDiff => write!(f, "examples_diff"),
         }
     }
 }
@@ -257,6 +267,7 @@ pub fn generate_all_variants(
                 strategy: Strategy::Optionals,
                 input: Value::Object(serde_json::Map::new()),
                 expectation: Expectation::Success,
+                expected_output: None,
             }]
         }
     };
@@ -275,32 +286,36 @@ pub fn generate_all_variants(
     // Strategy 4: Property-based random value generation (20 variants)
     variants.extend(proptest_gen::generate(model, input_shape_id, overrides, 20));
 
-    // Strategy 5: Examples from model
-    let op_shape_id = format!("{}#{}", model.service_name, operation_name);
-    // Try to find examples on the operation shape. We look up by the canonical
-    // shape ID first, then fall back to scanning all shapes. Use a flag to avoid
-    // generating duplicate examples when both paths resolve to the same shape.
-    let mut examples_added = false;
-    if let Some(op_shape) = model.shapes.get(&op_shape_id) {
-        let ex = examples::generate(&op_shape.traits);
-        if !ex.is_empty() {
-            variants.extend(ex);
-            examples_added = true;
-        }
-    }
-    if !examples_added {
-        for (shape_id, shape) in &model.shapes {
-            if shape_id.ends_with(&format!("#{}", operation_name))
-                && matches!(shape.shape_type, ShapeType::Operation)
-            {
-                variants.extend(examples::generate(&shape.traits));
-                break;
-            }
-        }
+    // Strategy 5 + 7: Examples from model. Both strategies want the same
+    // `ShapeTraits` (operation-level `@examples`); resolve once.
+    let op_traits = find_operation_traits(model, operation_name);
+    if let Some(traits) = op_traits {
+        variants.extend(examples::generate(traits));
+        variants.extend(examples_diff::generate(traits));
     }
 
     // Strategy 6: Negative testing
     variants.extend(negative::generate(model, input_shape_id, overrides));
 
     variants
+}
+
+/// Locate the `ShapeTraits` for an operation, looking up by canonical shape
+/// ID first, then falling back to a scan. Used by the `examples` and
+/// `examples_diff` strategies, which both consume operation-level traits.
+fn find_operation_traits<'a>(
+    model: &'a ServiceModel,
+    operation_name: &str,
+) -> Option<&'a crate::smithy::ShapeTraits> {
+    let canonical_id = format!("{}#{}", model.service_name, operation_name);
+    if let Some(op_shape) = model.shapes.get(&canonical_id) {
+        return Some(&op_shape.traits);
+    }
+    let suffix = format!("#{}", operation_name);
+    for (shape_id, shape) in &model.shapes {
+        if shape_id.ends_with(&suffix) && matches!(shape.shape_type, ShapeType::Operation) {
+            return Some(&shape.traits);
+        }
+    }
+    None
 }

--- a/crates/fakecloud-conformance/src/generators/negative.rs
+++ b/crates/fakecloud-conformance/src/generators/negative.rs
@@ -40,6 +40,7 @@ pub fn generate(
             strategy: Strategy::Negative,
             input: Value::Object(obj),
             expectation: Expectation::AnyError,
+            expected_output: None,
         });
     }
 
@@ -67,6 +68,7 @@ pub fn generate(
                         strategy: Strategy::Negative,
                         input,
                         expectation: Expectation::AnyError,
+                        expected_output: None,
                     });
                 }
             }
@@ -87,6 +89,7 @@ pub fn generate(
                         strategy: Strategy::Negative,
                         input,
                         expectation: Expectation::AnyError,
+                        expected_output: None,
                     });
                 }
             }
@@ -106,6 +109,7 @@ pub fn generate(
                             strategy: Strategy::Negative,
                             input,
                             expectation: Expectation::AnyError,
+                            expected_output: None,
                         });
                     }
                 }
@@ -127,6 +131,7 @@ pub fn generate(
                             strategy: Strategy::Negative,
                             input,
                             expectation: Expectation::AnyError,
+                            expected_output: None,
                         });
                     }
                 }
@@ -154,6 +159,7 @@ pub fn generate(
                 strategy: Strategy::Negative,
                 input,
                 expectation: Expectation::AnyError,
+                expected_output: None,
             });
         }
     }

--- a/crates/fakecloud-conformance/src/generators/optionals.rs
+++ b/crates/fakecloud-conformance/src/generators/optionals.rs
@@ -31,6 +31,7 @@ pub fn generate(
         strategy: Strategy::Optionals,
         input: required_input,
         expectation: Expectation::Success,
+        expected_output: None,
     });
 
     // All-fields variant (only when there are 2+ optional fields, otherwise it
@@ -42,6 +43,7 @@ pub fn generate(
             strategy: Strategy::Optionals,
             input: full_input,
             expectation: Expectation::Success,
+            expected_output: None,
         });
     }
 
@@ -67,6 +69,7 @@ pub fn generate(
             strategy: Strategy::Optionals,
             input,
             expectation: Expectation::Success,
+            expected_output: None,
         });
     }
 

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -112,6 +112,7 @@ pub fn generate(
             strategy: Strategy::Proptest,
             input,
             expectation: Expectation::Success,
+            expected_output: None,
         });
     }
 

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -185,18 +185,35 @@ pub fn probe_variant_with_model(
                 && (200..300).contains(&status_code)
                 && !body.is_empty()
             {
+                let mut all_violations = Vec::new();
                 if let Some((model, output_shape_id)) = model_info {
-                    let violations =
-                        shape_validator::validate_response(model, output_shape_id, &body, protocol);
-                    if !violations.is_empty() {
-                        let msg = violations
-                            .iter()
-                            .take(5)
-                            .map(|v| v.to_string())
-                            .collect::<Vec<_>>()
-                            .join("; ");
-                        probe_result.status = ProbeStatus::ShapeMismatch(msg);
+                    all_violations.extend(shape_validator::validate_response(
+                        model,
+                        output_shape_id,
+                        &body,
+                        protocol,
+                    ));
+                }
+                // Strategy 7 (`examples_diff`): the variant carries a documented
+                // response from the operation's `@examples` trait. Deep-diff
+                // it against the live response — every leaf in the documented
+                // output must exist (with matching JSON type) in actual. Catches
+                // optional-but-always-present fields that shape_validator can't
+                // see (#816).
+                if let Some(documented) = variant.expected_output.as_ref() {
+                    if let Ok(actual) = serde_json::from_str::<serde_json::Value>(&body) {
+                        all_violations
+                            .extend(shape_validator::diff_against_example(&actual, documented));
                     }
+                }
+                if !all_violations.is_empty() {
+                    let msg = all_violations
+                        .iter()
+                        .take(5)
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    probe_result.status = ProbeStatus::ShapeMismatch(msg);
                 }
             }
 

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -25,6 +25,22 @@ pub enum ShapeViolation {
     UnexpectedField { path: String, field: String },
     /// The response body could not be parsed.
     ParseError { message: String },
+    /// A field documented in the operation's `@examples` output is absent
+    /// from the live response (or has the wrong JSON type). Catches
+    /// "optional in Smithy but AWS always emits" bugs (#816).
+    ExamplesOutputDivergence {
+        path: String,
+        reason: ExamplesDivergenceReason,
+    },
+}
+
+/// What went wrong when diffing a response against a documented `@examples` output.
+#[derive(Debug, Clone)]
+pub enum ExamplesDivergenceReason {
+    /// The path exists in the documented output but not in the live response.
+    MissingField,
+    /// The path exists in both but the JSON value types differ.
+    WrongType { expected: String, got: String },
 }
 
 impl std::fmt::Display for ShapeViolation {
@@ -49,6 +65,115 @@ impl std::fmt::Display for ShapeViolation {
             }
             ShapeViolation::ParseError { message } => {
                 write!(f, "parse error: {}", message)
+            }
+            ShapeViolation::ExamplesOutputDivergence { path, reason } => match reason {
+                ExamplesDivergenceReason::MissingField => write!(
+                    f,
+                    "@examples output diverges at {}: documented field absent from live response",
+                    path
+                ),
+                ExamplesDivergenceReason::WrongType { expected, got } => write!(
+                    f,
+                    "@examples output diverges at {}: expected JSON {}, got {}",
+                    path, expected, got
+                ),
+            },
+        }
+    }
+}
+
+/// Deep-diff a live response against the operation's documented `@examples`
+/// output. Every leaf path present in `documented` must also exist in
+/// `actual` with the same JSON type. Values are intentionally not compared
+/// — many `@examples` use placeholders (`"examplebucket"`, `"123456789012"`)
+/// and string-equality would be noise.
+///
+/// Object members are recursed into. Arrays compare the first element of
+/// `documented` against the first element of `actual` if both are non-empty
+/// (the AWS examples always show a one-element array as a representative
+/// shape; comparing element 0 keeps the assertion structural).
+pub fn diff_against_example(actual: &Value, documented: &Value) -> Vec<ShapeViolation> {
+    let mut violations = Vec::new();
+    diff_at(actual, documented, "$", &mut violations);
+    violations
+}
+
+fn diff_at(actual: &Value, documented: &Value, path: &str, out: &mut Vec<ShapeViolation>) {
+    match documented {
+        Value::Object(doc_map) => {
+            let actual_map = match actual {
+                Value::Object(m) => m,
+                _ => {
+                    out.push(ShapeViolation::ExamplesOutputDivergence {
+                        path: path.to_string(),
+                        reason: ExamplesDivergenceReason::WrongType {
+                            expected: "object".to_string(),
+                            got: json_type_name(actual).to_string(),
+                        },
+                    });
+                    return;
+                }
+            };
+            for (key, doc_val) in doc_map {
+                let child_path = format!("{}.{}", path, key);
+                match actual_map.get(key) {
+                    Some(act_val) => diff_at(act_val, doc_val, &child_path, out),
+                    None => out.push(ShapeViolation::ExamplesOutputDivergence {
+                        path: child_path,
+                        reason: ExamplesDivergenceReason::MissingField,
+                    }),
+                }
+            }
+        }
+        Value::Array(doc_arr) => {
+            let actual_arr = match actual {
+                Value::Array(a) => a,
+                _ => {
+                    out.push(ShapeViolation::ExamplesOutputDivergence {
+                        path: path.to_string(),
+                        reason: ExamplesDivergenceReason::WrongType {
+                            expected: "array".to_string(),
+                            got: json_type_name(actual).to_string(),
+                        },
+                    });
+                    return;
+                }
+            };
+            // Documented arrays are representative — recurse into element 0
+            // when both sides have a first element. Empty actual is allowed
+            // (AWS examples show shape, not a guarantee of cardinality).
+            if let (Some(doc_first), Some(act_first)) = (doc_arr.first(), actual_arr.first()) {
+                let child_path = format!("{}[0]", path);
+                diff_at(act_first, doc_first, &child_path, out);
+            }
+        }
+        // For leaves we only assert JSON-type parity; values are placeholders.
+        _ => {
+            let actual_kind = json_type_name(actual);
+            let doc_kind = json_type_name(documented);
+            // null in the documented output means "present but value omitted";
+            // accept anything in the live response at that path.
+            if doc_kind != actual_kind && doc_kind != "null" {
+                // Smithy timestamps wire-encode as ISO-8601 strings or epoch
+                // numbers depending on protocol. Tolerate the cross-form only
+                // for paths whose member name looks like a timestamp.
+                let is_timestamp_name = path
+                    .rsplit(['.', '['])
+                    .next()
+                    .map(looks_like_timestamp_name)
+                    .unwrap_or(false);
+                let timestamp_ok = is_timestamp_name
+                    && ((doc_kind == "string" && actual_kind == "number")
+                        || (doc_kind == "number" && actual_kind == "string"));
+                if !timestamp_ok {
+                    out.push(ShapeViolation::ExamplesOutputDivergence {
+                        path: path.to_string(),
+                        reason: ExamplesDivergenceReason::WrongType {
+                            expected: doc_kind.to_string(),
+                            got: actual_kind.to_string(),
+                        },
+                    });
+                }
             }
         }
     }
@@ -424,6 +549,19 @@ fn validate_map(
         let child_path = format!("{}[{:?}]", path, key);
         validate_shape(model, value_target, val, &child_path, depth + 1, violations);
     }
+}
+
+/// Heuristic: does the trailing member name look like a Smithy timestamp?
+/// Used to scope the string-vs-number tolerance in `diff_against_example`.
+fn looks_like_timestamp_name(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.ends_with("time")
+        || n.ends_with("date")
+        || n.ends_with("timestamp")
+        || n.ends_with("at")
+        || n.ends_with("expires")
+        || n == "createdat"
+        || n == "modifiedat"
 }
 
 /// Return a human-readable name for a JSON value type.
@@ -831,5 +969,121 @@ mod tests {
             "expected an UnexpectedField(Items) violation, got {:?}",
             violations
         );
+    }
+
+    // ----- diff_against_example -----
+
+    #[test]
+    fn diff_flags_field_documented_but_missing() {
+        // Mirrors #816: documented output has BucketRegion, response doesn't.
+        let documented = serde_json::json!({
+            "Buckets": [{"Name": "x", "BucketRegion": "us-east-1"}]
+        });
+        let actual = serde_json::json!({
+            "Buckets": [{"Name": "x"}]
+        });
+        let v = diff_against_example(&actual, &documented);
+        assert!(
+            v.iter().any(|x| matches!(
+                x,
+                ShapeViolation::ExamplesOutputDivergence { path, reason: ExamplesDivergenceReason::MissingField }
+                    if path == "$.Buckets[0].BucketRegion"
+            )),
+            "expected MissingField at $.Buckets[0].BucketRegion, got {:?}",
+            v
+        );
+    }
+
+    #[test]
+    fn diff_flags_wrong_json_type() {
+        let documented = serde_json::json!({"Count": 3});
+        let actual = serde_json::json!({"Count": "three"});
+        let v = diff_against_example(&actual, &documented);
+        assert!(
+            v.iter().any(|x| matches!(
+                x,
+                ShapeViolation::ExamplesOutputDivergence { reason: ExamplesDivergenceReason::WrongType { expected, got }, .. }
+                    if expected == "number" && got == "string"
+            )),
+            "expected WrongType(number,string), got {:?}",
+            v
+        );
+    }
+
+    #[test]
+    fn diff_ignores_string_value_differences() {
+        // Documented uses placeholder, actual uses real value — both strings,
+        // so no violation. Value identity is not asserted.
+        let documented = serde_json::json!({"Name": "examplebucket"});
+        let actual = serde_json::json!({"Name": "production-logs"});
+        assert!(diff_against_example(&actual, &documented).is_empty());
+    }
+
+    #[test]
+    fn diff_ignores_extra_fields_in_response() {
+        // Live response superset of documented: not a violation.
+        let documented = serde_json::json!({"A": "x"});
+        let actual = serde_json::json!({"A": "y", "B": 42, "C": null});
+        assert!(diff_against_example(&actual, &documented).is_empty());
+    }
+
+    #[test]
+    fn diff_recurses_into_objects() {
+        let documented = serde_json::json!({"Owner": {"ID": "id", "DisplayName": "n"}});
+        let actual = serde_json::json!({"Owner": {"ID": "z"}});
+        let v = diff_against_example(&actual, &documented);
+        assert_eq!(v.len(), 1);
+        assert!(matches!(
+            &v[0],
+            ShapeViolation::ExamplesOutputDivergence { path, reason: ExamplesDivergenceReason::MissingField }
+                if path == "$.Owner.DisplayName"
+        ));
+    }
+
+    #[test]
+    fn diff_compares_first_array_element_when_both_present() {
+        let documented = serde_json::json!({"Items": [{"K": "v", "Region": "us-east-1"}]});
+        let actual = serde_json::json!({"Items": [{"K": "v"}]});
+        let v = diff_against_example(&actual, &documented);
+        assert!(v.iter().any(|x| matches!(
+            x,
+            ShapeViolation::ExamplesOutputDivergence { path, .. } if path == "$.Items[0].Region"
+        )));
+    }
+
+    #[test]
+    fn diff_allows_empty_actual_array() {
+        // AWS examples show shape with 1 element; live response with 0
+        // elements is fine — pagination, filtering, or just no resources.
+        let documented = serde_json::json!({"Items": [{"Name": "x"}]});
+        let actual = serde_json::json!({"Items": []});
+        assert!(diff_against_example(&actual, &documented).is_empty());
+    }
+
+    #[test]
+    fn diff_treats_documented_null_as_wildcard() {
+        // Documented `null` is a value placeholder — anything in actual is OK.
+        let documented = serde_json::json!({"Field": null});
+        let actual = serde_json::json!({"Field": "anything"});
+        assert!(diff_against_example(&actual, &documented).is_empty());
+    }
+
+    #[test]
+    fn diff_tolerates_timestamp_string_vs_number() {
+        // Smithy timestamps wire-encode as string OR number across protocols.
+        // Don't flag either form when the documented example shows the other.
+        let documented = serde_json::json!({"CreatedAt": "2024-01-01T00:00:00Z"});
+        let actual = serde_json::json!({"CreatedAt": 1704067200});
+        assert!(diff_against_example(&actual, &documented).is_empty());
+    }
+
+    #[test]
+    fn diff_handles_top_level_object_mismatch() {
+        let documented = serde_json::json!({"A": 1});
+        let actual = serde_json::json!([1, 2, 3]);
+        let v = diff_against_example(&actual, &documented);
+        assert!(v
+            .iter()
+            .any(|x| matches!(x, ShapeViolation::ExamplesOutputDivergence { .. })));
     }
 }


### PR DESCRIPTION
## Summary

New generator strategy (#7) that diffs every leaf field of an operation's documented `smithy.api#examples` output against the live fakecloud response.

Background: three recently-closed issues (#816, #817, #853) all slipped past the conformance harness. The harness was validating fakecloud against fakecloud's own understanding of Smithy, not against AWS's own truth — a closed loop that misses optional-but-always-emitted fields, identifier-form quirks, and silent input drops. This is the first of three batches that pull signal from sources we don't maintain.

This batch is the @examples branch: AWS itself commits canonical request/response pairs to its Smithy models. We have 577 of them across 20 of our 34 vendored services — pure data, zero hand-maintained allowlist. The diff is structural (path + JSON type) not value-equality, so placeholder strings like `"examplebucket"` aren't false-positives.

## Test plan

- [x] Unit tests for `diff_against_example` covering missing field, wrong type, nested object, list element shape, value-vs-type discipline, timestamp string/number tolerance, top-level mismatch, empty actual array, null-as-wildcard
- [x] Unit tests for `examples_diff::generate` covering empty-output skip and documented-output capture
- [x] `cargo test -p fakecloud-conformance --lib` -> 61 passed, 0 failed
- [x] `cargo clippy -p fakecloud-conformance --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo run -p fakecloud-conformance -- update-baseline` -> 80,073/81,489 -> 81,439/82,013 (per-service ratchet intact)

## Follow-ups

- Batch B: auto-discovered Create->Get round-trip echo (catches #853-class)
- Batch C: identifier-form fanout for REST URL labels (catches #817-class)
- Regression guards proving each strategy catches the original bug if reintroduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new `examples_diff` strategy that deep-diffs each operation’s documented `smithy.api#examples` output against the live response to catch missing fields and wrong JSON types. Coverage increases by +524 variants, lifting the baseline from 80,073/81,489 to 81,439/82,013.

- **New Features**
  - Introduce `examples_diff`: variants carry documented `output`; probe diffs every documented leaf path and JSON type, ignoring placeholder values.
  - Robust diff rules: tolerate timestamp string/number forms, compare arrays at index 0, treat documented `null` as wildcard, allow extra response fields, skip examples with empty output.
  - Plumbed through the harness: `TestVariant` gains `expected_output`, diff runs after shape validation, unified operation-trait lookup; README updated to seven strategies.

<sup>Written for commit 6f4c87dd4fff33b02d8bd2bb34a2a5438c9fbc91. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/886?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

