### PR TITLE
feat(ssm): SendCommand goes through Pending -> InProgress -> Success

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -2165,7 +2165,8 @@ async fn ssm_command_invocations() {
         .unwrap();
     let cmd_id = resp.command().unwrap().command_id().unwrap().to_string();
 
-    // GetCommandInvocation
+    // GetCommandInvocation: status advances Pending -> InProgress -> Success
+    // across successive calls (matching real SSM lifecycle).
     let resp = client
         .get_command_invocation()
         .command_id(&cmd_id)
@@ -2175,6 +2176,18 @@ async fn ssm_command_invocations() {
         .unwrap();
     assert_eq!(resp.command_id().unwrap(), cmd_id);
     assert_eq!(resp.instance_id().unwrap(), "i-1234567890abcdef0");
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_ssm::types::CommandInvocationStatus::InProgress)
+    );
+
+    let resp = client
+        .get_command_invocation()
+        .command_id(&cmd_id)
+        .instance_id("i-1234567890abcdef0")
+        .send()
+        .await
+        .unwrap();
     assert_eq!(
         resp.status(),
         Some(&aws_sdk_ssm::types::CommandInvocationStatus::Success)

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -136,7 +136,11 @@ impl SsmService {
             document_name: input.document_name.clone(),
             instance_ids: effective_instance_ids.clone(),
             parameters: input.parameters.clone(),
-            status: "Success".to_string(),
+            // Real SSM returns `Pending` on submit; transitions to
+            // `InProgress` and then `Success` (or `Failed`) as the
+            // agent reports back. fakecloud auto-advances the state
+            // on each read so callers see realistic lifecycle.
+            status: "Pending".to_string(),
             requested_date_time: now,
             comment: input.comment.clone(),
             output_s3_bucket_name: input.output_s3_bucket.clone(),
@@ -161,8 +165,8 @@ impl SsmService {
             "InstanceIds": effective_instance_ids,
             "Targets": input.targets,
             "Parameters": input.parameters,
-            "Status": "Success",
-            "StatusDetails": "Success",
+            "Status": "Pending",
+            "StatusDetails": "Pending",
             "RequestedDateTime": now.timestamp_millis() as f64 / 1000.0,
             "ExpiresAfter": expires.timestamp_millis() as f64 / 1000.0,
             "MaxConcurrency": input.max_concurrency.clone().unwrap_or_default(),
@@ -274,6 +278,26 @@ impl SsmService {
         let plugin_name = body["PluginName"].as_str();
         validate_optional_string_length("PluginName", plugin_name, 4, 500)?;
 
+        // Auto-advance lifecycle so callers polling Get see Pending
+        // -> InProgress -> Success across successive reads. This runs
+        // under the write lock to avoid clobbering admin-set
+        // `Failed` / `Cancelled` statuses.
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            if let Some(c) = state
+                .commands
+                .iter_mut()
+                .find(|c| c.command_id == command_id)
+            {
+                c.status = match c.status.as_str() {
+                    "Pending" => "InProgress".to_string(),
+                    "InProgress" => "Success".to_string(),
+                    other => other.to_string(),
+                };
+            }
+        }
+
         let accounts = self.state.read();
         let empty = SsmState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -310,13 +334,18 @@ impl SsmService {
             }
         }
 
+        let response_code = match cmd.status.as_str() {
+            "Success" => 0,
+            "Failed" => 1,
+            _ => -1,
+        };
         Ok(AwsResponse::ok_json(json!({
             "CommandId": cmd.command_id,
             "InstanceId": instance_id,
             "DocumentName": cmd.document_name,
-            "Status": "Success",
-            "StatusDetails": "Success",
-            "ResponseCode": 0,
+            "Status": cmd.status,
+            "StatusDetails": cmd.status,
+            "ResponseCode": response_code,
             "StandardOutputContent": "",
             "StandardOutputUrl": "",
             "StandardErrorContent": "",
@@ -353,8 +382,8 @@ impl SsmService {
                         "CommandId": c.command_id,
                         "InstanceId": iid,
                         "DocumentName": c.document_name,
-                        "Status": "Success",
-                        "StatusDetails": "Success",
+                        "Status": c.status,
+                        "StatusDetails": c.status,
                         "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
                         "Comment": c.comment,
                     })

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -2057,6 +2057,20 @@ fn get_command_invocation_success() {
     let svc = make_service();
     let cmd_id = send_command(&svc, "AWS-RunShellScript");
 
+    // Real SSM cycles Pending -> InProgress -> Success across polls.
+    // fakecloud auto-advances on every Get; two reads pin the
+    // InProgress and Success states respectively.
+    let req = make_request(
+        "GetCommandInvocation",
+        json!({
+            "CommandId": cmd_id,
+            "InstanceId": "i-1234567890abcdef0",
+        }),
+    );
+    let resp = svc.get_command_invocation(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Status"].as_str().unwrap(), "InProgress");
+
     let req = make_request(
         "GetCommandInvocation",
         json!({
@@ -2069,6 +2083,21 @@ fn get_command_invocation_success() {
     assert_eq!(body["CommandId"].as_str().unwrap(), cmd_id);
     assert_eq!(body["InstanceId"].as_str().unwrap(), "i-1234567890abcdef0");
     assert_eq!(body["Status"].as_str().unwrap(), "Success");
+    assert_eq!(body["ResponseCode"].as_i64().unwrap(), 0);
+}
+
+#[test]
+fn send_command_starts_pending() {
+    let svc = make_service();
+    let cmd_id = send_command(&svc, "AWS-RunShellScript");
+    let req = make_request("ListCommands", json!({"CommandId": cmd_id}));
+    let resp = svc.list_commands(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["Commands"][0]["Status"].as_str().unwrap(),
+        "Pending",
+        "SendCommand returns Pending until first poll advances it"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `SendCommand` stores the command as `Pending` instead of jumping straight to `Success`.
- `GetCommandInvocation` auto-advances the lifecycle on each poll: `Pending -> InProgress`, `InProgress -> Success`. Admin-set `Failed`/`Cancelled` statuses are preserved.
- `ListCommands` and `ListCommandInvocations` now read the live status, not a hardcoded value.
- `ResponseCode` reflects real status (0 on Success, 1 on Failed, -1 while in flight).
- Audit shard: `I1` in `/tmp/parity_audit/REPORT.md`.

## Test plan
- [x] `cargo test -p fakecloud-ssm --lib` (200 tests, 1 new + 1 updated):
  - `send_command_starts_pending`
  - `get_command_invocation_success` rewritten to assert the full lifecycle
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SSM SendCommand follow a realistic lifecycle. Commands start Pending and move to InProgress, then Success; polling GetCommandInvocation advances state, and list endpoints plus ResponseCode reflect live status.

- **New Features**
  - Lifecycle auto-advances on each GetCommandInvocation; admin-set Failed/Cancelled are preserved.
  - ListCommands and ListCommandInvocations return the current status instead of hardcoded Success.
  - ResponseCode now maps to status: 0 (Success), 1 (Failed), -1 (Pending/InProgress).

- **Migration**
  - Expect Pending on initial responses; poll GetCommandInvocation to progress the command.
  - Update tests or scripts that assumed immediate Success; e2e test now asserts Pending -> InProgress -> Success.

<sup>Written for commit 45ac0dc591d6e9965f8696f06a54e259856b6812. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/921?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

