### PR TITLE
feat(conformance): split 4xx by AWS error shape match

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,138 @@
 {
-  "variants_passed": 82151,
+  "variants_passed": 40593,
   "total_variants": 82739,
   "per_service": {
-    "states": {
-      "passed": 1259,
-      "total": 1295
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "iam": {
+      "passed": 1168,
+      "total": 6000
+    },
+    "lambda": {
+      "passed": 476,
+      "total": 3733
+    },
+    "application-autoscaling": {
+      "passed": 102,
+      "total": 951
+    },
+    "ssm": {
+      "passed": 5077,
+      "total": 5309
     },
     "kms": {
-      "passed": 2231,
+      "passed": 2068,
       "total": 2231
     },
-    "secretsmanager": {
-      "passed": 873,
-      "total": 875
-    },
-    "elasticloadbalancing": {
-      "passed": 1587,
-      "total": 1587
-    },
-    "events": {
-      "passed": 2119,
-      "total": 2119
-    },
-    "wafv2": {
-      "passed": 2141,
-      "total": 2141
-    },
-    "athena": {
-      "passed": 2320,
-      "total": 2320
-    },
-    "apigatewayv2": {
-      "passed": 2794,
-      "total": 2794
-    },
-    "ecr": {
-      "passed": 1804,
-      "total": 1805
+    "cloudformation": {
+      "passed": 1212,
+      "total": 3433
     },
     "elasticache": {
-      "passed": 2258,
+      "passed": 177,
       "total": 2258
     },
+    "athena": {
+      "passed": 334,
+      "total": 2320
+    },
     "route53": {
-      "passed": 2400,
+      "passed": 336,
       "total": 2400
     },
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
     "scheduler": {
-      "passed": 472,
+      "passed": 111,
       "total": 508
+    },
+    "logs": {
+      "passed": 3875,
+      "total": 3914
+    },
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
+    },
+    "wafv2": {
+      "passed": 420,
+      "total": 2141
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
     },
     "cognito-idp": {
       "passed": 4483,
       "total": 4484
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "logs": {
-      "passed": 3914,
-      "total": 3914
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
     },
     "sts": {
-      "passed": 448,
+      "passed": 366,
       "total": 448
-    },
-    "sns": {
-      "passed": 1027,
-      "total": 1027
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "bedrock-runtime": {
-      "passed": 447,
-      "total": 447
-    },
-    "bedrock": {
-      "passed": 3841,
-      "total": 3841
-    },
-    "application-autoscaling": {
-      "passed": 951,
-      "total": 951
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "cloudfront": {
-      "passed": 4115,
-      "total": 4115
     },
     "ecs": {
       "passed": 2126,
       "total": 2401
     },
-    "ssm": {
-      "passed": 5309,
-      "total": 5309
-    },
-    "s3": {
-      "passed": 3669,
-      "total": 3669
-    },
-    "cloudformation": {
-      "passed": 3433,
-      "total": 3433
-    },
-    "ses": {
-      "passed": 2867,
-      "total": 2867
-    },
-    "dynamodb": {
-      "passed": 2134,
-      "total": 2134
-    },
-    "kinesis": {
-      "passed": 1611,
-      "total": 1611
-    },
-    "lambda": {
-      "passed": 3733,
-      "total": 3733
+    "sqs": {
+      "passed": 36,
+      "total": 549
     },
     "apigatewayv1": {
       "passed": 3138,
       "total": 3375
     },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
     "rds": {
-      "passed": 5497,
+      "passed": 772,
       "total": 5497
+    },
+    "s3": {
+      "passed": 2916,
+      "total": 3669
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "acm": {
+      "passed": 74,
+      "total": 601
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "sns": {
+      "passed": 530,
+      "total": 1027
     }
   }
 }

--- a/crates/fakecloud-conformance/README.md
+++ b/crates/fakecloud-conformance/README.md
@@ -49,6 +49,16 @@ A single operation typically produces anywhere from a dozen to several hundred v
 
 Both directions are checked: the input must match what AWS accepts, and the output must match what AWS returns.
 
+#### 4xx responses are also validated against the model
+
+Synthetic placeholder inputs frequently provoke real AWS exceptions like `ResourceNotFoundException` or `ValidationException` from implemented handlers — those 4xxs are *expected* and shouldn't fail the variant. But a 4xx that comes from fakecloud's *own* routing layer (a URL form the dispatcher didn't recognise, an unhandled wire format) is a bug that previously slipped through as "well, it's a 4xx, probably fine." That's exactly how #817 stayed green.
+
+The classifier now splits 4xx by what's in the body:
+- **AWS error shape present** (`__type` JSON field, `<Code>` XML element) — handler ran. If the operation's Smithy `error_shapes` list is non-empty, the code's short name must match one of the declared exceptions; this catches stray fakecloud error types AWS would never emit.
+- **No recognisable AWS error code** — likely a routing miss or unhandled-form response. Fail.
+
+The check is fully Smithy-driven from each operation's already-parsed `error_shapes` — no allowlist of acceptable error strings to maintain.
+
 ### 5. Baseline and CI gate
 
 Results are written to [`conformance-baseline.json`](../../conformance-baseline.json) — total and per-service passed/total counts. The `check` subcommand compares the current run against the committed baseline and fails if any service's pass count drops. This runs on every PR. The baseline is a ratchet: it only goes up.

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -170,6 +170,16 @@ pub fn probe_variant_with_model(
 
     let duration_ms = start.elapsed().as_millis() as u64;
 
+    // Resolve the operation's declared error shapes once so the classifier
+    // can distinguish real handler-emitted exceptions from fakecloud's own
+    // routing-miss 4xxs.
+    let op_error_shapes: Option<Vec<String>> = model_info.and_then(|(m, _)| {
+        m.operations
+            .iter()
+            .find(|o| o.name == operation_name)
+            .map(|op| op.error_shapes.clone())
+    });
+
     match result {
         Ok((status_code, body)) => {
             let mut probe_result = classify_response(
@@ -178,6 +188,7 @@ pub fn probe_variant_with_model(
                 &body,
                 &variant.expectation,
                 duration_ms,
+                op_error_shapes.as_deref(),
             );
 
             // Run shape validation on successful responses
@@ -1127,12 +1138,132 @@ fn value_to_body(v: &serde_json::Value) -> String {
     }
 }
 
+/// Classify the response when the variant expected a successful outcome.
+///
+/// Pre-`Expectation::Success` policy was: any 2xx-or-4xx == Pass. Reasoning
+/// at the time was that synthetic placeholder inputs make a 4xx
+/// (ResourceNotFoundException, ValidationException) the *expected* shape
+/// for an implemented handler. The trade-off was that fakecloud's *own*
+/// routing-miss 4xxs (returning 404 for a URL form the router didn't
+/// know how to dispatch — exactly #817) were indistinguishable from
+/// real handler-emitted 4xxs and slipped through as Pass.
+///
+/// New policy splits 4xx by what the body looks like:
+/// - 4xx with an AWS-shaped error code in the body (`__type` JSON field
+///   or `<Code>` XML element) — handler ran, returned a real exception.
+///   If the op declares `error_shapes`, the code must short-name-match
+///   one of them (Smithy declares which exceptions an op can raise).
+///   Pass.
+/// - 4xx with no recognisable AWS error code, OR with a code that's
+///   absent from the op's declared `error_shapes` — likely fakecloud's
+///   own routing-miss / unhandled-form response. Fail.
+///
+/// Net effect: signed routing reaches a handler -> Pass. Routing
+/// silently misses (404 with body that doesn't match Smithy) -> Fail.
+fn classify_success_expectation(
+    http_status: u16,
+    body: &str,
+    op_error_shapes: Option<&[String]>,
+) -> ProbeStatus {
+    if (200..300).contains(&http_status) {
+        return ProbeStatus::Pass;
+    }
+    if !(400..500).contains(&http_status) {
+        return ProbeStatus::UnexpectedResult(format!(
+            "Expected success, got HTTP {}",
+            http_status
+        ));
+    }
+    let code = match extract_aws_error_code(body) {
+        Some(c) => c,
+        None => {
+            return ProbeStatus::UnexpectedResult(format!(
+                "HTTP {} with no AWS error code in body (likely routing miss): {}",
+                http_status,
+                truncate(body, 200)
+            ));
+        }
+    };
+    // Op model available -> require the code to be in its declared errors.
+    // Op model unavailable (no model for this service or unknown op) -> any
+    // AWS-shaped error counts as a handler response.
+    if let Some(declared) = op_error_shapes {
+        if declared.is_empty() || matches_declared_error(&code, declared) {
+            ProbeStatus::Pass
+        } else {
+            ProbeStatus::UnexpectedResult(format!(
+                "HTTP {} with undeclared error '{}' (not in op's Smithy error_shapes)",
+                http_status, code
+            ))
+        }
+    } else {
+        ProbeStatus::Pass
+    }
+}
+
+/// Pull the AWS error code out of a response body. Handles all four
+/// AWS wire forms:
+///   - JSON: `{"__type":"X"}` or `{"__type":"com.amazonaws.svc#X"}`
+///     (restJson1 / awsJson1.1)
+///   - JSON: `{"code":"X"}` / `{"Code":"X"}` (Smithy fallbacks some
+///     services use)
+///   - XML: `<Error><Code>X</Code></Error>` (restXml — S3, CloudFront)
+///   - XML: `<ErrorResponse><Error><Code>X</Code></Error></ErrorResponse>`
+///     (awsQuery — IAM, RDS, SNS, ELB, CFN, STS)
+///
+/// Returns the short name (after `#` if present). Returns `None` when
+/// the body has no recognisable AWS error code — the signal we care
+/// about for distinguishing real handler responses from routing misses.
+fn extract_aws_error_code(body: &str) -> Option<String> {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+        for key in ["__type", "Code", "code"] {
+            if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+                return Some(short_error_name(s));
+            }
+        }
+        // Some restJson1 services nest under `Error` or `error`.
+        for outer in ["Error", "error"] {
+            if let Some(inner) = v.get(outer) {
+                for key in ["Code", "code", "__type"] {
+                    if let Some(s) = inner.get(key).and_then(|x| x.as_str()) {
+                        return Some(short_error_name(s));
+                    }
+                }
+            }
+        }
+    }
+    // XML <Code>X</Code> — first occurrence wins.
+    if let Some(start) = body.find("<Code>") {
+        let after = &body[start + "<Code>".len()..];
+        if let Some(end) = after.find("</Code>") {
+            return Some(after[..end].trim().to_string());
+        }
+    }
+    None
+}
+
+/// Strip Smithy namespace from an error type. `com.amazonaws.lambda#X` -> `X`.
+fn short_error_name(s: &str) -> String {
+    let after_hash = s.rsplit('#').next().unwrap_or(s);
+    // Some services prefix with shape namespace via colon syntax.
+    let after_colon = after_hash.rsplit(':').next().unwrap_or(after_hash);
+    after_colon.trim().to_string()
+}
+
+fn matches_declared_error(code: &str, declared: &[String]) -> bool {
+    declared.iter().any(|id| {
+        let short = id.rsplit('#').next().unwrap_or(id);
+        short == code
+    })
+}
+
 fn classify_response(
     variant_name: &str,
     http_status: u16,
     body: &str,
     expectation: &Expectation,
     duration_ms: u64,
+    op_error_shapes: Option<&[String]>,
 ) -> ProbeResult {
     // Classify as NotImplemented when fakecloud signals "we did not find a
     // handler for this action" — as opposed to AWS-shaped errors that mean
@@ -1184,20 +1315,7 @@ fn classify_response(
     }
 
     let status = match expectation {
-        Expectation::Success => {
-            if (200..500).contains(&http_status) {
-                // 2xx = genuine success.
-                // 4xx = also treated as Pass because most "success" probes send synthetic
-                // placeholder data (no real fixtures), which triggers AWS validation errors
-                // (e.g. ResourceNotFoundException, ValidationException). The important signal
-                // is that the action was routed and processed — not that the dummy data was
-                // accepted. Once fixture support is added, this should be tightened to
-                // distinguish real validation errors from routing failures.
-                ProbeStatus::Pass
-            } else {
-                ProbeStatus::UnexpectedResult(format!("Expected success, got HTTP {}", http_status))
-            }
-        }
+        Expectation::Success => classify_success_expectation(http_status, body, op_error_shapes),
         Expectation::AnyError => {
             if http_status >= 400 {
                 ProbeStatus::Pass
@@ -1826,7 +1944,7 @@ mod tests {
         // API Gateway v2 emits `Unknown path: ...` when resolve_action
         // can't match a URL. Must classify as NotImplemented, not Pass.
         let body = r#"{"__type":"NotFoundException","message":"Unknown path: /v2/domainnames"}"#;
-        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, None);
         assert_eq!(result.status, ProbeStatus::NotImplemented);
     }
 
@@ -1835,7 +1953,7 @@ mod tests {
         // Lambda emits `UnknownOperationException` for URLs its
         // resolve_action doesn't recognize.
         let body = r#"{"__type":"UnknownOperationException","message":"Unknown operation: /foo"}"#;
-        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, None);
         assert_eq!(result.status, ProbeStatus::NotImplemented);
     }
 
@@ -1845,7 +1963,7 @@ mod tests {
         // in the response body.
         let body =
             r#"{"__type":"InvalidAction","message":"action Foo not implemented for service bar"}"#;
-        let result = classify_response("v1", 501, body, &Expectation::Success, 0);
+        let result = classify_response("v1", 501, body, &Expectation::Success, 0, None);
         assert_eq!(result.status, ProbeStatus::NotImplemented);
     }
 
@@ -1856,7 +1974,99 @@ mod tests {
         // confused with NotImplemented.
         let body =
             r#"{"__type":"ResourceNotFoundException","message":"Function not found: test-fn"}"#;
-        let result = classify_response("v1", 404, body, &Expectation::Success, 0);
+        let declared = vec!["com.amazonaws.lambda#ResourceNotFoundException".to_string()];
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, Some(&declared));
         assert_eq!(result.status, ProbeStatus::Pass);
+    }
+
+    // -- error-shape-driven 4xx classification --
+
+    #[test]
+    fn classify_404_with_no_aws_error_shape_fails() {
+        // Mirrors #817: routing miss returns 404 with a body that has no
+        // AWS error code. Must NOT pass — that's the gaming we're closing.
+        let body = r#"{"message":"Function not found"}"#;
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, None);
+        assert!(matches!(result.status, ProbeStatus::UnexpectedResult(_)));
+    }
+
+    #[test]
+    fn classify_404_with_undeclared_error_fails() {
+        // Handler-emitted error that doesn't appear in the op's Smithy
+        // error_shapes list — could be a stray fakecloud error type that
+        // AWS would never return. Flag it.
+        let body = r#"{"__type":"WeirdInternalException","message":"oops"}"#;
+        let declared = vec![
+            "com.amazonaws.svc#ResourceNotFoundException".to_string(),
+            "com.amazonaws.svc#ValidationException".to_string(),
+        ];
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, Some(&declared));
+        assert!(
+            matches!(result.status, ProbeStatus::UnexpectedResult(_)),
+            "got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn classify_400_with_xml_error_code_passes() {
+        // restXml + awsQuery both encode the error code in <Code>X</Code>.
+        let body =
+            r#"<?xml version="1.0"?><Error><Code>NoSuchBucket</Code><Message>x</Message></Error>"#;
+        let declared = vec!["com.amazonaws.s3#NoSuchBucket".to_string()];
+        let result = classify_response("v1", 404, body, &Expectation::Success, 0, Some(&declared));
+        assert_eq!(result.status, ProbeStatus::Pass);
+    }
+
+    #[test]
+    fn classify_400_query_protocol_error_passes() {
+        // awsQuery (IAM, RDS, …) wraps the error in <ErrorResponse><Error>...
+        let body = r#"<ErrorResponse><Error><Code>InvalidParameterValue</Code><Message>x</Message></Error></ErrorResponse>"#;
+        let declared = vec!["com.amazonaws.svc#InvalidParameterValue".to_string()];
+        let result = classify_response("v1", 400, body, &Expectation::Success, 0, Some(&declared));
+        assert_eq!(result.status, ProbeStatus::Pass);
+    }
+
+    #[test]
+    fn classify_4xx_no_op_model_lenient() {
+        // Op model unavailable (caller didn't pass declared errors): any
+        // AWS-shaped error counts as a real handler response.
+        let body = r#"{"__type":"SomeException"}"#;
+        let result = classify_response("v1", 400, body, &Expectation::Success, 0, None);
+        assert_eq!(result.status, ProbeStatus::Pass);
+    }
+
+    #[test]
+    fn classify_4xx_empty_error_shapes_lenient() {
+        // Op declares no errors (rare). Treat any AWS-shaped error as Pass.
+        let body = r#"{"__type":"SomeException"}"#;
+        let declared: Vec<String> = Vec::new();
+        let result = classify_response("v1", 400, body, &Expectation::Success, 0, Some(&declared));
+        assert_eq!(result.status, ProbeStatus::Pass);
+    }
+
+    #[test]
+    fn extract_error_code_from_namespaced_type() {
+        let body = r#"{"__type":"com.amazonaws.lambda#ResourceNotFoundException"}"#;
+        assert_eq!(
+            extract_aws_error_code(body),
+            Some("ResourceNotFoundException".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_error_code_from_xml() {
+        let body = r#"<Error><Code>NoSuchBucket</Code></Error>"#;
+        assert_eq!(
+            extract_aws_error_code(body),
+            Some("NoSuchBucket".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_error_code_returns_none_for_plain_message() {
+        // Routing-miss body shape — no recognisable AWS error code.
+        let body = r#"{"message":"Unknown URL"}"#;
+        assert_eq!(extract_aws_error_code(body), None);
     }
 }


### PR DESCRIPTION
## Summary

Closes the 4xx-is-always-Pass gaming hole that #817 slipped through.

The old classifier had this comment:
> 4xx = also treated as Pass because most "success" probes send synthetic placeholder data (no real fixtures), which triggers AWS validation errors (e.g. ResourceNotFoundException, ValidationException). The important signal is that the action was routed and processed — not that the dummy data was accepted.

The flaw: it conflated two very different 4xxs — a real handler-emitted AWS exception, and fakecloud's own routing-miss / unhandled-form 4xx. They look the same at HTTP-status level, so any wire-routing bug that produced a 404 was waved through as Pass.

New policy is Smithy-driven:
- **2xx** -> Pass (unchanged)
- **4xx** -> extract AWS error code (`__type` JSON / `<Code>` XML / `Error.Code` nested). If the op's `error_shapes` is non-empty, the code's short name must match one of the declared exceptions. If the body has no recognisable AWS error code at all, fail — that's the routing-miss signal.
- **5xx** -> Crash (unchanged)

The check is fully self-discovering from each operation's already-parsed `error_shapes` — zero allowlist to maintain.

## ⚠️ Baseline impact: 82,151 -> 40,593 passing variants (99.3% -> 49.1%)

The drop is the previously-hidden gaming surfacing as truth. Every newly-failing variant is a real divergence between fakecloud's responses and AWS's declared error contract. Two example classes:

- **Wrong error type**: SQS `AddPermission` returns `NotFoundException` but Smithy declares the op only emits `QueueDoesNotExist` / `InvalidAddress` / `OverLimit` / `RequestThrottled` / `UnsupportedOperation`. Real AWS would never emit `NotFoundException` for `AddPermission`.
- **Non-AWS-shaped 404s**: many ops with synthetic identifiers get 404s whose bodies are plain `{"message":"..."}` instead of an AWS error envelope. fakecloud's routing layer produces a non-conformant response.

Per the harness charter: surfacing these is the point. The new lower numbers become the ratchet floor — every future PR can either drive them down (by ignoring known gaps) or up (by fixing real bugs). They will not silently regress.

This PR does not fix any of the newly-revealed bugs — that's separate follow-up work, ticket-by-ticket. The goal here is purely to improve the conformance process so the bugs are *visible* in the first place.

## Test plan

- [x] Unit tests for `extract_aws_error_code` covering JSON `__type`, namespaced `__type`, XML `<Code>`, awsQuery nested `<Error><Code>`, plain message (returns None)
- [x] Unit tests for `classify_success_expectation` covering: 2xx Pass, 4xx with no AWS shape Fail, 4xx with undeclared error Fail, 4xx with declared error Pass, lenient fallback when no model
- [x] `cargo test -p fakecloud-conformance --lib` -> 81 passed, 0 failed
- [x] `cargo clippy -p fakecloud-conformance --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo run -p fakecloud-conformance -- update-baseline` -> 40,593/82,739 (49.1%) committed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens success classification: 4xx now pass only when the body contains an AWS error code that matches the operation’s Smithy-declared exceptions, closing the hole where routing misses were counted as success. Baseline is updated to reflect the newly surfaced gaps.

- **New Features**
  - Split 4xx by AWS error shape; extract codes from JSON `__type`/`Error.Code` and XML `<Code>`.
  - When modeled, require the code to match the op’s `error_shapes`; missing or undeclared code -> Fail. 2xx/5xx behavior unchanged.
  - Self-discovering (no allowlist). Added unit tests and README notes in `crates/fakecloud-conformance`.

- **Migration**
  - Baseline drops from 82,151 to 40,593 passes (99.3% -> 49.1%).
  - CI now flags routing misses and wrong error types instead of waving them through; this is the new ratchet floor.

<sup>Written for commit ff1fb61b9a48c6c62a012b51a352b154040ace9a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/889?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

