### PR TITLE
feat(organizations): implement handshake invitation flow

### DIFF
--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -42,6 +42,13 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "ListCreateAccountStatus",
     "CloseAccount",
     "RemoveAccountFromOrganization",
+    "InviteAccountToOrganization",
+    "AcceptHandshake",
+    "DeclineHandshake",
+    "CancelHandshake",
+    "DescribeHandshake",
+    "ListHandshakesForAccount",
+    "ListHandshakesForOrganization",
 ];
 
 pub struct OrganizationsService {
@@ -581,6 +588,143 @@ impl OrganizationsService {
         org.remove_account(&target).map_err(org_error_to_aws)?;
         Ok(AwsResponse::ok_json(json!({})))
     }
+
+    fn invite_account_to_organization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let target_obj = body.get("Target").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidInputException",
+                "Target is required",
+            )
+        })?;
+        let kind = target_obj
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ACCOUNT");
+        let id = target_obj
+            .get("Id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidInputException",
+                    "Target.Id is required",
+                )
+            })?
+            .to_string();
+        let notes = body
+            .get("Notes")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let target_email = if kind == "EMAIL" {
+            Some(id.clone())
+        } else {
+            None
+        };
+
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        let handshake = org
+            .invite_account(&req.account_id, &id, target_email, notes)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Handshake": handshake_payload(&handshake) }),
+        ))
+    }
+
+    fn accept_handshake(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        self.transition_handshake(req, "ACCEPTED")
+    }
+
+    fn decline_handshake(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        self.transition_handshake(req, "DECLINED")
+    }
+
+    fn cancel_handshake(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        self.transition_handshake(req, "CANCELED")
+    }
+
+    fn transition_handshake(
+        &self,
+        req: &AwsRequest,
+        new_state: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let id = required_str(&body, "HandshakeId")?.to_string();
+        let mut guard = self.state.write();
+        let org = guard.as_mut().ok_or_else(organizations_not_in_use)?;
+
+        // AcceptHandshake / DeclineHandshake belong to the *target*
+        // account; CancelHandshake belongs to the *source* (management)
+        // account. Enforce party-correctness so test harnesses catch
+        // misuse before AWS would.
+        let handshake = org.handshakes.get(&id).ok_or_else(|| {
+            org_error_to_aws(crate::state::OrgError::HandshakeNotFound(id.clone()))
+        })?;
+        let allowed = match new_state {
+            "ACCEPTED" | "DECLINED" => req.account_id == handshake.target_account_id,
+            "CANCELED" => req.account_id == handshake.source_account_id,
+            _ => false,
+        };
+        if !allowed {
+            return Err(org_error_to_aws(
+                crate::state::OrgError::InvalidHandshakeParty(req.account_id.clone()),
+            ));
+        }
+        let updated = org
+            .resolve_handshake(&id, new_state)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Handshake": handshake_payload(&updated) }),
+        ))
+    }
+
+    fn describe_handshake(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let id = required_str(&body, "HandshakeId")?.to_string();
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let handshake = org.handshakes.get(&id).ok_or_else(|| {
+            org_error_to_aws(crate::state::OrgError::HandshakeNotFound(id.clone()))
+        })?;
+        Ok(AwsResponse::ok_json(
+            json!({ "Handshake": handshake_payload(handshake) }),
+        ))
+    }
+
+    fn list_handshakes_for_account(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let entries: Vec<Value> = org
+            .list_handshakes(Some(&req.account_id))
+            .iter()
+            .map(handshake_payload)
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Handshakes": entries })))
+    }
+
+    fn list_handshakes_for_organization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_ref().expect("management gate proved Some");
+        let entries: Vec<Value> = org
+            .list_handshakes(None)
+            .iter()
+            .map(handshake_payload)
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Handshakes": entries })))
+    }
 }
 
 #[async_trait]
