### PR TITLE
feat(lambda): real AccountUsage + full ESM + Versions + Code.Location

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -342,6 +342,10 @@ impl LambdaService {
         if state.account_settings.is_none() {
             state.account_settings = Some(settings.clone());
         }
+        // Real AccountUsage so clients monitoring deployment quotas see
+        // accurate numbers. AWS sums total code size across all functions.
+        let function_count = state.functions.len() as i64;
+        let total_code_size: i64 = state.functions.values().map(|f| f.code_size).sum();
         ok(json!({
             "AccountLimit": {
                 "ConcurrentExecutions": settings.concurrent_executions,
@@ -351,8 +355,8 @@ impl LambdaService {
                 "UnreservedConcurrentExecutions": settings.concurrent_executions,
             },
             "AccountUsage": {
-                "TotalCodeSize": 0,
-                "FunctionCount": 0,
+                "TotalCodeSize": total_code_size,
+                "FunctionCount": function_count,
             },
         }))
     }
@@ -366,17 +370,28 @@ impl LambdaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
-            if !state.functions.contains_key(function_name) {
-                return Err(not_found("Function", function_name));
-            }
-            let versions: Vec<&String> = state
-                .function_versions
+            let func = state
+                .functions
                 .get(function_name)
-                .map(|v| v.iter().collect())
-                .unwrap_or_default();
-            ok(json!({
-                "Versions": versions,
-            }))
+                .ok_or_else(|| not_found("Function", function_name))?;
+            // AWS always returns $LATEST first, then numbered versions.
+            // Until PublishVersion snapshots real config (Phase D2), each
+            // numbered version reuses the current configuration with the
+            // Version field swapped — same as Moto.
+            let mut versions: Vec<serde_json::Value> = Vec::new();
+            let mut latest = self.function_config_json(func);
+            latest["Version"] = json!("$LATEST");
+            versions.push(latest);
+            if let Some(numbered) = state.function_versions.get(function_name) {
+                for v in numbered {
+                    let mut cfg = self.function_config_json(func);
+                    cfg["Version"] = json!(v);
+                    cfg["FunctionArn"] = json!(format!("{}:{v}", func.function_arn));
+                    cfg["MasterArn"] = json!(func.function_arn);
+                    versions.push(cfg);
+                }
+            }
+            ok(json!({ "Versions": versions }))
         })
     }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -974,11 +974,16 @@ impl LambdaService {
                 "RepositoryType": "ECR",
             })
         } else {
+            // fakecloud doesn't expose a presigned-download path yet; we
+            // synthesize a `_fakecloud/`-namespaced URL so it's obvious to
+            // operators that the URL isn't a real S3 link. (Real
+            // download support is tracked under follow-up GG batch.)
+            let region = func.function_arn.split(':').nth(3).unwrap_or("us-east-1");
             json!({
                 "Location": format!(
-                    "https://awslambda-{}-tasks.s3.{}.amazonaws.com/stub",
-                    func.function_arn.split(':').nth(3).unwrap_or("us-east-1"),
-                    func.function_arn.split(':').nth(3).unwrap_or("us-east-1")
+                    "https://prod-{region}-starport-layer-bucket.s3.{region}.amazonaws.com/_fakecloud/{account}/{name}/code.zip",
+                    account = state.account_id,
+                    name = function_name,
                 ),
                 "RepositoryType": "S3",
             })

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -230,6 +230,13 @@ impl LambdaService {
     }
 
     pub(super) fn event_source_mapping_json(&self, mapping: &EventSourceMapping) -> Value {
+        // EventSourceMappingArn is the EventSourceArn variant prefixed with
+        // the mapping uuid; AWS started returning it in 2024 so newer SDKs
+        // expect to round-trip it.
+        let esm_arn = format!(
+            "{}:event-source-mapping/{}",
+            mapping.function_arn, mapping.uuid
+        );
         let mut out = json!({
             "UUID": mapping.uuid,
             "FunctionArn": mapping.function_arn,
@@ -237,6 +244,18 @@ impl LambdaService {
             "BatchSize": mapping.batch_size,
             "State": mapping.state,
             "LastModified": mapping.last_modified.timestamp_millis() as f64 / 1000.0,
+            "EventSourceMappingArn": esm_arn,
+            // Default fields AWS always returns (zeros / empty arrays / nulls
+            // when unset). Avoids SDK deserialiser breaks on missing keys.
+            "MaximumRetryAttempts": -1,
+            "MaximumRecordAgeInSeconds": -1,
+            "BisectBatchOnFunctionError": false,
+            "TumblingWindowInSeconds": 0,
+            "Topics": [],
+            "Queues": [],
+            "SourceAccessConfigurations": [],
+            "LastProcessingResult": "No records processed",
+            "StateTransitionReason": "User action",
         });
         let obj = out.as_object_mut().expect("json! built object");
         if !mapping.filter_patterns.is_empty() {


### PR DESCRIPTION
## Summary

Phase B3 of /tmp/parity_audit/REPORT.md.

1. **GetAccountSettings.AccountUsage** was hardcoded \`{0, 0}\`; now sums real \`total_code_size\` and \`function_count\` from state.
2. **ListVersionsByFunction** returned bare version strings; now returns full \`FunctionConfiguration\` per version (with \`MasterArn\` + version-suffixed FunctionArn). Until Phase D2 wires real PublishVersion snapshots, numbered versions reuse current config with \`Version\` swapped — same as Moto.
3. **EventSourceMapping JSON** missing 10 always-present fields. Add \`EventSourceMappingArn\` (2024), \`MaximumRetryAttempts\`, \`MaximumRecordAgeInSeconds\`, \`BisectBatchOnFunctionError\`, \`TumblingWindowInSeconds\`, \`Topics\`, \`Queues\`, \`SourceAccessConfigurations\`, \`LastProcessingResult\`, \`StateTransitionReason\` with AWS-default sentinels.
4. **GetFunction.Code.Location**: previous URL had region duplicated and pointed at a fake-s3 host. Replaced with a \`_fakecloud/\`-namespaced path so it's obvious it's not a real S3 URL.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p fakecloud-lambda --lib\` 75 pass
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Lambda responses with AWS so newer SDKs deserialize correctly. Adds real account usage, full version configs, required event source mapping fields, and a clearer code download URL.

- **New Features**
  - `GetAccountSettings` now reports real `AccountUsage` (`TotalCodeSize`, `FunctionCount`) from state.
  - `ListVersionsByFunction` returns full `FunctionConfiguration` items: `$LATEST` first, then numbered versions with `FunctionArn` suffix and `MasterArn`.

- **Bug Fixes**
  - Event source mapping JSON includes `EventSourceMappingArn` and other always-present fields (retry/record age/bisect/tumbling window/topics/queues/source access/last result/state reason) with AWS defaults.
  - `GetFunction.Code.Location` now points to an `_fakecloud/`-namespaced S3 URL without duplicated region.

<sup>Written for commit a76a9bcdb03ba3d6521846d9fd092538a6f70bfc. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/893?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

