### PR TITLE
fix(s3): emit x-amz-transition-default-minimum-object-size on lifecycle GET

### DIFF
--- a/crates/fakecloud-e2e/tests/s3_lifecycle.rs
+++ b/crates/fakecloud-e2e/tests/s3_lifecycle.rs
@@ -1,0 +1,191 @@
+mod helpers;
+
+use aws_sdk_s3::types::{
+    BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule,
+    LifecycleRuleAndOperator, LifecycleRuleFilter, NoncurrentVersionExpiration, Tag, Transition,
+    TransitionDefaultMinimumObjectSize, TransitionStorageClass,
+};
+use helpers::TestServer;
+
+async fn round_trip(label: &str, rule: LifecycleRule) {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    let bucket = format!("lc-{}", label);
+
+    client.create_bucket().bucket(&bucket).send().await.unwrap();
+
+    client
+        .put_bucket_lifecycle_configuration()
+        .bucket(&bucket)
+        .lifecycle_configuration(
+            BucketLifecycleConfiguration::builder()
+                .rules(rule.clone())
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_bucket_lifecycle_configuration()
+        .bucket(&bucket)
+        .send()
+        .await
+        .unwrap();
+
+    let returned = resp.rules();
+    assert_eq!(returned.len(), 1, "{label}: rule count mismatch");
+    assert_eq!(&returned[0], &rule, "{label}: round-trip must match input");
+}
+
+#[tokio::test]
+async fn lifecycle_prefix_filter_round_trips() {
+    let rule = LifecycleRule::builder()
+        .id("r1")
+        .status(ExpirationStatus::Enabled)
+        .filter(LifecycleRuleFilter::builder().prefix("logs/").build())
+        .noncurrent_version_expiration(
+            NoncurrentVersionExpiration::builder()
+                .noncurrent_days(30)
+                .build(),
+        )
+        .build()
+        .unwrap();
+    round_trip("prefix", rule).await;
+}
+
+#[tokio::test]
+async fn lifecycle_empty_filter_round_trips() {
+    let rule = LifecycleRule::builder()
+        .id("r1")
+        .status(ExpirationStatus::Enabled)
+        .filter(LifecycleRuleFilter::builder().build())
+        .expiration(LifecycleExpiration::builder().days(7).build())
+        .build()
+        .unwrap();
+    round_trip("empty-filter", rule).await;
+}
+
+#[tokio::test]
+async fn lifecycle_and_filter_round_trips() {
+    let rule = LifecycleRule::builder()
+        .id("r1")
+        .status(ExpirationStatus::Enabled)
+        .filter(
+            LifecycleRuleFilter::builder()
+                .and(
+                    LifecycleRuleAndOperator::builder()
+                        .prefix("data/")
+                        .tags(Tag::builder().key("env").value("prod").build().unwrap())
+                        .object_size_greater_than(1024)
+                        .build(),
+                )
+                .build(),
+        )
+        .transitions(
+            Transition::builder()
+                .days(30)
+                .storage_class(TransitionStorageClass::Glacier)
+                .build(),
+        )
+        .build()
+        .unwrap();
+    round_trip("and-filter", rule).await;
+}
+
+/// Regression for the Terraform provider hang on `aws_s3_bucket_lifecycle_configuration`.
+///
+/// The provider's stable-state waiter polls `GetBucketLifecycleConfiguration`
+/// until its response — including the `TransitionDefaultMinimumObjectSize`
+/// field carried in the `x-amz-transition-default-minimum-object-size`
+/// header — `reflect.DeepEqual`s the user's input. The provider schema
+/// defaults the field to `all_storage_classes_128K`, so omitting the header
+/// on GET makes the waiter loop until the resource times out.
+#[tokio::test]
+async fn lifecycle_get_returns_default_transition_min_size_header() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    let bucket = "lc-tdmos-default";
+
+    client.create_bucket().bucket(bucket).send().await.unwrap();
+
+    let rule = LifecycleRule::builder()
+        .id("expire")
+        .status(ExpirationStatus::Enabled)
+        .filter(LifecycleRuleFilter::builder().prefix("").build())
+        .expiration(LifecycleExpiration::builder().days(1).build())
+        .build()
+        .unwrap();
+    client
+        .put_bucket_lifecycle_configuration()
+        .bucket(bucket)
+        .lifecycle_configuration(
+            BucketLifecycleConfiguration::builder()
+                .rules(rule)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_bucket_lifecycle_configuration()
+        .bucket(bucket)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.transition_default_minimum_object_size(),
+        Some(&TransitionDefaultMinimumObjectSize::AllStorageClasses128K),
+        "GET must echo the AWS default header so Terraform's stable-state waiter terminates"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_round_trips_explicit_transition_min_size_header() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+    let bucket = "lc-tdmos-explicit";
+
+    client.create_bucket().bucket(bucket).send().await.unwrap();
+
+    let rule = LifecycleRule::builder()
+        .id("expire")
+        .status(ExpirationStatus::Enabled)
+        .filter(LifecycleRuleFilter::builder().prefix("").build())
+        .expiration(LifecycleExpiration::builder().days(1).build())
+        .build()
+        .unwrap();
+    let put = client
+        .put_bucket_lifecycle_configuration()
+        .bucket(bucket)
+        .transition_default_minimum_object_size(
+            TransitionDefaultMinimumObjectSize::VariesByStorageClass,
+        )
+        .lifecycle_configuration(
+            BucketLifecycleConfiguration::builder()
+                .rules(rule)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        put.transition_default_minimum_object_size(),
+        Some(&TransitionDefaultMinimumObjectSize::VariesByStorageClass),
+    );
+
+    let resp = client
+        .get_bucket_lifecycle_configuration()
+        .bucket(bucket)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.transition_default_minimum_object_size(),
+        Some(&TransitionDefaultMinimumObjectSize::VariesByStorageClass),
+    );
+}

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -68,6 +68,8 @@ pub struct BucketMeta {
     pub accelerate_status: Option<String>,
     #[serde(default)]
     pub eventbridge_enabled: bool,
+    #[serde(default)]
+    pub lifecycle_transition_default_min_size: Option<String>,
 }
 
 fn default_time() -> DateTime<Utc> {

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -29,6 +29,7 @@ pub fn bucket_meta_snapshot(b: &S3Bucket) -> BucketMeta {
         acl_owner_id: b.acl_owner_id.clone(),
         accelerate_status: b.accelerate_status.clone(),
         eventbridge_enabled: b.eventbridge_enabled,
+        lifecycle_transition_default_min_size: b.lifecycle_transition_default_min_size.clone(),
     }
 }
 
