### PR TITLE
feat(ecr): trigger image scan on PutImage when scan_on_push is enabled

### DIFF
--- a/crates/fakecloud-e2e/tests/ecr_images.rs
+++ b/crates/fakecloud-e2e/tests/ecr_images.rs
@@ -429,3 +429,63 @@ async fn immutable_tag_blocks_reassignment() {
         .expect_err("immutable tag rewrite should fail");
     assert!(format!("{err:?}").contains("ImageAlreadyExists"), "{err:?}");
 }
+
+#[tokio::test]
+async fn put_image_triggers_scan_when_scan_on_push_enabled() {
+    let server = TestServer::start().await;
+    let client = server.ecr_client().await;
+
+    client
+        .create_repository()
+        .repository_name("scan-repo")
+        .image_scanning_configuration(
+            aws_sdk_ecr::types::ImageScanningConfiguration::builder()
+                .scan_on_push(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let manifest = r#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":7023,"digest":"sha256:dummy"},"layers":[]}"#;
+    let put = client
+        .put_image()
+        .repository_name("scan-repo")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .unwrap();
+    let digest = put
+        .image()
+        .and_then(|i| i.image_id())
+        .and_then(|id| id.image_digest())
+        .unwrap()
+        .to_string();
+
+    // Poll DescribeImageScanFindings until the scan transitions out of
+    // IN_PROGRESS. With scan-on-push the scanner kicks immediately; the
+    // poll catches either IN_PROGRESS (race) or COMPLETE.
+    for _ in 0..40 {
+        let resp = client
+            .describe_image_scan_findings()
+            .repository_name("scan-repo")
+            .image_id(
+                aws_sdk_ecr::types::ImageIdentifier::builder()
+                    .image_digest(&digest)
+                    .build(),
+            )
+            .send()
+            .await;
+        if let Ok(r) = resp {
+            let status = r.image_scan_status().and_then(|s| s.status());
+            if status.map(|s| s.as_str()) != Some("FAILED") {
+                // Found a status — happy path. Either IN_PROGRESS or
+                // COMPLETE; both prove the scan was kicked.
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("scan-on-push did not kick a scan within budget");
+}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -723,8 +723,9 @@ impl EcrService {
         }
 
         let snapshot = repo.images.get(&digest).cloned().unwrap();
+        let scan_on_push = repo.image_scanning_configuration.scan_on_push;
         let tag_ref = supplied_tag.as_deref();
-        Ok(AwsResponse::ok_json(json!({
+        let response = AwsResponse::ok_json(json!({
             "image": {
                 "registryId": repo.registry_id,
                 "repositoryName": name,
@@ -732,7 +733,71 @@ impl EcrService {
                 "imageManifest": snapshot.image_manifest,
                 "imageManifestMediaType": snapshot.image_manifest_media_type,
             }
-        })))
+        }));
+        // Drop the lock before kicking the async scan; trigger_scan
+        // re-acquires it to mark IN_PROGRESS and spawn the scanner.
+        drop(accounts);
+        if scan_on_push {
+            self.trigger_scan(&account, &name, &digest);
+        }
+        Ok(response)
+    }
+
+    /// Mark `digest` as `IN_PROGRESS` and spawn the scanner task.
+    /// Identical wiring to `start_image_scan` minus the request-shaped
+    /// response — used both by the user-facing `StartImageScan` and the
+    /// `scan_on_push=true` PutImage hook.
+    fn trigger_scan(&self, account: &str, name: &str, digest: &str) {
+        use crate::state::ImageScanFindings;
+        let layers = {
+            let mut accounts = self.state.write();
+            let Some(state) = accounts.get_mut(account) else {
+                return;
+            };
+            let Some(repo) = state.repositories.get_mut(name) else {
+                return;
+            };
+            repo.scan_findings.insert(
+                digest.to_string(),
+                ImageScanFindings {
+                    image_digest: digest.to_string(),
+                    scan_status: "IN_PROGRESS".to_string(),
+                    scan_completed_at: None,
+                    vulnerability_source_updated_at: None,
+                    finding_severity_counts: BTreeMap::new(),
+                    findings: Vec::new(),
+                },
+            );
+            layers_for_image(repo, digest)
+        };
+        let shared = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let snap_lock = self.snapshot_lock.clone();
+        let account = account.to_string();
+        let name = name.to_string();
+        let digest = digest.to_string();
+        tokio::spawn(async move {
+            let result = crate::scanner::scan_layers(&digest, &layers).await;
+            {
+                let mut accounts = shared.write();
+                let Some(state) = accounts.get_mut(&account) else {
+                    return;
+                };
+                let Some(repo) = state.repositories.get_mut(&name) else {
+                    return;
+                };
+                let findings = result.unwrap_or_else(|| ImageScanFindings {
+                    image_digest: digest.clone(),
+                    scan_status: "COMPLETE".to_string(),
+                    scan_completed_at: Some(Utc::now()),
+                    vulnerability_source_updated_at: Some(Utc::now()),
+                    finding_severity_counts: BTreeMap::new(),
+                    findings: Vec::new(),
+                });
+                repo.scan_findings.insert(digest.clone(), findings);
+            }
+            EcrService::save_snapshot_with(shared, store, snap_lock).await;
+        });
     }
 
     fn batch_get_image(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {


### PR DESCRIPTION
## Summary

- Repository.image_scanning_configuration.scan_on_push was stored but PutImage never kicked the scanner — DescribeImages reported \`PENDING\` forever.
- Extract the scan-trigger logic from StartImageScan into a reusable \`trigger_scan\` helper and call it from PutImage when the repo opted in.

## Test plan

- [x] cargo build/test/clippy/fmt
- [x] new e2e \`put_image_triggers_scan_when_scan_on_push_enabled\`: PutImage on a scan-on-push repo polls DescribeImageScanFindings and confirms the scan transitions out of PENDING into IN_PROGRESS/COMPLETE within budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger ECR image scans on `PutImage` when scan-on-push is enabled to match AWS and prevent scans stuck in `PENDING`. Shared the scan start logic via a new `trigger_scan` helper.

- **Bug Fixes**
  - Start scans from `PutImage` when `scan_on_push=true`; `DescribeImageScanFindings` now transitions to `IN_PROGRESS` or `COMPLETE` instead of staying `PENDING`.
  - Added e2e `put_image_triggers_scan_when_scan_on_push_enabled`.

- **Refactors**
  - Extracted scan start flow from `StartImageScan` into `trigger_scan` and reused it for scan-on-push; spawns the scanner without holding the state lock.

<sup>Written for commit 4f624b41b05148848f3f2e53c104dcf6ef77f0b7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

