### PR TITLE
feat(lambda): PublishVersion snapshots config + monotonic numbering

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -421,17 +421,18 @@ impl LambdaService {
                 .functions
                 .get(function_name)
                 .ok_or_else(|| not_found("Function", function_name))?;
-            // AWS always returns $LATEST first, then numbered versions.
-            // Until PublishVersion snapshots real config (Phase D2), each
-            // numbered version reuses the current configuration with the
-            // Version field swapped — same as Moto.
+            // AWS returns $LATEST first, then numbered versions in
+            // ascending order. Each numbered version is an immutable
+            // snapshot of the function at publish time.
             let mut versions: Vec<serde_json::Value> = Vec::new();
             let mut latest = self.function_config_json(func);
             latest["Version"] = json!("$LATEST");
             versions.push(latest);
+            let snapshots = state.function_version_snapshots.get(function_name);
             if let Some(numbered) = state.function_versions.get(function_name) {
                 for v in numbered {
-                    let mut cfg = self.function_config_json(func);
+                    let snap = snapshots.and_then(|m| m.get(v)).unwrap_or(func);
+                    let mut cfg = self.function_config_json(snap);
                     cfg["Version"] = json!(v);
                     cfg["FunctionArn"] = json!(format!("{}:{v}", func.function_arn));
                     cfg["MasterArn"] = json!(func.function_arn);

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1278,9 +1278,8 @@ impl LambdaService {
         function_name: &str,
         account_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let empty = LambdaState::new(account_id, "");
-        let state = accounts.get(account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
         let func = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -1292,10 +1291,43 @@ impl LambdaService {
             )
         })?;
 
-        let mut config = self.function_config_json(func);
-        // Stub: always return version "1"
-        config["Version"] = json!("1");
-        config["FunctionArn"] = json!(format!("{}:1", func.function_arn));
+        // Pick the next version number per function, monotonic per
+        // function arn, never reused. AWS uses sequential decimal
+        // strings starting at 1.
+        let existing = state
+            .function_versions
+            .get(function_name)
+            .cloned()
+            .unwrap_or_default();
+        let next: u64 = existing
+            .iter()
+            .filter_map(|v| v.parse::<u64>().ok())
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let next_str = next.to_string();
+
+        // Snapshot the function config + code for the new immutable version.
+        let mut snapshot = func.clone();
+        snapshot.version = next_str.clone();
+        snapshot.master_arn = Some(func.function_arn.clone());
+
+        // Append to numbered list and store the snapshot.
+        state
+            .function_versions
+            .entry(function_name.to_string())
+            .or_default()
+            .push(next_str.clone());
+        state
+            .function_version_snapshots
+            .entry(function_name.to_string())
+            .or_default()
+            .insert(next_str.clone(), snapshot.clone());
+
+        let mut config = self.function_config_json(&snapshot);
+        config["Version"] = json!(next_str);
+        config["FunctionArn"] = json!(format!("{}:{next_str}", func.function_arn));
+        config["MasterArn"] = json!(func.function_arn);
 
         Ok(AwsResponse::json(StatusCode::CREATED, config.to_string()))
     }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -484,6 +484,53 @@ async fn update_function_code_replaces_image_uri() {
 }
 
 #[tokio::test]
+async fn publish_version_increments_and_snapshots_config() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "vfn").await;
+
+    // Publish v1 with the seed Description ("")
+    let req = make_request(Method::POST, "/2015-03-31/functions/vfn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v1["Version"], "1");
+    assert!(v1["FunctionArn"].as_str().unwrap().ends_with(":1"));
+    assert_eq!(
+        v1["MasterArn"].as_str().unwrap(),
+        "arn:aws:lambda:us-east-1:123456789012:function:vfn"
+    );
+
+    // Mutate $LATEST description via UpdateFunctionConfiguration
+    let body = json!({ "Description": "after-v1" });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/vfn/configuration",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Publish v2 with the new Description
+    let req = make_request(Method::POST, "/2015-03-31/functions/vfn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v2["Version"], "2");
+    assert_eq!(v2["Description"].as_str().unwrap(), "after-v1");
+
+    // ListVersionsByFunction returns $LATEST + v1 + v2 with snapshots intact:
+    // v1 keeps its old description even after $LATEST was mutated.
+    let req = make_request(Method::GET, "/2015-03-31/functions/vfn/versions", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let versions = body["Versions"].as_array().unwrap();
+    assert_eq!(versions.len(), 3);
+    assert_eq!(versions[0]["Version"], "$LATEST");
+    assert_eq!(versions[0]["Description"].as_str().unwrap(), "after-v1");
+    assert_eq!(versions[1]["Version"], "1");
+    assert_eq!(versions[1]["Description"].as_str().unwrap(), "");
+    assert_eq!(versions[2]["Version"], "2");
+    assert_eq!(versions[2]["Description"].as_str().unwrap(), "after-v1");
+}
+
+#[tokio::test]
 async fn add_permission_builds_canonical_statement() {
     let svc = LambdaService::new(make_state());
     seed_function(&svc, "f").await;

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -172,6 +172,11 @@ pub struct LambdaState {
     /// Published versions per function (function_name -> Vec<version>).
     #[serde(default)]
     pub function_versions: BTreeMap<String, Vec<String>>,
+    /// Immutable per-version snapshot of the function (code + config),
+    /// keyed by `function_name -> version -> LambdaFunction`. AWS makes
+    /// each numbered version a frozen copy of `$LATEST` at publish time.
+    #[serde(default)]
+    pub function_version_snapshots: BTreeMap<String, BTreeMap<String, LambdaFunction>>,
     /// Layers keyed by name.
     #[serde(default)]
     pub layers: BTreeMap<String, Layer>,
@@ -338,6 +343,7 @@ impl LambdaState {
             invocations: Vec::new(),
             aliases: BTreeMap::new(),
             function_versions: BTreeMap::new(),
+            function_version_snapshots: BTreeMap::new(),
             layers: BTreeMap::new(),
             function_url_configs: BTreeMap::new(),
             function_concurrency: BTreeMap::new(),
@@ -361,6 +367,7 @@ impl LambdaState {
         self.invocations.clear();
         self.aliases.clear();
         self.function_versions.clear();
+        self.function_version_snapshots.clear();
         self.layers.clear();
         self.function_url_configs.clear();
         self.function_concurrency.clear();


### PR DESCRIPTION
## Summary

Earlier publish_version was a stub: it always returned Version=1 and ARN ending in :1, regardless of how many times you called it; the returned config was just \$LATEST projected — no immutable snapshot. Aliases pointing at numeric versions, version listings, and any client comparing version sha/desc all silently lied.

- Pick the next sequential version per function (max(existing)+1)
- Deep-copy the function (config + code) into state.function_version_snapshots[function_name][version] so $LATEST mutations don't leak into older versions
- Set master_arn on the snapshot so the response carries it
- list_versions_by_function reads the per-version snapshot map
- Test mutates Description on $LATEST after publishing v1 and verifies v1 keeps its original Description through ListVersions

Part of parity-audit Phase D (Lambda critical fixes).

## Test plan

- [x] cargo test -p fakecloud-lambda --lib (76 pass)
- [x] cargo clippy -p fakecloud-lambda --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real Lambda PublishVersion: monotonic per-function numbering and immutable per-version snapshots so `$LATEST` changes don’t affect older versions. ListVersions now reads from snapshots and includes `MasterArn`, matching AWS ordering and ARNs.

- **New Features**
  - Monotonic version numbers per function (max(existing)+1) using decimal strings.
  - Snapshot `$LATEST` code and config into `function_version_snapshots` on publish; responses come from the snapshot and include `MasterArn`.

- **Bug Fixes**
  - `ListVersionsByFunction` uses snapshots and returns `$LATEST` first, then numbered versions in ascending order with correct ARNs.
  - Publish no longer always returns `Version=1`; versions are stable and immutable, fixing aliases and metadata comparisons. Added a test verifying snapshot immutability and `MasterArn` across publishes and listings.

<sup>Written for commit acab3ee97b1cd31a178a76f9d792d496e8481e89. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/903?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

