### PR TITLE
test(ses): seed verified identity in template-render test

### DIFF
--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -382,6 +382,7 @@ async fn test_send_email_template_content() {
 #[tokio::test]
 async fn test_send_email_template_renders_subject_and_body() {
     let state = make_state();
+    seed_identity(&state, "sender@example.com");
     {
         use crate::state::EmailTemplate;
         let mut accounts = state.write();


### PR DESCRIPTION
## Summary
- Adds \`seed_identity(\"sender@example.com\")\` to \`test_send_email_template_renders_subject_and_body\` so it doesn't trip the X1 verified-sender gate.
- Without this fix, every PR rebased onto post-X1 main fails the \`test\` job (\`expected 200, got 400\`).

## Test plan
- [x] \`cargo test -p fakecloud-ses test_send_email_template_renders_subject_and_body\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed a verified sender identity in `test_send_email_template_renders_subject_and_body` to satisfy the X1 verified-sender gate and stop CI failures.

<sup>Written for commit 702ef15786e67ba1871c74a257f982dce914a14c. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/969?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

