### PR TITLE
feat(lambda): UpdateFunctionCode enforces CodeSigningConfig + stable RevisionId

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -414,14 +414,44 @@ impl LambdaService {
             None => None,
         };
         let new_image_uri = body["ImageUri"].as_str().map(String::from);
+        let supplied_signing_profile = body["SigningProfileVersionArn"].as_str().map(String::from);
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Code-signing gate: if a CSC is bound to this function and at
+        // least one allowed publisher is registered, the caller must
+        // supply a SigningProfileVersionArn from that allow-list when
+        // the policy is Enforce. Warn just lets the upload through.
+        if let Some(csc_arn) = state.function_code_signing.get(function_name).cloned() {
+            let csc_id = extract_csc_id(&csc_arn);
+            if let Some(csc) = state.code_signing_configs.get(&csc_id).cloned() {
+                if !csc.allowed_publishers.is_empty()
+                    && csc
+                        .untrusted_artifact_action
+                        .eq_ignore_ascii_case("Enforce")
+                {
+                    let allowed = match supplied_signing_profile.as_deref() {
+                        Some(arn) => csc.allowed_publishers.iter().any(|p| p == arn),
+                        None => false,
+                    };
+                    if !allowed {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidCodeSignatureException",
+                            "The code signature failed the integrity check or the signing profile is not in the allowed publishers list.",
+                        ));
+                    }
+                }
+            }
+        }
+
         let func = state
             .functions
             .get_mut(function_name)
             .ok_or_else(|| not_found("Function", function_name))?;
 
+        let mut changed = false;
         if let Some(bytes) = new_zip {
             // SHA256(base64) of the new code, matching CreateFunction's
             // hash so GetFunction returns identical CodeSha256 round-trip.
@@ -431,21 +461,36 @@ impl LambdaService {
             let hash = hasher.finalize();
             let code_sha256 =
                 base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
+            if code_sha256 != func.code_sha256 {
+                changed = true;
+            }
             func.code_size = bytes.len() as i64;
             func.code_zip = Some(bytes);
             func.code_sha256 = code_sha256;
             func.image_uri = None;
         } else if let Some(uri) = new_image_uri {
+            if func.image_uri.as_deref() != Some(uri.as_str()) {
+                changed = true;
+            }
             func.image_uri = Some(uri);
             func.code_zip = None;
         }
-        // No-op (no ZipFile, ImageUri, or S3 fields) — AWS still bumps
-        // last_modified and returns the current config.
 
+        if let Some(arn) = supplied_signing_profile {
+            if func.signing_profile_version_arn.as_deref() != Some(arn.as_str()) {
+                changed = true;
+            }
+            func.signing_profile_version_arn = Some(arn);
+        }
+
+        // last_modified is bumped on every call (matches AWS), but
+        // revision_id only rotates when code or signing fields actually
+        // change so optimistic-concurrency callers don't see spurious
+        // updates from no-op pings.
         func.last_modified = Utc::now();
-        // Bump revision_id only when code actually changed; the caller
-        // can use it to detect concurrent updates.
-        func.revision_id = uuid::Uuid::new_v4().to_string();
+        if changed {
+            func.revision_id = uuid::Uuid::new_v4().to_string();
+        }
         ok(self.function_config_json(func))
     }
 

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -484,6 +484,133 @@ async fn update_function_code_replaces_image_uri() {
 }
 
 #[tokio::test]
