### PR TITLE
feat(organizations): EnableAllFeatures + policy-type management

### DIFF
--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -57,6 +57,9 @@ pub static ORGANIZATIONS_ACTIONS: &[&str] = &[
     "DeregisterDelegatedAdministrator",
     "ListDelegatedAdministrators",
     "ListDelegatedServicesForAccount",
+    "EnableAllFeatures",
+    "EnablePolicyType",
+    "DisablePolicyType",
 ];
 
 pub struct OrganizationsService {
@@ -159,13 +162,17 @@ impl OrganizationsService {
     fn list_roots(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let guard = self.state.read();
         let org = self.require_member(&guard, &req.account_id)?;
+        let policy_types: Vec<Value> = org
+            .list_policy_type_statuses()
+            .into_iter()
+            .filter(|(_, status)| status == "ENABLED")
+            .map(|(t, status)| json!({"Type": t, "Status": status}))
+            .collect();
         let root = json!({
             "Id": org.root_id,
             "Arn": org.root_arn,
             "Name": org.root_name,
-            "PolicyTypes": [
-                {"Type": "SERVICE_CONTROL_POLICY", "Status": "ENABLED"}
-            ],
+            "PolicyTypes": policy_types,
         });
         Ok(AwsResponse::ok_json(json!({ "Roots": [root] })))
     }
@@ -864,6 +871,74 @@ impl OrganizationsService {
             json!({ "DelegatedServices": entries }),
         ))
     }
+
+    fn enable_all_features(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.enable_all_features();
+        // AWS returns a Handshake here; we synthesize a minimal accepted
+        // shape so SDKs can deserialize the response.
+        let handshake = json!({
+            "Id": "h-enableallfeatures",
+            "Arn": format!(
+                "arn:aws:organizations::{}:handshake/{}/enable-all-features/h-enableallfeatures",
+                org.management_account_id, org.org_id
+            ),
+            "Action": "ENABLE_ALL_FEATURES",
+            "State": "ACCEPTED",
+            "Parties": [],
+            "Resources": [],
+        });
+        Ok(AwsResponse::ok_json(json!({ "Handshake": handshake })))
+    }
+
+    fn enable_policy_type(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_type = required_str(&body, "PolicyType")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.enable_policy_type(&policy_type);
+        let policy_types: Vec<Value> = org
+            .list_policy_type_statuses()
+            .into_iter()
+            .filter(|(_, status)| status == "ENABLED")
+            .map(|(t, status)| json!({"Type": t, "Status": status}))
+            .collect();
+        Ok(AwsResponse::ok_json(json!({
+            "Root": {
+                "Id": org.root_id,
+                "Arn": org.root_arn,
+                "Name": org.root_name,
+                "PolicyTypes": policy_types,
+            }
+        })))
+    }
+
+    fn disable_policy_type(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let policy_type = required_str(&body, "PolicyType")?.to_string();
+        let mut guard = self.state.write();
+        self.require_member_management(&guard, &req.account_id)?;
+        let org = guard.as_mut().expect("management gate proved Some");
+        org.disable_policy_type(&policy_type)
+            .map_err(org_error_to_aws)?;
+        let policy_types: Vec<Value> = org
+            .list_policy_type_statuses()
+            .into_iter()
+            .filter(|(_, status)| status == "ENABLED")
+            .map(|(t, status)| json!({"Type": t, "Status": status}))
+            .collect();
+        Ok(AwsResponse::ok_json(json!({
+            "Root": {
+                "Id": org.root_id,
+                "Arn": org.root_arn,
+                "Name": org.root_name,
+                "PolicyTypes": policy_types,
+            }
+        })))
+    }
 }
 
 #[async_trait]
