### PR TITLE
feat(ssm): enforce parameter Expiration policy on read

### DIFF
--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -13,6 +13,36 @@ use crate::state::{SsmParameter, SsmParameterVersion, SsmState};
 
 use super::{missing, SsmService, PARAMETER_VERSION_LIMIT};
 
+/// Parse the `Expiration` policy timestamp from the parameter's `Policies`
+/// JSON. The wire format is an array of `{Type, Version, Attributes:{...}}`
+/// objects; for `Type=Expiration` the `Attributes.Timestamp` field is an
+/// ISO 8601 string. Returns `None` for any malformed/missing data — we
+/// fail open rather than rejecting parameters with unparseable policies.
+fn extract_expiration(policies_str: &str) -> Option<chrono::DateTime<Utc>> {
+    let value: Value = serde_json::from_str(policies_str).ok()?;
+    for policy in value.as_array()? {
+        if policy["Type"].as_str() == Some("Expiration") {
+            if let Some(ts) = policy["Attributes"]["Timestamp"].as_str() {
+                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+                    return Some(dt.with_timezone(&Utc));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Returns true if the parameter has an `Expiration` policy whose timestamp
+/// is in the past. AWS deletes expired advanced-tier parameters at the
+/// scheduled time; we lazily check on every read instead of running a
+/// background sweeper.
+pub(crate) fn is_param_expired(p: &SsmParameter) -> bool {
+    p.policies
+        .as_deref()
+        .and_then(extract_expiration)
+        .is_some_and(|exp| exp < Utc::now())
+}
+
 /// Build the JSON `Parameter` body for a historical version of `param`.
 /// `Get*Parameter*` returns the same shape whether the lookup landed on
 /// the current version or pulled an older one out of the history list,
@@ -534,6 +564,9 @@ impl SsmService {
         // Handle ARN-style names directly (they contain many colons)
         if raw_name.starts_with("arn:aws:ssm:") {
             let param = resolve_param_by_name_or_arn(state, raw_name)?;
+            if is_param_expired(param) {
+                return Err(param_not_found(raw_name));
+            }
             return Ok(AwsResponse::ok_json(json!({
                 "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
             })));
@@ -549,6 +582,9 @@ impl SsmService {
         // Try looking up by name or by ARN - use raw_name in error for full context
         let param = resolve_param_by_name_or_arn(state, base_name)
             .map_err(|_| param_not_found(raw_name))?;
+        if is_param_expired(param) {
+            return Err(param_not_found(raw_name));
+        }
 
         match selector {
             ParamSelector::None => Ok(AwsResponse::ok_json(json!({
@@ -656,20 +692,26 @@ impl SsmService {
                     }
                     ParamSelector::None => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            parameters.push(self.render_param_to_json(
-                                param,
-                                true,
-                                with_decryption,
-                                &req.region,
-                                &req.account_id,
-                            ));
+                            if is_param_expired(param) {
+                                invalid.push(raw_name.to_string());
+                            } else {
+                                parameters.push(self.render_param_to_json(
+                                    param,
+                                    true,
+                                    with_decryption,
+                                    &req.region,
+                                    &req.account_id,
+                                ));
+                            }
                         } else {
                             invalid.push(raw_name.to_string());
                         }
                     }
                     ParamSelector::Version(ver) => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            if param.version == ver {
+                            if is_param_expired(param) {
+                                invalid.push(raw_name.to_string());
+                            } else if param.version == ver {
                                 parameters.push(self.render_param_to_json(
                                     param,
                                     true,
@@ -696,6 +738,10 @@ impl SsmService {
                     }
                     ParamSelector::Label(ref label) => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
+                            if is_param_expired(param) {
+                                invalid.push(raw_name.to_string());
+                                continue;
+                            }
                             let mut found = false;
                             for (ver, labels) in &param.labels {
                                 if labels.contains(label) {
@@ -780,6 +826,7 @@ impl SsmService {
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
+            .filter(|p| !is_param_expired(p))
             .filter(|p| param_matches_path(p, path, recursive))
             .filter(|p| apply_parameter_filters(p, filters.as_ref()))
             .collect();

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -4034,3 +4034,139 @@ fn ssm_delete_resource_policy_not_found() {
     );
     assert!(svc.delete_resource_policy(&req).is_err());
 }
+
+#[test]
+fn get_parameter_with_expired_policy_returns_not_found() {
+    let svc = make_service();
+    let past = "1990-01-01T00:00:00.000Z";
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": past }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/expired",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let req = make_request("GetParameter", json!({ "Name": "/expired" }));
+    let err = match svc.get_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected expired param to be hidden"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn get_parameter_with_future_expiration_still_returned() {
+    let svc = make_service();
+    let future = "9999-01-01T00:00:00.000Z";
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": future }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/notyet",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let req = make_request("GetParameter", json!({ "Name": "/notyet" }));
+    let resp = svc.get_parameter(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Parameter"]["Value"], "v1");
+}
+
+#[test]
+fn get_parameters_drops_expired_into_invalid_list() {
+    let svc = make_service();
+    // Live param
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/live", "Value": "ok", "Type": "String" }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    // Expired param
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "1990-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/dead",
+            "Value": "no",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let req = make_request("GetParameters", json!({ "Names": ["/live", "/dead"] }));
+    let resp = svc.get_parameters(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let params = body["Parameters"].as_array().unwrap();
+    let invalid = body["InvalidParameters"].as_array().unwrap();
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0]["Name"], "/live");
+    assert!(invalid.iter().any(|v| v == "/dead"));
+}
+
+#[test]
+fn get_parameters_by_path_skips_expired_entries() {
+    let svc = make_service();
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/app/live", "Value": "ok", "Type": "String" }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "1990-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/app/dead",
+            "Value": "no",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let req = make_request("GetParametersByPath", json!({ "Path": "/app" }));
+    let resp = svc.get_parameters_by_path(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let names: Vec<&str> = body["Parameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["Name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["/app/live"]);
+}


### PR DESCRIPTION
## Summary

Advanced-tier SSM parameters can carry a `Policies` array with `Type=Expiration` + `Attributes.Timestamp`. AWS removes expired parameters at the scheduled time; this PR enforces the same lazily on every read.

- `GetParameter`: returns `ParameterNotFound` for expired parameters
- `GetParameters`: drops expired ones into `InvalidParameters`
- `GetParametersByPath`: filters expired ones out of the result set

Other policy types (`NoChangeNotification`, `ExpirationNotification`) remain stored but no-op (no event delivery yet).

## Test plan

- [x] Expired param hidden from `GetParameter`
- [x] Future-dated expiration still returned
- [x] `GetParameters` reports expired in `InvalidParameters` and live ones in `Parameters`
- [x] `GetParametersByPath` skips expired entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the SSM Advanced-tier `Expiration` policy during reads so expired parameters are hidden or reported as invalid, matching AWS behavior. Other policy types are stored but do nothing for now.

- **New Features**
  - Lazily parse `Policies` for `Type=Expiration` and compare `Attributes.Timestamp` to now (fail-open on malformed JSON).
  - `GetParameter`: expired => `ParameterNotFound`.
  - `GetParameters`: expired => added to `InvalidParameters`.
  - `GetParametersByPath`: expired => filtered out.
  - `NoChangeNotification` and `ExpirationNotification` remain no-op (no events).

<sup>Written for commit 041f2567734a6dad1eda9ae5bb621647684742e3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/927?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

