### PR TITLE
fix(lambda): normalize AddPermission action prefix and unify tag store

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -70,6 +70,30 @@ fn body(req: &AwsRequest) -> Value {
     serde_json::from_slice(&req.body).unwrap_or_else(|_| Value::Object(Default::default()))
 }
 
+/// Extract the function name from a Lambda function ARN, ignoring any
+/// trailing `:version` / `:alias` qualifier. Returns `None` for ARNs
+/// that name a different resource type (event-source mapping,
+/// code-signing config, layer, …) so the caller can fall through to
+/// the keyed tag bag.
+fn function_name_from_arn(arn: &str) -> Option<String> {
+    let rest = arn.strip_prefix("arn:aws:lambda:")?;
+    let mut parts = rest.splitn(5, ':');
+    let _region = parts.next()?;
+    let _account = parts.next()?;
+    let resource_kind = parts.next()?;
+    if resource_kind != "function" {
+        return None;
+    }
+    let name_with_qualifier = parts.next()?;
+    Some(
+        name_with_qualifier
+            .split(':')
+            .next()
+            .unwrap_or(name_with_qualifier)
+            .to_string(),
+    )
+}
+
 /// Build a fakecloud-hosted download URL for a layer version's ZIP. The URL
 /// is reachable on the same authority the SDK used for the original
 /// request, so test harnesses get a working `Location` they can `GET`
