### PR TITLE
refactor(iam): delete fabricated operations not in real AWS

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,50 +1,10 @@
 {
-  "variants_passed": 40593,
+  "variants_passed": 40540,
   "total_variants": 82739,
   "per_service": {
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
-    "iam": {
-      "passed": 1168,
-      "total": 6000
-    },
-    "lambda": {
-      "passed": 476,
-      "total": 3733
-    },
-    "application-autoscaling": {
-      "passed": 102,
-      "total": 951
-    },
-    "ssm": {
-      "passed": 5077,
-      "total": 5309
-    },
-    "kms": {
-      "passed": 2068,
-      "total": 2231
-    },
-    "cloudformation": {
-      "passed": 1212,
-      "total": 3433
-    },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
-    },
-    "athena": {
-      "passed": 334,
-      "total": 2320
-    },
-    "route53": {
-      "passed": 336,
-      "total": 2400
-    },
-    "states": {
-      "passed": 1253,
-      "total": 1295
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
     },
     "scheduler": {
       "passed": 111,
@@ -54,85 +14,125 @@
       "passed": 3875,
       "total": 3914
     },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "wafv2": {
-      "passed": 420,
-      "total": 2141
-    },
-    "events": {
-      "passed": 1970,
-      "total": 2119
-    },
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
-    },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
-    },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
-    },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "sts": {
-      "passed": 366,
-      "total": 448
-    },
-    "ecs": {
-      "passed": 2126,
-      "total": 2401
+    "ssm": {
+      "passed": 5077,
+      "total": 5309
     },
     "sqs": {
       "passed": 36,
       "total": 549
     },
-    "apigatewayv1": {
-      "passed": 3138,
-      "total": 3375
+    "route53": {
+      "passed": 336,
+      "total": 2400
     },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "s3": {
-      "passed": 2916,
-      "total": 3669
-    },
-    "ses": {
-      "passed": 231,
-      "total": 2867
+    "lambda": {
+      "passed": 476,
+      "total": 3733
     },
     "ecr": {
       "passed": 1764,
       "total": 1805
     },
-    "acm": {
-      "passed": 74,
-      "total": 601
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
+    "application-autoscaling": {
+      "passed": 102,
+      "total": 951
+    },
+    "wafv2": {
+      "passed": 420,
+      "total": 2141
+    },
+    "s3": {
+      "passed": 2916,
+      "total": 3669
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
     },
     "apigatewayv2": {
       "passed": 228,
       "total": 2794
     },
+    "cloudformation": {
+      "passed": 1212,
+      "total": 3433
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
+    },
     "sns": {
       "passed": 530,
       "total": 1027
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "acm": {
+      "passed": 74,
+      "total": 601
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "athena": {
+      "passed": 334,
+      "total": 2320
+    },
+    "sts": {
+      "passed": 359,
+      "total": 448
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
+    },
+    "kms": {
+      "passed": 2068,
+      "total": 2231
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "ecs": {
+      "passed": 2126,
+      "total": 2401
+    },
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "apigatewayv1": {
+      "passed": 3138,
+      "total": 3375
     }
   }
 }

--- a/crates/fakecloud-conformance/tests/iam.rs
+++ b/crates/fakecloud-conformance/tests/iam.rs
@@ -1752,51 +1752,6 @@ async fn iam_post_raw(server: &TestServer, params: &[(&str, &str)]) -> reqwest::
         .unwrap()
 }
 
-#[test_action("iam", "CreateDelegationRequest", checksum = "84b7a617")]
-#[test_action("iam", "GetDelegationRequest", checksum = "c7b7aff8")]
-#[test_action("iam", "ListDelegationRequests", checksum = "a06e2be5")]
-#[test_action("iam", "UpdateDelegationRequest", checksum = "0675f35d")]
-#[test_action("iam", "AcceptDelegationRequest", checksum = "d512c062")]
-#[test_action("iam", "RejectDelegationRequest", checksum = "4120b198")]
-#[test_action("iam", "AssociateDelegationRequest", checksum = "05f74036")]
-#[test_action("iam", "SendDelegationToken", checksum = "6d253750")]
-#[tokio::test]
-async fn iam_delegation_request_lifecycle() {
-    let server = TestServer::start().await;
-    let resp = iam_post_raw(
-        &server,
-        &[
-            ("Action", "CreateDelegationRequest"),
-            ("TargetAccount", "111122223333"),
-        ],
-    )
-    .await;
-    let body = resp.text().await.unwrap();
-    let id = body
-        .split("<DelegationRequestId>")
-        .nth(1)
-        .unwrap()
-        .split("</")
-        .next()
-        .unwrap()
-        .to_string();
-
-    for action in [
-        "GetDelegationRequest",
-        "UpdateDelegationRequest",
-        "AcceptDelegationRequest",
-        "AssociateDelegationRequest",
-        "RejectDelegationRequest",
-        "SendDelegationToken",
-    ] {
-        let resp = iam_post_raw(&server, &[("Action", action), ("DelegationRequestId", &id)]).await;
-        assert!(resp.status().is_success(), "{action}");
-    }
-
-    let resp = iam_post_raw(&server, &[("Action", "ListDelegationRequests")]).await;
-    assert!(resp.status().is_success());
-}
-
 #[test_action(
     "iam",
     "EnableOrganizationsRootCredentialsManagement",
@@ -1856,35 +1811,6 @@ async fn iam_organizations_lifecycle() {
         let resp = iam_post_raw(&server, &[("Action", action)]).await;
         assert!(resp.status().is_success(), "{action}");
     }
-}
-
-#[test_action("iam", "EnableOutboundWebIdentityFederation", checksum = "ed54ae5f")]
-#[test_action("iam", "DisableOutboundWebIdentityFederation", checksum = "2f6d24b9")]
-#[test_action("iam", "GetOutboundWebIdentityFederationInfo", checksum = "947612c4")]
-#[tokio::test]
-async fn iam_outbound_web_identity_federation() {
-    let server = TestServer::start().await;
-    let resp = iam_post_raw(
-        &server,
-        &[
-            ("Action", "EnableOutboundWebIdentityFederation"),
-            ("IssuerUrl", "https://example.com"),
-        ],
-    )
-    .await;
-    assert!(resp.status().is_success());
-    let resp = iam_post_raw(
-        &server,
-        &[("Action", "GetOutboundWebIdentityFederationInfo")],
-    )
-    .await;
-    assert!(resp.status().is_success());
-    let resp = iam_post_raw(
-        &server,
-        &[("Action", "DisableOutboundWebIdentityFederation")],
-    )
-    .await;
-    assert!(resp.status().is_success());
 }
 
 #[test_action("iam", "GenerateServiceLastAccessedDetails", checksum = "1222363b")]
@@ -2151,7 +2077,6 @@ async fn iam_policy_simulation() {
 }
 
 #[test_action("iam", "ChangePassword", checksum = "afd8c998")]
-#[test_action("iam", "GetHumanReadableSummary", checksum = "b37cb675")]
 #[test_action("iam", "SetSecurityTokenServicePreferences", checksum = "b48dcc82")]
 #[tokio::test]
 async fn iam_misc_account_ops() {
@@ -2165,8 +2090,6 @@ async fn iam_misc_account_ops() {
         ],
     )
     .await;
-    assert!(r.status().is_success());
-    let r = iam_post_raw(&server, &[("Action", "GetHumanReadableSummary")]).await;
     assert!(r.status().is_success());
     let r = iam_post_raw(
         &server,

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -129,32 +129,3 @@ async fn sts_assume_root() {
         .unwrap();
     assert!(resp.credentials().is_some());
 }
-
-#[test_action("sts", "GetDelegatedAccessToken", checksum = "93cb2870")]
-#[tokio::test]
-async fn sts_get_delegated_access_token() {
-    let server = TestServer::start().await;
-    let client = server.sts_client().await;
-    let resp = client
-        .get_delegated_access_token()
-        .trade_in_token("opaque-token")
-        .send()
-        .await
-        .unwrap();
-    assert!(resp.credentials().is_some());
-}
-
-#[test_action("sts", "GetWebIdentityToken", checksum = "9ea6bbde")]
-#[tokio::test]
-async fn sts_get_web_identity_token() {
-    let server = TestServer::start().await;
-    let client = server.sts_client().await;
-    let resp = client
-        .get_web_identity_token()
-        .audience("https://example.com")
-        .signing_algorithm("RS256")
-        .send()
-        .await
-        .unwrap();
-    assert!(resp.web_identity_token().is_some());
-}

--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -10,8 +10,7 @@ use http::StatusCode;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
-    DelegationRequest, IamState, OrganizationsAccessReport, OutboundWebIdentityFederation,
-    ServiceLastAccessedJob, ServiceSpecificCredential,
+    IamState, OrganizationsAccessReport, ServiceLastAccessedJob, ServiceSpecificCredential,
 };
 
 use super::{empty_response, parse_tags, tags_xml, IamService};
@@ -53,31 +52,6 @@ fn service_credential_xml(c: &ServiceSpecificCredential, include_password: bool)
         xml_escape(&c.user_name),
         xml_escape(&c.credential_id),
         xml_escape(&c.status),
-    )
-}
-
-fn delegation_request_xml(d: &DelegationRequest) -> String {
-    let perms: String = d
-        .permissions
-        .iter()
-        .map(|p| format!("      <member>{}</member>", xml_escape(p)))
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!(
-        "<DelegationRequest>\
-         <DelegationRequestId>{}</DelegationRequestId>\
-         <SourceAccount>{}</SourceAccount>\
-         <TargetAccount>{}</TargetAccount>\
-         <Status>{}</Status>\
-         <CreateDate>{}</CreateDate>\
-         <Permissions>{}</Permissions>\
-         </DelegationRequest>",
-        xml_escape(&d.id),
-        xml_escape(&d.source_account),
-        xml_escape(&d.target_account),
-        xml_escape(&d.status),
-        d.create_date.format("%Y-%m-%dT%H:%M:%SZ"),
-        perms,
     )
 }
 
@@ -248,160 +222,6 @@ impl IamService {
         ))
     }
 
