### PR TITLE
feat(cloudformation): substitute AWS::* pseudo-parameters

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -308,14 +308,11 @@ impl CloudFormationService {
         }
 
         let tags = Self::extract_tags(&params);
-        let parameters = Self::extract_parameters(&params);
+        let mut parameters = Self::extract_parameters(&params);
         let notification_arns = Self::extract_notification_arns(&params);
 
-        // First pass: parse to get resource definitions (without physical ID resolution)
-        let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
-            AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
-        })?;
-
+        // Seed AWS::* pseudo-parameters with stack-context values so
+        // resolve_refs can substitute them into resource properties.
         let stack_id = format!(
             "arn:aws:cloudformation:{}:{}:stack/{}/{}",
             req.region,
@@ -323,6 +320,29 @@ impl CloudFormationService {
             stack_name,
             uuid::Uuid::new_v4()
         );
+        parameters
+            .entry("AWS::Region".to_string())
+            .or_insert_with(|| req.region.clone());
+        parameters
+            .entry("AWS::AccountId".to_string())
+            .or_insert_with(|| req.account_id.clone());
+        parameters
+            .entry("AWS::StackId".to_string())
+            .or_insert_with(|| stack_id.clone());
+        parameters
+            .entry("AWS::StackName".to_string())
+            .or_insert_with(|| stack_name.clone());
+        parameters
+            .entry("AWS::Partition".to_string())
+            .or_insert_with(|| "aws".to_string());
+        parameters
+            .entry("AWS::URLSuffix".to_string())
+            .or_insert_with(|| "amazonaws.com".to_string());
+
+        // First pass: parse to get resource definitions (without physical ID resolution)
+        let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
+            AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+        })?;
 
         let provisioner = self.provisioner(&stack_id, &req.account_id, &req.region);
         let resources =
@@ -540,11 +560,7 @@ impl CloudFormationService {
     }
 
     fn update_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let input = UpdateStackInput::from_params(req)?;
-        let parsed =
-            template::parse_template(&input.template_body, &input.parameters).map_err(|e| {
-                AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
-            })?;
+        let mut input = UpdateStackInput::from_params(req)?;
 
         // Get stack_id before write lock for the provisioner
         let found_stack_id = {
@@ -561,6 +577,39 @@ impl CloudFormationService {
                 .map(|s| s.stack_id.clone())
                 .unwrap_or_default()
         };
+
+        // Seed pseudo-parameters before parsing — the StackId is now known
+        // (after the read above) so resolve_refs sees the same values that
+        // the original CreateStack invocation used.
+        input
+            .parameters
+            .entry("AWS::Region".to_string())
+            .or_insert_with(|| req.region.clone());
+        input
+            .parameters
+            .entry("AWS::AccountId".to_string())
+            .or_insert_with(|| req.account_id.clone());
+        input
+            .parameters
+            .entry("AWS::StackId".to_string())
+            .or_insert_with(|| found_stack_id.clone());
+        input
+            .parameters
+            .entry("AWS::StackName".to_string())
+            .or_insert_with(|| input.stack_name.clone());
+        input
+            .parameters
+            .entry("AWS::Partition".to_string())
+            .or_insert_with(|| "aws".to_string());
+        input
+            .parameters
+            .entry("AWS::URLSuffix".to_string())
+            .or_insert_with(|| "amazonaws.com".to_string());
+
+        let parsed =
+            template::parse_template(&input.template_body, &input.parameters).map_err(|e| {
+                AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", e)
+            })?;
 
         let provisioner = self.provisioner(&found_stack_id, &req.account_id, &req.region);
 

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -167,6 +167,28 @@ pub fn resolve_resource_properties_with_attrs(
     })
 }
 
