### PR TITLE
feat(lambda): emit full FunctionConfiguration response shape

### DIFF
--- a/crates/fakecloud-lambda/src/resource_policy.rs
+++ b/crates/fakecloud-lambda/src/resource_policy.rs
@@ -128,6 +128,20 @@ mod tests {
             image_uri: None,
             policy: policy.map(str::to_string),
             layers: Vec::new(),
+            revision_id: "test-rev".to_string(),
+            tracing_mode: None,
+            kms_key_arn: None,
+            ephemeral_storage_size: None,
+            vpc_config: None,
+            snap_start: None,
+            dead_letter_config_arn: None,
+            file_system_configs: Vec::new(),
+            logging_config: None,
+            image_config: None,
+            signing_profile_version_arn: None,
+            signing_job_arn: None,
+            runtime_version_config: None,
+            master_arn: None,
         }
     }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -157,6 +157,15 @@ struct CreateFunctionInput {
     code_fallback: Vec<u8>,
     image_uri: Option<String>,
     layer_arns: Vec<String>,
+    tracing_mode: Option<String>,
+    kms_key_arn: Option<String>,
+    ephemeral_storage_size: Option<i64>,
+    vpc_config: Option<serde_json::Value>,
+    snap_start: Option<serde_json::Value>,
+    dead_letter_config_arn: Option<String>,
+    file_system_configs: Vec<serde_json::Value>,
+    logging_config: Option<serde_json::Value>,
+    image_config: Option<serde_json::Value>,
 }
 
 impl CreateFunctionInput {
@@ -247,6 +256,29 @@ impl CreateFunctionInput {
             })
             .unwrap_or_default();
 
+        let tracing_mode = body["TracingConfig"]["Mode"].as_str().map(String::from);
+        let kms_key_arn = body["KMSKeyArn"].as_str().map(String::from);
+        let ephemeral_storage_size = body["EphemeralStorage"]["Size"].as_i64();
+        let vpc_config = body["VpcConfig"]
+            .is_object()
+            .then(|| body["VpcConfig"].clone());
+        let snap_start = body["SnapStart"]
+            .is_object()
+            .then(|| body["SnapStart"].clone());
+        let dead_letter_config_arn = body["DeadLetterConfig"]["TargetArn"]
+            .as_str()
+            .map(String::from);
+        let file_system_configs = body["FileSystemConfigs"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let logging_config = body["LoggingConfig"]
+            .is_object()
+            .then(|| body["LoggingConfig"].clone());
+        let image_config = body["ImageConfig"]
+            .is_object()
+            .then(|| body["ImageConfig"].clone());
+
         Ok(Self {
             function_name,
             runtime: body["Runtime"].as_str().unwrap_or("python3.12").to_string(),
@@ -266,6 +298,15 @@ impl CreateFunctionInput {
             code_fallback,
             image_uri,
             layer_arns,
+            tracing_mode,
+            kms_key_arn,
+            ephemeral_storage_size,
+            vpc_config,
+            snap_start,
+            dead_letter_config_arn,
+            file_system_configs,
+            logging_config,
+            image_config,
         })
     }
 }
@@ -937,6 +978,20 @@ impl LambdaService {
             image_uri: input.image_uri,
             policy: None,
             layers: layer_attachments,
+            revision_id: uuid::Uuid::new_v4().to_string(),
+            tracing_mode: input.tracing_mode,
+            kms_key_arn: input.kms_key_arn,
+            ephemeral_storage_size: input.ephemeral_storage_size,
+            vpc_config: input.vpc_config,
+            snap_start: input.snap_start,
+            dead_letter_config_arn: input.dead_letter_config_arn,
+            file_system_configs: input.file_system_configs,
+            logging_config: input.logging_config,
+            image_config: input.image_config,
+            signing_profile_version_arn: None,
+            signing_job_arn: None,
+            runtime_version_config: None,
+            master_arn: None,
         };
 
         let response = self.function_config_json(&func);
