### PR TITLE
feat(ssm): admin endpoint to override SendCommand status

### DIFF
--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -248,6 +248,19 @@ pub struct ForceDlqResponse {
     pub moved_messages: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetSsmCommandStatusRequest {
+    pub account_id: Option<String>,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetSsmCommandStatusResponse {
+    pub updated: bool,
+}
+
 // ── EventBridge ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1044,6 +1044,7 @@ async fn main() {
         } else {
             None
         };
+    let ssm_state_for_admin = ssm_state.clone();
     let mut ssm_service = SsmService::new(ssm_state)
         .with_secretsmanager(secretsmanager_state.clone())
         .with_kms_hook(kms_hook_for_services.clone());
@@ -3078,6 +3079,19 @@ async fn main() {
                     axum::Json(types::ForceDlqResponse {
                         moved_messages: moved,
                     })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ssm/commands/{command_id}/status",
+            axum::routing::post({
+                let ss = ssm_state_for_admin;
+                move |axum::extract::Path(command_id): axum::extract::Path<String>,
+                      axum::Json(body): axum::Json<types::SetSsmCommandStatusRequest>| async move {
+                    let account = body.account_id.as_deref().unwrap_or("000000000000");
+                    let svc = fakecloud_ssm::SsmService::new(ss);
+                    let updated = svc.set_command_status(account, &command_id, &body.status);
+                    axum::Json(types::SetSsmCommandStatusResponse { updated })
                 }
             }),
         )

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -63,6 +63,24 @@ impl SsmService {
         self
     }
 
+    /// Admin: force a SendCommand result to a specific terminal status
+    /// (e.g. "Failed", "Cancelled", "TimedOut"). Used by tests to
+    /// simulate command failures without waiting on a real SSM agent.
+    /// Returns `true` when the command was found and updated.
+    pub fn set_command_status(&self, account_id: &str, command_id: &str, status: &str) -> bool {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        if let Some(c) = state
+            .commands
+            .iter_mut()
+            .find(|c| c.command_id == command_id)
+        {
+            c.status = status.to_string();
+            return true;
+        }
+        false
+    }
+
     /// Persist current state as a snapshot. Held across the
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -2101,6 +2101,39 @@ fn send_command_starts_pending() {
 }
 
 #[test]
+fn set_command_status_overrides_lifecycle() {
+    let svc = make_service();
+    let cmd_id = send_command(&svc, "AWS-RunShellScript");
+    // Force a Failed status before any polling.
+    let updated = svc.set_command_status("123456789012", &cmd_id, "Failed");
+    assert!(updated);
+    // Even after multiple GetCommandInvocation polls (which would
+    // normally advance Pending -> InProgress -> Success), the forced
+    // status sticks since the auto-advance only fires when status is
+    // Pending or InProgress.
+    for _ in 0..3 {
+        let req = make_request(
+            "GetCommandInvocation",
+            json!({
+                "CommandId": cmd_id,
+                "InstanceId": "i-0000000000000000a",
+            }),
+        );
+        let _ = svc.get_command_invocation(&req);
+    }
+    let req = make_request("ListCommands", json!({"CommandId": cmd_id}));
+    let resp = svc.list_commands(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Commands"][0]["Status"].as_str().unwrap(), "Failed");
+}
+
+#[test]
+fn set_command_status_unknown_id_returns_false() {
+    let svc = make_service();
+    assert!(!svc.set_command_status("123456789012", "no-such-id", "Failed"));
+}
+
+#[test]
 fn get_command_invocation_wrong_instance_fails() {
     let svc = make_service();
     let cmd_id = send_command(&svc, "AWS-RunShellScript");


### PR DESCRIPTION
## Summary
- Add \`POST /_fakecloud/ssm/commands/{commandId}/status\` admin endpoint
- Lets tests inject Failed/Cancelled/TimedOut terminal states for SendCommand
- Existing GetCommandInvocation auto-advance only fires when status is Pending or InProgress, so the admin override stays sticky
- New \`SetSsmCommandStatusRequest\`/\`SetSsmCommandStatusResponse\` types in fakecloud-sdk

## Test plan
- [x] cargo test -p fakecloud-ssm --lib (206 passed including new tests)
- [x] cargo clippy -p fakecloud-ssm -p fakecloud --all-targets clean
- [x] New tests cover override sticking through subsequent polls + unknown id

Closes the I1 batch from /tmp/parity_audit/REPORT.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an admin endpoint to force SSM `SendCommand` status to a terminal state for easier failure-path testing. Overrides persist across `GetCommandInvocation` polls.

- **New Features**
  - Added `POST /_fakecloud/ssm/commands/{commandId}/status` in `fakecloud-server` to override a command’s status (accepts optional `accountId`, returns `updated`).
  - Implemented status override in `fakecloud-ssm`; auto-advance only runs on Pending/InProgress, so overrides stay sticky.
  - Introduced `SetSsmCommandStatusRequest` and `SetSsmCommandStatusResponse` in `fakecloud-sdk`.
  - Added tests for override persistence and unknown command IDs.

<sup>Written for commit c026ad7bfef6c271e4a726c8cb56525bd3434af4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/954?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

