### PR TITLE
feat(route53): GetChange transitions PENDING -> INSYNC after a few reads

### DIFF
--- a/crates/fakecloud-e2e/tests/route53.rs
+++ b/crates/fakecloud-e2e/tests/route53.rs
@@ -118,16 +118,23 @@ async fn change_and_list_resource_record_sets() {
         .collect();
     assert!(names.contains(&"api.rrset.example.com."));
 
-    let got_change = r53
-        .get_change()
-        .id(&change_id)
-        .send()
-        .await
-        .expect("get change");
-    assert_eq!(
-        got_change.change_info().unwrap().status().as_str(),
-        "INSYNC"
-    );
+    // Real Route53 returns PENDING during the propagation window then
+    // INSYNC. Poll up to 10 reads — fakecloud flips after a small
+    // fixed read-count threshold.
+    let mut status = String::new();
+    for _ in 0..10 {
+        let got = r53
+            .get_change()
+            .id(&change_id)
+            .send()
+            .await
+            .expect("get change");
+        status = got.change_info().unwrap().status().as_str().to_string();
+        if status == "INSYNC" {
+            break;
+        }
+    }
+    assert_eq!(status, "INSYNC");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -683,9 +683,10 @@ impl Route53Service {
         let change_id = generate_change_id();
         let change = StoredChange {
             id: change_id.clone(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: now,
             comment: cfg.comment,
+            read_count: 0,
         };
         account.changes.insert(change_id.clone(), change.clone());
         drop(state);
@@ -740,9 +741,10 @@ impl Route53Service {
         let change_id = generate_change_id();
         let change = StoredChange {
             id: change_id.clone(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: now,
             comment: cfg.comment,
+            read_count: 0,
         };
         account.changes.insert(change_id.clone(), change.clone());
         drop(state);

--- a/crates/fakecloud-route53/src/service.rs
+++ b/crates/fakecloud-route53/src/service.rs
@@ -322,9 +322,10 @@ impl Route53Service {
         let change_id = generate_change_id();
         let change = StoredChange {
             id: change_id.clone(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: now,
             comment: Some(format!("CreateHostedZone {}", id)),
+            read_count: 0,
         };
         account.changes.insert(change_id.clone(), change.clone());
         drop(state);
@@ -418,9 +419,10 @@ impl Route53Service {
         let change_id = generate_change_id();
         let change = StoredChange {
             id: change_id.clone(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: Some(format!("DeleteHostedZone {}", id)),
+            read_count: 0,
         };
         account.changes.insert(change_id.clone(), change.clone());
         drop(state);
@@ -687,9 +689,10 @@ impl Route53Service {
         let change_id = generate_change_id();
         let change = StoredChange {
             id: change_id.clone(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: cfg.change_batch.comment,
+            read_count: 0,
         };
         account.changes.insert(change_id.clone(), change.clone());
         drop(state);
@@ -737,18 +740,32 @@ impl Route53Service {
 impl Route53Service {
     fn get_change(&self, route: &Route) -> Result<AwsResponse, AwsServiceError> {
         let id = require_id(route)?;
-        let state = self.state.read();
-        let account = state.accounts.get(DEFAULT_ACCOUNT);
-        let change = account
-            .and_then(|a| a.changes.get(&id).cloned())
-            .ok_or_else(|| {
+        // Mirror real Route53's eventual-consistency window: bump the
+        // read counter, and once a few reads have happened (PROPAGATION
+        // threshold) flip the status from PENDING to INSYNC.
+        const PROPAGATION_READS: u32 = 5;
+        let change = {
+            let mut state = self.state.write();
+            let account = state.accounts.get_mut(DEFAULT_ACCOUNT).ok_or_else(|| {
                 aws_error(
                     StatusCode::NOT_FOUND,
                     "NoSuchChange",
                     format!("Change {} not found", id),
                 )
             })?;
-        drop(state);
+            let stored = account.changes.get_mut(&id).ok_or_else(|| {
+                aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NoSuchChange",
+                    format!("Change {} not found", id),
+                )
+            })?;
+            stored.read_count = stored.read_count.saturating_add(1);
+            if stored.status == "PENDING" && stored.read_count >= PROPAGATION_READS {
+                stored.status = "INSYNC".to_string();
+            }
+            stored.clone()
+        };
         let mut body = String::with_capacity(256);
         body.push_str(XML_DECL);
         body.push_str(&format!("<GetChangeResponse xmlns=\"{NS}\">"));
@@ -1977,9 +1994,10 @@ impl Route53Service {
             .insert(zone_id.clone(), "SIGNING".to_string());
         let change = StoredChange {
             id: generate_change_id(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: Some(format!("EnableHostedZoneDNSSEC {}", zone_id)),
+            read_count: 0,
         };
         account.changes.insert(change.id.clone(), change.clone());
         drop(state);
@@ -2006,9 +2024,10 @@ impl Route53Service {
             .insert(zone_id.clone(), "NOT_SIGNING".to_string());
         let change = StoredChange {
             id: generate_change_id(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: Some(format!("DisableHostedZoneDNSSEC {}", zone_id)),
+            read_count: 0,
         };
         account.changes.insert(change.id.clone(), change.clone());
         drop(state);
@@ -2073,9 +2092,10 @@ impl Route53Service {
             .insert((zone_id.clone(), cfg.name.clone()), ksk.clone());
         let change = StoredChange {
             id: generate_change_id(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: now,
             comment: Some(format!("CreateKeySigningKey {}/{}", zone_id, cfg.name)),
+            read_count: 0,
         };
         account.changes.insert(change.id.clone(), change.clone());
         drop(state);
@@ -2124,9 +2144,10 @@ impl Route53Service {
             .remove(&(zone_id.clone(), name.clone()));
         let change = StoredChange {
             id: generate_change_id(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: Some(format!("DeleteKeySigningKey {}/{}", zone_id, name)),
+            read_count: 0,
         };
         account.changes.insert(change.id.clone(), change.clone());
         drop(state);
@@ -2166,9 +2187,10 @@ impl Route53Service {
         ksk.last_modified_date = Utc::now();
         let change = StoredChange {
             id: generate_change_id(),
-            status: "INSYNC".to_string(),
+            status: "PENDING".to_string(),
             submitted_at: Utc::now(),
             comment: Some(format!("{} {}/{}", op, zone_id, name)),
+            read_count: 0,
         };
         account.changes.insert(change.id.clone(), change.clone());
         drop(state);
@@ -2679,6 +2701,46 @@ mod tests {
             "Failure: connection refused.".to_string(),
             None,
         ));
+    }
+
+    #[test]
+    fn get_change_starts_pending_then_flips_after_threshold_reads() {
+        use crate::state::StoredChange;
+        let state = Arc::new(RwLock::new(Route53Accounts::default()));
+        {
+            let mut s = state.write();
+            let account = s.accounts.entry(DEFAULT_ACCOUNT.to_string()).or_default();
+            account.changes.insert(
+                "C123".to_string(),
+                StoredChange::pending("C123".to_string(), Utc::now(), Some("test".to_string())),
+            );
+        }
+        let svc = Route53Service::new(state);
+        let route =
+            crate::router::route(&http::Method::GET, "/2013-04-01/change/C123", "").unwrap();
+
+        for i in 1..=5 {
+            svc.get_change(&route).unwrap();
+            let st = svc.state.read();
+            let stored = &st.accounts.get(DEFAULT_ACCOUNT).unwrap().changes["C123"];
+            if i < 5 {
+                assert_eq!(stored.status, "PENDING", "read {i}: expected PENDING");
+            } else {
+                assert_eq!(stored.status, "INSYNC", "read {i}: expected INSYNC");
+            }
+        }
+    }
+
+    #[test]
+    fn get_change_unknown_id_returns_404() {
+        let svc = Route53Service::new(Arc::new(RwLock::new(Route53Accounts::default())));
+        let route =
+            crate::router::route(&http::Method::GET, "/2013-04-01/change/CGHOST", "").unwrap();
+        let err = match svc.get_change(&route) {
+            Err(e) => e,
+            Ok(_) => panic!("expected NoSuchChange"),
+        };
+        assert_eq!(err.code(), "NoSuchChange");
     }
 
     #[test]

--- a/crates/fakecloud-route53/src/state.rs
+++ b/crates/fakecloud-route53/src/state.rs
@@ -80,6 +80,24 @@ pub struct StoredChange {
     pub status: String,
     pub submitted_at: DateTime<Utc>,
     pub comment: Option<String>,
+    /// Number of times GetChange has read this row. New changes start
+    /// at PENDING; once a few reads have happened we flip to INSYNC to
+    /// mirror real Route53's propagation delay without making tests
+    /// wait wall-clock seconds.
+    #[serde(default)]
+    pub read_count: u32,
+}
+
+impl StoredChange {
+    pub fn pending(id: String, submitted_at: DateTime<Utc>, comment: Option<String>) -> Self {
+        Self {
+            id,
+            status: "PENDING".to_string(),
+            submitted_at,
+            comment,
+            read_count: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Real Route53 changes propagate asynchronously: GetChange returns PENDING during the propagation window, then INSYNC once the change has settled. Previously fakecloud short-circuited every change to INSYNC immediately on creation, so tests for IaC (Terraform / CDK) wait loops that poll GetChange until INSYNC would never observe the PENDING phase real AWS emits.

This PR has StoredChange start at PENDING and tracks a read counter on the record. GetChange bumps the counter on every read, then flips to INSYNC once 5 reads have happened. That lets clients observe the PENDING phase deterministically without making tests wait wall-clock seconds.

## Test plan

- [x] `get_change_starts_pending_then_flips_after_threshold_reads` — first 4 reads see PENDING, 5th sees INSYNC
- [x] `get_change_unknown_id_returns_404` — keeps NotFound semantics
- [x] full route53 test suite (8 tests) green
- [x] `cargo clippy -p fakecloud-route53 --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route53 changes now start as PENDING and flip to INSYNC after 5 GetChange reads, mirroring AWS’s eventual consistency. This lets Terraform/CDK polling observe PENDING deterministically without wall-clock waits.

- **New Features**
  - In `fakecloud-route53`, `StoredChange` now starts as PENDING with `read_count: 0`; all change-creation paths updated.
  - `GetChange` increments `read_count` and flips to INSYNC on the 5th read.
  - Added unit tests and updated `fakecloud-e2e` to poll GetChange up to 10 reads; NotFound semantics unchanged.

<sup>Written for commit 6b938cd965f85e34da395384cf1b67c170908d89. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/940?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

