### PR TITLE
feat(ecs,ecr): emit always-present response fields on Task/Service/Image

### DIFF
--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -292,6 +292,27 @@ pub(crate) fn image_to_details(repo: &Repository, image: &Image, registry_id: &s
     if let Some(t) = image.last_recorded_pull_time {
         out["lastRecordedPullTime"] = json!(t.timestamp());
     }
+    // Surface scan state on the image itself (real ECR returns these
+    // unconditionally; SDK callers that watch scan-on-push completion poll
+    // DescribeImages and previously saw nothing).
+    if let Some(findings) = repo.scan_findings.get(&image.image_digest) {
+        out["imageScanStatus"] = json!({ "status": findings.scan_status });
+        let mut summary = serde_json::Map::new();
+        if let Some(ts) = findings.scan_completed_at {
+            summary.insert("imageScanCompletedAt".into(), json!(ts.timestamp()));
+        }
+        if let Some(ts) = findings.vulnerability_source_updated_at {
+            summary.insert("vulnerabilitySourceUpdatedAt".into(), json!(ts.timestamp()));
+        }
+        summary.insert(
+            "findingSeverityCounts".into(),
+            json!(findings.finding_severity_counts),
+        );
+        out["imageScanFindingsSummary"] = Value::Object(summary);
+    } else if repo.image_scanning_configuration.scan_on_push {
+        // Scan-on-push configured but the scan hasn't kicked yet.
+        out["imageScanStatus"] = json!({ "status": "PENDING" });
+    }
     out
 }
 

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -471,6 +471,55 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
     if let Some(ts) = task.connectivity_at {
         map.insert("connectivityAt".into(), json!(ts.timestamp()));
     }
+    // Always-present fields AWS returns. SDKs deserialize these
+    // unconditionally; without them, terraform/cdk plan diffs and
+    // observability hooks see missing keys.
+    map.insert("attachments".into(), json!([]));
+    map.insert("attributes".into(), json!([]));
+    map.insert("availabilityZone".into(), json!("us-east-1a"));
+    map.insert(
+        "containerInstanceArn".into(),
+        if task.launch_type == "EC2" || task.launch_type == "EXTERNAL" {
+            json!(format!(
+                "{}/container-instance/i-fakecloud-1",
+                task.cluster_arn
+            ))
+        } else {
+            Value::Null
+        },
+    );
+    map.insert("enableExecuteCommand".into(), json!(false));
+    map.insert("ephemeralStorage".into(), json!({ "sizeInGiB": 20 }));
+    map.insert(
+        "healthStatus".into(),
+        json!(task
+            .containers
+            .iter()
+            .find_map(|c| c.health_status.as_ref())
+            .map(|s| s.as_str())
+            .unwrap_or("HEALTHY")),
+    );
+    map.insert("version".into(), json!(1));
+    map.insert(
+        "platformFamily".into(),
+        match task.launch_type.as_str() {
+            "FARGATE" => json!("Linux"),
+            _ => Value::Null,
+        },
+    );
+    if let Some(ts) = task.stopped_at {
+        map.insert("executionStoppedAt".into(), json!(ts.timestamp()));
+    }
+    if !task.tags.is_empty() {
+        map.insert(
+            "tags".into(),
+            json!(task
+                .tags
+                .iter()
+                .map(|t| json!({ "key": t.key, "value": t.value }))
+                .collect::<Vec<_>>()),
+        );
+    }
     Value::Object(map)
 }
 
@@ -789,6 +838,34 @@ pub(crate) fn service_to_json(svc: &Service) -> Value {
         map.insert("createdBy".into(), json!(v));
     }
     map.insert("createdAt".into(), json!(svc.created_at.timestamp()));
+    // Always-present fields AWS returns; SDKs deserialize unconditionally.
+    map.insert("enableExecuteCommand".into(), json!(false));
+    map.insert("enableECSManagedTags".into(), json!(false));
+    map.insert("propagateTags".into(), json!("NONE"));
+    map.insert("healthCheckGracePeriodSeconds".into(), json!(0));
+    map.insert("platformVersion".into(), json!("LATEST"));
+    map.insert(
+        "platformFamily".into(),
+        match svc.launch_type.as_str() {
+            "FARGATE" => json!("Linux"),
+            _ => Value::Null,
+        },
+    );
+    map.insert("availabilityZoneRebalancing".into(), json!("DISABLED"));
+    map.insert("volumeConfigurations".into(), json!([]));
+    map.insert("taskSets".into(), json!([]));
+    map.insert("events".into(), json!([]));
+    map.insert("capacityProviderStrategy".into(), json!([]));
+    if !svc.tags.is_empty() {
+        map.insert(
+            "tags".into(),
+            json!(svc
+                .tags
+                .iter()
+                .map(|t| json!({ "key": t.key, "value": t.value }))
+                .collect::<Vec<_>>()),
+        );
+    }
     Value::Object(map)
 }
 


### PR DESCRIPTION
## Summary

ECS task_to_json dropped attachments, attributes, availabilityZone, containerInstanceArn, enableExecuteCommand, ephemeralStorage, healthStatus, version, platformFamily, executionStoppedAt. service_to_json dropped enableExecuteCommand, enableECSManagedTags, propagateTags, healthCheckGracePeriodSeconds, platformVersion, platformFamily, availabilityZoneRebalancing, volumeConfigurations, taskSets, events, capacityProviderStrategy. ECR DescribeImages dropped imageScanStatus + imageScanFindingsSummary. SDKs reading these fields raised UnmarshalException or saw missing data.

- Task/Service emit AWS-default values for every always-present field
- ECR image_to_details surfaces stored scan_findings; PENDING when scan-on-push is configured but hasn't run yet

Part of parity-audit Phase B (response field gaps).

## Test plan

- [x] cargo test -p fakecloud-ecs --lib (33 pass)
- [x] cargo test -p fakecloud-ecr --lib (19 pass)
- [x] cargo clippy -p fakecloud-ecs -p fakecloud-ecr --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ECS and ECR responses with AWS by emitting always-present fields and image scan details. This prevents SDK unmarshalling errors and stabilizes Terraform/CDK plans.

- **Bug Fixes**
  - `fakecloud-ecs`: Tasks and Services now include AWS-default values for always-present fields (e.g., empty arrays, default strings, nullables) to match real ECS responses.
  - `fakecloud-ecr`: DescribeImages now returns `imageScanStatus` and `imageScanFindingsSummary`; returns `PENDING` when scan-on-push is enabled but hasn’t run yet.

<sup>Written for commit 1c95672c6312564b7e312d9110b9aa593e8aba66. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/898?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