@@ -918,6 +993,9 @@ impl AwsService for OrganizationsService {
             "DeregisterDelegatedAdministrator" => self.deregister_delegated_administrator(&req),
             "ListDelegatedAdministrators" => self.list_delegated_administrators(&req),
             "ListDelegatedServicesForAccount" => self.list_delegated_services_for_account(&req),
+            "EnableAllFeatures" => self.enable_all_features(&req),
+            "EnablePolicyType" => self.enable_policy_type(&req),
+            "DisablePolicyType" => self.disable_policy_type(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "organizations",
                 &req.action,

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -61,6 +61,17 @@ pub struct OrganizationState {
     /// delegated administrators for that service.
     #[serde(default)]
     pub delegated_administrators: BTreeMap<String, BTreeMap<String, DelegatedAdministrator>>,
+    /// Policy types currently `ENABLED` for the org's root. SCP is
+    /// auto-enabled at bootstrap; everything else flips through
+    /// EnablePolicyType / DisablePolicyType.
+    #[serde(default = "default_enabled_policy_types")]
+    pub enabled_policy_types: HashSet<String>,
+}
+
+fn default_enabled_policy_types() -> HashSet<String> {
+    let mut s = HashSet::new();
+    s.insert(POLICY_TYPE_SCP.to_string());
+    s
 }
 
 impl OrganizationState {
@@ -142,7 +153,54 @@ impl OrganizationState {
             handshakes: BTreeMap::new(),
             trusted_services: HashSet::new(),
             delegated_administrators: BTreeMap::new(),
+            enabled_policy_types: default_enabled_policy_types(),
         }
+    }
+
+    /// Promote a `CONSOLIDATED_BILLING` org to `ALL`. Idempotent.
+    /// Real AWS Organizations sends an invitation to every member to
+    /// confirm the upgrade; we shortcut to immediate success.
+    pub fn enable_all_features(&mut self) {
+        self.feature_set = FEATURE_SET_ALL.to_string();
+    }
+
+    /// Mark `policy_type` as enabled on the root.
+    pub fn enable_policy_type(&mut self, policy_type: &str) {
+        self.enabled_policy_types.insert(policy_type.to_string());
+    }
+
+    /// Mark `policy_type` as disabled on the root. Refuses to drop
+    /// SCP — real Organizations doesn't allow it once an org exists.
+    pub fn disable_policy_type(&mut self, policy_type: &str) -> Result<(), OrgError> {
+        if policy_type == POLICY_TYPE_SCP {
+            return Err(OrgError::PolicyTypeNotSupported(
+                "SCP cannot be disabled".to_string(),
+            ));
+        }
+        self.enabled_policy_types.remove(policy_type);
+        Ok(())
+    }
+
+    /// List policy types in stable alphabetical order, with each
+    /// type's enabled state.
+    pub fn list_policy_type_statuses(&self) -> Vec<(String, String)> {
+        let known = [
+            POLICY_TYPE_SCP,
+            "TAG_POLICY",
+            "BACKUP_POLICY",
+            "AISERVICES_OPT_OUT_POLICY",
+            "RESOURCE_CONTROL_POLICY",
+        ];
+        let mut out = Vec::new();
+        for t in known {
+            let status = if self.enabled_policy_types.contains(t) {
+                "ENABLED"
+            } else {
+                "DISABLED"
+            };
+            out.push((t.to_string(), status.to_string()));
+        }
+        out
     }
 
     /// Allocate the next pseudo-random 12-digit account id that's not
@@ -1382,6 +1440,53 @@ mod tests {
         assert!(org
             .list_delegated_services_for_account("222222222222")
             .is_empty());
+    }
+
+    #[test]
+    fn enable_all_features_promotes_feature_set() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.feature_set = FEATURE_SET_CONSOLIDATED_BILLING.to_string();
+        org.enable_all_features();
+        assert_eq!(org.feature_set, FEATURE_SET_ALL);
+    }
+
+    #[test]
+    fn enable_policy_type_idempotent() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enable_policy_type("TAG_POLICY");
+        org.enable_policy_type("TAG_POLICY");
+        let statuses = org.list_policy_type_statuses();
+        let tag = statuses.iter().find(|(t, _)| t == "TAG_POLICY").unwrap();
+        assert_eq!(tag.1, "ENABLED");
+    }
+
+    #[test]
+    fn disable_policy_type_drops_to_disabled() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        org.enable_policy_type("TAG_POLICY");
+        org.disable_policy_type("TAG_POLICY").unwrap();
+        let statuses = org.list_policy_type_statuses();
+        let tag = statuses.iter().find(|(t, _)| t == "TAG_POLICY").unwrap();
+        assert_eq!(tag.1, "DISABLED");
+    }
+
+    #[test]
+    fn disable_policy_type_refuses_scp() {
+        let mut org = OrganizationState::bootstrap("111111111111");
+        let err = org.disable_policy_type(POLICY_TYPE_SCP).unwrap_err();
+        assert!(matches!(err, OrgError::PolicyTypeNotSupported(_)));
+    }
+
+    #[test]
+    fn list_policy_type_statuses_includes_all_known_types() {
+        let org = OrganizationState::bootstrap("111111111111");
+        let statuses = org.list_policy_type_statuses();
+        let types: Vec<_> = statuses.iter().map(|(t, _)| t.as_str()).collect();
+        assert!(types.contains(&"SERVICE_CONTROL_POLICY"));
+        assert!(types.contains(&"TAG_POLICY"));
+        assert!(types.contains(&"BACKUP_POLICY"));
+        assert!(types.contains(&"AISERVICES_OPT_OUT_POLICY"));
+        assert!(types.contains(&"RESOURCE_CONTROL_POLICY"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New ops: EnableAllFeatures, EnablePolicyType, DisablePolicyType.
- enabled_policy_types HashSet on OrganizationState; SCP locked enabled.
- ListRoots emits dynamic PolicyTypes reflecting current state.
- 5 new state-level tests.

## Test plan
- [x] cargo test -p fakecloud-organizations --lib (98 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add EnableAllFeatures and policy-type management to `fakecloud-organizations` so `ListRoots` and root responses reflect currently enabled policy types.

- **New Features**
  - Add `EnableAllFeatures`, `EnablePolicyType`, `DisablePolicyType` (management-account only).
  - Track enabled types on `OrganizationState` via `enabled_policy_types`; `SERVICE_CONTROL_POLICY` stays enabled and cannot be disabled.
  - `ListRoots` returns only enabled policy types; enable/disable calls return the updated `Root`.
  - `EnableAllFeatures` promotes the feature set to ALL and returns a minimal `Handshake` with state `ACCEPTED`; adds 5 state tests.

<sup>Written for commit 3e19ea62580ca672039947b37b671cbd46de5a34. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/959?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