@@ -1241,10 +1296,15 @@ impl LambdaService {
     }
 
     pub(crate) fn function_config_json(&self, func: &LambdaFunction) -> Value {
-        let mut env_vars = json!({});
-        if !func.environment.is_empty() {
-            env_vars = json!({ "Variables": func.environment });
-        }
+        // AWS always emits Environment with at least an empty Variables map.
+        let env_vars = if func.environment.is_empty() {
+            json!({ "Variables": {} })
+        } else {
+            json!({ "Variables": func.environment })
+        };
+
+        let tracing_mode = func.tracing_mode.as_deref().unwrap_or("PassThrough");
+        let ephemeral_size = func.ephemeral_storage_size.unwrap_or(512);
 
         let mut config = json!({
             "FunctionName": func.function_name,
@@ -1264,9 +1324,44 @@ impl LambdaService {
             "Environment": env_vars,
             "State": "Active",
             "LastUpdateStatus": "Successful",
-            "TracingConfig": { "Mode": "PassThrough" },
-            "RevisionId": uuid::Uuid::new_v4().to_string(),
+            "TracingConfig": { "Mode": tracing_mode },
+            "RevisionId": func.revision_id,
+            "EphemeralStorage": { "Size": ephemeral_size },
+            "SnapStart": func.snap_start.clone().unwrap_or_else(|| json!({
+                "ApplyOn": "None",
+                "OptimizationStatus": "Off",
+            })),
         });
+        if let Some(ref kms) = func.kms_key_arn {
+            config["KMSKeyArn"] = json!(kms);
+        }
+        if let Some(ref vpc) = func.vpc_config {
+            config["VpcConfig"] = vpc.clone();
+        }
+        if let Some(ref dlq) = func.dead_letter_config_arn {
+            config["DeadLetterConfig"] = json!({ "TargetArn": dlq });
+        }
+        if !func.file_system_configs.is_empty() {
+            config["FileSystemConfigs"] = json!(func.file_system_configs);
+        }
+        if let Some(ref lg) = func.logging_config {
+            config["LoggingConfig"] = lg.clone();
+        }
+        if let Some(ref ic) = func.image_config {
+            config["ImageConfigResponse"] = json!({ "ImageConfig": ic });
+        }
+        if let Some(ref s) = func.signing_profile_version_arn {
+            config["SigningProfileVersionArn"] = json!(s);
+        }
+        if let Some(ref s) = func.signing_job_arn {
+            config["SigningJobArn"] = json!(s);
+        }
+        if let Some(ref rv) = func.runtime_version_config {
+            config["RuntimeVersionConfig"] = rv.clone();
+        }
+        if let Some(ref m) = func.master_arn {
+            config["MasterArn"] = json!(m);
+        }
         if let Some(ref uri) = func.image_uri {
             config["Code"] = json!({
                 "ImageUri": uri,

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -46,6 +46,61 @@ pub struct LambdaFunction {
     /// cached size never goes stale.
     #[serde(default)]
     pub layers: Vec<AttachedLayer>,
+    /// `RevisionId` is a stable token AWS expects to round-trip through
+    /// optimistic-concurrency calls (`UpdateFunctionConfiguration`,
+    /// `UpdateFunctionCode`, `AddPermission`, …). It only changes when
+    /// the function config changes; we used to mint a fresh UUID per
+    /// `function_config_json` call which broke client-side ETag-style
+    /// guards.
+    #[serde(default = "default_revision_id")]
+    pub revision_id: String,
+    /// `TracingConfig.Mode` — `PassThrough` (default) or `Active`.
+    #[serde(default)]
+    pub tracing_mode: Option<String>,
+    /// `KMSKeyArn` for env-var encryption (defaults to AWS-managed
+    /// `aws/lambda` when unset, which we represent as `None`).
+    #[serde(default)]
+    pub kms_key_arn: Option<String>,
+    /// `EphemeralStorage.Size` in MiB. AWS default is 512.
+    #[serde(default)]
+    pub ephemeral_storage_size: Option<i64>,
+    /// `VpcConfig` (`SubnetIds`, `SecurityGroupIds`, `Ipv6AllowedForDualStack`).
+    /// fakecloud doesn't network-isolate; we just round-trip the shape.
+    #[serde(default)]
+    pub vpc_config: Option<serde_json::Value>,
+    /// `SnapStart` (`ApplyOn`, `OptimizationStatus`).
+    #[serde(default)]
+    pub snap_start: Option<serde_json::Value>,
+    /// `DeadLetterConfig.TargetArn` for async-invoke failures.
+    #[serde(default)]
+    pub dead_letter_config_arn: Option<String>,
+    /// `FileSystemConfigs` (EFS access points). Round-tripped only.
+    #[serde(default)]
+    pub file_system_configs: Vec<serde_json::Value>,
+    /// `LoggingConfig` (LogFormat, ApplicationLogLevel, SystemLogLevel,
+    /// LogGroup).
+    #[serde(default)]
+    pub logging_config: Option<serde_json::Value>,
+    /// `ImageConfigResponse.ImageConfig` for container-package functions.
+    #[serde(default)]
+    pub image_config: Option<serde_json::Value>,
+    /// `SigningProfileVersionArn` populated by code signing.
+    #[serde(default)]
+    pub signing_profile_version_arn: Option<String>,
+    /// `SigningJobArn` populated by code signing.
+    #[serde(default)]
+    pub signing_job_arn: Option<String>,
+    /// `RuntimeVersionConfig` (`RuntimeVersionArn`).
+    #[serde(default)]
+    pub runtime_version_config: Option<serde_json::Value>,
+    /// `MasterArn` — only set on numbered versions; points at the parent
+    /// `$LATEST` ARN.
+    #[serde(default)]
+    pub master_arn: Option<String>,
+}
+
+fn default_revision_id() -> String {
+    uuid::Uuid::new_v4().to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Phase B2 of /tmp/parity_audit/REPORT.md. Audit found Lambda \`function_config_json\` was missing ~12 fields AWS always emits, and minted a fresh \`RevisionId\` per call — breaking client-side optimistic concurrency.

Adds to \`LambdaFunction\` state and emits in \`function_config_json\`:

- \`revision_id\` — stable per function, not per call
- \`tracing_mode\` — echoes user input instead of hardcoded \`PassThrough\`
- \`kms_key_arn\`
- \`ephemeral_storage_size\` (defaults to 512 MiB)
- \`vpc_config\`, \`snap_start\`, \`dead_letter_config\`
- \`file_system_configs\`, \`logging_config\`, \`image_config\` -> \`ImageConfigResponse\`
- \`signing_profile_version_arn\` / \`signing_job_arn\`
- \`runtime_version_config\`
- \`master_arn\` (for numbered versions)

\`CreateFunction\` parses each from the request body. \`Environment.Variables\` always present (AWS-shape).

Response-shape only. Phase D5 will wire the runtime side (\`EphemeralStorage\` -> \`--tmpfs\` at docker run, etc.).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo test -p fakecloud-lambda --lib\` 75 pass
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit the full AWS Lambda FunctionConfiguration response shape and make RevisionId stable per function to restore optimistic concurrency and improve AWS parity. Response-shape only; runtime effects will come later.

- New Features
  - `function_config_json` now includes: `TracingConfig` (uses request Mode), `KMSKeyArn`, `EphemeralStorage` (default 512), `VpcConfig`, `SnapStart` (default Off), `DeadLetterConfig`, `FileSystemConfigs`, `LoggingConfig`, `ImageConfigResponse`, `SigningProfileVersionArn`, `SigningJobArn`, `RuntimeVersionConfig`, `MasterArn`.
  - `CreateFunction` parses these fields from the request.
  - Always emit `Environment: { Variables: {} }` when no env vars are set.

- Bug Fixes
  - Replace per-call `RevisionId` with a stable token that only changes on config updates, so client-side concurrency checks work.

<sup>Written for commit 30e980df50d1235822c6d98c789a76c034fd1eac. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/892?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

