### PR TITLE
feat(organizations): CreateAccount lifecycle + CloseAccount + RemoveAccountFromOrganization

### DIFF
--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -36,6 +36,12 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "DetachPolicy",
     "ListPoliciesForTarget",
     "ListTargetsForPolicy",
+    "CreateAccount",
+    "CreateGovCloudAccount",
+    "DescribeCreateAccountStatus",
+    "ListCreateAccountStatus",
+    "CloseAccount",
+    "RemoveAccountFromOrganization",
 ];
 
 pub struct OrganizationsService {
@@ -463,6 +469,118 @@ impl OrganizationsService {
         }
         Ok(())
     }
+
+    fn create_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let email = required_str(&body, "Email")?.to_string();
+        let name = required_str(&body, "AccountName")?.to_string();
+
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        let status = org.create_account(&email, &name, None);
+        Ok(AwsResponse::ok_json(json!({
+            "CreateAccountStatus": create_account_status_payload(&status),
+        })))
+    }
+
+    fn create_gov_cloud_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let email = required_str(&body, "Email")?.to_string();
+        let name = required_str(&body, "AccountName")?.to_string();
+
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        // The GovCloud "paired" id is a 12-digit account id in the
+        // GovCloud partition; we mint one alongside the commercial id
+        // so callers see both, matching the real AWS response.
+        let gov_id = org.next_account_id();
+        let status = org.create_account(&email, &name, Some(gov_id));
+        Ok(AwsResponse::ok_json(json!({
+            "CreateAccountStatus": create_account_status_payload(&status),
+        })))
+    }
+
+    fn describe_create_account_status(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let request_id = required_str(&body, "CreateAccountRequestId")?.to_string();
+
+        let mut guard = self.state.write();
+        let org = guard.as_mut().ok_or_else(organizations_not_in_use)?;
+        if !org.accounts.contains_key(&req.account_id) {
+            return Err(organizations_not_in_use());
+        }
+        let status = org
+            .complete_or_describe_create_account(&request_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "CreateAccountStatusNotFoundException",
+                    format!("Create account status with id {request_id} was not found."),
+                )
+            })?;
+        Ok(AwsResponse::ok_json(json!({
+            "CreateAccountStatus": create_account_status_payload(&status),
+        })))
+    }
+
+    fn list_create_account_status(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let states: Vec<String> = body
+            .get("States")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        if !org.accounts.contains_key(&req.account_id) {
+            return Err(organizations_not_in_use());
+        }
+        let statuses: Vec<Value> = org
+            .create_account_requests
+            .values()
+            .filter(|s| states.is_empty() || states.iter().any(|st| st == &s.state))
+            .map(create_account_status_payload)
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "CreateAccountStatuses": statuses }),
+        ))
+    }
+
+    fn close_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let target = required_str(&body, "AccountId")?.to_string();
+
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.close_account(&target).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn remove_account_from_organization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let target = required_str(&body, "AccountId")?.to_string();
+
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.remove_account(&target).map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
 }
 
 #[async_trait]
@@ -495,6 +613,12 @@ impl AwsService for OrganizationsService {
             "DetachPolicy" => self.detach_policy(&req),
             "ListPoliciesForTarget" => self.list_policies_for_target(&req),
             "ListTargetsForPolicy" => self.list_targets_for_policy(&req),
+            "CreateAccount" => self.create_account(&req),
+            "CreateGovCloudAccount" => self.create_gov_cloud_account(&req),
+            "DescribeCreateAccountStatus" => self.describe_create_account_status(&req),
+            "ListCreateAccountStatus" => self.list_create_account_status(&req),
+            "CloseAccount" => self.close_account(&req),
+            "RemoveAccountFromOrganization" => self.remove_account_from_organization(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,
@@ -657,7 +781,39 @@ fn org_error_to_aws(err: OrgError) -> AwsServiceError {
             "TargetNotFoundException",
             format!("The target with id {id} was not found."),
         ),
+        OrgError::AccountChangesNotAllowed(id) => AwsServiceError::aws_error(
+            StatusCode::FORBIDDEN,
+            "ConstraintViolationException",
+            format!("Account {id} cannot be removed or closed (management account)."),
+        ),
+        OrgError::CreateAccountStatusNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "CreateAccountStatusNotFoundException",
+            format!("Create account status with id {id} was not found."),
+        ),
     }
