### PR TITLE
feat(organizations): trusted services + delegated administrators

### DIFF
--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
 
@@ -49,6 +50,13 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "DescribeHandshake",
     "ListHandshakesForAccount",
     "ListHandshakesForOrganization",
+    "EnableAWSServiceAccess",
+    "DisableAWSServiceAccess",
+    "ListAWSServiceAccessForOrganization",
+    "RegisterDelegatedAdministrator",
+    "DeregisterDelegatedAdministrator",
+    "ListDelegatedAdministrators",
+    "ListDelegatedServicesForAccount",
 ];
 
 pub struct OrganizationsService {
@@ -725,6 +733,137 @@ impl OrganizationsService {
             .collect();
         Ok(AwsResponse::ok_json(json!({ "Handshakes": entries })))
     }
+
+    fn enable_aws_service_access(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let principal = required_str(&body, "ServicePrincipal")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.enable_aws_service_access(&principal);
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn disable_aws_service_access(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let principal = required_str(&body, "ServicePrincipal")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.disable_aws_service_access(&principal)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_aws_service_access_for_organization(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_ref().expect("management gate proved Some");
+        let entries: Vec<Value> = org
+            .list_trusted_services()
+            .into_iter()
+            .map(|svc| {
+                json!({
+                    "ServicePrincipal": svc,
+                    "DateEnabled": Utc::now().timestamp() as f64,
+                })
+            })
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "EnabledServicePrincipals": entries }),
+        ))
+    }
+
+    fn register_delegated_administrator(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let account_id = required_str(&body, "AccountId")?.to_string();
+        let principal = required_str(&body, "ServicePrincipal")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.register_delegated_administrator(&account_id, &principal)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn deregister_delegated_administrator(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let account_id = required_str(&body, "AccountId")?.to_string();
+        let principal = required_str(&body, "ServicePrincipal")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.deregister_delegated_administrator(&account_id, &principal)
+            .map_err(org_error_to_aws)?;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_delegated_administrators(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let filter = body
+            .get("ServicePrincipal")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_ref().expect("management gate proved Some");
+        let entries: Vec<Value> = org
+            .list_delegated_administrators(filter.as_deref())
+            .into_iter()
+            .filter_map(|admin| {
+                let acct = org.accounts.get(&admin.account_id)?;
+                Some(json!({
+                    "Id": acct.id,
+                    "Arn": acct.arn,
+                    "Email": acct.email,
+                    "Name": acct.name,
+                    "Status": acct.status,
+                    "JoinedMethod": acct.joined_method,
+                    "JoinedTimestamp": acct.joined_timestamp.timestamp() as f64,
+                    "DelegationEnabledDate": admin.registered_at.timestamp() as f64,
+                }))
+            })
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "DelegatedAdministrators": entries }),
+        ))
+    }
+
+    fn list_delegated_services_for_account(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let account_id = required_str(&body, "AccountId")?.to_string();
+        let guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_ref().expect("management gate proved Some");
+        let entries: Vec<Value> = org
+            .list_delegated_services_for_account(&account_id)
+            .into_iter()
+            .map(|svc| {
+                json!({
+                    "ServicePrincipal": svc,
+                    "DelegationEnabledDate": Utc::now().timestamp() as f64,
+                })
+            })
+            .collect();
+        Ok(AwsResponse::ok_json(
+            json!({ "DelegatedServices": entries }),
+        ))
+    }
 }
 
 #[async_trait]
@@ -770,6 +909,15 @@ impl AwsService for OrganizationsService {
             "DescribeHandshake" => self.describe_handshake(&req),
             "ListHandshakesForAccount" => self.list_handshakes_for_account(&req),
             "ListHandshakesForOrganization" => self.list_handshakes_for_organization(&req),
+            "EnableAWSServiceAccess" => self.enable_aws_service_access(&req),
+            "DisableAWSServiceAccess" => self.disable_aws_service_access(&req),
+            "ListAWSServiceAccessForOrganization" => {
+                self.list_aws_service_access_for_organization(&req)
+            }
+            "RegisterDelegatedAdministrator" => self.register_delegated_administrator(&req),
+            "DeregisterDelegatedAdministrator" => self.deregister_delegated_administrator(&req),
+            "ListDelegatedAdministrators" => self.list_delegated_administrators(&req),
+            "ListDelegatedServicesForAccount" => self.list_delegated_services_for_account(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,
@@ -971,6 +1119,21 @@ fn org_error_to_aws(err: OrgError) -> AwsServiceError {
             StatusCode::BAD_REQUEST,
             "AccountAlreadyRegisteredException",
             format!("Account {account} is already a member of this organization."),
+        ),
+        OrgError::AWSServiceAccessNotEnabled(svc) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AWSOrganizationsNotInUseException",
+            format!("AWS service access for {svc} is not enabled."),
+        ),
+        OrgError::DelegatedAdministratorAlreadyRegistered(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AccountAlreadyRegisteredException",
+            format!("Account {id} is already registered as a delegated administrator."),
+        ),
+        OrgError::DelegatedAdministratorNotRegistered(id) => AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AccountNotRegisteredException",
+            format!("Account {id} is not registered as a delegated administrator."),
         ),
     }
 }

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -53,6 +53,14 @@ pub struct OrganizationState {
     /// `ACCEPTED` / `DECLINED` / `CANCELED` / `EXPIRED`.
     #[serde(default)]
     pub handshakes: BTreeMap<String, Handshake>,
+    /// AWS service principals enabled via `EnableAWSServiceAccess`.
+    /// Stored as the principal hostname (eg. `config.amazonaws.com`).
+    #[serde(default)]
+    pub trusted_services: HashSet<String>,
+    /// Service principal -> set of member account ids registered as
+    /// delegated administrators for that service.
+    #[serde(default)]
+    pub delegated_administrators: BTreeMap<String, BTreeMap<String, DelegatedAdministrator>>,
 }
 
 impl OrganizationState {
@@ -132,6 +140,8 @@ impl OrganizationState {
             attachments,
             create_account_requests: BTreeMap::new(),
             handshakes: BTreeMap::new(),
+            trusted_services: HashSet::new(),
+            delegated_administrators: BTreeMap::new(),
         }
     }
 
