### PR TITLE
feat(lambda): Invoke runs from numbered version snapshot

### DIFF
--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1237,7 +1237,21 @@ impl LambdaService {
             let accounts = self.state.read();
             let empty = LambdaState::new(account_id, "");
             let state = accounts.get(account_id).unwrap_or(&empty);
-            let func = state.functions.get(function_name).cloned().ok_or_else(|| {
+            // Resolve numbered versions to the immutable snapshot stored
+            // by PublishVersion so an alias pinned to v1 runs the v1 code
+            // even after $LATEST is mutated. Falls back to $LATEST when
+            // the snapshot is missing (legacy state) so we never 404 a
+            // routable invoke.
+            let func = match resolved_version.as_deref() {
+                Some(v) => state
+                    .function_version_snapshots
+                    .get(function_name)
+                    .and_then(|m| m.get(v))
+                    .cloned()
+                    .or_else(|| state.functions.get(function_name).cloned()),
+                None => state.functions.get(function_name).cloned(),
+            }
+            .ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::NOT_FOUND,
                     "ResourceNotFoundException",


### PR DESCRIPTION
## Summary
Builds on D2 (#971): when Invoke resolves a qualifier to a numbered version (directly or via an alias), it now loads the immutable snapshot recorded at PublishVersion time instead of the live \$LATEST record. An alias pinned to v1 keeps running v1 code even after \$LATEST is mutated, matching AWS canary-deploy semantics. Snapshot miss falls back to \$LATEST so legacy state still routes.

## Test plan
- [x] cargo test -p fakecloud-lambda --lib (80 pass)
- [x] cargo clippy -p fakecloud-lambda --all-targets -- -D warnings