### PR TITLE
feat(cloudformation): real Fn::GetAtt resolution per resource type

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -20,6 +20,27 @@ use fakecloud_ssm::{SharedSsmState, SsmParameter};
 use crate::state::StackResource;
 use crate::template::ResourceDefinition;
 
+/// What a resource provisioner returns. The physical id is what `Ref` resolves
+/// to; `attributes` is what `Fn::GetAtt` resolves to (per-resource-type).
+pub struct ProvisionResult {
+    pub physical_id: String,
+    pub attributes: BTreeMap<String, String>,
+}
+
+impl ProvisionResult {
+    pub fn new(physical_id: impl Into<String>) -> Self {
+        Self {
+            physical_id: physical_id.into(),
+            attributes: BTreeMap::new(),
+        }
+    }
+
+    pub fn with(mut self, key: &str, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.to_string(), value.into());
+        self
+    }
+}
+
 /// Holds references to all service states so CloudFormation can provision resources.
 pub struct ResourceProvisioner {
     pub sqs_state: SharedSqsState,
@@ -50,9 +71,9 @@ impl ResourceProvisioner {
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
             "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
-            t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
-                self.create_custom_resource(resource)
-            }
+            t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
+                .create_custom_resource(resource)
+                .map(ProvisionResult::new),
             other => Err(format!("Unsupported resource type: {other}")),
         };
 
@@ -68,12 +89,13 @@ impl ResourceProvisioner {
             None
         };
 