+/// Substitute a pseudo-parameter with the value provided through the
+/// stack `parameters` map (keyed by the same `AWS::*` name). When the
+/// caller hasn't supplied a value, fall back to the canonical default
+/// for that parameter (commercial partition / us-east-1 / empty list).
+fn pseudo_value(name: &str, parameters: &BTreeMap<String, String>) -> Option<Value> {
+    if let Some(v) = parameters.get(name) {
+        return Some(Value::String(v.clone()));
+    }
+    match name {
+        "AWS::Partition" => Some(Value::String("aws".to_string())),
+        "AWS::URLSuffix" => Some(Value::String("amazonaws.com".to_string())),
+        "AWS::Region" => Some(Value::String("us-east-1".to_string())),
+        // NotificationARNs is an array; default to empty.
+        "AWS::NotificationARNs" => Some(Value::Array(Vec::new())),
+        // NoValue is sentinel - emit an explicit JSON null so callers can
+        // treat it as "drop this property". CloudFormation strips it from
+        // the resolved object; we leave that responsibility to consumers.
+        "AWS::NoValue" => Some(Value::Null),
+        _ => None,
+    }
+}
+
 /// Resolve `Ref`, `Fn::GetAtt`, `Fn::Join`, and `Fn::Sub` in property values.
 fn resolve_refs(
     value: &Value,
@@ -187,8 +209,12 @@ fn resolve_refs(
                     if let Some(physical_id) = resource_physical_ids.get(ref_name) {
                         return Value::String(physical_id.clone());
                     }
-                    // 3. Allow pseudo-references to pass through as the ref name
+                    // 3. Substitute pseudo-references with their stack-context
+                    //    value (or a sane default for shape-only parity).
                     if PSEUDO_REFS.contains(&ref_name) {
+                        if let Some(v) = pseudo_value(ref_name, parameters) {
+                            return v;
+                        }
                         return Value::String(ref_name.to_string());
                     }
                     // 4. If it's a known logical resource in the template but not yet
@@ -448,6 +474,61 @@ Resources:
         assert_eq!(
             sub.properties["TopicArn"],
             Value::String("MyTopic".to_string())
+        );
+    }
+
+    #[test]
+    fn pseudo_ref_substitutes_when_param_provided() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueArn": {
+                            "Fn::Join": ["", [
+                                "arn:", {"Ref": "AWS::Partition"}, ":sqs:",
+                                {"Ref": "AWS::Region"}, ":", {"Ref": "AWS::AccountId"},
+                                ":", {"Ref": "AWS::StackName"}, "-q"
+                            ]]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "us-west-2".to_string());
+        params.insert("AWS::AccountId".to_string(), "111122223333".to_string());
+        params.insert("AWS::Partition".to_string(), "aws".to_string());
+        params.insert("AWS::StackName".to_string(), "demo".to_string());
+
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["QueueArn"],
+            Value::String("arn:aws:sqs:us-west-2:111122223333:demo-q".to_string())
+        );
+    }
+
+    #[test]
+    fn pseudo_ref_partition_default_when_unset() {
+        let template = r#"{
+            "Resources": {
+                "MyQueue": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "Partition": {"Ref": "AWS::Partition"},
+                        "Suffix": {"Ref": "AWS::URLSuffix"}
+                    }
+                }
+            }
+        }"#;
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Partition"],
+            Value::String("aws".to_string())
+        );
+        assert_eq!(
+            parsed.resources[0].properties["Suffix"],
+            Value::String("amazonaws.com".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- CreateStack/UpdateStack seed AWS::Region/AccountId/StackId/StackName/Partition/URLSuffix into parameters before parsing
- \`resolve_refs\` substitutes pseudo-refs from those values; canonical defaults when unset (\`aws\`, \`amazonaws.com\`, \`us-east-1\`, empty NotificationARNs list, null for NoValue)
- Previously pseudo-refs leaked through verbatim into resource properties

## Test plan
- [x] cargo test -p fakecloud-cloudformation --lib (85 passed)
- [x] cargo clippy -p fakecloud-cloudformation --all-targets clean
- [x] New tests cover param-substitution path + default fallbacks

Closes the BB6 batch from /tmp/parity_audit/REPORT.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Substitutes CloudFormation `AWS::*` pseudo-parameters during template parsing so resource properties get concrete values instead of literal pseudo-ref strings. Applies to both CreateStack and UpdateStack with sane defaults when values are missing.

- **Bug Fixes**
  - Seeded `AWS::Region`, `AWS::AccountId`, `AWS::StackId`, `AWS::StackName`, `AWS::Partition`, and `AWS::URLSuffix` into the parameter map before parsing.
  - `resolve_refs` now falls back to defaults when unset: `aws` (Partition), `amazonaws.com` (URLSuffix), `us-east-1` (Region), empty list for `AWS::NotificationARNs`, and `null` for `AWS::NoValue`.
  - `UpdateStack` uses the existing StackId when seeding to keep values stable across updates.

<sup>Written for commit ebd963a006969587613b977e880ffc6a0eebd6bb. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

