### PR TITLE
feat(organizations): tagging + nav + effective/resource policy

### DIFF
--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -60,6 +60,15 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "EnableAllFeatures",
     "EnablePolicyType",
     "DisablePolicyType",
+    "TagResource",
+    "UntagResource",
+    "ListTagsForResource",
+    "ListParents",
+    "ListChildren",
+    "DescribeEffectivePolicy",
+    "PutResourcePolicy",
+    "DeleteResourcePolicy",
+    "DescribeResourcePolicy",
 ];
 
 pub struct OrganizationsService {
@@ -939,6 +948,213 @@ impl OrganizationsService {
             }
         })))
     }
+    fn tag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_id = required_str(&body, "ResourceId")?.to_string();
+        let tags = parse_tags(body.get("Tags"));
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.set_resource_tags(&resource_id, &tags);
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn untag_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_id = required_str(&body, "ResourceId")?.to_string();
+        let tag_keys: Vec<String> = body
+            .get("TagKeys")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.untag_resource(&resource_id, &tag_keys);
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn list_tags_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let resource_id = required_str(&body, "ResourceId")?.to_string();
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let tags: Vec<Value> = org
+            .list_resource_tags(&resource_id)
+            .into_iter()
+            .map(|(k, v)| json!({"Key": k, "Value": v}))
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Tags": tags })))
+    }
+
+    fn list_parents(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let child_id = required_str(&body, "ChildId")?.to_string();
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let parents = match org.parent_of(&child_id) {
+            Some((id, kind)) => vec![json!({"Id": id, "Type": kind})],
+            None => Vec::new(),
+        };
+        Ok(AwsResponse::ok_json(json!({ "Parents": parents })))
+    }
+
+    fn list_children(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let parent_id = required_str(&body, "ParentId")?.to_string();
+        let child_type = required_str(&body, "ChildType")?.to_string();
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let children: Vec<Value> = org
+            .list_children(&parent_id, &child_type)
+            .into_iter()
+            .map(|id| json!({"Id": id, "Type": child_type}))
+            .collect();
+        Ok(AwsResponse::ok_json(json!({ "Children": children })))
+    }
+
+    fn describe_effective_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_type = required_str(&body, "PolicyType")?.to_string();
+        let target_id = body
+            .get("TargetId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| req.account_id.clone());
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        // The effective policy is the union of every policy of `policy_type`
+        // attached up the org hierarchy from `target_id` to root. We
+        // present it as a single Statement[] union so callers can audit.
+        let mut statements: Vec<Value> = Vec::new();
+        for ancestor in ancestors_for(org, &target_id) {
+            if let Some(policy_ids) = org.attachments.get(&ancestor) {
+                for pid in policy_ids {
+                    if let Some(policy) = org.policies.get(pid) {
+                        if policy.policy_type == policy_type {
+                            if let Ok(content) = serde_json::from_str::<Value>(&policy.content) {
+                                if let Some(arr) =
+                                    content.get("Statement").and_then(|v| v.as_array())
+                                {
+                                    statements.extend(arr.iter().cloned());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let merged = json!({"Version": "2012-10-17", "Statement": statements});
+        let payload = json!({
+            "EffectivePolicy": {
+                "PolicyType": policy_type,
+                "TargetId": target_id,
+                "PolicyContent": merged.to_string(),
+                "LastUpdatedTimestamp": Utc::now().timestamp() as f64,
+            }
+        });
+        Ok(AwsResponse::ok_json(payload))
+    }
+
+    fn put_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let content = required_str(&body, "Content")?.to_string();
+        // Reject malformed JSON up front.
+        serde_json::from_str::<Value>(&content).map_err(|_| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidInputException",
+                "Content must be valid JSON",
+            )
+        })?;
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.resource_policy = Some(content);
+        let payload = json!({
+            "ResourcePolicy": {
+                "ResourcePolicySummary": {
+                    "Id": "rp-fakecloud",
+                    "Arn": format!(
+                        "arn:aws:organizations::{}:resourcepolicy/{}/rp-fakecloud",
+                        org.management_account_id, org.org_id
+                    ),
+                },
+                "Content": org.resource_policy.clone(),
+            }
+        });
+        Ok(AwsResponse::ok_json(payload))
+    }
+
+    fn delete_resource_policy(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.resource_policy = None;
+        Ok(AwsResponse::ok_json(json!({})))
+    }
+
+    fn describe_resource_policy(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let guard = self.state.read();
+        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
+        let content = org.resource_policy.clone().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourcePolicyNotFoundException",
+                "No resource policy is attached to this organization.",
+            )
+        })?;
+        Ok(AwsResponse::ok_json(json!({
+            "ResourcePolicy": {
+                "ResourcePolicySummary": {
+                    "Id": "rp-fakecloud",
+                    "Arn": format!(
+                        "arn:aws:organizations::{}:resourcepolicy/{}/rp-fakecloud",
+                        org.management_account_id, org.org_id
+                    ),
+                },
+                "Content": content,
+            }
+        })))
+    }
+}
+
+fn parse_tags(value: Option<&Value>) -> Vec<(String, String)> {
+    let arr = match value.and_then(|v| v.as_array()) {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    arr.iter()
+        .filter_map(|v| {
+            let k = v.get("Key")?.as_str()?.to_string();
+            let value = v.get("Value")?.as_str()?.to_string();
+            Some((k, value))
+        })
+        .collect()
+}
+
+/// Walk from `target_id` up to root (inclusive) via OU/account parents.
+/// Used by `DescribeEffectivePolicy` to union policy statements across
+/// every level. Keeps the input id at the front so direct attachments
+/// take precedence in iteration order.
+fn ancestors_for(org: &OrganizationState, target_id: &str) -> Vec<String> {
+    let mut chain = vec![target_id.to_string()];
+    let mut cursor = target_id.to_string();
+    while let Some((parent, _)) = org.parent_of(&cursor) {
+        if parent.is_empty() {
+            break;
+        }
+        chain.push(parent.clone());
+        if parent.starts_with("r-") {
+            break;
+        }
+        cursor = parent;
+    }
+    chain
 }
 
 #[async_trait]
@@ -996,6 +1212,15 @@ impl AwsService for OrganizationsService {
             "EnableAllFeatures" => self.enable_all_features(&req),
             "EnablePolicyType" => self.enable_policy_type(&req),
             "DisablePolicyType" => self.disable_policy_type(&req),
+            "TagResource" => self.tag_resource(&req),
+            "UntagResource" => self.untag_resource(&req),
+            "ListTagsForResource" => self.list_tags_for_resource(&req),
+            "ListParents" => self.list_parents(&req),
+            "ListChildren" => self.list_children(&req),
+            "DescribeEffectivePolicy" => self.describe_effective_policy(&req),
+            "PutResourcePolicy" => self.put_resource_policy(&req),
+            "DeleteResourcePolicy" => self.delete_resource_policy(&req),
+            "DescribeResourcePolicy" => self.describe_resource_policy(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -66,6 +66,14 @@ pub struct OrganizationState {
     /// EnablePolicyType / DisablePolicyType.
     #[serde(default = "default_enabled_policy_types")]
     pub enabled_policy_types: HashSet<String>,
+    /// Tag bag keyed by resource id (account id, OU id, root id, policy id).
+    #[serde(default)]
+    pub resource_tags: BTreeMap<String, BTreeMap<String, String>>,
+    /// Resource policy attached to the org via `PutResourcePolicy`.
+    /// AWS Organizations supports a single resource policy per org;
+    /// `None` means unset (the default).
+    #[serde(default)]
+    pub resource_policy: Option<String>,
 }
 
 fn default_enabled_policy_types() -> HashSet<String> {
@@ -154,6 +162,75 @@ impl OrganizationState {
             trusted_services: HashSet::new(),
             delegated_administrators: BTreeMap::new(),
             enabled_policy_types: default_enabled_policy_types(),
+            resource_tags: BTreeMap::new(),
+            resource_policy: None,
+        }
+    }
+
+    /// Replace `resource_id`'s tag set with `tags`. Used for both
+    /// adding new tag keys and overwriting existing ones; matches
+    /// `TagResource` semantics.
+    pub fn set_resource_tags(&mut self, resource_id: &str, tags: &[(String, String)]) {
+        let entry = self
+            .resource_tags
+            .entry(resource_id.to_string())
+            .or_default();
+        for (k, v) in tags {
+            entry.insert(k.clone(), v.clone());
+        }
+    }
+
+    /// Drop `tag_keys` from `resource_id`'s tag set. No-op if absent.
+    pub fn untag_resource(&mut self, resource_id: &str, tag_keys: &[String]) {
+        if let Some(entry) = self.resource_tags.get_mut(resource_id) {
+            for k in tag_keys {
+                entry.remove(k);
+            }
+        }
+    }
+
+    /// Read `resource_id`'s tag set (alphabetical by key).
+    pub fn list_resource_tags(&self, resource_id: &str) -> Vec<(String, String)> {
+        self.resource_tags
+            .get(resource_id)
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
+    }
+
+    /// Find the immediate parent of `child_id` (account or OU). Returns
+    /// `(parent_id, parent_type)` matching the
+    /// `(ROOT|ORGANIZATIONAL_UNIT)` AWS shape.
+    pub fn parent_of(&self, child_id: &str) -> Option<(String, String)> {
+        if let Some(account) = self.accounts.get(child_id) {
+            return Some((
+                account.parent_id.clone(),
+                parent_type_for(self, &account.parent_id),
+            ));
+        }
+        if let Some(ou) = self.ous.get(child_id) {
+            return Some((ou.parent_id.clone(), parent_type_for(self, &ou.parent_id)));
+        }
+        None
+    }
+
+    /// List immediate children of `parent_id`. `child_type` is one of
+    /// `ACCOUNT` or `ORGANIZATIONAL_UNIT`; AWS only allows one type per
+    /// `ListChildren` call.
+    pub fn list_children(&self, parent_id: &str, child_type: &str) -> Vec<String> {
+        match child_type {
+            "ACCOUNT" => self
+                .accounts
+                .values()
+                .filter(|a| a.parent_id == parent_id)
+                .map(|a| a.id.clone())
+                .collect(),
+            "ORGANIZATIONAL_UNIT" => self
+                .ous
+                .values()
+                .filter(|o| o.parent_id == parent_id)
+                .map(|o| o.id.clone())
+                .collect(),
+            _ => Vec::new(),
         }
     }
 
@@ -1005,6 +1082,17 @@ pub struct Policy {
     pub content: String,
 }
 
+/// Resolve `parent_id` to the AWS-shape parent type:
+/// - root id (starts with `r-`) -> "ROOT"
+/// - everything else -> "ORGANIZATIONAL_UNIT"
+fn parent_type_for(_org: &OrganizationState, parent_id: &str) -> String {
+    if parent_id.starts_with("r-") {
+        "ROOT".to_string()
+    } else {
+        "ORGANIZATIONAL_UNIT".to_string()
+    }
+}
+
 /// Generate a lowercase alphanumeric ID fragment of `len` characters.
 /// Used for org/root/OU/policy IDs. Pulled from a UUID v4 so the PRNG
 /// is the one already pulled in by the rest of fakecloud.
@@ -1487,6 +1575,55 @@ mod tests {
         assert!(types.contains(&"BACKUP_POLICY"));
         assert!(types.contains(&"AISERVICES_OPT_OUT_POLICY"));
         assert!(types.contains(&"RESOURCE_CONTROL_POLICY"));
+    }
+
+    #[test]
+    fn set_resource_tags_overwrites_existing_keys() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.set_resource_tags(
+            "111111111111",
+            &[("env".into(), "dev".into()), ("team".into(), "core".into())],
+        );
+        org.set_resource_tags("111111111111", &[("env".into(), "prod".into())]);
+        let tags = org.list_resource_tags("111111111111");
+        let env = tags.iter().find(|(k, _)| k == "env").unwrap();
+        assert_eq!(env.1, "prod");
+    }
+
+    #[test]
+    fn untag_resource_drops_only_listed_keys() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.set_resource_tags(
+            "111111111111",
+            &[("env".into(), "dev".into()), ("team".into(), "core".into())],
+        );
+        org.untag_resource("111111111111", &["env".into()]);
+        let keys: Vec<_> = org
+            .list_resource_tags("111111111111")
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(keys, vec!["team"]);
+    }
+
+    #[test]
+    fn parent_of_account_returns_root() {
+        let org = OrganizationState::bootstrap("111111111111");
+        let (parent, kind) = org.parent_of("111111111111").unwrap();
+        assert_eq!(parent, org.root_id);
+        assert_eq!(kind, "ROOT");
+    }
+
+    #[test]
+    fn list_children_separates_accounts_from_ous() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let root = org.root_id.clone();
+        let ou = org.create_ou(&root, "Engineering").unwrap();
+        org.enroll_account_if_missing("222222222222");
+        let accounts = org.list_children(&org.root_id, "ACCOUNT");
+        assert!(accounts.contains(&"222222222222".to_string()));
+        let ous = org.list_children(&org.root_id, "ORGANIZATIONAL_UNIT");
+        assert!(ous.contains(&ou.id));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New ops: TagResource, UntagResource, ListTagsForResource, ListParents, ListChildren, DescribeEffectivePolicy, PutResourcePolicy, DeleteResourcePolicy, DescribeResourcePolicy.
- Per-resource tag bag on OrganizationState; org-wide resource policy stored as a single optional string.
- DescribeEffectivePolicy walks ancestor chain, unions Statement[] across attached policies of the requested type.
- PutResourcePolicy validates JSON.
- 4 new state-level tests (tag overwrite/untag, parent/child resolution).

## Test plan
- [x] cargo test -p fakecloud-organizations --lib (97 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tagging, org hierarchy navigation, and effective/resource policy support to Organizations. Provides AWS-shaped tag and parent/child APIs, merges effective policies across ancestors, and manages a single org resource policy with JSON validation; mutating ops are restricted to the management account.

- **New Features**
  - Tagging: `TagResource`, `UntagResource`, `ListTagsForResource` with per-resource tag bag; overwrites existing keys.
  - Hierarchy: `ListParents`, `ListChildren` (requires `ChildType`); returns `{Id, Type}` for root/OU.
  - Effective policy: `DescribeEffectivePolicy` unions matching `Statement[]` up the chain; `TargetId` optional (defaults to caller); returns merged JSON string with timestamp.
  - Resource policy: `PutResourcePolicy`, `DescribeResourcePolicy`, `DeleteResourcePolicy`; validates JSON; returns summary (Id, ARN) and content; not-found error when absent.
  - Tests: 4 state tests for tag overwrite/untag and parent/child resolution.

<sup>Written for commit 3b806d6cae6b02a6655a3bb8e748e38cb695d75e. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/958?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

