### PR TITLE
feat(conformance): Create->Get round-trip echo strategy

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,138 @@
 {
-  "variants_passed": 81439,
-  "total_variants": 82013,
+  "variants_passed": 81521,
+  "total_variants": 82104,
   "per_service": {
-    "secretsmanager": {
-      "passed": 872,
-      "total": 874
-    },
-    "iam": {
-      "passed": 5998,
-      "total": 5998
-    },
-    "lambda": {
-      "passed": 3388,
-      "total": 3388
-    },
-    "logs": {
-      "passed": 3911,
-      "total": 3911
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "ssm": {
-      "passed": 5305,
-      "total": 5305
-    },
-    "states": {
-      "passed": 1256,
-      "total": 1292
-    },
-    "route53": {
-      "passed": 2400,
-      "total": 2400
-    },
-    "wafv2": {
-      "passed": 2141,
-      "total": 2141
-    },
-    "cloudfront": {
-      "passed": 4115,
-      "total": 4115
-    },
-    "sts": {
-      "passed": 448,
-      "total": 448
-    },
-    "ecs": {
-      "passed": 2126,
-      "total": 2401
-    },
-    "ses": {
-      "passed": 2859,
-      "total": 2859
-    },
-    "elasticloadbalancing": {
-      "passed": 1587,
-      "total": 1587
-    },
-    "events": {
-      "passed": 2108,
-      "total": 2108
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "scheduler": {
-      "passed": 460,
-      "total": 491
+    "dynamodb": {
+      "passed": 2134,
+      "total": 2134
     },
     "rds": {
       "passed": 5497,
       "total": 5497
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "secretsmanager": {
+      "passed": 873,
+      "total": 875
+    },
+    "lambda": {
+      "passed": 3393,
+      "total": 3393
+    },
+    "s3": {
+      "passed": 3669,
+      "total": 3669
+    },
+    "ecs": {
+      "passed": 2126,
+      "total": 2401
+    },
+    "iam": {
+      "passed": 6000,
+      "total": 6000
+    },
+    "route53": {
+      "passed": 2400,
+      "total": 2400
+    },
+    "ses": {
+      "passed": 2867,
+      "total": 2867
+    },
+    "states": {
+      "passed": 1259,
+      "total": 1295
+    },
+    "scheduler": {
+      "passed": 462,
+      "total": 493
+    },
+    "wafv2": {
+      "passed": 2141,
+      "total": 2141
     },
     "bedrock": {
-      "passed": 3593,
-      "total": 3593
-    },
-    "ecr": {
-      "passed": 1804,
-      "total": 1805
-    },
-    "apigatewayv2": {
-      "passed": 2769,
-      "total": 2769
-    },
-    "dynamodb": {
-      "passed": 2133,
-      "total": 2133
-    },
-    "athena": {
-      "passed": 2320,
-      "total": 2320
-    },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
-    },
-    "cloudformation": {
-      "passed": 3430,
-      "total": 3430
-    },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
+      "passed": 3596,
+      "total": 3596
     },
     "bedrock-runtime": {
       "passed": 412,
       "total": 412
     },
-    "s3": {
-      "passed": 3662,
-      "total": 3662
+    "elasticache": {
+      "passed": 2258,
+      "total": 2258
     },
-    "apigatewayv1": {
-      "passed": 3134,
-      "total": 3362
+    "events": {
+      "passed": 2119,
+      "total": 2119
+    },
+    "logs": {
+      "passed": 3914,
+      "total": 3914
+    },
+    "ssm": {
+      "passed": 5309,
+      "total": 5309
+    },
+    "apigatewayv2": {
+      "passed": 2794,
+      "total": 2794
+    },
+    "cloudformation": {
+      "passed": 3433,
+      "total": 3433
+    },
+    "ecr": {
+      "passed": 1804,
+      "total": 1805
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
     "application-autoscaling": {
       "passed": 951,
       "total": 951
     },
-    "elasticache": {
-      "passed": 2258,
-      "total": 2258
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
-    "acm": {
-      "passed": 601,
-      "total": 601
+    "apigatewayv1": {
+      "passed": 3138,
+      "total": 3375
+    },
+    "sts": {
+      "passed": 448,
+      "total": 448
+    },
+    "cloudfront": {
+      "passed": 4115,
+      "total": 4115
+    },
+    "athena": {
+      "passed": 2320,
+      "total": 2320
+    },
+    "elasticloadbalancing": {
+      "passed": 1587,
+      "total": 1587
+    },
+    "kms": {
+      "passed": 2231,
+      "total": 2231
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
+    "kinesis": {
+      "passed": 1611,
+      "total": 1611
     }
   }
 }

--- a/crates/fakecloud-conformance/README.md
+++ b/crates/fakecloud-conformance/README.md
@@ -16,9 +16,9 @@ We wanted an oracle outside the loop. AWS publishes Smithy models for every serv
 
 AWS's Smithy JSON models for each service are committed to [`aws-models/`](../../aws-models/) (e.g. `s3.json`, `dynamodb.json`, `lambda.json`). `smithy.rs` parses them into a `ServiceModel` with shapes, operations, traits (`@length`, `@range`, `@required`, `@enum`, `@examples`), and error definitions.
 
-### 2. Generate inputs with seven orthogonal strategies
+### 2. Generate inputs with eight orthogonal strategies
 
-For every operation, [`generators/`](./src/generators/) produces test variants using seven independent strategies. Each one targets a different class of bug:
+For every operation, [`generators/`](./src/generators/) produces test variants using eight independent strategies. Each one targets a different class of bug:
 
 | Strategy | What it generates | What it catches |
 |---|---|---|
@@ -29,6 +29,7 @@ For every operation, [`generators/`](./src/generators/) produces test variants u
 | **Model examples** (`examples.rs`) | The `@examples` trait from the Smithy model itself — AWS's own canonical inputs | Divergence from AWS's documented examples |
 | **Negative** (`negative.rs`) | Missing required fields, out-of-range values, invalid enums, wrong types | Validation gaps, silent-pass bugs, 500s that should be 400s |
 | **Examples diff** (`examples_diff.rs`) | The `@examples` trait's documented *output* — diffs every leaf field/JSON-type against the live response | Optional-in-Smithy fields that AWS's own examples document, but fakecloud doesn't return |
+| **Round-trip echo** (`round_trip.rs`) | Walks the Smithy graph to pair every `Create*`/`Put*`/`Update*` with its matching `Get*`/`Describe*`. Sends the writer with one optional input field set, then chases the reader and asserts that field echoed | Silent input drops on Create/Put/Update — the field is accepted at the wire layer but lost before storage (e.g. Lambda `Layers` dropped on `CreateFunction`, [#853](https://github.com/faiscadev/fakecloud/issues/853)) |
 
 A single operation typically produces anywhere from a dozen to several hundred variants. Across all 33 services the baseline is **80,074 / 81,489 variants passing (98.3%)** — see [`conformance-baseline.json`](../../conformance-baseline.json) for the per-service breakdown.
 

--- a/crates/fakecloud-conformance/src/generators/boundary.rs
+++ b/crates/fakecloud-conformance/src/generators/boundary.rs
@@ -56,6 +56,7 @@ pub fn generate(
                         input,
                         expectation: Expectation::Success,
                         expected_output: None,
+                        followup: None,
                     });
                 }
                 if let Some(max) = merged.length_max {
@@ -73,6 +74,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }
@@ -90,6 +92,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }
@@ -113,6 +116,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }
@@ -135,6 +139,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                     if let Some(max) = merged.range_max {
@@ -149,6 +154,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                     if let (Some(min), Some(max)) = (merged.range_min, merged.range_max) {
@@ -163,6 +169,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::Success,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }

--- a/crates/fakecloud-conformance/src/generators/enum_exhaust.rs
+++ b/crates/fakecloud-conformance/src/generators/enum_exhaust.rs
@@ -49,6 +49,7 @@ pub fn generate(
                     input,
                     expectation: Expectation::Success,
                     expected_output: None,
+                    followup: None,
                 }
             })
             .collect();
@@ -76,6 +77,7 @@ pub fn generate(
                 input,
                 expectation: Expectation::Success,
                 expected_output: None,
+                followup: None,
             });
         }
     } else {
@@ -92,6 +94,7 @@ pub fn generate(
                     input,
                     expectation: Expectation::Success,
                     expected_output: None,
+                    followup: None,
                 });
             }
         }