+}
+
+fn create_account_status_payload(status: &crate::state::CreateAccountStatus) -> Value {
+    let mut obj = json!({
+        "Id": status.id,
+        "AccountName": status.account_name,
+        "State": status.state,
+        "RequestedTimestamp": status.requested_timestamp.timestamp() as f64,
+    });
+    if let Some(account_id) = &status.account_id {
+        obj["AccountId"] = json!(account_id);
+    }
+    if let Some(ts) = status.completed_timestamp {
+        obj["CompletedTimestamp"] = json!(ts.timestamp() as f64);
+    }
+    if let Some(reason) = &status.failure_reason {
+        obj["FailureReason"] = json!(reason);
+    }
+    if let Some(gov_id) = &status.gov_cloud_account_id {
+        obj["GovCloudAccountId"] = json!(gov_id);
+    }
+    obj
 }
 
 fn organization_payload(org: &OrganizationState) -> Value {
@@ -1793,5 +1949,244 @@ mod tests {
             .await,
         );
         assert_eq!(err.code(), "PolicyNotFoundException");
+    }
+
+    // ── account lifecycle (CreateAccount, Describe/ListCreateAccountStatus,
+    //    CloseAccount, RemoveAccountFromOrganization) ─────────────────────
+
+    fn body_value(resp: AwsResponse) -> Value {
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_account_starts_in_progress_then_describes_succeeded() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateAccount",
+                json!({"Email": "new@example.com", "AccountName": "New"}),
+            ))
+            .await
+            .unwrap();
+        let body = body_value(resp);
+        let status = &body["CreateAccountStatus"];
+        let request_id = status["Id"].as_str().unwrap().to_string();
+        assert_eq!(status["State"].as_str().unwrap(), "IN_PROGRESS");
+        assert_eq!(status["AccountName"].as_str().unwrap(), "New");
+        let new_account_id = status["AccountId"].as_str().unwrap().to_string();
+        assert_eq!(new_account_id.len(), 12);
+
+        // First Describe should flip the status to SUCCEEDED.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "DescribeCreateAccountStatus",
+                json!({"CreateAccountRequestId": request_id}),
+            ))
+            .await
+            .unwrap();
+        let body = body_value(resp);
+        assert_eq!(
+            body["CreateAccountStatus"]["State"].as_str().unwrap(),
+            "SUCCEEDED"
+        );
+        assert!(body["CreateAccountStatus"]["CompletedTimestamp"].is_number());
+    }
+
+    #[tokio::test]
+    async fn create_account_only_management_account_can_call() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        // Enroll a non-management account first.
+        svc.handle(req_with(
+            "111111111111",
+            "CreateAccount",
+            json!({"Email": "non-mgmt@example.com", "AccountName": "NonMgmt"}),
+        ))
+        .await
+        .unwrap();
+        // Find the new id via list.
+        let resp = svc
+            .handle(req_with("111111111111", "ListAccounts", json!({})))
+            .await
+            .unwrap();
+        let listed = body_value(resp);
+        let new_id = listed["Accounts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["Name"].as_str() == Some("NonMgmt"))
+            .unwrap()["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let err = expect_err(
+            svc.handle(req_with(
+                &new_id,
+                "CreateAccount",
+                json!({"Email": "x@example.com", "AccountName": "X"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+
+    #[tokio::test]
+    async fn list_create_account_status_filters_by_state() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateAccount",
+                json!({"Email": "a@example.com", "AccountName": "A"}),
+            ))
+            .await
+            .unwrap();
+        let request_id = body_value(resp)["CreateAccountStatus"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        // Filter for IN_PROGRESS first — should include the new request.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"States": ["IN_PROGRESS"]}),
+            ))
+            .await
+            .unwrap();
+        let listed = body_value(resp);
+        let arr = listed["CreateAccountStatuses"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["Id"].as_str().unwrap(), request_id);
+
+        // Flip to SUCCEEDED via Describe, then refilter.
+        svc.handle(req_with(
+            "111111111111",
+            "DescribeCreateAccountStatus",
+            json!({"CreateAccountRequestId": request_id}),
+        ))
+        .await
+        .unwrap();
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"States": ["IN_PROGRESS"]}),
+            ))
+            .await
+            .unwrap();
+        assert!(body_value(resp)["CreateAccountStatuses"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn close_account_marks_suspended_and_management_is_protected() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let new_resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateAccount",
+                json!({"Email": "a@example.com", "AccountName": "A"}),
+            ))
+            .await
+            .unwrap();
+        let new_id = body_value(new_resp)["CreateAccountStatus"]["AccountId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        svc.handle(req_with(
+            "111111111111",
+            "CloseAccount",
+            json!({"AccountId": new_id}),
+        ))
+        .await
+        .unwrap();
+        // Status should be SUSPENDED via DescribeAccount.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "DescribeAccount",
+                json!({"AccountId": new_id}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            body_value(resp)["Account"]["Status"].as_str().unwrap(),
+            "SUSPENDED"
+        );
+
+        // Management account cannot be closed.
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "CloseAccount",
+                json!({"AccountId": "111111111111"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "ConstraintViolationException");
+    }
+
+    #[tokio::test]
+    async fn remove_account_from_organization_drops_member() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let new_resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateAccount",
+                json!({"Email": "a@example.com", "AccountName": "A"}),
+            ))
+            .await
+            .unwrap();
+        let new_id = body_value(new_resp)["CreateAccountStatus"]["AccountId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        svc.handle(req_with(
+            "111111111111",
+            "RemoveAccountFromOrganization",
+            json!({"AccountId": new_id}),
+        ))
+        .await
+        .unwrap();
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "DescribeAccount",
+                json!({"AccountId": new_id}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "AccountNotFoundException");
+    }
+
+    #[tokio::test]
+    async fn create_gov_cloud_account_returns_paired_id() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "CreateGovCloudAccount",
+                json!({"Email": "gov@example.com", "AccountName": "Gov"}),
+            ))
+            .await
+            .unwrap();
+        let body = body_value(resp);
+        let status = &body["CreateAccountStatus"];
+        assert!(status["AccountId"].is_string());
+        assert!(status["GovCloudAccountId"].is_string());
+        assert_ne!(
+            status["AccountId"].as_str().unwrap(),
+            status["GovCloudAccountId"].as_str().unwrap()
+        );
     }
 }

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -42,6 +42,12 @@ pub struct OrganizationState {
     pub policies: BTreeMap<String, Policy>,
     /// target_id -> attached policy ids. Targets are root id, OU id, or account id.
     pub attachments: BTreeMap<String, HashSet<String>>,
+    /// `CreateAccount` / `CreateGovCloudAccount` request statuses keyed
+    /// by request id (`car-...`). Lifecycles transition through
+    /// `IN_PROGRESS` -> `SUCCEEDED` (or `FAILED`) and remain queryable
+    /// via `DescribeCreateAccountStatus` and `ListCreateAccountStatus`.
+    #[serde(default)]
+    pub create_account_requests: BTreeMap<String, CreateAccountStatus>,
 }
 
 impl OrganizationState {
@@ -119,7 +125,114 @@ impl OrganizationState {
             accounts,
             policies,
             attachments,
+            create_account_requests: BTreeMap::new(),
         }
+    }
+
+    /// Allocate the next pseudo-random 12-digit account id that's not
+    /// already a member. Mirrors AWS's account-id format (numeric,
+    /// 12 digits, no leading zero stripping).
+    pub fn next_account_id(&self) -> String {
+        loop {
+            let mut id = String::with_capacity(12);
+            for _ in 0..12 {
+                let u = Uuid::new_v4();
+                let byte = u.as_bytes()[0];
+                id.push(((byte % 10) + b'0') as char);
+            }
+            if !id.starts_with('0') && !self.accounts.contains_key(&id) {
+                return id;
+            }
+        }
+    }
+
+    /// Synchronously create a new member account under the root and
+    /// record an `IN_PROGRESS` `CreateAccountStatus`. The status is
+    /// flipped to `SUCCEEDED` on the next `DescribeCreateAccountStatus`
+    /// (matching the typical poll-then-observe AWS shape) so callers
+    /// see both phases.
+    pub fn create_account(
+        &mut self,
+        email: &str,
+        name: &str,
+        gov_cloud_paired_id: Option<String>,
+    ) -> CreateAccountStatus {
+        let now = Utc::now();
+        let request_id = format!("car-{}", random_id(20));
+        let new_account_id = self.next_account_id();
+        let arn = format!(
+            "arn:aws:organizations::{}:account/{}/{}",
+            self.management_account_id, self.org_id, new_account_id
+        );
+        let account = MemberAccount {
+            id: new_account_id.clone(),
+            arn,
+            email: email.to_string(),
+            name: name.to_string(),
+            status: "ACTIVE".to_string(),
+            joined_method: "CREATED".to_string(),
+            joined_timestamp: now,
+            parent_id: self.root_id.clone(),
+        };
+        self.accounts.insert(new_account_id.clone(), account);
+
+        let status = CreateAccountStatus {
+            id: request_id.clone(),
+            account_id: Some(new_account_id),
+            account_name: name.to_string(),
+            state: "IN_PROGRESS".to_string(),
+            requested_timestamp: now,
+            completed_timestamp: None,
+            failure_reason: None,
+            gov_cloud_account_id: gov_cloud_paired_id,
+        };
+        self.create_account_requests
+            .insert(request_id, status.clone());
+        status
+    }
+
+    /// Look up a `CreateAccountStatus` by its `car-...` id. If still
+    /// `IN_PROGRESS`, flip it to `SUCCEEDED` and stamp the completion
+    /// timestamp before returning. Returns `None` if no such request.
+    pub fn complete_or_describe_create_account(
+        &mut self,
+        request_id: &str,
+    ) -> Option<CreateAccountStatus> {
+        let status = self.create_account_requests.get_mut(request_id)?;
+        if status.state == "IN_PROGRESS" {
+            status.state = "SUCCEEDED".to_string();
+            status.completed_timestamp = Some(Utc::now());
+        }
+        Some(status.clone())
+    }
+
+    /// Mark `account_id` as `SUSPENDED` (mirrors `CloseAccount`). The
+    /// account stays enrolled in the org so `ListAccounts` still shows
+    /// it, matching real AWS retention semantics.
+    pub fn close_account(&mut self, account_id: &str) -> Result<(), OrgError> {
+        if account_id == self.management_account_id {
+            return Err(OrgError::AccountChangesNotAllowed(account_id.to_string()));
+        }
+        let account = self
+            .accounts
+            .get_mut(account_id)
+            .ok_or_else(|| OrgError::AccountNotFound(account_id.to_string()))?;
+        account.status = "SUSPENDED".to_string();
+        Ok(())
+    }
+
+    /// Remove a member account from the organization. The management
+    /// account cannot be removed.
+    pub fn remove_account(&mut self, account_id: &str) -> Result<(), OrgError> {
+        if account_id == self.management_account_id {
+            return Err(OrgError::AccountChangesNotAllowed(account_id.to_string()));
+        }
+        if self.accounts.remove(account_id).is_none() {
+            return Err(OrgError::AccountNotFound(account_id.to_string()));
+        }
+        // Detach any direct policy attachments for the now-orphan id.
+        self.attachments.remove(account_id);
+        Ok(())
     }
 
     /// Returns `true` iff `account_id` is the management account.
