### PR TITLE
feat(sns): track SubscriptionsDeleted per topic

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -214,6 +214,7 @@ impl ResourceProvisioner {
             tags: Vec::new(),
             is_fifo: topic_name.ends_with(".fifo"),
             created_at: Utc::now(),
+            subscriptions_deleted: 0,
         };
 
         state.topics.insert(topic_arn.clone(), topic);

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -244,6 +244,7 @@ mod tests {
             tags: Vec::new(),
             is_fifo: false,
             created_at: Utc::now(),
+            subscriptions_deleted: 0,
         };
         (topic, arn)
     }

--- a/crates/fakecloud-sns/src/resource_policy.rs
+++ b/crates/fakecloud-sns/src/resource_policy.rs
@@ -107,6 +107,7 @@ mod tests {
                 tags: Vec::new(),
                 is_fifo: false,
                 created_at: Utc::now(),
+                subscriptions_deleted: 0,
             },
         );
         state

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -509,6 +509,7 @@ impl SnsService {
                 tags,
                 is_fifo,
                 created_at: Utc::now(),
+                subscriptions_deleted: 0,
             };
             state.topics.insert(topic_arn.clone(), topic);
         }
@@ -652,7 +653,10 @@ impl SnsService {
             format_attr("Owner", &state.account_id),
             format_attr("SubscriptionsConfirmed", &subs_confirmed.to_string()),
             format_attr("SubscriptionsPending", &subs_pending.to_string()),
-            format_attr("SubscriptionsDeleted", "0"),
+            format_attr(
+                "SubscriptionsDeleted",
+                &topic.subscriptions_deleted.to_string(),
+            ),
         ];
 
         // EffectiveDeliveryPolicy: merge any user-set DeliveryPolicy
@@ -928,11 +932,22 @@ impl SnsService {
 
     fn unsubscribe(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let sub_arn = required(req, "SubscriptionArn")?;
-        self.state
-            .write()
-            .get_or_create(&req.account_id)
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(&req.account_id);
+        // Snapshot the parent topic ARN before removing the subscription
+        // so we can bump SubscriptionsDeleted on the right topic. Real
+        // SNS exposes this counter on GetTopicAttributes.
+        let parent_topic = state
             .subscriptions
-            .remove(&sub_arn);
+            .get(&sub_arn)
+            .map(|s| s.topic_arn.clone());
+        if state.subscriptions.remove(&sub_arn).is_some() {
+            if let Some(arn) = parent_topic {
+                if let Some(topic) = state.topics.get_mut(&arn) {
+                    topic.subscriptions_deleted = topic.subscriptions_deleted.saturating_add(1);
+                }
+            }
+        }
 
         Ok(xml_resp(
             &format!(

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -152,6 +152,7 @@ fn add_permission_with_invalid_policy_returns_error_not_panic() {
                 is_fifo: false,
                 tags: vec![],
                 created_at: Utc::now(),
+                subscriptions_deleted: 0,
             },
         );
     }
@@ -388,6 +389,56 @@ fn unsubscribe_removes_subscription() {
     assert!(
         s.default_ref().subscriptions.is_empty(),
         "Subscription should be removed"
+    );
+    // SubscriptionsDeleted on the parent topic must reflect the
+    // unsubscribe so GetTopicAttributes returns a real cumulative count.
+    assert_eq!(
+        s.default_ref()
+            .topics
+            .get(topic_arn)
+            .map(|t| t.subscriptions_deleted),
+        Some(1)
+    );
+}
+
+#[test]
+fn get_topic_attributes_emits_subscriptions_deleted() {
+    let (svc, _state) = make_sns();
+    let req = sns_request("CreateTopic", vec![("Name", "sd-topic")]);
+    assert_ok(&svc.create_topic(&req));
+
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:sd-topic";
+    // Two subscriptions, then unsubscribe both.
+    for ep in ["a@example.com", "b@example.com"] {
+        let req = sns_request(
+            "Subscribe",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Protocol", "email"),
+                ("Endpoint", ep),
+            ],
+        );
+        assert_ok(&svc.subscribe(&req));
+    }
+    let sub_arns: Vec<String> = svc
+        .state
+        .read()
+        .default_ref()
+        .subscriptions
+        .keys()
+        .cloned()
+        .collect();
+    for arn in sub_arns {
+        let req = sns_request("Unsubscribe", vec![("SubscriptionArn", &arn)]);
+        assert_ok(&svc.unsubscribe(&req));
+    }
+
+    let req = sns_request("GetTopicAttributes", vec![("TopicArn", topic_arn)]);
+    let resp = svc.get_topic_attributes(&req).unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<key>SubscriptionsDeleted</key><value>2</value>"),
+        "expected SubscriptionsDeleted=2 in response, got: {body}"
     );
 }
 

--- a/crates/fakecloud-sns/src/state.rs
+++ b/crates/fakecloud-sns/src/state.rs
@@ -11,6 +11,13 @@ pub struct SnsTopic {
     pub tags: Vec<(String, String)>,
     pub is_fifo: bool,
     pub created_at: DateTime<Utc>,
+    /// Cumulative count of subscriptions that have been deleted from this
+    /// topic. AWS exposes this as `SubscriptionsDeleted` on
+    /// `GetTopicAttributes`; it never decreases. Bumped on every
+    /// successful `Unsubscribe`. Cascade deletions from `DeleteTopic`
+    /// reset along with the topic itself, so we don't bump there.
+    #[serde(default)]
+    pub subscriptions_deleted: u64,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary
K6 polish from /tmp/parity_audit/messaging.md: SubscriptionsDeleted was hard-coded to 0 on GetTopicAttributes. Real SNS exposes a cumulative count of every subscription ever deleted from the topic. Added a u64 counter on SnsTopic that bumps on every successful Unsubscribe so callers see realistic deletion counts.

## Test plan
- [x] cargo test -p fakecloud-sns --lib (180 pass)
- [x] cargo clippy -p fakecloud-sns --all-targets -- -D warnings
- [x] new test get_topic_attributes_emits_subscriptions_deleted; existing unsubscribe_removes_subscription extended