### PR TITLE
feat(ses): render Content.Template at SendEmail/SendBulkEmail

### DIFF
--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -9,6 +9,35 @@ use crate::state::SentEmail;
 use super::{extract_string_array, SesV2Service};
 
 impl SesV2Service {
+    /// Render `template_name` with `template_data` (JSON object string)
+    /// against the caller's stored templates. Empty result on missing
+    /// template or missing inputs — matches real SES which sends the
+    /// raw template body when data is malformed.
+    fn render_template_for_send(
+        &self,
+        account_id: &str,
+        template_name: Option<&str>,
+        template_data: Option<&str>,
+    ) -> super::templates::RenderedTemplate {
+        let empty = super::templates::RenderedTemplate {
+            subject: None,
+            html: None,
+            text: None,
+        };
+        let Some(name) = template_name else {
+            return empty;
+        };
+        let data_str = template_data.unwrap_or("{}");
+        let accounts = self.state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return empty;
+        };
+        let Some(template) = state.templates.get(name) else {
+            return empty;
+        };
+        super::templates::render_template(template, data_str)
+    }
+
     /// Reject the send if either account-level sending or the resolved
     /// configuration set's sending flag is paused. Real SES surfaces
     /// these as `AccountSendingPausedException` and
@@ -86,7 +115,21 @@ impl SesV2Service {
                 let tmpl = &body["Content"]["Template"];
                 let tmpl_name = tmpl["TemplateName"].as_str().map(|s| s.to_string());
                 let tmpl_data = tmpl["TemplateData"].as_str().map(|s| s.to_string());
-                (None, None, None, None, tmpl_name, tmpl_data)
+                // Render via the same engine RenderEmailTemplate uses so
+                // SentEmail captures the materialized subject/html/text.
+                let rendered = self.render_template_for_send(
+                    &req.account_id,
+                    tmpl_name.as_deref(),
+                    tmpl_data.as_deref(),
+                );
+                (
+                    rendered.subject,
+                    rendered.html,
+                    rendered.text,
+                    None,
+                    tmpl_name,
+                    tmpl_data,
+                )
             } else {
                 (None, None, None, None, None, None)
             };
