### PR TITLE
feat(kinesis): GetShardIterator supports AT_TIMESTAMP

### DIFF
--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -256,6 +256,29 @@ pub(crate) fn shard_iterator_start_index(
             let sequence_number = require_starting_sequence_number(body)?;
             Ok(find_record_index_by_sequence_number(shard, sequence_number)? + 1)
         }
+        "AT_TIMESTAMP" => {
+            // AWS encodes Timestamp as epoch seconds (float, with optional
+            // fractional millis). Find the first record whose
+            // approximate_arrival_timestamp is at or after that mark; fall
+            // through to past-the-end when no record qualifies, so the
+            // following GetRecords returns an empty page rather than 400.
+            let ts_value = body["Timestamp"]
+                .as_f64()
+                .ok_or_else(|| invalid_argument("Timestamp is required"))?;
+            if !ts_value.is_finite() || ts_value < 0.0 {
+                return Err(invalid_argument("Timestamp must be a non-negative epoch"));
+            }
+            let secs = ts_value.trunc() as i64;
+            let nanos = ((ts_value - ts_value.trunc()) * 1_000_000_000.0) as u32;
+            let target = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, nanos)
+                .ok_or_else(|| invalid_argument("Timestamp is invalid"))?;
+            let idx = shard
+                .records
+                .iter()
+                .position(|r| r.approximate_arrival_timestamp >= target)
+                .unwrap_or(shard.records.len());
+            Ok(idx)
+        }
         _ => Err(invalid_argument("Unsupported ShardIteratorType")),
     }
 }

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -168,6 +168,44 @@ fn latest_iterator_starts_after_existing_records() {
     assert_eq!(index, 2);
 }
 
+#[test]
+fn at_timestamp_iterator_finds_first_record_at_or_after() {
+    let mut shard = test_shard();
+    append_record(&mut shard, "key", b"first".to_vec());
+    append_record(&mut shard, "key", b"second".to_vec());
+
+    // Stamp the second record well after the first so we can target it.
+    let early = chrono::Utc::now() - chrono::Duration::hours(2);
+    let later = chrono::Utc::now() - chrono::Duration::minutes(30);
+    shard.records[0].approximate_arrival_timestamp = early;
+    shard.records[1].approximate_arrival_timestamp = later;
+
+    // Pick a timestamp between the two — must land on record index 1.
+    let between = (early + chrono::Duration::hours(1)).timestamp() as f64;
+    let index =
+        shard_iterator_start_index(&shard, "AT_TIMESTAMP", &json!({"Timestamp": between})).unwrap();
+    assert_eq!(index, 1);
+
+    // Timestamp before everything — index 0.
+    let before = (early - chrono::Duration::minutes(1)).timestamp() as f64;
+    let index =
+        shard_iterator_start_index(&shard, "AT_TIMESTAMP", &json!({"Timestamp": before})).unwrap();
+    assert_eq!(index, 0);
+
+    // Timestamp after everything — points past the end (empty page).
+    let after = (later + chrono::Duration::hours(1)).timestamp() as f64;
+    let index =
+        shard_iterator_start_index(&shard, "AT_TIMESTAMP", &json!({"Timestamp": after})).unwrap();
+    assert_eq!(index, 2);
+}
+
+#[test]
+fn at_timestamp_iterator_rejects_missing_field() {
+    let shard = test_shard();
+    let err = shard_iterator_start_index(&shard, "AT_TIMESTAMP", &json!({})).unwrap_err();
+    assert_eq!(err.code(), "InvalidArgumentException");
+}
+
 // ── Helpers for the expanded test suite ─────────────────────────
 
 fn make_service() -> (KinesisService, SharedKinesisState) {


### PR DESCRIPTION
## Summary
K13 from /tmp/parity_audit/messaging.md: AT_TIMESTAMP iterator type was returning InvalidArgumentException. Real Kinesis lets clients seek records by approximate_arrival_timestamp. Parses Timestamp as epoch-seconds float and finds the first record whose arrival is at or after the target. Returns past-the-end on miss so the following GetRecords yields an empty page rather than 400.

## Test plan
- [x] cargo test -p fakecloud-kinesis --lib (95 pass)
- [x] cargo clippy -p fakecloud-kinesis --all-targets -- -D warnings
- [x] new tests cover before/between/after positions and missing-field rejection