### PR TITLE
feat(elasticache): RebootCacheCluster restarts the engine container

### DIFF
--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -156,6 +156,33 @@ impl ElastiCacheRuntime {
         }
     }
 
+    /// Restart the underlying container (`docker restart`) for an
+    /// ElastiCache resource, mirroring real ElastiCache's
+    /// RebootCacheCluster behaviour. Returns `Unavailable` if the
+    /// resource has no live container tracked here. Any failure from
+    /// the CLI surfaces as `ContainerStartFailed` so the caller can
+    /// translate it to an AWS error.
+    pub async fn restart_container(&self, resource_id: &str) -> Result<(), RuntimeError> {
+        let container_id = {
+            let containers = self.containers.read();
+            containers
+                .get(resource_id)
+                .map(|c| c.container_id.clone())
+                .ok_or(RuntimeError::Unavailable)?
+        };
+        let output = tokio::process::Command::new(&self.cli)
+            .args(["restart", &container_id])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub async fn stop_all(&self) {
         let containers: Vec<String> = {
             let mut containers = self.containers.write();

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -282,7 +282,7 @@ impl AwsService for ElastiCacheService {
             "ResetCacheParameterGroup" => self.reset_cache_parameter_group(&request),
             "DescribeCacheParameters" => self.describe_cache_parameters(&request),
             "ModifyCacheCluster" => self.modify_cache_cluster(&request),
-            "RebootCacheCluster" => self.reboot_cache_cluster(&request),
+            "RebootCacheCluster" => self.reboot_cache_cluster(&request).await,
             "ListAllowedNodeTypeModifications" => {
                 self.list_allowed_node_type_modifications(&request)
             }
@@ -3692,19 +3692,43 @@ impl ElastiCacheService {
         ))
     }
 
-    fn reboot_cache_cluster(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn reboot_cache_cluster(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "CacheClusterId")?;
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
-        let cluster = state.cache_clusters.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "CacheClusterNotFound",
-                format!("CacheCluster {id} not found."),
-            )
-        })?;
-        cluster.cache_cluster_status = "rebooting cache cluster nodes".to_string();
-        let xml = cache_cluster_xml(cluster, true);
+        let xml = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let cluster = state.cache_clusters.get_mut(&id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "CacheClusterNotFound",
+                    format!("CacheCluster {id} not found."),
+                )
+            })?;
+            cluster.cache_cluster_status = "rebooting cache cluster nodes".to_string();
+            cache_cluster_xml(cluster, true)
+        };
+        // Restart the underlying engine container so a real client
+        // observes the reboot. Best-effort: if no runtime is wired up
+        // (eg. tests, environments without docker) the API call still
+        // reflects the rebooting state.
+        if let Some(runtime) = &self.runtime {
+            if let Err(error) = runtime.restart_container(&id).await {
+                tracing::warn!(
+                    cluster_id = %id,
+                    %error,
+                    "RebootCacheCluster: container restart failed, returning rebooting state anyway"
+                );
+            } else {
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(&request.account_id);
+                if let Some(cluster) = state.cache_clusters.get_mut(&id) {
+                    cluster.cache_cluster_status = "available".to_string();
+                }
+            }
+        }
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -2897,15 +2897,65 @@ fn modify_unknown_cache_cluster_errors() {
     assert_eq!(err.code(), "CacheClusterNotFound");
 }
 
-#[test]
-fn reboot_unknown_cluster_errors() {
+#[tokio::test]
+async fn reboot_unknown_cluster_errors() {
     let svc = fresh_service();
     let req = request("RebootCacheCluster", &[("CacheClusterId", "ghost")]);
-    let err = match svc.reboot_cache_cluster(&req) {
+    let err = match svc.reboot_cache_cluster(&req).await {
         Err(e) => e,
         Ok(_) => panic!("expected error"),
     };
     assert_eq!(err.code(), "CacheClusterNotFound");
+}
+
+#[tokio::test]
+async fn reboot_cache_cluster_marks_rebooting_when_no_runtime() {
+    // Without a wired-up container runtime the API still flips status
+    // to "rebooting cache cluster nodes" so SDK clients can observe
+    // the reboot transition.
+    let svc = fresh_service();
+    {
+        let mut state = svc.state.write();
+        let account = state.get_or_create("123456789012");
+        account.cache_clusters.insert(
+            "test-cc".to_string(),
+            CacheCluster {
+                cache_cluster_id: "test-cc".to_string(),
+                cache_node_type: "cache.t4g.micro".to_string(),
+                engine: "redis".to_string(),
+                engine_version: "7.1".to_string(),
+                cache_cluster_status: "available".to_string(),
+                num_cache_nodes: 1,
+                preferred_availability_zone: "us-east-1a".to_string(),
+                cache_subnet_group_name: None,
+                auto_minor_version_upgrade: true,
+                arn: "arn:aws:elasticache:us-east-1:123456789012:cluster:test-cc".to_string(),
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                endpoint_address: "127.0.0.1".to_string(),
+                endpoint_port: 6379,
+                container_id: "abc123".to_string(),
+                host_port: 6379,
+                replication_group_id: None,
+            },
+        );
+    }
+    let req = request("RebootCacheCluster", &[("CacheClusterId", "test-cc")]);
+    let resp = svc.reboot_cache_cluster(&req).await.unwrap();
+    let body_str = body(resp);
+    assert!(body_str.contains("rebooting cache cluster nodes"));
+    let state = svc.state.read();
+    let cluster = state
+        .get("123456789012")
+        .unwrap()
+        .cache_clusters
+        .get("test-cc")
+        .unwrap();
+    // Without a runtime, status remains in the rebooting transition
+    // since fakecloud has nothing to verify the engine came back up.
+    assert_eq!(
+        cluster.cache_cluster_status,
+        "rebooting cache cluster nodes"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Real ElastiCache RebootCacheCluster restarts the underlying Redis or Memcached engine. Previously fakecloud only flipped the API status to 'rebooting' but left the engine container running, so any connected client kept its state across the reboot — the opposite of what the API documents.

This PR calls `docker restart <container_id>` against the tracked engine container, mirroring the real lifecycle. On success the cluster transitions back to 'available'. On failure (engine refusing to come back, container missing, etc) we leave the cluster in the 'rebooting' state so SDKs see what real AWS would surface during the same window.

When no container runtime is wired up (eg. unit tests on hosts without docker/podman) the API still flips status to 'rebooting' so SDK clients can observe the transition.

## Test plan

- [x] `reboot_unknown_cluster_errors` — keeps NotFound semantics
- [x] `reboot_cache_cluster_marks_rebooting_when_no_runtime` — fall-through path
- [x] full elasticache test suite (179 tests) green
- [x] `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
RebootCacheCluster now restarts the underlying Redis/Memcached container to match real ElastiCache behavior. Clients see an actual reboot; on success the cluster returns to available, otherwise it stays in "rebooting".

- **New Features**
  - `fakecloud-elasticache`: RebootCacheCluster triggers a container restart (`docker restart <container_id>`).
  - Added `ElastiCacheRuntime::restart_container` to run the CLI and surface failures.
  - Made `reboot_cache_cluster` async; sets status to "rebooting" first, then "available" on success. If no runtime or restart fails, it remains "rebooting" and logs a warning.

<sup>Written for commit 6a87b9d149d06856358ab57e46015d724b6f4472. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/937?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

