### PR TITLE
feat(rds): DescribeEvents serves real events from in-memory ring

### DIFF
--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -540,7 +540,7 @@ impl RdsService {
             // ── Account / events / regions / log files / capacity ──
             "DescribeAccountAttributes" => Ok(xml_response("DescribeAccountAttributes", "    <AccountQuotas/>".to_string(), &rid)),
             "DescribeEventCategories" => Ok(xml_response("DescribeEventCategories", "    <EventCategoriesMapList/>".to_string(), &rid)),
-            "DescribeEvents" => Ok(xml_response("DescribeEvents", "    <Events/>".to_string(), &rid)),
+            "DescribeEvents" => self.describe_events(req, &rid),
             "DescribeSourceRegions" => Ok(xml_response("DescribeSourceRegions", "    <SourceRegions/>".to_string(), &rid)),
             "DescribeDBLogFiles" => Ok(xml_response("DescribeDBLogFiles", "    <DescribeDBLogFiles/>".to_string(), &rid)),
             "DownloadDBLogFilePortion" => Ok(xml_response("DownloadDBLogFilePortion", "    <LogFileData></LogFileData>\n    <Marker>0</Marker>\n    <AdditionalDataPending>false</AdditionalDataPending>".to_string(), &rid)),
@@ -657,6 +657,87 @@ fn event_sub_xml(v: &Value) -> String {
         xml_escape(v["Status"].as_str().unwrap_or("active")),
         v["Enabled"].as_bool().unwrap_or(true),
     )
+}
+
+impl RdsService {
+    /// Real DescribeEvents implementation: read the per-account events
+    /// ring written to by `emit_event`. Honour SourceType /
+    /// SourceIdentifier / Duration / StartTime / EndTime / EventCategories
+    /// filters and emit them as the DescribeEventsResult shape.
+    pub(crate) fn describe_events(
+        &self,
+        req: &AwsRequest,
+        rid: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let source_type = get_param(req, "SourceType");
+        let source_identifier = get_param(req, "SourceIdentifier");
+        let event_categories: Vec<String> = (1..=20)
+            .filter_map(|i| get_param(req, &format!("EventCategories.member.{i}")))
+            .collect();
+        let duration_minutes: i64 = get_param(req, "Duration")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60);
+        let now = chrono::Utc::now();
+        let start_time = get_param(req, "StartTime")
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|| now - chrono::Duration::minutes(duration_minutes));
+        let end_time = get_param(req, "EndTime")
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or(now);
+
+        let state = self.state_handle().read();
+        let events = state
+            .get(&req.account_id)
+            .map(|s| s.events.clone())
+            .unwrap_or_default();
+        drop(state);
+
+        let mut body = String::from("    <Events>\n");
+        for e in events.iter().filter(|e| {
+            source_type.as_deref().is_none_or(|t| e.source_type == t)
+                && source_identifier
+                    .as_deref()
+                    .is_none_or(|i| e.source_identifier == i)
+                && (event_categories.is_empty()
+                    || event_categories
+                        .iter()
+                        .any(|c| e.event_categories.iter().any(|ec| ec == c)))
+                && e.date >= start_time
+                && e.date <= end_time
+        }) {
+            body.push_str("      <Event>\n");
+            body.push_str(&format!(
+                "        <SourceIdentifier>{}</SourceIdentifier>\n",
+                xml_escape(&e.source_identifier),
+            ));
+            body.push_str(&format!(
+                "        <SourceType>{}</SourceType>\n",
+                xml_escape(&e.source_type),
+            ));
+            body.push_str(&format!(
+                "        <Message>{}</Message>\n",
+                xml_escape(&e.message),
+            ));
+            body.push_str(&format!(
+                "        <SourceArn>{}</SourceArn>\n",
+                xml_escape(&e.source_arn),
+            ));
+            body.push_str("        <EventCategories>\n");
+            for cat in &e.event_categories {
+                body.push_str(&format!(
+                    "          <EventCategory>{}</EventCategory>\n",
+                    xml_escape(cat),
+                ));
+            }
+            body.push_str("        </EventCategories>\n");
+            body.push_str(&format!("        <Date>{}</Date>\n", e.date.to_rfc3339(),));
+            body.push_str("      </Event>\n");
+        }
+        body.push_str("    </Events>");
+        Ok(xml_response("DescribeEvents", body, rid))
+    }
 }
 
 fn global_cluster_xml(v: &Value) -> String {
@@ -798,6 +879,70 @@ mod tests {
             Err(e) => panic!("{action} failed: {e:?}"),
         };
         assert!(resp.status.is_success(), "{action} status: {}", resp.status);
+    }
+
+    #[test]
+    fn describe_events_returns_emitted_events() {
+        let svc = svc();
+        // Push two events directly into state.
+        {
+            let state = svc.state_handle();
+            let mut accounts = state.write();
+            let s = accounts.get_or_create("000000000000");
+            s.push_event(crate::state::RdsEventRecord {
+                source_identifier: "instance-a".to_string(),
+                source_type: "db-instance".to_string(),
+                source_arn: "arn:aws:rds:us-east-1:000000000000:db:instance-a".to_string(),
+                event_id: "RDS-EVENT-0001".to_string(),
+                event_categories: vec!["creation".to_string()],
+                message: "DB instance created".to_string(),
+                date: chrono::Utc::now(),
+            });
+            s.push_event(crate::state::RdsEventRecord {
+                source_identifier: "instance-b".to_string(),
+                source_type: "db-instance".to_string(),
+                source_arn: "arn:aws:rds:us-east-1:000000000000:db:instance-b".to_string(),
+                event_id: "RDS-EVENT-0002".to_string(),
+                event_categories: vec!["failure".to_string()],
+                message: "DB instance failed".to_string(),
+                date: chrono::Utc::now(),
+            });
+        }
+        let resp = svc
+            .handle_extra_action(&req("DescribeEvents", &[]))
+            .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("instance-a"), "missing instance-a in {body}");
+        assert!(body.contains("instance-b"), "missing instance-b in {body}");
+        assert!(body.contains("DB instance created"));
+    }
+
+    #[test]
+    fn describe_events_filters_by_source_identifier() {
+        let svc = svc();
+        {
+            let state = svc.state_handle();
+            let mut accounts = state.write();
+            let s = accounts.get_or_create("000000000000");
+            for id in ["i-a", "i-b", "i-c"] {
+                s.push_event(crate::state::RdsEventRecord {
+                    source_identifier: id.to_string(),
+                    source_type: "db-instance".to_string(),
+                    source_arn: format!("arn:aws:rds:us-east-1:000000000000:db:{id}"),
+                    event_id: "RDS-EVENT-0001".to_string(),
+                    event_categories: vec!["creation".to_string()],
+                    message: format!("created {id}"),
+                    date: chrono::Utc::now(),
+                });
+            }
+        }
+        let resp = svc
+            .handle_extra_action(&req("DescribeEvents", &[("SourceIdentifier", "i-b")]))
+            .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("created i-b"));
+        assert!(!body.contains("created i-a"));
+        assert!(!body.contains("created i-c"));
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -256,7 +256,9 @@ impl RdsService {
     }
 
     /// Emit an `aws.rds` EventBridge event mirroring the AWS RDS event schema.
