### PR TITLE
feat(eventbridge): round-trip full target config on PutTargets

### DIFF
--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -210,6 +210,7 @@ mod tests {
                 input_path: None,
                 input_transformer: None,
                 sqs_parameters: None,
+                ..Default::default()
             }],
             tags: BTreeMap::new(),
             last_fired: None,

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -117,6 +117,17 @@ pub(crate) fn parse_target(target: &Value) -> EventTarget {
         input_path: target["InputPath"].as_str().map(|s| s.to_string()),
         input_transformer: target.get("InputTransformer").cloned(),
         sqs_parameters: target.get("SqsParameters").cloned(),
+        role_arn: target["RoleArn"].as_str().map(|s| s.to_string()),
+        dead_letter_config: target.get("DeadLetterConfig").cloned(),
+        retry_policy: target.get("RetryPolicy").cloned(),
+        ecs_parameters: target.get("EcsParameters").cloned(),
+        batch_parameters: target.get("BatchParameters").cloned(),
+        kinesis_parameters: target.get("KinesisParameters").cloned(),
+        redshift_data_parameters: target.get("RedshiftDataParameters").cloned(),
+        http_parameters: target.get("HttpParameters").cloned(),
+        sage_maker_pipeline_parameters: target.get("SageMakerPipelineParameters").cloned(),
+        app_sync_parameters: target.get("AppSyncParameters").cloned(),
+        run_command_parameters: target.get("RunCommandParameters").cloned(),
     }
 }
 
@@ -133,6 +144,39 @@ pub(crate) fn target_to_json(t: &EventTarget) -> Value {
     }
     if let Some(ref sp) = t.sqs_parameters {
         obj["SqsParameters"] = sp.clone();
+    }
+    if let Some(ref ra) = t.role_arn {
+        obj["RoleArn"] = json!(ra);
+    }
+    if let Some(ref dlc) = t.dead_letter_config {
+        obj["DeadLetterConfig"] = dlc.clone();
+    }
+    if let Some(ref rp) = t.retry_policy {
+        obj["RetryPolicy"] = rp.clone();
+    }
+    if let Some(ref p) = t.ecs_parameters {
+        obj["EcsParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.batch_parameters {
+        obj["BatchParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.kinesis_parameters {
+        obj["KinesisParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.redshift_data_parameters {
+        obj["RedshiftDataParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.http_parameters {
+        obj["HttpParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.sage_maker_pipeline_parameters {
+        obj["SageMakerPipelineParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.app_sync_parameters {
+        obj["AppSyncParameters"] = p.clone();
+    }
+    if let Some(ref p) = t.run_command_parameters {
+        obj["RunCommandParameters"] = p.clone();
     }
     obj
 }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -554,6 +554,7 @@ mod tests {
                     input_path: None,
                     input_transformer: None,
                     sqs_parameters: None,
+                    ..Default::default()
                 }],
                 tags: BTreeMap::new(),
                 last_fired: None,

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -117,6 +117,17 @@ impl EventBridgeService {
                 )
             })),
             sqs_parameters: None,
+            role_arn: None,
+            dead_letter_config: None,
+            retry_policy: None,
+            ecs_parameters: None,
+            batch_parameters: None,
+            kinesis_parameters: None,
+            redshift_data_parameters: None,
+            http_parameters: None,
+            sage_maker_pipeline_parameters: None,
+            app_sync_parameters: None,
+            run_command_parameters: None,
         };
 
         let archive_rule = EventRule {

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -1571,6 +1571,7 @@ fn put_rule_overlay_preserves_existing_targets() {
             input_path: None,
             input_transformer: None,
             sqs_parameters: None,
+            ..Default::default()
         });
     }
 
