### PR TITLE
feat(cognito): expose pool JWKS + OIDC discovery endpoints

### DIFF
--- a/crates/fakecloud-cognito/src/jwt.rs
+++ b/crates/fakecloud-cognito/src/jwt.rs
@@ -17,7 +17,6 @@ use serde_json::Value;
 
 /// Generate a fresh RSA-2048 keypair, returning the PKCS#8 PEM-encoded
 /// private key (which embeds the public half).
-#[allow(dead_code)]
 pub(crate) fn generate_pool_signing_key() -> String {
     let mut rng = rand::thread_rng();
     // 2048 bits matches what Cognito issues today; the PKCS#8 encoding
@@ -58,8 +57,7 @@ pub(crate) fn sign_rs256(header: &Value, payload: &Value, private_key_pem: &str)
 /// (`{"keys": [<jwk>]}`) with the `kid` baked in. Matches the shape the
 /// AWS-published `/.well-known/jwks.json` endpoints serve. Used by the
 /// JWKS HTTP endpoint (Y2) which is wired in fakecloud-server.
-#[allow(dead_code)]
-pub(crate) fn jwks_document(private_key_pem: &str, kid: &str) -> Value {
+pub fn jwks_document(private_key_pem: &str, kid: &str) -> Value {
     use rsa::pkcs8::DecodePrivateKey;
     let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let Ok(private_key) = RsaPrivateKey::from_pkcs8_pem(private_key_pem) else {

--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -1,8 +1,10 @@
-pub(crate) mod jwt;
+pub mod jwt;
 pub(crate) mod service;
 pub(crate) mod state;
 pub mod triggers;
 pub mod user_status;
 
-pub use service::CognitoService;
+pub use service::{
+    ensure_pool_signing_key, oidc_discovery_document, pool_jwks_document, CognitoService,
+};
 pub use state::{CognitoSnapshot, SharedCognitoState, COGNITO_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1591,5 +1591,96 @@ fn sign_jwt(
     format!("{header_b64}.{payload_b64}.{sig_b64}")
 }
 
+/// Look up a pool's signing key, generating one off the runtime thread if
+/// missing. Returns `(pkcs8_pem, kid)` for callers that need to sign a
+/// JWT or render a JWKS document. The expensive RSA-2048 keygen only
+/// runs once per pool — subsequent calls hit the cache.
+pub async fn ensure_pool_signing_key(
+    state: &SharedCognitoState,
+    pool_id: &str,
+) -> Option<(String, String)> {
+    {
+        let mas = state.read();
+        for (_, account) in mas.iter() {
+            if let Some(pool) = account.user_pools.get(pool_id) {
+                if let (Some(p), Some(k)) = (&pool.signing_key_pem, &pool.signing_kid) {
+                    return Some((p.clone(), k.clone()));
+                }
+                break;
+            }
+        }
+    }
+    let generated = tokio::task::spawn_blocking(crate::jwt::generate_pool_signing_key)
+        .await
+        .ok()?;
+    let mut mas = state.write();
+    let mut result = None;
+    for (_, account) in mas.iter_mut() {
+        if let Some(pool) = account.user_pools.get_mut(pool_id) {
+            if pool.signing_key_pem.is_none() {
+                pool.signing_key_pem = Some(generated.clone());
+            }
+            if let (Some(p), Some(k)) = (&pool.signing_key_pem, &pool.signing_kid) {
+                result = Some((p.clone(), k.clone()));
+            }
+            break;
+        }
+    }
+    result
+}
+
+/// JWKS document for a pool (`{"keys": [<jwk>]}`). Triggers lazy keypair
+/// generation when the pool was created before any sign call ran.
+pub async fn pool_jwks_document(state: &SharedCognitoState, pool_id: &str) -> Option<Value> {
+    let (pem, kid) = ensure_pool_signing_key(state, pool_id).await?;
+    Some(crate::jwt::jwks_document(&pem, &kid))
+}
+
+/// Cognito-shaped OpenID-Connect discovery document for a pool. Mirrors
+/// the document AWS publishes at
+/// `https://cognito-idp.<region>.amazonaws.com/<pool>/.well-known/openid-configuration`.
+/// `base_url` is the externally-reachable origin (scheme+host+port) that
+/// clients use to reach fakecloud, so the URLs we hand back resolve.
+pub fn oidc_discovery_document(pool_id: &str, region: &str, base_url: &str) -> Value {
+    let issuer = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
+    let trimmed = base_url.trim_end_matches('/');
+    serde_json::json!({
+        "issuer": issuer,
+        "authorization_endpoint": format!("{trimmed}/oauth2/authorize"),
+        "token_endpoint": format!("{trimmed}/oauth2/token"),
+        "userinfo_endpoint": format!("{trimmed}/oauth2/userInfo"),
+        "revocation_endpoint": format!("{trimmed}/oauth2/revoke"),
+        "jwks_uri": format!("{trimmed}/{pool_id}/.well-known/jwks.json"),
+        "response_types_supported": ["code", "token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ],
+        "scopes_supported": ["openid", "email", "phone", "profile", "aws.cognito.signin.user.admin"],
+        "claims_supported": [
+            "sub",
+            "iss",
+            "aud",
+            "name",
+            "email",
+            "email_verified",
+            "phone_number",
+            "phone_number_verified",
+            "cognito:username",
+            "cognito:groups",
+            "auth_time",
+            "exp",
+            "iat",
+            "token_use",
+            "jti",
+        ],
+        "code_challenge_methods_supported": ["S256", "plain"],
+        "grant_types_supported": ["authorization_code", "implicit", "refresh_token", "client_credentials"],
+    })
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4701,3 +4701,73 @@ async fn cognito_simulation_auth_events() {
     assert_eq!(failure["username"], "evuser");
     assert_eq!(failure["success"], false);
 }
+
+#[tokio::test]
+async fn cognito_well_known_jwks_returns_public_key() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("jwks-pool")
+        .send()
+        .await
+        .expect("create user pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/{}/.well-known/jwks.json", server.endpoint(), pool_id);
+    let body: serde_json::Value = http.get(&url).send().await.unwrap().json().await.unwrap();
+    let keys = body["keys"].as_array().expect("keys array");
+    assert_eq!(keys.len(), 1);
+    let key = &keys[0];
+    assert_eq!(key["alg"], "RS256");
+    assert_eq!(key["kty"], "RSA");
+    assert_eq!(key["use"], "sig");
+    assert!(key["kid"].as_str().unwrap().contains(&pool_id));
+    assert!(key["n"].as_str().unwrap().len() > 100);
+    assert!(!key["e"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cognito_well_known_openid_configuration_uses_pool_region() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oidc-pool")
+        .send()
+        .await
+        .expect("create user pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!(
+        "{}/{}/.well-known/openid-configuration",
+        server.endpoint(),
+        pool_id
+    );
+    let body: serde_json::Value = http.get(&url).send().await.unwrap().json().await.unwrap();
+    let issuer = body["issuer"].as_str().unwrap();
+    assert!(issuer.contains(&pool_id));
+    assert!(issuer.contains("us-east-1"));
+    assert!(body["jwks_uri"]
+        .as_str()
+        .unwrap()
+        .ends_with(&format!("/{pool_id}/.well-known/jwks.json")));
+    let algs = body["id_token_signing_alg_values_supported"]
+        .as_array()
+        .unwrap();
+    assert_eq!(algs[0], "RS256");
+}
+
+#[tokio::test]
+async fn cognito_well_known_jwks_404_for_unknown_pool() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let url = format!("{}/us-east-1_NOPE99999/.well-known/jwks.json", server.endpoint());
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4766,8 +4766,10 @@ async fn cognito_well_known_openid_configuration_uses_pool_region() {
 async fn cognito_well_known_jwks_404_for_unknown_pool() {
     let server = TestServer::start().await;
     let http = reqwest::Client::new();
-    let url = format!("{}/us-east-1_NOPE99999/.well-known/jwks.json", server.endpoint());
+    let url = format!(
+        "{}/us-east-1_NOPE99999/.well-known/jwks.json",
+        server.endpoint()
+    );
     let resp = http.get(&url).send().await.unwrap();
     assert_eq!(resp.status(), 404);
 }
-

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -578,6 +578,8 @@ async fn main() {
     let cognito_tokens_state = cognito_state.clone();
     let cognito_expire_state = cognito_state.clone();
     let cognito_events_state = cognito_state.clone();
+    let cognito_jwks_state = cognito_state.clone();
+    let cognito_oidc_state = cognito_state.clone();
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -3454,6 +3456,72 @@ async fn main() {
                         axum::Json(types::ExpireTokensResponse {
                             expired_tokens: expired as u64,
                         })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/{pool_id}/.well-known/jwks.json",
+            axum::routing::get({
+                let cs = cognito_jwks_state;
+                move |axum::extract::Path(pool_id): axum::extract::Path<String>| {
+                    let cs = cs.clone();
+                    async move {
+                        match fakecloud_cognito::pool_jwks_document(&cs, &pool_id).await {
+                            Some(doc) => (axum::http::StatusCode::OK, axum::Json(doc)),
+                            None => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({
+                                    "error": "User pool not found",
+                                    "pool_id": pool_id,
+                                })),
+                            ),
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/{pool_id}/.well-known/openid-configuration",
+            axum::routing::get({
+                let cs = cognito_oidc_state;
+                move |headers: axum::http::HeaderMap,
+                      axum::extract::Path(pool_id): axum::extract::Path<String>| {
+                    let cs = cs.clone();
+                    async move {
+                        let exists = {
+                            let mas = cs.read();
+                            let found = mas
+                                .iter()
+                                .any(|(_, account)| account.user_pools.contains_key(&pool_id));
+                            drop(mas);
+                            found
+                        };
+                        if !exists {
+                            return (
+                                axum::http::StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({
+                                    "error": "User pool not found",
+                                    "pool_id": pool_id,
+                                })),
+                            );
+                        }
+                        let region = pool_id
+                            .split_once('_')
+                            .map(|(r, _)| r.to_string())
+                            .unwrap_or_else(|| "us-east-1".to_string());
+                        let host = headers
+                            .get(axum::http::header::HOST)
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("localhost")
+                            .to_string();
+                        let base_url = format!("http://{host}");
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(fakecloud_cognito::oidc_discovery_document(
+                                &pool_id, &region, &base_url,
+                            )),
+                        )
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- Adds `GET /{pool_id}/.well-known/jwks.json` returning the pool's RSA public key in JWK format so SDKs can verify RS256 tokens against the discovery URL.
- Adds `GET /{pool_id}/.well-known/openid-configuration` returning the standard OIDC discovery document with `issuer`, `jwks_uri`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `revocation_endpoint`, supported algs/scopes/claims.
- Lazy RSA-2048 keypair generation runs on first sign/JWKS hit via `spawn_blocking` and is persisted to pool state, avoiding the runtime-blocking burst that broke Y1's first attempt.

## Test plan
- [x] `cognito_well_known_jwks_returns_public_key` - SDK creates pool, fetches JWKS, validates kty/alg/use/kid/n/e
- [x] `cognito_well_known_openid_configuration_uses_pool_region` - issuer + jwks_uri + algs check out
- [x] `cognito_well_known_jwks_404_for_unknown_pool` - returns 404 for unknown pool
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Existing 292 cognito unit tests still pass