### PR TITLE
feat(conformance): identifier-form fanout strategy

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,138 @@
 {
-  "variants_passed": 81521,
-  "total_variants": 82104,
+  "variants_passed": 82151,
+  "total_variants": 82739,
   "per_service": {
-    "dynamodb": {
-      "passed": 2134,
-      "total": 2134
-    },
-    "rds": {
-      "passed": 5497,
-      "total": 5497
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "secretsmanager": {
-      "passed": 873,
-      "total": 875
-    },
-    "lambda": {
-      "passed": 3393,
-      "total": 3393
-    },
-    "s3": {
-      "passed": 3669,
-      "total": 3669
-    },
-    "ecs": {
-      "passed": 2126,
-      "total": 2401
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "route53": {
-      "passed": 2400,
-      "total": 2400
-    },
-    "ses": {
-      "passed": 2867,
-      "total": 2867
-    },
     "states": {
       "passed": 1259,
       "total": 1295
-    },
-    "scheduler": {
-      "passed": 462,
-      "total": 493
-    },
-    "wafv2": {
-      "passed": 2141,
-      "total": 2141
-    },
-    "bedrock": {
-      "passed": 3596,
-      "total": 3596
-    },
-    "bedrock-runtime": {
-      "passed": 412,
-      "total": 412
-    },
-    "elasticache": {
-      "passed": 2258,
-      "total": 2258
-    },
-    "events": {
-      "passed": 2119,
-      "total": 2119
-    },
-    "logs": {
-      "passed": 3914,
-      "total": 3914
-    },
-    "ssm": {
-      "passed": 5309,
-      "total": 5309
-    },
-    "apigatewayv2": {
-      "passed": 2794,
-      "total": 2794
-    },
-    "cloudformation": {
-      "passed": 3433,
-      "total": 3433
-    },
-    "ecr": {
-      "passed": 1804,
-      "total": 1805
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "application-autoscaling": {
-      "passed": 951,
-      "total": 951
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "apigatewayv1": {
-      "passed": 3138,
-      "total": 3375
-    },
-    "sts": {
-      "passed": 448,
-      "total": 448
-    },
-    "cloudfront": {
-      "passed": 4115,
-      "total": 4115
-    },
-    "athena": {
-      "passed": 2320,
-      "total": 2320
-    },
-    "elasticloadbalancing": {
-      "passed": 1587,
-      "total": 1587
     },
     "kms": {
       "passed": 2231,
       "total": 2231
     },
+    "secretsmanager": {
+      "passed": 873,
+      "total": 875
+    },
+    "elasticloadbalancing": {
+      "passed": 1587,
+      "total": 1587
+    },
+    "events": {
+      "passed": 2119,
+      "total": 2119
+    },
+    "wafv2": {
+      "passed": 2141,
+      "total": 2141
+    },
+    "athena": {
+      "passed": 2320,
+      "total": 2320
+    },
+    "apigatewayv2": {
+      "passed": 2794,
+      "total": 2794
+    },
+    "ecr": {
+      "passed": 1804,
+      "total": 1805
+    },
+    "elasticache": {
+      "passed": 2258,
+      "total": 2258
+    },
+    "route53": {
+      "passed": 2400,
+      "total": 2400
+    },
+    "scheduler": {
+      "passed": 472,
+      "total": 508
+    },
     "cognito-idp": {
       "passed": 4483,
       "total": 4484
     },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "logs": {
+      "passed": 3914,
+      "total": 3914
+    },
+    "sts": {
+      "passed": 448,
+      "total": 448
+    },
+    "sns": {
+      "passed": 1027,
+      "total": 1027
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "bedrock-runtime": {
+      "passed": 447,
+      "total": 447
+    },
+    "bedrock": {
+      "passed": 3841,
+      "total": 3841
+    },
+    "application-autoscaling": {
+      "passed": 951,
+      "total": 951
+    },
+    "iam": {
+      "passed": 6000,
+      "total": 6000
+    },
+    "cloudfront": {
+      "passed": 4115,
+      "total": 4115
+    },
+    "ecs": {
+      "passed": 2126,
+      "total": 2401
+    },
+    "ssm": {
+      "passed": 5309,
+      "total": 5309
+    },
+    "s3": {
+      "passed": 3669,
+      "total": 3669
+    },
+    "cloudformation": {
+      "passed": 3433,
+      "total": 3433
+    },
+    "ses": {
+      "passed": 2867,
+      "total": 2867
+    },
+    "dynamodb": {
+      "passed": 2134,
+      "total": 2134
+    },
     "kinesis": {
       "passed": 1611,
       "total": 1611
+    },
+    "lambda": {
+      "passed": 3733,
+      "total": 3733
+    },
+    "apigatewayv1": {
+      "passed": 3138,
+      "total": 3375
+    },
+    "rds": {
+      "passed": 5497,
+      "total": 5497
     }
   }
 }

--- a/crates/fakecloud-conformance/README.md
+++ b/crates/fakecloud-conformance/README.md
@@ -16,9 +16,9 @@ We wanted an oracle outside the loop. AWS publishes Smithy models for every serv
 
 AWS's Smithy JSON models for each service are committed to [`aws-models/`](../../aws-models/) (e.g. `s3.json`, `dynamodb.json`, `lambda.json`). `smithy.rs` parses them into a `ServiceModel` with shapes, operations, traits (`@length`, `@range`, `@required`, `@enum`, `@examples`), and error definitions.
 
-### 2. Generate inputs with eight orthogonal strategies
+### 2. Generate inputs with nine orthogonal strategies
 
-For every operation, [`generators/`](./src/generators/) produces test variants using eight independent strategies. Each one targets a different class of bug:
+For every operation, [`generators/`](./src/generators/) produces test variants using nine independent strategies. Each one targets a different class of bug:
 
 | Strategy | What it generates | What it catches |
 |---|---|---|
@@ -30,6 +30,7 @@ For every operation, [`generators/`](./src/generators/) produces test variants u
 | **Negative** (`negative.rs`) | Missing required fields, out-of-range values, invalid enums, wrong types | Validation gaps, silent-pass bugs, 500s that should be 400s |
 | **Examples diff** (`examples_diff.rs`) | The `@examples` trait's documented *output* — diffs every leaf field/JSON-type against the live response | Optional-in-Smithy fields that AWS's own examples document, but fakecloud doesn't return |
 | **Round-trip echo** (`round_trip.rs`) | Walks the Smithy graph to pair every `Create*`/`Put*`/`Update*` with its matching `Get*`/`Describe*`. Sends the writer with one optional input field set, then chases the reader and asserts that field echoed | Silent input drops on Create/Put/Update — the field is accepted at the wire layer but lost before storage (e.g. Lambda `Layers` dropped on `CreateFunction`, [#853](https://github.com/faiscadev/fakecloud/issues/853)) |
+| **Identifier-form fanout** (`id_forms.rs`) | For URL-bound `@httpLabel` members whose `@pattern` admits an ARN, sends the operation with each accepted identifier form: bare name, `name:qualifier`, partial ARN, full ARN, URL-encoded full ARN | REST endpoints that 404 on alternate identifier forms (e.g. Lambda `GetFunction` rejecting full ARNs, [#817](https://github.com/faiscadev/fakecloud/issues/817)) |
 
 A single operation typically produces anywhere from a dozen to several hundred variants. Across all 33 services the baseline is **80,074 / 81,489 variants passing (98.3%)** — see [`conformance-baseline.json`](../../conformance-baseline.json) for the per-service breakdown.
 

--- a/crates/fakecloud-conformance/src/generators/id_forms.rs
+++ b/crates/fakecloud-conformance/src/generators/id_forms.rs
@@ -1,0 +1,380 @@
+//! Strategy 8: identifier-form fanout.
+//!
+//! AWS REST APIs that take an identifier in the URL path (e.g.
+//! `GET /2015-03-31/functions/{FunctionName}` for Lambda) typically
+//! accept the identifier in multiple forms: bare name, `name:qualifier`,
+//! partial ARN, full ARN, URL-encoded full ARN. The conformance harness
+//! historically only generated the bare name — #817 was missed because
+//! the ARN form returned 404 from fakecloud and the negative-strategy
+//! classifier waved it through.
+//!
+//! This strategy walks each REST operation's URL labels (members marked
+//! `@httpLabel`) and inspects the `@pattern` trait on the member's target
+//! shape. If the pattern admits ARN input (`smithy::pattern_admits_arn`),
+//! we emit one variant per accepted form. Each variant overrides the
+//! identifier value in the variant's input — the probe layer's
+//! Smithy-driven URL builder substitutes it into the path automatically.
+//! For Lambda/S3 (still on the legacy hardcoded routing table), the
+//! probe layer also consults the variant input for known label names.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::{build_required_input, Expectation, Strategy, TestVariant};
+use crate::smithy::{
+    effective_shape_type, pattern_admits_arn, ServiceModel, ShapeTraits, ShapeType,
+};
+
+const FAKE_ACCOUNT: &str = "123456789012";
+
+/// Per-service ARN service prefix used to synthesise `arn:aws:<svc>:...` forms.
+/// Mirrors the SigV4 service identifier most services use.
+fn arn_service_prefix(service_name: &str) -> &'static str {
+    match service_name {
+        "lambda" => "lambda",
+        "s3" => "s3",
+        "iam" => "iam",
+        "ses" | "sesv2" => "ses",
+        "states" => "states",
+        "ecs" => "ecs",
+        "ecr" => "ecr",
+        _ => "service",
+    }
+}
+
+pub fn generate(
+    model: &ServiceModel,
+    operation_name: &str,
+    overrides: &HashMap<String, Value>,
+) -> Vec<TestVariant> {
+    let op = match model.operations.iter().find(|o| o.name == operation_name) {
+        Some(o) => o,
+        None => return Vec::new(),
+    };
+    // Op must be REST-bound (have `@http`) and have at least one
+    // httpLabel-marked input member; everything else falls through to
+    // the existing strategies.
+    if op.http_uri.is_none() {
+        return Vec::new();
+    }
+    let input_shape_id = match op.input_shape.as_deref() {
+        Some(id) => id,
+        None => return Vec::new(),
+    };
+
+    let labels = httplabel_members_with_arn_pattern(model, input_shape_id);
+    if labels.is_empty() {
+        return Vec::new();
+    }
+
+    let mut variants = Vec::new();
+    let svc = arn_service_prefix(&model.service_name);
+    for (member_name, default_value) in labels {
+        // Derive the bare-name basis from the schema's default. Strip
+        // any `arn:` prefix the default happens to carry so the synthetic
+        // forms below are always layered on a clean identifier.
+        let base = strip_arn(&default_value);
+        let forms = vec![
+            ("bare", base.clone()),
+            ("qualifier", format!("{}:LATEST", base)),
+            ("partial_arn", format!("{}:function:{}", FAKE_ACCOUNT, base)),
+            (
+                "full_arn",
+                format!(
+                    "arn:aws:{}:us-east-1:{}:function:{}",
+                    svc, FAKE_ACCOUNT, base
+                ),
+            ),
+            (
+                "encoded_full_arn",
+                url_encode_colons(&format!(
+                    "arn:aws:{}:us-east-1:{}:function:{}",
+                    svc, FAKE_ACCOUNT, base
+                )),
+            ),
+        ];
+        for (form_name, value) in forms {
+            let mut local_overrides = overrides.clone();
+            local_overrides.insert(member_name.clone(), Value::String(value));
+            let input = build_required_input(model, input_shape_id, &local_overrides);
+            variants.push(TestVariant {
+                name: format!("id_form_{}_{}", member_name, form_name),
+                strategy: Strategy::IdForms,
+                input,
+                expectation: Expectation::Success,
+                expected_output: None,
+                followup: None,
+            });
+        }
+    }
+    variants
+}
+
+/// Find input members carrying `@httpLabel` whose target string shape's
+/// `@pattern` trait admits an ARN. Returns `(member_name, default_value)`
+/// where the default is the schema-driven bare value used as the basis
+/// for ARN synthesis.
+fn httplabel_members_with_arn_pattern(
+    model: &ServiceModel,
+    input_shape_id: &str,
+) -> Vec<(String, String)> {
+    let members = match effective_shape_type(model, input_shape_id) {
+        Some(ShapeType::Structure { members }) => members,
+        _ => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for member in members {
+        let traits = effective_traits(model, &member.target, &member.traits);
+        if !traits.http_label && !member.traits.http_label {
+            continue;
+        }
+        let pattern = traits.pattern.as_deref().unwrap_or("");
+        if !pattern_admits_arn(pattern) {
+            continue;
+        }
+        let default = super::default_value_for_shape(model, &member.target, 0);
+        let default_str = match default {
+            Value::String(s) => s,
+            _ => continue,
+        };
+        out.push((member.name.clone(), default_str));
+    }
+    out
+}
+
+/// Pull the most specific traits available: target shape's traits beat
+/// the member's traits when both carry a value (matches Smithy lookup
+/// semantics for `@pattern` and `@httpLabel`).
+fn effective_traits<'a>(
+    model: &'a ServiceModel,
+    target_id: &str,
+    member_traits: &'a ShapeTraits,
+) -> std::borrow::Cow<'a, ShapeTraits> {
+    match model.shapes.get(target_id) {
+        Some(shape) => std::borrow::Cow::Owned(merged_traits(&shape.traits, member_traits)),
+        None => std::borrow::Cow::Borrowed(member_traits),
+    }
+}
+
+fn merged_traits(target: &ShapeTraits, member: &ShapeTraits) -> ShapeTraits {
+    ShapeTraits {
+        documentation: member
+            .documentation
+            .clone()
+            .or_else(|| target.documentation.clone()),
+        length_min: member.length_min.or(target.length_min),
+        length_max: member.length_max.or(target.length_max),
+        range_min: member.range_min.or(target.range_min),
+        range_max: member.range_max.or(target.range_max),
+        pattern: member.pattern.clone().or_else(|| target.pattern.clone()),
+        deprecated: member.deprecated || target.deprecated,
+        sensitive: member.sensitive || target.sensitive,
+        error: member.error.clone().or_else(|| target.error.clone()),
+        http_error: member.http_error.or(target.http_error),
+        default_value: member
+            .default_value
+            .clone()
+            .or_else(|| target.default_value.clone()),
+        examples: if member.examples.is_empty() {
+            target.examples.clone()
+        } else {
+            member.examples.clone()
+        },
+        http_label: member.http_label || target.http_label,
+        http_query: member
+            .http_query
+            .clone()
+            .or_else(|| target.http_query.clone()),
+        http_header: member
+            .http_header
+            .clone()
+            .or_else(|| target.http_header.clone()),
+        http_payload: member.http_payload || target.http_payload,
+        json_name: member
+            .json_name
+            .clone()
+            .or_else(|| target.json_name.clone()),
+    }
+}
+
+fn strip_arn(value: &str) -> String {
+    if let Some(rest) = value.strip_prefix("arn:") {
+        // Keep only the resource segment: arn:aws:svc:region:account:resource[/X]
+        rest.rsplit(':').next().unwrap_or(value).to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn url_encode_colons(s: &str) -> String {
+    s.replace(':', "%3A")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::smithy::{Member, Operation, Shape, ShapeTraits};
+
+    fn op_with_uri(name: &str, input: &str) -> Operation {
+        Operation {
+            name: name.to_string(),
+            input_shape: Some(input.to_string()),
+            output_shape: None,
+            error_shapes: Vec::new(),
+            http_method: Some("GET".to_string()),
+            http_uri: Some("/2015-03-31/functions/{FunctionName}".to_string()),
+            http_code: None,
+        }
+    }
+
+    fn structure(id: &str, members: Vec<Member>) -> Shape {
+        Shape {
+            shape_id: id.to_string(),
+            shape_type: ShapeType::Structure { members },
+            traits: ShapeTraits::default(),
+        }
+    }
+
+    fn lambda_function_name_shape() -> Shape {
+        Shape {
+            shape_id: "test#FunctionName".to_string(),
+            shape_type: ShapeType::String { enum_values: None },
+            traits: ShapeTraits {
+                pattern: Some(
+                    "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}(-gov)?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?".to_string(),
+                ),
+                ..ShapeTraits::default()
+            },
+        }
+    }
+
+    #[test]
+    fn emits_five_variants_for_arn_admitting_label() {
+        let mut shapes = std::collections::HashMap::new();
+        shapes.insert(
+            "test#GetFunctionRequest".to_string(),
+            structure(
+                "test#GetFunctionRequest",
+                vec![Member {
+                    name: "FunctionName".to_string(),
+                    target: "test#FunctionName".to_string(),
+                    required: true,
+                    traits: ShapeTraits {
+                        http_label: true,
+                        ..ShapeTraits::default()
+                    },
+                }],
+            ),
+        );
+        shapes.insert(
+            "test#FunctionName".to_string(),
+            lambda_function_name_shape(),
+        );
+
+        let model = ServiceModel {
+            service_name: "lambda".to_string(),
+            operations: vec![op_with_uri("GetFunction", "test#GetFunctionRequest")],
+            shapes,
+        };
+
+        let variants = generate(&model, "GetFunction", &HashMap::new());
+        let names: Vec<&str> = variants.iter().map(|v| v.name.as_str()).collect();
+        assert_eq!(variants.len(), 5, "expected 5 forms, got {:?}", names);
+        // Every variant carries the FunctionName override.
+        for v in &variants {
+            let obj = v.input.as_object().expect("object");
+            assert!(obj.contains_key("FunctionName"));
+            assert_eq!(v.strategy, Strategy::IdForms);
+        }
+        // Spot-check the full-ARN form.
+        let full = variants
+            .iter()
+            .find(|v| v.name.contains("full_arn") && !v.name.contains("encoded"))
+            .expect("full_arn variant present");
+        let val = full
+            .input
+            .as_object()
+            .unwrap()
+            .get("FunctionName")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert!(val.starts_with("arn:aws:lambda:"), "got {val}");
+        // URL-encoded form.
+        let enc = variants
+            .iter()
+            .find(|v| v.name.contains("encoded_full_arn"))
+            .unwrap();
+        let enc_val = enc
+            .input
+            .as_object()
+            .unwrap()
+            .get("FunctionName")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert!(enc_val.contains("%3A"), "got {enc_val}");
+    }
+
+    #[test]
+    fn skips_when_pattern_does_not_admit_arn() {
+        let mut shapes = std::collections::HashMap::new();
+        shapes.insert(
+            "test#NamedRequest".to_string(),
+            structure(
+                "test#NamedRequest",
+                vec![Member {
+                    name: "Name".to_string(),
+                    target: "test#NameOnly".to_string(),
+                    required: true,
+                    traits: ShapeTraits {
+                        http_label: true,
+                        ..ShapeTraits::default()
+                    },
+                }],
+            ),
+        );
+        shapes.insert(
+            "test#NameOnly".to_string(),
+            Shape {
+                shape_id: "test#NameOnly".to_string(),
+                shape_type: ShapeType::String { enum_values: None },
+                traits: ShapeTraits {
+                    pattern: Some("[a-zA-Z0-9_-]+".to_string()),
+                    ..ShapeTraits::default()
+                },
+            },
+        );
+        let model = ServiceModel {
+            service_name: "iam".to_string(),
+            operations: vec![op_with_uri("GetThing", "test#NamedRequest")],
+            shapes,
+        };
+        assert!(generate(&model, "GetThing", &HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn skips_when_no_http_uri() {
+        let mut shapes = std::collections::HashMap::new();
+        shapes.insert(
+            "test#Req".to_string(),
+            structure(
+                "test#Req",
+                vec![Member {
+                    name: "X".to_string(),
+                    target: "smithy.api#String".to_string(),
+                    required: true,
+                    traits: ShapeTraits::default(),
+                }],
+            ),
+        );
+        let mut op = op_with_uri("Foo", "test#Req");
+        op.http_uri = None;
+        let model = ServiceModel {
+            service_name: "lambda".to_string(),
+            operations: vec![op],
+            shapes,
+        };
+        assert!(generate(&model, "Foo", &HashMap::new()).is_empty());
+    }
+}

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -2,6 +2,7 @@ pub mod boundary;
 pub mod enum_exhaust;
 pub mod examples;
 pub mod examples_diff;
+pub mod id_forms;
 pub mod negative;
 pub mod optionals;
 pub mod proptest_gen;
@@ -69,6 +70,11 @@ pub enum Strategy {
     ExamplesDiff,
     /// Strategy 8: Auto-discovered Create->Get round-trip echo
     RoundTrip,
+    /// Strategy 9: Identifier-form fanout for httpLabel-bound members whose
+    /// `@pattern` admits an ARN. Generates one variant per accepted form:
+    /// bare name, `name:qualifier`, partial ARN, full ARN, URL-encoded
+    /// full ARN. Catches "GetFunction returns 404 for ARN form" (#817).
+    IdForms,
 }
 
 impl std::fmt::Display for Strategy {
@@ -82,6 +88,7 @@ impl std::fmt::Display for Strategy {
             Strategy::Negative => write!(f, "negative"),
             Strategy::ExamplesDiff => write!(f, "examples_diff"),
             Strategy::RoundTrip => write!(f, "round_trip"),
+            Strategy::IdForms => write!(f, "id_forms"),
         }
     }
 }
@@ -324,6 +331,10 @@ pub fn generate_all_variants(
 
     // Strategy 8: auto-discovered Create/Put/Update -> Get/Describe round-trip echo
     variants.extend(round_trip::generate(model, operation_name, overrides));
+
+    // Strategy 9: Identifier-form fanout for httpLabel-bound members whose
+    // `@pattern` admits an ARN. Catches #817-class wire-form 404s.
+    variants.extend(id_forms::generate(model, operation_name, overrides));
 
     variants
 }

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -829,6 +829,15 @@ fn legacy_rest_request(
     variant: &TestVariant,
 ) -> RestRequestParts {
     let (method, path, query) = rest_request_config(service_name, operation_name);
+    // Hardcoded paths in `rest_request_config` use placeholder identifiers
+    // (`test-conformance-function`, `test-conformance-bucket`, `test-key`).
+    // Strategies that need to exercise alternative identifier forms
+    // (id_forms — bare/ARN/partial) inject the desired value into
+    // `variant.input`; substitute it in here so the URL actually carries
+    // the form being tested. Without this swap, the probe would silently
+    // send the placeholder name and the new forms would be invisible at
+    // the wire layer.
+    let path = legacy_substitute_identifiers(&path, service_name, &variant.input);
     let url = match query {
         Some(qs) => format!("{}{}?{}", endpoint, path, qs),
         None => format!("{}{}", endpoint, path),
@@ -840,6 +849,36 @@ fn legacy_rest_request(
         None
     };
     (method, url, Vec::new(), body)
+}
+
+/// Replace the hardcoded placeholder identifiers in legacy REST paths
+/// with the value the variant put in its input, when present. Mirrors
+/// the substitution `build_http_request_from_model` does via
+/// `@httpLabel`, but for the hand-curated Lambda/S3 routing tables.
+fn legacy_substitute_identifiers(
+    path: &str,
+    service_name: &str,
+    input: &serde_json::Value,
+) -> String {
+    let obj = match input.as_object() {
+        Some(o) => o,
+        None => return path.to_string(),
+    };
+    let mut out = path.to_string();
+    let subs: &[(&str, &str)] = match service_name {
+        "lambda" => &[("test-conformance-function", "FunctionName")],
+        "s3" => &[("test-conformance-bucket", "Bucket"), ("test-key", "Key")],
+        _ => &[],
+    };
+    for (placeholder, member) in subs {
+        if let Some(serde_json::Value::String(value)) = obj.get(*member) {
+            // The legacy path is unencoded; the variant value may be raw
+            // ARN or already URL-encoded. Trust the variant — the
+            // id_forms strategy decides whether to URL-encode.
+            out = out.replace(placeholder, value);
+        }
+    }
+    out
 }
 
 /// Build an HTTP request for an operation from the `@http` / `@httpLabel` /

--- a/crates/fakecloud-conformance/src/smithy.rs
+++ b/crates/fakecloud-conformance/src/smithy.rs
@@ -742,6 +742,17 @@ pub fn primitive_compatible(model: &ServiceModel, a: &str, b: &str) -> bool {
     }
 }
 
+/// Best-effort heuristic: does this `@pattern` regex admit ARN-form input?
+///
+/// AWS Smithy patterns that allow both bare names and ARNs typically
+/// contain a literal `arn:` in an alternation. We accept anything that
+/// mentions `arn:` literally — that covers every ARN-tolerant shape in
+/// the vendored models (verified against `aws-models/lambda.json`,
+/// `aws-models/iam.json`, `aws-models/s3.json`).
+pub fn pattern_admits_arn(pattern: &str) -> bool {
+    pattern.contains("arn:")
+}
+
 /// Load the service map from service-map.json.
 pub fn load_service_map(models_dir: &Path) -> Result<HashMap<String, ServiceMapEntry>, String> {
     let path = models_dir.join("service-map.json");
@@ -941,5 +952,24 @@ mod tests {
             .expect("CreateTable must pair with DescribeTable");
         assert_eq!(table_pair.reader.name, "DescribeTable");
         assert_eq!(table_pair.id_source_field, "TableName");
+    }
+
+    #[test]
+    fn pattern_admits_arn_recognises_lambda_function_name() {
+        // Real Lambda FunctionName pattern admits both bare names and ARNs.
+        let p = "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}(-gov)?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?";
+        assert!(pattern_admits_arn(p));
+    }
+
+    #[test]
+    fn pattern_admits_arn_rejects_bare_name_only() {
+        let p = "[a-zA-Z0-9_-]+";
+        assert!(!pattern_admits_arn(p));
+    }
+
+    #[test]
+    fn pattern_admits_arn_recognises_iam_role_pattern() {
+        let p = "^arn:[\\w+=/,.@-]+:iam::\\d+:role/[\\w+=,.@-]+$";
+        assert!(pattern_admits_arn(p));
     }
 }


### PR DESCRIPTION
## Summary

New generator strategy (#9) that exercises every accepted form of a REST URL identifier. Final batch of three (#886 + #887 are A and B).

Background: #817 was missed because conformance only ever sent the bare-name form of `FunctionName` to Lambda's `GetFunction`. Real AWS accepts `FunctionName`, `name:qualifier`, partial ARN, full ARN, and URL-encoded full ARN. fakecloud only routed the bare name; the ARN form returned 404 silently. This strategy walks each REST operation's `@httpLabel` members, finds the ones whose `@pattern` admits ARNs (via `smithy::pattern_admits_arn`), and emits 5 variants — one per form.

Self-discovering: zero per-op or per-service config. Any future service that ships ARN-tolerant patterns gets the fanout for free.

The probe layer's `build_http_request_from_model` already substitutes httpLabel members from variant input into URLs, so the strategy works for non-Lambda/S3 services with no probe changes. Lambda and S3 stay on the legacy hardcoded routing table; `legacy_substitute_identifiers` maps placeholder names (`test-conformance-function`, `test-conformance-bucket`, `test-key`) onto the variant input value when present.

## Test plan

- [x] Unit tests for `pattern_admits_arn` against real Lambda/IAM patterns
- [x] Unit tests for `id_forms::generate` covering 5-form expansion, no-arn-pattern skip, no-http-uri skip
- [x] `cargo test -p fakecloud-conformance --lib` -> 72 passed, 0 failed
- [x] `cargo clippy -p fakecloud-conformance --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo run -p fakecloud-conformance -- update-baseline` -> 81,521/82,104 -> 82,151/82,739 (per-service ratchet intact)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an identifier-form fanout generator in `fakecloud-conformance` to exercise all accepted REST URL identifier forms and ensure alternates (like ARNs) are handled. Also updates the probe to substitute these values into legacy Lambda/S3 paths so the forms reach the wire.

- **New Features**
  - Auto-discovers `@httpLabel` members whose `@pattern` admits ARNs via `smithy::pattern_admits_arn`; no per-service config.
  - Generates 5 forms per matching label: bare name, `name:qualifier`, partial ARN, full ARN, URL-encoded full ARN. For Lambda/S3, `legacy_substitute_identifiers` replaces placeholders in hardcoded paths.
  - Baseline: 82,151/82,739 (was 81,521/82,104).

<sup>Written for commit b63b16a7a729a516ecb5927c6425fa468b545744. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/888?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

