### PR TITLE
feat(dynamodb): DescribeEndpoints + DescribeLimits become region-aware

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/streams.rs
+++ b/crates/fakecloud-dynamodb/src/service/streams.rs
@@ -12,25 +12,30 @@ impl DynamoDbService {
 
     pub(super) fn describe_endpoints(
         &self,
-        _req: &AwsRequest,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         Self::ok_json(json!({
             "Endpoints": [{
-                "Address": "dynamodb.us-east-1.amazonaws.com",
+                "Address": format!("dynamodb.{}.amazonaws.com", req.region),
                 "CachePeriodInMinutes": 1440
             }]
         }))
     }
 
-    pub(super) fn describe_limits(
-        &self,
-        _req: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
+    pub(super) fn describe_limits(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        // Smaller commercial regions cap per-account capacity at 40k while
+        // the major ones (us-east-1 etc.) sit at 80k. Per-table caps stay
+        // at 40k everywhere.
+        let account_cap = match req.region.as_str() {
+            "ap-south-1" | "ap-northeast-2" | "ap-southeast-1" | "ap-southeast-2"
+            | "ca-central-1" | "eu-central-1" | "eu-north-1" | "sa-east-1" | "us-west-1" => 40_000,
+            _ => 80_000,
+        };
         Self::ok_json(json!({
-            "AccountMaxReadCapacityUnits": 80000,
-            "AccountMaxWriteCapacityUnits": 80000,
-            "TableMaxReadCapacityUnits": 40000,
-            "TableMaxWriteCapacityUnits": 40000
+            "AccountMaxReadCapacityUnits": account_cap,
+            "AccountMaxWriteCapacityUnits": account_cap,
+            "TableMaxReadCapacityUnits": 40_000,
+            "TableMaxWriteCapacityUnits": 40_000
         }))
     }
 

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -627,21 +627,38 @@ fn resource_policy_lifecycle() {
 }
 
 #[test]
-fn describe_endpoints() {
+fn describe_endpoints_uses_request_region() {
     let svc = make_service();
-    let req = make_request("DescribeEndpoints", json!({}));
+    let mut req = make_request("DescribeEndpoints", json!({}));
+    req.region = "eu-west-1".to_string();
     let resp = svc.describe_endpoints(&req).unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["Endpoints"][0]["Address"],
+        "dynamodb.eu-west-1.amazonaws.com"
+    );
     assert_eq!(body["Endpoints"][0]["CachePeriodInMinutes"], 1440);
 }
 
 #[test]
-fn describe_limits() {
+fn describe_limits_default_account_cap() {
     let svc = make_service();
     let req = make_request("DescribeLimits", json!({}));
     let resp = svc.describe_limits(&req).unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert_eq!(body["TableMaxReadCapacityUnits"], 40000);
+    assert_eq!(body["AccountMaxReadCapacityUnits"], 80_000);
+    assert_eq!(body["TableMaxReadCapacityUnits"], 40_000);
+}
+
+#[test]
+fn describe_limits_smaller_region_lower_cap() {
+    let svc = make_service();
+    let mut req = make_request("DescribeLimits", json!({}));
+    req.region = "ap-south-1".to_string();
+    let resp = svc.describe_limits(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["AccountMaxReadCapacityUnits"], 40_000);
+    assert_eq!(body["AccountMaxWriteCapacityUnits"], 40_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`DescribeEndpoints` was emitting hardcoded `dynamodb.us-east-1.amazonaws.com` regardless of the caller's region; SDKs that bind to that endpoint when configured for non-us-east-1 saw routing failures. It now uses `req.region`.

`DescribeLimits` returned 80k account capacity unconditionally. Real DynamoDB caps account capacity at 40k in the smaller commercial regions (`ap-south-1`, `ap-northeast-2`, `ap-southeast-1/2`, `ca-central-1`, `eu-central-1`, `eu-north-1`, `sa-east-1`, `us-west-1`) and 80k in the rest. Per-table limits stay at 40k everywhere.

## Test plan

- [x] `DescribeEndpoints` echoes the request region in the address
- [x] Default region returns 80k account caps
- [x] `ap-south-1` returns 40k account caps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make DynamoDB `DescribeEndpoints` and `DescribeLimits` region-aware to match AWS behavior. Fixes wrong endpoint for non‑`us-east-1` and returns correct account capacity (40k in smaller regions, 80k elsewhere); per-table limits remain 40k.

- **Bug Fixes**
  - `DescribeEndpoints`: builds `dynamodb.<region>.amazonaws.com` from `req.region` to prevent routing failures outside `us-east-1`.
  - `DescribeLimits`: sets account caps to 40k in smaller regions (`ap-south-1`, `ap-northeast-2`, `ap-southeast-1/2`, `ca-central-1`, `eu-central-1`, `eu-north-1`, `sa-east-1`, `us-west-1`), else 80k; per-table caps stay 40k.

<sup>Written for commit 5569318d211a43ca56f2b929f9cdbc468758de1d. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/929?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

