### PR TITLE
fix(s3): DeleteObjects batch honors COMPLIANCE retention and legal hold

### DIFF
--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -2605,6 +2605,24 @@ impl S3Service {
                     ));
                 }
             } else {
+                // Mirror single-DeleteObject's lock check: an
+                // unversioned-bucket batch delete must respect
+                // COMPLIANCE retention and legal-hold per key,
+                // otherwise compliance can be sidestepped via the
+                // batch endpoint.
+                let lock_denied = b
+                    .objects
+                    .get(key)
+                    .filter(|existing| !existing.is_delete_marker)
+                    .and_then(|existing| check_object_lock_for_overwrite(existing, req));
+                if let Some(code) = lock_denied {
+                    error_xml.push_str(&format!(
+                        "<Error><Key>{}</Key><Code>{}</Code><Message>Access Denied</Message></Error>",
+                        xml_escape(key),
+                        code,
+                    ));
+                    continue;
+                }
                 b.objects.remove(key);
                 self.store
                     .delete_object(bucket, key, None)

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3691,3 +3691,48 @@ fn bucket_tagging_lifecycle() {
     svc.delete_bucket_tagging("123456789012", &req, "bt")
         .unwrap();
 }
+
+#[tokio::test]
+async fn delete_objects_batch_respects_compliance_retention() {
+    // Single DeleteObject already gates COMPLIANCE retention; the
+    // batch DeleteObjects unversioned arm previously skipped the
+    // gate, letting a caller sidestep compliance via the batch
+    // endpoint. This test pins the gate in place.
+    let svc = make_service();
+    seed_bucket(&svc, "comp-batch");
+    seed_object(&svc, "comp-batch", "locked.txt", b"x");
+    seed_object(&svc, "comp-batch", "free.txt", b"y");
+
+    // Apply COMPLIANCE retention to one of the two objects.
+    let body = b"<Retention><Mode>COMPLIANCE</Mode><RetainUntilDate>2099-01-01T00:00:00Z</RetainUntilDate></Retention>";
+    let req = make_request(
+        Method::PUT,
+        "/comp-batch/locked.txt",
+        &[("retention", "")],
+        body,
+    );
+    svc.put_object_retention("123456789012", &req, "comp-batch", "locked.txt")
+        .unwrap();
+
+    // Batch delete both — compliance object must come back as Error.
+    let xml = r#"<Delete><Object><Key>locked.txt</Key></Object><Object><Key>free.txt</Key></Object></Delete>"#;
+    let req = make_request(
+        Method::POST,
+        "/comp-batch",
+        &[("delete", "")],
+        xml.as_bytes(),
+    );
+    let resp = svc
+        .delete_objects("123456789012", &req, "comp-batch")
+        .unwrap();
+    let body_str = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body_str.contains("<Key>locked.txt</Key>") && body_str.contains("InvalidRequest")
+            || body_str.contains("<Key>locked.txt</Key>") && body_str.contains("AccessDenied"),
+        "expected locked.txt to surface as Error in DeleteResult, got: {body_str}"
+    );
+    assert!(
+        body_str.contains("<Deleted><Key>free.txt</Key>"),
+        "expected free.txt to be deleted, got: {body_str}"
+    );
+}


### PR DESCRIPTION
## Summary

E3 from the parity audit. Single DeleteObject already gates COMPLIANCE retention + legal hold, but the batch DeleteObjects unversioned arm skipped the gate, letting a caller sidestep compliance via the batch endpoint.

Each unversioned-arm key now passes through `check_object_lock_for_overwrite`. Denied keys surface as `<Error>` entries in `DeleteResult`, unaffected keys still delete in the same call.

## Test plan

- [x] `cargo test -p fakecloud-s3 --lib` (289 pass)
- [x] `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `delete_objects_batch_respects_compliance_retention` — locked key surfaces as Error, free key deletes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes S3 `DeleteObjects` batch on unversioned buckets to honor COMPLIANCE retention and legal hold. Locked keys now surface as `<Error>` entries while other keys still delete in the same request.

- **Bug Fixes**
  - Run `check_object_lock_for_overwrite` per key in the unversioned batch path.
  - Return `<Error>` entries (e.g., `InvalidRequest`/`AccessDenied`) for locked keys without aborting the batch.
  - Added test `delete_objects_batch_respects_compliance_retention` to pin behavior.

<sup>Written for commit 05d6675d4f838eea2b2645d27821793e008af0b1. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/909?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

