### PR TITLE
feat(elbv2): enforce deletion_protection.enabled on DeleteLoadBalancer

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -359,6 +359,26 @@ impl Elbv2Service {
         let arn = required_query_param(req, "LoadBalancerArn")?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
+        if let Some(lb) = st.load_balancers.get(&arn) {
+            // ELBv2 rejects DeleteLoadBalancer when
+            // `deletion_protection.enabled=true` is in the LB
+            // attribute set. The attribute is opt-in and defaults
+            // off, so absence is permissive.
+            if lb
+                .attributes
+                .get("deletion_protection.enabled")
+                .map(|v| v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "OperationNotPermitted",
+                    format!(
+                        "Load balancer '{arn}' cannot be deleted because deletion protection is enabled"
+                    ),
+                ));
+            }
+        }
         st.load_balancers.remove(&arn);
         let listener_arns: Vec<String> = st
             .listeners

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -74,6 +74,61 @@ async fn create_validates_name() {
 }
 
 #[tokio::test]
+async fn delete_lb_blocked_when_deletion_protection_enabled() {
+    let svc = svc();
+    svc.handle(req(
+        "CreateLoadBalancer",
+        &[("Name", "guarded"), ("Subnets.member.1", "subnet-1")],
+    ))
+    .await
+    .unwrap();
+    let arn = {
+        let st = svc.state.read();
+        st.get("123456789012")
+            .unwrap()
+            .load_balancers
+            .keys()
+            .next()
+            .cloned()
+            .unwrap()
+    };
+
+    // Enable deletion protection.
+    svc.handle(req(
+        "ModifyLoadBalancerAttributes",
+        &[
+            ("LoadBalancerArn", &arn),
+            ("Attributes.member.1.Key", "deletion_protection.enabled"),
+            ("Attributes.member.1.Value", "true"),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    let err = svc
+        .handle(req("DeleteLoadBalancer", &[("LoadBalancerArn", &arn)]))
+        .await
+        .err()
+        .expect("delete must fail under deletion_protection");
+    assert_eq!(err.code(), "OperationNotPermitted");
+
+    // After turning protection off, delete succeeds.
+    svc.handle(req(
+        "ModifyLoadBalancerAttributes",
+        &[
+            ("LoadBalancerArn", &arn),
+            ("Attributes.member.1.Key", "deletion_protection.enabled"),
+            ("Attributes.member.1.Value", "false"),
+        ],
+    ))
+    .await
+    .unwrap();
+    svc.handle(req("DeleteLoadBalancer", &[("LoadBalancerArn", &arn)]))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn delete_lb_is_idempotent() {
     let svc = svc();
     svc.handle(req("CreateLoadBalancer", &[("Name", "foo")]))


### PR DESCRIPTION
## Summary
- \`DeleteLoadBalancer\` now reads the LB's \`attributes\` map and rejects with \`OperationNotPermitted\` when \`deletion_protection.enabled=true\`. Defaults to off.
- Audit shard: \`Q1\` in \`/tmp/parity_audit/REPORT.md\`.

## Test plan
- [x] \`cargo test -p fakecloud-elbv2 --lib\` — new test \`delete_lb_blocked_when_deletion_protection_enabled\` covers both block + unblock.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces deletion protection in `fakecloud-elbv2` for `DeleteLoadBalancer`. The call now fails with `OperationNotPermitted` when `deletion_protection.enabled` is true, preventing accidental deletes and matching ELBv2 behavior.

- **New Features**
  - `DeleteLoadBalancer` reads LB `attributes` and blocks deletion when `deletion_protection.enabled=true` (absent defaults to off).
  - Added test `delete_lb_blocked_when_deletion_protection_enabled` covering block and unblock.

<sup>Written for commit 343c28887447d3e247ea474e8f1df161bdca53ec. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/923?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

