### PR TITLE
feat(route53): admin-controllable health check status + last-failure reason

### DIFF
--- a/crates/fakecloud-route53/src/service.rs
+++ b/crates/fakecloud-route53/src/service.rs
@@ -866,6 +866,8 @@ impl Route53Service {
             version: 1,
             config: cfg.health_check_config,
             created_time: Utc::now(),
+            status_line: "Success: HTTP Status Code 200, OK.".to_string(),
+            last_failure_reason: None,
         };
         account.health_checks.insert(id.clone(), stored.clone());
         drop(state);
@@ -1119,15 +1121,38 @@ impl Route53Service {
                 esc(&checker_ip_for_region(region))
             ));
             body.push_str("<StatusReport>");
-            body.push_str("<Status>Success: HTTP Status Code 200, OK.</Status>");
+            body.push_str(&format!("<Status>{}</Status>", esc(&hc.status_line)));
             body.push_str(&format!("<CheckedTime>{}</CheckedTime>", now));
             body.push_str("</StatusReport>");
             body.push_str("</HealthCheckObservation>");
         }
         body.push_str("</HealthCheckObservations>");
         body.push_str("</GetHealthCheckStatusResponse>");
-        let _ = hc;
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+
+    /// Admin: flip a health check's status + optional last-failure
+    /// reason. Powers the
+    /// `PUT /_fakecloud/route53/health-checks/{id}/status` endpoint
+    /// in fakecloud-server. Returns `false` if the id doesn't exist.
+    pub fn set_health_check_status(
+        &self,
+        id: &str,
+        status_line: String,
+        last_failure_reason: Option<String>,
+    ) -> bool {
+        let mut state = self.state.write();
+        let Some(account) = state.accounts.get_mut(DEFAULT_ACCOUNT) else {
+            return false;
+        };
+        let Some(hc) = account.health_checks.get_mut(id) else {
+            return false;
+        };
+        hc.status_line = status_line;
+        if last_failure_reason.is_some() {
+            hc.last_failure_reason = last_failure_reason;
+        }
+        true
     }
 
     fn get_health_check_last_failure_reason(
@@ -1136,21 +1161,35 @@ impl Route53Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = require_id(route)?;
         let state = self.state.read();
-        let _hc = state
+        let hc = state
             .accounts
             .get(DEFAULT_ACCOUNT)
             .and_then(|a| a.health_checks.get(&id).cloned())
             .ok_or_else(|| no_such_health_check(&id))?;
         drop(state);
-        // Real Route 53 returns an empty observations list when the
-        // checker has not seen a failure yet. fakecloud has no live
-        // checker, so the list is always empty.
         let mut body = String::with_capacity(256);
         body.push_str(XML_DECL);
         body.push_str(&format!(
             "<GetHealthCheckLastFailureReasonResponse xmlns=\"{NS}\">"
         ));
-        body.push_str("<HealthCheckObservations></HealthCheckObservations>");
+        body.push_str("<HealthCheckObservations>");
+        if let Some(reason) = hc.last_failure_reason.as_deref() {
+            let now = rfc3339(&Utc::now());
+            for region in checker_regions() {
+                body.push_str("<HealthCheckObservation>");
+                body.push_str(&format!("<Region>{}</Region>", esc(region)));
+                body.push_str(&format!(
+                    "<IPAddress>{}</IPAddress>",
+                    esc(&checker_ip_for_region(region))
+                ));
+                body.push_str("<StatusReport>");
+                body.push_str(&format!("<Status>{}</Status>", esc(reason)));
+                body.push_str(&format!("<CheckedTime>{}</CheckedTime>", now));
+                body.push_str("</StatusReport>");
+                body.push_str("</HealthCheckObservation>");
+            }
+        }
+        body.push_str("</HealthCheckObservations>");
         body.push_str("</GetHealthCheckLastFailureReasonResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }
@@ -2587,3 +2626,77 @@ impl Route53Service {
 #[path = "helpers.rs"]
 mod helpers;
 use helpers::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::HealthCheckConfig;
+    use crate::state::{Route53Accounts, StoredHealthCheck};
+
+    fn svc_with_health_check(id: &str) -> Route53Service {
+        let state = Arc::new(RwLock::new(Route53Accounts::default()));
+        {
+            let mut s = state.write();
+            let account = s.accounts.entry(DEFAULT_ACCOUNT.to_string()).or_default();
+            account.health_checks.insert(
+                id.to_string(),
+                StoredHealthCheck {
+                    id: id.to_string(),
+                    caller_reference: "ref".to_string(),
+                    version: 1,
+                    config: HealthCheckConfig::default(),
+                    created_time: Utc::now(),
+                    status_line: "Success: HTTP Status Code 200, OK.".to_string(),
+                    last_failure_reason: None,
+                },
+            );
+        }
+        Route53Service::new(state)
+    }
+
+    #[test]
+    fn set_health_check_status_flips_status_and_failure_reason() {
+        let svc = svc_with_health_check("hc-1");
+        assert!(svc.set_health_check_status(
+            "hc-1",
+            "Failure: Connection refused.".to_string(),
+            Some("Failure: connect() returned ECONNREFUSED".to_string()),
+        ));
+        let st = svc.state.read();
+        let hc = &st.accounts.get(DEFAULT_ACCOUNT).unwrap().health_checks["hc-1"];
+        assert_eq!(hc.status_line, "Failure: Connection refused.");
+        assert_eq!(
+            hc.last_failure_reason.as_deref().unwrap(),
+            "Failure: connect() returned ECONNREFUSED"
+        );
+    }
+
+    #[test]
+    fn set_health_check_status_returns_false_for_unknown_id() {
+        let svc = svc_with_health_check("hc-1");
+        assert!(!svc.set_health_check_status(
+            "ghost",
+            "Failure: connection refused.".to_string(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn set_health_check_status_preserves_existing_reason_when_none() {
+        let svc = svc_with_health_check("hc-1");
+        svc.set_health_check_status(
+            "hc-1",
+            "Failure: timeout".to_string(),
+            Some("Failure: connect() timed out".to_string()),
+        );
+        // Subsequent flip with None for reason should not clobber.
+        svc.set_health_check_status("hc-1", "Success: HTTP 200".to_string(), None);
+        let st = svc.state.read();
+        let hc = &st.accounts.get(DEFAULT_ACCOUNT).unwrap().health_checks["hc-1"];
+        assert_eq!(hc.status_line, "Success: HTTP 200");
+        assert_eq!(
+            hc.last_failure_reason.as_deref().unwrap(),
+            "Failure: connect() timed out"
+        );
+    }
+}

--- a/crates/fakecloud-route53/src/state.rs
+++ b/crates/fakecloud-route53/src/state.rs
@@ -89,6 +89,20 @@ pub struct StoredHealthCheck {
     pub version: i64,
     pub config: HealthCheckConfig,
     pub created_time: DateTime<Utc>,
+    /// Reported `Status` line for `GetHealthCheckStatus`. Defaults to
+    /// the canonical Route 53 healthy phrase. Flipped via the admin
+    /// endpoint at `PUT /_fakecloud/route53/health-checks/{id}/status`
+    /// so callers can simulate failover scenarios in tests.
+    #[serde(default = "default_health_status")]
+    pub status_line: String,
+    /// Last failure reason returned by `GetHealthCheckLastFailureReason`.
+    /// `None` when the check has never reported a failure.
+    #[serde(default)]
+    pub last_failure_reason: Option<String>,
+}
+
+fn default_health_status() -> String {
+    "Success: HTTP Status Code 200, OK.".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -1051,3 +1051,21 @@ pub struct CreateAdminResponse {
     pub account_id: String,
     pub arn: String,
 }
+
+/// Body for `PUT /_fakecloud/route53/health-checks/{id}/status`. The
+/// admin endpoint flips a stored Route 53 health check's reported
+/// status (and optionally the last-failure-reason observation) so
+/// tests can simulate failover scenarios without a live checker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Route53HealthCheckStatusRequest {
+    /// New `Status` line returned by `GetHealthCheckStatus`. Use
+    /// AWS's canonical phrases like `Success: HTTP Status Code 200, OK.`
+    /// for healthy or `Failure: Connection refused.` for unhealthy.
+    pub status: String,
+    /// Optional last-failure observation surfaced by
+    /// `GetHealthCheckLastFailureReason`. `None` leaves the prior
+    /// value intact.
+    #[serde(default)]
+    pub last_failure_reason: Option<String>,
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2001,8 +2001,10 @@ async fn main() {
     let cloudfront_service = CloudFrontService::new(cloudfront_state.clone());
     registry.register(Arc::new(cloudfront_service));
 
-    let route53_service = fakecloud_route53::Route53Service::new(route53_state.clone());
-    registry.register(Arc::new(route53_service));
+    let route53_service = Arc::new(fakecloud_route53::Route53Service::new(
+        route53_state.clone(),
+    ));
+    registry.register(route53_service.clone());
 
     let acm_service = fakecloud_acm::AcmService::new(acm_state.clone());
     registry.register(Arc::new(acm_service));
@@ -4637,6 +4639,28 @@ async fn main() {
                             &body.account_id,
                             &body.user_name,
                         ))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/route53/health-checks/{id}/status",
+            axum::routing::put({
+                let svc = route53_service.clone();
+                move |axum::extract::Path(id): axum::extract::Path<String>,
+                      axum::Json(body): axum::Json<types::Route53HealthCheckStatusRequest>| {
+                    let svc = svc.clone();
+                    async move {
+                        let ok = svc.set_health_check_status(
+                            &id,
+                            body.status,
+                            body.last_failure_reason,
+                        );
+                        if ok {
+                            axum::Json(serde_json::json!({"status": "ok"}))
+                        } else {
+                            axum::Json(serde_json::json!({"status": "not_found"}))
+                        }
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- \`GetHealthCheckStatus\` reads a stored \`status_line\` instead of always returning the canonical healthy phrase.
- \`GetHealthCheckLastFailureReason\` returns observations only when an admin-set reason exists.
- New admin endpoint: \`PUT /_fakecloud/route53/health-checks/{id}/status\` with body \`{status, lastFailureReason?}\` (typed via \`Route53HealthCheckStatusRequest\`) flips both fields so tests can simulate failover.
- Audit shard: \`U1\` in \`/tmp/parity_audit/REPORT.md\`.

## Test plan
- [x] \`cargo test -p fakecloud-route53 --lib\` (3 new tests cover flip, unknown id, preserve-reason-when-None)
- [x] \`cargo build -p fakecloud\` — admin endpoint wired
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin endpoint to control Route 53 health check status and last failure reason so tests can simulate failover. `GetHealthCheckStatus` and `GetHealthCheckLastFailureReason` now return stored values to better mirror AWS.

- **New Features**
  - New admin endpoint: PUT /_fakecloud/route53/health-checks/{id}/status in `fakecloud-server`. Body uses `Route53HealthCheckStatusRequest` with fields: status and optional lastFailureReason. Returns {"status":"ok"} or {"status":"not_found"}.
  - `GetHealthCheckStatus` in `fakecloud-route53` reads a stored status_line. Defaults to "Success: HTTP Status Code 200, OK.".
  - `GetHealthCheckLastFailureReason` returns observations only when a last failure reason exists. Empty list otherwise.
  - Data model change in `fakecloud-route53`: `StoredHealthCheck` adds status_line and last_failure_reason (with sensible defaults). Audit shard: U1 in /tmp/parity_audit/REPORT.md.

<sup>Written for commit 6ca3eca7cbdfafb78550a0248ae29ea69b739a66. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/925?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

