### PR TITLE
feat(sns): POST SubscriptionConfirmation to HTTP/HTTPS endpoints

### DIFF
--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -246,6 +246,44 @@ pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String 
     sns_event.to_string()
 }
 
+/// Build an SNS SubscriptionConfirmation envelope as a JSON string.
+/// AWS POSTs this to HTTP/HTTPS endpoints right after Subscribe so the
+/// subscriber can echo the Token back via ConfirmSubscription.
+pub(crate) fn build_subscription_confirmation_envelope(topic_arn: &str, token: &str) -> String {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "Type".to_string(),
+        Value::String("SubscriptionConfirmation".to_string()),
+    );
+    map.insert(
+        "MessageId".to_string(),
+        Value::String(uuid::Uuid::new_v4().to_string()),
+    );
+    map.insert("Token".to_string(), Value::String(token.to_string()));
+    map.insert("TopicArn".to_string(), Value::String(topic_arn.to_string()));
+    map.insert(
+        "Message".to_string(),
+        Value::String(format!(
+            "You have chosen to subscribe to the topic {topic_arn}.\nTo confirm the subscription, visit the SubscribeURL included in this message."
+        )),
+    );
+    map.insert(
+        "SubscribeURL".to_string(),
+        Value::String(format!(
+            "https://sns.amazonaws.com/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+        )),
+    );
+    map.insert(
+        "Timestamp".to_string(),
+        Value::String(Utc::now().to_rfc3339()),
+    );
+    map.insert(
+        "SignatureVersion".to_string(),
+        Value::String("1".to_string()),
+    );
+    Value::Object(map).to_string()
+}
+
 /// Build an SNS notification envelope as JSON string.
 /// Subject and MessageAttributes are only included when present.
 pub(crate) fn build_sns_envelope(
@@ -1249,4 +1287,27 @@ pub(crate) fn validate_numeric_filter(arr: &[Value]) -> Result<(), AwsServiceErr
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod confirmation_envelope_tests {
+    use super::build_subscription_confirmation_envelope;
+    use serde_json::Value;
+
+    #[test]
+    fn envelope_carries_token_and_subscribe_url() {
+        let topic = "arn:aws:sns:us-east-1:123456789012:test-topic";
+        let token = "tok-abc";
+        let body = build_subscription_confirmation_envelope(topic, token);
+        let parsed: Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(parsed["Type"], "SubscriptionConfirmation");
+        assert_eq!(parsed["TopicArn"], topic);
+        assert_eq!(parsed["Token"], token);
+        let url = parsed["SubscribeURL"].as_str().unwrap();
+        assert!(url.contains("Action=ConfirmSubscription"));
+        assert!(url.contains(token));
+        assert!(url.contains(topic));
+        assert!(parsed["Timestamp"].is_string());
+        assert!(parsed["MessageId"].is_string());
+    }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -853,16 +853,53 @@ impl SnsService {
 
         let sub = SnsSubscription {
             subscription_arn: sub_arn.clone(),
-            topic_arn,
-            protocol,
-            endpoint,
+            topic_arn: topic_arn.clone(),
+            protocol: protocol.clone(),
+            endpoint: endpoint.clone(),
             owner: account_id,
             attributes,
             confirmed,
-            confirmation_token,
+            confirmation_token: confirmation_token.clone(),
         };
 
         state.subscriptions.insert(sub_arn.clone(), sub);
+        // Drop the write lock before any async work.
+        drop(accounts);
+
+        // For HTTP/HTTPS protocols, AWS POSTs a SubscriptionConfirmation
+        // envelope to the endpoint and the subscriber must call back with
+        // ConfirmSubscription using the embedded Token. Without this POST
+        // any subscriber following AWS docs sits forever unconfirmed.
+        if !confirmed && (protocol == "http" || protocol == "https") {
+            // Skip the spawn when no Tokio runtime is in scope (sync unit
+            // tests). Production callers always run inside the server
+            // runtime.
+            if tokio::runtime::Handle::try_current().is_err() {
+                // fall through; nothing to spawn
+            } else if let Some(token) = confirmation_token {
+                let endpoint_url = endpoint.clone();
+                let topic = topic_arn.clone();
+                tokio::spawn(async move {
+                    let body = build_subscription_confirmation_envelope(&topic, &token);
+                    let client = reqwest::Client::new();
+                    let result = client
+                        .post(&endpoint_url)
+                        .header("Content-Type", "application/json")
+                        .header("x-amz-sns-message-type", "SubscriptionConfirmation")
+                        .header("x-amz-sns-topic-arn", &topic)
+                        .body(body)
+                        .send()
+                        .await;
+                    if let Err(e) = result {
+                        tracing::warn!(
+                            endpoint = %endpoint_url,
+                            error = %e,
+                            "SNS SubscriptionConfirmation POST failed"
+                        );
+                    }
+                });
+            }
+        }
 
         Ok(xml_resp(
             &format!(


### PR DESCRIPTION
## Summary
K3 from /tmp/parity_audit/messaging.md (HIGH): Subscribe stashed a confirmation_token but never POSTed the SubscriptionConfirmation envelope to HTTP/HTTPS subscriber endpoints. Subscribers following AWS docs (read Token from envelope, call ConfirmSubscription) sat forever unconfirmed. Now spawns a fire-and-forget POST after the write lock drops, with the canonical JSON envelope (Type/Token/TopicArn/MessageId/SubscribeURL/Timestamp) and the AWS x-amz-sns-message-type header.

## Test plan
- [x] cargo test -p fakecloud-sns --lib (180 pass)
- [x] cargo clippy -p fakecloud-sns --all-targets -- -D warnings
- [x] new test envelope_carries_token_and_subscribe_url asserts wire format