@@ -218,6 +219,7 @@ pub fn s3_bucket_from_snapshot(
         acl: meta.acl.clone(),
         encryption_config: None,
         lifecycle_config: None,
+        lifecycle_transition_default_min_size: meta.lifecycle_transition_default_min_size.clone(),
         policy: None,
         cors_config: None,
         notification_config: None,

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -271,21 +271,17 @@ impl S3Service {
             self.store
                 .put_bucket_subresource(bucket, BucketSubresource::Lifecycle, &body_str)
                 .map_err(super::persistence_error)?;
-            let meta = bucket_meta_snapshot(b);
-            self.store
-                .put_bucket_meta(bucket, &meta)
-                .map_err(super::persistence_error)?;
         } else {
             b.lifecycle_config = None;
             b.lifecycle_transition_default_min_size = None;
             self.store
                 .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle)
                 .map_err(super::persistence_error)?;
-            let meta = bucket_meta_snapshot(b);
-            self.store
-                .put_bucket_meta(bucket, &meta)
-                .map_err(super::persistence_error)?;
         }
+        let meta = bucket_meta_snapshot(b);
+        self.store
+            .put_bucket_meta(bucket, &meta)
+            .map_err(super::persistence_error)?;
         let mut resp = empty_response(StatusCode::OK);
         insert_tdmos_header(&mut resp.headers, tdmos.as_deref());
         Ok(resp)

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -134,6 +134,22 @@ pub(crate) fn grants_are_public(grants: &[crate::state::AclGrant]) -> bool {
     })
 }
 