-    // ── Delegation requests ──
-
-    pub(super) fn create_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let target = required_param(&req.query_params, "TargetAccount")?;
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let id = random_id("DR-");
-        let dr = DelegationRequest {
-            id: id.clone(),
-            source_account: state.account_id.clone(),
-            target_account: target,
-            status: "Pending".to_string(),
-            create_date: Utc::now(),
-            permissions: Vec::new(),
-        };
-        state.delegation_requests.insert(id.clone(), dr.clone());
-        let body = format!(
-            "  <CreateDelegationRequestResult>{}</CreateDelegationRequestResult>",
-            delegation_request_xml(&dr)
-        );
-        Ok(xml_response(
-            "CreateDelegationRequest",
-            &body,
-            &req.request_id,
-        ))
-    }
-
-    pub(super) fn accept_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        self.update_delegation_status(req, "AcceptDelegationRequest", "Accepted")
-    }
-
-    pub(super) fn reject_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        self.update_delegation_status(req, "RejectDelegationRequest", "Rejected")
-    }
-
-    pub(super) fn associate_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        self.update_delegation_status(req, "AssociateDelegationRequest", "Associated")
-    }
-
-    pub(super) fn update_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let id = required_param(&req.query_params, "DelegationRequestId")?;
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let dr = state.delegation_requests.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NoSuchEntity",
-                format!("DelegationRequest {id} not found"),
-            )
-        })?;
-        if let Some(s) = req.query_params.get("Status") {
-            dr.status = s.clone();
-        }
-        Ok(AwsResponse::xml(
-            StatusCode::OK,
-            empty_response("UpdateDelegationRequest", &req.request_id),
-        ))
-    }
-
-    fn update_delegation_status(
-        &self,
-        req: &AwsRequest,
-        action: &str,
-        new_status: &str,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let id = required_param(&req.query_params, "DelegationRequestId")?;
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let dr = state.delegation_requests.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NoSuchEntity",
-                format!("DelegationRequest {id} not found"),
-            )
-        })?;
-        dr.status = new_status.to_string();
-        Ok(AwsResponse::xml(
-            StatusCode::OK,
-            empty_response(action, &req.request_id),
-        ))
-    }
-
-    pub(super) fn get_delegation_request(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let id = required_param(&req.query_params, "DelegationRequestId")?;
-        let accounts = self.state.read();
-        let empty = IamState::new(&req.account_id);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let dr = state.delegation_requests.get(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NoSuchEntity",
-                format!("DelegationRequest {id} not found"),
-            )
-        })?;
-        let body = format!(
-            "  <GetDelegationRequestResult>{}</GetDelegationRequestResult>",
-            delegation_request_xml(dr)
-        );
-        Ok(xml_response("GetDelegationRequest", &body, &req.request_id))
-    }
-
-    pub(super) fn list_delegation_requests(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let empty = IamState::new(&req.account_id);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let members: String = state
-            .delegation_requests
-            .values()
-            .map(delegation_request_xml)
-            .collect::<Vec<_>>()
-            .join("\n");
-        let body = format!(
-            "  <ListDelegationRequestsResult>\n    <DelegationRequests>{members}</DelegationRequests>\n  </ListDelegationRequestsResult>"
-        );
-        Ok(xml_response(
-            "ListDelegationRequests",
-            &body,
-            &req.request_id,
-        ))
-    }
-
-    pub(super) fn send_delegation_token(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let _id = required_param(&req.query_params, "DelegationRequestId")?;
-        let body = format!(
-            "  <SendDelegationTokenResult><Token>{}</Token></SendDelegationTokenResult>",
-            random_id("TOK")
-        );
-        Ok(xml_response("SendDelegationToken", &body, &req.request_id))
-    }
-
     // ── Organizations integration ──
 
     pub(super) fn enable_organizations_root_credentials_management(
@@ -544,68 +364,6 @@ impl IamService {
         );
         Ok(xml_response(
             "ListOrganizationsFeatures",
-            &body,
-            &req.request_id,
-        ))
-    }
-
-    // ── Outbound web identity federation ──
-
-    pub(super) fn enable_outbound_web_identity_federation(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let issuer = req
-            .query_params
-            .get("IssuerUrl")
-            .cloned()
-            .unwrap_or_default();
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        state.outbound_web_identity_federation = Some(OutboundWebIdentityFederation {
-            enabled: true,
-            issuer_url: issuer,
-            audience: Vec::new(),
-        });
-        Ok(AwsResponse::xml(
-            StatusCode::OK,
-            empty_response("EnableOutboundWebIdentityFederation", &req.request_id),
-        ))
-    }
-
-    pub(super) fn disable_outbound_web_identity_federation(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        if let Some(ref mut cfg) = state.outbound_web_identity_federation {
-            cfg.enabled = false;
-        }
-        Ok(AwsResponse::xml(
-            StatusCode::OK,
-            empty_response("DisableOutboundWebIdentityFederation", &req.request_id),
-        ))
-    }
-
-    pub(super) fn get_outbound_web_identity_federation_info(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let empty = IamState::new(&req.account_id);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let (enabled, issuer) = state
-            .outbound_web_identity_federation
-            .as_ref()
-            .map(|c| (c.enabled, c.issuer_url.clone()))
-            .unwrap_or((false, String::new()));
-        let body = format!(
-            "  <GetOutboundWebIdentityFederationInfoResult><Enabled>{enabled}</Enabled><IssuerUrl>{}</IssuerUrl></GetOutboundWebIdentityFederationInfoResult>",
-            xml_escape(&issuer)
-        );
-        Ok(xml_response(
-            "GetOutboundWebIdentityFederationInfo",
             &body,
             &req.request_id,
         ))
@@ -960,18 +718,6 @@ impl IamService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             empty_response("ResyncMFADevice", &req.request_id),
-        ))
-    }
-
-    pub(super) fn get_human_readable_summary(
-        &self,
-        req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
-        let body = "  <GetHumanReadableSummaryResult><Summary>FakeCloud IAM emulator account summary</Summary></GetHumanReadableSummaryResult>";
-        Ok(xml_response(
-            "GetHumanReadableSummary",
-            body,
-            &req.request_id,
         ))
     }
 

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -283,16 +283,6 @@ impl AwsService for IamService {
             "ResetServiceSpecificCredential" => self.reset_service_specific_credential(&req),
             "UpdateServiceSpecificCredential" => self.update_service_specific_credential(&req),
 
-            // Delegation requests
-            "CreateDelegationRequest" => self.create_delegation_request(&req),
-            "AcceptDelegationRequest" => self.accept_delegation_request(&req),
-            "RejectDelegationRequest" => self.reject_delegation_request(&req),
-            "AssociateDelegationRequest" => self.associate_delegation_request(&req),
-            "GetDelegationRequest" => self.get_delegation_request(&req),
-            "ListDelegationRequests" => self.list_delegation_requests(&req),
-            "UpdateDelegationRequest" => self.update_delegation_request(&req),
-            "SendDelegationToken" => self.send_delegation_token(&req),
-
             // Organizations integration
             "EnableOrganizationsRootCredentialsManagement" => {
                 self.enable_organizations_root_credentials_management(&req)
@@ -305,17 +295,6 @@ impl AwsService for IamService {
             "GenerateOrganizationsAccessReport" => self.generate_organizations_access_report(&req),
             "GetOrganizationsAccessReport" => self.get_organizations_access_report(&req),
             "ListOrganizationsFeatures" => self.list_organizations_features(&req),
-
-            // Outbound web identity federation
-            "EnableOutboundWebIdentityFederation" => {
-                self.enable_outbound_web_identity_federation(&req)
-            }
-            "DisableOutboundWebIdentityFederation" => {
-                self.disable_outbound_web_identity_federation(&req)
-            }
-            "GetOutboundWebIdentityFederationInfo" => {
-                self.get_outbound_web_identity_federation_info(&req)
-            }
 
             // Service last accessed details
             "GenerateServiceLastAccessedDetails" => {
@@ -348,7 +327,6 @@ impl AwsService for IamService {
             "ChangePassword" => self.change_password(&req),
             "GetMFADevice" => self.get_mfa_device(&req),
             "ResyncMFADevice" => self.resync_mfa_device(&req),
-            "GetHumanReadableSummary" => self.get_human_readable_summary(&req),
             "SetSecurityTokenServicePreferences" => {
                 self.set_security_token_service_preferences(&req)
             }
@@ -556,14 +534,6 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ListServiceSpecificCredentials",
     "ResetServiceSpecificCredential",
     "UpdateServiceSpecificCredential",
-    "CreateDelegationRequest",
-    "AcceptDelegationRequest",
-    "RejectDelegationRequest",
-    "AssociateDelegationRequest",
-    "GetDelegationRequest",
-    "ListDelegationRequests",
-    "UpdateDelegationRequest",
-    "SendDelegationToken",
     "EnableOrganizationsRootCredentialsManagement",
     "DisableOrganizationsRootCredentialsManagement",
     "EnableOrganizationsRootSessions",
@@ -571,9 +541,6 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "GenerateOrganizationsAccessReport",
     "GetOrganizationsAccessReport",
     "ListOrganizationsFeatures",
-    "EnableOutboundWebIdentityFederation",
-    "DisableOutboundWebIdentityFederation",
-    "GetOutboundWebIdentityFederationInfo",
     "GenerateServiceLastAccessedDetails",
     "GetServiceLastAccessedDetails",
     "GetServiceLastAccessedDetailsWithEntities",
@@ -594,7 +561,6 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "ChangePassword",
     "GetMFADevice",
     "ResyncMFADevice",
-    "GetHumanReadableSummary",
     "SetSecurityTokenServicePreferences",
     "UpdateServerCertificate",
 ];

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -3234,29 +3234,6 @@ fn service_specific_credentials_lifecycle() {
 }
 
 #[test]
-fn delegation_request_lifecycle() {
-    let svc = make_service();
-    let resp = svc
-        .create_delegation_request(&make_request(
-            "CreateDelegationRequest",
-            vec![
-                ("TargetAccount", "999999999999"),
-                ("Permissions.member.1", "s3:Get*"),
-            ],
-        ))
-        .unwrap();
-    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
-    let id = extract_xml_tag(&body, "DelegationRequestId");
-    svc.get_delegation_request(&make_request(
-        "GetDelegationRequest",
-        vec![("DelegationRequestId", id)],
-    ))
-    .unwrap();
-    svc.list_delegation_requests(&make_request("ListDelegationRequests", vec![]))
-        .unwrap();
-}
-
-#[test]
 fn organizations_root_creds_and_sessions() {
     let svc = make_service();
     svc.enable_organizations_root_credentials_management(&make_request(
@@ -3281,26 +3258,6 @@ fn organizations_root_creds_and_sessions() {
     .unwrap();
     svc.list_organizations_features(&make_request("ListOrganizationsFeatures", vec![]))
         .unwrap();
-}
-
-#[test]
-fn outbound_wif_round_trip() {
-    let svc = make_service();
-    svc.enable_outbound_web_identity_federation(&make_request(
-        "EnableOutboundWebIdentityFederation",
-        vec![],
-    ))
-    .unwrap();
-    svc.get_outbound_web_identity_federation_info(&make_request(
-        "GetOutboundWebIdentityFederationInfo",
-        vec![],
-    ))
-    .unwrap();
-    svc.disable_outbound_web_identity_federation(&make_request(
-        "DisableOutboundWebIdentityFederation",
-        vec![],
-    ))
-    .unwrap();
 }
 
 #[test]
@@ -3406,8 +3363,6 @@ fn misc_extras_smoke() {
         vec![("OldPassword", "p"), ("NewPassword", "q")],
     ))
     .unwrap();
-    svc.get_human_readable_summary(&make_request("GetHumanReadableSummary", vec![]))
-        .unwrap();
     svc.set_security_token_service_preferences(&make_request(
         "SetSecurityTokenServicePreferences",
         vec![("GlobalEndpointTokenVersion", "v2Token")],

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -307,9 +307,6 @@ pub struct IamState {
     /// Per-user service-specific credentials (Codecommit/Keyspaces).
     #[serde(default)]
     pub service_specific_credentials: BTreeMap<String, Vec<ServiceSpecificCredential>>, // user -> creds
-    /// Active delegation requests keyed by id.
-    #[serde(default)]
-    pub delegation_requests: BTreeMap<String, DelegationRequest>,
     /// Per-resource-arn tag map for SAML/Server cert/MFA device tags.
     #[serde(default)]
     pub extra_tags: BTreeMap<String, Vec<(String, String)>>,
@@ -318,9 +315,6 @@ pub struct IamState {
     pub organizations_root_credentials_management: bool,
     #[serde(default)]
     pub organizations_root_sessions: bool,
-    /// Outbound web identity federation configuration.
-    #[serde(default)]
-    pub outbound_web_identity_federation: Option<OutboundWebIdentityFederation>,
     /// Generated ServiceLastAccessed jobs keyed by job id.
     #[serde(default)]
     pub service_last_accessed_jobs: BTreeMap<String, ServiceLastAccessedJob>,
@@ -338,23 +332,6 @@ pub struct ServiceSpecificCredential {
     pub service_password: String,
     pub status: String,
     pub create_date: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DelegationRequest {
-    pub id: String,
-    pub source_account: String,
-    pub target_account: String,
-    pub status: String,
-    pub create_date: DateTime<Utc>,
-    pub permissions: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutboundWebIdentityFederation {
-    pub enabled: bool,
-    pub issuer_url: String,
-    pub audience: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -402,11 +379,9 @@ impl IamState {
             ssh_public_keys: BTreeMap::new(),
             access_key_last_used: BTreeMap::new(),
             service_specific_credentials: BTreeMap::new(),
-            delegation_requests: BTreeMap::new(),
             extra_tags: BTreeMap::new(),
             organizations_root_credentials_management: false,
             organizations_root_sessions: false,
-            outbound_web_identity_federation: None,
             service_last_accessed_jobs: BTreeMap::new(),
             organizations_access_reports: BTreeMap::new(),
         }

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -96,7 +96,6 @@ fn is_mutating_action(action: &str) -> bool {
             | "GetSessionToken"
             | "GetFederationToken"
             | "AssumeRoot"
-            | "GetDelegatedAccessToken"
     )
 }
 
@@ -118,8 +117,6 @@ impl AwsService for StsService {
             "GetAccessKeyInfo" => self.get_access_key_info(&req),
             "DecodeAuthorizationMessage" => self.decode_authorization_message(&req),
             "AssumeRoot" => self.assume_root(&req),
-            "GetDelegatedAccessToken" => self.get_delegated_access_token(&req),
-            "GetWebIdentityToken" => self.get_web_identity_token(&req),
             _ => Err(AwsServiceError::action_not_implemented("sts", &req.action)),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
@@ -144,8 +141,6 @@ impl AwsService for StsService {
             "GetAccessKeyInfo",
             "DecodeAuthorizationMessage",
             "AssumeRoot",
-            "GetDelegatedAccessToken",
-            "GetWebIdentityToken",
         ]
     }
 
@@ -172,8 +167,6 @@ impl AwsService for StsService {
             "GetAccessKeyInfo" => "GetAccessKeyInfo",
             "DecodeAuthorizationMessage" => "DecodeAuthorizationMessage",
             "AssumeRoot" => "AssumeRoot",
-            "GetDelegatedAccessToken" => "GetDelegatedAccessToken",
-            "GetWebIdentityToken" => "GetWebIdentityToken",
             _ => return None,
         };
         let resource = match action {
@@ -1024,176 +1017,6 @@ impl StsService {
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
-
-    /// GetDelegatedAccessToken: trades an opaque token for short-lived
-    /// credentials bound to the caller's principal. We accept any non-empty
-    /// trade-in token (the emulator does not issue verifiable trade-in tokens
-    /// upstream), mint fresh STS credentials, and tie them to the caller's
-    /// access key (or account root when unauthenticated).
-    fn get_delegated_access_token(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let trade_in = req.query_params.get("TradeInToken").ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MissingParameter",
-                "The request must contain the parameter TradeInToken",
-            )
-        })?;
-        validate_string_length("tradeInToken", trade_in, 1, 4096)?;
-
-        let partition = partition_for_region(&req.region);
-        let expiration_at = compute_expiration_at(req, DEFAULT_SESSION_TOKEN_DURATION)?;
-        let expiration = format_expiration(expiration_at);
-
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let (assumed_principal, user_id, account_id) =
-            if let Some(akid) = extract_access_key(req).as_deref() {
-                if let Some(lookup) = state.credential_secret_readonly(akid) {
-                    (lookup.principal_arn, lookup.user_id, lookup.account_id)
-                } else {
-                    (
-                        format!("arn:{}:iam::{}:root", partition, state.account_id),
-                        state.account_id.clone(),
-                        state.account_id.clone(),
-                    )
-                }
-            } else {
-                (
-                    format!("arn:{}:iam::{}:root", partition, state.account_id),
-                    state.account_id.clone(),
-                    state.account_id.clone(),
-                )
-            };
-
-        let creds = StsCredentials::generate();
-        state.credential_identities.insert(
-            creds.access_key_id.clone(),
-            CredentialIdentity {
-                arn: assumed_principal.clone(),
-                user_id: user_id.clone(),
-                account_id: account_id.clone(),
-            },
-        );
-        state.sts_temp_credentials.insert(
-            creds.access_key_id.clone(),
-            StsTempCredential {
-                access_key_id: creds.access_key_id.clone(),
-                secret_access_key: creds.secret_access_key.clone(),
-                session_token: creds.session_token.clone(),
-                principal_arn: assumed_principal.clone(),
-                user_id,
-                account_id,
-                expiration: expiration_at,
-                session_policies: Vec::new(),
-            },
-        );
-
-        let xml = xml_responses::get_delegated_access_token_response(
-            &creds,
-            &expiration,
-            &assumed_principal,
-            &req.request_id,
-        );
-        Ok(AwsResponse::xml(StatusCode::OK, xml))
-    }
-
-    /// GetWebIdentityToken: issues a signed JWT representing the caller. We
-    /// produce an unsigned JWT (alg "none"-style) since the emulator has no
-    /// signing key material; the structure matches AWS so client decoders
-    /// see standard JWT claims.
-    fn get_web_identity_token(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // Audience.member.N (Query protocol). Required.
-        let mut audiences: Vec<String> = Vec::new();
-        for i in 1..=12 {
-            let key = format!("Audience.member.{i}");
-            match req.query_params.get(&key) {
-                Some(a) => audiences.push(a.clone()),
-                None => break,
-            }
-        }
-        if audiences.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MissingParameter",
-                "The request must contain the parameter Audience",
-            ));
-        }
-
-        let signing = req.query_params.get("SigningAlgorithm").ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MissingParameter",
-                "The request must contain the parameter SigningAlgorithm",
-            )
-        })?;
-        if signing != "RS256" && signing != "ES384" {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                "SigningAlgorithm must be one of RS256, ES384",
-            ));
-        }
-
-        let duration = if let Some(ds) = req.query_params.get("DurationSeconds") {
-            ds.parse::<i64>().map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationError",
-                    format!(
-                        "Value '{}' at 'durationSeconds' failed to satisfy constraint: \
-                         Member must be a valid integer",
-                        ds
-                    ),
-                )
-            })?
-        } else {
-            300
-        };
-        if !(60..=3600).contains(&duration) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationError",
-                "durationSeconds must be between 60 and 3600",
-            ));
-        }
-
-        let partition = partition_for_region(&req.region);
-        let accounts = self.state.read();
-        let empty = IamState::new(&req.account_id);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let subject = if let Some(akid) = extract_access_key(req).as_deref() {
-            state
-                .credential_secret_readonly(akid)
-                .map(|l| l.principal_arn)
-                .unwrap_or_else(|| format!("arn:{}:iam::{}:root", partition, state.account_id))
-        } else {
-            format!("arn:{}:iam::{}:root", partition, state.account_id)
-        };
-
-        let now = chrono::Utc::now().timestamp();
-        let exp = now + duration;
-        let header = base64_url(br#"{"alg":"none","typ":"JWT"}"#);
-        let payload = serde_json::json!({
-            "iss": format!("https://sts.{}.amazonaws.com", req.region),
-            "sub": subject,
-            "aud": audiences,
-            "iat": now,
-            "exp": exp,
-        });
-        let payload_b64 = base64_url(payload.to_string().as_bytes());
-        let token = format!("{}.{}.", header, payload_b64);
-        let expiration =
-            format_expiration(chrono::Utc::now() + chrono::Duration::seconds(duration));
-
-        let xml =
-            xml_responses::get_web_identity_token_response(&token, &expiration, &req.request_id);
-        Ok(AwsResponse::xml(StatusCode::OK, xml))
-    }
-}
-
-fn base64_url(input: &[u8]) -> String {
-    use base64::Engine;
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(input)
 }
 
 /// Extract account ID from an ARN like `arn:aws:iam::123456789012:role/name`.
