### PR TITLE
feat(s3): validate KMS key id on PutBucketEncryption and use real JSON parse for IsPublic

### DIFF
--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -60,6 +60,21 @@ impl PublicAccessBlockFlags {
     }
 }
 
+/// Validate that a `PutBucketEncryption` body referencing `aws:kms`
+/// or `aws:kms:dsse` includes a non-empty `KMSMasterKeyID`. Real
+/// AWS rejects these as `InvalidArgument` since there's no key the
+/// bucket can encrypt against.
+fn has_kms_master_key_id(xml: &str) -> bool {
+    let Some(start) = xml.find("<KMSMasterKeyID>") else {
+        return false;
+    };
+    let value_start = start + "<KMSMasterKeyID>".len();
+    let Some(end_offset) = xml[value_start..].find("</KMSMasterKeyID>") else {
+        return false;
+    };
+    !xml[value_start..value_start + end_offset].trim().is_empty()
+}
+
 /// Detect whether a parsed bucket-policy document grants access to an
 /// anonymous principal. Mirrors AWS's "is public" classifier:
 /// `Effect=Allow` with `Principal:"*"` or `{"AWS":"*"}` (or a list
@@ -129,6 +144,19 @@ impl S3Service {
         bucket: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body_str = std::str::from_utf8(&req.body).unwrap_or("").to_string();
+        // aws:kms / aws:kms:dsse rules require KMSMasterKeyID — AWS
+        // rejects these with InvalidArgument when the field is
+        // missing or empty, since the bucket would otherwise have
+        // no key to encrypt against.
+        if (body_str.contains("aws:kms") || body_str.contains("aws:kms:dsse"))
+            && !has_kms_master_key_id(&body_str)
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidArgument",
+                "Default KMS encryption requires KMSMasterKeyID",
+            ));
+        }
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state
@@ -1602,16 +1630,10 @@ impl S3Service {
             .buckets
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        let is_public = b
-            .policy
-            .as_deref()
-            .map(|p| {
-                // Whitespace-tolerant detection: strip all whitespace
-                // before scanning for the wildcard principal markers.
-                let compact: String = p.chars().filter(|c| !c.is_whitespace()).collect();
-                compact.contains("\"Principal\":\"*\"") || compact.contains("\"AWS\":\"*\"")
-            })
-            .unwrap_or(false);
+        // Real JSON parse instead of substring scanning so a policy
+        // containing the literal string `"Principal":"*"` inside a
+        // Description field doesn't get falsely classified public.
+        let is_public = b.policy.as_deref().map(policy_is_public).unwrap_or(false);
         let body = format!("<PolicyStatus><IsPublic>{is_public}</IsPublic></PolicyStatus>");
         Ok(s3_xml(StatusCode::OK, body))
     }

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3887,3 +3887,55 @@ async fn bucket_owner_enforced_rejects_put_object_with_acl_header() {
     };
     assert_eq!(err.status(), StatusCode::BAD_REQUEST);
 }
+
+#[test]
+fn put_bucket_encryption_aws_kms_requires_kms_master_key_id() {
+    // AWS rejects PutBucketEncryption with aws:kms but no
+    // KMSMasterKeyID — there's no key for the bucket to default
+    // encrypt against. fakecloud was silently accepting it.
+    let svc = make_service();
+    seed_bucket(&svc, "kmsenc");
+
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/kmsenc", &[("encryption", "")], body);
+    let err = match svc.put_bucket_encryption("123456789012", &req, "kmsenc") {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidArgument when KMSMasterKeyID is missing"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:kms</SSEAlgorithm><KMSMasterKeyID>alias/aws/s3</KMSMasterKeyID></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/kmsenc", &[("encryption", "")], body);
+    svc.put_bucket_encryption("123456789012", &req, "kmsenc")
+        .unwrap();
+}
+
+#[test]
+fn get_bucket_policy_status_uses_real_json_parse() {
+    // Substring scan would falsely flag a Description string as
+    // public. Real JSON parse only flags actual Principal=*.
+    let svc = make_service();
+    seed_bucket(&svc, "polstat");
+
+    let policy = br#"{"Version":"2012-10-17","Id":"some \"Principal\":\"*\" string","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:role/r"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::polstat/*"}]}"#;
+    let req = make_request(Method::PUT, "/polstat", &[("policy", "")], policy);
+    svc.put_bucket_policy("123456789012", &req, "polstat")
+        .unwrap();
+    let resp = svc
+        .get_bucket_policy_status("123456789012", "polstat")
+        .unwrap();
+    assert!(std::str::from_utf8(resp.body.expect_bytes())
+        .unwrap()
+        .contains("<IsPublic>false</IsPublic>"));
+
+    let policy = br#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::polstat/*"}]}"#;
+    let req = make_request(Method::PUT, "/polstat", &[("policy", "")], policy);
+    svc.put_bucket_policy("123456789012", &req, "polstat")
+        .unwrap();
+    let resp = svc
+        .get_bucket_policy_status("123456789012", "polstat")
+        .unwrap();
+    assert!(std::str::from_utf8(resp.body.expect_bytes())
+        .unwrap()
+        .contains("<IsPublic>true</IsPublic>"));
+}


### PR DESCRIPTION
## Summary

Two of the highest-value items from the E6 polish bucket in the parity audit. The remaining E6 items (versioning Suspended object_id=null, PutObject preserving Cache-Control / Content-Disposition / Content-Language / Expires headers, PutObjectRetention COMPLIANCE-only-extend, CRC32C/CRC64NVME checksum support) deserve their own focused PRs and are deferred.

- PutBucketEncryption rejects aws:kms / aws:kms:dsse with no KMSMasterKeyID (InvalidArgument 400)
- GetBucketPolicyStatus.IsPublic uses serde_json instead of substring scan

## Test plan

- [x] `cargo test -p fakecloud-s3 --lib` (290 pass)
- [x] `cargo clippy -p fakecloud-s3 --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `put_bucket_encryption_aws_kms_requires_kms_master_key_id`
- [x] `get_bucket_policy_status_uses_real_json_parse` (negative + positive cases)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces KMS key ID on `PutBucketEncryption` for `aws:kms`/`aws:kms:dsse` and switches `GetBucketPolicyStatus.IsPublic` to real JSON parsing to mirror AWS and avoid false positives.

- **Bug Fixes**
  - `PutBucketEncryption` with `aws:kms` or `aws:kms:dsse` now returns 400 `InvalidArgument` when `KMSMasterKeyID` is missing or empty.
  - `GetBucketPolicyStatus.IsPublic` now JSON-parses the policy and inspects each statement for `Effect=Allow` with `Principal:"*"` or `{"AWS":"*"}`, instead of substring scanning.

<sup>Written for commit 5ec02107c90137b79a76bb8ed297c01462c112e4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/912?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