--- a/crates/fakecloud-conformance/src/generators/examples.rs
+++ b/crates/fakecloud-conformance/src/generators/examples.rs
@@ -24,6 +24,7 @@ pub fn generate(traits: &ShapeTraits) -> Vec<TestVariant> {
             input: example.input.clone(),
             expectation: Expectation::Success,
             expected_output: None,
+            followup: None,
         })
         .collect()
 }

--- a/crates/fakecloud-conformance/src/generators/examples_diff.rs
+++ b/crates/fakecloud-conformance/src/generators/examples_diff.rs
@@ -35,6 +35,7 @@ pub fn generate(traits: &ShapeTraits) -> Vec<TestVariant> {
             input: example.input.clone(),
             expectation: Expectation::Success,
             expected_output: Some(example.output.clone()),
+            followup: None,
         })
         .collect()
 }

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -5,6 +5,7 @@ pub mod examples_diff;
 pub mod negative;
 pub mod optionals;
 pub mod proptest_gen;
+pub mod round_trip;
 
 use serde_json::Value;
 use std::collections::HashMap;
@@ -28,6 +29,26 @@ pub struct TestVariant {
     /// matching JSON type) in the actual response. Catches "optional in
     /// Smithy but AWS always emits" bugs (see #816).
     pub expected_output: Option<Value>,
+    /// Optional second-step probe instructions (e.g. follow Create with Get
+    /// and assert each input field echoes in the output). Set by the
+    /// `round_trip` strategy. Catches silent-input-drop bugs (#853).
+    pub followup: Option<RoundTripFollowup>,
+}
+
+/// Instructs the probe layer to fire a second request after the variant's
+/// own Create/Put/Update succeeds, then verify that selected input fields
+/// were preserved in the resource's GET response.
+#[derive(Debug, Clone)]
+pub struct RoundTripFollowup {
+    /// Operation to invoke against fakecloud after the variant succeeds.
+    pub get_operation: String,
+    /// Member name shared between the writer's input and the reader's
+    /// input. The probe pulls the identifier value out of the variant's
+    /// own input by this name and re-uses it for the reader's input.
+    pub id_field: String,
+    /// (input_field, output_field) pairs that must echo verbatim from the
+    /// Create input into the Get output.
+    pub echo_fields: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +67,8 @@ pub enum Strategy {
     Negative,
     /// Strategy 7: Documented `@examples` output diff against live response
     ExamplesDiff,
+    /// Strategy 8: Auto-discovered Create->Get round-trip echo
+    RoundTrip,
 }
 
 impl std::fmt::Display for Strategy {
@@ -58,6 +81,7 @@ impl std::fmt::Display for Strategy {
             Strategy::Examples => write!(f, "examples"),
             Strategy::Negative => write!(f, "negative"),
             Strategy::ExamplesDiff => write!(f, "examples_diff"),
+            Strategy::RoundTrip => write!(f, "round_trip"),
         }
     }
 }