@@ -619,6 +763,13 @@ impl AwsService for OrganizationsService {
             "ListCreateAccountStatus" => self.list_create_account_status(&req),
             "CloseAccount" => self.close_account(&req),
             "RemoveAccountFromOrganization" => self.remove_account_from_organization(&req),
+            "InviteAccountToOrganization" => self.invite_account_to_organization(&req),
+            "AcceptHandshake" => self.accept_handshake(&req),
+            "DeclineHandshake" => self.decline_handshake(&req),
+            "CancelHandshake" => self.cancel_handshake(&req),
+            "DescribeHandshake" => self.describe_handshake(&req),
+            "ListHandshakesForAccount" => self.list_handshakes_for_account(&req),
+            "ListHandshakesForOrganization" => self.list_handshakes_for_organization(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,
@@ -791,7 +942,62 @@ fn org_error_to_aws(err: OrgError) -> AwsServiceError {
             "CreateAccountStatusNotFoundException",
             format!("Create account status with id {id} was not found."),
         ),
+        OrgError::HandshakeNotFound(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "HandshakeNotFoundException",
+            format!("The handshake with id {id} was not found."),
+        ),
+        OrgError::HandshakeAlreadyResolved(state) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidHandshakeTransitionException",
+            format!("Handshake is already in terminal state {state}."),
+        ),
+        OrgError::InvalidHandshakeState(state) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidHandshakeTransitionException",
+            format!("State {state} is not a valid terminal handshake state."),
+        ),
+        OrgError::InvalidHandshakeParty(account) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AccessDeniedException",
+            format!("Account {account} is not party to this handshake's transition."),
+        ),
+        OrgError::DuplicateHandshakeForAccount(account) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "DuplicateHandshakeException",
+            format!("An OPEN handshake already exists for account {account}."),
+        ),
+        OrgError::AccountAlreadyMember(account) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AccountAlreadyRegisteredException",
+            format!("Account {account} is already a member of this organization."),
+        ),
     }
