### PR TITLE
feat(dynamodb): emit ConsumedCapacity + ItemCollectionMetrics on data-plane ops

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -9,9 +9,10 @@ use fakecloud_core::validation::*;
 use crate::state::AttributeValue;
 
 use super::{
-    apply_update_expression, evaluate_condition, execute_partiql_statement, extract_key, get_table,
-    get_table_mut, parse_expression_attribute_names, parse_expression_attribute_values,
-    require_str, DynamoDbService,
+    apply_update_expression, build_consumed_capacity, evaluate_condition,
+    execute_partiql_statement, extract_key, get_table, get_table_mut,
+    parse_expression_attribute_names, parse_expression_attribute_values, require_str,
+    return_consumed_mode, return_icm_mode, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -24,7 +25,7 @@ impl DynamoDbService {
             &["INDEXES", "TOTAL", "NONE"],
         )?;
 
-        let return_consumed = body["ReturnConsumedCapacity"].as_str().unwrap_or("NONE");
+        let return_consumed = return_consumed_mode(&body).to_string();
 
         let request_items = body["RequestItems"]
             .as_object()
@@ -61,13 +62,12 @@ impl DynamoDbService {
                     items.push(json!(table.items[idx]));
                 }
             }
+            let key_count = keys.len().max(1) as f64;
             responses.insert(table_name.clone(), items);
 
-            if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
-                consumed_capacity.push(json!({
-                    "TableName": table_name,
-                    "CapacityUnits": 1.0,
-                }));
+            let cc = build_consumed_capacity(&return_consumed, table_name, key_count * 0.5, 0.0);
+            if !cc.is_null() {
+                consumed_capacity.push(cc);
             }
         }
 
@@ -76,7 +76,7 @@ impl DynamoDbService {
             "UnprocessedKeys": {},
         });
 
-        if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
+        if !consumed_capacity.is_empty() {
             result["ConsumedCapacity"] = json!(consumed_capacity);
         }
 
@@ -100,10 +100,8 @@ impl DynamoDbService {
             &["SIZE", "NONE"],
         )?;
 
-        let return_consumed = body["ReturnConsumedCapacity"].as_str().unwrap_or("NONE");
-        let return_icm = body["ReturnItemCollectionMetrics"]
-            .as_str()
-            .unwrap_or("NONE");
+        let return_consumed = return_consumed_mode(&body).to_string();
+        let return_icm = return_icm_mode(&body).to_string();
 
         let request_items = body["RequestItems"]
             .as_object()
@@ -138,6 +136,7 @@ impl DynamoDbService {
                 )
             })?;
 
+            let mut write_count = 0u32;
             for request in reqs {
                 if let Some(put_req) = request.get("PutRequest") {
                     let item: HashMap<String, AttributeValue> =
@@ -148,22 +147,27 @@ impl DynamoDbService {
                     } else {
                         table.items.push(item);
                     }
+                    write_count += 1;
                 } else if let Some(del_req) = request.get("DeleteRequest") {
                     let key: HashMap<String, AttributeValue> =
                         serde_json::from_value(del_req["Key"].clone()).unwrap_or_default();
                     if let Some(idx) = table.find_item_index(&key) {
                         table.items.remove(idx);
                     }
+                    write_count += 1;
                 }
             }
 
             table.recalculate_stats();
 
-            if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
-                consumed_capacity.push(json!({
-                    "TableName": table_name,
-                    "CapacityUnits": 1.0,
-                }));
+            let cc = build_consumed_capacity(
+                &return_consumed,
+                table_name,
+                0.0,
+                write_count.max(1) as f64,
+            );
+            if !cc.is_null() {
+                consumed_capacity.push(cc);
             }
 
             if return_icm == "SIZE" {
@@ -175,7 +179,7 @@ impl DynamoDbService {
             "UnprocessedItems": {},
         });
 
-        if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
+        if !consumed_capacity.is_empty() {
             result["ConsumedCapacity"] = json!(consumed_capacity);
         }
 
@@ -196,6 +200,7 @@ impl DynamoDbService {
             &body["ReturnConsumedCapacity"],
             &["INDEXES", "TOTAL", "NONE"],
         )?;
+        let return_consumed = return_consumed_mode(&body).to_string();
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -208,6 +213,7 @@ impl DynamoDbService {
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
         let mut responses: Vec<Value> = Vec::new();
+        let mut per_table_count: HashMap<String, u32> = HashMap::new();
 
         for ti in transact_items {
             let get = &ti["Get"];
@@ -230,9 +236,26 @@ impl DynamoDbService {
                     responses.push(json!({}));
                 }
             }
+            *per_table_count.entry(table_name.to_string()).or_insert(0) += 1;
         }
 
