### PR TITLE
feat(kms): real ECDSA Sign/Verify for ECC_NIST_P256/P384 and SECG_P256K1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -2924,6 +2925,9 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-persistence",
  "http 1.4.0",
+ "k256",
+ "p256 0.13.2",
+ "p384",
  "parking_lot",
  "rand 0.8.5",
  "rsa",
@@ -3759,6 +3763,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,6 +4228,20 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -4727,6 +4754,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -27,3 +27,6 @@ aes-gcm = "0.10"
 rsa = { workspace = true }
 rand = "0.8"
 signature = "2"
+p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
+p384 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
+k256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }

--- a/crates/fakecloud-kms/src/asym_ecdsa.rs
+++ b/crates/fakecloud-kms/src/asym_ecdsa.rs
@@ -1,0 +1,323 @@
+//! Real ECDSA Sign/Verify for KMS asymmetric specs.
+//!
+//! AWS KMS supports four ECDSA curves: NIST P-256, P-384, P-521, and
+//! SECG (Bitcoin's secp256k1). We implement P-256, P-384, and P-256K1
+//! against the `p256` / `p384` / `k256` crates. P-521 has no widely
+//! used pure-Rust ECDSA crate at this version, so it falls through to
+//! the legacy fake-bytes path documented in `service_crypto.rs`.
+
+use rsa::sha2::{Sha256, Sha384};
+use signature::{Signer, Verifier};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EcdsaError {
+    #[error("unsupported signing algorithm for this curve: {0}")]
+    UnsupportedAlgorithm(String),
+    #[error("key material is corrupt: {0}")]
+    CorruptKey(String),
+    #[error("crypto failure: {0}")]
+    CryptoFailure(String),
+}
+
+pub type KeyPair = (Vec<u8>, Vec<u8>);
+
+/// Returns `(pkcs8_private_der, spki_public_der)` for an ECDSA spec
+/// we generate real keypairs for. Returns `Ok(None)` for specs we
+/// don't handle here (P-521, SM2) so the caller can fall back to the
+/// placeholder bytes generator.
+pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, EcdsaError> {
+    use p256::pkcs8::EncodePrivateKey as _;
+    match key_spec {
+        "ECC_NIST_P256" => {
+            let mut rng = rand::thread_rng();
+            let sk = p256::ecdsa::SigningKey::random(&mut rng);
+            let priv_der = sk
+                .to_pkcs8_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("p256 pkcs8 encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            let vk = sk.verifying_key();
+            let pub_der = {
+                use p256::pkcs8::EncodePublicKey as _;
+                vk.to_public_key_der()
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("p256 spki encode: {e}")))?
+                    .as_bytes()
+                    .to_vec()
+            };
+            Ok(Some((priv_der, pub_der)))
+        }
+        "ECC_NIST_P384" => {
+            use p384::pkcs8::{EncodePrivateKey as _, EncodePublicKey as _};
+            let mut rng = rand::thread_rng();
+            let sk = p384::ecdsa::SigningKey::random(&mut rng);
+            let priv_der = sk
+                .to_pkcs8_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("p384 pkcs8 encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            let vk = sk.verifying_key();
+            let pub_der = vk
+                .to_public_key_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("p384 spki encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            Ok(Some((priv_der, pub_der)))
+        }
+        "ECC_SECG_P256K1" => {
+            use k256::pkcs8::{EncodePrivateKey as _, EncodePublicKey as _};
+            let mut rng = rand::thread_rng();
+            let sk = k256::ecdsa::SigningKey::random(&mut rng);
+            let priv_der = sk
+                .to_pkcs8_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("k256 pkcs8 encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            let vk = sk.verifying_key();
+            let pub_der = vk
+                .to_public_key_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("k256 spki encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            Ok(Some((priv_der, pub_der)))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Sign `message` with the curve+algorithm combination AWS expects.
+/// `message_is_digest` corresponds to KMS's `MessageType=DIGEST`.
+pub fn sign(
+    key_spec: &str,
+    priv_der: &[u8],
+    signing_algorithm: &str,
+    message: &[u8],
+    message_is_digest: bool,
+) -> Result<Vec<u8>, EcdsaError> {
+    match (key_spec, signing_algorithm) {
+        ("ECC_NIST_P256", "ECDSA_SHA_256") => {
+            use p256::pkcs8::DecodePrivateKey as _;
+            let sk = p256::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p256 decode: {e}")))?;
+            if message_is_digest {
+                let digest = digest_to_array_32(message)?;
+                let sig: p256::ecdsa::Signature = sk
+                    .sign_prehash_recoverable(&digest)
+                    .map(|(s, _)| s)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("p256 sign prehash: {e}")))?;
+                Ok(sig.to_der().as_bytes().to_vec())
+            } else {
+                let sig: p256::ecdsa::Signature = sk.sign(message);
+                Ok(sig.to_der().as_bytes().to_vec())
+            }
+        }
+        ("ECC_NIST_P384", "ECDSA_SHA_384") => {
+            use p384::pkcs8::DecodePrivateKey as _;
+            let sk = p384::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p384 decode: {e}")))?;
+            if message_is_digest {
+                let digest = digest_to_array_48(message)?;
+                let sig: p384::ecdsa::Signature = sk
+                    .sign_prehash_recoverable(&digest)
+                    .map(|(s, _)| s)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("p384 sign prehash: {e}")))?;
+                Ok(sig.to_der().as_bytes().to_vec())
+            } else {
+                let sig: p384::ecdsa::Signature = sk.sign(message);
+                Ok(sig.to_der().as_bytes().to_vec())
+            }
+        }
+        ("ECC_SECG_P256K1", "ECDSA_SHA_256") => {
+            use k256::pkcs8::DecodePrivateKey as _;
+            let sk = k256::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("k256 decode: {e}")))?;
+            if message_is_digest {
+                let digest = digest_to_array_32(message)?;
+                let sig: k256::ecdsa::Signature = sk
+                    .sign_prehash_recoverable(&digest)
+                    .map(|(s, _)| s)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("k256 sign prehash: {e}")))?;
+                Ok(sig.to_der().as_bytes().to_vec())
+            } else {
+                let sig: k256::ecdsa::Signature = sk.sign(message);
+                Ok(sig.to_der().as_bytes().to_vec())
+            }
+        }
+        _ => Err(EcdsaError::UnsupportedAlgorithm(format!(
+            "{key_spec}/{signing_algorithm}"
+        ))),
+    }
+}
+
+pub fn verify(
+    key_spec: &str,
+    priv_der: &[u8],
+    signing_algorithm: &str,
+    message: &[u8],
+    signature: &[u8],
+    message_is_digest: bool,
+) -> Result<bool, EcdsaError> {
+    match (key_spec, signing_algorithm) {
+        ("ECC_NIST_P256", "ECDSA_SHA_256") => {
+            use p256::pkcs8::DecodePrivateKey as _;
+            let sk = p256::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p256 decode: {e}")))?;
+            let vk = sk.verifying_key();
+            let sig = p256::ecdsa::Signature::from_der(signature).or_else(|_| {
+                p256::ecdsa::Signature::try_from(signature)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("p256 sig parse: {e}")))
+            });
+            let sig = match sig {
+                Ok(s) => s,
+                Err(_) => return Ok(false),
+            };
+            if message_is_digest {
+                use p256::ecdsa::signature::hazmat::PrehashVerifier;
+                Ok(vk.verify_prehash(message, &sig).is_ok())
+            } else {
+                Ok(vk.verify(message, &sig).is_ok())
+            }
+        }
+        ("ECC_NIST_P384", "ECDSA_SHA_384") => {
+            use p384::pkcs8::DecodePrivateKey as _;
+            let sk = p384::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p384 decode: {e}")))?;
+            let vk = sk.verifying_key();
+            let sig = p384::ecdsa::Signature::from_der(signature).or_else(|_| {
+                p384::ecdsa::Signature::try_from(signature)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("p384 sig parse: {e}")))
+            });
+            let sig = match sig {
+                Ok(s) => s,
+                Err(_) => return Ok(false),
+            };
+            if message_is_digest {
+                use p384::ecdsa::signature::hazmat::PrehashVerifier;
+                Ok(vk.verify_prehash(message, &sig).is_ok())
+            } else {
+                Ok(vk.verify(message, &sig).is_ok())
+            }
+        }
+        ("ECC_SECG_P256K1", "ECDSA_SHA_256") => {
+            use k256::pkcs8::DecodePrivateKey as _;
+            let sk = k256::ecdsa::SigningKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("k256 decode: {e}")))?;
+            let vk = sk.verifying_key();
+            let sig = k256::ecdsa::Signature::from_der(signature).or_else(|_| {
+                k256::ecdsa::Signature::try_from(signature)
+                    .map_err(|e| EcdsaError::CryptoFailure(format!("k256 sig parse: {e}")))
+            });
+            let sig = match sig {
+                Ok(s) => s,
+                Err(_) => return Ok(false),
+            };
+            if message_is_digest {
+                use k256::ecdsa::signature::hazmat::PrehashVerifier;
+                Ok(vk.verify_prehash(message, &sig).is_ok())
+            } else {
+                Ok(vk.verify(message, &sig).is_ok())
+            }
+        }
+        _ => Err(EcdsaError::UnsupportedAlgorithm(format!(
+            "{key_spec}/{signing_algorithm}"
+        ))),
+    }
+}
+
+fn digest_to_array_32(d: &[u8]) -> Result<[u8; 32], EcdsaError> {
+    d.try_into().map_err(|_| {
+        EcdsaError::CryptoFailure("MessageType=DIGEST requires 32-byte digest for SHA-256".into())
+    })
+}
+
+fn digest_to_array_48(d: &[u8]) -> Result<[u8; 48], EcdsaError> {
+    d.try_into().map_err(|_| {
+        EcdsaError::CryptoFailure("MessageType=DIGEST requires 48-byte digest for SHA-384".into())
+    })
+}
+
+#[allow(dead_code)]
+fn _unused_imports_keepalive() {
+    let _ = Sha256::default();
+    let _ = Sha384::default();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p256_sign_verify_roundtrip_with_message() {
+        let (priv_der, _pub_der) = generate_keypair("ECC_NIST_P256").unwrap().unwrap();
+        let msg = b"hello p256";
+        let sig = sign("ECC_NIST_P256", &priv_der, "ECDSA_SHA_256", msg, false).unwrap();
+        assert!(verify(
+            "ECC_NIST_P256",
+            &priv_der,
+            "ECDSA_SHA_256",
+            msg,
+            &sig,
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn p384_sign_verify_roundtrip_with_message() {
+        let (priv_der, _) = generate_keypair("ECC_NIST_P384").unwrap().unwrap();
+        let msg = b"hello p384";
+        let sig = sign("ECC_NIST_P384", &priv_der, "ECDSA_SHA_384", msg, false).unwrap();
+        assert!(verify(
+            "ECC_NIST_P384",
+            &priv_der,
+            "ECDSA_SHA_384",
+            msg,
+            &sig,
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn k256_sign_verify_roundtrip_with_message() {
+        let (priv_der, _) = generate_keypair("ECC_SECG_P256K1").unwrap().unwrap();
+        let msg = b"hello secp256k1";
+        let sig = sign("ECC_SECG_P256K1", &priv_der, "ECDSA_SHA_256", msg, false).unwrap();
+        assert!(verify(
+            "ECC_SECG_P256K1",
+            &priv_der,
+            "ECDSA_SHA_256",
+            msg,
+            &sig,
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn p256_tampered_message_fails_verify() {
+        let (priv_der, _) = generate_keypair("ECC_NIST_P256").unwrap().unwrap();
+        let sig = sign("ECC_NIST_P256", &priv_der, "ECDSA_SHA_256", b"a", false).unwrap();
+        assert!(!verify(
+            "ECC_NIST_P256",
+            &priv_der,
+            "ECDSA_SHA_256",
+            b"b",
+            &sig,
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn unsupported_curve_returns_none_for_keypair() {
+        // P-521 is currently out of scope here.
+        assert!(generate_keypair("ECC_NIST_P521").unwrap().is_none());
+    }
+
+    #[test]
+    fn p256_get_public_key_is_real_parseable_spki() {
+        use p256::pkcs8::DecodePublicKey;
+        let (_priv_der, pub_der) = generate_keypair("ECC_NIST_P256").unwrap().unwrap();
+        assert!(p256::PublicKey::from_public_key_der(&pub_der).is_ok());
+    }
+}

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -499,16 +499,27 @@ impl KmsService {
             .policy
             .unwrap_or_else(|| default_key_policy(&state.account_id));
 
-        let (asym_priv, asym_pub) = asym::generate_keypair(&input.key_spec)
-            .map_err(|e| {
-                AwsServiceError::aws_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "KMSInternalException",
-                    format!("failed to generate asymmetric key: {e}"),
-                )
-            })?
-            .map(|(p, k)| (Some(p), Some(k)))
-            .unwrap_or((None, None));
+        let mut asym_priv: Option<Vec<u8>> = None;
+        let mut asym_pub: Option<Vec<u8>> = None;
+        if let Some((p, k)) = asym::generate_keypair(&input.key_spec).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "KMSInternalException",
+                format!("failed to generate asymmetric key: {e}"),
+            )
+        })? {
+            asym_priv = Some(p);
+            asym_pub = Some(k);
+        } else if let Some((p, k)) = asym_ecdsa::generate_keypair(&input.key_spec).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "KMSInternalException",
+                format!("failed to generate ecdsa key: {e}"),
+            )
+        })? {
+            asym_priv = Some(p);
+            asym_pub = Some(k);
+        }
 
         let key = KmsKey {
             key_id: key_id.clone(),
@@ -1286,6 +1297,8 @@ impl KmsService {
 
 #[path = "asym.rs"]
 pub(crate) mod asym;
+#[path = "asym_ecdsa.rs"]
+pub(crate) mod asym_ecdsa;
 #[path = "service_aliases.rs"]
 mod service_aliases;
 #[path = "service_crypto.rs"]

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -373,24 +373,41 @@ impl KmsService {
         let message_is_digest = body["MessageType"].as_str() == Some("DIGEST");
 
         let signature_bytes = if let Some(priv_der) = &key.asymmetric_private_key_der {
-            super::asym::rsa_sign(
-                priv_der,
-                signing_algorithm,
-                &message_bytes,
-                message_is_digest,
-            )
-            .map_err(|e| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    format!("Sign failed: {e}"),
+            if signing_algorithm.starts_with("ECDSA") {
+                super::asym_ecdsa::sign(
+                    &key.key_spec,
+                    priv_der,
+                    signing_algorithm,
+                    &message_bytes,
+                    message_is_digest,
                 )
-            })?
+                .map_err(|e| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!("Sign failed: {e}"),
+                    )
+                })?
+            } else {
+                super::asym::rsa_sign(
+                    priv_der,
+                    signing_algorithm,
+                    &message_bytes,
+                    message_is_digest,
+                )
+                .map_err(|e| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!("Sign failed: {e}"),
+                    )
+                })?
+            }
         } else {
             // Legacy fake-bytes path for specs whose real-crypto branch
-            // hasn't landed yet (ECDSA in G2, etc.). Keeps the rest of
-            // the surface working until the per-spec branches replace
-            // this with `super::asym::*` paths.
+            // hasn't landed yet (P-521, SM2). Keeps the rest of the
+            // surface working until later G batches replace this with
+            // real-crypto paths.
             let sig_data = format!(
                 "fakecloud-sig:{}:{}:{}",
                 key.key_id, signing_algorithm, message_b64
@@ -454,14 +471,26 @@ impl KmsService {
         let message_is_digest = body["MessageType"].as_str() == Some("DIGEST");
 
         let signature_valid = if let Some(priv_der) = &key.asymmetric_private_key_der {
-            super::asym::rsa_verify(
-                priv_der,
-                signing_algorithm,
-                &message_bytes,
-                &signature_bytes,
-                message_is_digest,
-            )
-            .unwrap_or(false)
+            if signing_algorithm.starts_with("ECDSA") {
+                super::asym_ecdsa::verify(
+                    &key.key_spec,
+                    priv_der,
+                    signing_algorithm,
+                    &message_bytes,
+                    &signature_bytes,
+                    message_is_digest,
+                )
+                .unwrap_or(false)
+            } else {
+                super::asym::rsa_verify(
+                    priv_der,
+                    signing_algorithm,
+                    &message_bytes,
+                    &signature_bytes,
+                    message_is_digest,
+                )
+                .unwrap_or(false)
+            }
         } else {
             // Legacy fake-bytes verify (paired with the legacy Sign
             // path above). Replaced spec-by-spec as later G batches

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -1171,6 +1171,117 @@ fn sign_with_ecc_key() {
 }
 
 #[test]
+fn ecdsa_p256_sign_verify_round_trips_with_real_signature() {
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "SIGN_VERIFY", "KeySpec": "ECC_NIST_P256" }),
+    );
+    let message = b"ecc roundtrip";
+    let message_b64 = base64::engine::general_purpose::STANDARD.encode(message);
+
+    let resp = svc
+        .sign(&make_request(
+            "Sign",
+            json!({
+                "KeyId": key_id,
+                "Message": message_b64,
+                "SigningAlgorithm": "ECDSA_SHA_256",
+            }),
+        ))
+        .unwrap();
+    let sig_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let signature = sig_body["Signature"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .verify(&make_request(
+            "Verify",
+            json!({
+                "KeyId": key_id,
+                "Message": message_b64,
+                "Signature": signature,
+                "SigningAlgorithm": "ECDSA_SHA_256",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body["SignatureValid"].as_bool().unwrap());
+
+    // Tampered message must fail.
+    let bad_b64 = base64::engine::general_purpose::STANDARD.encode(b"different");
+    assert!(svc
+        .verify(&make_request(
+            "Verify",
+            json!({
+                "KeyId": key_id,
+                "Message": bad_b64,
+                "Signature": signature,
+                "SigningAlgorithm": "ECDSA_SHA_256",
+            }),
+        ))
+        .is_err());
+}
+
+#[test]
+fn ecdsa_p256_get_public_key_is_real_parseable_spki() {
+    use base64::Engine;
+    use p256::pkcs8::DecodePublicKey;
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "SIGN_VERIFY", "KeySpec": "ECC_NIST_P256" }),
+    );
+    let resp = svc
+        .get_public_key(&make_request("GetPublicKey", json!({ "KeyId": key_id })))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+    assert!(p256::PublicKey::from_public_key_der(&der).is_ok());
+}
+
+#[test]
+fn ecdsa_p384_sign_verify_round_trips() {
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "SIGN_VERIFY", "KeySpec": "ECC_NIST_P384" }),
+    );
+    let message_b64 = base64::engine::general_purpose::STANDARD.encode(b"p384");
+    let resp = svc
+        .sign(&make_request(
+            "Sign",
+            json!({
+                "KeyId": key_id,
+                "Message": message_b64,
+                "SigningAlgorithm": "ECDSA_SHA_384",
+            }),
+        ))
+        .unwrap();
+    let sig = serde_json::from_slice::<Value>(resp.body.expect_bytes()).unwrap()["Signature"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let resp = svc
+        .verify(&make_request(
+            "Verify",
+            json!({
+                "KeyId": key_id,
+                "Message": message_b64,
+                "Signature": sig,
+                "SigningAlgorithm": "ECDSA_SHA_384",
+            }),
+        ))
+        .unwrap();
+    assert!(
+        serde_json::from_slice::<Value>(resp.body.expect_bytes()).unwrap()["SignatureValid"]
+            .as_bool()
+            .unwrap()
+    );
+}
+
+#[test]
 fn sign_wrong_key_usage_fails() {
     let svc = make_service();
     let key_id = create_key(&svc); // ENCRYPT_DECRYPT


### PR DESCRIPTION
## Summary
- Real ECDSA keypair generation for `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_SECG_P256K1` via `p256` / `p384` / `k256`.
- `Sign` produces ASN.1 DER ECDSA signatures (matches AWS KMS output format), honors `MessageType=DIGEST`.
- `Verify` decodes DER and returns `KMSInvalidSignatureException` on bad sig.
- `GetPublicKey` returns parseable SPKI DER (verified via `p256::PublicKey::from_public_key_der`).
- `ECC_NIST_P521` and `SM2` stay on placeholder bytes path.
- Builds on G1 (#917) — set the base to `worktree-g1-kms-rsa` so this PR rebase-merges cleanly once G1 lands.
- Audit shard: `G2` in `/tmp/parity_audit/REPORT.md`.

## Test plan
- [x] `cargo test -p fakecloud-kms --lib` (148 tests, 9 ECDSA-specific):
  - `p256_sign_verify_roundtrip_with_message`
  - `p384_sign_verify_roundtrip_with_message`
  - `k256_sign_verify_roundtrip_with_message`
  - `p256_tampered_message_fails_verify`
  - `unsupported_curve_returns_none_for_keypair`
  - `p256_get_public_key_is_real_parseable_spki`
  - `ecdsa_p256_sign_verify_round_trips_with_real_signature`
  - `ecdsa_p256_get_public_key_is_real_parseable_spki`
  - `ecdsa_p384_sign_verify_round_trips`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add real ECDSA keypair generation and Sign/Verify for `ECC_NIST_P256`, `ECC_NIST_P384`, and `ECC_SECG_P256K1`. Outputs AWS-compatible ASN.1 DER signatures and SPKI public keys.

- **New Features**
  - Generate real ECDSA keys via `p256`/`p384`/`k256`; store PKCS#8 private and SPKI public DER.
  - Sign produces ASN.1 DER ECDSA and honors `MessageType=DIGEST`.
  - Verify parses DER; invalid signatures return `KMSInvalidSignatureException`.
  - Service routes ECDSA Sign/Verify to the new module; `ECC_NIST_P521` and `SM2` remain on the placeholder path.
  - `GetPublicKey` returns parseable SPKI DER for ECDSA keys.

- **Dependencies**
  - Add `p256`, `p384`, and `k256` to `fakecloud-kms`.

<sup>Written for commit edbe171c357433370526e052cd983c02aea751b7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/919?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

