### PR TITLE
feat(s3): enforce PublicAccessBlock on PutBucketPolicy and PutBucket/Object ACL

### DIFF
--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -45,6 +45,10 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        // Snapshot PAB before taking the write lock — `pab_flags`
+        // reads its own lock and would deadlock under the same
+        // upgrade.
+        let pab = self.pab_flags(account_id, bucket);
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state
@@ -54,25 +58,38 @@ impl S3Service {
         let owner_id = b.acl_owner_id.clone();
         let obj = b.objects.get_mut(key).ok_or_else(|| no_such_key(key))?;
 
-        if let Some(acl) = canned {
-            obj.acl_grants = canned_acl_grants_for_object(&acl, &owner_id);
+        let proposed_grants = if let Some(acl) = &canned {
+            canned_acl_grants_for_object(acl, &owner_id)
         } else {
-            // Check for grant headers
             let has_grant_headers = req.headers.keys().any(|k| {
                 let name = k.as_str();
                 name.starts_with("x-amz-grant-")
             });
             if has_grant_headers {
-                obj.acl_grants = parse_grant_headers(&req.headers);
+                parse_grant_headers(&req.headers)
             } else {
-                // Parse from body
                 let body_str = std::str::from_utf8(&req.body).unwrap_or("");
                 if !body_str.is_empty() {
-                    let grants = parse_acl_xml(body_str)?;
-                    obj.acl_grants = grants;
+                    parse_acl_xml(body_str)?
+                } else {
+                    obj.acl_grants.clone()
                 }
             }
+        };
+
+        if let Some(flags) = pab {
+            if flags.block_public_acls
+                && super::config::grants_are_public(&proposed_grants)
+                && !super::config::grants_are_public(&obj.acl_grants)
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDenied",
+                    "User is not authorized to perform: s3:PutObjectAcl. Reason: Public Access Block (BlockPublicAcls)",
+                ));
+            }
         }
+        obj.acl_grants = proposed_grants;
 
         let meta = object_meta_snapshot(obj);
         self.store

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -15,6 +15,110 @@ use super::{
     s3_xml, validate_lifecycle_xml, validate_tags, xml_escape, S3Service,
 };
 
+/// Decoded `PublicAccessBlockConfiguration` flags. Each flag defaults
+/// to `false` when missing from the stored XML, matching AWS's
+/// `GetPublicAccessBlock` echo path.
+///
+/// `ignore_public_acls` and `restrict_public_buckets` gate
+/// **read-time** evaluation (effective ACL / effective policy lookup)
+/// — fakecloud doesn't yet evaluate effective access at GetObject
+/// time, so we parse and store them but they are not read from on
+/// the request path. Removing them would silently drop the values
+/// from `GetPublicAccessBlock` round-trips.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PublicAccessBlockFlags {
+    pub block_public_acls: bool,
+    #[allow(dead_code)]
+    pub ignore_public_acls: bool,
+    pub block_public_policy: bool,
+    #[allow(dead_code)]
+    pub restrict_public_buckets: bool,
+}
+
+impl PublicAccessBlockFlags {
+    fn parse(xml: &str) -> Self {
+        fn flag(xml: &str, name: &str) -> bool {
+            let open = format!("<{name}>");
+            let close = format!("</{name}>");
+            let Some(start) = xml.find(&open) else {
+                return false;
+            };
+            let value_start = start + open.len();
+            let Some(end_offset) = xml[value_start..].find(&close) else {
+                return false;
+            };
+            xml[value_start..value_start + end_offset]
+                .trim()
+                .eq_ignore_ascii_case("true")
+        }
+        Self {
+            block_public_acls: flag(xml, "BlockPublicAcls"),
+            ignore_public_acls: flag(xml, "IgnorePublicAcls"),
+            block_public_policy: flag(xml, "BlockPublicPolicy"),
+            restrict_public_buckets: flag(xml, "RestrictPublicBuckets"),
+        }
+    }
+}
+
+/// Detect whether a parsed bucket-policy document grants access to an
+/// anonymous principal. Mirrors AWS's "is public" classifier:
+/// `Effect=Allow` with `Principal:"*"` or `{"AWS":"*"}` (or a list
+/// containing `"*"`) and no `Condition` block constraining the
+/// principal further. We deliberately mark conditioned policies as
+/// non-public — that matches AWS's `BlockPublicPolicy` behavior since
+/// IP / VPC / source-account conditions specifically narrow the
+/// principal.
+pub(crate) fn policy_is_public(policy_json: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(policy_json) else {
+        return false;
+    };
+    let statements = match value.get("Statement") {
+        Some(serde_json::Value::Array(a)) => a.clone(),
+        Some(s) => vec![s.clone()],
+        None => return false,
+    };
+    statements.iter().any(|st| {
+        if st.get("Effect").and_then(|v| v.as_str()) != Some("Allow") {
+            return false;
+        }
+        if st.get("Condition").is_some() {
+            return false;
+        }
+        principal_includes_wildcard(st.get("Principal").unwrap_or(&serde_json::Value::Null))
+    })
+}
+
+fn principal_includes_wildcard(p: &serde_json::Value) -> bool {
+    match p {
+        serde_json::Value::String(s) => s == "*",
+        serde_json::Value::Object(m) => m.values().any(value_contains_star),
+        _ => false,
+    }
+}
+
+fn value_contains_star(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::String(s) => s == "*",
+        serde_json::Value::Array(arr) => arr.iter().any(value_contains_star),
+        _ => false,
+    }
+}
+
+/// Detect whether a set of ACL grants grants to a public group
+/// (AllUsers / AuthenticatedUsers). Used by PutBucketAcl /
+/// PutObjectAcl to gate the `BlockPublicAcls` flag.
+pub(crate) fn grants_are_public(grants: &[crate::state::AclGrant]) -> bool {
+    grants.iter().any(|g| {
+        g.grantee_uri
+            .as_deref()
+            .map(|u| {
+                u.contains("acs.amazonaws.com/groups/global/AllUsers")
+                    || u.contains("acs.amazonaws.com/groups/global/AuthenticatedUsers")
+            })
+            .unwrap_or(false)
+    })
+}
+
 impl S3Service {
     // ---- Encryption ----
 
@@ -181,6 +285,18 @@ impl S3Service {
                 "MalformedPolicy",
                 "This policy contains invalid Json",
             ));
