### PR TITLE
feat(elasticache): persist + render encryption/log/cluster fields on ReplicationGroup

### DIFF
--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -255,6 +255,41 @@ pub(crate) fn parse_cache_usage_limits(
 ///   `{param}.{member_name}.1=val1&{param}.{member_name}.2=val2`
 ///
 /// Returns the values sorted by index.
+/// Parse `LogDeliveryConfigurations.LogDeliveryConfigurationRequest.N.*`
+/// into structured records. ElastiCache emits two destination types:
+/// `cloudwatch-logs` and `kinesis-firehose`; details vary by type but
+/// we keep the raw payload string.
+pub(crate) fn parse_log_delivery_configs(req: &AwsRequest) -> Vec<LogDeliveryConfiguration> {
+    let mut out = Vec::new();
+    for i in 1.. {
+        let base = format!("LogDeliveryConfigurations.LogDeliveryConfigurationRequest.{i}");
+        let log_type = optional_query_param(req, &format!("{base}.LogType"));
+        let dest_type = optional_query_param(req, &format!("{base}.DestinationType"));
+        if log_type.is_none() && dest_type.is_none() {
+            break;
+        }
+        let log_format = optional_query_param(req, &format!("{base}.LogFormat"))
+            .unwrap_or_else(|| "json".into());
+        let cw_group = optional_query_param(
+            req,
+            &format!("{base}.DestinationDetails.CloudWatchLogsDetails.LogGroup"),
+        );
+        let kinesis = optional_query_param(
+            req,
+            &format!("{base}.DestinationDetails.KinesisFirehoseDetails.DeliveryStream"),
+        );
+        let destination_details = cw_group.or(kinesis);
+        out.push(LogDeliveryConfiguration {
+            log_type: log_type.unwrap_or_default(),
+            destination_type: dest_type.unwrap_or_default(),
+            destination_details,
+            log_format,
+            status: "active".to_string(),
+        });
+    }
+    out
+}
+
 pub(crate) fn parse_member_list(
     params: &std::collections::HashMap<String, String>,
     param: &str,
@@ -669,61 +704,188 @@ pub(crate) fn replication_group_xml(g: &ReplicationGroup, region: &str) -> Strin
         .unwrap_or_default();
 
     let primary_az = format!("{region}a");
+    let kms_xml = g
+        .kms_key_id
+        .as_ref()
+        .map(|k| format!("<KmsKeyId>{}</KmsKeyId>", xml_escape(k)))
+        .unwrap_or_default();
+    let user_groups_xml = if g.user_group_ids.is_empty() {
+        "<UserGroupIds/>".to_string()
+    } else {
+        format!(
+            "<UserGroupIds>{}</UserGroupIds>",
+            g.user_group_ids
+                .iter()
+                .map(|u| format!("<member>{}</member>", xml_escape(u)))
+                .collect::<String>()
+        )
+    };
+    let log_delivery_xml = if g.log_delivery_configurations.is_empty() {
+        "<LogDeliveryConfigurations/>".to_string()
+    } else {
+        let entries: String = g
+            .log_delivery_configurations
+            .iter()
+            .map(log_delivery_configuration_xml)
+            .collect();
+        format!("<LogDeliveryConfigurations>{entries}</LogDeliveryConfigurations>")
+    };
+    let data_tiering_xml = g
+        .data_tiering
+        .as_ref()
+        .map(|d| format!("<DataTiering>{}</DataTiering>", xml_escape(d)))
+        .unwrap_or_default();
+    let ip_discovery_xml = g
+        .ip_discovery
+        .as_ref()
+        .map(|v| format!("<IpDiscovery>{}</IpDiscovery>", xml_escape(v)))
+        .unwrap_or_default();
+    let network_type_xml = g
+        .network_type
+        .as_ref()
+        .map(|v| format!("<NetworkType>{}</NetworkType>", xml_escape(v)))
+        .unwrap_or_default();
+    let transit_encryption_mode_xml = g
+        .transit_encryption_mode
+        .as_ref()
+        .map(|v| {
+            format!(
+                "<TransitEncryptionMode>{}</TransitEncryptionMode>",
+                xml_escape(v)
+            )
+        })
+        .unwrap_or_default();
+    let configuration_endpoint_xml = match (
+        g.configuration_endpoint_address.as_ref(),
+        g.configuration_endpoint_port,
+    ) {
+        (Some(addr), Some(port)) => format!(
+            "<ConfigurationEndpoint><Address>{}</Address><Port>{}</Port></ConfigurationEndpoint>",
+            xml_escape(addr),
+            port
+        ),
+        _ => String::new(),
+    };
+    let replication_group_create_time_xml = format!(
+        "<ReplicationGroupCreateTime>{}</ReplicationGroupCreateTime>",
+        xml_escape(&g.created_at)
+    );
+
+    let id = xml_escape(&g.replication_group_id);
+    let description = xml_escape(&g.description);
+    let status = xml_escape(&g.status);
+    let endpoint_address = xml_escape(&g.endpoint_address);
+    let endpoint_port = g.endpoint_port;
+    let primary_cluster = xml_escape(g.member_clusters.first().map(|s| s.as_str()).unwrap_or(""));
+    let primary_az_xml = xml_escape(&primary_az);
+    let automatic_failover = if g.automatic_failover_enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    let multi_az = if g.multi_az_enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    let snapshot_retention = g.snapshot_retention_limit;
+    let snapshot_window = xml_escape(&g.snapshot_window);
+    let cache_node_type = xml_escape(&g.cache_node_type);
+    let cluster_enabled = if g.cluster_enabled { "true" } else { "false" };
+    let auth_token_enabled = if g.auth_token_enabled {
+        "true"
+    } else {
+        "false"
+    };
+    let transit_enc = if g.transit_encryption_enabled {
+        "true"
+    } else {
+        "false"
+    };
+    let at_rest_enc = if g.at_rest_encryption_enabled {
+        "true"
+    } else {
+        "false"
+    };
+    let arn = xml_escape(&g.arn);
 
     format!(
-        "<ReplicationGroupId>{}</ReplicationGroupId>\
-         <Description>{}</Description>\
+        "<ReplicationGroupId>{id}</ReplicationGroupId>\
+         <Description>{description}</Description>\
          {global_replication_group_info_xml}\
-         <Status>{}</Status>\
+         <Status>{status}</Status>\
+         {replication_group_create_time_xml}\
          <MemberClusters>{member_clusters_xml}</MemberClusters>\
          <NodeGroups>\
          <NodeGroup>\
          <NodeGroupId>0001</NodeGroupId>\
          <Status>available</Status>\
          <PrimaryEndpoint>\
-         <Address>{}</Address>\
-         <Port>{}</Port>\
+         <Address>{endpoint_address}</Address>\
+         <Port>{endpoint_port}</Port>\
          </PrimaryEndpoint>\
          <ReaderEndpoint>\
-         <Address>{}</Address>\
-         <Port>{}</Port>\
+         <Address>{endpoint_address}</Address>\
+         <Port>{endpoint_port}</Port>\
          </ReaderEndpoint>\
          <NodeGroupMembers>\
          <NodeGroupMember>\
-         <CacheClusterId>{}</CacheClusterId>\
+         <CacheClusterId>{primary_cluster}</CacheClusterId>\
          <CacheNodeId>0001</CacheNodeId>\
-         <PreferredAvailabilityZone>{}</PreferredAvailabilityZone>\
+         <PreferredAvailabilityZone>{primary_az_xml}</PreferredAvailabilityZone>\
          <CurrentRole>primary</CurrentRole>\
          </NodeGroupMember>\
          </NodeGroupMembers>\
          </NodeGroup>\
          </NodeGroups>\
-         <AutomaticFailover>{}</AutomaticFailover>\
-         <SnapshotRetentionLimit>{}</SnapshotRetentionLimit>\
-         <SnapshotWindow>{}</SnapshotWindow>\
-         <ClusterEnabled>false</ClusterEnabled>\
-         <CacheNodeType>{}</CacheNodeType>\
-         <TransitEncryptionEnabled>false</TransitEncryptionEnabled>\
-         <AtRestEncryptionEnabled>false</AtRestEncryptionEnabled>\
-         <ARN>{}</ARN>",
-        xml_escape(&g.replication_group_id),
-        xml_escape(&g.description),
-        xml_escape(&g.status),
-        xml_escape(&g.endpoint_address),
-        g.endpoint_port,
-        xml_escape(&g.endpoint_address),
-        g.endpoint_port,
-        xml_escape(g.member_clusters.first().map(|s| s.as_str()).unwrap_or("")),
-        xml_escape(&primary_az),
-        if g.automatic_failover_enabled {
-            "enabled"
-        } else {
-            "disabled"
-        },
-        g.snapshot_retention_limit,
-        xml_escape(&g.snapshot_window),
-        xml_escape(&g.cache_node_type),
-        xml_escape(&g.arn),
+         <AutomaticFailover>{automatic_failover}</AutomaticFailover>\
+         <MultiAZ>{multi_az}</MultiAZ>\
+         <SnapshotRetentionLimit>{snapshot_retention}</SnapshotRetentionLimit>\
+         <SnapshotWindow>{snapshot_window}</SnapshotWindow>\
+         <ClusterEnabled>{cluster_enabled}</ClusterEnabled>\
+         <CacheNodeType>{cache_node_type}</CacheNodeType>\
+         <AuthTokenEnabled>{auth_token_enabled}</AuthTokenEnabled>\
+         <TransitEncryptionEnabled>{transit_enc}</TransitEncryptionEnabled>\
+         <AtRestEncryptionEnabled>{at_rest_enc}</AtRestEncryptionEnabled>\
+         {kms_xml}\
+         {user_groups_xml}\
+         {log_delivery_xml}\
+         {data_tiering_xml}\
+         {ip_discovery_xml}\
+         {network_type_xml}\
+         {transit_encryption_mode_xml}\
+         {configuration_endpoint_xml}\
+         <PendingModifiedValues/>\
+         <ARN>{arn}</ARN>",
+    )
+}
+
+pub(crate) fn log_delivery_configuration_xml(c: &LogDeliveryConfiguration) -> String {
+    let detail = c
+        .destination_details
+        .as_deref()
+        .map(|d| {
+            if c.destination_type == "cloudwatch-logs" {
+                format!(
+                    "<DestinationDetails><CloudWatchLogsDetails><LogGroup>{}</LogGroup></CloudWatchLogsDetails></DestinationDetails>",
+                    xml_escape(d)
+                )
+            } else if c.destination_type == "kinesis-firehose" {
+                format!(
+                    "<DestinationDetails><KinesisFirehoseDetails><DeliveryStream>{}</DeliveryStream></KinesisFirehoseDetails></DestinationDetails>",
+                    xml_escape(d)
+                )
+            } else {
+                String::new()
+            }
+        })
+        .unwrap_or_default();
+    format!(
+        "<LogDeliveryConfiguration><LogType>{}</LogType><DestinationType>{}</DestinationType>{detail}<LogFormat>{}</LogFormat><Status>{}</Status></LogDeliveryConfiguration>",
+        xml_escape(&c.log_type),
+        xml_escape(&c.destination_type),
+        xml_escape(&c.log_format),
+        xml_escape(&c.status),
     )
 }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -15,8 +15,8 @@ use crate::state::{
     default_engine_versions, default_parameters_for_family, CacheCluster, CacheEngineVersion,
     CacheParameterGroup, CacheSnapshot, CacheSubnetGroup, ElastiCacheSnapshot, ElastiCacheState,
     ElastiCacheUser, ElastiCacheUserGroup, EngineDefaultParameter, GlobalReplicationGroup,
-    GlobalReplicationGroupMember, RecurringCharge, ReplicationGroup, ReservedCacheNode,
-    ReservedCacheNodesOffering, ServerlessCache, ServerlessCacheDataStorage,
+    GlobalReplicationGroupMember, LogDeliveryConfiguration, RecurringCharge, ReplicationGroup,
+    ReservedCacheNode, ReservedCacheNodesOffering, ServerlessCache, ServerlessCacheDataStorage,
     ServerlessCacheEcpuPerSecond, ServerlessCacheEndpoint, ServerlessCacheSnapshot,
     ServerlessCacheUsageLimits, SharedElastiCacheState, ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
 };
@@ -1103,6 +1103,33 @@ impl ElastiCacheService {
             optional_query_param(request, "AutomaticFailoverEnabled").as_deref(),
         )?
         .unwrap_or(false);
+        let transit_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "TransitEncryptionEnabled").as_deref(),
+        )?
+        .unwrap_or(false);
+        let at_rest_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "AtRestEncryptionEnabled").as_deref(),
+        )?
+        .unwrap_or(false);
+        let multi_az_enabled =
+            parse_optional_bool(optional_query_param(request, "MultiAZEnabled").as_deref())?
+                .unwrap_or(false);
+        let auth_token_enabled = optional_query_param(request, "AuthToken").is_some();
+        let kms_key_id = optional_query_param(request, "KmsKeyId");
+        let user_group_ids = parse_query_list_param(request, "UserGroupIds", "UserGroupId");
+        let num_node_groups = optional_query_param(request, "NumNodeGroups")
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(1);
+        let cluster_enabled = num_node_groups > 1;
+        let replicas_per_node_group = optional_query_param(request, "ReplicasPerNodeGroup")
+            .and_then(|v| v.parse::<i32>().ok());
+        let data_tiering =
+            parse_optional_bool(optional_query_param(request, "DataTieringEnabled").as_deref())?
+                .map(|b| if b { "enabled" } else { "disabled" }.to_string());
+        let ip_discovery = optional_query_param(request, "IpDiscovery");
+        let network_type = optional_query_param(request, "NetworkType");
+        let transit_encryption_mode = optional_query_param(request, "TransitEncryptionMode");
+        let log_delivery_configurations = parse_log_delivery_configs(request);
         // Reserve the ID under a write lock before starting the container.
         {
             let mut accounts = self.state.write();
@@ -1175,6 +1202,30 @@ impl ElastiCacheService {
             member_clusters,
             snapshot_retention_limit: 0,
             snapshot_window: "05:00-09:00".to_string(),
+            transit_encryption_enabled,
+            at_rest_encryption_enabled,
+            cluster_enabled,
+            kms_key_id,
+            auth_token_enabled,
+            user_group_ids,
+            multi_az_enabled,
+            log_delivery_configurations,
+            data_tiering,
+            ip_discovery,
+            network_type,
+            transit_encryption_mode,
+            num_node_groups,
+            configuration_endpoint_address: if cluster_enabled {
+                Some("127.0.0.1".to_string())
+            } else {
+                None
+            },
+            configuration_endpoint_port: if cluster_enabled {
+                Some(running.host_port)
+            } else {
+                None
+            },
+            replicas_per_node_group,
         };
 
         let xml = replication_group_xml(&group, &region);

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -857,6 +857,22 @@ fn add_cluster_to_replication_group_updates_members_and_count() {
             member_clusters: vec!["rg-1-001".to_string()],
             snapshot_retention_limit: 0,
             snapshot_window: "05:00-09:00".to_string(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            cluster_enabled: false,
+            kms_key_id: None,
+            auth_token_enabled: false,
+            user_group_ids: Vec::new(),
+            multi_az_enabled: false,
+            log_delivery_configurations: Vec::new(),
+            data_tiering: None,
+            ip_discovery: None,
+            network_type: None,
+            transit_encryption_mode: None,
+            num_node_groups: 1,
+            configuration_endpoint_address: None,
+            configuration_endpoint_port: None,
+            replicas_per_node_group: None,
         },
     );
 
@@ -901,6 +917,22 @@ async fn delete_cache_cluster_removes_cluster_from_replication_group() {
                 member_clusters: vec!["delete-rg-001".to_string(), "delete-rg-cluster".to_string()],
                 snapshot_retention_limit: 0,
                 snapshot_window: "05:00-09:00".to_string(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                cluster_enabled: false,
+                kms_key_id: None,
+                auth_token_enabled: false,
+                user_group_ids: Vec::new(),
+                multi_az_enabled: false,
+                log_delivery_configurations: Vec::new(),
+                data_tiering: None,
+                ip_discovery: None,
+                network_type: None,
+                transit_encryption_mode: None,
+                num_node_groups: 1,
+                configuration_endpoint_address: None,
+                configuration_endpoint_port: None,
+                replicas_per_node_group: None,
             },
         );
     }