-        Self::ok_json(json!({ "Responses": responses }))
+        let mut result = json!({ "Responses": responses });
+        let consumed: Vec<Value> = per_table_count
+            .iter()
+            .filter_map(|(t, n)| {
+                let cc = build_consumed_capacity(&return_consumed, t, (*n as f64) * 2.0, 0.0);
+                if cc.is_null() {
+                    None
+                } else {
+                    Some(cc)
+                }
+            })
+            .collect();
+        if !consumed.is_empty() {
+            result["ConsumedCapacity"] = json!(consumed);
+        }
+
+        Self::ok_json(result)
     }
 
     pub(super) fn transact_write_items(
@@ -256,6 +279,8 @@ impl DynamoDbService {
             &body["ReturnItemCollectionMetrics"],
             &["SIZE", "NONE"],
         )?;
+        let return_consumed = return_consumed_mode(&body).to_string();
+        let return_icm = return_icm_mode(&body).to_string();
         let transact_items = body["TransactItems"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -270,6 +295,7 @@ impl DynamoDbService {
         // First pass: validate all conditions
         let mut cancellation_reasons: Vec<Value> = Vec::new();
         let mut any_failed = false;
+        let mut per_table_writes: HashMap<String, u32> = HashMap::new();
 
         for ti in transact_items {
             if let Some(put) = ti.get("Put") {
@@ -393,6 +419,7 @@ impl DynamoDbService {
                     table.items.push(item);
                 }
                 table.recalculate_stats();
+                *per_table_writes.entry(table_name.to_string()).or_insert(0) += 1;
             } else if let Some(delete) = ti.get("Delete") {
                 let table_name = delete["TableName"].as_str().unwrap_or_default();
                 let key: HashMap<String, AttributeValue> =
@@ -402,6 +429,7 @@ impl DynamoDbService {
                     table.items.remove(idx);
                 }
                 table.recalculate_stats();
+                *per_table_writes.entry(table_name.to_string()).or_insert(0) += 1;
             } else if let Some(update) = ti.get("Update") {
                 let table_name = update["TableName"].as_str().unwrap_or_default();
                 let key: HashMap<String, AttributeValue> =
@@ -432,11 +460,35 @@ impl DynamoDbService {
                     )?;
                 }
                 table.recalculate_stats();
+                *per_table_writes.entry(table_name.to_string()).or_insert(0) += 1;
             }
             // ConditionCheck: no write needed
         }
 
-        Self::ok_json(json!({}))
+        let mut result = json!({});
+        let consumed: Vec<Value> = per_table_writes
+            .iter()
+            .filter_map(|(t, n)| {
+                let cc = build_consumed_capacity(&return_consumed, t, 0.0, (*n as f64) * 2.0);
+                if cc.is_null() {
+                    None
+                } else {
+                    Some(cc)
+                }
+            })
+            .collect();
+        if !consumed.is_empty() {
+            result["ConsumedCapacity"] = json!(consumed);
+        }
+        if return_icm == "SIZE" {
+            let icm: HashMap<String, Vec<Value>> = per_table_writes
+                .keys()
+                .map(|t| (t.clone(), vec![]))
+                .collect();
+            result["ItemCollectionMetrics"] = json!(icm);
+        }
+
+        Self::ok_json(result)
     }
 
     // ── PartiQL ─────────────────────────────────────────────────────────

--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -2542,3 +2542,58 @@ pub(crate) fn split_partiql_pairs(s: &str) -> Vec<&str> {
 pub(crate) fn count_params_in_str(s: &str) -> usize {
     s.chars().filter(|c| *c == '?').count()
 }
+
+/// Build a `ConsumedCapacity` JSON object matching AWS shape.
+/// Mode is one of `"TOTAL" | "INDEXES"`. Anything else returns `Value::Null`.
+/// `read_units` and `write_units` are the consumed CU; either may be 0.
+/// `INDEXES` mode also emits an empty `Table`/`GlobalSecondaryIndexes`/
+/// `LocalSecondaryIndexes` breakdown so SDKs that deserialize the index
+/// map round-trip.
+pub(crate) fn build_consumed_capacity(
+    mode: &str,
+    table_name: &str,
+    read_units: f64,
+    write_units: f64,
+) -> Value {
+    if mode != "TOTAL" && mode != "INDEXES" {
+        return Value::Null;
+    }
+    let total = read_units + write_units;
+    let mut cc = json!({
+        "TableName": table_name,
+        "CapacityUnits": total,
+    });
+    if read_units > 0.0 {
+        cc["ReadCapacityUnits"] = json!(read_units);
+    }
+    if write_units > 0.0 {
+        cc["WriteCapacityUnits"] = json!(write_units);
+    }
+    if mode == "INDEXES" {
+        let mut table_breakdown = json!({ "CapacityUnits": total });
+        if read_units > 0.0 {
+            table_breakdown["ReadCapacityUnits"] = json!(read_units);
+        }
+        if write_units > 0.0 {
+            table_breakdown["WriteCapacityUnits"] = json!(write_units);
+        }
+        cc["Table"] = table_breakdown;
+        cc["GlobalSecondaryIndexes"] = json!({});
+        cc["LocalSecondaryIndexes"] = json!({});
+    }
+    cc
+}
+
+/// Read the request body's `ReturnConsumedCapacity` value with default
+/// `"NONE"`, returning the canonical mode string.
+pub(crate) fn return_consumed_mode(body: &Value) -> &str {
+    body["ReturnConsumedCapacity"].as_str().unwrap_or("NONE")
+}
+
+/// Read the request body's `ReturnItemCollectionMetrics` value with
+/// default `"NONE"`.
+pub(crate) fn return_icm_mode(body: &Value) -> &str {
+    body["ReturnItemCollectionMetrics"]
+        .as_str()
+        .unwrap_or("NONE")
+}

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -6,10 +6,10 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use super::{
-    apply_update_expression, evaluate_condition, extract_key, get_table, get_table_mut,
-    parse_expression_attribute_names, parse_expression_attribute_values, project_item,
-    require_object, require_str, validate_key_attributes_in_key, validate_key_in_item,
-    DynamoDbService,
+    apply_update_expression, build_consumed_capacity, evaluate_condition, extract_key, get_table,
+    get_table_mut, parse_expression_attribute_names, parse_expression_attribute_values,
+    project_item, require_object, require_str, return_consumed_mode, return_icm_mode,
+    validate_key_attributes_in_key, validate_key_in_item, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -22,6 +22,8 @@ impl DynamoDbService {
         let expr_attr_names = parse_expression_attribute_names(&body);
         let expr_attr_values = parse_expression_attribute_values(&body);
         let return_values = body["ReturnValues"].as_str().unwrap_or("NONE").to_string();
+        let return_consumed = return_consumed_mode(&body).to_string();
+        let return_icm = return_icm_mode(&body).to_string();
 
         // --- Acquire write lock ONLY for validation + mutation ---
         // Capture kinesis delivery info alongside the return value
@@ -134,6 +136,13 @@ impl DynamoDbService {
         if let Some(old) = old_item {
             result["Attributes"] = json!(old);
         }
+        let cc = build_consumed_capacity(&return_consumed, table_name, 0.0, 1.0);
+        if !cc.is_null() {
+            result["ConsumedCapacity"] = cc;
+        }
+        if return_icm == "SIZE" {
+            result["ItemCollectionMetrics"] = json!({});
+        }
 
         Self::ok_json(result)
     }
@@ -143,6 +152,7 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
         let key = require_object(&body, "Key")?;
+        let return_consumed = return_consumed_mode(&body).to_string();
 
         // --- Use a read lock for the lookup (allows concurrent GetItem calls) ---
         let (result, needs_insights, kms_audit) = {
@@ -152,7 +162,7 @@ impl DynamoDbService {
             let table = get_table(&state.tables, table_name)?;
             let needs_insights = table.contributor_insights_status == "ENABLED";
 
-            let result = match table.find_item_index(&key) {
+            let mut result = match table.find_item_index(&key) {
                 Some(idx) => {
                     let item = &table.items[idx];
                     let projected = project_item(item, &body);
@@ -160,6 +170,10 @@ impl DynamoDbService {
                 }
                 None => json!({}),
             };
+            let cc = build_consumed_capacity(&return_consumed, table_name, 0.5, 0.0);
+            if !cc.is_null() {
+                result["ConsumedCapacity"] = cc;
+            }
             let kms_audit = if table.sse_type.as_deref() == Some("KMS") {
                 Some((table.arn.clone(), table.sse_kms_key_arn.clone()))
             } else {
@@ -278,11 +292,9 @@ impl DynamoDbService {
                 .as_str()
                 .unwrap_or("NONE");
 
-            if return_consumed == "TOTAL" || return_consumed == "INDEXES" {
-                result["ConsumedCapacity"] = json!({
-                    "TableName": table_name,
-                    "CapacityUnits": 1.0,
-                });
+            let cc = build_consumed_capacity(return_consumed, table_name, 0.0, 1.0);
+            if !cc.is_null() {
+                result["ConsumedCapacity"] = cc;
             }
 
             if return_icm == "SIZE" {
@@ -310,6 +322,8 @@ impl DynamoDbService {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
         let key = require_object(&body, "Key")?;
+        let return_consumed = return_consumed_mode(&body).to_string();
+        let return_icm = return_icm_mode(&body).to_string();
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -427,6 +441,13 @@ impl DynamoDbService {
             result["Attributes"] = json!(old);
         } else if let Some(new) = new_item {
             result["Attributes"] = json!(new);
+        }
+        let cc = build_consumed_capacity(&return_consumed, table_name, 0.0, 1.0);
+        if !cc.is_null() {
+            result["ConsumedCapacity"] = cc;
+        }
+        if return_icm == "SIZE" {
+            result["ItemCollectionMetrics"] = json!({});
         }
 
         Self::ok_json(result)

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -7,15 +7,17 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::state::AttributeValue;
 
 use super::{
-    compare_attribute_values, evaluate_filter_expression, evaluate_key_condition,
-    extract_key_for_schema, get_table, item_matches_key, parse_expression_attribute_names,
-    parse_expression_attribute_values, parse_key_map, project_item, require_str, DynamoDbService,
+    build_consumed_capacity, compare_attribute_values, evaluate_filter_expression,
+    evaluate_key_condition, extract_key_for_schema, get_table, item_matches_key,
+    parse_expression_attribute_names, parse_expression_attribute_values, parse_key_map,
+    project_item, require_str, return_consumed_mode, DynamoDbService,
 };
 
 impl DynamoDbService {
     pub(super) fn query(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
+        let return_consumed = return_consumed_mode(&body).to_string();
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
@@ -196,6 +198,16 @@ impl DynamoDbService {
             result["LastEvaluatedKey"] = json!(lek);
         }
 
+        let cc = build_consumed_capacity(
+            &return_consumed,
+            table_name,
+            (scanned_count.max(1) as f64) * 0.5,
+            0.0,
+        );
+        if !cc.is_null() {
+            result["ConsumedCapacity"] = cc;
+        }
+
         drop(accounts);
 
         if !accessed_keys.is_empty() {
@@ -221,6 +233,7 @@ impl DynamoDbService {
     pub(super) fn scan(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = Self::parse_body(req)?;
         let table_name = require_str(&body, "TableName")?;
+        let return_consumed = return_consumed_mode(&body).to_string();
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
@@ -301,6 +314,16 @@ impl DynamoDbService {
 
         if let Some(lek) = last_evaluated_key {
             result["LastEvaluatedKey"] = json!(lek);
+        }
+
+        let cc = build_consumed_capacity(
+            &return_consumed,
+            table_name,
+            (scanned_count.max(1) as f64) * 0.5,
+            0.0,
+        );
+        if !cc.is_null() {
+            result["ConsumedCapacity"] = cc;
         }
 
         drop(accounts);

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -2916,6 +2916,189 @@ fn put_item_returns_old_item() {
     assert_eq!(b["Attributes"]["v"]["N"], "1");
 }
 
+#[test]
+fn put_item_emits_consumed_capacity_when_requested() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": {"pk": {"S": "cc"}, "v": {"N": "1"}},
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let resp = svc.put_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["ConsumedCapacity"]["TableName"], "test-table");
+    assert_eq!(b["ConsumedCapacity"]["CapacityUnits"], 1.0);
+    assert_eq!(b["ConsumedCapacity"]["WriteCapacityUnits"], 1.0);
+    // TOTAL must not include the breakdown.
+    assert!(b["ConsumedCapacity"].get("Table").is_none());
+}
+
+#[test]
+fn put_item_consumed_capacity_indexes_includes_breakdown() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": {"pk": {"S": "cc"}, "v": {"N": "1"}},
+            "ReturnConsumedCapacity": "INDEXES",
+        }),
+    );
+    let resp = svc.put_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["ConsumedCapacity"]["Table"]["CapacityUnits"], 1.0);
+    assert!(b["ConsumedCapacity"]["GlobalSecondaryIndexes"].is_object());
+    assert!(b["ConsumedCapacity"]["LocalSecondaryIndexes"].is_object());
+}
+
+#[test]
+fn put_item_consumed_capacity_omitted_by_default() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": {"pk": {"S": "cc"}, "v": {"N": "1"}},
+        }),
+    );
+    let resp = svc.put_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert!(b.get("ConsumedCapacity").is_none());
+}
+
+#[test]
+fn get_item_emits_consumed_capacity_when_requested() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": {"pk": {"S": "g"}, "v": {"N": "1"}},
+        }),
+    );
+    svc.put_item(&req).unwrap();
+
+    let req = make_request(
+        "GetItem",
+        json!({
+            "TableName": "test-table",
+            "Key": {"pk": {"S": "g"}},
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let resp = svc.get_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["ConsumedCapacity"]["TableName"], "test-table");
+    assert_eq!(b["ConsumedCapacity"]["ReadCapacityUnits"], 0.5);
+}
+
+#[test]
+fn query_emits_consumed_capacity_when_requested() {
+    let svc = make_service();
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "qcc",
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            "BillingMode": "PAY_PER_REQUEST",
+        }),
+    );
+    svc.create_table(&req).unwrap();
+    let put = make_request(
+        "PutItem",
+        json!({
+            "TableName": "qcc",
+            "Item": {"pk": {"S": "p"}, "sk": {"S": "s"}},
+        }),
+    );
+    svc.put_item(&put).unwrap();
+
+    let req = make_request(
+        "Query",
+        json!({
+            "TableName": "qcc",
+            "KeyConditionExpression": "pk = :p",
+            "ExpressionAttributeValues": {":p": {"S": "p"}},
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let resp = svc.query(&req).unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["ConsumedCapacity"]["TableName"], "qcc");
+    assert!(
+        b["ConsumedCapacity"]["CapacityUnits"]
+            .as_f64()
+            .unwrap_or(0.0)
+            >= 0.5
+    );
+}
+
+#[test]
+fn batch_get_item_emits_consumed_capacity() {
+    let svc = make_service();
+    create_test_table(&svc);
+    let put = make_request(
+        "PutItem",
+        json!({
+            "TableName": "test-table",
+            "Item": {"pk": {"S": "bg"}},
+        }),
+    );
+    svc.put_item(&put).unwrap();
+
+    let req = make_request(
+        "BatchGetItem",
+        json!({
+            "RequestItems": {
+                "test-table": {"Keys": [{"pk": {"S": "bg"}}]},
+            },
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let resp = svc.batch_get_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert!(b["ConsumedCapacity"].is_array());
+    assert_eq!(b["ConsumedCapacity"][0]["TableName"], "test-table");
+}
+
+#[test]
+fn transact_write_items_emits_consumed_capacity() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    let req = make_request(
+        "TransactWriteItems",
+        json!({
+            "TransactItems": [
+                {"Put": {"TableName": "test-table", "Item": {"pk": {"S": "tw"}}}},
+            ],
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let resp = svc.transact_write_items(&req).unwrap();
+    let b = body_json(&resp);
+    assert!(b["ConsumedCapacity"].is_array());
+    assert_eq!(b["ConsumedCapacity"][0]["TableName"], "test-table");
+}
+
 // ── UpdateItem ──
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `build_consumed_capacity` / `return_consumed_mode` / `return_icm_mode` helpers
- Emit ConsumedCapacity on: PutItem, GetItem, UpdateItem, Query, Scan, BatchGetItem, BatchWriteItem, TransactGetItems, TransactWriteItems
- INDEXES mode now emits Table / GlobalSecondaryIndexes / LocalSecondaryIndexes breakdown
- Emit ItemCollectionMetrics on PutItem/UpdateItem/TransactWriteItems when ReturnItemCollectionMetrics=SIZE
- Real DynamoDB always populates these when requested; we were dropping them silently. Cost-attribution + autoscaling consumers were getting zero values.

Part of the parity-audit Phase B (response field gaps).

## Test plan

- [x] cargo test -p fakecloud-dynamodb --lib (226 pass)
- [x] cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit DynamoDB ConsumedCapacity and ItemCollectionMetrics on data‑plane APIs to match AWS responses. Fixes missing fields used by cost attribution and autoscaling.

- **New Features**
  - Return ConsumedCapacity when requested on PutItem, GetItem, UpdateItem, Query, Scan, BatchGetItem, BatchWriteItem, TransactGetItems, and TransactWriteItems.
  - Support INDEXES mode with Table/GlobalSecondaryIndexes/LocalSecondaryIndexes breakdown.
  - Return ItemCollectionMetrics on PutItem/UpdateItem/TransactWriteItems when ReturnItemCollectionMetrics=SIZE.
  - Add helpers `build_consumed_capacity`, `return_consumed_mode`, `return_icm_mode`, and tests for TOTAL vs INDEXES vs NONE.

<sup>Written for commit c79844b53aec3f135df6900a5c08a078b76c199f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/894?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