@@ -268,6 +292,7 @@ pub fn generate_all_variants(
                 input: Value::Object(serde_json::Map::new()),
                 expectation: Expectation::Success,
                 expected_output: None,
+                followup: None,
             }]
         }
     };
@@ -296,6 +321,9 @@ pub fn generate_all_variants(
 
     // Strategy 6: Negative testing
     variants.extend(negative::generate(model, input_shape_id, overrides));
+
+    // Strategy 8: auto-discovered Create/Put/Update -> Get/Describe round-trip echo
+    variants.extend(round_trip::generate(model, operation_name, overrides));
 
     variants
 }

--- a/crates/fakecloud-conformance/src/generators/negative.rs
+++ b/crates/fakecloud-conformance/src/generators/negative.rs
@@ -41,6 +41,7 @@ pub fn generate(
             input: Value::Object(obj),
             expectation: Expectation::AnyError,
             expected_output: None,
+            followup: None,
         });
     }
 
@@ -69,6 +70,7 @@ pub fn generate(
                         input,
                         expectation: Expectation::AnyError,
                         expected_output: None,
+                        followup: None,
                     });
                 }
             }
@@ -90,6 +92,7 @@ pub fn generate(
                         input,
                         expectation: Expectation::AnyError,
                         expected_output: None,
+                        followup: None,
                     });
                 }
             }
@@ -110,6 +113,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::AnyError,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }
@@ -132,6 +136,7 @@ pub fn generate(
                             input,
                             expectation: Expectation::AnyError,
                             expected_output: None,
+                            followup: None,
                         });
                     }
                 }
@@ -160,6 +165,7 @@ pub fn generate(
                 input,
                 expectation: Expectation::AnyError,
                 expected_output: None,
+                followup: None,
             });
         }
     }

--- a/crates/fakecloud-conformance/src/generators/optionals.rs
+++ b/crates/fakecloud-conformance/src/generators/optionals.rs
@@ -32,6 +32,7 @@ pub fn generate(
         input: required_input,
         expectation: Expectation::Success,
         expected_output: None,
+        followup: None,
     });
 
     // All-fields variant (only when there are 2+ optional fields, otherwise it
@@ -44,6 +45,7 @@ pub fn generate(
             input: full_input,
             expectation: Expectation::Success,
             expected_output: None,
+            followup: None,
         });
     }
 
@@ -70,6 +72,7 @@ pub fn generate(
             input,
             expectation: Expectation::Success,
             expected_output: None,
+            followup: None,
         });
     }
 

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -113,6 +113,7 @@ pub fn generate(
             input,
             expectation: Expectation::Success,
             expected_output: None,
+            followup: None,
         });
     }
 