+}
+
+fn handshake_payload(h: &crate::state::Handshake) -> Value {
+    let parties = json!([
+        {"Id": h.source_account_id, "Type": "ACCOUNT"},
+        {"Id": h.target_account_id, "Type": h.target_kind},
+    ]);
+    let resources = json!([
+        {"Type": "ORGANIZATION", "Value": h.organization_id},
+        {"Type": "ACCOUNT", "Value": h.target_account_id},
+    ]);
+    let mut obj = json!({
+        "Id": h.id,
+        "Arn": h.arn,
+        "Action": h.action,
+        "State": h.state,
+        "RequestedTimestamp": h.requested_timestamp.timestamp() as f64,
+        "ExpirationTimestamp": h.expiration_timestamp.timestamp() as f64,
+        "Parties": parties,
+        "Resources": resources,
+    });
+    if let Some(notes) = &h.notes {
+        obj["Notes"] = json!(notes);
+    }
+    obj
 }
 
 fn create_account_status_payload(status: &crate::state::CreateAccountStatus) -> Value {

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -48,6 +48,11 @@ pub struct OrganizationState {
     /// via `DescribeCreateAccountStatus` and `ListCreateAccountStatus`.
     #[serde(default)]
     pub create_account_requests: BTreeMap<String, CreateAccountStatus>,
+    /// `InviteAccountToOrganization` handshakes keyed by id (`h-...`).
+    /// Lifecycles transition `REQUESTED` -> `OPEN` (peer side) ->
+    /// `ACCEPTED` / `DECLINED` / `CANCELED` / `EXPIRED`.
+    #[serde(default)]
+    pub handshakes: BTreeMap<String, Handshake>,
 }
 
 impl OrganizationState {
@@ -126,6 +131,7 @@ impl OrganizationState {
             policies,
             attachments,
             create_account_requests: BTreeMap::new(),
+            handshakes: BTreeMap::new(),
         }
     }
 
@@ -189,6 +195,118 @@ impl OrganizationState {
         self.create_account_requests
             .insert(request_id, status.clone());
         status
+    }
+
+    /// Issue a new pending invitation handshake to `target_account_id`.
+    /// Idempotent: a duplicate live handshake to the same account
+    /// returns `DuplicateHandshakeForAccount`.
+    pub fn invite_account(
+        &mut self,
+        source_account_id: &str,
+        target_account_id: &str,
+        target_email: Option<String>,
+        notes: Option<String>,
+    ) -> Result<Handshake, OrgError> {
+        if self.accounts.contains_key(target_account_id) {
+            return Err(OrgError::AccountAlreadyMember(
+                target_account_id.to_string(),
+            ));
+        }
+        for h in self.handshakes.values() {
+            if h.target_account_id == target_account_id
+                && matches!(h.state.as_str(), "REQUESTED" | "OPEN")
+            {
+                return Err(OrgError::DuplicateHandshakeForAccount(
+                    target_account_id.to_string(),
+                ));
+            }
+        }
+        let now = Utc::now();
+        let id = format!("h-{}", random_id(32));
+        let arn = format!(
+            "arn:aws:organizations::{}:handshake/{}/invite/{}",
+            self.management_account_id, self.org_id, id
+        );
+        let kind = if target_account_id.chars().all(|c| c.is_ascii_digit()) {
+            "ACCOUNT".to_string()
+        } else {
+            "EMAIL".to_string()
+        };
+        let handshake = Handshake {
+            id: id.clone(),
+            arn,
+            action: "INVITE".to_string(),
+            state: "OPEN".to_string(),
+            requested_timestamp: now,
+            expiration_timestamp: now + chrono::Duration::days(15),
+            source_account_id: source_account_id.to_string(),
+            target_account_id: target_account_id.to_string(),
+            target_email,
+            target_kind: kind,
+            notes,
+            organization_id: self.org_id.clone(),
+        };
+        self.handshakes.insert(id, handshake.clone());
+        Ok(handshake)
+    }
+
+    /// Move a live handshake from `OPEN` into `new_state`. Caller decides
+    /// whether the transition is allowed for the current API caller —
+    /// this just enforces lifecycle (open -> terminal) and stamps
+    /// `expiration_timestamp` to now on accept/decline/cancel so the
+    /// resolved-at moment is recoverable.
+    pub fn resolve_handshake(&mut self, id: &str, new_state: &str) -> Result<Handshake, OrgError> {
+        let handshake = self
+            .handshakes
+            .get_mut(id)
+            .ok_or_else(|| OrgError::HandshakeNotFound(id.to_string()))?;
+        if !matches!(handshake.state.as_str(), "OPEN" | "REQUESTED") {
+            return Err(OrgError::HandshakeAlreadyResolved(handshake.state.clone()));
+        }
+        if !matches!(new_state, "ACCEPTED" | "DECLINED" | "CANCELED" | "EXPIRED") {
+            return Err(OrgError::InvalidHandshakeState(new_state.to_string()));
+        }
+        handshake.state = new_state.to_string();
+        handshake.expiration_timestamp = Utc::now();
+        let snapshot = handshake.clone();
+        if new_state == "ACCEPTED" && !self.accounts.contains_key(&snapshot.target_account_id) {
+            let now = Utc::now();
+            let arn = format!(
+                "arn:aws:organizations::{}:account/{}/{}",
+                self.management_account_id, self.org_id, snapshot.target_account_id
+            );
+            let email = snapshot
+                .target_email
+                .clone()
+                .unwrap_or_else(|| format!("{}@example.com", snapshot.target_account_id));
+            self.accounts.insert(
+                snapshot.target_account_id.clone(),
+                MemberAccount {
+                    id: snapshot.target_account_id.clone(),
+                    arn,
+                    email,
+                    name: format!("Account {}", snapshot.target_account_id),
+                    status: "ACTIVE".to_string(),
+                    joined_method: "INVITED".to_string(),
+                    joined_timestamp: now,
+                    parent_id: self.root_id.clone(),
+                },
+            );
+        }
+        Ok(snapshot)
+    }
+
+    /// Return a clone of every handshake currently tracked for the org,
+    /// optionally filtered by destination account id.
+    pub fn list_handshakes(&self, only_target_account: Option<&str>) -> Vec<Handshake> {
+        self.handshakes
+            .values()
+            .filter(|h| match only_target_account {
+                Some(acct) => h.target_account_id == acct,
+                None => true,
+            })
+            .cloned()
+            .collect()
     }
 
     /// Look up a `CreateAccountStatus` by its `car-...` id. If still
@@ -621,6 +739,12 @@ pub enum OrgError {
     TargetNotFound(String),
     AccountChangesNotAllowed(String),
     CreateAccountStatusNotFound(String),
+    HandshakeNotFound(String),
+    HandshakeAlreadyResolved(String),
+    InvalidHandshakeState(String),
+    InvalidHandshakeParty(String),
+    DuplicateHandshakeForAccount(String),
+    AccountAlreadyMember(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -656,6 +780,25 @@ pub struct MemberAccount {
     pub joined_method: String,
     pub joined_timestamp: DateTime<Utc>,
     pub parent_id: String,
+}
+
+/// `InviteAccountToOrganization` handshake. Captures both parties so
+/// `ListHandshakesForAccount` can filter by destination, and stores
+/// the resolved state plus when each transition happened.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Handshake {
+    pub id: String,
+    pub arn: String,
+    pub action: String,
+    pub state: String,
+    pub requested_timestamp: DateTime<Utc>,
+    pub expiration_timestamp: DateTime<Utc>,
+    pub source_account_id: String,
+    pub target_account_id: String,
+    pub target_email: Option<String>,
+    pub target_kind: String,
+    pub notes: Option<String>,
+    pub organization_id: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1046,5 +1189,71 @@ mod tests {
         org.attach_policy(&p.id, &root).unwrap();
         let targets = org.targets_for_policy(&p.id).unwrap();
         assert_eq!(targets.len(), 1);
+    }
+
+    #[test]
+    fn invite_account_creates_open_handshake() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let h = org
+            .invite_account("111111111111", "222222222222", None, None)
+            .unwrap();
+        assert_eq!(h.state, "OPEN");
+        assert!(h.id.starts_with("h-"));
+        assert!(org.handshakes.contains_key(&h.id));
+    }
+
+    #[test]
+    fn invite_rejects_existing_member() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org
+            .invite_account("111111111111", "111111111111", None, None)
+            .unwrap_err();
+        assert!(matches!(err, OrgError::AccountAlreadyMember(_)));
+    }
+
+    #[test]
+    fn duplicate_open_invite_rejected() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.invite_account("111111111111", "333333333333", None, None)
+            .unwrap();
+        let err = org
+            .invite_account("111111111111", "333333333333", None, None)
+            .unwrap_err();
+        assert!(matches!(err, OrgError::DuplicateHandshakeForAccount(_)));
+    }
+
+    #[test]
+    fn accept_handshake_enrolls_account() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let h = org
+            .invite_account("111111111111", "444444444444", None, None)
+            .unwrap();
+        assert!(!org.accounts.contains_key("444444444444"));
+        let resolved = org.resolve_handshake(&h.id, "ACCEPTED").unwrap();
+        assert_eq!(resolved.state, "ACCEPTED");
+        let acct = org.accounts.get("444444444444").unwrap();
+        assert_eq!(acct.joined_method, "INVITED");
+    }
+
+    #[test]
+    fn decline_handshake_does_not_enroll() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let h = org
+            .invite_account("111111111111", "555555555555", None, None)
+            .unwrap();
+        let resolved = org.resolve_handshake(&h.id, "DECLINED").unwrap();
+        assert_eq!(resolved.state, "DECLINED");
+        assert!(!org.accounts.contains_key("555555555555"));
+    }
+
+    #[test]
+    fn resolve_handshake_terminal_locked() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let h = org
+            .invite_account("111111111111", "666666666666", None, None)
+            .unwrap();
+        org.resolve_handshake(&h.id, "ACCEPTED").unwrap();
+        let err = org.resolve_handshake(&h.id, "DECLINED").unwrap_err();
+        assert!(matches!(err, OrgError::HandshakeAlreadyResolved(_)));
     }
 }