@@ -970,6 +1002,22 @@ fn service_with_replication_group(group_id: &str, num_clusters: i32) -> ElastiCa
                 member_clusters,
                 snapshot_retention_limit: 0,
                 snapshot_window: "05:00-09:00".to_string(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                cluster_enabled: false,
+                kms_key_id: None,
+                auth_token_enabled: false,
+                user_group_ids: Vec::new(),
+                multi_az_enabled: false,
+                log_delivery_configurations: Vec::new(),
+                data_tiering: None,
+                ip_discovery: None,
+                network_type: None,
+                transit_encryption_mode: None,
+                num_node_groups: 1,
+                configuration_endpoint_address: None,
+                configuration_endpoint_port: None,
+                replicas_per_node_group: None,
             },
         );
     }
@@ -1184,6 +1232,73 @@ fn delete_global_replication_group_clears_primary_group_association() {
     let primary_group = state.replication_groups.get("primary-rg").unwrap();
     assert!(primary_group.global_replication_group_id.is_none());
     assert!(primary_group.global_replication_group_role.is_none());
+}
+
+#[test]
+fn replication_group_xml_emits_dynamic_encryption_and_kms() {
+    let mut state = crate::state::ElastiCacheState::new("123456789012", "us-east-1");
+    state.replication_groups.insert(
+        "enc-rg".to_string(),
+        ReplicationGroup {
+            replication_group_id: "enc-rg".to_string(),
+            description: "encrypted".to_string(),
+            global_replication_group_id: None,
+            global_replication_group_role: None,
+            status: "available".to_string(),
+            cache_node_type: "cache.t3.micro".to_string(),
+            engine: "redis".to_string(),
+            engine_version: "7.1".to_string(),
+            num_cache_clusters: 1,
+            automatic_failover_enabled: true,
+            endpoint_address: "127.0.0.1".to_string(),
+            endpoint_port: 6379,
+            arn: "arn:aws:elasticache:us-east-1:123:replicationgroup:enc-rg".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            container_id: "c".to_string(),
+            host_port: 6379,
+            member_clusters: vec!["enc-rg-001".to_string()],
+            snapshot_retention_limit: 5,
+            snapshot_window: "05:00-09:00".to_string(),
+            transit_encryption_enabled: true,
+            at_rest_encryption_enabled: true,
+            cluster_enabled: true,
+            kms_key_id: Some("arn:aws:kms:us-east-1:123:key/abc-123".to_string()),
+            auth_token_enabled: true,
+            user_group_ids: vec!["ug-prod".to_string()],
+            multi_az_enabled: true,
+            log_delivery_configurations: vec![crate::state::LogDeliveryConfiguration {
+                log_type: "slow-log".to_string(),
+                destination_type: "cloudwatch-logs".to_string(),
+                destination_details: Some("/aws/elasticache/slow".to_string()),
+                log_format: "json".to_string(),
+                status: "active".to_string(),
+            }],
+            data_tiering: Some("disabled".to_string()),
+            ip_discovery: Some("ipv4".to_string()),
+            network_type: Some("dual_stack".to_string()),
+            transit_encryption_mode: Some("required".to_string()),
+            num_node_groups: 2,
+            configuration_endpoint_address: Some("config.local".to_string()),
+            configuration_endpoint_port: Some(6379),
+            replicas_per_node_group: Some(1),
+        },
+    );
+    let xml =
+        super::replication_group_xml(state.replication_groups.get("enc-rg").unwrap(), "us-east-1");
+    assert!(xml.contains("<TransitEncryptionEnabled>true</TransitEncryptionEnabled>"));
+    assert!(xml.contains("<AtRestEncryptionEnabled>true</AtRestEncryptionEnabled>"));
+    assert!(xml.contains("<ClusterEnabled>true</ClusterEnabled>"));
+    assert!(xml.contains("<KmsKeyId>arn:aws:kms:us-east-1:123:key/abc-123</KmsKeyId>"));
+    assert!(xml.contains("<AuthTokenEnabled>true</AuthTokenEnabled>"));
+    assert!(xml.contains("<MultiAZ>enabled</MultiAZ>"));
+    assert!(xml.contains("<UserGroupIds><member>ug-prod</member></UserGroupIds>"));
+    assert!(xml.contains("<LogDeliveryConfigurations>"));
+    assert!(xml.contains("<DataTiering>disabled</DataTiering>"));
+    assert!(xml.contains("<NetworkType>dual_stack</NetworkType>"));
+    assert!(xml.contains("<TransitEncryptionMode>required</TransitEncryptionMode>"));
+    assert!(xml.contains("<ConfigurationEndpoint>"));
+    assert!(xml
+        .contains("<ReplicationGroupCreateTime>2024-01-01T00:00:00Z</ReplicationGroupCreateTime>"));
 }
 
 #[test]

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -128,6 +128,54 @@ pub struct ReplicationGroup {
     pub member_clusters: Vec<String>,
     pub snapshot_retention_limit: i32,
     pub snapshot_window: String,
+    /// Stored at create / modify time so DescribeReplicationGroups returns
+    /// the actual configuration instead of canned defaults. AWS always
+    /// emits these flags; SDKs that read them (terraform plan diff,
+    /// compliance checks) saw stale `false` for everyone.
+    #[serde(default)]
+    pub transit_encryption_enabled: bool,
+    #[serde(default)]
+    pub at_rest_encryption_enabled: bool,
+    #[serde(default)]
+    pub cluster_enabled: bool,
+    #[serde(default)]
+    pub kms_key_id: Option<String>,
+    #[serde(default)]
+    pub auth_token_enabled: bool,
+    #[serde(default)]
+    pub user_group_ids: Vec<String>,
+    #[serde(default)]
+    pub multi_az_enabled: bool,
+    #[serde(default)]
+    pub log_delivery_configurations: Vec<LogDeliveryConfiguration>,
+    #[serde(default)]
+    pub data_tiering: Option<String>,
+    #[serde(default)]
+    pub ip_discovery: Option<String>,
+    #[serde(default)]
+    pub network_type: Option<String>,
+    #[serde(default)]
+    pub transit_encryption_mode: Option<String>,
+    #[serde(default)]
+    pub num_node_groups: i32,
+    #[serde(default)]
+    pub configuration_endpoint_address: Option<String>,
+    #[serde(default)]
+    pub configuration_endpoint_port: Option<u16>,
+    #[serde(default)]
+    pub replicas_per_node_group: Option<i32>,
+}
+
+/// AWS's LogDeliveryConfiguration shape, retained verbatim so we can
+/// echo the exact request back. Stored as raw fields for both
+/// CloudWatch + Firehose destinations.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct LogDeliveryConfiguration {
+    pub log_type: String,
+    pub destination_type: String,
+    pub destination_details: Option<String>,
+    pub log_format: String,
+    pub status: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1069,6 +1117,22 @@ mod tests {
                 member_clusters: vec!["my-group-001".to_string()],
                 snapshot_retention_limit: 0,
                 snapshot_window: "05:00-09:00".to_string(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                cluster_enabled: false,
+                kms_key_id: None,
+                auth_token_enabled: false,
+                user_group_ids: Vec::new(),
+                multi_az_enabled: false,
+                log_delivery_configurations: Vec::new(),
+                data_tiering: None,
+                ip_discovery: None,
+                network_type: None,
+                transit_encryption_mode: None,
+                num_node_groups: 1,
+                configuration_endpoint_address: None,
+                configuration_endpoint_port: None,
+                replicas_per_node_group: None,
             },
         );
         assert_eq!(state.replication_groups.len(), 1);