--- a/crates/fakecloud-conformance/src/generators/round_trip.rs
+++ b/crates/fakecloud-conformance/src/generators/round_trip.rs
@@ -1,0 +1,355 @@
+//! Strategy 7: auto-discovered Create/Put/Update -> Get/Describe round-trip echo.
+//!
+//! Walks the Smithy graph at variant-generation time to pair every
+//! mutating operation with its matching read operation (by structural
+//! identifier match — see `smithy::find_round_trip_pairs`). For each pair
+//! the strategy picks one optional input field on the writer whose name
+//! also appears on the reader's output, and emits a `TestVariant` that
+//! sets that field. The probe layer then chases the variant by sending
+//! Get/Describe with the writer's returned identifier and asserts the
+//! optional value made the round-trip — catches silent-input-drop bugs
+//! like #853 (Lambda `Layers` dropped on CreateFunction).
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::{
+    build_required_input, default_value_for_shape, Expectation, RoundTripFollowup, Strategy,
+    TestVariant,
+};
+use crate::smithy::{
+    effective_shape_type, find_round_trip_pairs, primitive_compatible, Member, RoundTripPair,
+    ServiceModel, ShapeType,
+};
+
+pub fn generate(
+    model: &ServiceModel,
+    operation_name: &str,
+    overrides: &HashMap<String, Value>,
+) -> Vec<TestVariant> {
+    // The strategy is keyed on the *writer* op (the variant is for Create);
+    // the followup runs Get inside `probe::probe_variant_with_model`.
+    let pair = match find_pair_for_writer(model, operation_name) {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+
+    let writer_input_id = match pair.writer.input_shape.as_deref() {
+        Some(id) => id,
+        None => return Vec::new(),
+    };
+    let reader_output_id = match pair.reader.output_shape.as_deref() {
+        Some(id) => id,
+        None => return Vec::new(),
+    };
+
+    let writer_input_members = structure_members(model, writer_input_id);
+    let reader_output_members = structure_members(model, reader_output_id);
+
+    // Find an optional input field whose name + target shape also appears
+    // on the reader's output. That's the field whose round-trip we'll
+    // assert. Skip the identifier itself — it's already being validated
+    // by virtue of the followup Get succeeding.
+    let echo_field = match writer_input_members.iter().find(|wm| {
+        !wm.required
+            && wm.name != pair.id_source_field
+            && reader_output_members
+                .iter()
+                .any(|rm| rm.name == wm.name && primitive_compatible(model, &rm.target, &wm.target))
+    }) {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+
+    let mut input = build_required_input(model, writer_input_id, overrides);
+    if let Value::Object(ref mut obj) = input {
+        let echo_value = optional_field_value(model, echo_field);
+        obj.insert(echo_field.name.clone(), echo_value);
+    }
+
+    let followup = RoundTripFollowup {
+        get_operation: pair.reader.name.clone(),
+        id_field: pair.id_source_field.clone(),
+        echo_fields: vec![(echo_field.name.clone(), echo_field.name.clone())],
+    };
+
+    vec![TestVariant {
+        name: format!("round_trip_{}", echo_field.name),
+        strategy: Strategy::RoundTrip,
+        input,
+        expectation: Expectation::Success,
+        expected_output: None,
+        followup: Some(followup),
+    }]
+}
+
+fn find_pair_for_writer(model: &ServiceModel, writer_name: &str) -> Option<RoundTripPair> {
+    find_round_trip_pairs(model)
+        .into_iter()
+        .find(|p| p.writer.name == writer_name)
+}
+
+fn structure_members(model: &ServiceModel, shape_id: &str) -> Vec<Member> {
+    match effective_shape_type(model, shape_id) {
+        Some(ShapeType::Structure { members }) => members,
+        _ => Vec::new(),
+    }
+}
+
+/// Pick a non-default value for an optional field. Use the schema's
+/// `default_value_for_shape`; for collections, populate one element so the
+/// round-trip assertion has something to compare. A bare `[]` would echo
+/// `[]` even on a service that drops the field on the floor (#853 was
+/// invisible precisely because a missing optional looks like an empty
+/// optional in JSON).
+fn optional_field_value(model: &ServiceModel, member: &Member) -> Value {
+    let target_type = effective_shape_type(model, &member.target);
+    match target_type {
+        Some(ShapeType::List { member_target }) => {
+            Value::Array(vec![default_value_for_shape(model, &member_target, 0)])
+        }
+        Some(ShapeType::Map {
+            key_target: _,
+            value_target,
+        }) => {
+            let mut obj = serde_json::Map::new();
+            obj.insert(
+                "k".to_string(),
+                default_value_for_shape(model, &value_target, 0),
+            );
+            Value::Object(obj)
+        }
+        _ => default_value_for_shape(model, &member.target, 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::smithy::{Operation, Shape, ShapeTraits};
+
+    fn op(
+        name: &str,
+        input: Option<&str>,
+        output: Option<&str>,
+        method: Option<&str>,
+        uri: Option<&str>,
+    ) -> Operation {
+        Operation {
+            name: name.to_string(),
+            input_shape: input.map(String::from),
+            output_shape: output.map(String::from),
+            error_shapes: Vec::new(),
+            http_method: method.map(String::from),
+            http_uri: uri.map(String::from),
+            http_code: None,
+        }
+    }
+
+    fn structure(id: &str, members: Vec<Member>) -> Shape {
+        Shape {
+            shape_id: id.to_string(),
+            shape_type: ShapeType::Structure { members },
+            traits: ShapeTraits::default(),
+        }
+    }
+
+    fn member(name: &str, target: &str, required: bool) -> Member {
+        Member {
+            name: name.to_string(),
+            target: target.to_string(),
+            required,
+            traits: ShapeTraits::default(),
+        }
+    }
+
+    fn lambda_layers_model() -> ServiceModel {
+        // Mirrors the #853 scenario in miniature:
+        // CreateFunction(FunctionName, Layers?) -> { FunctionArn }
+        // GetFunctionConfiguration(FunctionName) -> { FunctionArn, FunctionName, Layers? }
+        let mut shapes = std::collections::HashMap::new();
+
+        shapes.insert(
+            "test#StringList".to_string(),
+            Shape {
+                shape_id: "test#StringList".to_string(),
+                shape_type: ShapeType::List {
+                    member_target: "smithy.api#String".to_string(),
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+
+        shapes.insert(
+            "test#CreateFunctionRequest".to_string(),
+            structure(
+                "test#CreateFunctionRequest",
+                vec![
+                    member("FunctionName", "smithy.api#String", true),
+                    member("Layers", "test#StringList", false),
+                ],
+            ),
+        );
+        shapes.insert(
+            "test#CreateFunctionResponse".to_string(),
+            structure(
+                "test#CreateFunctionResponse",
+                vec![
+                    member("FunctionName", "smithy.api#String", false),
+                    member("FunctionArn", "smithy.api#String", false),
+                ],
+            ),
+        );
+        shapes.insert(
+            "test#GetFunctionConfigurationRequest".to_string(),
+            structure(
+                "test#GetFunctionConfigurationRequest",
+                vec![member("FunctionName", "smithy.api#String", true)],
+            ),
+        );
+        shapes.insert(
+            "test#GetFunctionConfigurationResponse".to_string(),
+            structure(
+                "test#GetFunctionConfigurationResponse",
+                vec![
+                    member("FunctionName", "smithy.api#String", false),
+                    member("Layers", "test#StringList", false),
+                ],
+            ),
+        );
+
+        ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![
+                op(
+                    "CreateFunction",
+                    Some("test#CreateFunctionRequest"),
+                    Some("test#CreateFunctionResponse"),
+                    Some("POST"),
+                    Some("/functions"),
+                ),
+                op(
+                    "GetFunctionConfiguration",
+                    Some("test#GetFunctionConfigurationRequest"),
+                    Some("test#GetFunctionConfigurationResponse"),
+                    Some("GET"),
+                    Some("/functions/{FunctionName}/configuration"),
+                ),
+            ],
+            shapes,
+        }
+    }
+
+    #[test]
+    fn discovers_create_get_pair_and_emits_round_trip_variant() {
+        let model = lambda_layers_model();
+        let variants = generate(&model, "CreateFunction", &HashMap::new());
+        assert_eq!(variants.len(), 1, "expected one round-trip variant");
+        let v = &variants[0];
+        assert_eq!(v.strategy, Strategy::RoundTrip);
+        let f = v.followup.as_ref().expect("followup must be set");
+        assert_eq!(f.get_operation, "GetFunctionConfiguration");
+        assert_eq!(f.id_field, "FunctionName");
+        assert_eq!(
+            f.echo_fields,
+            vec![("Layers".to_string(), "Layers".to_string())]
+        );
+        // input has the required FunctionName + the optional Layers populated
+        // with one element so the echo check has something to compare.
+        let obj = v.input.as_object().expect("object input");
+        assert!(obj.contains_key("FunctionName"));
+        let layers = obj
+            .get("Layers")
+            .expect("Layers populated")
+            .as_array()
+            .unwrap();
+        assert_eq!(layers.len(), 1);
+    }
+
+    #[test]
+    fn skips_when_no_echoable_optional_exists() {
+        // Writer has only required fields → no optional to round-trip on.
+        let mut shapes = std::collections::HashMap::new();
+        shapes.insert(
+            "test#PutThingRequest".to_string(),
+            structure(
+                "test#PutThingRequest",
+                vec![member("Id", "smithy.api#String", true)],
+            ),
+        );
+        shapes.insert(
+            "test#PutThingResponse".to_string(),
+            structure(
+                "test#PutThingResponse",
+                vec![member("Id", "smithy.api#String", false)],
+            ),
+        );
+        shapes.insert(
+            "test#GetThingRequest".to_string(),
+            structure(
+                "test#GetThingRequest",
+                vec![member("Id", "smithy.api#String", true)],
+            ),
+        );
+        shapes.insert(
+            "test#GetThingResponse".to_string(),
+            structure(
+                "test#GetThingResponse",
+                vec![member("Id", "smithy.api#String", false)],
+            ),
+        );
+        let model = ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![
+                op(
+                    "PutThing",
+                    Some("test#PutThingRequest"),
+                    Some("test#PutThingResponse"),
+                    None,
+                    None,
+                ),
+                op(
+                    "GetThing",
+                    Some("test#GetThingRequest"),
+                    Some("test#GetThingResponse"),
+                    None,
+                    None,
+                ),
+            ],
+            shapes,
+        };
+        let variants = generate(&model, "PutThing", &HashMap::new());
+        assert!(variants.is_empty());
+    }
+
+    #[test]
+    fn skips_when_no_reader_exists() {
+        let mut shapes = std::collections::HashMap::new();
+        shapes.insert(
+            "test#CreateOrphanRequest".to_string(),
+            structure(
+                "test#CreateOrphanRequest",
+                vec![member("Name", "smithy.api#String", true)],
+            ),
+        );
+        shapes.insert(
+            "test#CreateOrphanResponse".to_string(),
+            structure(
+                "test#CreateOrphanResponse",
+                vec![member("Name", "smithy.api#String", false)],
+            ),
+        );
+        let model = ServiceModel {
+            service_name: "test".to_string(),
+            operations: vec![op(
+                "CreateOrphan",
+                Some("test#CreateOrphanRequest"),
+                Some("test#CreateOrphanResponse"),
+                None,
+                None,
+            )],
+            shapes,
+        };
+        assert!(generate(&model, "CreateOrphan", &HashMap::new()).is_empty());
+    }
+}

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -206,6 +206,21 @@ pub fn probe_variant_with_model(
                             .extend(shape_validator::diff_against_example(&actual, documented));
                     }
                 }
+                // Strategy 8 (`round_trip`): chase the Create with the
+                // discovered Get/Describe, assert each input field echoed.
+                // Only meaningful when we have a model to find the followup
+                // operation in.
+                if let (Some(followup), Some((model, _))) = (variant.followup.as_ref(), model_info)
+                {
+                    all_violations.extend(run_round_trip_followup(
+                        client,
+                        endpoint,
+                        service_name,
+                        variant,
+                        followup,
+                        model,
+                    ));
+                }
                 if !all_violations.is_empty() {
                     let msg = all_violations
                         .iter()
@@ -1232,6 +1247,104 @@ fn truncate(s: &str, max: usize) -> &str {
             .unwrap_or(0);
         &s[..boundary]
     }
+}
+
+/// After a Create/Put/Update variant succeeds, fire its discovered
+/// Get/Describe followup and assert each input field that was set on the
+/// Create echoes through the Get response. Returns a list of violations
+/// (empty if everything echoed cleanly or the followup couldn't be
+/// reached for benign reasons; reports HTTP errors as a single violation
+/// so harness operators can spot pairs that need bespoke handling).
+fn run_round_trip_followup(
+    client: &reqwest::blocking::Client,
+    endpoint: &str,
+    service_name: &str,
+    create_variant: &TestVariant,
+    followup: &crate::generators::RoundTripFollowup,
+    model: &ServiceModel,
+) -> Vec<shape_validator::ShapeViolation> {
+    let mut violations = Vec::new();
+
+    // The resource identifier we used on Create is the same value we
+    // need to feed into Get/Describe. Read it straight off the variant's
+    // own input — no need to parse the Create response, which avoids
+    // false negatives on services whose Create output wraps the
+    // identifier in a sub-structure.
+    let create_obj = match create_variant.input.as_object() {
+        Some(o) => o,
+        None => return violations,
+    };
+    let id_value = match create_obj.get(&followup.id_field) {
+        Some(v) if !v.is_null() => v.clone(),
+        _ => return violations,
+    };
+
+    let mut get_input = serde_json::Map::new();
+    get_input.insert(followup.id_field.clone(), id_value);
+    let get_variant = TestVariant {
+        name: format!("{}__followup_get", create_variant.name),
+        strategy: crate::generators::Strategy::RoundTrip,
+        input: serde_json::Value::Object(get_input),
+        expectation: crate::generators::Expectation::Success,
+        expected_output: None,
+        followup: None,
+    };
+
+    // Resolve the Get op's output shape so the recursive probe can keep
+    // shape validation on. Without it the followup is still useful (we
+    // still echo-check) but skipped if the op isn't in the model.
+    let get_op = match model
+        .operations
+        .iter()
+        .find(|o| o.name == followup.get_operation)
+    {
+        Some(op) => op,
+        None => return violations,
+    };
+    let get_output_shape = match get_op.output_shape.as_deref() {
+        Some(s) => s,
+        None => return violations,
+    };
+
+    // Recurse via the public probe entry. The Get variant has no
+    // `followup`, so this terminates after one extra hop.
+    let get_result = probe_variant_with_model(
+        client,
+        endpoint,
+        service_name,
+        &followup.get_operation,
+        &get_variant,
+        Some((model, get_output_shape)),
+    );
+
+    // Only echo-check on a clean 2xx with a parseable body. A 4xx/5xx on
+    // the followup is its own signal — surface as a single violation
+    // rather than fabricate a misleading echo failure.
+    if !(200..300).contains(&get_result.http_status) {
+        violations.push(shape_validator::ShapeViolation::RoundTripFieldNotEchoed {
+            field: format!("(followup {})", followup.get_operation),
+            sent: serde_json::Value::String(format!("HTTP {}", get_result.http_status)),
+            received: None,
+        });
+        return violations;
+    }
+    let get_body: serde_json::Value = match serde_json::from_str(&get_result.response_body) {
+        Ok(v) => v,
+        Err(_) => return violations,
+    };
+
+    // Pull each echo field from the Create variant's input and compare
+    // against the Get output.
+    for (input_field, output_field) in &followup.echo_fields {
+        let sent = match create_obj.get(input_field) {
+            Some(v) => v,
+            None => continue,
+        };
+        if let Some(v) = shape_validator::echo_check(output_field, sent, &get_body) {
+            violations.push(v);
+        }
+    }
+    violations
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -32,6 +32,14 @@ pub enum ShapeViolation {
         path: String,
         reason: ExamplesDivergenceReason,
     },
+    /// An input field on a Create/Put/Update operation did not echo into
+    /// the corresponding Get/Describe response. Catches silent-input-drop
+    /// bugs (#853 Lambda Layers).
+    RoundTripFieldNotEchoed {
+        field: String,
+        sent: serde_json::Value,
+        received: Option<serde_json::Value>,
+    },
 }
 
 /// What went wrong when diffing a response against a documented `@examples` output.
@@ -78,7 +86,55 @@ impl std::fmt::Display for ShapeViolation {
                     path, expected, got
                 ),
             },
+            ShapeViolation::RoundTripFieldNotEchoed {
+                field,
+                sent,
+                received,
+            } => match received {
+                Some(r) => write!(
+                    f,
+                    "round-trip mismatch for '{}': sent {}, got {}",
+                    field, sent, r
+                ),
+                None => write!(
+                    f,
+                    "round-trip drop for '{}': sent {}, got nothing back",
+                    field, sent
+                ),
+            },
         }
+    }
+}
+
+/// Compare a value sent on a Create/Put/Update input against the value
+/// returned for the same-named field on the corresponding Get/Describe
+/// output. Used by the `round_trip` strategy.
+///
+/// Equality is `serde_json::Value` deep-equality. The intent is to catch
+/// fakecloud silently dropping a field at the input layer or at the
+/// storage layer; the diff is binary. Treat `null` and "field absent"
+/// the same on the output side because some protocols omit nulls.
+pub fn echo_check(
+    field: &str,
+    sent: &serde_json::Value,
+    output: &serde_json::Value,
+) -> Option<ShapeViolation> {
+    let received = match output {
+        serde_json::Value::Object(map) => map.get(field),
+        _ => None,
+    };
+    match received {
+        Some(serde_json::Value::Null) | None => Some(ShapeViolation::RoundTripFieldNotEchoed {
+            field: field.to_string(),
+            sent: sent.clone(),
+            received: None,
+        }),
+        Some(v) if v == sent => None,
+        Some(v) => Some(ShapeViolation::RoundTripFieldNotEchoed {
+            field: field.to_string(),
+            sent: sent.clone(),
+            received: Some(v.clone()),
+        }),
     }
 }
 