@@ -506,6 +619,23 @@ pub enum OrgError {
     PolicyInUse(String),
     PolicyNotAttached(String),
     TargetNotFound(String),
+    AccountChangesNotAllowed(String),
+    CreateAccountStatusNotFound(String),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateAccountStatus {
+    pub id: String,
+    pub account_id: Option<String>,
+    pub account_name: String,
+    pub state: String,
+    pub requested_timestamp: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_timestamp: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    #[serde(default)]
+    pub gov_cloud_account_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- `CreateAccount` enrolls a fresh 12-digit member account under root and returns a `CreateAccountStatus` (`car-...`) in `IN_PROGRESS`.
- `DescribeCreateAccountStatus` synthetically flips `IN_PROGRESS` -> `SUCCEEDED` on first call (stamps `CompletedTimestamp`) so callers see both phases.
- `ListCreateAccountStatus` filters by `States[]`.
- `CreateGovCloudAccount` pairs the commercial id with a synthetic GovCloud id (both surfaced).
- `CloseAccount` marks the target `SUSPENDED`; `RemoveAccountFromOrganization` drops the member and clears policy attachments. Both protect the management account via `ConstraintViolationException`.
- All four mutating ops gated to the management account.
- Audit shard: `H1` in `/tmp/parity_audit/REPORT.md`.

## Test plan
- [x] `cargo test -p fakecloud-organizations --lib` (93 tests, 6 new):
  - `create_account_starts_in_progress_then_describes_succeeded`
  - `create_account_only_management_account_can_call`
  - `list_create_account_status_filters_by_state`
  - `close_account_marks_suspended_and_management_is_protected`
  - `remove_account_from_organization_drops_member`
  - `create_gov_cloud_account_returns_paired_id`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add account lifecycle APIs to `fakecloud-organizations`: create, track, close, and remove member accounts. Includes GovCloud pairing and strict management-only access with management account protection.

- **New Features**
  - CreateAccount: enrolls under root; returns `CreateAccountStatus` (`car-...`) in `IN_PROGRESS`.
  - DescribeCreateAccountStatus: first call flips to `SUCCEEDED` and stamps `CompletedTimestamp`.
  - ListCreateAccountStatus: supports filtering by `States[]`.
  - CreateGovCloudAccount: returns commercial `AccountId` plus paired `GovCloudAccountId`.
  - CloseAccount: marks the target `SUSPENDED`; management account is protected (`ConstraintViolationException`).
  - RemoveAccountFromOrganization: removes the member and clears direct policy attachments; management account is protected.
  - Access control: all mutating ops require the management account; others get `AccessDeniedException`.

<sup>Written for commit f0106d99a2f56e11bb6b711092b1a6de644a4e0e. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

