### PR TITLE
fix(iam): include AWS managed policies in ListAttachedRolePolicies

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -710,6 +710,44 @@ async fn iam_attach_detach_role_policy() {
     assert!(attached.attached_policies().is_empty());
 }
 
+#[tokio::test]
+async fn iam_list_attached_role_policies_includes_aws_managed() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    client
+        .create_role()
+        .role_name("task-exec")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy";
+    client
+        .attach_role_policy()
+        .role_name("task-exec")
+        .policy_arn(managed_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let attached = client
+        .list_attached_role_policies()
+        .role_name("task-exec")
+        .send()
+        .await
+        .unwrap();
+    let policies = attached.attached_policies();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].policy_arn(), Some(managed_arn));
+    assert_eq!(
+        policies[0].policy_name(),
+        Some("AmazonECSTaskExecutionRolePolicy"),
+    );
+}
+
 // ---- IAM Inline Policy Tests ----
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -748,6 +748,72 @@ async fn iam_list_attached_role_policies_includes_aws_managed() {
     );
 }
 
+#[tokio::test]
+async fn iam_list_attached_user_policies_includes_aws_managed() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("managed-user")
+        .send()
+        .await
+        .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+    client
+        .attach_user_policy()
+        .user_name("managed-user")
+        .policy_arn(managed_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let attached = client
+        .list_attached_user_policies()
+        .user_name("managed-user")
+        .send()
+        .await
+        .unwrap();
+    let policies = attached.attached_policies();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].policy_arn(), Some(managed_arn));
+    assert_eq!(policies[0].policy_name(), Some("AdministratorAccess"));
+}
+
+#[tokio::test]
+async fn iam_list_attached_group_policies_includes_aws_managed() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_group()
+        .group_name("managed-grp")
+        .send()
+        .await
+        .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess";
+    client
+        .attach_group_policy()
+        .group_name("managed-grp")
+        .policy_arn(managed_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let attached = client
+        .list_attached_group_policies()
+        .group_name("managed-grp")
+        .send()
+        .await
+        .unwrap();
+    let policies = attached.attached_policies();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].policy_arn(), Some(managed_arn));
+    assert_eq!(policies[0].policy_name(), Some("ReadOnlyAccess"));
+}
+
 // ---- IAM Inline Policy Tests ----
 
 #[tokio::test]

--- a/crates/fakecloud-iam/src/iam_service/account.rs
+++ b/crates/fakecloud-iam/src/iam_service/account.rs
@@ -6,7 +6,7 @@ use fakecloud_core::validation::*;
 
 use crate::state::{AccountPasswordPolicy, IamState, VirtualMfaDevice};
 
-use super::{empty_response, parse_tags, tags_xml, url_encode, IamService};
+use super::{attached_policy_name, empty_response, parse_tags, tags_xml, url_encode, IamService};
 use fakecloud_core::query::required_param;
 
 use fakecloud_aws::xml::xml_escape;
