### PR TITLE
feat(scheduler): evaluate cron against ScheduleExpressionTimezone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3126,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "chrono-tz",
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
@@ -4791,12 +4802,30 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6221,7 +6250,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ thiserror = "2"
 clap = { version = "4", features = ["derive", "env"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/fakecloud-scheduler/Cargo.toml
+++ b/crates/fakecloud-scheduler/Cargo.toml
@@ -13,6 +13,7 @@ fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/fakecloud-scheduler/src/expr.rs
+++ b/crates/fakecloud-scheduler/src/expr.rs
@@ -138,14 +138,53 @@ pub fn is_due(expr: &Expr, last_fired: Option<DateTime<Utc>>, now: DateTime<Utc>
 /// per-minute dedupe has to live in the ticker because we need to
 /// track fires across multiple calls without mutating the cron state.
 pub fn matches_cron(c: &CronExpr, now: DateTime<Utc>) -> bool {
+    matches_cron_fields(
+        c,
+        now.minute(),
+        now.hour(),
+        now.day(),
+        now.month(),
+        now.weekday().num_days_from_sunday(),
+    )
+}
+
+/// `matches_cron` evaluated against the local time in IANA timezone `tz`.
+/// AWS Scheduler interprets cron in `ScheduleExpressionTimezone` rather
+/// than UTC; unknown names fall back to UTC so we never silently lose a
+/// schedule (the service layer rejects bad names at create time).
+pub fn matches_cron_in_tz(c: &CronExpr, now: DateTime<Utc>, tz: &str) -> bool {
+    match tz.parse::<chrono_tz::Tz>() {
+        Ok(tz) => {
+            let local = now.with_timezone(&tz);
+            matches_cron_fields(
+                c,
+                local.minute(),
+                local.hour(),
+                local.day(),
+                local.month(),
+                local.weekday().num_days_from_sunday(),
+            )
+        }
+        Err(_) => matches_cron(c, now),
+    }
+}
+
+fn matches_cron_fields(
+    c: &CronExpr,
+    minute: u32,
+    hour: u32,
+    day: u32,
+    month: u32,
+    day_of_week: u32,
+) -> bool {
     let match_field = |f: &CronField, actual: u32| -> bool {
         matches!(f, CronField::Any) || matches!(f, CronField::Value(v) if *v == actual)
     };
-    match_field(&c.minute, now.minute())
-        && match_field(&c.hour, now.hour())
-        && match_field(&c.day_of_month, now.day())
-        && match_field(&c.month, now.month())
-        && match_field(&c.day_of_week, now.weekday().num_days_from_sunday())
+    match_field(&c.minute, minute)
+        && match_field(&c.hour, hour)
+        && match_field(&c.day_of_month, day)
+        && match_field(&c.month, month)
+        && match_field(&c.day_of_week, day_of_week)
 }
 
 #[cfg(test)]
@@ -207,6 +246,32 @@ mod tests {
         assert!(parse("every day at noon").is_none());
         assert!(parse("").is_none());
         assert!(parse("at").is_none());
+    }
+
+    #[test]
+    fn matches_cron_in_tz_uses_local_hour() {
+        // 12:00 UTC == 04:00 America/Los_Angeles in winter.
+        // A schedule of "cron(0 4 * * ? *)" in LA tz must match,
+        // but the same schedule against the UTC-only matcher must miss.
+        let now = Utc.with_ymd_and_hms(2026, 1, 15, 12, 0, 0).unwrap();
+        let cron = parse("cron(0 4 * * ? *)").unwrap();
+        let cron = match cron {
+            Expr::Cron(c) => c,
+            _ => panic!("expected Cron"),
+        };
+        assert!(matches_cron_in_tz(&cron, now, "America/Los_Angeles"));
+        assert!(!matches_cron(&cron, now));
+    }
+
+    #[test]
+    fn matches_cron_in_tz_falls_back_to_utc_for_unknown_zone() {
+        // Hour 12 UTC matches "cron(0 12 * * ? *)" if tz is unparseable.
+        let now = Utc.with_ymd_and_hms(2026, 1, 15, 12, 0, 0).unwrap();
+        let cron = match parse("cron(0 12 * * ? *)").unwrap() {
+            Expr::Cron(c) => c,
+            _ => panic!("expected Cron"),
+        };
+        assert!(matches_cron_in_tz(&cron, now, "Not/A_Real_Zone"));
     }
 
     #[test]

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -73,10 +73,12 @@ impl Ticker {
                     let Some(expr) = expr::parse(&sched.schedule_expression) else {
                         continue;
                     };
+                    let tz = sched.schedule_expression_timezone.clone();
                     if !is_due_with_dedup(
                         &expr,
                         sched.last_fired,
                         now,
+                        tz.as_deref(),
                         &(account_id.clone(), key.clone()),
                         cron_last_minute,
                     ) {
@@ -158,7 +160,10 @@ fn post_fire_action(expr: &Expr, schedule: &crate::state::Schedule) -> PostFire 
 
 /// Identity of the last minute-slot a cron schedule fired in. Keyed
 /// by full (year, ordinal, hour, minute) so subsequent days of the
-/// same (hour, minute) are treated as fresh fires.
+/// same (hour, minute) are treated as fresh fires. The fields come
+/// from the schedule's local timezone (or UTC when no tz is set) so
+/// a cron firing at local midnight dedupes across the whole 24-hour
+/// window even when UTC has already rolled over.
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct CronFireStamp {
     year: i32,
@@ -168,12 +173,27 @@ struct CronFireStamp {
 }
 
 impl CronFireStamp {
-    fn from(now: DateTime<Utc>) -> Self {
+    fn from_utc(now: DateTime<Utc>) -> Self {
         Self {
             year: now.year(),
             ordinal: now.ordinal(),
             hour: now.hour(),
             minute: now.minute(),
+        }
+    }
+
+    fn from_local(now: DateTime<Utc>, tz: &str) -> Self {
+        match tz.parse::<chrono_tz::Tz>() {
+            Ok(tz) => {
+                let local = now.with_timezone(&tz);
+                Self {
+                    year: local.year(),
+                    ordinal: local.ordinal(),
+                    hour: local.hour(),
+                    minute: local.minute(),
+                }
+            }
+            Err(_) => Self::from_utc(now),
         }
     }
 }
@@ -182,15 +202,23 @@ fn is_due_with_dedup(
     expr: &Expr,
     last_fired: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
+    tz: Option<&str>,
     key: &(String, ScheduleKey),
     cron_last_minute: &mut HashMap<(String, ScheduleKey), CronFireStamp>,
 ) -> bool {
     match expr {
         Expr::Cron(c) => {
-            if !expr::matches_cron(c, now) {
+            let matched = match tz {
+                Some(tz) => expr::matches_cron_in_tz(c, now, tz),
+                None => expr::matches_cron(c, now),
+            };
+            if !matched {
                 return false;
             }
-            let current = CronFireStamp::from(now);
+            let current = match tz {
+                Some(tz) => CronFireStamp::from_local(now, tz),
+                None => CronFireStamp::from_utc(now),
+            };
             if cron_last_minute.get(key) == Some(&current) {
                 return false;
             }


### PR DESCRIPTION
## Summary

EventBridge Scheduler interprets cron expressions in the `ScheduleExpressionTimezone` rather than UTC. Previously the ticker matched cron fields against `Utc::now()` unconditionally, so `cron(0 4 * * ? *)` with `ScheduleExpressionTimezone=America/Los_Angeles` would never fire at 04:00 LA, only at 04:00 UTC.

Adds `matches_cron_in_tz(c, now, tz_name)` using `chrono-tz` to resolve IANA names. The ticker passes the schedule's tz when present and falls back to UTC otherwise. `CronFireStamp` (the per-minute dedupe key) also moves to local fields so the dedupe window aligns with the local minute-slot.

## Test plan

- [x] `matches_cron_in_tz` matches cron(0 4) at 12:00 UTC for LA tz, doesn't match the same cron in UTC
- [x] Unknown tz name falls back to UTC matcher

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evaluate cron expressions in the schedule’s `ScheduleExpressionTimezone` instead of always UTC to match EventBridge behavior. Also align per-minute dedupe to the schedule’s local minute.

- **Bug Fixes**
  - Added `matches_cron_in_tz` using `chrono-tz`; ticker passes the schedule’s timezone and falls back to UTC for missing/unknown zones.
  - `CronFireStamp` now uses local year/ordinal/hour/minute so dedupe matches the local minute slot.
  - Added tests for timezone matching and unknown-zone fallback.

- **Dependencies**
  - Added `chrono-tz`.

<sup>Written for commit cc67a49c8b438ca6139f2e56a8a8939331dff760. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