--- a/crates/fakecloud-conformance/src/smithy.rs
+++ b/crates/fakecloud-conformance/src/smithy.rs
@@ -595,6 +595,153 @@ pub fn effective_shape_type(model: &ServiceModel, shape_id: &str) -> Option<Shap
     }
 }
 
+/// A round-trip pair: a mutating op (`Create*`/`Put*`/`Update*`) and a
+/// matching read op (`Get*`/`Describe*`) that retrieves the same resource,
+/// linked by the identifier the user supplies on both inputs.
+#[derive(Debug, Clone)]
+pub struct RoundTripPair {
+    /// The mutating operation (`Create*`/`Put*`/`Update*`).
+    pub writer: Operation,
+    /// The corresponding read operation (`Get*`/`Describe*`).
+    pub reader: Operation,
+    /// Member name shared between writer's *input* and reader's *input* —
+    /// the resource identifier. The same value flows into both requests
+    /// without the round-trip strategy needing to parse the writer's
+    /// response.
+    pub id_source_field: String,
+}
+
+/// Discover Create/Put/Update -> Get/Describe pairs by walking the service
+/// model. The match is structural with a name hint:
+///
+/// 1. The writer's name starts with `Create`, `Put`, or `Update`.
+/// 2. The reader's name starts with `Get` or `Describe` AND its remaining
+///    suffix overlaps with the writer's suffix (the noun the writer
+///    creates appears in the reader's name — e.g. `CreateFunction` <->
+///    `GetFunctionConfiguration`).
+/// 3. There exists at least one structure member that appears on both
+///    writer.input AND reader.input by the same name and primitive-
+///    compatible target shape — this is the resource identifier the
+///    user supplies on both calls.
+///
+/// When multiple readers qualify, prefer the one whose suffix is shortest
+/// (closest to the bare resource — `GetFunction` over
+/// `GetFunctionConfiguration` when both exist). Pairs that fail #3 are
+/// skipped: they typically need cross-resource state (e.g. `CreateAlias`
+/// needs a function) and the strategy can't drive them from schema alone.
+pub fn find_round_trip_pairs(model: &ServiceModel) -> Vec<RoundTripPair> {
+    let mut pairs = Vec::new();
+    for writer in &model.operations {
+        let writer_suffix = match strip_writer_prefix(&writer.name) {
+            Some(s) => s,
+            None => continue,
+        };
+        let writer_input_members =
+            structure_members_for(model, writer.input_shape.as_deref().unwrap_or(""));
+        if writer_input_members.is_empty() {
+            continue;
+        }
+
+        let mut candidates: Vec<(&Operation, &str)> = Vec::new();
+        for reader in &model.operations {
+            let reader_suffix = match strip_reader_prefix(&reader.name) {
+                Some(s) => s,
+                None => continue,
+            };
+            let name_match = reader_suffix.starts_with(writer_suffix)
+                || writer_suffix.starts_with(reader_suffix);
+            if !name_match {
+                continue;
+            }
+            candidates.push((reader, reader_suffix));
+        }
+        candidates.sort_by_key(|(_, suf)| suf.len());
+
+        for (reader, _) in candidates {
+            let reader_input_members =
+                structure_members_for(model, reader.input_shape.as_deref().unwrap_or(""));
+            let binding = writer_input_members.iter().find(|wm| {
+                reader_input_members.iter().any(|rm| {
+                    rm.name == wm.name && primitive_compatible(model, &rm.target, &wm.target)
+                })
+            });
+            if let Some(bind) = binding {
+                pairs.push(RoundTripPair {
+                    writer: writer.clone(),
+                    reader: reader.clone(),
+                    id_source_field: bind.name.clone(),
+                });
+                break;
+            }
+        }
+    }
+    pairs
+}
+
+fn strip_writer_prefix(name: &str) -> Option<&str> {
+    for prefix in ["Create", "Put", "Update"] {
+        if let Some(suffix) = name.strip_prefix(prefix) {
+            if !suffix.is_empty() {
+                return Some(suffix);
+            }
+        }
+    }
+    None
+}
+
+fn strip_reader_prefix(name: &str) -> Option<&str> {
+    for prefix in ["Get", "Describe"] {
+        if let Some(suffix) = name.strip_prefix(prefix) {
+            if !suffix.is_empty() {
+                return Some(suffix);
+            }
+        }
+    }
+    None
+}
+
+fn structure_members_for(model: &ServiceModel, shape_id: &str) -> Vec<Member> {
+    if shape_id.is_empty() {
+        return Vec::new();
+    }
+    match effective_shape_type(model, shape_id) {
+        Some(ShapeType::Structure { members }) => members,
+        _ => Vec::new(),
+    }
+}
+
+/// Two shapes are "primitive compatible" if they resolve to the same
+/// JSON-level type bucket. Used to bind identifier members across writer
+/// and reader inputs even when the shape IDs differ — Lambda's
+/// `CreateFunctionRequest.FunctionName` (`FunctionName` shape) and
+/// `GetFunctionRequest.FunctionName` (`NamespacedFunctionName` shape)
+/// are both strings, so the round-trip identifier round-trips fine even
+/// though Smithy declares them as distinct typedefs.
+pub fn primitive_compatible(model: &ServiceModel, a: &str, b: &str) -> bool {
+    fn bucket(t: &ShapeType) -> u8 {
+        match t {
+            ShapeType::String { .. } | ShapeType::Enum { .. } => 1,
+            ShapeType::Integer | ShapeType::Long | ShapeType::IntEnum { .. } => 2,
+            ShapeType::Float | ShapeType::Double => 3,
+            ShapeType::Boolean => 4,
+            ShapeType::Blob => 5,
+            ShapeType::Timestamp => 6,
+            ShapeType::List { .. } => 7,
+            ShapeType::Map { .. } => 8,
+            ShapeType::Structure { .. } => 9,
+            ShapeType::Union { .. } => 10,
+            _ => 0,
+        }
+    }
+    match (
+        effective_shape_type(model, a),
+        effective_shape_type(model, b),
+    ) {
+        (Some(ta), Some(tb)) => bucket(&ta) != 0 && bucket(&ta) == bucket(&tb),
+        _ => false,
+    }
+}
+
 /// Load the service map from service-map.json.
 pub fn load_service_map(models_dir: &Path) -> Result<HashMap<String, ServiceMapEntry>, String> {
     let path = models_dir.join("service-map.json");
@@ -759,5 +906,40 @@ mod tests {
             fn_name.traits.http_label || target_traits.http_label,
             "FunctionName carries @httpLabel"
         );
+    }
+
+    #[test]
+    fn round_trip_pairs_discover_lambda_create_get() {
+        // The whole point of #853: CreateFunction <-> GetFunction(Configuration)
+        // must be discovered automatically from the Smithy graph.
+        let dir = models_dir();
+        let model = parse_model(&dir.join("lambda.json")).unwrap();
+        let pairs = find_round_trip_pairs(&model);
+        let lambda_pair = pairs
+            .iter()
+            .find(|p| p.writer.name == "CreateFunction")
+            .expect("CreateFunction must pair with a reader");
+        assert!(
+            matches!(
+                lambda_pair.reader.name.as_str(),
+                "GetFunction" | "GetFunctionConfiguration"
+            ),
+            "got reader {}",
+            lambda_pair.reader.name
+        );
+        assert_eq!(lambda_pair.id_source_field, "FunctionName");
+    }
+
+    #[test]
+    fn round_trip_pairs_discover_dynamodb_create_describe() {
+        let dir = models_dir();
+        let model = parse_model(&dir.join("dynamodb.json")).unwrap();
+        let pairs = find_round_trip_pairs(&model);
+        let table_pair = pairs
+            .iter()
+            .find(|p| p.writer.name == "CreateTable")
+            .expect("CreateTable must pair with DescribeTable");
+        assert_eq!(table_pair.reader.name, "DescribeTable");
+        assert_eq!(table_pair.id_source_field, "TableName");
     }
 }