@@ -1752,104 +1575,5 @@ mod tests {
             ],
         );
         assert!(svc.assume_root(&req).is_err());
-    }
-
-    // ── GetDelegatedAccessToken ──
-
-    #[tokio::test]
-    async fn get_delegated_access_token_succeeds() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetDelegatedAccessToken",
-            vec![("TradeInToken", "any-non-empty-token")],
-        );
-        let resp = svc.get_delegated_access_token(&req).unwrap();
-        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
-        assert!(body.contains("AssumedPrincipal"), "{body}");
-    }
-
-    #[tokio::test]
-    async fn get_delegated_access_token_missing_token_errors() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request("GetDelegatedAccessToken", vec![]);
-        assert!(svc.get_delegated_access_token(&req).is_err());
-    }
-
-    // ── GetWebIdentityToken ──
-
-    #[tokio::test]
-    async fn get_web_identity_token_succeeds() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetWebIdentityToken",
-            vec![
-                ("Audience.member.1", "https://example.com"),
-                ("SigningAlgorithm", "RS256"),
-                ("DurationSeconds", "300"),
-            ],
-        );
-        let resp = svc.get_web_identity_token(&req).unwrap();
-        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
-        assert!(body.contains("WebIdentityToken"), "{body}");
-        // JWT structure: header.payload.signature (signature blank).
-        assert!(body.contains("."), "{body}");
-    }
-
-    #[tokio::test]
-    async fn get_web_identity_token_missing_audience_errors() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request("GetWebIdentityToken", vec![("SigningAlgorithm", "RS256")]);
-        assert!(svc.get_web_identity_token(&req).is_err());
-    }
-
-    #[tokio::test]
-    async fn get_web_identity_token_missing_signing_errors() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetWebIdentityToken",
-            vec![("Audience.member.1", "https://example.com")],
-        );
-        assert!(svc.get_web_identity_token(&req).is_err());
-    }
-
-    #[tokio::test]
-    async fn get_web_identity_token_rejects_unknown_algorithm() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetWebIdentityToken",
-            vec![
-                ("Audience.member.1", "https://example.com"),
-                ("SigningAlgorithm", "HS256"),
-            ],
-        );
-        assert!(svc.get_web_identity_token(&req).is_err());
-    }
-
-    #[tokio::test]
-    async fn get_web_identity_token_rejects_non_numeric_duration() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetWebIdentityToken",
-            vec![
-                ("Audience.member.1", "https://example.com"),
-                ("SigningAlgorithm", "RS256"),
-                ("DurationSeconds", "not-a-number"),
-            ],
-        );
-        assert!(svc.get_web_identity_token(&req).is_err());
-    }
-
-    #[tokio::test]
-    async fn get_web_identity_token_rejects_out_of_range_duration() {
-        let (svc, _) = make_sts_service();
-        let req = sts_request(
-            "GetWebIdentityToken",
-            vec![
-                ("Audience.member.1", "https://example.com"),
-                ("SigningAlgorithm", "RS256"),
-                ("DurationSeconds", "10"),
-            ],
-        );
-        assert!(svc.get_web_identity_token(&req).is_err());
     }
 }

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -819,52 +819,6 @@ pub fn assume_root_response(
     )
 }
 
