### PR TITLE
feat(cloudformation): parse Outputs + ImportValue + ListExports

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -529,8 +529,68 @@ impl CloudFormationService {
             "RecordHandlerProgress" => Ok(xml_response_no_result("RecordHandlerProgress", &rid)),
 
             // ── Imports / exports ──
-            "ListExports" => Ok(xml_response("ListExports", "    <Exports/>".to_string(), &rid)),
-            "ListImports" => Ok(xml_response("ListImports", "    <Imports/>".to_string(), &rid)),
+            "ListExports" => {
+                let accounts = self.state.read();
+                let mut entries = String::new();
+                if let Some(state) = accounts.get(&aid) {
+                    for stack in state.stacks.values() {
+                        if stack.status == "DELETE_COMPLETE" {
+                            continue;
+                        }
+                        for output in &stack.outputs {
+                            if let Some(export) = &output.export_name {
+                                entries.push_str(&format!(
+                                    "      <member>\n        <ExportingStackId>{}</ExportingStackId>\n        <Name>{}</Name>\n        <Value>{}</Value>\n      </member>\n",
+                                    xml_escape(&stack.stack_id),
+                                    xml_escape(export),
+                                    xml_escape(&output.value),
+                                ));
+                            }
+                        }
+                    }
+                }
+                let inner = if entries.is_empty() {
+                    "    <Exports/>".to_string()
+                } else {
+                    format!("    <Exports>\n{entries}    </Exports>")
+                };
+                Ok(xml_response("ListExports", inner, &rid))
+            }
+            "ListImports" => {
+                let export_name = params
+                    .get("ExportName")
+                    .cloned()
+                    .ok_or_else(|| missing("ExportName"))?;
+                let accounts = self.state.read();
+                let mut entries = String::new();
+                if let Some(state) = accounts.get(&aid) {
+                    for stack in state.stacks.values() {
+                        if stack.status == "DELETE_COMPLETE" {
+                            continue;
+                        }
+                        // A stack imports the export if its raw template
+                        // text references `Fn::ImportValue` with that name
+                        // (string-match keeps us protocol-light).
+                        let needle_a = format!("\"{}\"", export_name);
+                        let needle_b = format!("'{}'", export_name);
+                        if stack.template.contains("ImportValue")
+                            && (stack.template.contains(&needle_a)
+                                || stack.template.contains(&needle_b))
+                        {
+                            entries.push_str(&format!(
+                                "      <member>{}</member>\n",
+                                xml_escape(&stack.name)
+                            ));
+                        }
+                    }
+                }
+                let inner = if entries.is_empty() {
+                    "    <Imports/>".to_string()
+                } else {
+                    format!("    <Imports>\n{entries}    </Imports>")
+                };
+                Ok(xml_response("ListImports", inner, &rid))
+            }
 
             // ── Stack policies ──
             "GetStackPolicy" => {
@@ -821,7 +881,7 @@ mod tests {
         ok("ListHookResults", &[]);
         ok("RecordHandlerProgress", &[]);
         ok("ListExports", &[]);
-        ok("ListImports", &[]);
+        ok("ListImports", &[("ExportName", "SomeExport")]);
         ok("GetStackPolicy", &[("StackName", "s")]);
         ok("SetStackPolicy", &[("StackName", "s")]);
         ok("UpdateTerminationProtection", &[("StackName", "s")]);

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -18,6 +18,7 @@ use fakecloud_ssm::SharedSsmState;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::resource_provisioner::ResourceProvisioner;
+use crate::state;
 use crate::state::{
     CloudFormationSnapshot, CloudFormationState, SharedCloudFormationState, Stack, StackResource,
     CLOUDFORMATION_SNAPSHOT_SCHEMA_VERSION,
@@ -272,6 +273,132 @@ impl CloudFormationService {
         }
     }
 
+    /// Build a Fn::ImportValue lookup map across every stack in the
+    /// account: each stack's exported outputs map their `ExportName` to
+    /// the resolved value.
+    fn collect_account_imports(
+        state: &SharedCloudFormationState,
+        account_id: &str,
+        skip_stack: Option<&str>,
+    ) -> BTreeMap<String, String> {
+        let mut imports = BTreeMap::new();
+        let accounts = state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return imports;
+        };
+        for stack in state.stacks.values() {
+            if matches!(skip_stack, Some(skip) if skip == stack.name) {
+                continue;
+            }
+            if stack.status == "DELETE_COMPLETE" {
+                continue;
+            }
+            for output in &stack.outputs {
+                if let Some(export) = &output.export_name {
+                    imports.insert(export.clone(), output.value.clone());
+                }
+            }
+        }
+        imports
+    }
+
+    /// Resolve every `Outputs.*` entry in `template_body` after the stack
+    /// has been provisioned. `resources` is the post-create / post-update
+    /// vec; we rebuild the physical-id and attribute maps from it before
+    /// invoking the template parser.
+    fn resolve_template_outputs(
+        template_body: &str,
+        parameters: &BTreeMap<String, String>,
+        resources: &[StackResource],
+        state: &SharedCloudFormationState,
+    ) -> Vec<state::StackOutput> {
+        let value: serde_json::Value = if template_body.trim_start().starts_with('{') {
+            match serde_json::from_str(template_body) {
+                Ok(v) => v,
+                Err(_) => return Vec::new(),
+            }
+        } else {
+            match serde_yaml::from_str(template_body) {
+                Ok(v) => v,
+                Err(_) => return Vec::new(),
+            }
+        };
+
+        let resources_obj = match value.get("Resources").and_then(|v| v.as_object()) {
+            Some(o) => o.clone(),
+            None => return Vec::new(),
+        };
+
+        let mut physical_ids: BTreeMap<String, String> = BTreeMap::new();
+        let mut attributes: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        for r in resources {
+            physical_ids.insert(r.logical_id.clone(), r.physical_id.clone());
+            attributes.insert(r.logical_id.clone(), r.attributes.clone());
+        }
+
+        let imports = {
+            let accounts = state.read();
+            let mut out = BTreeMap::new();
+            // Walk every account so cross-stack imports work even if
+            // future use-cases serve mixed accounts.
+            for (_account, st) in accounts.iter() {
+                for stack in st.stacks.values() {
+                    if stack.status == "DELETE_COMPLETE" {
+                        continue;
+                    }
+                    for o in &stack.outputs {
+                        if let Some(export) = &o.export_name {
+                            out.insert(export.clone(), o.value.clone());
+                        }
+                    }
+                }
+            }
+            out
+        };
+
+        let parsed = template::parse_outputs(
+            &value,
+            parameters,
+            &resources_obj,
+            &physical_ids,
+            &attributes,
+            &imports,
+        );
+
+        parsed
+            .into_iter()
+            .map(|o| state::StackOutput {
+                key: o.logical_id,
+                value: o.value,
+                description: o.description,
+                export_name: o.export_name,
+            })
+            .collect()
+    }
+
+    /// Reject creates/updates whose outputs would re-export a name that
+    /// another live stack already exports. Mirrors real CloudFormation.
+    fn ensure_export_uniqueness(
+        state: &SharedCloudFormationState,
+        account_id: &str,
+        stack_name: &str,
+        outputs: &[state::StackOutput],
+    ) -> Result<(), AwsServiceError> {
+        let existing = Self::collect_account_imports(state, account_id, Some(stack_name));
+        for o in outputs {
+            if let Some(export) = &o.export_name {
+                if existing.contains_key(export) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationError",
+                        format!("Export with name {export} is already exported by another stack"),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn create_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let params = Self::get_all_params(req);
 
@@ -348,6 +475,11 @@ impl CloudFormationService {
         let resources =
             provision_stack_resources(&provisioner, &parsed.resources, template_body, &parameters)?;
 
+        let outputs =
+            Self::resolve_template_outputs(template_body, &parameters, &resources, &self.state);
+
+        Self::ensure_export_uniqueness(&self.state, &req.account_id, stack_name, &outputs)?;
+
         let stack = Stack {
             name: stack_name.clone(),
             stack_id: stack_id.clone(),
@@ -360,6 +492,7 @@ impl CloudFormationService {
             updated_at: None,
             description: parsed.description,
             notification_arns: notification_arns.clone(),
+            outputs,
         };
 
         {
@@ -645,7 +778,7 @@ impl CloudFormationService {
         } else {
             "UPDATE_COMPLETE".to_string()
         };
-        stack.parameters = input.parameters;
+        stack.parameters = input.parameters.clone();
         if !input.tags.is_empty() {
             stack.tags = input.tags;
         }
@@ -654,6 +787,10 @@ impl CloudFormationService {
         if !input.notification_arns.is_empty() {
             stack.notification_arns = input.notification_arns.clone();
         }
+        if update_result.is_ok() {
+            stack.outputs.clear();
+        }
+        let resources_snapshot = stack.resources.clone();
         let notification_arns = stack.notification_arns.clone();
         let stack_name_for_notif = stack.name.clone();
 
@@ -674,6 +811,26 @@ impl CloudFormationService {
         }
 
         drop(accounts);
+
+        let outputs = Self::resolve_template_outputs(
+            &input.template_body,
+            &input.parameters,
+            &resources_snapshot,
+            &self.state,
+        );
+        Self::ensure_export_uniqueness(&self.state, &req.account_id, &input.stack_name, &outputs)?;
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            if let Some(stack) = state
+                .stacks
+                .values_mut()
+                .find(|s| s.stack_id == stack_id && s.status != "DELETE_COMPLETE")
+            {
+                stack.outputs = outputs;
+            }
+        }
+
         Self::send_stack_notification(
             &self.deps.delivery,
             &notification_arns,
@@ -1322,5 +1479,110 @@ mod tests {
         );
         let req = make_request("UpdateStack", params);
         assert!(svc.update_stack(&req).is_err());
+    }
+
+    #[test]
+    fn create_stack_resolves_outputs_and_records_export() {
+        let svc = make_service();
+        let template = r#"{
+            "Resources": {
+                "Q": {"Type":"AWS::SQS::Queue","Properties":{"QueueName":"out-q"}}
+            },
+            "Outputs": {
+                "QueueUrl": {
+                    "Value": {"Ref": "Q"},
+                    "Description": "Url",
+                    "Export": {"Name": "TheQueueUrl"}
+                }
+            }
+        }"#;
+        let mut params = HashMap::new();
+        params.insert("StackName".to_string(), "outs".to_string());
+        params.insert("TemplateBody".to_string(), template.to_string());
+        let req = make_request("CreateStack", params);
+        svc.create_stack(&req).expect("create stack");
+
+        let accounts = svc.state.read();
+        let stack = accounts
+            .get("123456789012")
+            .unwrap()
+            .stacks
+            .get("outs")
+            .unwrap();
+        assert_eq!(stack.outputs.len(), 1);
+        assert_eq!(stack.outputs[0].key, "QueueUrl");
+        assert_eq!(stack.outputs[0].export_name.as_deref(), Some("TheQueueUrl"));
+        assert!(!stack.outputs[0].value.is_empty());
+    }
+
+    #[test]
+    fn create_stack_rejects_duplicate_export_name() {
+        let svc = make_service();
+        let mk = |name: &str| {
+            let template = format!(
+                r#"{{
+                    "Resources": {{"Q":{{"Type":"AWS::SQS::Queue","Properties":{{"QueueName":"q-{name}"}}}}}},
+                    "Outputs": {{"QueueUrl":{{"Value":{{"Ref":"Q"}},"Export":{{"Name":"DupExport"}}}}}}
+                }}"#
+            );
+            let mut params = HashMap::new();
+            params.insert("StackName".to_string(), name.to_string());
+            params.insert("TemplateBody".to_string(), template);
+            make_request("CreateStack", params)
+        };
+        match svc.create_stack(&mk("first")) {
+            Ok(_) => {}
+            Err(e) => panic!("first stack: {e:?}"),
+        }
+        match svc.create_stack(&mk("second")) {
+            Ok(_) => panic!("expected duplicate-export error"),
+            Err(e) => assert!(
+                format!("{e:?}").contains("already exported"),
+                "expected duplicate-export error, got {e:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn import_value_resolves_against_other_stack_export() {
+        let svc = make_service();
+
+        let producer_tpl = r#"{
+            "Resources": {"Q":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"prod-q"}}},
+            "Outputs": {"Out":{"Value":{"Ref":"Q"},"Export":{"Name":"SharedQueueUrl"}}}
+        }"#;
+        let mut p = HashMap::new();
+        p.insert("StackName".to_string(), "producer".to_string());
+        p.insert("TemplateBody".to_string(), producer_tpl.to_string());
+        svc.create_stack(&make_request("CreateStack", p))
+            .expect("producer");
+
+        let consumer_tpl = r#"{
+            "Resources": {"Q2":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cons-q"}}},
+            "Outputs": {"Imp":{"Value":{"Fn::ImportValue":"SharedQueueUrl"}}}
+        }"#;
+        let mut p = HashMap::new();
+        p.insert("StackName".to_string(), "consumer".to_string());
+        p.insert("TemplateBody".to_string(), consumer_tpl.to_string());
+        svc.create_stack(&make_request("CreateStack", p))
+            .expect("consumer");
+
+        let accounts = svc.state.read();
+        let prod_url = accounts
+            .get("123456789012")
+            .unwrap()
+            .stacks
+            .get("producer")
+            .unwrap()
+            .outputs[0]
+            .value
+            .clone();
+        let cons = accounts
+            .get("123456789012")
+            .unwrap()
+            .stacks
+            .get("consumer")
+            .unwrap();
+        assert_eq!(cons.outputs[0].value, prod_url);
     }
 }

--- a/crates/fakecloud-cloudformation/src/state.rs
+++ b/crates/fakecloud-cloudformation/src/state.rs
@@ -19,6 +19,14 @@ pub struct StackResource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StackOutput {
+    pub key: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub export_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stack {
     pub name: String,
     pub stack_id: String,
@@ -31,6 +39,8 @@ pub struct Stack {
     pub updated_at: Option<DateTime<Utc>>,
     pub description: Option<String>,
     pub notification_arns: Vec<String>,
+    #[serde(default)]
+    pub outputs: Vec<StackOutput>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,6 +138,7 @@ mod tests {
                 updated_at: None,
                 description: None,
                 notification_arns: vec![],
+                outputs: vec![],
             },
         );
         state.reset();

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -7,6 +7,18 @@ use std::collections::BTreeMap;
 pub struct ParsedTemplate {
     pub description: Option<String>,
     pub resources: Vec<ResourceDefinition>,
+    pub outputs: Vec<TemplateOutput>,
+}
+
+/// Resolved Outputs entry from the template's top-level `Outputs` block.
+/// `value` is the post-resolution string; `export_name` is set when the
+/// output declares `Export.Name`.
+#[derive(Debug, Clone)]
+pub struct TemplateOutput {
+    pub logical_id: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub export_name: Option<String>,
 }
 
 /// A single resource from the template.
@@ -105,10 +117,82 @@ pub fn parse_template_with_resolution(
         });
     }
 
+    let outputs = parse_outputs(
+        &value,
+        parameters,
+        resources_obj,
+        resource_physical_ids,
+        resource_attributes,
+        &BTreeMap::new(),
+    );
+
     Ok(ParsedTemplate {
         description,
         resources,
+        outputs,
     })
+}
+
+/// Parse the template's `Outputs` block into resolved entries. Each
+/// `Value` is fully resolved (Ref / GetAtt / Sub / Join / Fn::ImportValue)
+/// to a string. Imports use `imports` for cross-stack lookups.
+pub fn parse_outputs(
+    template: &Value,
+    parameters: &BTreeMap<String, String>,
+    resources: &serde_json::Map<String, Value>,
+    resource_physical_ids: &BTreeMap<String, String>,
+    resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+    imports: &BTreeMap<String, String>,
+) -> Vec<TemplateOutput> {
+    let outputs_obj = match template.get("Outputs").and_then(|v| v.as_object()) {
+        Some(o) => o,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for (logical_id, body) in outputs_obj {
+        let raw_value = match body.get("Value") {
+            Some(v) => v,
+            None => continue,
+        };
+        let resolved = resolve_refs_with_imports(
+            raw_value,
+            parameters,
+            resources,
+            resource_physical_ids,
+            resource_attributes,
+            imports,
+        );
+        let value = match resolved {
+            Value::String(s) => s,
+            other => other.to_string(),
+        };
+        let description = body
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let export_name = body.get("Export").and_then(|e| e.get("Name")).map(|n| {
+            let resolved = resolve_refs_with_imports(
+                n,
+                parameters,
+                resources,
+                resource_physical_ids,
+                resource_attributes,
+                imports,
+            );
+            match resolved {
+                Value::String(s) => s,
+                other => other.to_string(),
+            }
+        });
+        out.push(TemplateOutput {
+            logical_id: logical_id.clone(),
+            value,
+            description,
+            export_name,
+        });
+    }
+    out
 }
 
 /// Re-resolve a single resource definition's properties with updated physical IDs.
@@ -190,13 +274,35 @@ fn pseudo_value(name: &str, parameters: &BTreeMap<String, String>) -> Option<Val
     }
 }
 
-/// Resolve `Ref`, `Fn::GetAtt`, `Fn::Join`, and `Fn::Sub` in property values.
+/// Resolve `Ref`, `Fn::GetAtt`, `Fn::Join`, and `Fn::Sub` in property
+/// values. Cross-stack `Fn::ImportValue` is not consulted; use
+/// `resolve_refs_with_imports` for that.
 fn resolve_refs(
     value: &Value,
     parameters: &BTreeMap<String, String>,
     _resources: &serde_json::Map<String, Value>,
     resource_physical_ids: &BTreeMap<String, String>,
     resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Value {
+    resolve_refs_with_imports(
+        value,
+        parameters,
+        _resources,
+        resource_physical_ids,
+        resource_attributes,
+        &BTreeMap::new(),
+    )
+}
+
+/// Resolve `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, and
+/// `Fn::ImportValue` in property values.
+fn resolve_refs_with_imports(
+    value: &Value,
+    parameters: &BTreeMap<String, String>,
+    _resources: &serde_json::Map<String, Value>,
+    resource_physical_ids: &BTreeMap<String, String>,
+    resource_attributes: &BTreeMap<String, BTreeMap<String, String>>,
+    imports: &BTreeMap<String, String>,
 ) -> Value {
     match value {
         Value::Object(map) => {
@@ -228,6 +334,27 @@ fn resolve_refs(
                     return Value::String(ref_name.to_string());
                 }
             }
+            // Fn::ImportValue: look up an exported value from another stack.
+            // Resolves to the empty string when the export name isn't known
+            // (callers that need strict failure can pre-validate).
+            if let Some(import_val) = map.get("Fn::ImportValue") {
+                let resolved = resolve_refs_with_imports(
+                    import_val,
+                    parameters,
+                    _resources,
+                    resource_physical_ids,
+                    resource_attributes,
+                    imports,
+                );
+                let key = match &resolved {
+                    Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                if let Some(v) = imports.get(&key) {
+                    return Value::String(v.clone());
+                }
+                return Value::String(String::new());
+            }
             if let Some(getatt_val) = map.get("Fn::GetAtt") {
                 if let Some((logical_id, attr_name)) = parse_getatt(getatt_val) {
                     if let Some(attrs) = resource_attributes.get(&logical_id) {
@@ -249,12 +376,13 @@ fn resolve_refs(
                             let resolved_parts: Vec<String> = parts
                                 .iter()
                                 .map(|p| {
-                                    let resolved = resolve_refs(
+                                    let resolved = resolve_refs_with_imports(
                                         p,
                                         parameters,
                                         _resources,
                                         resource_physical_ids,
                                         resource_attributes,
+                                        imports,
                                     );
                                     match resolved {
                                         Value::String(s) => s,
@@ -270,12 +398,13 @@ fn resolve_refs(
             // Fn::Base64: base64-encode a string (or recursively-resolved
             // value).
             if let Some(b64_val) = map.get("Fn::Base64") {
-                let resolved = resolve_refs(
+                let resolved = resolve_refs_with_imports(
                     b64_val,
                     parameters,
                     _resources,
                     resource_physical_ids,
                     resource_attributes,
+                    imports,
                 );
                 let s = match &resolved {
                     Value::String(s) => s.clone(),
@@ -287,12 +416,13 @@ fn resolve_refs(
             }
             // Fn::Length: number of elements in an array.
             if let Some(len_val) = map.get("Fn::Length") {
-                let resolved = resolve_refs(
+                let resolved = resolve_refs_with_imports(
                     len_val,
                     parameters,
                     _resources,
                     resource_physical_ids,
                     resource_attributes,
+                    imports,
                 );
                 if let Some(arr) = resolved.as_array() {
                     return Value::Number(serde_json::Number::from(arr.len()));
@@ -301,12 +431,13 @@ fn resolve_refs(
             }
             // Fn::ToJsonString: serialize a value as a JSON string.
             if let Some(to_json) = map.get("Fn::ToJsonString") {
-                let resolved = resolve_refs(
+                let resolved = resolve_refs_with_imports(
                     to_json,
                     parameters,
                     _resources,
                     resource_physical_ids,
                     resource_attributes,
+                    imports,
                 );
                 let s = serde_json::to_string(&resolved).unwrap_or_default();
                 return Value::String(s);
@@ -317,12 +448,13 @@ fn resolve_refs(
                 if let Some(arr) = split_val.as_array() {
                     if arr.len() == 2 {
                         let delim = arr[0].as_str().unwrap_or("");
-                        let src_resolved = resolve_refs(
+                        let src_resolved = resolve_refs_with_imports(
                             &arr[1],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
                         let src = match src_resolved {
                             Value::String(s) => s,
@@ -341,19 +473,21 @@ fn resolve_refs(
             if let Some(sel_val) = map.get("Fn::Select") {
                 if let Some(arr) = sel_val.as_array() {
                     if arr.len() == 2 {
-                        let idx_val = resolve_refs(
+                        let idx_val = resolve_refs_with_imports(
                             &arr[0],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
-                        let list_val = resolve_refs(
+                        let list_val = resolve_refs_with_imports(
                             &arr[1],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
                         let idx: usize = match &idx_val {
                             Value::Number(n) => n.as_u64().unwrap_or(0) as usize,
@@ -376,26 +510,29 @@ fn resolve_refs(
             if let Some(cidr_val) = map.get("Fn::Cidr") {
                 if let Some(arr) = cidr_val.as_array() {
                     if arr.len() == 3 {
-                        let block_val = resolve_refs(
+                        let block_val = resolve_refs_with_imports(
                             &arr[0],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
-                        let count_val = resolve_refs(
+                        let count_val = resolve_refs_with_imports(
                             &arr[1],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
-                        let bits_val = resolve_refs(
+                        let bits_val = resolve_refs_with_imports(
                             &arr[2],
                             parameters,
                             _resources,
                             resource_physical_ids,
                             resource_attributes,
+                            imports,
                         );
                         let block_str = match &block_val {
                             Value::String(s) => s.clone(),
@@ -444,12 +581,13 @@ fn resolve_refs(
             for (k, v) in map {
                 new_map.insert(
                     k.clone(),
-                    resolve_refs(
+                    resolve_refs_with_imports(
                         v,
                         parameters,
                         _resources,
                         resource_physical_ids,
                         resource_attributes,
+                        imports,
                     ),
                 );
             }
@@ -458,12 +596,13 @@ fn resolve_refs(
         Value::Array(arr) => Value::Array(
             arr.iter()
                 .map(|v| {
-                    resolve_refs(
+                    resolve_refs_with_imports(
                         v,
                         parameters,
                         _resources,
                         resource_physical_ids,
                         resource_attributes,
+                        imports,
                     )
                 })
                 .collect(),

--- a/crates/fakecloud-cloudformation/src/xml_responses.rs
+++ b/crates/fakecloud-cloudformation/src/xml_responses.rs
@@ -120,12 +120,42 @@ fn stack_member_xml(stack: &Stack) -> String {
         format!("\n        <NotificationARNs>\n{members}\n        </NotificationARNs>")
     };
 
+    let outputs_xml = if stack.outputs.is_empty() {
+        String::new()
+    } else {
+        let members: String = stack
+            .outputs
+            .iter()
+            .map(|o| {
+                let desc = o
+                    .description
+                    .as_ref()
+                    .map(|d| format!("\n            <Description>{}</Description>", xml_escape(d)))
+                    .unwrap_or_default();
+                let export = o
+                    .export_name
+                    .as_ref()
+                    .map(|n| format!("\n            <ExportName>{}</ExportName>", xml_escape(n)))
+                    .unwrap_or_default();
+                format!(
+                    "          <member>\n            <OutputKey>{}</OutputKey>\n            <OutputValue>{}</OutputValue>{}{}\n          </member>",
+                    xml_escape(&o.key),
+                    xml_escape(&o.value),
+                    desc,
+                    export,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n        <Outputs>\n{members}\n        </Outputs>")
+    };
+
     format!(
         r#"      <member>
         <StackName>{name}</StackName>
         <StackId>{id}</StackId>
         <StackStatus>{status}</StackStatus>
-        <CreationTime>{created}</CreationTime>{description_xml}{tags_xml}{params_xml}{notification_arns_xml}
+        <CreationTime>{created}</CreationTime>{description_xml}{tags_xml}{params_xml}{notification_arns_xml}{outputs_xml}
       </member>"#,
         name = xml_escape(&stack.name),
         id = xml_escape(&stack.stack_id),
@@ -288,6 +318,7 @@ mod tests {
             updated_at: None,
             description: None,
             notification_arns: vec![],
+            outputs: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary
- Parses top-level Outputs block, resolves each Value (Ref/GetAtt/Sub/Join/ImportValue), stores typed Vec<StackOutput> on Stack.
- DescribeStacks now emits Outputs[].OutputKey/OutputValue/Description/ExportName.
- ListExports walks live stacks and emits real ExportingStackId/Name/Value members.
- ListImports walks every stack template for Fn::ImportValue references to the requested ExportName.
- Fn::ImportValue resolves against an account-wide export map built at create/update time.
- create/update reject when an Output's ExportName collides with another stack's export.

## Test plan
- [x] cargo test -p fakecloud-cloudformation --lib (92 tests pass, including 3 new outputs/imports tests)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse and resolve template `Outputs` and cross-stack `Fn::ImportValue` in `fakecloud-cloudformation`. Surface outputs, exports, and imports in `DescribeStacks`, `ListExports`, and `ListImports`.

- **New Features**
  - Resolve and persist stack outputs after create/update; enforce unique `Export` names account‑wide.
  - Build an export map at create/update and use it to resolve `Fn::ImportValue`.
  - `DescribeStacks` returns resolved outputs (`OutputKey`, `OutputValue`, `Description`, `ExportName`).
  - `ListExports` returns live exports with `ExportingStackId`, `Name`, and `Value`.
  - `ListImports` lists stacks that reference a given `ExportName`.

<sup>Written for commit 04dbd6b8c8e123b220a423c046d74ec09aa57c10. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/955?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