### PR DESCRIPTION
## Summary

CreateReplicationGroup ignored TransitEncryptionEnabled, AtRestEncryptionEnabled, KmsKeyId, AuthToken, UserGroupIds, NumNodeGroups, MultiAZEnabled, LogDeliveryConfigurations, DataTieringEnabled, IpDiscovery, NetworkType, TransitEncryptionMode, ReplicasPerNodeGroup. DescribeReplicationGroups always emitted hardcoded false / canned defaults.

- Extend ReplicationGroup state with all of the above (serde defaults so existing snapshots still load)
- Parse from CreateReplicationGroup query parameters; cluster_enabled = NumNodeGroups>1
- Render dynamically: KMS, UserGroupIds, MultiAZ, LogDeliveryConfigurations, DataTiering, IpDiscovery, NetworkType, TransitEncryptionMode, ConfigurationEndpoint, ReplicationGroupCreateTime, PendingModifiedValues
- parse_log_delivery_configs handles the AWS nested log delivery request (cloudwatch-logs + kinesis-firehose destinations)
- Test asserts all fields render dynamically off stored values

Part of parity-audit Phase B (response field gaps).

## Test plan

- [x] cargo test -p fakecloud-elasticache --lib (178 pass)
- [x] cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and return real encryption, KMS, auth token, user groups, Multi-AZ, cluster, and log delivery settings for ElastiCache ReplicationGroups. DescribeReplicationGroups now reflects CreateReplicationGroup inputs instead of hardcoded defaults.

- **New Features**
  - Persist previously ignored fields (encryption, KMS, auth token, user groups, node groups, Multi-AZ, log delivery, data tiering, IP/network, transit mode, replicas) with serde defaults; parse on CreateReplicationGroup; derive `cluster_enabled` from `NumNodeGroups > 1` and set ConfigurationEndpoint when clustered.
  - Add `parse_log_delivery_configs` to handle AWS-shaped `LogDeliveryConfigurations` for `cloudwatch-logs` and `kinesis-firehose`.
  - Emit dynamic XML for KMS, UserGroupIds, MultiAZ, LogDeliveryConfigurations, DataTiering, IpDiscovery, NetworkType, TransitEncryptionMode, ConfigurationEndpoint, ReplicationGroupCreateTime, PendingModifiedValues, and cluster flags.

<sup>Written for commit 766f30ecc82b3f96d93e885ce170ae3982b31fcf. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/896?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