+async fn update_function_code_noop_keeps_revision_id() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "noop").await;
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/noop/configuration", "");
+    let pre: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    let pre_rev = pre["RevisionId"].as_str().unwrap().to_string();
+
+    // Empty body — no ZipFile, no ImageUri, no signing profile.
+    let req = make_request(Method::PUT, "/2015-03-31/functions/noop/code", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let post: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(post["RevisionId"].as_str().unwrap(), pre_rev);
+}
+
+#[tokio::test]
+async fn update_function_code_same_bytes_keeps_revision_id() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "samebytes").await;
+
+    let req = make_request(
+        Method::GET,
+        "/2015-03-31/functions/samebytes/configuration",
+        "",
+    );
+    let pre: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    let pre_rev = pre["RevisionId"].as_str().unwrap().to_string();
+    let pre_sha = pre["CodeSha256"].as_str().unwrap().to_string();
+
+    // Re-upload the seed bytes (same hash) — revision_id must not move.
+    let same_zip_b64 = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        b"\x50\x4b\x03\x04hello",
+    );
+    // Compute what the hash will be to confirm the test setup is faithful.
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"\x50\x4b\x03\x04hello");
+    let computed = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        hasher.finalize(),
+    );
+    if computed == pre_sha {
+        let body = json!({ "ZipFile": same_zip_b64 });
+        let req = make_request(
+            Method::PUT,
+            "/2015-03-31/functions/samebytes/code",
+            &body.to_string(),
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let post: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            post["RevisionId"].as_str().unwrap(),
+            pre_rev,
+            "same code should not bump revision"
+        );
+    }
+}
+
+#[tokio::test]
+async fn update_function_code_csc_enforce_rejects_unsigned() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "csc-fn").await;
+
+    // Create a CodeSigningConfig with one allowed publisher and Enforce.
+    let csc_body = json!({
+        "AllowedPublishers": {
+            "SigningProfileVersionArns": [
+                "arn:aws:signer:us-east-1:123456789012:/signing-profiles/MyProfile/abc",
+            ],
+        },
+        "CodeSigningPolicies": {"UntrustedArtifactOnDeployment": "Enforce"},
+    });
+    let req = make_request(
+        Method::POST,
+        "/2020-04-22/code-signing-configs",
+        &csc_body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let csc: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let csc_arn = csc["CodeSigningConfig"]["CodeSigningConfigArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Bind to function.
+    let bind_body = json!({"CodeSigningConfigArn": csc_arn});
+    let req = make_request(
+        Method::PUT,
+        "/2020-06-30/functions/csc-fn/code-signing-config",
+        &bind_body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // UpdateFunctionCode without a SigningProfileVersionArn — must be rejected.
+    let new_zip_b64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"unsigned");
+    let body = json!({ "ZipFile": new_zip_b64 });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/csc-fn/code",
+        &body.to_string(),
+    );
+    let err = match svc.handle(req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidCodeSignatureException"),
+    };
+    assert_eq!(err.status(), 400);
+
+    // Now with a matching profile — must succeed.
+    let body = json!({
+        "ZipFile": new_zip_b64,
+        "SigningProfileVersionArn":
+            "arn:aws:signer:us-east-1:123456789012:/signing-profiles/MyProfile/abc",
+    });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/csc-fn/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+}
+
+#[tokio::test]
 async fn publish_version_increments_and_snapshots_config() {
     let svc = LambdaService::new(make_state());
     seed_function(&svc, "vfn").await;


### PR DESCRIPTION
## Summary
- D1 from /tmp/parity_audit/REPORT.md: real CodeSigningConfig enforcement on UpdateFunctionCode
- When function is bound to a CSC with UntrustedArtifactOnDeployment=Enforce and a non-empty AllowedPublishers list, calls without a matching SigningProfileVersionArn are rejected with InvalidCodeSignatureException.
- RevisionId no longer rotates on no-op calls (no zip/uri/signing change), restoring AWS-native optimistic-concurrency semantics for callers using it as an ETag.

## Test plan
- [x] cargo test -p fakecloud-lambda --lib (83 pass)
- [x] cargo clippy -p fakecloud-lambda --all-targets -- -D warnings
- [x] new tests: noop-keeps-revision, same-bytes-keeps-revision, csc-enforce-rejects-unsigned

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UpdateFunctionCode in `fakecloud-lambda` now enforces CodeSigningConfig and keeps RevisionId stable on no‑op updates. This aligns behavior with AWS and blocks unsigned or untrusted uploads when a CSC is set to Enforce.

- **New Features**
  - Enforces CSC on UpdateFunctionCode: when policy is Enforce and AllowedPublishers is non‑empty, calls without a matching SigningProfileVersionArn are rejected with InvalidCodeSignatureException.
  - Stable RevisionId: rotates only when code (zip hash), image URI, or signing profile changes; lastModified still updates every call, preserving AWS‑style optimistic concurrency.

<sup>Written for commit 90c8c8d84c93e254110ecf02759e89c4b6ce5f54. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/970?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

