### PR TITLE
test(bedrock): serialize BEDROCK_ECHO env mutation with embed test

### DIFF
--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -451,9 +451,22 @@ mod tests {
     use bytes::Bytes;
     use fakecloud_core::multi_account::MultiAccountState;
     use http::{HeaderMap, Method};
-    use parking_lot::RwLock;
+    use parking_lot::{Mutex, RwLock};
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::OnceLock;
+
+    /// Global mutex to serialize tests that mutate the process-wide
+    /// `BEDROCK_ECHO` env var with sibling tests in the same binary that
+    /// observe model behavior. Without it the parallel test harness
+    /// races: e.g. `invoke_amazon_titan_embed_returns_vector` runs while
+    /// `invoke_echo_mode_reflects_prompt` still has the flag flipped, and
+    /// the embed handler returns the echo branch's text instead of the
+    /// embedding vector.
+    fn echo_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn shared() -> SharedBedrockState {
         let multi: MultiAccountState<BedrockState> =
@@ -518,11 +531,12 @@ mod tests {
 
     #[test]
     fn invoke_echo_mode_reflects_prompt() {
-        // SAFETY: BEDROCK_ECHO mutation is process-global; serialize via
-        // a single-threaded test runner is not assumed. We restore on
-        // exit so any sibling tests in the same binary see the prior value.
+        // BEDROCK_ECHO mutation is process-global; the lock serializes
+        // this test with sibling tests in the same binary that observe
+        // model output (e.g. titan-embed) so they don't race the flag.
+        let _g = echo_lock().lock();
         let prev = std::env::var("BEDROCK_ECHO").ok();
-        // SAFETY: tests run with single-threaded harness; env mutation is brief.
+        // SAFETY: lock above pins us to a single mutation window.
         unsafe { std::env::set_var("BEDROCK_ECHO", "1") };
 
         let s = shared();
@@ -567,6 +581,9 @@ mod tests {
 
     #[test]
     fn invoke_amazon_titan_embed_returns_vector() {
+        // Lock against `invoke_echo_mode_reflects_prompt` so we don't
+        // observe the echo branch's text when the flag is mid-flip.
+        let _g = echo_lock().lock();
         let s = shared();
         let resp = invoke_model(&s, &req(), "amazon.titan-embed-text-v1", b"{}").unwrap();
         let v: Value =


### PR DESCRIPTION
## Summary

- invoke_echo_mode_reflects_prompt mutates a process-wide BEDROCK_ECHO env var that invoke_amazon_titan_embed_returns_vector observes through the same runtime path.
- Without a lock the parallel test harness races: the embed call sees BEDROCK_ECHO=1 mid-flip and returns the echo branch's text, then panics on the missing \`embedding\` key.
- Add a static OnceLock<Mutex<()>> shared between the two tests so they serialize.

## Test plan

- [x] cargo test -p fakecloud-bedrock --lib (334 passed)
- [x] cargo clippy -p fakecloud-bedrock --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in `fakecloud-bedrock` by serializing `BEDROCK_ECHO` env mutations with the titan embed test using a static `OnceLock<Mutex<()>>`. Prevents parallel runs from returning echo text and panicking on missing `embedding`.

- **Bug Fixes**
  - Added a global lock via `OnceLock<Mutex<()>>` to serialize tests that touch `BEDROCK_ECHO`.
  - Guarded `invoke_echo_mode_reflects_prompt` and `invoke_amazon_titan_embed_returns_vector` with the lock.

<sup>Written for commit b611c0a67de54f3f570b568c979ae156363b1d3f. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/964?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