### PR DESCRIPTION
## Summary
- New ops: InviteAccountToOrganization, AcceptHandshake, DeclineHandshake, CancelHandshake, DescribeHandshake, ListHandshakesForAccount, ListHandshakesForOrganization.
- Handshake struct on OrganizationState; lifecycle OPEN -> ACCEPTED / DECLINED / CANCELED with party-correctness checks (target accepts/declines, source cancels).
- ACCEPTED transitions enroll the target account in the org under root.
- 6 new state-level tests cover the invite/accept/decline/duplicate paths.

## Test plan
- [x] cargo test -p fakecloud-organizations --lib (99 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the organization invitation handshake flow so accounts can be invited, accept/decline, and be enrolled automatically on accept. Enforces party checks (target accepts/declines; source cancels) and adds describe/list APIs.

- **New Features**
  - Adds `InviteAccountToOrganization`, `AcceptHandshake`, `DeclineHandshake`, `CancelHandshake`, `DescribeHandshake`, `ListHandshakesForAccount`, `ListHandshakesForOrganization`.
  - Stores handshakes on org state with lifecycle: OPEN → ACCEPTED/DECLINED/CANCELED/EXPIRED.
  - ACCEPTED enrolls the target account under the root with joined_method=INVITED.
  - Permission checks: only target can accept/decline; only source can cancel; org-level list gated by management.
  - Returns structured handshake payloads; maps errors for not found, duplicates, invalid transitions, and access denied.
  - Adds 6 state-level tests for invite, accept, decline, duplicate, and terminal-state guards.

<sup>Written for commit 931548769d18d823430a923059f1f085fcfbf6d0. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/956?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

