### PR TITLE
feat(ses): gate sends on verified sender identity

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -383,6 +383,13 @@ async fn test_send_raw_email_v1() {
     let server = TestServer::start().await;
     let client = server.ses_client().await;
 
+    client
+        .verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
     let raw_message = aws_sdk_ses::types::RawMessage::builder()
         .data(aws_sdk_ses::primitives::Blob::new(
             "From: sender@example.com\r\nTo: to@example.com\r\nSubject: Raw Test\r\n\r\nBody",
@@ -559,6 +566,13 @@ async fn test_send_templated_email_missing_template() {
 async fn test_send_bulk_templated_email_v1() {
     let server = TestServer::start().await;
     let client = server.ses_client().await;
+
+    client
+        .verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
 
     client
         .create_template()

--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -327,6 +327,13 @@ async fn test_send_email_v1() {
     let server = TestServer::start().await;
     let client = server.ses_client().await;
 
+    client
+        .verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .expect("verify identity");
+
     let resp = client
         .send_email()
         .source("sender@example.com")
@@ -502,6 +509,13 @@ async fn test_template_lifecycle_v1() {
 async fn test_send_templated_email_v1() {
     let server = TestServer::start().await;
     let client = server.ses_client().await;
+
+    client
+        .verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .expect("verify identity");
 
     // Create template first
     client

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -8,6 +8,19 @@ use crate::state::SentEmail;
 
 use super::{extract_string_array, SesV2Service};
 
+/// Extract bare email address from a "From" header. Strips display-name
+/// wrappers like `Foo <foo@example.com>` and surrounding whitespace.
+fn extract_email_address(from: &str) -> &str {
+    if let Some(start) = from.rfind('<') {
+        if let Some(end) = from.rfind('>') {
+            if end > start {
+                return from[start + 1..end].trim();
+            }
+        }
+    }
+    from.trim()
+}
+
 impl SesV2Service {
     /// Reject the send if either account-level sending or the resolved
     /// configuration set's sending flag is paused. Real SES surfaces
@@ -41,6 +54,57 @@ impl SesV2Service {
         None
     }
 
+    /// Reject sends where the sender is not a verified identity. Mirrors
+    /// real SES: every From address must either match a verified email
+    /// identity exactly, or its domain must match a verified domain
+    /// identity.
+    pub(super) fn reject_unverified_sender(
+        &self,
+        account_id: &str,
+        from: &str,
+    ) -> Option<AwsResponse> {
+        let email = extract_email_address(from);
+        if email.is_empty() {
+            return Some(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "BadRequestException",
+                "FromEmailAddress is required",
+            ));
+        }
+        let domain = email.split_once('@').map(|(_, d)| d).unwrap_or("");
+
+        let accounts = self.state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return Some(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "MessageRejected",
+                &format!("Email address is not verified. The following identities failed the check in region {}: {}", "us-east-1", email),
+            ));
+        };
+
+        let email_ok = state
+            .identities
+            .get(email)
+            .map(|id| id.verified)
+            .unwrap_or(false);
+        let domain_ok = !domain.is_empty()
+            && state
+                .identities
+                .get(domain)
+                .map(|id| id.verified)
+                .unwrap_or(false);
+
+        if email_ok || domain_ok {
+            None
+        } else {
+            Some(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "MessageRejected",
+                &format!("Email address is not verified. The following identities failed the check in region {}: {}", "us-east-1", email),
+            ))
+        }
+    }
+
     pub(super) fn send_email(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body: Value = Self::parse_body(req)?;
 
@@ -59,6 +123,9 @@ impl SesV2Service {
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
         let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
         if let Some(err) = self.check_sending_enabled(&req.account_id, config_set_name.as_deref()) {
+            return Ok(err);
+        }
+        if let Some(err) = self.reject_unverified_sender(&req.account_id, &from) {
             return Ok(err);
         }
 
@@ -130,6 +197,9 @@ impl SesV2Service {
         let body: Value = Self::parse_body(req)?;
 
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
+        if let Some(err) = self.reject_unverified_sender(&req.account_id, &from) {
+            return Ok(err);
+        }
         let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
         if let Some(err) = self.check_sending_enabled(&req.account_id, config_set_name.as_deref()) {
             return Ok(err);

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -16,6 +16,37 @@ fn make_state() -> SharedSesState {
     ))
 }
 
+/// Seed a verified identity for the default test account so send tests
+/// don't trip the verified-sender gate.
+fn seed_identity(state: &SharedSesState, name: &str) {
+    use crate::state::EmailIdentity;
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    let identity_type = if name.contains('@') {
+        "EMAIL_ADDRESS"
+    } else {
+        "DOMAIN"
+    };
+    st.identities.insert(
+        name.to_string(),
+        EmailIdentity {
+            identity_name: name.to_string(),
+            identity_type: identity_type.to_string(),
+            verified: true,
+            created_at: chrono::Utc::now(),
+            dkim_signing_enabled: true,
+            dkim_signing_attributes_origin: "AWS_SES".to_string(),
+            dkim_domain_signing_private_key: None,
+            dkim_domain_signing_selector: None,
+            dkim_next_signing_key_length: None,
+            email_forwarding_enabled: true,
+            mail_from_domain: None,
+            mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            configuration_set_name: None,
+        },
+    );
+}
+
 fn make_request(method: Method, path: &str, body: &str) -> AwsRequest {
     make_request_with_query(method, path, body, "", HashMap::new())
 }
@@ -190,6 +221,7 @@ async fn test_template_lifecycle() {
 #[tokio::test]
 async fn test_send_email() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -279,6 +311,7 @@ async fn test_configuration_set_lifecycle() {
 #[tokio::test]
 async fn test_send_email_raw_content() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -314,6 +347,7 @@ async fn test_send_email_raw_content() {
 #[tokio::test]
 async fn test_send_email_template_content() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -362,6 +396,7 @@ async fn test_send_email_missing_content() {
 #[tokio::test]
 async fn test_send_email_with_cc_and_bcc() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -394,6 +429,7 @@ async fn test_send_email_with_cc_and_bcc() {
 #[tokio::test]
 async fn test_send_bulk_email() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -492,6 +528,47 @@ async fn test_send_email_rejects_when_config_set_paused() {
     assert_eq!(resp.status, StatusCode::BAD_REQUEST);
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["__type"], "ConfigurationSetSendingPausedException");
+}
+
+#[tokio::test]
+async fn test_send_email_rejects_unverified_sender() {
+    let state = make_state();
+    let svc = SesV2Service::new(state);
+
+    // No identity registered for sender@example.com → MessageRejected.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["recipient@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "MessageRejected");
+}
+
+#[tokio::test]
+async fn test_send_email_accepts_verified_domain() {
+    let state = make_state();
+    // Verify the domain only → full address should be allowed.
+    seed_identity(&state, "example.com");
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["recipient@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -95,6 +95,67 @@ pub(crate) fn required_param<'a>(
     })
 }
 
+/// Gate every SES v1 send path on a verified sender. Mirrors the v2
+/// `reject_unverified_sender` rule: the From address must match a
+/// verified email identity exactly, or its domain must match a verified
+/// domain identity. Real SES surfaces this as `MessageRejected`.
+pub(crate) fn check_v1_verified_sender(
+    state: &SharedSesState,
+    account_id: &str,
+    from: &str,
+) -> Result<(), AwsServiceError> {
+    let email = if let Some(start) = from.rfind('<') {
+        if let Some(end) = from.rfind('>') {
+            if end > start {
+                from[start + 1..end].trim()
+            } else {
+                from.trim()
+            }
+        } else {
+            from.trim()
+        }
+    } else {
+        from.trim()
+    };
+    if email.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MessageRejected",
+            "Email address is not verified.".to_string(),
+        ));
+    }
+    let domain = email.split_once('@').map(|(_, d)| d).unwrap_or("");
+
+    let accounts = state.read();
+    let verified = accounts
+        .get(account_id)
+        .map(|st| {
+            let email_ok = st
+                .identities
+                .get(email)
+                .map(|id| id.verified)
+                .unwrap_or(false);
+            let domain_ok = !domain.is_empty()
+                && st
+                    .identities
+                    .get(domain)
+                    .map(|id| id.verified)
+                    .unwrap_or(false);
+            email_ok || domain_ok
+        })
+        .unwrap_or(false);
+
+    if verified {
+        Ok(())
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MessageRejected",
+            format!("Email address is not verified. The following identities failed the check in region us-east-1: {email}"),
+        ))
+    }
+}
+
 /// Parse a receipt rule from form parameters (for Create/Update).
 pub(crate) fn parse_receipt_rule(
     params: &HashMap<String, String>,
@@ -861,6 +922,7 @@ pub(crate) fn send_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    check_v1_verified_sender(state, &req.account_id, from)?;
     let to = parse_member_list(&req.query_params, "Destination.ToAddresses");
     let cc = parse_member_list(&req.query_params, "Destination.CcAddresses");
     let bcc = parse_member_list(&req.query_params, "Destination.BccAddresses");
@@ -911,6 +973,9 @@ pub(crate) fn send_raw_email(
 ) -> Result<AwsResponse, AwsServiceError> {
     let raw_data = required_param(&req.query_params, "RawMessage.Data")?;
     let from = req.query_params.get("Source").cloned().unwrap_or_default();
+    if !from.is_empty() {
+        check_v1_verified_sender(state, &req.account_id, &from)?;
+    }
     let to = parse_member_list(&req.query_params, "Destinations");
 
     let message_id = format!(
@@ -954,6 +1019,7 @@ pub(crate) fn send_templated_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    check_v1_verified_sender(state, &req.account_id, from)?;
     let template_name = required_param(&req.query_params, "Template")?;
     let template_data = required_param(&req.query_params, "TemplateData")?;
     let to = parse_member_list(&req.query_params, "Destination.ToAddresses");
@@ -1015,6 +1081,7 @@ pub(crate) fn send_bulk_templated_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    check_v1_verified_sender(state, &req.account_id, from)?;
     let template_name = required_param(&req.query_params, "Template")?;
     let default_template_data = req
         .query_params

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -15,6 +15,35 @@ fn make_state() -> SharedSesState {
     ))
 }
 
+fn seed_identity(state: &SharedSesState, name: &str) {
+    use crate::state::EmailIdentity;
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    let identity_type = if name.contains('@') {
+        "EMAIL_ADDRESS"
+    } else {
+        "DOMAIN"
+    };
+    st.identities.insert(
+        name.to_string(),
+        EmailIdentity {
+            identity_name: name.to_string(),
+            identity_type: identity_type.to_string(),
+            verified: true,
+            created_at: chrono::Utc::now(),
+            dkim_signing_enabled: true,
+            dkim_signing_attributes_origin: "AWS_SES".to_string(),
+            dkim_domain_signing_private_key: None,
+            dkim_domain_signing_selector: None,
+            dkim_next_signing_key_length: None,
+            email_forwarding_enabled: true,
+            mail_from_domain: None,
+            mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            configuration_set_name: None,
+        },
+    );
+}
+
 fn make_v1_request(action: &str, params: Vec<(&str, &str)>) -> AwsRequest {
     let mut query_params: HashMap<String, String> = HashMap::new();
     query_params.insert("Action".to_string(), action.to_string());
@@ -937,6 +966,7 @@ fn test_get_identity_mail_from_domain_attributes() {
 #[test]
 fn test_send_email_v1() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let req = make_v1_request(
         "SendEmail",
         vec![
@@ -969,6 +999,7 @@ fn test_send_email_v1() {
 #[test]
 fn test_send_raw_email() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let req = make_v1_request(
         "SendRawEmail",
         vec![
@@ -994,6 +1025,7 @@ fn test_send_raw_email() {
 #[test]
 fn test_send_templated_email() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     // Create template first
     handle_v1_action(
         &state,
@@ -1034,6 +1066,7 @@ fn test_send_templated_email() {
 #[test]
 fn test_send_templated_email_missing_template() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     let req = make_v1_request(
         "SendTemplatedEmail",
         vec![
@@ -1052,6 +1085,7 @@ fn test_send_templated_email_missing_template() {
 #[test]
 fn test_send_bulk_templated_email() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     handle_v1_action(
         &state,
         &make_v1_request(
@@ -1330,6 +1364,7 @@ fn test_get_send_quota() {
 #[test]
 fn test_get_send_statistics() {
     let state = make_state();
+    seed_identity(&state, "a@b.com");
     // Send an email first
     handle_v1_action(
         &state,


### PR DESCRIPTION
## Summary
- Reject SES v2 SendEmail / SendBulkEmail and v1 SendEmail / SendRawEmail / SendTemplatedEmail / SendBulkTemplatedEmail when the From address is not a registered+verified identity
- Match real SES error: HTTP 400 MessageRejected with the canonical `Email address is not verified. The following identities failed the check ...` message
- Domain-level identities verify any address in that domain (Foo <foo@example.com> still parsed correctly via display-name stripping)

## Test plan
- [x] cargo test -p fakecloud-ses --lib (195 passed)
- [x] cargo clippy -p fakecloud-ses --all-targets -- -D warnings clean
- [x] New tests: rejects unverified sender, accepts verified domain

Closes the X1 batch from /tmp/parity_audit/REPORT.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate all SES send APIs on a verified sender identity to mirror AWS behavior. Unverified From addresses now return HTTP 400 MessageRejected with the SES-consistent message.

- New Features
  - Enforce verified sender on v2 SendEmail/SendBulkEmail and v1 SendEmail/SendRawEmail/SendTemplatedEmail/SendBulkTemplatedEmail.
  - Accept a verified email identity or a verified domain; strips display names like `Foo <foo@example.com>`.
  - Tests cover rejecting unverified senders and allowing verified domains; seed verified identities across all v1 e2e send paths and unit tests.

- Migration
  - Seed a verified identity (email or domain) before sending in tests/fixtures, otherwise sends are rejected.

<sup>Written for commit dbe8b8c2059794fd5850b0a2604e7d170369a5e3. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/945?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