-        result.map(|physical_id| StackResource {
+        result.map(|res| StackResource {
             logical_id: resource.logical_id.clone(),
-            physical_id,
+            physical_id: res.physical_id,
             resource_type: resource.resource_type.clone(),
             status: "CREATE_COMPLETE".to_string(),
             service_token,
+            attributes: res.attributes,
         })
     }
 
@@ -99,7 +121,7 @@ impl ResourceProvisioner {
 
     // --- SQS ---
 
-    fn create_sqs_queue(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_sqs_queue(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let queue_name = props
             .get("QueueName")
@@ -131,7 +153,7 @@ impl ResourceProvisioner {
         let queue = SqsQueue {
             queue_name: queue_name.to_string(),
             queue_url: queue_url.clone(),
-            arn,
+            arn: arn.clone(),
             created_at: Utc::now(),
             messages: std::collections::VecDeque::new(),
             inflight: Vec::new(),
@@ -150,7 +172,10 @@ impl ResourceProvisioner {
             .insert(queue_name.to_string(), queue_url.clone());
         state.queues.insert(queue_url.clone(), queue);
 
-        Ok(queue_url)
+        Ok(ProvisionResult::new(queue_url.clone())
+            .with("Arn", arn)
+            .with("QueueName", queue_name)
+            .with("QueueUrl", queue_url))
     }
 
     fn delete_sqs_queue(&self, physical_id: &str) -> Result<(), String> {
@@ -164,7 +189,7 @@ impl ResourceProvisioner {
 
     // --- SNS ---
 
-    fn create_sns_topic(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_sns_topic(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let topic_name = props
             .get("TopicName")
@@ -188,7 +213,9 @@ impl ResourceProvisioner {
         };
 
         state.topics.insert(topic_arn.clone(), topic);
-        Ok(topic_arn)
+        Ok(ProvisionResult::new(topic_arn.clone())
+            .with("TopicArn", topic_arn)
+            .with("TopicName", topic_name))
     }
 
     fn delete_sns_topic(&self, physical_id: &str) -> Result<(), String> {
@@ -204,7 +231,10 @@ impl ResourceProvisioner {
 
     // --- SNS Subscription ---
 
-    fn create_sns_subscription(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_sns_subscription(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let topic_arn = props
             .get("TopicArn")
@@ -241,7 +271,7 @@ impl ResourceProvisioner {
         };
 
         state.subscriptions.insert(sub_arn.clone(), subscription);
-        Ok(sub_arn)
+        Ok(ProvisionResult::new(sub_arn.clone()).with("Arn", sub_arn))
     }
 
     fn delete_sns_subscription(&self, physical_id: &str) -> Result<(), String> {
@@ -253,7 +283,10 @@ impl ResourceProvisioner {
 
     // --- SSM ---
 
-    fn create_ssm_parameter(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_ssm_parameter(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let name = props
             .get("Name")
@@ -303,7 +336,9 @@ impl ResourceProvisioner {
         };
 
         state.parameters.insert(name.to_string(), parameter);
-        Ok(name.to_string())
+        Ok(ProvisionResult::new(name)
+            .with("Type", param_type)
+            .with("Value", value))
     }
 
     fn delete_ssm_parameter(&self, physical_id: &str) -> Result<(), String> {
@@ -315,7 +350,7 @@ impl ResourceProvisioner {
 
     // --- IAM Role ---
 
-    fn create_iam_role(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_iam_role(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let role_name = props
             .get("RoleName")
@@ -350,7 +385,7 @@ impl ResourceProvisioner {
 
         let role = IamRole {
             role_name: role_name.to_string(),
-            role_id,
+            role_id: role_id.clone(),
             arn: arn.clone(),
             path: path.to_string(),
             assume_role_policy_document: assume_role_policy,
@@ -365,7 +400,9 @@ impl ResourceProvisioner {
         };
 
         state.roles.insert(role_name.to_string(), role);
-        Ok(arn)
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("RoleId", role_id))
     }
 
     fn delete_iam_role(&self, physical_id: &str) -> Result<(), String> {
@@ -387,7 +424,7 @@ impl ResourceProvisioner {
 
     // --- IAM Policy ---
 
-    fn create_iam_policy(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_iam_policy(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let policy_name = props
             .get("PolicyName")
@@ -445,7 +482,7 @@ impl ResourceProvisioner {
         };
 
         state.policies.insert(arn.clone(), policy);
-        Ok(arn)
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
     }
 
     fn delete_iam_policy(&self, physical_id: &str) -> Result<(), String> {
@@ -457,7 +494,7 @@ impl ResourceProvisioner {
 
     // --- S3 ---
 
-    fn create_s3_bucket(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_s3_bucket(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let bucket_name = props
             .get("BucketName")
@@ -466,9 +503,21 @@ impl ResourceProvisioner {
 
         let mut __s3_mas = self.s3_state.write();
         let state = __s3_mas.get_or_create(&self.account_id);
+        let region = state.region.clone();
         let bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
         state.buckets.insert(bucket_name.to_string(), bucket);
-        Ok(bucket_name.to_string())
+
+        let arn = format!("arn:aws:s3:::{bucket_name}");
+        let domain_name = format!("{bucket_name}.s3.amazonaws.com");
+        let regional_domain_name = format!("{bucket_name}.s3.{region}.amazonaws.com");
+        let dual_stack_domain_name = format!("{bucket_name}.s3.dualstack.{region}.amazonaws.com");
+        let website_url = format!("http://{bucket_name}.s3-website-{region}.amazonaws.com");
+        Ok(ProvisionResult::new(bucket_name)
+            .with("Arn", arn)
+            .with("DomainName", domain_name)
+            .with("RegionalDomainName", regional_domain_name)
+            .with("DualStackDomainName", dual_stack_domain_name)
+            .with("WebsiteURL", website_url))
     }
 
     fn delete_s3_bucket(&self, physical_id: &str) -> Result<(), String> {
@@ -480,7 +529,10 @@ impl ResourceProvisioner {
 
     // --- EventBridge ---
 
-    fn create_eventbridge_rule(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_eventbridge_rule(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let rule_name = props
             .get("Name")
@@ -549,7 +601,7 @@ impl ResourceProvisioner {
         state
             .rules
             .insert((event_bus_name.to_string(), rule_name.to_string()), rule);
-        Ok(arn)
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
     }
 
     fn delete_eventbridge_rule(&self, physical_id: &str) -> Result<(), String> {
@@ -569,7 +621,10 @@ impl ResourceProvisioner {
 
     // --- DynamoDB ---
 
-    fn create_dynamodb_table(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_dynamodb_table(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let table_name = props
             .get("TableName")
@@ -698,6 +753,7 @@ impl ResourceProvisioner {
         } else {
             None
         };
+        let stream_arn_attr = stream_arn.clone();
 
         let table = DynamoTable {
             name: table_name.to_string(),
@@ -733,7 +789,11 @@ impl ResourceProvisioner {
         };
 
         state.tables.insert(table_name.to_string(), table);
-        Ok(arn)
+        let mut result = ProvisionResult::new(arn.clone()).with("Arn", arn);
+        if let Some(stream_arn_value) = stream_arn_attr {
+            result = result.with("StreamArn", stream_arn_value);
+        }
+        Ok(result)
     }
 
     fn delete_dynamodb_table(&self, physical_id: &str) -> Result<(), String> {
@@ -753,7 +813,7 @@ impl ResourceProvisioner {
 
     // --- CloudWatch Logs ---
 
-    fn create_log_group(&self, resource: &ResourceDefinition) -> Result<String, String> {
+    fn create_log_group(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
         let log_group_name = props
             .get("LogGroupName")
@@ -792,7 +852,7 @@ impl ResourceProvisioner {
         state
             .log_groups
             .insert(log_group_name.to_string(), log_group);
-        Ok(arn)
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
     }
 
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -41,6 +41,7 @@ fn provision_stack_resources(
 ) -> Result<Vec<StackResource>, AwsServiceError> {
     let mut resources = Vec::new();
     let mut physical_ids: BTreeMap<String, String> = BTreeMap::new();
+    let mut attributes: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     let mut pending: Vec<&template::ResourceDefinition> = resource_defs.iter().collect();
     let max_passes = pending.len() + 1;
 
@@ -52,11 +53,12 @@ fn provision_stack_resources(
         let mut made_progress = false;
 
         for resource_def in pending {
-            let resolved_def = template::resolve_resource_properties(
+            let resolved_def = template::resolve_resource_properties_with_attrs(
                 resource_def,
                 template_body,
                 parameters,
                 &physical_ids,
+                &attributes,
             )
             .map_err(|e| {
                 AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
@@ -67,6 +69,10 @@ fn provision_stack_resources(
                     physical_ids.insert(
                         stack_resource.logical_id.clone(),
                         stack_resource.physical_id.clone(),
+                    );
+                    attributes.insert(
+                        stack_resource.logical_id.clone(),
+                        stack_resource.attributes.clone(),
                     );
                     resources.push(stack_resource);
                     made_progress = true;
@@ -80,11 +86,12 @@ fn provision_stack_resources(
             // No progress — report the first failure and rollback anything
             // we already created.
             let resource_def = pending[0];
-            let resolved_def = template::resolve_resource_properties(
+            let resolved_def = template::resolve_resource_properties_with_attrs(
                 resource_def,
                 template_body,
                 parameters,
                 &physical_ids,
+                &attributes,
             )
             .unwrap_or_else(|_| resource_def.clone());
             let err = provisioner.create_resource(&resolved_def).unwrap_err();
@@ -884,21 +891,27 @@ fn apply_resource_updates(
         .resources
         .retain(|r| new_logical_ids.contains(&r.logical_id));
 
-    // Build physical ID map from existing resources
+    // Build physical ID + attribute maps from existing resources
     let mut physical_ids: BTreeMap<String, String> = stack
         .resources
         .iter()
         .map(|r| (r.logical_id.clone(), r.physical_id.clone()))
         .collect();
+    let mut attributes: BTreeMap<String, BTreeMap<String, String>> = stack
+        .resources
+        .iter()
+        .map(|r| (r.logical_id.clone(), r.attributes.clone()))
+        .collect();
 
     // Create new resources
     for resource_def in new_resource_defs {
         if !old_logical_ids.contains(&resource_def.logical_id) {
-            let resolved_def = template::resolve_resource_properties(
+            let resolved_def = template::resolve_resource_properties_with_attrs(
                 resource_def,
                 template_body,
                 parameters,
                 &physical_ids,
+                &attributes,
             )
             .map_err(|e| {
                 format!(
@@ -912,6 +925,10 @@ fn apply_resource_updates(
                     physical_ids.insert(
                         stack_resource.logical_id.clone(),
                         stack_resource.physical_id.clone(),
+                    );
+                    attributes.insert(
+                        stack_resource.logical_id.clone(),
+                        stack_resource.attributes.clone(),
                     );
                     stack.resources.push(stack_resource);
                 }

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -12,6 +12,10 @@ pub struct StackResource {
     pub status: String,
     /// For custom resources, the Lambda ARN (ServiceToken) used for invocation.
     pub service_token: Option<String>,
+    /// Per-resource attributes resolvable via `Fn::GetAtt`. Populated at
+    /// provisioning time by each resource type's create handler.
+    #[serde(default)]
+    pub attributes: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -42,6 +42,23 @@ pub fn parse_template_with_physical_ids(
     parameters: &BTreeMap<String, String>,
     resource_physical_ids: &BTreeMap<String, String>,
 ) -> Result<ParsedTemplate, String> {
+    parse_template_with_resolution(
+        template_body,
+        parameters,
+        resource_physical_ids,
+        &BTreeMap::new(),
+    )
+}
+
+/// Parse a CloudFormation template, resolving `Ref` via `resource_physical_ids`
+/// and `Fn::GetAtt` via `resource_attributes` (keyed by logical id, then
+/// attribute name).
+pub fn parse_template_with_resolution(
+    template_body: &str,
+    parameters: &BTreeMap<String, String>,
+    resource_physical_ids: &BTreeMap<String, String>,
+    resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<ParsedTemplate, String> {
     let value: Value = if template_body.trim_start().starts_with('{') {
         serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
     } else {
@@ -77,6 +94,7 @@ pub fn parse_template_with_physical_ids(
             parameters,
             resources_obj,
             resource_physical_ids,
+            resource_attributes,
         );
 
         resources.push(ResourceDefinition {
@@ -99,6 +117,24 @@ pub fn resolve_resource_properties(
     parameters: &BTreeMap<String, String>,
     resource_physical_ids: &BTreeMap<String, String>,
 ) -> Result<ResourceDefinition, String> {
+    resolve_resource_properties_with_attrs(
+        resource,
+        template_body,
+        parameters,
+        resource_physical_ids,
+        &BTreeMap::new(),
+    )
+}
+
+/// Re-resolve a single resource definition's properties with updated physical
+/// IDs and attribute values for `Fn::GetAtt`.
+pub fn resolve_resource_properties_with_attrs(
+    resource: &ResourceDefinition,
+    template_body: &str,
+    parameters: &BTreeMap<String, String>,
+    resource_physical_ids: &BTreeMap<String, String>,
+    resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<ResourceDefinition, String> {
     let value: Value = if template_body.trim_start().starts_with('{') {
         serde_json::from_str(template_body).map_err(|e| format!("Invalid JSON template: {e}"))?
     } else {
@@ -116,7 +152,13 @@ pub fn resolve_resource_properties(
         .cloned()
         .unwrap_or(Value::Object(serde_json::Map::new()));
 
-    let resolved = resolve_refs(&raw_props, parameters, resources_obj, resource_physical_ids);
+    let resolved = resolve_refs(
+        &raw_props,
+        parameters,
+        resources_obj,
+        resource_physical_ids,
+        resource_attributes,
+    );
 
     Ok(ResourceDefinition {
         logical_id: resource.logical_id.clone(),
@@ -125,12 +167,13 @@ pub fn resolve_resource_properties(
     })
 }
 
-/// Resolve { "Ref": "param_name" } and { "Fn::GetAtt": [...] } in property values.
+/// Resolve `Ref`, `Fn::GetAtt`, `Fn::Join`, and `Fn::Sub` in property values.
 fn resolve_refs(
     value: &Value,
     parameters: &BTreeMap<String, String>,
     _resources: &serde_json::Map<String, Value>,
     resource_physical_ids: &BTreeMap<String, String>,
+    resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
 ) -> Value {
     match value {
         Value::Object(map) => {
@@ -158,6 +201,19 @@ fn resolve_refs(
                     return Value::String(ref_name.to_string());
                 }
             }
+            if let Some(getatt_val) = map.get("Fn::GetAtt") {
+                if let Some((logical_id, attr_name)) = parse_getatt(getatt_val) {
+                    if let Some(attrs) = resource_attributes.get(&logical_id) {
+                        if let Some(attr_value) = attrs.get(&attr_name) {
+                            return Value::String(attr_value.clone());
+                        }
+                    }
+                    // Resource not yet provisioned, or attribute unknown.
+                    // Surface a placeholder so the consumer can still string-format
+                    // it; multi-pass provisioning will retry once attributes land.
+                    return Value::String(format!("{logical_id}.{attr_name}"));
+                }
+            }
             if let Some(join_val) = map.get("Fn::Join") {
                 if let Some(arr) = join_val.as_array() {
                     if arr.len() == 2 {
@@ -171,6 +227,7 @@ fn resolve_refs(
                                         parameters,
                                         _resources,
                                         resource_physical_ids,
+                                        resource_attributes,
                                     );
                                     match resolved {
                                         Value::String(s) => s,
@@ -193,6 +250,12 @@ fn resolve_refs(
                     for (k, v) in resource_physical_ids {
                         result = result.replace(&format!("${{{k}}}"), v);
                     }
+                    // GetAtt-style substitutions: ${LogicalId.AttrName}
+                    for (logical, attrs) in resource_attributes {
+                        for (attr, value) in attrs {
+                            result = result.replace(&format!("${{{logical}.{attr}}}"), value);
+                        }
+                    }
                     return Value::String(result);
                 }
             }
@@ -201,17 +264,55 @@ fn resolve_refs(
             for (k, v) in map {
                 new_map.insert(
                     k.clone(),
-                    resolve_refs(v, parameters, _resources, resource_physical_ids),
+                    resolve_refs(
+                        v,
+                        parameters,
+                        _resources,
+                        resource_physical_ids,
+                        resource_attributes,
+                    ),
                 );
             }
             Value::Object(new_map)
         }
         Value::Array(arr) => Value::Array(
             arr.iter()
-                .map(|v| resolve_refs(v, parameters, _resources, resource_physical_ids))
+                .map(|v| {
+                    resolve_refs(
+                        v,
+                        parameters,
+                        _resources,
+                        resource_physical_ids,
+                        resource_attributes,
+                    )
+                })
                 .collect(),
         ),
         other => other.clone(),
+    }
+}
+
+/// Parse a `Fn::GetAtt` argument. Accepts either the array form
+/// `["LogicalId", "Attr"]` (also nested attribute paths joined with `.`)
+/// or the short string form `"LogicalId.Attr"`.
+fn parse_getatt(value: &Value) -> Option<(String, String)> {
+    match value {
+        Value::Array(arr) if arr.len() >= 2 => {
+            let logical_id = arr[0].as_str()?.to_string();
+            let parts: Vec<String> = arr[1..]
+                .iter()
+                .map(|v| match v {
+                    Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                })
+                .collect();
+            Some((logical_id, parts.join(".")))
+        }
+        Value::String(s) => {
+            let (logical_id, attr) = s.split_once('.')?;
+            Some((logical_id.to_string(), attr.to_string()))
+        }
+        _ => None,
     }
 }
 
@@ -438,6 +539,169 @@ Resources:
         let params = BTreeMap::new();
         let result = parse_template(r#"{"Resources":{"R":{"Properties":{}}}}"#, &params);
         assert!(result.is_err());
+    }
+
+    // ── Fn::GetAtt ──
+
+    #[test]
+    fn fn_getatt_resolves_attribute_in_array_form() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": { "QueueName": "q1" }
+                },
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "t1",
+                        "DataProtectionPolicy": {
+                            "Fn::GetAtt": ["MyQueue", "Arn"]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let mut attrs = BTreeMap::new();
+        let mut q_attrs = BTreeMap::new();
+        q_attrs.insert(
+            "Arn".to_string(),
+            "arn:aws:sqs:us-east-1:123456789012:q1".to_string(),
+        );
+        attrs.insert("MyQueue".to_string(), q_attrs);
+
+        let parsed =
+            parse_template_with_resolution(template, &BTreeMap::new(), &BTreeMap::new(), &attrs)
+                .unwrap();
+        let topic = parsed
+            .resources
+            .iter()
+            .find(|r| r.logical_id == "MyTopic")
+            .unwrap();
+        assert_eq!(
+            topic.properties["DataProtectionPolicy"],
+            Value::String("arn:aws:sqs:us-east-1:123456789012:q1".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_getatt_resolves_attribute_in_short_string_form() {
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": "t1",
+                        "PolicyArn": { "Fn::GetAtt": "MyQueue.Arn" }
+                    }
+                }
+            }
+        }"#;
+
+        let mut attrs = BTreeMap::new();
+        let mut q_attrs = BTreeMap::new();
+        q_attrs.insert(
+            "Arn".to_string(),
+            "arn:aws:sqs:us-east-1:123456789012:q1".to_string(),
+        );
+        attrs.insert("MyQueue".to_string(), q_attrs);
+
+        let parsed =
+            parse_template_with_resolution(template, &BTreeMap::new(), &BTreeMap::new(), &attrs)
+                .unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["PolicyArn"],
+            Value::String("arn:aws:sqs:us-east-1:123456789012:q1".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_getatt_unknown_resource_returns_placeholder() {
+        let template = r#"{
+            "Resources": {
+                "MyTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": { "Fn::GetAtt": ["MyQueue", "Arn"] }
+                    }
+                }
+            }
+        }"#;
+
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        // Unresolved GetAtt becomes a placeholder; multi-pass provisioning
+        // re-resolves once the target is known.
+        assert_eq!(
+            parsed.resources[0].properties["TopicName"],
+            Value::String("MyQueue.Arn".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_getatt_inside_fn_join_resolves() {
+        let template = r#"{
+            "Resources": {
+                "MyParam": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": "/app/q",
+                        "Type": "String",
+                        "Value": {
+                            "Fn::Join": [":", ["queue", { "Fn::GetAtt": ["MyQueue", "Arn"] }]]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let mut attrs = BTreeMap::new();
+        let mut q_attrs = BTreeMap::new();
+        q_attrs.insert(
+            "Arn".to_string(),
+            "arn:aws:sqs:us-east-1:123456789012:q1".to_string(),
+        );
+        attrs.insert("MyQueue".to_string(), q_attrs);
+
+        let parsed =
+            parse_template_with_resolution(template, &BTreeMap::new(), &BTreeMap::new(), &attrs)
+                .unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Value"],
+            Value::String("queue:arn:aws:sqs:us-east-1:123456789012:q1".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_sub_resolves_getatt_style_substitution() {
+        let template = r#"{
+            "Resources": {
+                "MyParam": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Name": "/app/q",
+                        "Type": "String",
+                        "Value": { "Fn::Sub": "Queue arn is ${MyQueue.Arn}" }
+                    }
+                }
+            }
+        }"#;
+
+        let mut attrs = BTreeMap::new();
+        let mut q_attrs = BTreeMap::new();
+        q_attrs.insert(
+            "Arn".to_string(),
+            "arn:aws:sqs:us-east-1:123456789012:q1".to_string(),
+        );
+        attrs.insert("MyQueue".to_string(), q_attrs);
+
+        let parsed =
+            parse_template_with_resolution(template, &BTreeMap::new(), &BTreeMap::new(), &attrs)
+                .unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Value"],
+            Value::String("Queue arn is arn:aws:sqs:us-east-1:123456789012:q1".to_string())
+        );
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/xml_responses.rs
+++ b/crates/fakecloud-cloudformation/src/xml_responses.rs
@@ -298,6 +298,7 @@ mod tests {
             resource_type: resource_type.to_string(),
             status: "CREATE_COMPLETE".to_string(),
             service_token: None,
+            attributes: std::collections::BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Each provisioner now returns `ProvisionResult { physical_id, attributes }` where attributes is a per-resource-type map populated at create time. The multi-pass provisioner threads the attribute map alongside the existing physical-id map so resources can resolve `{ "Fn::GetAtt": ["Logical","Attr"] }` to the actual attribute value (Arn, DomainName, StreamArn, etc.) in the same incremental order they are already provisioned.

Adds attributes per supported type:
- `AWS::SQS::Queue`: Arn, QueueName, QueueUrl
- `AWS::SNS::Topic`: TopicArn, TopicName
- `AWS::SNS::Subscription`: Arn
- `AWS::SSM::Parameter`: Type, Value
- `AWS::IAM::Role`: Arn, RoleId
- `AWS::IAM::Policy`: Arn
- `AWS::S3::Bucket`: Arn, DomainName, RegionalDomainName, DualStackDomainName, WebsiteURL
- `AWS::Events::Rule`: Arn
- `AWS::DynamoDB::Table`: Arn, StreamArn (when streams enabled)
- `AWS::Logs::LogGroup`: Arn

Also extends `Fn::Sub` to substitute `${LogicalId.AttrName}` placeholders, and parses both the array form `["Logical","Attr"]` and the short string form `"Logical.Attr"` of `Fn::GetAtt`.

## Test plan

- [x] Unit tests: array form + short string form Fn::GetAtt resolves
- [x] Unit tests: nested Fn::GetAtt inside Fn::Join resolves
- [x] Unit tests: \${Logical.Attr} substitution inside Fn::Sub
- [x] Unit tests: unresolved Fn::GetAtt becomes "Logical.Attr" placeholder so multi-pass retry can re-resolve once attributes land
- [x] Existing 78 cloudformation tests still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real CloudFormation `Fn::GetAtt` resolution by capturing per-resource attributes at create time and threading them through the multi-pass provisioner. Also extends `Fn::Sub` to resolve `${LogicalId.AttrName}` and supports both array and short-string `Fn::GetAtt` forms.

- **New Features**
  - `Fn::GetAtt` now resolves to actual values; unresolved lookups become `LogicalId.Attr` placeholders for later passes.
  - `Fn::Sub` supports `${LogicalId.AttrName}` substitutions.
  - Attributes are populated for SQS Queue, SNS Topic/Subscription, SSM Parameter, IAM Role/Policy, S3 Bucket, Events Rule, DynamoDB Table, and Logs LogGroup.

- **Refactors**
  - Provisioners return `ProvisionResult { physical_id, attributes }`; `StackResource` stores `attributes`.
  - Added `parse_template_with_resolution` and `resolve_resource_properties_with_attrs`; provisioning threads an attribute map alongside the physical ID map.

<sup>Written for commit 054e3cf38c5b1e941bc02d91891e2328a8fc71d5. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/926?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