+        }
+        // Enforce PublicAccessBlock.BlockPublicPolicy: AWS rejects
+        // PutBucketPolicy that grants public access while the flag is
+        // set, with `AccessDenied` and a body explaining the gate.
+        if let Some(flags) = self.pab_flags(account_id, bucket) {
+            if flags.block_public_policy && policy_is_public(&body_str) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDenied",
+                    "User is not authorized to perform: s3:PutBucketPolicy. Reason: Public Access Block (BlockPublicPolicy)",
+                ));
+            }
         }
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
@@ -572,6 +688,24 @@ impl S3Service {
         Ok(s3_xml(StatusCode::OK, body))
     }
 
+    // ---- PublicAccessBlock helpers ----
+
+    /// Read each `PublicAccessBlock` flag from the bucket's stored XML.
+    /// Missing fields default to `false` per AWS, which mirrors the
+    /// `GetPublicAccessBlock` echo path. Returns `None` when no
+    /// configuration is set, so callers can short-circuit.
+    pub(super) fn pab_flags(
+        &self,
+        account_id: &str,
+        bucket: &str,
+    ) -> Option<PublicAccessBlockFlags> {
+        let accts = self.state.read();
+        let state = accts.get(account_id)?;
+        let b = state.buckets.get(bucket)?;
+        let xml = b.public_access_block.as_ref()?;
+        Some(PublicAccessBlockFlags::parse(xml))
+    }
+
     // ---- PublicAccessBlock ----
 
     pub(super) fn put_public_access_block(
@@ -843,6 +977,7 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        let pab = self.pab_flags(account_id, bucket);
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state
@@ -850,14 +985,27 @@ impl S3Service {
             .get_mut(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
 
-        if let Some(acl) = canned {
-            b.acl_grants = canned_acl_grants(&acl, &b.acl_owner_id.clone());
+        let proposed_grants = if let Some(acl) = &canned {
+            canned_acl_grants(acl, &b.acl_owner_id.clone())
         } else {
-            // Parse ACL from body (AccessControlPolicy XML)
             let body_str = std::str::from_utf8(&req.body).unwrap_or("");
-            let grants = parse_acl_xml(body_str)?;
-            b.acl_grants = grants;
+            parse_acl_xml(body_str)?
+        };
+
+        // PublicAccessBlock.BlockPublicAcls rejects any new grant that
+        // would expose the bucket to AllUsers / AuthenticatedUsers,
+        // whether sourced via canned ACL header, x-amz-grant-* headers,
+        // or AccessControlPolicy XML body.
+        if let Some(flags) = pab {
+            if flags.block_public_acls && grants_are_public(&proposed_grants) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDenied",
+                    "User is not authorized to perform: s3:PutBucketAcl. Reason: Public Access Block (BlockPublicAcls)",
+                ));
+            }
         }
+        b.acl_grants = proposed_grants;
 
         let snap = AclSnapshot {
             owner_id: b.acl_owner_id.clone(),

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -1222,6 +1222,83 @@ fn public_access_block_put_get_delete_round_trip() {
 }
 
 #[test]
+fn block_public_policy_rejects_wildcard_principal_policy() {
+    // PAB.BlockPublicPolicy=true must reject PutBucketPolicy that
+    // grants Allow to Principal "*" — the canonical "public read"
+    // shape — with AccessDenied.
+    let svc = make_service();
+    seed_bucket(&svc, "locked");
+
+    let pab_body = br#"<PublicAccessBlockConfiguration><BlockPublicPolicy>true</BlockPublicPolicy></PublicAccessBlockConfiguration>"#;
+    let req = make_request(
+        Method::PUT,
+        "/locked",
+        &[("publicAccessBlock", "")],
+        pab_body,
+    );
+    svc.put_public_access_block("123456789012", &req, "locked")
+        .unwrap();
+
+    let policy = br#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::locked/*"}]}"#;
+    let req = make_request(Method::PUT, "/locked", &[("policy", "")], policy);
+    let err = match svc.put_bucket_policy("123456789012", &req, "locked") {
+        Err(e) => e,
+        Ok(_) => panic!("expected BlockPublicPolicy to reject public policy"),
+    };
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn block_public_policy_allows_non_public_policy() {
+    // A policy that names a specific AWS principal must not be
+    // blocked even when BlockPublicPolicy is set.
+    let svc = make_service();
+    seed_bucket(&svc, "locked");
+
+    let pab_body = br#"<PublicAccessBlockConfiguration><BlockPublicPolicy>true</BlockPublicPolicy></PublicAccessBlockConfiguration>"#;
+    let req = make_request(
+        Method::PUT,
+        "/locked",
+        &[("publicAccessBlock", "")],
+        pab_body,
+    );
+    svc.put_public_access_block("123456789012", &req, "locked")
+        .unwrap();
+
+    let policy = br#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:role/r"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::locked/*"}]}"#;
+    let req = make_request(Method::PUT, "/locked", &[("policy", "")], policy);
+    svc.put_bucket_policy("123456789012", &req, "locked")
+        .expect("named-principal policy should be allowed");
+}
+
+#[test]
+fn block_public_acls_rejects_canned_public_read() {
+    // PAB.BlockPublicAcls=true must reject `x-amz-acl: public-read`
+    // on PutBucketAcl, which adds an AllUsers READ grant.
+    let svc = make_service();
+    seed_bucket(&svc, "locked");
+
+    let pab_body = br#"<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls></PublicAccessBlockConfiguration>"#;
+    let req = make_request(
+        Method::PUT,
+        "/locked",
+        &[("publicAccessBlock", "")],
+        pab_body,
+    );
+    svc.put_public_access_block("123456789012", &req, "locked")
+        .unwrap();
+
+    let mut req = make_request(Method::PUT, "/locked", &[("acl", "")], &[]);
+    req.headers
+        .insert("x-amz-acl", "public-read".parse().unwrap());
+    let err = match svc.put_bucket_acl("123456789012", &req, "locked") {
+        Err(e) => e,
+        Ok(_) => panic!("expected BlockPublicAcls to reject public-read canned ACL"),
+    };
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+}
+
+#[test]
 fn bucket_website_put_get_delete_round_trip() {
     let svc = make_service();
     seed_bucket(&svc, "b");


### PR DESCRIPTION
## Summary

E1 from the parity audit. PublicAccessBlock was stored as raw XML and ignored at write-time — public ACLs / policies could still be set on buckets that had explicitly opted out.

- Parse stored XML into typed flags
- `BlockPublicPolicy=true` -> reject `PutBucketPolicy` whose Allow statements have wildcard Principal and no Condition narrowing it
- `BlockPublicAcls=true` -> reject `PutBucketAcl` / `PutObjectAcl` that grant to AllUsers / AuthenticatedUsers via canned ACL, grant-headers, or AccessControlPolicy XML
- `IgnorePublicAcls` and `RestrictPublicBuckets` are read-time evaluation gates that fakecloud doesn't currently apply at GetObject; they remain stored and round-trip but are documented as no-ops

## Test plan

- [x] `cargo test -p fakecloud-s3 --lib` (291 tests pass)
- [x] `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `block_public_policy_rejects_wildcard_principal_policy`
- [x] `block_public_policy_allows_non_public_policy` (named principal not blocked)
- [x] `block_public_acls_rejects_canned_public_read`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces S3 PublicAccessBlock at write time by blocking public bucket policies and ACLs when configured. Addresses parity audit E1 and prevents reintroducing public access through `PutBucketPolicy`, `PutBucketAcl`, and `PutObjectAcl`.

- **New Features**
  - Parse stored `PublicAccessBlockConfiguration` XML into flags with sensible defaults.
  - Reject `PutBucketPolicy` when `BlockPublicPolicy=true` and the policy has an unconditioned `Effect: Allow` with a wildcard `Principal`.
  - Reject `PutBucketAcl` and `PutObjectAcl` when `BlockPublicAcls=true` and grants include AllUsers or AuthenticatedUsers; for objects, only if the change newly introduces public access.
  - Store `IgnorePublicAcls` and `RestrictPublicBuckets` for round-trips; they’re documented as read-time gates and remain no-ops for now.

<sup>Written for commit c240ee3e9bc6d87eacff8d1990d1244b318f75ed. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/907?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