-pub fn get_delegated_access_token_response(
-    creds: &StsCredentials,
-    expiration: &str,
-    assumed_principal: &str,
-    request_id: &str,
-) -> String {
-    let access_key_id = creds.access_key_id.as_str();
-    let secret_access_key = creds.secret_access_key.as_str();
-    let session_token = creds.session_token.as_str();
-    let assumed_principal = xml_escape(assumed_principal);
-    format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<GetDelegatedAccessTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <GetDelegatedAccessTokenResult>
-    <Credentials>
-      <AccessKeyId>{access_key_id}</AccessKeyId>
-      <SecretAccessKey>{secret_access_key}</SecretAccessKey>
-      <SessionToken>{session_token}</SessionToken>
-      <Expiration>{expiration}</Expiration>
-    </Credentials>
-    <PackedPolicySize>0</PackedPolicySize>
-    <AssumedPrincipal>{assumed_principal}</AssumedPrincipal>
-  </GetDelegatedAccessTokenResult>
-  <ResponseMetadata>
-    <RequestId>{request_id}</RequestId>
-  </ResponseMetadata>
-</GetDelegatedAccessTokenResponse>"#,
-    )
-}
-
-pub fn get_web_identity_token_response(token: &str, expiration: &str, request_id: &str) -> String {
-    let token = xml_escape(token);
-    format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<GetWebIdentityTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <GetWebIdentityTokenResult>
-    <WebIdentityToken>{token}</WebIdentityToken>
-    <Expiration>{expiration}</Expiration>
-  </GetWebIdentityTokenResult>
-  <ResponseMetadata>
-    <RequestId>{request_id}</RequestId>
-  </ResponseMetadata>
-</GetWebIdentityTokenResponse>"#,
-    )
-}
-
 pub fn decode_authorization_message_response(decoded_message: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- Delete 12 IAM/STS operations dispatched as if they were real AWS APIs but absent from the AWS Smithy model. They were inflating the surface and lying to the conformance harness.
- Remove corresponding state types, helpers, XML responders, unit tests, and conformance tests.
- Keep `EnableOrganizationsRootCredentialsManagement` and related Organizations integration ops — those are real IAM 2024 additions.

Removed:

| Service | Operations |
|---|---|
| IAM | `CreateDelegationRequest`, `AcceptDelegationRequest`, `RejectDelegationRequest`, `AssociateDelegationRequest`, `UpdateDelegationRequest`, `GetDelegationRequest`, `ListDelegationRequests`, `SendDelegationToken` |
| IAM | `EnableOutboundWebIdentityFederation`, `DisableOutboundWebIdentityFederation`, `GetOutboundWebIdentityFederationInfo` |
| IAM | `GetHumanReadableSummary` |
| STS | `GetDelegatedAccessToken`, `GetWebIdentityToken` |

Phase A1 of the parity-gap remediation plan from /tmp/parity_audit/REPORT.md.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p fakecloud-iam --lib\` 368 pass
- [x] \`cargo test -p fakecloud-conformance --test iam --test sts\` 53 pass
- [x] No remaining references in SDKs / docs / website (verified via grep)
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed 12 fabricated IAM/STS actions that don’t exist in AWS and regenerated the conformance baseline to reflect the reduced surface. This aligns with the AWS Smithy model and removes false positives in the conformance harness.

- **Refactors**
  - Deleted IAM “DelegationRequest” suite (Create/Accept/Reject/Associate/Update/Get/List/SendDelegationToken), “OutboundWebIdentityFederation” suite (Enable/Disable/GetInfo), and `GetHumanReadableSummary`. Deleted STS `GetDelegatedAccessToken` and `GetWebIdentityToken`.
  - Removed related state types (`DelegationRequest`, `OutboundWebIdentityFederation`), helpers, XML responders, and tests in `fakecloud-iam` and `fakecloud-conformance`. Kept `EnableOrganizationsRootCredentialsManagement` and related Organizations ops (real IAM 2024 additions). Phase A1 of the parity-gap plan.
  - Regenerated `conformance-baseline.json` with a net drop of 53 variants overall (IAM −46, STS −7).

- **Migration**
  - These actions now return “ActionNotImplemented”. Remove any calls to them in local tests or scripts.
  - No impact to standard AWS SDK clients, since these actions were never in AWS.

<sup>Written for commit 762af6ac2bb783f9d00837847bae92f4f5633cf4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/890?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

