### PR TITLE
feat(dynamodb): accept table ARN (and sub-resource ARNs) anywhere TableName is read

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -81,15 +81,31 @@ pub(crate) fn require_object(
     Ok(obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
 }
 
+/// AWS DDB ops accept either a bare table name or an ARN of the form
+/// `arn:aws:dynamodb:REGION:ACCOUNT:table/NAME[/index/...|/stream/...|/backup/...]`
+/// in `TableName`. Real DynamoDB normalizes both transparently; the
+/// SDKs send ARNs in cross-account scenarios. Strip everything past
+/// `:table/` and any sub-resource segment so callers can use one path.
+pub(crate) fn resolve_table_name(input: &str) -> &str {
+    if let Some(rest) = input.strip_prefix("arn:aws:dynamodb:") {
+        if let Some(after_table) = rest.split(":table/").nth(1) {
+            // Drop any /index/<n>, /stream/<n>, /backup/<n> suffix.
+            return after_table.split('/').next().unwrap_or(after_table);
+        }
+    }
+    input
+}
+
 pub(crate) fn get_table<'a>(
     tables: &'a BTreeMap<String, DynamoTable>,
     name: &str,
 ) -> Result<&'a DynamoTable, AwsServiceError> {
-    tables.get(name).ok_or_else(|| {
+    let resolved = resolve_table_name(name);
+    tables.get(resolved).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "ResourceNotFoundException",
-            format!("Requested resource not found: Table: {name} not found"),
+            format!("Requested resource not found: Table: {resolved} not found"),
         )
     })
 }
@@ -98,11 +114,12 @@ pub(crate) fn get_table_mut<'a>(
     tables: &'a mut BTreeMap<String, DynamoTable>,
     name: &str,
 ) -> Result<&'a mut DynamoTable, AwsServiceError> {
-    tables.get_mut(name).ok_or_else(|| {
+    let resolved = resolve_table_name(name).to_string();
+    tables.get_mut(&resolved).ok_or_else(|| {
         AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "ResourceNotFoundException",
-            format!("Requested resource not found: Table: {name} not found"),
+            format!("Requested resource not found: Table: {resolved} not found"),
         )
     })
 }

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3982,6 +3982,57 @@ fn update_continuous_backups_unknown_table_errors() {
 // ── items.rs: put_item error branches ──
 
 #[test]
+fn put_item_accepts_table_arn() {
+    let svc = make_service();
+    create_test_table(&svc);
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "arn:aws:dynamodb:us-east-1:123456789012:table/test-table",
+            "Item": {"pk": {"S": "from-arn"}}
+        }),
+    );
+    svc.put_item(&req).unwrap();
+
+    let req = make_request(
+        "GetItem",
+        json!({
+            "TableName": "arn:aws:dynamodb:us-east-1:123456789012:table/test-table/index/idx",
+            "Key": {"pk": {"S": "from-arn"}},
+        }),
+    );
+    let resp = svc.get_item(&req).unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["Item"]["pk"]["S"], "from-arn");
+}
+
+#[test]
+fn resolve_table_name_strips_arn_and_subresources() {
+    use super::resolve_table_name;
+    assert_eq!(resolve_table_name("plain-name"), "plain-name");
+    assert_eq!(
+        resolve_table_name("arn:aws:dynamodb:us-east-1:123:table/my-tbl"),
+        "my-tbl"
+    );
+    assert_eq!(
+        resolve_table_name("arn:aws:dynamodb:us-east-1:123:table/my-tbl/index/by-foo"),
+        "my-tbl"
+    );
+    assert_eq!(
+        resolve_table_name(
+            "arn:aws:dynamodb:us-east-1:123:table/my-tbl/stream/2025-01-01T00:00:00.000"
+        ),
+        "my-tbl"
+    );
+    assert_eq!(
+        resolve_table_name(
+            "arn:aws:dynamodb:us-east-1:123:table/my-tbl/backup/01700000000000-deadbeef"
+        ),
+        "my-tbl"
+    );
+}
+
+#[test]
 fn put_item_unknown_table_errors() {
     let svc = make_service();
     let req = make_request(


### PR DESCRIPTION
## Summary

Real DynamoDB transparently accepts either the table name or its ARN in TableName fields, including index/stream/backup sub-resource ARNs. SDKs in cross-account scenarios send full ARNs; we returned ResourceNotFoundException.

- resolve_table_name(input) strips arn:aws:dynamodb prefix + any /index/, /stream/, /backup/ suffix
- get_table / get_table_mut normalize at the entry point, so all ~30 TableName-reading ops accept ARNs without per-site changes
- Tests cover plain name, full ARN, index/stream/backup variants

Part of parity-audit Phase C (input acceptance gaps).

## Test plan

- [x] cargo test -p fakecloud-dynamodb --lib (228 pass)
- [x] cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`fakecloud-dynamodb` now accepts table ARNs (and sub-resource ARNs) anywhere `TableName` is read, matching real DynamoDB. This fixes cross-account SDK calls that send full ARNs and previously hit ResourceNotFoundException.

- **New Features**
  - Added `resolve_table_name` to strip `arn:aws:dynamodb:...:table/<name>` and any `/index|/stream|/backup` suffix.
  - Normalized inputs in `get_table` and `get_table_mut`, so all operations that read `TableName` accept ARNs without per-site changes.
  - Added tests for plain names, full ARNs, and index/stream/backup variants.

<sup>Written for commit ca309138d12b7b8bf6c61ec5b2763c0822f14fb3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/899?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

