### PR TITLE
feat(s3): close response field gaps surfaced by parity audit

### DIFF
--- a/crates/fakecloud-s3/src/service/buckets.rs
+++ b/crates/fakecloud-s3/src/service/buckets.rs
@@ -101,10 +101,10 @@ impl S3Service {
         let mut buckets_xml = String::new();
         for b in page {
             buckets_xml.push_str(&format!(
-                "<Bucket><Name>{}</Name><CreationDate>{}</CreationDate><BucketRegion>{}</BucketRegion></Bucket>",
-                xml_escape(&b.name),
-                b.creation_date.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
-                xml_escape(&b.region),
+                "<Bucket><Name>{name}</Name><CreationDate>{cd}</CreationDate><BucketRegion>{region}</BucketRegion><BucketArn>arn:aws:s3:::{name}</BucketArn></Bucket>",
+                name = xml_escape(&b.name),
+                cd = b.creation_date.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+                region = xml_escape(&b.region),
             ));
         }
 
@@ -353,18 +353,29 @@ impl S3Service {
         let accts = self.state.read();
         let __empty = crate::state::S3State::new(account_id, "us-east-1");
         let state = accts.get(account_id).unwrap_or(&__empty);
-        if !state.buckets.contains_key(bucket) {
-            return Err(AwsServiceError::aws_error(
+        let b = state.buckets.get(bucket).ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchBucket",
                 format!("The specified bucket does not exist: {bucket}"),
-            ));
+            )
+        })?;
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = http::HeaderValue::from_str(&b.region) {
+            headers.insert("x-amz-bucket-region", v);
         }
+        // Region buckets are the only type fakecloud creates; AWS Toolkit
+        // checks this header to disambiguate from "directory bucket" /
+        // "access point alias" forms.
+        headers.insert(
+            "x-amz-bucket-location-type",
+            http::HeaderValue::from_static("Region"),
+        );
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/xml".to_string(),
             body: Bytes::new().into(),
-            headers: HeaderMap::new(),
+            headers,
         })
     }
 

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2241,6 +2241,14 @@ pub(crate) fn parse_delete_objects_xml(xml: &str) -> Vec<DeleteObjectEntry> {
     entries
 }
 
