### PR TITLE
feat(kinesis): emit EnhancedMonitoring + StreamModeDetails + KeyId on DescribeStream and real StreamSummaries

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -228,14 +228,25 @@ impl KinesisService {
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let stream = state.lookup_stream(&body)?;
 
+        let enhanced_monitoring = if stream.enhanced_metrics.is_empty() {
+            json!([{ "ShardLevelMetrics": Vec::<String>::new() }])
+        } else {
+            json!([{ "ShardLevelMetrics": stream.enhanced_metrics }])
+        };
+
         Ok(AwsResponse::ok_json(json!({
             "StreamDescription": {
                 "EncryptionType": stream.encryption_type,
+                "EnhancedMonitoring": enhanced_monitoring,
                 "HasMoreShards": false,
+                "KeyId": stream.key_id,
                 "RetentionPeriodHours": stream.retention_period_hours,
                 "Shards": stream.shards.iter().map(shard_to_json).collect::<Vec<_>>(),
                 "StreamARN": stream.stream_arn,
                 "StreamCreationTimestamp": stream.stream_creation_timestamp.timestamp_millis() as f64 / 1000.0,
+                "StreamModeDetails": {
+                    "StreamMode": stream.stream_mode,
+                },
                 "StreamName": stream.stream_name,
                 "StreamStatus": stream.stream_status
             }
@@ -301,11 +312,26 @@ impl KinesisService {
         let page_len = remaining.min(limit as usize);
         let has_more_streams = remaining > page_len;
         let selected: Vec<String> = names.into_iter().skip(start).take(page_len).collect();
+        let summaries: Vec<Value> = selected
+            .iter()
+            .filter_map(|name| state.streams.get(name))
+            .map(|s| {
+                json!({
+                    "StreamName": s.stream_name,
+                    "StreamARN": s.stream_arn,
+                    "StreamStatus": s.stream_status,
+                    "StreamModeDetails": {
+                        "StreamMode": s.stream_mode,
+                    },
+                    "StreamCreationTimestamp": s.stream_creation_timestamp.timestamp_millis() as f64 / 1000.0,
+                })
+            })
+            .collect();
 
         Ok(AwsResponse::ok_json(json!({
             "HasMoreStreams": has_more_streams,
             "StreamNames": selected,
-            "StreamSummaries": []
+            "StreamSummaries": summaries
         })))
     }
 

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -217,6 +217,16 @@ fn describe_stream_returns_shard_descriptions() {
     assert_eq!(desc["StreamName"], json!("orders"));
     assert_eq!(desc["StreamStatus"], json!("ACTIVE"));
     assert_eq!(desc["Shards"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        desc["StreamModeDetails"]["StreamMode"],
+        json!("PROVISIONED")
+    );
+    assert!(desc["EnhancedMonitoring"].is_array());
+    assert_eq!(
+        desc["EnhancedMonitoring"][0]["ShardLevelMetrics"],
+        json!(Vec::<String>::new())
+    );
+    assert!(desc.get("KeyId").is_some());
 }
 
 #[test]
@@ -270,6 +280,15 @@ fn list_streams_sorts_and_paginates() {
     let names: Vec<String> = serde_json::from_value(body["StreamNames"].clone()).unwrap();
     assert_eq!(names, vec!["charlie"]);
     assert_eq!(body["HasMoreStreams"], json!(false));
+    let summaries = body["StreamSummaries"].as_array().expect("array");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0]["StreamName"], json!("charlie"));
+    assert_eq!(summaries[0]["StreamStatus"], json!("ACTIVE"));
+    assert_eq!(
+        summaries[0]["StreamModeDetails"]["StreamMode"],
+        json!("PROVISIONED")
+    );
+    assert!(summaries[0]["StreamARN"].is_string());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

DescribeStream omitted EnhancedMonitoring (always-present in real Kinesis), StreamModeDetails, and KeyId. ListStreams returned StreamSummaries: [] even when streams existed. SDK clients reading these saw missing/empty data.

- DescribeStream emits EnhancedMonitoring with stored shard-level metrics, StreamModeDetails, KeyId
- ListStreams populates real StreamSummaries (name/arn/status/mode/createTimestamp) per stream
- Tests cover both shapes

Part of parity-audit Phase B (response field gaps).

## Test plan

- [x] cargo test -p fakecloud-kinesis --lib (93 pass)
- [x] cargo clippy -p fakecloud-kinesis --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing Kinesis fields and real summaries in `fakecloud-kinesis`: `DescribeStream` now includes EnhancedMonitoring, StreamModeDetails, and KeyId; `ListStreams` returns actual StreamSummaries. This aligns responses with AWS so SDKs and tooling receive expected data.

- **Bug Fixes**
  - DescribeStream: emits EnhancedMonitoring (stored shard metrics), StreamModeDetails (mode), and KeyId.
  - ListStreams: populates StreamSummaries with name, ARN, status, mode, and creationTimestamp for each stream.

<sup>Written for commit f585e9e9ffe57df2d33ad439800ad34470499018. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/897?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

