### PR TITLE
feat(s3): enforce BucketOwnerEnforced on ACL writes

### DIFF
--- a/crates/fakecloud-s3/src/service/acl.rs
+++ b/crates/fakecloud-s3/src/service/acl.rs
@@ -45,6 +45,14 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        if self.bucket_owner_enforced(account_id, bucket) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AccessControlListNotSupported",
+                "The bucket does not allow ACLs",
+            ));
+        }
+
         // Snapshot PAB before taking the write lock — `pab_flags`
         // reads its own lock and would deadlock under the same
         // upgrade.

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -977,6 +977,18 @@ impl S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        // BucketOwnerEnforced disables ACLs on this bucket entirely;
+        // any ACL-mutating call rejects with
+        // `AccessControlListNotSupported` so the caller can't write a
+        // grant the bucket would silently ignore.
+        if self.bucket_owner_enforced(account_id, bucket) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AccessControlListNotSupported",
+                "The bucket does not allow ACLs",
+            ));
+        }
+
         let pab = self.pab_flags(account_id, bucket);
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
@@ -1172,6 +1184,26 @@ impl S3Service {
             .delete_bucket_subresource(bucket, BucketSubresource::Replication)
             .map_err(super::persistence_error)?;
         Ok(empty_response(StatusCode::NO_CONTENT))
+    }
+
+    /// Returns true when the bucket has
+    /// `ObjectOwnership=BucketOwnerEnforced` set in its
+    /// `OwnershipControls` configuration. Under that mode AWS
+    /// disables ACLs entirely — every ACL-mutating call must reject
+    /// with `AccessControlListNotSupported` so callers don't
+    /// silently no-op against a bucket that ignores their grants.
+    pub(super) fn bucket_owner_enforced(&self, account_id: &str, bucket: &str) -> bool {
+        let accts = self.state.read();
+        let Some(state) = accts.get(account_id) else {
+            return false;
+        };
+        let Some(b) = state.buckets.get(bucket) else {
+            return false;
+        };
+        b.ownership_controls
+            .as_deref()
+            .map(|xml| xml.contains("BucketOwnerEnforced"))
+            .unwrap_or(false)
     }
 
     pub(super) fn put_bucket_ownership_controls(

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -670,6 +670,21 @@ impl S3Service {
             ));
         }
 
+        // BucketOwnerEnforced disables object ACLs at write-time too:
+        // any x-amz-acl or x-amz-grant-* header rejects with
+        // AccessControlListNotSupported. Plain PutObject without ACL
+        // headers continues to work — only attempts to set a grant
+        // are rejected.
+        if (acl_header.is_some() || has_grant_headers)
+            && self.bucket_owner_enforced(account_id, bucket)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AccessControlListNotSupported",
+                "The bucket does not allow ACLs",
+            ));
+        }
+
         // Parse tags from header
         let tags = if let Some(tagging) = &tagging_header {
             let parsed = parse_url_encoded_tags(tagging);

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3813,3 +3813,77 @@ async fn delete_objects_batch_respects_compliance_retention() {
         "expected free.txt to be deleted, got: {body_str}"
     );
 }
+
+#[tokio::test]
+async fn bucket_owner_enforced_rejects_put_bucket_acl_and_object_acl() {
+    let svc = make_service();
+    seed_bucket(&svc, "owner-enforced");
+
+    let body = br#"<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>"#;
+    let req = make_request(
+        Method::PUT,
+        "/owner-enforced",
+        &[("ownershipControls", "")],
+        body,
+    );
+    svc.put_bucket_ownership_controls("123456789012", &req, "owner-enforced")
+        .unwrap();
+
+    let mut req = make_request(Method::PUT, "/owner-enforced", &[("acl", "")], b"");
+    req.headers.insert("x-amz-acl", "private".parse().unwrap());
+    let err = match svc.put_bucket_acl("123456789012", &req, "owner-enforced") {
+        Err(e) => e,
+        Ok(_) => panic!("PutBucketAcl should be rejected under BucketOwnerEnforced"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+    // Seed an object first (PutObject without ACL header is fine).
+    let req = make_request(Method::PUT, "/owner-enforced/k", &[], b"x");
+    svc.put_object("123456789012", &req, "owner-enforced", "k")
+        .await
+        .unwrap();
+
+    let mut req = make_request(Method::PUT, "/owner-enforced/k", &[("acl", "")], b"");
+    req.headers
+        .insert("x-amz-acl", "public-read".parse().unwrap());
+    let err = match svc.put_object_acl("123456789012", &req, "owner-enforced", "k") {
+        Err(e) => e,
+        Ok(_) => panic!("PutObjectAcl should be rejected under BucketOwnerEnforced"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn bucket_owner_enforced_rejects_put_object_with_acl_header() {
+    let svc = make_service();
+    seed_bucket(&svc, "noaclonput");
+
+    let body = br#"<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>"#;
+    let req = make_request(
+        Method::PUT,
+        "/noaclonput",
+        &[("ownershipControls", "")],
+        body,
+    );
+    svc.put_bucket_ownership_controls("123456789012", &req, "noaclonput")
+        .unwrap();
+
+    // Plain PutObject still works.
+    let req = make_request(Method::PUT, "/noaclonput/plain", &[], b"x");
+    svc.put_object("123456789012", &req, "noaclonput", "plain")
+        .await
+        .unwrap();
+
+    // PutObject with x-amz-acl rejects.
+    let mut req = make_request(Method::PUT, "/noaclonput/withacl", &[], b"x");
+    req.headers
+        .insert("x-amz-acl", "public-read".parse().unwrap());
+    let err = match svc
+        .put_object("123456789012", &req, "noaclonput", "withacl")
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("PutObject with x-amz-acl should be rejected under BucketOwnerEnforced"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary

E2 from the parity audit. `OwnershipControls=BucketOwnerEnforced` was stored but never read at write-time, so ACL writes silently no-oped against a bucket that ignored them.

- `PutBucketAcl` -> `AccessControlListNotSupported` 400
- `PutObjectAcl` -> `AccessControlListNotSupported` 400
- `PutObject` with `x-amz-acl` or `x-amz-grant-*` -> `AccessControlListNotSupported` 400
- Plain `PutObject` without ACL headers continues to work

## Test plan

- [x] `cargo test -p fakecloud-s3 --lib` (290 pass)
- [x] `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `bucket_owner_enforced_rejects_put_bucket_acl_and_object_acl`
- [x] `bucket_owner_enforced_rejects_put_object_with_acl_header` (incl. plain PutObject still works)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce S3 BucketOwnerEnforced semantics: ACL writes now return 400 AccessControlListNotSupported when `OwnershipControls=BucketOwnerEnforced`. Plain PutObject without ACL headers still works.

- **Bug Fixes**
  - Reject `PutBucketAcl`, `PutObjectAcl`, and `PutObject` with `x-amz-acl`/`x-amz-grant-*`; added `bucket_owner_enforced(...)` helper and tests.

<sup>Written for commit 92dffc8f674d60e71cd0ea40a055b6ff40980deb. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/908?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