-    /// No-op when the delivery bus isn't wired (tests, minimal configs).
+    /// Also records into the per-account events ring so DescribeEvents
+    /// can serve the row. No-op for the EventBridge side when the bus
+    /// isn't wired (tests, minimal configs).
     pub(crate) fn emit_event(
         &self,
         source_type: RdsSourceType,
@@ -266,8 +268,17 @@ impl RdsService {
         event_categories: &[&str],
         message: &str,
     ) {
-        emit_event_static(
+        // Source the account_id off the source_arn (segment 4) — that's
+        // the canonical ARN form for RDS resources.
+        let account_id = source_arn.split(':').nth(4).unwrap_or("");
+        emit_event_static_with_state(
             self.delivery_bus.as_ref(),
+            Some(&self.state),
+            if account_id.is_empty() {
+                None
+            } else {
+                Some(account_id)
+            },
             source_type,
             source_identifier,
             source_arn,

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -621,6 +621,11 @@ pub(crate) fn tag_xml(tag: &RdsTag) -> String {
 
 /// Free-standing version of `emit_event` so background tasks (which
 /// don't have a `&self`) can publish RDS events through the same path.
+///
+/// When `state` and `account_id` are provided the event is also
+/// recorded in the per-account events ring so DescribeEvents can serve
+/// it. Background tasks that already cleared their account state pass
+/// `None` for those parameters.
 pub(crate) fn emit_event_static(
     delivery_bus: Option<&Arc<DeliveryBus>>,
     source_type: RdsSourceType,
@@ -630,6 +635,45 @@ pub(crate) fn emit_event_static(
     event_categories: &[&str],
     message: &str,
 ) {
+    emit_event_static_with_state(
+        delivery_bus,
+        None,
+        None,
+        source_type,
+        source_identifier,
+        source_arn,
+        event_id,
+        event_categories,
+        message,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn emit_event_static_with_state(
+    delivery_bus: Option<&Arc<DeliveryBus>>,
+    state: Option<&crate::state::SharedRdsState>,
+    account_id: Option<&str>,
+    source_type: RdsSourceType,
+    source_identifier: &str,
+    source_arn: &str,
+    event_id: &str,
+    event_categories: &[&str],
+    message: &str,
+) {
+    let now = Utc::now();
+    if let (Some(state), Some(account_id)) = (state, account_id) {
+        let mut accounts = state.write();
+        let s = accounts.get_or_create(account_id);
+        s.push_event(crate::state::RdsEventRecord {
+            source_identifier: source_identifier.to_string(),
+            source_type: source_type.as_str().to_string(),
+            source_arn: source_arn.to_string(),
+            event_id: event_id.to_string(),
+            event_categories: event_categories.iter().map(|s| s.to_string()).collect(),
+            message: message.to_string(),
+            date: now,
+        });
+    }
     let Some(bus) = delivery_bus else {
         return;
     };
@@ -637,7 +681,7 @@ pub(crate) fn emit_event_static(
         "EventCategories": event_categories,
         "SourceType": source_type.as_str(),
         "SourceArn": source_arn,
-        "Date": Utc::now().to_rfc3339(),
+        "Date": now.to_rfc3339(),
         "Message": message,
         "SourceIdentifier": source_identifier,
         "EventID": event_id,

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -233,6 +233,22 @@ pub struct RdsState {
     /// without proliferating per-category fields.
     #[serde(default)]
     pub extras: BTreeMap<String, BTreeMap<String, serde_json::Value>>,
+    /// In-memory ring of RDS events emitted by the service, used by
+    /// `DescribeEvents`. Capped at the most recent ~14 days of events
+    /// (matching real RDS retention) by [`Self::push_event`].
+    #[serde(default)]
+    pub events: Vec<RdsEventRecord>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RdsEventRecord {
+    pub source_identifier: String,
+    pub source_type: String,
+    pub source_arn: String,
+    pub event_id: String,
+    pub event_categories: Vec<String>,
+    pub message: String,
+    pub date: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -288,6 +304,7 @@ impl RdsState {
             subnet_groups: BTreeMap::new(),
             parameter_groups: default_parameter_groups(account_id, region),
             extras: BTreeMap::new(),
+            events: Vec::new(),
         }
     }
 
@@ -298,6 +315,16 @@ impl RdsState {
         self.subnet_groups.clear();
         self.parameter_groups = default_parameter_groups(&self.account_id, &self.region);
         self.extras.clear();
+        self.events.clear();
+    }
+
+    /// Append an event row to the in-memory ring, dropping the oldest
+    /// entries beyond a 14-day window (matching real RDS retention).
+    pub fn push_event(&mut self, event: RdsEventRecord) {
+        const RETENTION_DAYS: i64 = 14;
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(RETENTION_DAYS);
+        self.events.retain(|e| e.date >= cutoff);
+        self.events.push(event);
     }
 
     pub fn db_instance_arn(&self, db_instance_identifier: &str) -> String {


### PR DESCRIPTION
## Summary

Real RDS keeps a 14-day ring of management-plane events (DescribeEvents) — instance creation, failover, parameter group apply, etc. fakecloud previously returned an empty `<Events/>` regardless of how many CreateDBInstance / RebootDBInstance / ModifyDBCluster calls had hit it.

This PR records every `emit_event` call into a per-account events ring (capped at 14 days, matching real RDS). DescribeEvents reads that ring and applies the SourceType / SourceIdentifier / EventCategories / Duration / StartTime / EndTime filters, emitting the canonical DescribeEventsResult shape.

## Test plan

- [x] `describe_events_returns_emitted_events` — pushed events surface in response
- [x] `describe_events_filters_by_source_identifier` — filter respected
- [x] full fakecloud-rds test suite (123 tests) green
- [x] `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
DescribeEvents now returns real RDS events from a per-account, in-memory ring with 14-day retention. It supports standard filters and returns the canonical DescribeEventsResult.

- **New Features**
  - Record every `emit_event` into the account’s event ring (14-day retention); background paths use `emit_event_static_with_state`.
  - Apply `SourceType`, `SourceIdentifier`, `EventCategories`, `Duration`, `StartTime`, and `EndTime` filters when serving `DescribeEvents`.
  - Add `RdsEventRecord` and `RdsState::push_event` to store and trim events.
  - Extract account ID from `source_arn` to store events under the correct account.

<sup>Written for commit 649527007c223d7b1831689e4d09f30c7c1498aa. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/942?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