@@ -43,13 +43,11 @@ fn build_user_details_xml(state: &IamState) -> String {
                 .get(&u.user_name)
                 .map(|arns| {
                     arns.iter()
-                        .filter_map(|arn| {
-                            state.policies.get(arn).map(|p| {
-                                format!(
-                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                                    p.policy_name, p.arn
-                                )
-                            })
+                        .map(|arn| {
+                            let policy_name = attached_policy_name(state, arn);
+                            format!(
+                                "          <member>\n            <PolicyName>{policy_name}</PolicyName>\n            <PolicyArn>{arn}</PolicyArn>\n          </member>"
+                            )
                         })
                         .collect::<Vec<_>>()
                         .join("\n")
@@ -106,13 +104,11 @@ fn build_role_details_xml(state: &IamState) -> String {
                 .get(&r.role_name)
                 .map(|arns| {
                     arns.iter()
-                        .filter_map(|arn| {
-                            state.policies.get(arn).map(|p| {
-                                format!(
-                                    "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                                    p.policy_name, p.arn
-                                )
-                            })
+                        .map(|arn| {
+                            let policy_name = attached_policy_name(state, arn);
+                            format!(
+                                "          <member>\n            <PolicyName>{policy_name}</PolicyName>\n            <PolicyArn>{arn}</PolicyArn>\n          </member>"
+                            )
                         })
                         .collect::<Vec<_>>()
                         .join("\n")
@@ -168,13 +164,11 @@ fn build_group_details_xml(state: &IamState) -> String {
             let attached: String = g
                 .attached_policies
                 .iter()
-                .filter_map(|arn| {
-                    state.policies.get(arn).map(|p| {
-                        format!(
-                            "          <member>\n            <PolicyName>{}</PolicyName>\n            <PolicyArn>{}</PolicyArn>\n          </member>",
-                            p.policy_name, p.arn
-                        )
-                    })
+                .map(|arn| {
+                    let policy_name = attached_policy_name(state, arn);
+                    format!(
+                        "          <member>\n            <PolicyName>{policy_name}</PolicyName>\n            <PolicyArn>{arn}</PolicyArn>\n          </member>"
+                    )
                 })
                 .collect::<Vec<_>>()
                 .join("\n");

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -596,13 +596,11 @@ impl IamService {
         let members: String = group
             .attached_policies
             .iter()
-            .filter_map(|arn| {
-                state.policies.get(arn).map(|p| {
-                    format!(
-                        "      <member>\n        <PolicyName>{}</PolicyName>\n        <PolicyArn>{}</PolicyArn>\n      </member>",
-                        p.policy_name, p.arn
-                    )
-                })
+            .map(|arn| {
+                let policy_name = super::attached_policy_name(state, arn);
+                format!(
+                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
+                )
             })
             .collect::<Vec<_>>()
             .join("\n");

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -770,6 +770,20 @@ pub(crate) fn validate_untag_keys(keys: &[String]) -> Result<(), AwsServiceError
     Ok(())
 }
 
+/// Resolve the `PolicyName` to render for an attached managed policy ARN.
+///
+/// Customer-managed policies live in `state.policies` with their stored name.
+/// AWS-managed policies (`arn:aws:iam::aws:policy/...`) are accepted by the
+/// `Attach*Policy` calls without being inserted into state, so we derive the
+/// name from the ARN's last path segment to match what AWS itself returns.
+pub(crate) fn attached_policy_name(state: &crate::state::IamState, arn: &str) -> String {
+    state
+        .policies
+        .get(arn)
+        .map(|p| p.policy_name.clone())
+        .unwrap_or_else(|| arn.rsplit('/').next().unwrap_or(arn).to_string())
+}
+
 pub(crate) fn empty_response(action: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -634,13 +634,7 @@ impl IamService {
         let members: String = policy_arns
             .iter()
             .map(|arn| {
-                let policy_name = state
-                    .policies
-                    .get(arn)
-                    .map(|p| p.policy_name.clone())
-                    .unwrap_or_else(|| {
-                        arn.rsplit('/').next().unwrap_or(arn.as_str()).to_string()
-                    });
+                let policy_name = super::attached_policy_name(state, arn);
                 format!(
                     "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
                 )

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -633,13 +633,17 @@ impl IamService {
 
         let members: String = policy_arns
             .iter()
-            .filter_map(|arn| {
-                state.policies.get(arn).map(|p| {
-                    format!(
-                        "      <member>\n        <PolicyName>{}</PolicyName>\n        <PolicyArn>{}</PolicyArn>\n      </member>",
-                        p.policy_name, p.arn
-                    )
-                })
+            .map(|arn| {
+                let policy_name = state
+                    .policies
+                    .get(arn)
+                    .map(|p| p.policy_name.clone())
+                    .unwrap_or_else(|| {
+                        arn.rsplit('/').next().unwrap_or(arn.as_str()).to_string()
+                    });
+                format!(
+                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
+                )
             })
             .collect::<Vec<_>>()
             .join("\n");

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -2229,8 +2229,11 @@ fn list_attached_role_policies_includes_aws_managed() {
 #[test]
 fn list_attached_user_policies_includes_aws_managed() {
     let svc = make_service();
-    svc.create_user(&make_request("CreateUser", vec![("UserName", "managed-user")]))
-        .unwrap();
+    svc.create_user(&make_request(
+        "CreateUser",
+        vec![("UserName", "managed-user")],
+    ))
+    .unwrap();
 
     let managed_arn = "arn:aws:iam::aws:policy/AdministratorAccess";
     svc.attach_user_policy(&make_request(
@@ -2259,8 +2262,11 @@ fn list_attached_user_policies_includes_aws_managed() {
 #[test]
 fn list_attached_group_policies_includes_aws_managed() {
     let svc = make_service();
-    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "managed-grp")]))
-        .unwrap();
+    svc.create_group(&make_request(
+        "CreateGroup",
+        vec![("GroupName", "managed-grp")],
+    ))
+    .unwrap();
 
     let managed_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess";
     svc.attach_group_policy(&make_request(

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -2226,6 +2226,66 @@ fn list_attached_role_policies_includes_aws_managed() {
     );
 }
 
+#[test]
+fn list_attached_user_policies_includes_aws_managed() {
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "managed-user")]))
+        .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+    svc.attach_user_policy(&make_request(
+        "AttachUserPolicy",
+        vec![("UserName", "managed-user"), ("PolicyArn", managed_arn)],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .list_attached_user_policies(&make_request(
+            "ListAttachedUserPolicies",
+            vec![("UserName", "managed-user")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains(managed_arn),
+        "managed policy ARN missing from response: {body}"
+    );
+    assert!(
+        body.contains("<PolicyName>AdministratorAccess</PolicyName>"),
+        "managed policy name missing from response: {body}"
+    );
+}
+
+#[test]
+fn list_attached_group_policies_includes_aws_managed() {
+    let svc = make_service();
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "managed-grp")]))
+        .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess";
+    svc.attach_group_policy(&make_request(
+        "AttachGroupPolicy",
+        vec![("GroupName", "managed-grp"), ("PolicyArn", managed_arn)],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .list_attached_group_policies(&make_request(
+            "ListAttachedGroupPolicies",
+            vec![("GroupName", "managed-grp")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains(managed_arn),
+        "managed policy ARN missing from response: {body}"
+    );
+    assert!(
+        body.contains("<PolicyName>ReadOnlyAccess</PolicyName>"),
+        "managed policy name missing from response: {body}"
+    );
+}
+
 // ── users.rs additional coverage ──
 
 #[test]

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -2189,6 +2189,43 @@ fn attach_detach_list_role_policies_managed() {
     .unwrap();
 }
 
+#[test]
+fn list_attached_role_policies_includes_aws_managed() {
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    svc.create_role(&make_request(
+        "CreateRole",
+        vec![
+            ("RoleName", "task-exec"),
+            ("AssumeRolePolicyDocument", trust),
+        ],
+    ))
+    .unwrap();
+
+    let managed_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy";
+    svc.attach_role_policy(&make_request(
+        "AttachRolePolicy",
+        vec![("RoleName", "task-exec"), ("PolicyArn", managed_arn)],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .list_attached_role_policies(&make_request(
+            "ListAttachedRolePolicies",
+            vec![("RoleName", "task-exec")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        body.contains(managed_arn),
+        "managed policy ARN missing from response: {body}"
+    );
+    assert!(
+        body.contains("<PolicyName>AmazonECSTaskExecutionRolePolicy</PolicyName>"),
+        "managed policy name missing from response: {body}"
+    );
+}
+
 // ── users.rs additional coverage ──
 
 #[test]

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -1457,13 +1457,11 @@ impl IamService {
 
         let members: String = policy_arns
             .iter()
-            .filter_map(|arn| {
-                state.policies.get(arn).map(|p| {
-                    format!(
-                        "      <member>\n        <PolicyName>{}</PolicyName>\n        <PolicyArn>{}</PolicyArn>\n      </member>",
-                        p.policy_name, p.arn
-                    )
-                })
+            .map(|arn| {
+                let policy_name = super::attached_policy_name(state, arn);
+                format!(
+                    "      <member>\n        <PolicyName>{policy_name}</PolicyName>\n        <PolicyArn>{arn}</PolicyArn>\n      </member>"
+                )
             })
             .collect::<Vec<_>>()
             .join("\n");


### PR DESCRIPTION
AttachRolePolicy accepts AWS managed policy ARNs (arn:aws:iam::aws:policy/...) without storing them in state.policies, but list_attached_role_policies used filter_map on state.policies.get(arn) and silently dropped them. Terraform's read-back-with-retry on aws_iam_role_policy_attachment then hung waiting for consistency that would never arrive.

Derive PolicyName from the ARN's last path segment when the policy isn't in state, matching what AWS returns. Adds a unit and an e2e regression test.