### PR TITLE
feat(ses): MailFromDomain MX/TXT records + status lifecycle

### DIFF
--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -127,6 +127,13 @@ pub struct SesEmailsResponse {
     pub emails: Vec<SentEmail>,
 }
 
+/// Admin payload to flip an identity's `MailFromDomainStatus` for tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SesMailFromStatusRequest {
+    pub status: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboundEmailRequest {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2606,6 +2606,40 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/ses/identities/{name}/mail-from-status",
+            axum::routing::post({
+                let ss = ses_emails_state.clone();
+                move |axum::extract::Path(name): axum::extract::Path<String>,
+                      axum::Json(body): axum::Json<types::SesMailFromStatusRequest>| async move {
+                    let mut accounts = ss.write();
+                    let state = accounts.default_mut();
+                    let Some(identity) = state.identities.get_mut(&name) else {
+                        return (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "identity not found"})),
+                        );
+                    };
+                    let allowed = ["NotStarted", "Pending", "Success", "Failed"];
+                    if !allowed.contains(&body.status.as_str()) {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            axum::Json(serde_json::json!({
+                                "error": "status must be one of NotStarted/Pending/Success/Failed",
+                            })),
+                        );
+                    }
+                    identity.mail_from_domain_status = body.status.clone();
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(serde_json::json!({
+                            "identity": name,
+                            "mailFromDomainStatus": body.status,
+                        })),
+                    )
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/ses/inbound",
             axum::routing::post({
                 let ss = ses_inbound_state.clone();

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -523,6 +523,7 @@ mod tests {
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: config_set.map(|s| s.to_string()),
         }
     }

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -9,6 +9,27 @@ use crate::state::SesState;
 
 use super::SesV2Service;
 
+/// Expected DNS records the customer must publish for SES to accept the
+/// configured mail-from domain. Mirrors the JSON shape SES returns in
+/// `GetEmailIdentity.MailFromAttributes.MailFromDomainDnsRecords`.
+pub(crate) fn mail_from_dns_records(domain: &str, region: &str) -> Vec<Value> {
+    if domain.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        json!({
+            "Name": domain,
+            "Type": "MX",
+            "Value": format!("10 feedback-smtp.{region}.amazonses.com"),
+        }),
+        json!({
+            "Name": domain,
+            "Type": "TXT",
+            "Value": "\"v=spf1 include:amazonses.com ~all\"",
+        }),
+    ]
+}
+
 impl SesV2Service {
     pub(super) fn create_email_identity(
         &self,
@@ -56,6 +77,7 @@ impl SesV2Service {
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         };
 
@@ -109,10 +131,10 @@ impl SesV2Service {
         identity_name: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let empty = SesState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let identity = match state.identities.get(identity_name) {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let region = state.region.clone();
+        let identity = match state.identities.get_mut(identity_name) {
             Some(id) => id,
             None => {
                 return Ok(Self::json_error(
@@ -123,12 +145,19 @@ impl SesV2Service {
             }
         };
 
-        let mail_from_domain = identity.mail_from_domain.as_deref().unwrap_or("");
-        let mail_from_status = if mail_from_domain.is_empty() {
-            "FAILED"
-        } else {
-            "SUCCESS"
-        };
+        let mail_from_domain = identity.mail_from_domain.clone().unwrap_or_default();
+        // Auto-advance Pending -> Success on next read; matches real SES once
+        // it observes the expected MX/TXT records on the configured mail-from
+        // domain. Admin endpoint flips back to Failed for tests.
+        if identity.mail_from_domain_status == "Pending" && !mail_from_domain.is_empty() {
+            identity.mail_from_domain_status = "Success".to_string();
+        }
+        if mail_from_domain.is_empty() {
+            identity.mail_from_domain_status = "NotStarted".to_string();
+        }
+        let mail_from_status = identity.mail_from_domain_status.clone();
+        let behavior = identity.mail_from_behavior_on_mx_failure.clone();
+        let mail_from_dns = mail_from_dns_records(&mail_from_domain, &region);
 
         let mut response = json!({
             "IdentityType": identity.identity_type,
@@ -147,10 +176,13 @@ impl SesV2Service {
             "MailFromAttributes": {
                 "MailFromDomain": mail_from_domain,
                 "MailFromDomainStatus": mail_from_status,
-                "BehaviorOnMxFailure": identity.mail_from_behavior_on_mx_failure,
+                "BehaviorOnMxFailure": behavior,
             },
             "Tags": [],
         });
+        if !mail_from_dns.is_empty() {
+            response["MailFromAttributes"]["MailFromDomainDnsRecords"] = json!(mail_from_dns);
+        }
 
         if let Some(ref cs) = identity.configuration_set_name {
             response["ConfigurationSetName"] = json!(cs);
@@ -476,7 +508,14 @@ impl SesV2Service {
         };
 
         if let Some(domain) = body["MailFromDomain"].as_str() {
-            identity.mail_from_domain = Some(domain.to_string());
+            let trimmed = domain.trim();
+            if trimmed.is_empty() {
+                identity.mail_from_domain = None;
+                identity.mail_from_domain_status = "NotStarted".to_string();
+            } else {
+                identity.mail_from_domain = Some(trimmed.to_string());
+                identity.mail_from_domain_status = "Pending".to_string();
+            }
         }
         if let Some(behavior) = body["BehaviorOnMxFailure"].as_str() {
             identity.mail_from_behavior_on_mx_failure = behavior.to_string();

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -42,6 +42,7 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         },
     );
@@ -1973,6 +1974,51 @@ async fn test_put_email_identity_mail_from_attributes() {
         body["MailFromAttributes"]["BehaviorOnMxFailure"],
         "REJECT_MESSAGE"
     );
+}
+
+#[tokio::test]
+async fn test_mail_from_status_lifecycle() {
+    let state = make_state();
+    let svc = SesV2Service::new(state.clone());
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/identities",
+        r#"{"EmailIdentity": "example.com"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    // No mail-from configured -> NotStarted, no DNS records.
+    let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["MailFromAttributes"]["MailFromDomainStatus"],
+        "NotStarted"
+    );
+    assert!(body["MailFromAttributes"]["MailFromDomainDnsRecords"].is_null());
+
+    // Set mail-from -> first read auto-advances Pending -> Success +
+    // emits expected MX/TXT records.
+    let req = make_request(
+        Method::PUT,
+        "/v2/email/identities/example.com/mail-from",
+        r#"{"MailFromDomain": "mail.example.com", "BehaviorOnMxFailure": "USE_DEFAULT_VALUE"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/v2/email/identities/example.com", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["MailFromAttributes"]["MailFromDomainStatus"],
+        "Success"
+    );
+    let dns = &body["MailFromAttributes"]["MailFromDomainDnsRecords"];
+    assert_eq!(dns.as_array().map(|a| a.len()), Some(2));
+    assert_eq!(dns[0]["Name"], "mail.example.com");
+    assert_eq!(dns[0]["Type"], "MX");
+    assert_eq!(dns[1]["Type"], "TXT");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -21,6 +21,11 @@ pub struct EmailIdentity {
     // Mail-from attributes
     pub mail_from_domain: Option<String>,
     pub mail_from_behavior_on_mx_failure: String,
+    /// Real SES walks PENDING -> SUCCESS once it observes MX/TXT records.
+    /// Default `NotStarted`; set to `Pending` on first PutMailFromAttributes;
+    /// auto-advances to `Success` on next read or via admin endpoint.
+    #[serde(default)]
+    pub mail_from_domain_status: String,
     // Configuration set association
     pub configuration_set_name: Option<String>,
 }

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -484,6 +484,7 @@ pub(crate) fn verify_email_identity(
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         });
     Ok(xml_metadata_only("VerifyEmailIdentity", &req.request_id))
@@ -511,6 +512,7 @@ pub(crate) fn verify_domain_identity(
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         });
     // Return a verification token
@@ -545,6 +547,7 @@ pub(crate) fn verify_domain_dkim(
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         });
     // Return 3 DKIM tokens
@@ -824,9 +827,8 @@ pub(crate) fn get_identity_mail_from_domain_attributes(
     state: &SharedSesState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let accounts = state.read();
-    let empty = SesState::new(&req.account_id, &req.region);
-    let st = accounts.get(&req.account_id).unwrap_or(&empty);
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(&req.account_id);
     let mut inner = String::from("<MailFromDomainAttributes>");
     for i in 1.. {
         let key = format!("Identities.member.{i}");
@@ -835,20 +837,23 @@ pub(crate) fn get_identity_mail_from_domain_attributes(
                 inner.push_str("<entry>");
                 inner.push_str(&format!("<key>{}</key>", xml_escape(identity_name)));
                 inner.push_str("<value>");
-                if let Some(identity) = st.identities.get(identity_name.as_str()) {
-                    let mail_from = identity.mail_from_domain.as_deref().unwrap_or("");
-                    let behavior = &identity.mail_from_behavior_on_mx_failure;
-                    let status = if mail_from.is_empty() {
-                        "NotStarted"
-                    } else {
-                        "Success"
-                    };
+                if let Some(identity) = st.identities.get_mut(identity_name.as_str()) {
+                    let mail_from = identity.mail_from_domain.clone().unwrap_or_default();
+                    if identity.mail_from_domain_status == "Pending" && !mail_from.is_empty() {
+                        identity.mail_from_domain_status = "Success".to_string();
+                    }
+                    if mail_from.is_empty() {
+                        identity.mail_from_domain_status = "NotStarted".to_string();
+                    }
+                    let behavior = identity.mail_from_behavior_on_mx_failure.clone();
+                    let status = identity.mail_from_domain_status.clone();
                     inner.push_str(&format!(
                         "<MailFromDomain>{}</MailFromDomain>\
-                         <MailFromDomainStatus>{status}</MailFromDomainStatus>\
+                         <MailFromDomainStatus>{}</MailFromDomainStatus>\
                          <BehaviorOnMXFailure>{}</BehaviorOnMXFailure>",
-                        xml_escape(mail_from),
-                        xml_escape(behavior),
+                        xml_escape(&mail_from),
+                        xml_escape(&status),
+                        xml_escape(&behavior),
                     ));
                 } else {
                     inner.push_str(
@@ -891,6 +896,11 @@ pub(crate) fn set_identity_mail_from_domain(
     if let Some(id) = st.identities.get_mut(identity) {
         id.mail_from_domain = mail_from_domain.filter(|s| !s.is_empty());
         id.mail_from_behavior_on_mx_failure = behavior;
+        id.mail_from_domain_status = if id.mail_from_domain.is_some() {
+            "Pending".to_string()
+        } else {
+            "NotStarted".to_string()
+        };
     } else {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -39,6 +39,7 @@ fn seed_identity(state: &SharedSesState, name: &str) {
             email_forwarding_enabled: true,
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         },
     );


### PR DESCRIPTION
## Summary
- Adds `mail_from_domain_status` to `EmailIdentity` and walks the lifecycle (`NotStarted` -> `Pending` on Set, `Pending` -> `Success` on next read).
- Returns the expected `MX` (`10 feedback-smtp.<region>.amazonses.com`) and `TXT` (`v=spf1 include:amazonses.com ~all`) records under `GetEmailIdentity.MailFromAttributes.MailFromDomainDnsRecords`.
- Adds `POST /_fakecloud/ses/identities/:name/mail-from-status` admin endpoint to flip status (e.g. `Failed`) for tests.

## Test plan
- [x] cargo test -p fakecloud-ses (197 tests pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Mail-From domain status lifecycle and returns MX/TXT DNS records in SES identity responses for closer AWS parity. Adds an admin endpoint to override status for tests.

- **New Features**
  - Added `mail_from_domain_status`: NotStarted, Pending, Success, Failed (defaults to NotStarted).
  - Setting mail-from via v2 `PutEmailIdentityMailFromAttributes` or v1 `SetIdentityMailFromDomain` sets status to Pending; clearing/blank resets to NotStarted.
  - Reading via v2 `GetEmailIdentity` or v1 `GetIdentityMailFromDomainAttributes` auto-advances Pending → Success when a mail-from domain is set.
  - When set, `MailFromAttributes.MailFromDomainDnsRecords` includes MX `10 feedback-smtp.<region>.amazonses.com` and TXT `"v=spf1 include:amazonses.com ~all"`.
  - New admin endpoint `POST /_fakecloud/ses/identities/{name}/mail-from-status` to set status via `{ "status": "NotStarted" | "Pending" | "Success" | "Failed" }` with validation.

<sup>Written for commit fd66f2a5c97ad118f7695bcaf68b3f6e6225c63c. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/966?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