@@ -1730,6 +1731,87 @@ fn describe_rule_unknown_errors() {
     let req = make_request("DescribeRule", json!({ "Name": "ghost" }));
     let err = svc.describe_rule(&req).err().expect("expected error");
     assert_eq!(err.code(), "ResourceNotFoundException");
+}
+
+#[test]
+fn put_targets_round_trips_full_target_config() {
+    let svc = make_service();
+    put_rule_simple(&svc, "r1");
+    let req = make_request(
+        "PutTargets",
+        json!({
+            "Rule": "r1",
+            "Targets": [{
+                "Id": "t1",
+                "Arn": "arn:aws:ecs:us-east-1:123456789012:cluster/c1",
+                "RoleArn": "arn:aws:iam::123456789012:role/InvokeRole",
+                "DeadLetterConfig": {
+                    "Arn": "arn:aws:sqs:us-east-1:123456789012:dlq"
+                },
+                "RetryPolicy": {
+                    "MaximumRetryAttempts": 2,
+                    "MaximumEventAgeInSeconds": 600
+                },
+                "EcsParameters": {
+                    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/td:1",
+                    "TaskCount": 1,
+                    "LaunchType": "FARGATE"
+                },
+                "HttpParameters": {
+                    "PathParameterValues": ["v1"],
+                    "HeaderParameters": {"X-Trace": "abc"},
+                    "QueryStringParameters": {"q": "1"}
+                },
+                "KinesisParameters": { "PartitionKeyPath": "$.detail.id" },
+                "BatchParameters": {
+                    "JobDefinition": "arn:aws:batch:us-east-1:123456789012:job-definition/jd:1",
+                    "JobName": "j"
+                },
+                "RedshiftDataParameters": {
+                    "Database": "db", "Sql": "SELECT 1"
+                },
+                "SageMakerPipelineParameters": {
+                    "PipelineParameterList": [{"Name": "k", "Value": "v"}]
+                },
+                "AppSyncParameters": { "GraphQLOperation": "query Foo { id }" },
+                "RunCommandParameters": {
+                    "RunCommandTargets": [{"Key": "tag:env", "Values": ["prod"]}]
+                }
+            }]
+        }),
+    );
+    svc.put_targets(&req).unwrap();
+
+    let list_req = make_request("ListTargetsByRule", json!({"Rule": "r1"}));
+    let resp = svc.list_targets_by_rule(&list_req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let target = &body["Targets"][0];
+    assert_eq!(
+        target["RoleArn"],
+        "arn:aws:iam::123456789012:role/InvokeRole"
+    );
+    assert_eq!(
+        target["DeadLetterConfig"]["Arn"],
+        "arn:aws:sqs:us-east-1:123456789012:dlq"
+    );
+    assert_eq!(target["RetryPolicy"]["MaximumRetryAttempts"], 2);
+    assert_eq!(target["EcsParameters"]["LaunchType"], "FARGATE");
+    assert_eq!(
+        target["HttpParameters"]["HeaderParameters"]["X-Trace"],
+        "abc"
+    );
+    assert_eq!(
+        target["KinesisParameters"]["PartitionKeyPath"],
+        "$.detail.id"
+    );
+    assert_eq!(target["BatchParameters"]["JobName"], "j");
+    assert_eq!(target["RedshiftDataParameters"]["Database"], "db");
+    assert!(target["SageMakerPipelineParameters"]["PipelineParameterList"].is_array());
+    assert!(target["AppSyncParameters"]["GraphQLOperation"]
+        .as_str()
+        .unwrap_or("")
+        .contains("Foo"));
+    assert!(target["RunCommandParameters"]["RunCommandTargets"].is_array());
 }
 
 #[test]

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -284,6 +284,7 @@ mod tests {
                 input_path: None,
                 input_transformer: None,
                 sqs_parameters: None,
+                ..Default::default()
             }],
         );
 
@@ -343,6 +344,7 @@ mod tests {
                 input_path: None,
                 input_transformer: None,
                 sqs_parameters: None,
+                ..Default::default()
             }],
         );
 
