### PR TITLE
feat(sqs): emit MD5OfMessageSystemAttributes on SendMessage

### DIFF
--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -217,6 +217,7 @@ pub(crate) fn process_batch_send_entry(
     };
 
     let message_attributes = parse_message_attributes(entry);
+    let system_attributes = parse_message_system_attributes(entry);
 
     let sequence_number = if cfg.is_fifo {
         let seq = queue.next_sequence_number;
@@ -230,6 +231,11 @@ pub(crate) fn process_batch_send_entry(
         None
     } else {
         Some(md5_of_message_attributes(&message_attributes))
+    };
+    let md5_of_system_attrs = if system_attributes.is_empty() {
+        None
+    } else {
+        Some(md5_of_message_system_attributes(&system_attributes))
     };
 
     let msg = SqsMessage {
@@ -258,6 +264,9 @@ pub(crate) fn process_batch_send_entry(
     }
     if let Some(md5) = &md5_of_attrs {
         entry_resp["MD5OfMessageAttributes"] = json!(md5);
+    }
+    if let Some(md5) = &md5_of_system_attrs {
+        entry_resp["MD5OfMessageSystemAttributes"] = json!(md5);
     }
     queue.messages.push_back(msg);
     Ok(BatchEntryOutcome::Success(entry_resp))
@@ -1173,6 +1182,29 @@ pub(crate) fn find_message_id_for_receipt(
         }
     }
     None
+}
+
+/// MD5 of message system attributes per AWS specification. System
+/// attributes (e.g. `AWSTraceHeader`) are always typed as `String`, so
+/// the wire format is the same shape as `md5_of_message_attributes`
+/// with transport type 1 and `String` data type for each entry.
+pub(crate) fn md5_of_message_system_attributes(attrs: &BTreeMap<String, String>) -> String {
+    use md5::Digest;
+    let mut sorted: Vec<(&String, &String)> = attrs.iter().collect();
+    sorted.sort_by_key(|(k, _)| k.as_str());
+
+    let mut hasher = Md5::new();
+    for (name, value) in sorted {
+        hasher.update((name.len() as u32).to_be_bytes());
+        hasher.update(name.as_bytes());
+        let data_type = "String";
+        hasher.update((data_type.len() as u32).to_be_bytes());
+        hasher.update(data_type.as_bytes());
+        hasher.update([1u8]); // STRING transport type
+        hasher.update((value.len() as u32).to_be_bytes());
+        hasher.update(value.as_bytes());
+    }
+    format!("{:032x}", hasher.finalize())
 }
 
 /// Parse MessageSystemAttributes (e.g., AWSTraceHeader) from the request body.

--- a/crates/fakecloud-sqs/src/service.rs
+++ b/crates/fakecloud-sqs/src/service.rs
@@ -1014,6 +1014,11 @@ impl SqsService {
         } else {
             Some(md5_of_message_attributes(&message_attributes))
         };
+        let md5_of_system_attrs = if system_attributes.is_empty() {
+            None
+        } else {
+            Some(md5_of_message_system_attributes(&system_attributes))
+        };
         // Validate delay seconds range before acquiring lock
         let raw_delay = val_as_i64(&body["DelaySeconds"]);
         if let Some(d) = raw_delay {
@@ -1074,6 +1079,9 @@ impl SqsService {
                         });
                         if let Some(ref md5) = md5_of_attrs {
                             resp["MD5OfMessageAttributes"] = json!(md5);
+                        }
+                        if let Some(ref md5) = md5_of_system_attrs {
+                            resp["MD5OfMessageSystemAttributes"] = json!(md5);
                         }
                         return Ok(sqs_response("SendMessage", resp, &request_id, is_query));
                     }
@@ -1170,6 +1178,9 @@ impl SqsService {
         }
         if let Some(md5) = &md5_of_attrs {
             resp["MD5OfMessageAttributes"] = json!(md5);
+        }
+        if let Some(md5) = &md5_of_system_attrs {
+            resp["MD5OfMessageSystemAttributes"] = json!(md5);
         }
 
         Ok(sqs_response("SendMessage", resp, &request_id, is_query))

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -307,6 +307,34 @@ fn send_message_returns_md5() {
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert!(body["MD5OfMessageBody"].as_str().is_some());
     assert!(body["MessageId"].as_str().is_some());
+    // No system attributes set => no MD5OfMessageSystemAttributes field
+    assert!(body.get("MD5OfMessageSystemAttributes").is_none());
+}
+
+#[test]
+fn send_message_returns_md5_of_system_attributes() {
+    let svc = make_service();
+    let url = create_queue(&svc, "sysattr-queue");
+    let req = make_request(
+        "SendMessage",
+        json!({
+            "QueueUrl": url,
+            "MessageBody": "test",
+            "MessageSystemAttributes": {
+                "AWSTraceHeader": {
+                    "DataType": "String",
+                    "StringValue": "Root=1-abc-def"
+                }
+            }
+        }),
+    );
+    let resp = svc.send_message(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let md5 = body["MD5OfMessageSystemAttributes"]
+        .as_str()
+        .expect("MD5OfMessageSystemAttributes missing");
+    assert_eq!(md5.len(), 32);
+    assert!(md5.chars().all(|c| c.is_ascii_hexdigit()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Real SQS computes an MD5 over `MessageSystemAttributes` (currently just `AWSTraceHeader`) using the same wire encoding as `MessageAttributes` — name length + name + data-type length + data-type + transport=1 + value length + value, sorted by name. Send paths now compute and surface this hash whenever system attributes are present.

`SendMessage`, `SendMessage` (FIFO dedup-cache hit), and `SendMessageBatch` all emit `MD5OfMessageSystemAttributes` when the entry has at least one system attribute.

## Test plan

- [x] No system attrs => `MD5OfMessageSystemAttributes` absent
- [x] AWSTraceHeader set => 32-char hex digest returned

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS-compatible MD5 hashing for `MessageSystemAttributes` and returns `MD5OfMessageSystemAttributes` in `SendMessage` and `SendMessageBatch` responses when system attributes are present, including FIFO dedup-cache hits. This aligns `fakecloud-sqs` with real SQS behavior for `AWSTraceHeader`.

- **New Features**
  - Computes the hash using AWS’s wire encoding and name-sorted order.
  - Returns `MD5OfMessageSystemAttributes` in `SendMessage`, `SendMessageBatch`, and FIFO dedup-hit responses.
  - Omits the field when no system attributes are provided.
  - Adds tests for presence/absence and format of the MD5.

<sup>Written for commit 4e392316b6bbd1e625b844fd72871c283117b273. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/934?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