### PR DESCRIPTION
## Summary

New generator strategy (#8) that pairs every Create*/Put*/Update* operation with its matching Get*/Describe* by walking the Smithy graph, then asserts that each input field set on the writer echoes through the reader.

Background: this is batch B of three (#886 was batch A). #853 was an example of a class of bug that conformance couldn't see — Lambda CreateFunction silently dropped the `Layers` input. The wire request was accepted, the response shape was valid, the model said `Layers` was optional both ways. Nothing in the schema-only generators looked at the round-trip — that's what this strategy adds.

Self-discovering: zero per-op or per-service config. The pair-finding algorithm (smithy::find_round_trip_pairs) uses name shape (Create<X> <-> Get<X> or Get<X>Configuration) plus a structural identifier match between writer.input and reader.input. Lambda CreateFunction <-> GetFunctionConfiguration, DynamoDB CreateTable <-> DescribeTable, IAM CreateRole <-> GetRole, etc. are all picked up automatically.

The probe layer chases the variant: extracts the identifier from the variant's own input (no need to parse the writer's response — sidesteps services whose Create output wraps the identifier in a sub-structure), fires the discovered Get/Describe, and runs echo_check on each (input_field, output_field) pair. Failures surface as ShapeViolation::RoundTripFieldNotEchoed.

## Test plan

- [x] Unit tests for find_round_trip_pairs against real Lambda + DynamoDB models
- [x] Unit tests for round_trip generator covering pair discovery, echo-field selection, no-reader skip, no-echoable-optional skip
- [x] `cargo test -p fakecloud-conformance --lib` -> 66 passed, 0 failed
- [x] `cargo clippy -p fakecloud-conformance --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo run -p fakecloud-conformance -- update-baseline` -> 81,439/82,013 -> 81,521/82,104 (per-service ratchet intact)

## Follow-ups

- Batch C: identifier-form fanout for REST URL labels (catches #817-class)
- Regression guards proving each strategy catches the original bug if reintroduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Create/Put/Update → Get/Describe round‑trip echo generator to `fakecloud-conformance` to catch silent input drops and increase coverage (+82 passed / +91 total variants).

- **New Features**
  - Auto-discovers operation pairs via `smithy::find_round_trip_pairs` (name overlap + shared identifier on both inputs).
  - Generates `Strategy::RoundTrip` variants that set one optional writer input, then runs a follow‑up reader call using `RoundTripFollowup`.
  - Probe sends the discovered Get/Describe and checks echoes with `shape_validator::echo_check`.
  - New violation: `ShapeViolation::RoundTripFieldNotEchoed` to flag mismatches or missing fields.
  - `TestVariant` extended with `followup` to support chained probes; README updated to list eight strategies.
  - Unit tests cover pair discovery (Lambda, DynamoDB), generator behavior, and probe follow‑up; baseline updated to reflect new variants.

<sup>Written for commit c51ca03754c53e2518cd7865fad2bfded11532cd. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/887?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

