### PR TITLE
feat(sqs): accept queue ARN in QueueUrl fields

### DIFF
--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -1083,11 +1083,25 @@ pub(crate) fn md5_of_message_attributes_from_refs(
     format!("{:032x}", hasher.finalize())
 }
 
-/// Resolve a QueueUrl that might be a queue name, a path, or a full URL
+/// Resolve a QueueUrl that might be a queue name, a path, a full URL, or
+/// an SQS ARN (`arn:aws:sqs:REGION:ACCOUNT:queue-name`). Real SQS accepts
+/// all four interchangeably; SDKs in cross-account or IaC configs often
+/// hand us the ARN.
 pub(crate) fn resolve_queue_url(input: &str, state: &crate::state::SqsState) -> Option<String> {
     // Direct match
     if state.queues.contains_key(input) {
         return Some(input.to_string());
+    }
+    // ARN form: extract queue name (last segment after the colon-prefix)
+    if let Some(rest) = input.strip_prefix("arn:aws:sqs:") {
+        // rest = "REGION:ACCOUNT:queue-name"
+        if let Some(name) = rest.rsplit(':').next() {
+            if !name.is_empty() {
+                if let Some(url) = state.name_to_url.get(name) {
+                    return Some(url.clone());
+                }
+            }
+        }
     }
     // Try as queue name
     if let Some(url) = state.name_to_url.get(input) {

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -142,6 +142,19 @@ fn create_queue_returns_url() {
 }
 
 #[test]
+fn send_message_accepts_queue_arn() {
+    let svc = make_service();
+    create_queue(&svc, "arn-queue");
+    let arn = "arn:aws:sqs:us-east-1:123456789012:arn-queue";
+    let id = send_msg(&svc, arn, "hello");
+    assert!(!id.is_empty());
+
+    let messages = receive_msgs(&svc, arn, 1);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["Body"], "hello");
+}
+
+#[test]
 fn create_queue_idempotent_same_attributes() {
     let svc = make_service();
     let url1 = create_queue(&svc, "my-queue");


### PR DESCRIPTION
## Summary

Real SQS accepts queue name, full URL, URL path, or ARN (`arn:aws:sqs:REGION:ACCOUNT:queue-name`) in any QueueUrl field. SDKs in cross-account or IaC configs often hand us the ARN.

- resolve_queue_url strips arn:aws:sqs prefix and resolves the bare queue name
- Test: SendMessage + ReceiveMessage via ARN succeed

Part of parity-audit Phase C (input acceptance gaps).

## Test plan

- [x] cargo test -p fakecloud-sqs --lib (130 pass)
- [x] cargo clippy -p fakecloud-sqs --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept SQS queue ARNs anywhere a QueueUrl is expected in `fakecloud-sqs`, matching AWS behavior. This lets SDKs and IaC that pass ARNs work without changes.

- **New Features**
  - Parse `arn:aws:sqs:REGION:ACCOUNT:queue-name` inputs by extracting the queue name and resolving to the queue URL.
  - Added test covering SendMessage and ReceiveMessage via ARN.

<sup>Written for commit 2ca950aa309f536c575c9b309a8b0da5fe5bf709. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/900?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

