### PR TITLE
feat(lambda): GetFunction(Qualifier) returns version snapshot

### DIFF
--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1113,11 +1113,12 @@ impl LambdaService {
         function_name: &str,
         account_id: &str,
         region: &str,
+        qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let accounts = self.state.read();
         let empty = LambdaState::new(account_id, region);
         let state = accounts.get(account_id).unwrap_or(&empty);
-        let func = state.functions.get(function_name).ok_or_else(|| {
+        let live = state.functions.get(function_name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
@@ -1128,7 +1129,38 @@ impl LambdaService {
             )
         })?;
 
-        let config = self.function_config_json(func);
+        // Resolve the qualifier to either $LATEST (live config) or a
+        // numbered immutable snapshot. Aliases route through
+        // `resolve_qualifier_to_version` so weighted aliases still pick
+        // between the underlying numbered versions.
+        let resolved_version = resolve_qualifier_to_version(state, function_name, qualifier);
+        let (func, version_label) = match resolved_version {
+            None => (live, "$LATEST".to_string()),
+            Some(v) => {
+                let snap = state
+                    .function_version_snapshots
+                    .get(function_name)
+                    .and_then(|m| m.get(&v))
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "ResourceNotFoundException",
+                            format!(
+                                "Function not found: arn:aws:lambda:{}:{}:function:{}:{v}",
+                                state.region, state.account_id, function_name
+                            ),
+                        )
+                    })?;
+                (snap, v)
+            }
+        };
+
+        let mut config = self.function_config_json(func);
+        config["Version"] = json!(version_label);
+        if version_label != "$LATEST" {
+            config["FunctionArn"] = json!(format!("{}:{version_label}", live.function_arn));
+            config["MasterArn"] = json!(live.function_arn);
+        }
         let code = if let Some(ref uri) = func.image_uri {
             json!({
                 "ImageUri": uri,
@@ -1153,7 +1185,7 @@ impl LambdaService {
         let response = json!({
             "Code": code,
             "Configuration": config,
-            "Tags": func.tags,
+            "Tags": live.tags,
         });
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
@@ -1668,6 +1700,7 @@ impl AwsService for LambdaService {
                 resource_name.as_deref().unwrap_or(""),
                 aid,
                 req.region.as_str(),
+                req.query_params.get("Qualifier").map(String::as_str),
             ),
             "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or(""), aid),
             "Invoke" => {

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -531,6 +531,93 @@ async fn publish_version_increments_and_snapshots_config() {
 }
 
 #[tokio::test]
+async fn get_function_with_qualifier_returns_snapshot() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "qfn").await;
+
+    // Publish v1 of the seed config, then mutate $LATEST.
+    let req = make_request(Method::POST, "/2015-03-31/functions/qfn/versions", "{}");
+    svc.handle(req).await.unwrap();
+    let body = json!({ "Description": "post-v1" });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/qfn/configuration",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // GetFunction?Qualifier=1 must return the v1 snapshot, not $LATEST.
+    let mut req = make_request(Method::GET, "/2015-03-31/functions/qfn", "");
+    req.query_params
+        .insert("Qualifier".to_string(), "1".to_string());
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Configuration"]["Version"], "1");
+    assert_eq!(body["Configuration"]["Description"].as_str().unwrap(), "");
+    assert!(body["Configuration"]["FunctionArn"]
+        .as_str()
+        .unwrap()
+        .ends_with(":1"));
+
+    // GetFunction without qualifier returns $LATEST with the new description.
+    let req = make_request(Method::GET, "/2015-03-31/functions/qfn", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Configuration"]["Version"], "$LATEST");
+    assert_eq!(
+        body["Configuration"]["Description"].as_str().unwrap(),
+        "post-v1"
+    );
+}
+
+#[tokio::test]
+async fn get_function_with_alias_resolves_to_version_snapshot() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "afn").await;
+
+    // Publish v1, mutate $LATEST, create alias pointing at v1.
+    let req = make_request(Method::POST, "/2015-03-31/functions/afn/versions", "{}");
+    svc.handle(req).await.unwrap();
+    let body = json!({ "Description": "post-publish" });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/afn/configuration",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let body = json!({"Name": "PROD", "FunctionVersion": "1"});
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/afn/aliases",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // GetFunction?Qualifier=PROD must hit the v1 snapshot.
+    let mut req = make_request(Method::GET, "/2015-03-31/functions/afn", "");
+    req.query_params
+        .insert("Qualifier".to_string(), "PROD".to_string());
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Configuration"]["Description"].as_str().unwrap(), "");
+}
+
+#[tokio::test]
+async fn get_function_unknown_qualifier_404s() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "missing").await;
+
+    let mut req = make_request(Method::GET, "/2015-03-31/functions/missing", "");
+    req.query_params
+        .insert("Qualifier".to_string(), "99".to_string());
+    let err = match svc.handle(req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected ResourceNotFoundException"),
+    };
+    assert_eq!(err.status(), 404);
+}
+
+#[tokio::test]
 async fn add_permission_builds_canonical_statement() {
     let svc = LambdaService::new(make_state());
     seed_function(&svc, "f").await;
@@ -901,7 +988,7 @@ async fn publish_version_unknown_function_errors() {
 async fn get_function_unknown_errors() {
     let svc = LambdaService::new(make_state());
     assert!(svc
-        .get_function("ghost", "123456789012", "us-east-1")
+        .get_function("ghost", "123456789012", "us-east-1", None)
         .is_err());
 }
 


### PR DESCRIPTION
## Summary
D2 from /tmp/parity_audit/REPORT.md: when a caller passes Qualifier=N or an alias name, GetFunction now returns the immutable snapshot recorded by PublishVersion rather than the live \$LATEST config. Aliases route through the existing resolve_qualifier_to_version path, so weighted aliases pick a numbered version. Missing snapshot lookups surface as a ResourceNotFoundException qualified with the version suffix.

## Test plan
- [x] cargo test -p fakecloud-lambda --lib (83 pass)
- [x] cargo clippy -p fakecloud-lambda --all-targets -- -D warnings
- [x] new tests cover qualifier=N, alias, and unknown-qualifier 404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GetFunction now returns the immutable version snapshot when a Qualifier (number or alias) is provided, instead of the live $LATEST config. This aligns with AWS and returns a 404 for missing snapshots.

- **New Features**
  - If Qualifier is a version or alias, return the published snapshot; otherwise return $LATEST. Aliases (including weighted) resolve to a numbered version.
  - Response matches AWS: sets Configuration.Version; for snapshots, FunctionArn is suffixed with :N and MasterArn is the base ARN; unknown qualifier returns 404 ResourceNotFoundException with a version-qualified ARN.

<sup>Written for commit ddd0916d136093c2c5569be1b184a38a5819cafe. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

