### PR TITLE
feat(ses): honor account/config-set sending pause flags

### DIFF
--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -9,6 +9,38 @@ use crate::state::SentEmail;
 use super::{extract_string_array, SesV2Service};
 
 impl SesV2Service {
+    /// Reject the send if either account-level sending or the resolved
+    /// configuration set's sending flag is paused. Real SES surfaces
+    /// these as `AccountSendingPausedException` and
+    /// `ConfigurationSetSendingPausedException` (HTTP 400).
+    fn check_sending_enabled(
+        &self,
+        account_id: &str,
+        config_set_name: Option<&str>,
+    ) -> Option<AwsResponse> {
+        let accounts = self.state.read();
+        let state = accounts.get(account_id)?;
+        if !state.account_settings.sending_enabled {
+            return Some(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "AccountSendingPausedException",
+                "Email sending is disabled for your account.",
+            ));
+        }
+        if let Some(name) = config_set_name {
+            if let Some(cs) = state.configuration_sets.get(name) {
+                if !cs.sending_enabled {
+                    return Some(Self::json_error(
+                        StatusCode::BAD_REQUEST,
+                        "ConfigurationSetSendingPausedException",
+                        &format!("Email sending is disabled for the configuration set {name}."),
+                    ));
+                }
+            }
+        }
+        None
+    }
+
     pub(super) fn send_email(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body: Value = Self::parse_body(req)?;
 
@@ -25,12 +57,14 @@ impl SesV2Service {
         }
 
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
+        let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
+        if let Some(err) = self.check_sending_enabled(&req.account_id, config_set_name.as_deref()) {
+            return Ok(err);
+        }
 
         let to = extract_string_array(&body["Destination"]["ToAddresses"]);
         let cc = extract_string_array(&body["Destination"]["CcAddresses"]);
         let bcc = extract_string_array(&body["Destination"]["BccAddresses"]);
-
-        let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
 
         let (subject, html_body, text_body, raw_data, template_name, template_data) =
             if body["Content"]["Simple"].is_object() {
@@ -97,6 +131,9 @@ impl SesV2Service {
 
         let from = body["FromEmailAddress"].as_str().unwrap_or("").to_string();
         let config_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
+        if let Some(err) = self.check_sending_enabled(&req.account_id, config_set_name.as_deref()) {
+            return Ok(err);
+        }
 
         let entries = match body["BulkEmailEntries"].as_array() {
             Some(arr) if !arr.is_empty() => arr.clone(),

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -429,6 +429,72 @@ async fn test_send_bulk_email() {
 }
 
 #[tokio::test]
+async fn test_send_email_rejects_when_account_paused() {
+    let state = make_state();
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.account_settings.sending_enabled = false;
+    }
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "AccountSendingPausedException");
+}
+
+#[tokio::test]
+async fn test_send_email_rejects_when_config_set_paused() {
+    let state = make_state();
+    {
+        use crate::state::ConfigurationSet;
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.configuration_sets.insert(
+            "paused".to_string(),
+            ConfigurationSet {
+                name: "paused".to_string(),
+                sending_enabled: false,
+                tls_policy: "OPTIONAL".to_string(),
+                sending_pool_name: None,
+                custom_redirect_domain: None,
+                https_policy: None,
+                suppressed_reasons: Vec::new(),
+                reputation_metrics_enabled: false,
+                vdm_options: None,
+                archive_arn: None,
+            },
+        );
+    }
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}},
+            "ConfigurationSetName": "paused"
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "ConfigurationSetSendingPausedException");
+}
+
+#[tokio::test]
 async fn test_send_bulk_email_empty_entries() {
     let state = make_state();
     let svc = SesV2Service::new(state);


### PR DESCRIPTION
## Summary
- Gate v2 SendEmail/SendBulkEmail on \`state.account_settings.sending_enabled\` and the resolved \`ConfigurationSet.sending_enabled\`
- Return canonical \`AccountSendingPausedException\` / \`ConfigurationSetSendingPausedException\` (HTTP 400)

## Test plan
- [x] cargo test -p fakecloud-ses --lib (197 passed)
- [x] cargo clippy -p fakecloud-ses --all-targets clean
- [x] New tests: account paused, config-set paused

Closes the X2 batch from /tmp/parity_audit/REPORT.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SES v2 `SendEmail` and `SendBulkEmail` now honor account and configuration set sending pause flags, returning canonical 400 errors when paused. This makes `fakecloud-ses` reflect `PutAccountSendingAttributes` and `PutConfigurationSetSendingOptions` correctly.

- **New Features**
  - Reject sends when `state.account_settings.sending_enabled` is false or the resolved config set’s `sending_enabled` is false.
  - Return `AccountSendingPausedException` or `ConfigurationSetSendingPausedException` (HTTP 400); added tests for both paths.

<sup>Written for commit 5ba1ad175f582652ee58f70f8b5bdb090d41f190. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/946?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