+const LIFECYCLE_TDMOS_HEADER: &str = "x-amz-transition-default-minimum-object-size";
+
+/// Default value real AWS returns on `GetBucketLifecycleConfiguration` for
+/// general purpose buckets when none was supplied at PUT. The Terraform
+/// provider's stable-state waiter compares this against its schema default
+/// (`all_storage_classes_128K`) — omitting the header makes the waiter loop
+/// indefinitely.
+const LIFECYCLE_TDMOS_DEFAULT: &str = "all_storage_classes_128K";
+
+fn insert_tdmos_header(headers: &mut HeaderMap, value: Option<&str>) {
+    let v = value.unwrap_or(LIFECYCLE_TDMOS_DEFAULT);
+    if let Ok(parsed) = v.parse() {
+        headers.insert(LIFECYCLE_TDMOS_HEADER, parsed);
+    }
+}
+
 impl S3Service {
     // ---- Encryption ----
 
@@ -237,6 +253,12 @@ impl S3Service {
         // If there are no <Rule> elements at all, treat as deleting the configuration
         let has_rules = body_str.contains("<Rule>");
 
+        let tdmos = req
+            .headers
+            .get(LIFECYCLE_TDMOS_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
         let mut accts = self.state.write();
         let state = accts.get_or_create(account_id);
         let b = state
@@ -245,16 +267,28 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         if has_rules {
             b.lifecycle_config = Some(body_str.clone());
+            b.lifecycle_transition_default_min_size = tdmos.clone();
             self.store
                 .put_bucket_subresource(bucket, BucketSubresource::Lifecycle, &body_str)
                 .map_err(super::persistence_error)?;
+            let meta = bucket_meta_snapshot(b);
+            self.store
+                .put_bucket_meta(bucket, &meta)
+                .map_err(super::persistence_error)?;
         } else {
             b.lifecycle_config = None;
+            b.lifecycle_transition_default_min_size = None;
             self.store
                 .delete_bucket_subresource(bucket, BucketSubresource::Lifecycle)
                 .map_err(super::persistence_error)?;
+            let meta = bucket_meta_snapshot(b);
+            self.store
+                .put_bucket_meta(bucket, &meta)
+                .map_err(super::persistence_error)?;
         }
-        Ok(empty_response(StatusCode::OK))
+        let mut resp = empty_response(StatusCode::OK);
+        insert_tdmos_header(&mut resp.headers, tdmos.as_deref());
+        Ok(resp)
     }
 
     pub(super) fn get_bucket_lifecycle(
@@ -270,7 +304,14 @@ impl S3Service {
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
         match &b.lifecycle_config {
-            Some(config) => Ok(s3_xml(StatusCode::OK, config.clone())),
+            Some(config) => {
+                let mut resp = s3_xml(StatusCode::OK, config.clone());
+                insert_tdmos_header(
+                    &mut resp.headers,
+                    b.lifecycle_transition_default_min_size.as_deref(),
+                );
+                Ok(resp)
+            }
             None => Err(AwsServiceError::aws_error_with_fields(
                 StatusCode::NOT_FOUND,
                 "NoSuchLifecycleConfiguration",

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -109,6 +109,11 @@ pub struct S3Bucket {
     pub acl: Option<String>,
     pub encryption_config: Option<String>,
     pub lifecycle_config: Option<String>,
+    /// Value of the `x-amz-transition-default-minimum-object-size` header
+    /// supplied on PutBucketLifecycleConfiguration. Echoed back as a header
+    /// on the corresponding GET (and PUT) response. Real AWS defaults to
+    /// `all_storage_classes_128K` for general purpose buckets.
+    pub lifecycle_transition_default_min_size: Option<String>,
     pub policy: Option<String>,
     pub cors_config: Option<String>,
     pub notification_config: Option<String>,
@@ -160,6 +165,7 @@ impl S3Bucket {
             acl: None,
             encryption_config: None,
             lifecycle_config: None,
+            lifecycle_transition_default_min_size: None,
             policy: None,
             cors_config: None,
             notification_config: None,


### PR DESCRIPTION
GetBucketLifecycleConfiguration on real AWS always returns the TransitionDefaultMinimumObjectSize value via the
x-amz-transition-default-minimum-object-size response header (default all_storage_classes_128K for general purpose buckets). The Terraform provider's stable-state waiter for aws_s3_bucket_lifecycle_configuration deep-equals the user's input — including this field, which it defaults to all_storage_classes_128K — against repeated GET responses. Omitting the header made the comparison never succeed, so the resource hung on its 3-minute create timeout even though the body round-tripped fine.

Capture the header on PUT, persist it via BucketMeta, and echo it on both PUT and GET responses, defaulting to all_storage_classes_128K when unset. Adds e2e regression tests that assert the default and an explicitly-supplied non-default value both round-trip via the SDK.