### PR TITLE
feat(secretsmanager): enforce resource policy on cross-account GetSecretValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-iam",
  "fakecloud-persistence",
  "http 1.4.0",
  "parking_lot",

--- a/crates/fakecloud-secretsmanager/Cargo.toml
+++ b/crates/fakecloud-secretsmanager/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-iam = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -298,9 +298,24 @@ impl SecretsManagerService {
         validate_optional_string_length("versionId", body["VersionId"].as_str(), 32, 64)?;
         validate_optional_string_length("versionStage", body["VersionStage"].as_str(), 1, 256)?;
 
+        // Resolve owning account from an ARN form. Cross-account
+        // GetSecretValue then evaluates `secret.resource_policy` via
+        // the IAM evaluator before returning the value.
+        let owner_account = secret_owner_account(&secret_id, &req.account_id);
         let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
+        let state = accounts.get_or_create(&owner_account);
         let secret = self.find_secret_mut(state, &secret_id)?;
+        if owner_account != req.account_id {
+            let policy_doc = secret.resource_policy.as_deref().unwrap_or("");
+            let secret_arn = secret.arn.clone();
+            if !resource_policy_allows(policy_doc, &req.account_id, &secret_arn) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "AccessDeniedException",
+                    "User is not authorized to perform: secretsmanager:GetSecretValue on the requested resource",
+                ));
+            }
+        }
 
         if secret.deleted {
             return Err(AwsServiceError::aws_error(
@@ -2048,6 +2063,57 @@ impl AwsService for SecretsManagerService {
 #[path = "service_helpers.rs"]
 mod service_helpers;
 pub(crate) use service_helpers::*;
+
+/// Extract the owning account-id from an `arn:aws:secretsmanager:...:ACCOUNT:secret:...`
+/// secret id. Returns `caller_account` when the input is a bare name
+/// or a same-account ARN.
+fn secret_owner_account(secret_id: &str, caller_account: &str) -> String {
+    if !secret_id.starts_with("arn:aws:secretsmanager:") {
+        return caller_account.to_string();
+    }
+    let parts: Vec<&str> = secret_id.splitn(7, ':').collect();
+    if parts.len() < 5 {
+        return caller_account.to_string();
+    }
+    let account = parts[4];
+    if account.is_empty() {
+        caller_account.to_string()
+    } else {
+        account.to_string()
+    }
+}
+
+/// Evaluate a Secrets Manager resource policy against a cross-account
+/// caller. Empty policy implicitly denies (real AWS behaviour). Uses
+/// the shared IAM evaluator so the same policy semantics apply
+/// service-wide.
+fn resource_policy_allows(policy_doc: &str, caller_account: &str, secret_arn: &str) -> bool {
+    if policy_doc.is_empty() {
+        return false;
+    }
+    use fakecloud_core::auth::{Principal, PrincipalType};
+    use fakecloud_iam::evaluator::{evaluate, EvalRequest, PolicyDocument};
+    let doc = PolicyDocument::parse(policy_doc);
+    let principal_arn = format!("arn:aws:iam::{caller_account}:root");
+    let principal = Principal {
+        arn: principal_arn.clone(),
+        user_id: principal_arn.clone(),
+        account_id: caller_account.to_string(),
+        principal_type: PrincipalType::User,
+        source_identity: None,
+        tags: None,
+    };
+    let req = EvalRequest {
+        principal: &principal,
+        action: "secretsmanager:GetSecretValue".to_string(),
+        resource: secret_arn.to_string(),
+        context: Default::default(),
+    };
+    matches!(
+        evaluate(&[doc], &req),
+        fakecloud_iam::evaluator::Decision::Allow
+    )
+}
 
 #[cfg(test)]
 #[path = "service_tests.rs"]

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -2178,3 +2178,99 @@ fn test_filter_all_searches_name_desc_tags() {
     // No match
     assert!(!filter_all(&secret, &["zzzz"]));
 }
+
+// ── Cross-account GetSecretValue: resource policy enforcement ────
+
+fn make_request_for(action: &str, account: &str, body: &str) -> AwsRequest {
+    let mut req = make_request(action, body);
+    req.account_id = account.to_string();
+    req
+}
+
+#[tokio::test]
+async fn cross_account_get_secret_value_denied_without_policy() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    // Owner creates the secret in account 111111111111.
+    let req = make_request_for(
+        "CreateSecret",
+        "111111111111",
+        r#"{"Name": "shared/secret", "SecretString": "ssss"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let arn = body["ARN"].as_str().unwrap().to_string();
+
+    // Another account asks for it without any resource policy in
+    // place — must be denied.
+    let req = make_request_for(
+        "GetSecretValue",
+        "222222222222",
+        &format!(r#"{{"SecretId": "{arn}"}}"#),
+    );
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.code(), "AccessDeniedException");
+}
+
+#[tokio::test]
+async fn cross_account_get_secret_value_allowed_with_matching_policy() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    // Owner creates the secret.
+    let req = make_request_for(
+        "CreateSecret",
+        "111111111111",
+        r#"{"Name": "shared/secret", "SecretString": "shhh"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let arn = body["ARN"].as_str().unwrap().to_string();
+
+    // Owner attaches a resource policy granting GetSecretValue to
+    // the cross-account principal.
+    let policy = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "*"
+        }]
+    });
+    let put_policy = make_request_for(
+        "PutResourcePolicy",
+        "111111111111",
+        &format!(
+            r#"{{"SecretId": "{arn}", "ResourcePolicy": {}}}"#,
+            serde_json::to_string(&policy.to_string()).unwrap()
+        ),
+    );
+    svc.handle(put_policy).await.unwrap();
+
+    // Cross-account caller now succeeds.
+    let req = make_request_for(
+        "GetSecretValue",
+        "222222222222",
+        &format!(r#"{{"SecretId": "{arn}"}}"#),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["SecretString"].as_str().unwrap(), "shhh");
+}
+
+#[test]
+fn secret_owner_account_extracts_from_arn() {
+    assert_eq!(
+        secret_owner_account(
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:s-abc123",
+            "999999999999"
+        ),
+        "111111111111"
+    );
+    assert_eq!(
+        secret_owner_account("plain-name", "999999999999"),
+        "999999999999"
+    );
+}


### PR DESCRIPTION
## Summary
- Cross-account \`GetSecretValue\` now resolves the secret in the owner's account state and runs \`secret.resource_policy\` through the IAM evaluator.
- Empty / missing policy implicitly denies (real AWS).
- Returns \`AccessDeniedException\` on deny.
- Audit shard: \`J1\` in \`/tmp/parity_audit/REPORT.md\`.

## Test plan
- [x] \`cargo test -p fakecloud-secretsmanager --lib\` (107 tests, 3 new):
  - \`cross_account_get_secret_value_denied_without_policy\`
  - \`cross_account_get_secret_value_allowed_with_matching_policy\`
  - \`secret_owner_account_extracts_from_arn\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces resource policy on cross-account GetSecretValue in `fakecloud-secretsmanager`. We now resolve the secret’s owner account from the ARN and evaluate `secret.resource_policy` via the IAM evaluator; empty or missing policy denies with `AccessDeniedException`.

- **New Features**
  - Cross-account `GetSecretValue` evaluates the secret’s resource policy using the shared IAM evaluator; default deny when policy is empty or missing.
  - Resolve state via the owner account derived from the secret ARN to read the correct secret.
  - Denied access returns `AccessDeniedException` to match AWS.

- **Dependencies**
  - Added `fakecloud-iam`.

<sup>Written for commit c79ae11c2800334eafb1b3e20a2db0ab92e80e7f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/922?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