@@ -1467,6 +1491,18 @@ impl LambdaService {
             .unwrap_or_default();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // For function ARNs, write directly onto the function's `tags`
+        // map so `GetFunction` and `ListTagsForResource` agree without
+        // a second lookup. Non-function ARNs (event source mappings,
+        // code-signing configs) fall back to the keyed bag.
+        if let Some(name) = function_name_from_arn(resource_arn) {
+            if let Some(func) = state.functions.get_mut(&name) {
+                for (k, v) in &new_tags {
+                    func.tags.insert(k.clone(), v.clone());
+                }
+                return empty();
+            }
+        }
         let entry = state.tags.entry(resource_arn.to_string()).or_default();
         for (k, v) in new_tags {
             entry.retain(|(ek, _)| ek != &k);
@@ -1480,14 +1516,25 @@ impl LambdaService {
         resource_arn: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // AWS sends keys as repeated `tagKeys=K1&tagKeys=K2` query
+        // params. Some SDKs also serialize `tagKeys.member.1=K1` /
+        // `tagKeys.1=K1` — accept both shapes.
         let mut keys: Vec<String> = Vec::new();
         for (k, v) in &req.query_params {
-            if k.starts_with("tagKeys") {
+            if k == "tagKeys" || k.starts_with("tagKeys.") {
                 keys.push(v.clone());
             }
         }
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        if let Some(name) = function_name_from_arn(resource_arn) {
+            if let Some(func) = state.functions.get_mut(&name) {
+                for k in &keys {
+                    func.tags.remove(k);
+                }
+                return empty();
+            }
+        }
         if let Some(entry) = state.tags.get_mut(resource_arn) {
             entry.retain(|(k, _)| !keys.contains(k));
         }
@@ -1501,6 +1548,16 @@ impl LambdaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
+            if let Some(name) = function_name_from_arn(resource_arn) {
+                if let Some(func) = state.functions.get(&name) {
+                    let tags: serde_json::Map<String, Value> = func
+                        .tags
+                        .iter()
+                        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                        .collect();
+                    return ok(json!({"Tags": tags}));
+                }
+            }
             let tags: serde_json::Map<String, Value> = state
                 .tags
                 .get(resource_arn)

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -140,11 +140,21 @@ impl LambdaService {
             );
         }
 
+        // Normalize Action: callers commonly pass either `InvokeFunction`
+        // or `lambda:InvokeFunction`. Always store as `lambda:<verb>` —
+        // double-prefixing (`lambda:lambda:InvokeFunction`) breaks the
+        // evaluator's resource-action matcher and confuses any client
+        // that round-trips the policy doc.
+        let normalized_action = if action.contains(':') {
+            action.clone()
+        } else {
+            format!("lambda:{action}")
+        };
         let mut new_statement = serde_json::Map::new();
         new_statement.insert("Sid".to_string(), json!(statement_id));
         new_statement.insert("Effect".to_string(), json!("Allow"));
         new_statement.insert("Principal".to_string(), principal_value);
-        new_statement.insert("Action".to_string(), json!(format!("lambda:{action}")));
+        new_statement.insert("Action".to_string(), json!(normalized_action));
         new_statement.insert("Resource".to_string(), json!(func.function_arn));
         if !condition.is_empty() {
             new_statement.insert("Condition".to_string(), Value::Object(condition));

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -831,3 +831,69 @@ async fn list_event_source_mappings_empty_ok() {
     let resp = svc.list_event_source_mappings("123456789012").unwrap();
     assert_eq!(resp.status, http::StatusCode::OK);
 }
+
+#[tokio::test]
+async fn add_permission_does_not_double_prefix_lambda_action() {
+    // Callers commonly pass either `InvokeFunction` or
+    // `lambda:InvokeFunction`. Both must canonicalize to the same
+    // single-prefixed form — never `lambda:lambda:InvokeFunction`.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "f").await;
+
+    let body = json!({
+        "StatementId": "already-prefixed",
+        "Action": "lambda:InvokeFunction",
+        "Principal": "s3.amazonaws.com",
+    });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/f/policy",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let out: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let statement: Value = serde_json::from_str(out["Statement"].as_str().unwrap()).unwrap();
+    assert_eq!(statement["Action"], "lambda:InvokeFunction");
+}
+
+#[tokio::test]
+async fn tag_resource_round_trips_via_get_function_and_list_tags() {
+    // TagResource on a function ARN must surface in GetFunction.Tags
+    // (read from `func.tags`) AND in ListTagsForResource — proving
+    // both code paths read from a single source of truth.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "f").await;
+
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:f";
+    let body = json!({"Tags": {"env": "prod", "team": "core"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/2017-03-31/tags/{arn}"), "");
+    let resp = svc.handle(req).await.unwrap();
+    let listed: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(listed["Tags"]["env"], "prod");
+    assert_eq!(listed["Tags"]["team"], "core");
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/f", "");
+    let resp = svc.handle(req).await.unwrap();
+    let func: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(func["Tags"]["env"], "prod");
+    assert_eq!(func["Tags"]["team"], "core");
+
+    let mut req = make_request(Method::DELETE, &format!("/2017-03-31/tags/{arn}"), "");
+    req.query_params
+        .insert("tagKeys".to_string(), "env".to_string());
+    req.raw_query = "tagKeys=env".to_string();
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/2017-03-31/tags/{arn}"), "");
+    let resp = svc.handle(req).await.unwrap();
+    let listed: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(listed["Tags"].get("env").is_none());
+    assert_eq!(listed["Tags"]["team"], "core");
+}


### PR DESCRIPTION
## Summary

D3 from the parity audit (`/tmp/parity_audit/REPORT.md`).

- AddPermission stops double-prefixing actions: when the caller passes `lambda:InvokeFunction`, the stored statement now keeps `lambda:InvokeFunction` instead of producing `lambda:lambda:InvokeFunction` which broke the IAM evaluator's resource-action match.
- Tag storage unified for function ARNs: `TagResource` / `UntagResource` / `ListTagsForResource` now read and write `func.tags` directly when the ARN names a function, so `GetFunction.Tags` and `ListTagsForResource` always agree. Non-function ARNs (event source mappings, code-signing configs) keep using the keyed bag.
- `UntagResource` accepts both `tagKeys=` (Lambda's REST shape) and `tagKeys.N=` query forms.

## Test plan

- [x] `cargo test -p fakecloud-lambda --lib`
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] New unit test: `add_permission_does_not_double_prefix_lambda_action`
- [x] New unit test: `tag_resource_round_trips_via_get_function_and_list_tags` (TagResource -> GetFunction.Tags + ListTagsForResource agreement, then UntagResource)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda permission action normalization and unifies tag storage for function ARNs to match AWS behavior. Prevents double-prefixed actions and keeps `GetFunction.Tags` consistent with `ListTagsForResource`.

- **Bug Fixes**
  - `AddPermission`: normalize `Action`; keeps `lambda:InvokeFunction` if provided and avoids `lambda:lambda:InvokeFunction`.
  - For function ARNs, `TagResource`/`UntagResource`/`ListTagsForResource` read/write `func.tags`; non-function ARNs still use the keyed tag store.
  - `UntagResource` now accepts both `tagKeys=` and `tagKeys.N=` query forms.

<sup>Written for commit 52988a1c43e7fbee9b64b304dbabd718acb7e2b5. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