@@ -407,6 +409,7 @@ mod tests {
                     input_path: None,
                     input_transformer: None,
                     sqs_parameters: None,
+                    ..Default::default()
                 },
                 EventTarget {
                     id: "t-lambda".to_string(),
@@ -415,6 +418,7 @@ mod tests {
                     input_path: None,
                     input_transformer: None,
                     sqs_parameters: None,
+                    ..Default::default()
                 },
                 EventTarget {
                     id: "t-logs".to_string(),
@@ -423,6 +427,7 @@ mod tests {
                     input_path: None,
                     input_transformer: None,
                     sqs_parameters: None,
+                    ..Default::default()
                 },
             ],
         );
@@ -456,6 +461,7 @@ mod tests {
                 input_path: None,
                 input_transformer: None,
                 sqs_parameters: Some(json!({"MessageGroupId": "g1"})),
+                ..Default::default()
             }],
         );
         let ctx = FireRuleContext {
@@ -479,6 +485,7 @@ mod tests {
             input_path: None,
             input_transformer: None,
             sqs_parameters: None,
+            ..Default::default()
         };
         let body = resolve_target_body(&target, &json!({"ignored": 1}), "ignored");
         assert_eq!(body, "{\"literal\":true}");
@@ -493,6 +500,7 @@ mod tests {
             input_path: Some("$.detail".to_string()),
             input_transformer: None,
             sqs_parameters: None,
+            ..Default::default()
         };
         let event = json!({"detail": {"k": 1}, "other": 2});
         let body = resolve_target_body(&target, &event, "fallback");
@@ -508,6 +516,7 @@ mod tests {
             input_path: Some("$.detail.nested".to_string()),
             input_transformer: None,
             sqs_parameters: None,
+            ..Default::default()
         };
         let body = resolve_target_body(&target, &json!({}), "full-event");
         assert_eq!(body, "full-event");
@@ -522,6 +531,7 @@ mod tests {
             input_path: None,
             input_transformer: None,
             sqs_parameters: None,
+            ..Default::default()
         };
         let body = resolve_target_body(&target, &json!({}), "full-event");
         assert_eq!(body, "full-event");

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -39,7 +39,7 @@ pub struct EventRule {
 /// Composite key for rules: (event_bus_name, rule_name)
 pub type RuleKey = (String, String);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EventTarget {
     pub id: String,
     pub arn: String,
@@ -47,6 +47,28 @@ pub struct EventTarget {
     pub input_path: Option<String>,
     pub input_transformer: Option<Value>,
     pub sqs_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_arn: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dead_letter_config: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_policy: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ecs_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kinesis_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redshift_data_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sage_maker_pipeline_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_sync_parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_command_parameters: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Extends \`EventTarget\` to capture every parameter \`PutTargets\` accepts (\`RoleArn\`, \`DeadLetterConfig\`, \`RetryPolicy\`, \`EcsParameters\`, \`BatchParameters\`, \`KinesisParameters\`, \`RedshiftDataParameters\`, \`HttpParameters\`, \`SageMakerPipelineParameters\`, \`AppSyncParameters\`, \`RunCommandParameters\`).
- \`parse_target\` reads each field, \`target_to_json\` emits them. \`DescribeRule\`/\`ListTargetsByRule\` round-trip the full config instead of silently dropping it.

## Test plan
- [x] \`cargo test -p fakecloud-eventbridge\` (197 tests, includes new \`put_targets_round_trips_full_target_config\`)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
EventBridge `PutTargets` now preserves and returns the full target configuration. `DescribeRule` and `ListTargetsByRule` include every target field instead of dropping them.

- **New Features**
  - `EventTarget` now stores all `PutTargets` parameters (RoleArn, DeadLetterConfig, RetryPolicy, EcsParameters, BatchParameters, KinesisParameters, RedshiftDataParameters, HttpParameters, SageMakerPipelineParameters, AppSyncParameters, RunCommandParameters).
  - `parse_target` reads these fields and `target_to_json` emits them, enabling full round-trip parity with AWS.
  - Derived `Default` for `EventTarget` to keep call sites concise.

<sup>Written for commit 12dfadc7d736e1dfbfa190cf5688dca7609217cb. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/967?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