@@ -164,15 +207,21 @@ impl SesV2Service {
                 .or_else(|| body["DefaultContent"]["Template"]["TemplateData"].as_str())
                 .map(|s| s.to_string());
 
+            let rendered = self.render_template_for_send(
+                &req.account_id,
+                template_name.as_deref(),
+                template_data.as_deref(),
+            );
+
             let sent = SentEmail {
                 message_id: message_id.clone(),
                 from: from.clone(),
                 to,
                 cc,
                 bcc,
-                subject: None,
-                html_body: None,
-                text_body: None,
+                subject: rendered.subject,
+                html_body: rendered.html,
+                text_body: rendered.text,
                 raw_data: None,
                 template_name,
                 template_data,

--- a/crates/fakecloud-ses/src/service/templates.rs
+++ b/crates/fakecloud-ses/src/service/templates.rs
@@ -198,35 +198,11 @@ impl SesV2Service {
             }
         };
 
-        // Parse template data JSON
-        let data: HashMap<String, Value> =
-            serde_json::from_str(&template_data_str).unwrap_or_default();
-
-        let substitute = |text: &str| -> String {
-            let mut result = text.to_string();
-            for (key, value) in &data {
-                let placeholder = format!("{{{{{}}}}}", key);
-                let replacement = match value {
-                    Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                };
-                result = result.replace(&placeholder, &replacement);
-            }
-            result
-        };
-
-        let rendered_subject = template
-            .subject
-            .as_deref()
-            .map(&substitute)
-            .unwrap_or_default();
-        let rendered_html = template.html_body.as_deref().map(&substitute);
-        let rendered_text = template.text_body.as_deref().map(&substitute);
-
+        let rendered = render_template(template, &template_data_str);
         let mime = crate::mime::build_message(&crate::mime::MimeInputs {
-            subject: &rendered_subject,
-            text: rendered_text.as_deref(),
-            html: rendered_html.as_deref(),
+            subject: rendered.subject.as_deref().unwrap_or(""),
+            text: rendered.text.as_deref(),
+            html: rendered.html.as_deref(),
         });
 
         let response = json!({
@@ -234,5 +210,37 @@ impl SesV2Service {
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
+    }
+}
+
+/// Result of rendering an `EmailTemplate` with caller-supplied JSON
+/// substitutions. All three fields are pre-substituted strings.
+pub struct RenderedTemplate {
+    pub subject: Option<String>,
+    pub html: Option<String>,
+    pub text: Option<String>,
+}
+
+/// Render an `EmailTemplate`'s subject/html/text by substituting
+/// `{{ key }}` placeholders with values from `template_data_str` (a
+/// JSON object). Falls back to empty data when the JSON is malformed.
+pub fn render_template(template: &EmailTemplate, template_data_str: &str) -> RenderedTemplate {
+    let data: HashMap<String, Value> = serde_json::from_str(template_data_str).unwrap_or_default();
+    let substitute = |text: &str| -> String {
+        let mut result = text.to_string();
+        for (key, value) in &data {
+            let placeholder = format!("{{{{{}}}}}", key);
+            let replacement = match value {
+                Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            result = result.replace(&placeholder, &replacement);
+        }
+        result
+    };
+    RenderedTemplate {
+        subject: template.subject.as_deref().map(&substitute),
+        html: template.html_body.as_deref().map(&substitute),
+        text: template.text_body.as_deref().map(&substitute),
     }
 }

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -346,6 +346,52 @@ async fn test_send_email_template_content() {
 }
 
 #[tokio::test]
+async fn test_send_email_template_renders_subject_and_body() {
+    let state = make_state();
+    {
+        use crate::state::EmailTemplate;
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.templates.insert(
+            "welcome".to_string(),
+            EmailTemplate {
+                template_name: "welcome".to_string(),
+                subject: Some("Hi {{name}}".to_string()),
+                html_body: Some("<p>Hi {{name}}</p>".to_string()),
+                text_body: Some("Hi {{name}}".to_string()),
+                created_at: chrono::Utc::now(),
+            },
+        );
+    }
+    let svc = SesV2Service::new(state.clone());
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["to@example.com"]},
+            "Content": {
+                "Template": {
+                    "TemplateName": "welcome",
+                    "TemplateData": "{\"name\": \"Alice\"}"
+                }
+            }
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let mas_r = state.read();
+    let s = mas_r.default_ref();
+    let sent = &s.sent_emails[0];
+    assert_eq!(sent.subject.as_deref(), Some("Hi Alice"));
+    assert_eq!(sent.html_body.as_deref(), Some("<p>Hi Alice</p>"));
+    assert_eq!(sent.text_body.as_deref(), Some("Hi Alice"));
+    assert_eq!(sent.template_name.as_deref(), Some("welcome"));
+}
+
+#[tokio::test]
 async fn test_send_email_missing_content() {
     let state = make_state();
     let svc = SesV2Service::new(state);


### PR DESCRIPTION
## Summary
- Render Content.Template subject/html/text at send time via the same handlebars-style engine used by RenderEmailTemplate.
- SendBulkEmail entries render per-entry with ReplacementTemplateData fallback to DefaultContent.Template.TemplateData.
- New public render_template helper in templates module.
- Test: confirms rendered fields land on SentEmail.

## Test plan
- [x] cargo test -p fakecloud-ses --lib (196 pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render `Content.Template` at send time for `SendEmail` and `SendBulkEmail`, so `SentEmail` stores the materialized subject, HTML, and text. Uses the same `{{key}}` substitution as `RenderEmailTemplate` for consistency and better introspection/event fanout.

- **New Features**
  - `SendEmail`/`SendBulkEmail`: render template subject/html/text at send time; populate `SentEmail.subject/html_body/text_body`.
  - `SendBulkEmail`: render per entry with `ReplacementTemplateData`, fallback to `DefaultContent.Template.TemplateData`.
  - Added public `render_template` in `templates` for shared substitution; added a test to verify rendered fields on `SentEmail`.

<sup>Written for commit 3d4d4c1bf1363c7ddd22d5aa040b9551197dd176. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/961?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