@@ -307,6 +317,121 @@ impl OrganizationState {
             })
             .cloned()
             .collect()
+    }
+
+    /// Mark `service_principal` as a trusted service. Idempotent.
+    pub fn enable_aws_service_access(&mut self, service_principal: &str) {
+        self.trusted_services.insert(service_principal.to_string());
+    }
+
+    /// Drop `service_principal` from the trusted set. Also removes any
+    /// delegated administrators registered for that principal — real
+    /// Organizations rejects DisableAWSServiceAccess if delegates exist;
+    /// we mirror that gate via a separate `disable_aws_service_access`
+    /// returning `Err` when delegates are still registered.
+    pub fn disable_aws_service_access(&mut self, service_principal: &str) -> Result<(), OrgError> {
+        if let Some(delegates) = self.delegated_administrators.get(service_principal) {
+            if !delegates.is_empty() {
+                return Err(OrgError::DelegatedAdministratorAlreadyRegistered(
+                    service_principal.to_string(),
+                ));
+            }
+        }
+        self.trusted_services.remove(service_principal);
+        self.delegated_administrators.remove(service_principal);
+        Ok(())
+    }
+
+    /// Iterate enabled trusted services in alphabetical order.
+    pub fn list_trusted_services(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.trusted_services.iter().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Register `account_id` as a delegated administrator for the given
+    /// `service_principal`. Requires the service to already be trusted
+    /// (matches AWS Organizations) and the account to already be a member.
+    pub fn register_delegated_administrator(
+        &mut self,
+        account_id: &str,
+        service_principal: &str,
+    ) -> Result<DelegatedAdministrator, OrgError> {
+        if !self.accounts.contains_key(account_id) {
+            return Err(OrgError::AccountNotFound(account_id.to_string()));
+        }
+        if !self.trusted_services.contains(service_principal) {
+            return Err(OrgError::AWSServiceAccessNotEnabled(
+                service_principal.to_string(),
+            ));
+        }
+        let entry = self
+            .delegated_administrators
+            .entry(service_principal.to_string())
+            .or_default();
+        if entry.contains_key(account_id) {
+            return Err(OrgError::DelegatedAdministratorAlreadyRegistered(
+                account_id.to_string(),
+            ));
+        }
+        let admin = DelegatedAdministrator {
+            account_id: account_id.to_string(),
+            service_principal: service_principal.to_string(),
+            registered_at: Utc::now(),
+        };
+        entry.insert(account_id.to_string(), admin.clone());
+        Ok(admin)
+    }
+
+    /// Drop a delegated administrator registration.
+    pub fn deregister_delegated_administrator(
+        &mut self,
+        account_id: &str,
+        service_principal: &str,
+    ) -> Result<(), OrgError> {
+        let entry = self
+            .delegated_administrators
+            .get_mut(service_principal)
+            .ok_or_else(|| {
+                OrgError::DelegatedAdministratorNotRegistered(service_principal.to_string())
+            })?;
+        if entry.remove(account_id).is_none() {
+            return Err(OrgError::DelegatedAdministratorNotRegistered(
+                account_id.to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// List delegated administrators, optionally filtered by service.
+    pub fn list_delegated_administrators(
+        &self,
+        service_principal_filter: Option<&str>,
+    ) -> Vec<DelegatedAdministrator> {
+        let mut out = Vec::new();
+        for (svc, admins) in &self.delegated_administrators {
+            if let Some(filter) = service_principal_filter {
+                if filter != svc {
+                    continue;
+                }
+            }
+            for admin in admins.values() {
+                out.push(admin.clone());
+            }
+        }
+        out
+    }
+
+    /// List service principals that `account_id` is a delegated admin for.
+    pub fn list_delegated_services_for_account(&self, account_id: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for (svc, admins) in &self.delegated_administrators {
+            if admins.contains_key(account_id) {
+                out.push(svc.clone());
+            }
+        }
+        out.sort();
+        out
     }
 
     /// Look up a `CreateAccountStatus` by its `car-...` id. If still
@@ -745,6 +870,16 @@ pub enum OrgError {
     InvalidHandshakeParty(String),
     DuplicateHandshakeForAccount(String),
     AccountAlreadyMember(String),
+    AWSServiceAccessNotEnabled(String),
+    DelegatedAdministratorAlreadyRegistered(String),
+    DelegatedAdministratorNotRegistered(String),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DelegatedAdministrator {
+    pub account_id: String,
+    pub service_principal: String,
+    pub registered_at: DateTime<Utc>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1176,6 +1311,77 @@ mod tests {
             .collect();
         types.sort();
         assert_eq!(types, vec!["ACCOUNT", "ORGANIZATIONAL_UNIT", "ROOT"]);
+    }
+
+    #[test]
+    fn enable_aws_service_access_is_idempotent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enable_aws_service_access("config.amazonaws.com");
+        org.enable_aws_service_access("config.amazonaws.com");
+        let trusted = org.list_trusted_services();
+        assert_eq!(trusted, vec!["config.amazonaws.com"]);
+    }
+
+    #[test]
+    fn disable_aws_service_access_blocked_when_delegates_exist() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        org.enable_aws_service_access("ssm.amazonaws.com");
+        org.register_delegated_administrator("222222222222", "ssm.amazonaws.com")
+            .unwrap();
+        let err = org
+            .disable_aws_service_access("ssm.amazonaws.com")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OrgError::DelegatedAdministratorAlreadyRegistered(_)
+        ));
+    }
+
+    #[test]
+    fn disable_aws_service_access_drops_when_clean() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enable_aws_service_access("ssm.amazonaws.com");
+        org.disable_aws_service_access("ssm.amazonaws.com").unwrap();
+        assert!(org.list_trusted_services().is_empty());
+    }
+
+    #[test]
+    fn register_delegated_administrator_requires_trusted_service() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        let err = org
+            .register_delegated_administrator("222222222222", "ssm.amazonaws.com")
+            .unwrap_err();
+        assert!(matches!(err, OrgError::AWSServiceAccessNotEnabled(_)));
+    }
+
+    #[test]
+    fn list_delegated_services_for_account_returns_principals() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        org.enable_aws_service_access("ssm.amazonaws.com");
+        org.enable_aws_service_access("config.amazonaws.com");
+        org.register_delegated_administrator("222222222222", "ssm.amazonaws.com")
+            .unwrap();
+        org.register_delegated_administrator("222222222222", "config.amazonaws.com")
+            .unwrap();
+        let svcs = org.list_delegated_services_for_account("222222222222");
+        assert_eq!(svcs, vec!["config.amazonaws.com", "ssm.amazonaws.com"]);
+    }
+
+    #[test]
+    fn deregister_delegated_administrator_removes_entry() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enroll_account_if_missing("222222222222");
+        org.enable_aws_service_access("ssm.amazonaws.com");
+        org.register_delegated_administrator("222222222222", "ssm.amazonaws.com")
+            .unwrap();
+        org.deregister_delegated_administrator("222222222222", "ssm.amazonaws.com")
+            .unwrap();
+        assert!(org
+            .list_delegated_services_for_account("222222222222")
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New ops: EnableAWSServiceAccess, DisableAWSServiceAccess, ListAWSServiceAccessForOrganization, RegisterDelegatedAdministrator, DeregisterDelegatedAdministrator, ListDelegatedAdministrators, ListDelegatedServicesForAccount.
- Trusted service principals + per-service delegated-administrator maps on OrganizationState.
- Disable rejected while delegates exist; register requires service to be trusted first.
- 6 new state-level tests.

## Test plan
- [x] cargo test -p fakecloud-organizations --lib (99 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trusted service access and delegated administrator support to Organizations in `fakecloud-organizations`. Enables AWS-compatible ops to manage service trust and per-service admin delegation from the management account.

- **New Features**
  - New actions: EnableAWSServiceAccess, DisableAWSServiceAccess, ListAWSServiceAccessForOrganization, RegisterDelegatedAdministrator, DeregisterDelegatedAdministrator, ListDelegatedAdministrators, ListDelegatedServicesForAccount.
  - Organization state tracks trusted `ServicePrincipal`s and per-service delegated administrators.
  - Rules enforced: cannot disable a service while delegates exist; registering a delegate requires the service to be trusted; all actions require management account access.
  - List endpoints include timestamps; `ListDelegatedAdministrators` returns the same Account shape as DescribeAccount and supports optional `ServicePrincipal` filtering.
  - Errors mirror AWS: AWSOrganizationsNotInUseException, AccountAlreadyRegisteredException, AccountNotRegisteredException; 6 new state tests cover the lifecycle.

<sup>Written for commit 20c7a8abe8d440c8c10f3c9f275e611bda6d3260. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/957?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

