### PR TITLE
feat(logs): enforce retention on GetLogEvents and FilterLogEvents

### DIFF
--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -766,6 +766,39 @@ pub(crate) mod test_helpers {
         svc.put_log_events(&req).unwrap();
     }
 
+    pub fn put_events_at(
+        svc: &LogsService,
+        group: &str,
+        stream: &str,
+        messages: &[&str],
+        timestamp: i64,
+    ) {
+        let events: Vec<serde_json::Value> = messages
+            .iter()
+            .enumerate()
+            .map(
+                |(i, msg)| serde_json::json!({ "timestamp": timestamp + i as i64, "message": msg }),
+            )
+            .collect();
+        let req = make_request(
+            "PutLogEvents",
+            serde_json::json!({
+                "logGroupName": group,
+                "logStreamName": stream,
+                "logEvents": events,
+            }),
+        );
+        svc.put_log_events(&req).unwrap();
+    }
+
+    pub fn put_retention(svc: &LogsService, group: &str, days: i32) {
+        let req = make_request(
+            "PutRetentionPolicy",
+            serde_json::json!({ "logGroupName": group, "retentionInDays": days }),
+        );
+        svc.put_retention_policy(&req).unwrap();
+    }
+
     #[test]
     fn array_filter_pattern_does_not_match() {
         assert!(

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -712,11 +712,20 @@ impl LogsService {
             )
         })?;
 
+        let retention_cutoff = group
+            .retention_in_days
+            .map(|d| Utc::now().timestamp_millis() - (d as i64) * 86_400_000);
+
         // All events are indexed 0..n
         let all_events: Vec<&LogEvent> = stream
             .events
             .iter()
             .filter(|e| {
+                if let Some(cutoff) = retention_cutoff {
+                    if e.timestamp < cutoff {
+                        return false;
+                    }
+                }
                 if let Some(start) = start_time {
                     if e.timestamp < start {
                         return false;
@@ -893,6 +902,10 @@ impl LogsService {
 
         let mut filtered_events: Vec<Value> = Vec::new();
 
+        let retention_cutoff = group
+            .retention_in_days
+            .map(|d| Utc::now().timestamp_millis() - (d as i64) * 86_400_000);
+
         let streams: Vec<(&String, &LogStream)> = if !stream_names.is_empty() {
             group
                 .log_streams
@@ -911,6 +924,11 @@ impl LogsService {
 
         for (_, stream) in streams {
             for event in &stream.events {
+                if let Some(cutoff) = retention_cutoff {
+                    if event.timestamp < cutoff {
+                        continue;
+                    }
+                }
                 if let Some(start) = start_time {
                     if event.timestamp < start {
                         continue;
@@ -1989,6 +2007,68 @@ mod tests {
             json!({"logGroupName": "g", "logStreamName": "missing"}),
         );
         assert!(svc.get_log_events(&req).is_err());
+    }
+
+    // ── retention enforcement ──
+
+    #[test]
+    fn get_log_events_drops_events_older_than_retention() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        // 12 days ago: still inside the 14-day PutLogEvents window,
+        // but older than a 1-day retention.
+        let twelve_days_ago = now - 12 * 86_400_000;
+        put_events_at(&svc, "g", "s", &["old1", "old2"], twelve_days_ago);
+        put_events(&svc, "g", "s", &["fresh"]);
+        put_retention(&svc, "g", 1);
+
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "s", "startFromHead": true}),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let events = body["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1, "expected only the fresh event");
+        assert_eq!(events[0]["message"].as_str().unwrap(), "fresh");
+    }
+
+    #[test]
+    fn get_log_events_no_retention_returns_all_events() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        put_events_at(&svc, "g", "s", &["old"], now - 12 * 86_400_000);
+        put_events(&svc, "g", "s", &["fresh"]);
+
+        let req = make_request(
+            "GetLogEvents",
+            json!({"logGroupName": "g", "logStreamName": "s", "startFromHead": true}),
+        );
+        let resp = svc.get_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn filter_log_events_drops_events_older_than_retention() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        create_stream(&svc, "g", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        put_events_at(&svc, "g", "s", &["stale"], now - 12 * 86_400_000);
+        put_events(&svc, "g", "s", &["recent"]);
+        put_retention(&svc, "g", 1);
+
+        let req = make_request("FilterLogEvents", json!({"logGroupName": "g"}));
+        let resp = svc.filter_log_events(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let events = body["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["message"].as_str().unwrap(), "recent");
     }
 
     // ── deliveries coverage ──


### PR DESCRIPTION
## Summary
- Filter events older than `retentionInDays * 86_400_000 ms` at read-time in `GetLogEvents` and `FilterLogEvents`.
- Groups without a retention policy keep unlimited retention.
- Cutoff is computed once per request from `Utc::now()`, then applied alongside the existing `startTime`/`endTime` window.
- Audit shard: `Z4` in `/tmp/parity_audit/REPORT.md` — \"Lazy-on-read filter for retention\".

## Test plan
- [x] `cargo test -p fakecloud-logs` (3 new tests):
  - `get_log_events_drops_events_older_than_retention`
  - `get_log_events_no_retention_returns_all_events`
  - `filter_log_events_drops_events_older_than_retention`
- [x] `cargo clippy -p fakecloud-logs --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces log retention on reads: `GetLogEvents` and `FilterLogEvents` now drop events older than `retentionInDays`. Groups without a policy keep unlimited retention; the cutoff works with `startTime`/`endTime`.

- **New Features**
  - Compute the cutoff once per request using `Utc::now()` and filter before pagination.
  - Add test helpers `put_events_at` and `put_retention`; add 3 tests covering retention and no-retention paths.

<sup>Written for commit 05696b44c6fd2df4834ac3001a9968ce1adff06f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/916?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

