### PR TITLE
feat(eventbridge): add suffix / equals-ignore-case / cidr / wildcard / $or filter operators

### DIFF
--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -315,10 +315,9 @@ pub(crate) fn matches_pattern(
         Err(_) => return false,
     };
 
-    let pattern_obj = match pattern.as_object() {
-        Some(o) => o,
-        None => return false,
-    };
+    if !pattern.is_object() {
+        return false;
+    }
 
     let detail_value: Value = serde_json::from_str(detail).unwrap_or(json!({}));
     let event = json!({
@@ -330,20 +329,23 @@ pub(crate) fn matches_pattern(
         "resources": resources,
     });
 
-    for (key, pattern_value) in pattern_obj {
-        let event_value = &event[key];
-        if !matches_value(pattern_value, event_value) {
-            return false;
-        }
-    }
-
-    true
+    matches_value(&pattern, &event)
 }
 
 pub(crate) fn matches_value(pattern: &Value, event_value: &Value) -> bool {
     match pattern {
         Value::Object(obj) => {
+            // `$or` is a sibling-level alternation: any alternative pattern
+            // matched against this same event level passes the whole object.
+            if let Some(Value::Array(alternatives)) = obj.get("$or") {
+                return alternatives
+                    .iter()
+                    .any(|alt| matches_value(alt, event_value));
+            }
             for (key, sub_pattern) in obj {
+                if key == "$or" {
+                    continue;
+                }
                 let sub_value = &event_value[key];
                 if !matches_value(sub_pattern, sub_value) {
                     return false;
@@ -362,6 +364,30 @@ pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool 
             if let Some(prefix_val) = obj.get("prefix") {
                 if let (Some(prefix), Some(actual)) = (prefix_val.as_str(), event_value.as_str()) {
                     return actual.starts_with(prefix);
+                }
+                return false;
+            }
+            if let Some(suffix_val) = obj.get("suffix") {
+                if let (Some(suffix), Some(actual)) = (suffix_val.as_str(), event_value.as_str()) {
+                    return actual.ends_with(suffix);
+                }
+                return false;
+            }
+            if let Some(eqic_val) = obj.get("equals-ignore-case") {
+                if let (Some(expected), Some(actual)) = (eqic_val.as_str(), event_value.as_str()) {
+                    return expected.eq_ignore_ascii_case(actual);
+                }
+                return false;
+            }
+            if let Some(cidr_val) = obj.get("cidr") {
+                if let (Some(cidr), Some(actual)) = (cidr_val.as_str(), event_value.as_str()) {
+                    return cidr_matches(cidr, actual);
+                }
+                return false;
+            }
+            if let Some(wild_val) = obj.get("wildcard") {
+                if let (Some(pattern), Some(actual)) = (wild_val.as_str(), event_value.as_str()) {
+                    return wildcard_matches(pattern, actual);
                 }
                 return false;
             }
@@ -385,6 +411,94 @@ pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool 
         }
         _ => values_equal(pattern_elem, event_value),
     }
+}
+
+/// `wildcard` matcher: `*` matches any run of characters (including empty);
+/// `\*` is a literal asterisk.
+pub(crate) fn wildcard_matches(pattern: &str, actual: &str) -> bool {
+    let mut segments: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                current.push(next);
+            }
+        } else if c == '*' {
+            segments.push(std::mem::take(&mut current));
+        } else {
+            current.push(c);
+        }
+    }
+    segments.push(current);
+
+    if segments.len() == 1 {
+        return segments[0] == actual;
+    }
+
+    let mut pos = 0;
+    let first = &segments[0];
+    if !actual[pos..].starts_with(first.as_str()) {
+        return false;
+    }
+    pos += first.len();
+
+    let last_idx = segments.len() - 1;
+    for (i, seg) in segments.iter().enumerate().skip(1) {
+        if i == last_idx {
+            // The trailing segment must match the tail.
+            if !actual[pos..].ends_with(seg.as_str()) {
+                return false;
+            }
+            return actual.len().saturating_sub(pos) >= seg.len();
+        }
+        match actual[pos..].find(seg.as_str()) {
+            Some(idx) => pos += idx + seg.len(),
+            None => return false,
+        }
+    }
+    true
+}
+
+/// IPv4 CIDR membership test for the `cidr` filter.
+pub(crate) fn cidr_matches(cidr: &str, actual: &str) -> bool {
+    let (net_str, prefix_str) = match cidr.split_once('/') {
+        Some(parts) => parts,
+        None => return false,
+    };
+    let prefix: u32 = match prefix_str.parse() {
+        Ok(p) if p <= 32 => p,
+        _ => return false,
+    };
+    let net = match parse_ipv4(net_str) {
+        Some(n) => n,
+        None => return false,
+    };
+    let value = match parse_ipv4(actual) {
+        Some(v) => v,
+        None => return false,
+    };
+    if prefix == 0 {
+        return true;
+    }
+    let mask = u32::MAX << (32 - prefix);
+    (net & mask) == (value & mask)
+}
+
+fn parse_ipv4(s: &str) -> Option<u32> {
+    let mut parts = s.split('.');
+    let mut result: u32 = 0;
+    for _ in 0..4 {
+        let octet: u32 = parts.next()?.parse().ok()?;
+        if octet > 255 {
+            return None;
+        }
+        result = (result << 8) | octet;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(result)
 }
 
 /// For each archive on `event_bus_name` whose event pattern matches the

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2937,3 +2937,89 @@ fn list_endpoints_empty_ok() {
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert!(body["Endpoints"].is_array());
 }
+
+// ── filter operators (K8) ──
+
+#[test]
+fn pattern_matches_suffix_operator() {
+    assert!(test_matches(
+        Some(r#"{"source": [{"suffix": ".prod"}]}"#),
+        "my.app.prod",
+        "T",
+        "{}"
+    ));
+    assert!(!test_matches(
+        Some(r#"{"source": [{"suffix": ".prod"}]}"#),
+        "my.app.dev",
+        "T",
+        "{}"
+    ));
+}
+
+#[test]
+fn pattern_matches_equals_ignore_case_operator() {
+    assert!(test_matches(
+        Some(r#"{"detail-type": [{"equals-ignore-case": "ORDER"}]}"#),
+        "x",
+        "Order",
+        "{}"
+    ));
+    assert!(!test_matches(
+        Some(r#"{"detail-type": [{"equals-ignore-case": "ORDER"}]}"#),
+        "x",
+        "Shipment",
+        "{}"
+    ));
+}
+
+#[test]
+fn pattern_matches_cidr_operator() {
+    assert!(test_matches(
+        Some(r#"{"detail": {"ip": [{"cidr": "10.0.0.0/8"}]}}"#),
+        "x",
+        "T",
+        r#"{"ip": "10.5.5.5"}"#
+    ));
+    assert!(!test_matches(
+        Some(r#"{"detail": {"ip": [{"cidr": "10.0.0.0/8"}]}}"#),
+        "x",
+        "T",
+        r#"{"ip": "192.168.1.1"}"#
+    ));
+}
+
+#[test]
+fn pattern_matches_wildcard_operator() {
+    assert!(test_matches(
+        Some(r#"{"source": [{"wildcard": "*.prod.*"}]}"#),
+        "service.prod.us-east-1",
+        "T",
+        "{}"
+    ));
+    assert!(!test_matches(
+        Some(r#"{"source": [{"wildcard": "*.prod.*"}]}"#),
+        "service.dev.us-east-1",
+        "T",
+        "{}"
+    ));
+    // Anchored prefix-suffix
+    assert!(test_matches(
+        Some(r#"{"source": [{"wildcard": "svc.*.app"}]}"#),
+        "svc.x.y.app",
+        "T",
+        "{}"
+    ));
+}
+
+#[test]
+fn pattern_matches_or_alternation() {
+    let pat = Some(
+        r#"{"$or": [
+            {"source": ["a.app"]},
+            {"detail-type": ["Special"]}
+        ]}"#,
+    );
+    assert!(test_matches(pat, "a.app", "Anything", "{}"));
+    assert!(test_matches(pat, "other.app", "Special", "{}"));
+    assert!(!test_matches(pat, "other.app", "Other", "{}"));
+}


### PR DESCRIPTION
## Summary

Real EventBridge supports more filter operators than fakecloud was modelling. Adds:

- `suffix` — string ends-with
- `equals-ignore-case` — ASCII-insensitive equality
- `cidr` — IPv4 CIDR membership
- `wildcard` — `*` glob with `\*` escape
- `$or` — sibling-level alternation that any-matches the same event scope

`matches_pattern` now reuses `matches_value`, so `$or` works at any nesting depth (top-level event keys, inside `detail.{...}`, etc.) instead of only the entry point.

## Test plan

- [x] `suffix` matches `.prod` and rejects `.dev`
- [x] `equals-ignore-case` matches `Order` against `ORDER`
- [x] `cidr` matches `10.5.5.5` against `10.0.0.0/8` and rejects `192.168.1.1`
- [x] `wildcard` matches `*.prod.*` against `service.prod.us-east-1`, with prefix-suffix anchoring
- [x] `$or` selects either alternative branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `suffix`, `equals-ignore-case`, `cidr`, `wildcard`, and `$or` filters for EventBridge patterns, and update matching so `$or` works at any depth.

- **New Features**
  - New filters: `suffix` (ends-with), `equals-ignore-case` (ASCII case-insensitive), `cidr` (IPv4 CIDR), `wildcard` (`*` with `\*` escape), `$or`.
  - `wildcard` is anchored to prefix/suffix.

- **Refactors**
  - `matches_pattern` now delegates to `matches_value`, enabling `$or` at any nesting level (top-level keys, `detail`, etc.).

<sup>Written for commit 4ddadaa88b7f1a292eb104fc74db7dd5c13819a9. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/930?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