+/// Returns true when the request body's top-level <Quiet> element is "true".
+/// AWS docs: when Quiet=true, only failed deletes are emitted.
+pub(crate) fn parse_delete_objects_quiet(xml: &str) -> bool {
+    extract_xml_value(xml, "Quiet")
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Minimal XML parser for `<Tagging><TagSet><Tag><Key>k</Key><Value>v</Value></Tag>...`.
 /// Returns a Vec to preserve insertion order and detect duplicates.
 pub(crate) fn parse_tagging_xml(xml: &str) -> Vec<(String, String)> {

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -435,9 +435,15 @@ impl S3Service {
                 // IfNoneMatch does NOT apply to re-completions
                 if let Some(obj) = b.objects.get(key) {
                     let etag = obj.etag.clone();
+                    let location = format!(
+                        "https://{bucket_h}.s3.amazonaws.com/{key_h}",
+                        bucket_h = xml_escape(bucket),
+                        key_h = xml_escape(key),
+                    );
                     let body = format!(
                         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
                          <CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+                         <Location>{location}</Location>\
                          <Bucket>{}</Bucket>\
                          <Key>{}</Key>\
                          <ETag>&quot;{}&quot;</ETag>\
@@ -629,9 +635,15 @@ impl S3Service {
             );
         }
 
+        let location = format!(
+            "https://{bucket_h}.s3.amazonaws.com/{key_h}",
+            bucket_h = xml_escape(bucket),
+            key_h = xml_escape(key),
+        );
         let body = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
              <CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Location>{location}</Location>\
              <Bucket>{}</Bucket>\
              <Key>{}</Key>\
              <ETag>&quot;{}&quot;</ETag>\

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -14,9 +14,10 @@ use super::{
     canned_acl_grants_for_object, check_get_conditionals, check_head_conditionals,
     check_object_lock_for_overwrite, compute_checksum, deliver_notifications, etag_matches,
     extract_user_metadata, extract_xml_value, is_frozen, is_valid_storage_class,
-    make_delete_marker, no_such_bucket, no_such_key, parse_delete_objects_xml, parse_grant_headers,
-    parse_range_header, parse_url_encoded_tags, precondition_failed, replicate_through_store,
-    resolve_object, s3_xml, url_encode_s3_key, xml_escape, RangeResult, S3Service,
+    make_delete_marker, no_such_bucket, no_such_key, parse_delete_objects_quiet,
+    parse_delete_objects_xml, parse_grant_headers, parse_range_header, parse_url_encoded_tags,
+    precondition_failed, replicate_through_store, resolve_object, s3_xml, url_encode_s3_key,
+    xml_escape, RangeResult, S3Service,
 };
 
 impl S3Service {
@@ -92,6 +93,7 @@ impl S3Service {
                 xml_escape(key)
             };
 
+            // ListObjectsV1 always emits Owner per Contents (no fetch-owner toggle).
             contents.push_str(&format!(
                 "<Contents>\
                  <Key>{}</Key>\
@@ -99,12 +101,14 @@ impl S3Service {
                  <ETag>&quot;{}&quot;</ETag>\
                  <Size>{}</Size>\
                  <StorageClass>{}</StorageClass>\
+                 <Owner><ID>{owner}</ID><DisplayName>{owner}</DisplayName></Owner>\
                  </Contents>",
                 display_key,
                 obj.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
                 obj.etag,
                 obj.size,
                 obj.storage_class,
+                owner = xml_escape(&b.acl_owner_id),
             ));
             last_key = key.clone();
             count += 1;
@@ -220,7 +224,20 @@ impl S3Service {
             .map(|v| v == "true")
             .unwrap_or(false);
 
-        let effective_start = continuation.as_deref().unwrap_or(&start_after);
+        // continuation token is base64(URL_SAFE_NO_PAD)-encoded key on the way
+        // out; decode it on the way back in. Fall back to treating it as a raw
+        // key for forward-compat with clients that don't round-trip.
+        let decoded_continuation = continuation.as_ref().map(|ct| {
+            use base64::Engine;
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(ct.as_bytes())
+                .ok()
+                .and_then(|b| String::from_utf8(b).ok())
+                .unwrap_or_else(|| ct.clone())
+        });
+        let effective_start = decoded_continuation
+            .as_deref()
+            .unwrap_or(start_after.as_str());
 
         let mut contents = String::new();
         let mut common_prefixes: Vec<String> = Vec::new();
@@ -328,11 +345,14 @@ impl S3Service {
             ));
         }
 
+        // NextContinuationToken must be opaque and safe for query-string
+        // round-trip. Base64-encode the last_key so keys with `&`/`=`/spaces
+        // don't break the next page.
         let next_token = if is_truncated {
-            format!(
-                "<NextContinuationToken>{}</NextContinuationToken>",
-                xml_escape(&last_key)
-            )
+            use base64::Engine;
+            let encoded =
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(last_key.as_bytes());
+            format!("<NextContinuationToken>{encoded}</NextContinuationToken>")
         } else {
             String::new()
         };
@@ -1886,6 +1906,12 @@ impl S3Service {
         if let Some(ref redirect) = obj.website_redirect_location {
             headers.insert("x-amz-website-redirect-location", redirect.parse().unwrap());
         }
+        if !obj.tags.is_empty() {
+            headers.insert(
+                "x-amz-tagging-count",
+                obj.tags.len().to_string().parse().unwrap(),
+            );
+        }
 
         if let Some(vid) = &obj.version_id {
             headers.insert("x-amz-version-id", vid.parse().unwrap());
@@ -2451,6 +2477,7 @@ impl S3Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("");
         let entries = parse_delete_objects_xml(body_str);
+        let quiet = parse_delete_objects_quiet(body_str);
 
         if entries.is_empty() {
             return Err(AwsServiceError::aws_error(
@@ -2553,11 +2580,13 @@ impl S3Service {
                 self.store
                     .delete_object(bucket, key, Some(vid.as_str()))
                     .map_err(super::persistence_error)?;
-                deleted_xml.push_str(&format!(
-                    "<Deleted><Key>{}</Key><VersionId>{}</VersionId></Deleted>",
-                    xml_escape(key),
-                    xml_escape(vid),
-                ));
+                if !quiet {
+                    deleted_xml.push_str(&format!(
+                        "<Deleted><Key>{}</Key><VersionId>{}</VersionId></Deleted>",
+                        xml_escape(key),
+                        xml_escape(vid),
+                    ));
+                }
             } else if versioning_enabled {
                 let dm_id = Uuid::new_v4().to_string();
                 let marker = make_delete_marker(key, &dm_id);
@@ -2569,19 +2598,23 @@ impl S3Service {
                 self.store
                     .delete_object(bucket, key, None)
                     .map_err(super::persistence_error)?;
-                deleted_xml.push_str(&format!(
-                    "<Deleted><Key>{}</Key><DeleteMarker>true</DeleteMarker><DeleteMarkerVersionId>{}</DeleteMarkerVersionId></Deleted>",
-                    xml_escape(key), dm_id,
-                ));
+                if !quiet {
+                    deleted_xml.push_str(&format!(
+                        "<Deleted><Key>{}</Key><DeleteMarker>true</DeleteMarker><DeleteMarkerVersionId>{}</DeleteMarkerVersionId></Deleted>",
+                        xml_escape(key), dm_id,
+                    ));
+                }
             } else {
                 b.objects.remove(key);
                 self.store
                     .delete_object(bucket, key, None)
                     .map_err(super::persistence_error)?;
-                deleted_xml.push_str(&format!(
-                    "<Deleted><Key>{}</Key></Deleted>",
-                    xml_escape(key)
-                ));
+                if !quiet {
+                    deleted_xml.push_str(&format!(
+                        "<Deleted><Key>{}</Key></Deleted>",
+                        xml_escape(key)
+                    ));
+                }
             }
         }
 

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3004,6 +3004,27 @@ fn head_bucket_exists_returns_ok() {
 }
 
 #[test]
+fn head_bucket_returns_x_amz_bucket_region_header() {
+    // Regression for issue #816 / #817 class: AWS Toolkit reads
+    // x-amz-bucket-region from HeadBucket to do region routing.
+    let svc = make_service();
+    seed_bucket(&svc, "hbr");
+    let resp = svc.head_bucket("123456789012", "hbr").unwrap();
+    assert_eq!(
+        resp.headers
+            .get("x-amz-bucket-region")
+            .and_then(|v| v.to_str().ok()),
+        Some("us-east-1"),
+    );
+    assert_eq!(
+        resp.headers
+            .get("x-amz-bucket-location-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("Region"),
+    );
+}
+
+#[test]
 fn get_bucket_location_us_east_1_returns_empty() {
     let svc = make_service();
     seed_bucket(&svc, "loc");


### PR DESCRIPTION
## Summary

Phase B1 of the /tmp/parity_audit/REPORT.md remediation. Closes a class of AWS-Toolkit-visible cosmetic gaps (same shape as #816) plus two real-tool-breaking issues:

- HeadBucket now emits \`x-amz-bucket-region\` + \`x-amz-bucket-location-type\` headers
- ListBuckets emits \`BucketArn\` per bucket entry (AWS 2024 addition)
- ListObjectsV1 emits \`<Owner>\` per Contents
- ListObjectsV2 \`NextContinuationToken\` base64url-encoded, decoded on resume — keys with \`&\`/\`=\`/spaces no longer break pagination
- DeleteObjects honors top-level \`<Quiet>\` flag
- HeadObject emits \`x-amz-tagging-count\`
- CompleteMultipartUpload emits \`<Location>\`

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo test -p fakecloud-s3 --lib\` 288 pass (1 new unit test)
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns S3 responses with AWS to close parity audit gaps and fix SDK/Toolkit routing and pagination edge cases. Adds missing headers and XML fields, and makes ListObjectsV2 tokens URL-safe.

- **New Features**
  - Buckets: HeadBucket now sends x-amz-bucket-region and x-amz-bucket-location-type; ListBuckets adds BucketArn per bucket.
  - Listings: ListObjectsV1 includes Owner per Contents; ListObjectsV2 NextContinuationToken is base64url-encoded and decoded on resume to handle keys with &, =, and spaces.
  - Deletes: DeleteObjects honors top-level Quiet (only failed deletes are returned when true).
  - Objects: HeadObject emits x-amz-tagging-count when tags are present; CompleteMultipartUpload includes a Location virtual-host URL.

<sup>Written for commit 06504a9de17be986d61b1d02ff42b4c06f1b22a8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/891?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

