### PR TITLE
fix(ecr): GetLifecyclePolicy returns the actual lastEvaluatedAt

### DIFF
--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1330,6 +1330,7 @@ impl EcrService {
             repo.images.remove(digest);
             repo.image_tags.retain(|_, d| d != digest);
         }
+        repo.lifecycle_policy_last_evaluated_at = Some(Utc::now());
         let registry_id = repo.registry_id.clone();
         Ok(AwsResponse::ok_json(json!({
             "registryId": registry_id,
@@ -1354,11 +1355,15 @@ impl EcrService {
             .lifecycle_policy
             .clone()
             .ok_or_else(|| lifecycle_policy_not_found(&name))?;
+        let last_eval = repo
+            .lifecycle_policy_last_evaluated_at
+            .map(|t| t.timestamp())
+            .unwrap_or(0);
         Ok(AwsResponse::ok_json(json!({
             "registryId": repo.registry_id,
             "repositoryName": name,
             "lifecyclePolicyText": policy,
-            "lastEvaluatedAt": Utc::now().timestamp(),
+            "lastEvaluatedAt": last_eval,
         })))
     }
 
@@ -1381,12 +1386,17 @@ impl EcrService {
             .lifecycle_policy
             .take()
             .ok_or_else(|| lifecycle_policy_not_found(&name))?;
+        let last_eval = repo
+            .lifecycle_policy_last_evaluated_at
+            .take()
+            .map(|t| t.timestamp())
+            .unwrap_or(0);
         let registry_id = repo.registry_id.clone();
         Ok(AwsResponse::ok_json(json!({
             "registryId": registry_id,
             "repositoryName": name,
             "lifecyclePolicyText": policy,
-            "lastEvaluatedAt": Utc::now().timestamp(),
+            "lastEvaluatedAt": last_eval,
         })))
     }
 

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -121,6 +121,12 @@ pub struct Repository {
     pub policy: Option<String>,
     /// Repository-level lifecycle policy document JSON.
     pub lifecycle_policy: Option<String>,
+    /// Last time the lifecycle policy was evaluated against this
+    /// repository's images. `None` until the policy has been applied
+    /// at least once. Surfaced through `GetLifecyclePolicy`'s
+    /// `lastEvaluatedAt` field.
+    #[serde(default)]
+    pub lifecycle_policy_last_evaluated_at: Option<DateTime<Utc>>,
     /// Per-image scan findings, keyed by manifest digest.
     #[serde(default)]
     pub scan_findings: BTreeMap<String, ImageScanFindings>,
@@ -164,6 +170,7 @@ impl Repository {
             tags: BTreeMap::new(),
             policy: None,
             lifecycle_policy: None,
+            lifecycle_policy_last_evaluated_at: None,
             scan_findings: BTreeMap::new(),
             images: BTreeMap::new(),
             image_tags: BTreeMap::new(),


### PR DESCRIPTION
## Summary

Previously every call to `GetLifecyclePolicy` returned a fresh `Utc::now()` timestamp regardless of when the policy was actually applied. `Repository` now stores `lifecycle_policy_last_evaluated_at`, which `PutLifecyclePolicy` sets to the moment it ran the policy + pruned matching images. `DeleteLifecyclePolicy` clears the timestamp alongside the policy.

## Test plan

- [x] Existing ECR tests still pass (default `None` value works because `Repository::new` initializes it)
- [x] `lastEvaluatedAt` is now sourced from the stored value rather than synthesized at read time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ECR `GetLifecyclePolicy` to return the real `lastEvaluatedAt` based on when the lifecycle policy ran. Add `lifecycle_policy_last_evaluated_at` to the repository; set it in `PutLifecyclePolicy`, return it in `GetLifecyclePolicy`, and clear it in `DeleteLifecyclePolicy`.

<sup>Written for commit b07c65afbd8480ed71c7e84bcb6d3d2c40433936. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/933?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

