### PR TITLE
feat(kms): accept alias/* in EnableKeyRotation/DisableKeyRotation/GetKeyRotationStatus

### DIFF
--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -950,15 +950,7 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        // Aliases should fail for rotation operations
-        if key_id.starts_with("alias/") {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            ));
-        }
-
+        // Real KMS resolves alias/* and alias-ARNs identically to a key id.
         let resolved = self
             .resolve_key_id_for(&req.account_id, &req.region, &key_id)
             .ok_or_else(|| {
@@ -993,14 +985,9 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        if key_id.starts_with("alias/") {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            ));
-        }
-
+        // Real KMS resolves alias/* and alias-ARNs identically to a key id
+        // here. Earlier code rejected `alias/*` outright, breaking IaC
+        // configs that reference keys by alias.
         let resolved = self
             .resolve_key_id_for(&req.account_id, &req.region, &key_id)
             .ok_or_else(|| {
@@ -1029,14 +1016,7 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        if key_id.starts_with("alias/") {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotFoundException",
-                format!("Invalid keyId {key_id}"),
-            ));
-        }
-
+        // Real KMS resolves alias/* and alias-ARNs identically to a key id.
         let resolved = self
             .resolve_key_id_for(&req.account_id, &req.region, &key_id)
             .ok_or_else(|| {

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2062,6 +2062,29 @@ fn disable_key_unknown_errors() {
 }
 
 #[test]
+fn enable_key_rotation_accepts_alias() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let req = make_request(
+        "CreateAlias",
+        json!({
+            "AliasName": "alias/my-key",
+            "TargetKeyId": key_id,
+        }),
+    );
+    svc.create_alias(&req).unwrap();
+
+    let req = make_request("EnableKeyRotation", json!({ "KeyId": "alias/my-key" }));
+    svc.enable_key_rotation(&req).unwrap();
+
+    let req = make_request("GetKeyRotationStatus", json!({ "KeyId": "alias/my-key" }));
+    let resp = svc.get_key_rotation_status(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body["KeyRotationEnabled"].as_bool().unwrap());
+}
+
+#[test]
 fn enable_disable_key_rotation_unknown_errors() {
     let svc = make_service();
     let req = make_request(


### PR DESCRIPTION
## Summary

Real KMS accepts either a key id or an alias (alias/* or alias ARN) for all rotation ops. We rejected alias/* outright with NotFoundException, breaking IaC configs that reference keys by alias.

- Drop the alias-rejection in enable_key_rotation, disable_key_rotation, get_key_rotation_status; resolve_key_id_for already handles alias resolution like every other crypto op
- Test asserts EnableKeyRotation+GetKeyRotationStatus succeed via alias

Part of parity-audit Phase C (input acceptance gaps).

## Test plan

- [x] cargo test -p fakecloud-kms --lib (135 pass)
- [x] cargo clippy -p fakecloud-kms --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `alias/*` and alias ARNs in KMS rotation APIs to match AWS and unblock IaC configs that reference keys by alias.

- **Bug Fixes**
  - Removed alias rejection in `EnableKeyRotation`, `DisableKeyRotation`, and `GetKeyRotationStatus`; use `resolve_key_id_for` to map aliases to key IDs.
  - Added a test that enables rotation and checks status via `alias/my-key`.

<sup>Written for commit b4448dacd9139ff09c49156b8b54a2e4db991837. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/901?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

