### PR TITLE
feat(sqs): enforce queue access policies via ResourcePolicyProvider

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -1827,3 +1827,137 @@ async fn kms_key_policy_deny_beats_identity_allow() {
         "expected AccessDenied for bob, got {err:?}"
     );
 }
+
+// ======================================================================
+// Phase 2b: SQS queue policies
+//
+// Mirrors the SNS topic-policy block above. Drives the resource-policy
+// evaluator path end-to-end for SQS: dispatch fetches the queue policy
+// via the `SqsResourcePolicyProvider` and hands it to the evaluator
+// alongside the caller's identity policies.
+// ======================================================================
+
+async fn seed_queue_with_policy(
+    server: &TestServer,
+    name: &str,
+    policy_json: &str,
+) -> (String, String) {
+    let boot = sdk_config_with(server, "test", "test").await;
+    let sqs_boot = aws_sdk_sqs::Client::new(&boot);
+    let queue_url = sqs_boot
+        .create_queue()
+        .queue_name(name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    sqs_boot
+        .set_queue_attributes()
+        .queue_url(&queue_url)
+        .attributes(aws_sdk_sqs::types::QueueAttributeName::Policy, policy_json)
+        .send()
+        .await
+        .unwrap();
+    let attrs = sqs_boot
+        .get_queue_attributes()
+        .queue_url(&queue_url)
+        .attribute_names(aws_sdk_sqs::types::QueueAttributeName::QueueArn)
+        .send()
+        .await
+        .unwrap();
+    let arn = attrs
+        .attributes()
+        .and_then(|m| m.get(&aws_sdk_sqs::types::QueueAttributeName::QueueArn))
+        .unwrap()
+        .clone();
+    (queue_url, arn)
+}
+
+#[tokio::test]
+async fn queue_policy_grants_send_without_identity_policy() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "qp_sender").await;
+    let (queue_url, _) = seed_queue_with_policy(
+        &server,
+        "qp-shared",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":{"AWS":"arn:aws:iam::123456789012:user/qp_sender"},
+            "Action":"sqs:SendMessage",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body("hello")
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn queue_policy_explicit_deny_beats_identity_allow() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "qp_blocked").await;
+    let (queue_url, queue_arn) = seed_queue_with_policy(
+        &server,
+        "qp-locked",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Deny",
+            "Principal":{"AWS":"arn:aws:iam::123456789012:user/qp_blocked"},
+            "Action":"sqs:SendMessage",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+    let identity_policy = format!(
+        r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Action":"sqs:SendMessage","Resource":"{queue_arn}"}}]}}"#
+    );
+    attach_inline_policy(&server, "qp_blocked", "AllowQp", &identity_policy).await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    let err = sqs
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("nope")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("AccessDenied"),
+        "expected AccessDenied, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn queue_policy_principal_wildcard_grants_any_user() {
+    let server = start_strict().await;
+    let (akid, secret) = bootstrap_user(&server, "qp_anyone").await;
+    let (queue_url, _) = seed_queue_with_policy(
+        &server,
+        "qp-public",
+        r#"{"Version":"2012-10-17","Statement":[{
+            "Effect":"Allow",
+            "Principal":"*",
+            "Action":"sqs:SendMessage",
+            "Resource":"*"
+        }]}"#,
+    )
+    .await;
+
+    let cfg = sdk_config_with(&server, &akid, &secret).await;
+    let sqs = aws_sdk_sqs::Client::new(&cfg);
+    sqs.send_message()
+        .queue_url(&queue_url)
+        .message_body("hi")
+        .send()
+        .await
+        .unwrap();
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2423,7 +2423,7 @@ async fn main() {
     let lifecycle_processor = fakecloud_s3::lifecycle::LifecycleProcessor::new(s3_state.clone());
     tokio::spawn(lifecycle_processor.run());
 
-    let mut sqs_lambda_poller = SqsLambdaPoller::new(sqs_state, lambda_state.clone());
+    let mut sqs_lambda_poller = SqsLambdaPoller::new(sqs_state.clone(), lambda_state.clone());
     if let Some(ref ld) = lambda_delivery {
         sqs_lambda_poller = sqs_lambda_poller.with_lambda_delivery(ld.clone());
     }
@@ -2488,6 +2488,9 @@ async fn main() {
                 fakecloud_s3::resource_policy::S3ResourcePolicyProvider::shared(s3_state.clone()),
                 fakecloud_sns::resource_policy::SnsResourcePolicyProvider::shared(
                     sns_state.clone(),
+                ),
+                fakecloud_sqs::resource_policy::SqsResourcePolicyProvider::shared(
+                    sqs_state.clone(),
                 ),
                 fakecloud_lambda::resource_policy::LambdaResourcePolicyProvider::shared(
                     lambda_state.clone(),

--- a/crates/fakecloud-sqs/src/lib.rs
+++ b/crates/fakecloud-sqs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod delivery;
+pub mod resource_policy;
 pub(crate) mod service;
 pub mod simulation;
 pub(crate) mod state;

--- a/crates/fakecloud-sqs/src/resource_policy.rs
+++ b/crates/fakecloud-sqs/src/resource_policy.rs
@@ -1,0 +1,199 @@
+//! SQS implementation of [`ResourcePolicyProvider`].
+//!
+//! SQS persists queue access policies as raw JSON in
+//! [`crate::state::SqsQueue::attributes`] under the `Policy` key — both
+//! `SetQueueAttributes` and `AddPermission` / `RemovePermission` write
+//! through that same slot. This file is the read-side bridge that
+//! dispatch consults via `evaluate_with_resource_policy`, so cross-account
+//! callers are gated by the queue's policy in addition to identity
+//! policies and SCPs.
+//!
+//! Mirrors `fakecloud_sns::resource_policy` intentionally: single-service
+//! gate, ARN parsing, state lookup, return `None` for anything not owned
+//! here so providers compose safely.
+
+use std::sync::Arc;
+
+use fakecloud_core::auth::ResourcePolicyProvider;
+
+use crate::state::SharedSqsState;
+
+/// Concrete [`ResourcePolicyProvider`] backed by the in-memory
+/// [`crate::state::SqsState`]. Server bootstrap clone-shares it via
+/// [`fakecloud_core::auth::MultiResourcePolicyProvider`].
+pub struct SqsResourcePolicyProvider {
+    state: SharedSqsState,
+}
+
+impl SqsResourcePolicyProvider {
+    pub fn new(state: SharedSqsState) -> Self {
+        Self { state }
+    }
+
+    /// Convenience constructor returning an
+    /// `Arc<dyn ResourcePolicyProvider>` so bootstrap can push it
+    /// directly into a `MultiResourcePolicyProvider`.
+    pub fn shared(state: SharedSqsState) -> Arc<dyn ResourcePolicyProvider> {
+        Arc::new(Self::new(state))
+    }
+}
+
+impl ResourcePolicyProvider for SqsResourcePolicyProvider {
+    fn resource_policy(&self, service: &str, resource_arn: &str) -> Option<String> {
+        if !service.eq_ignore_ascii_case("sqs") {
+            return None;
+        }
+        if !is_sqs_queue_arn(resource_arn) {
+            return None;
+        }
+        let accts = self.state.read();
+        let acct = resource_arn.split(':').nth(4).unwrap_or("");
+        let state = accts.get(acct).unwrap_or_else(|| accts.default_ref());
+        state
+            .queues
+            .values()
+            .find(|q| q.arn == resource_arn)
+            .and_then(|q| q.attributes.get("Policy"))
+            .cloned()
+    }
+}
+
+/// Light validity check on an SQS queue ARN. Accepts the
+/// `arn:aws:sqs:REGION:ACCOUNT:NAME` shape and nothing else — anything
+/// that doesn't look like an SQS queue ARN short-circuits to `None`.
+fn is_sqs_queue_arn(arn: &str) -> bool {
+    let Some(rest) = arn.strip_prefix("arn:aws:sqs:") else {
+        return false;
+    };
+    let parts: Vec<&str> = rest.splitn(3, ':').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    parts.iter().all(|p| !p.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{SqsQueue, SqsState};
+    use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::collections::{BTreeMap, VecDeque};
+
+    fn state_with_queue(arn: &str, policy: Option<&str>) -> SharedSqsState {
+        let state = Arc::new(RwLock::new(MultiAccountState::<SqsState>::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4566",
+        )));
+        let mut attrs = BTreeMap::new();
+        if let Some(p) = policy {
+            attrs.insert("Policy".to_string(), p.to_string());
+        }
+        let queue_name = arn.rsplit(':').next().unwrap_or("q").to_string();
+        let queue_url = format!("http://localhost:4566/123456789012/{queue_name}");
+        let queue = SqsQueue {
+            queue_name: queue_name.clone(),
+            queue_url: queue_url.clone(),
+            arn: arn.to_string(),
+            created_at: Utc::now(),
+            messages: VecDeque::new(),
+            inflight: Vec::new(),
+            attributes: attrs,
+            is_fifo: queue_name.ends_with(".fifo"),
+            dedup_cache: BTreeMap::new(),
+            redrive_policy: None,
+            tags: BTreeMap::new(),
+            next_sequence_number: 0,
+            permission_labels: Vec::new(),
+            receipt_handle_map: BTreeMap::new(),
+        };
+        state.write().default_mut().queues.insert(queue_url, queue);
+        state
+    }
+
+    #[test]
+    fn returns_stored_policy_for_sqs_arn() {
+        let policy_json = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let arn = "arn:aws:sqs:us-east-1:123456789012:my-queue";
+        let state = state_with_queue(arn, Some(policy_json));
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("sqs", arn),
+            Some(policy_json.to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_queue_has_no_policy_attribute() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:my-queue";
+        let state = state_with_queue(arn, None);
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert_eq!(provider.resource_policy("sqs", arn), None);
+    }
+
+    #[test]
+    fn returns_none_when_queue_missing() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:other";
+        let state = state_with_queue(arn, Some("{}"));
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert_eq!(
+            provider.resource_policy("sqs", "arn:aws:sqs:us-east-1:123456789012:my-queue"),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_for_non_sqs_service_prefix() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:q";
+        let state = state_with_queue(arn, Some("{}"));
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert_eq!(provider.resource_policy("sns", arn), None);
+        assert_eq!(provider.resource_policy("s3", arn), None);
+    }
+
+    #[test]
+    fn service_prefix_match_is_case_insensitive() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:q";
+        let state = state_with_queue(arn, Some("{}"));
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert!(provider.resource_policy("SQS", arn).is_some());
+    }
+
+    #[test]
+    fn returns_none_for_malformed_arn() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:q";
+        let state = state_with_queue(arn, Some("{}"));
+        let provider = SqsResourcePolicyProvider::new(state);
+        assert_eq!(provider.resource_policy("sqs", ""), None);
+        assert_eq!(provider.resource_policy("sqs", "not-an-arn"), None);
+        assert_eq!(provider.resource_policy("sqs", "arn:aws:sqs:"), None);
+        assert_eq!(
+            provider.resource_policy("sqs", "arn:aws:sns:us-east-1:123456789012:q"),
+            None
+        );
+    }
+
+    #[test]
+    fn is_sqs_queue_arn_rejects_empty_segments() {
+        assert!(!is_sqs_queue_arn("arn:aws:sqs:::q"));
+        assert!(!is_sqs_queue_arn("arn:aws:sqs:us-east-1::q"));
+        assert!(!is_sqs_queue_arn("arn:aws:sqs:us-east-1:123456789012:"));
+    }
+
+    #[test]
+    fn is_sqs_queue_arn_accepts_fifo_suffix() {
+        assert!(is_sqs_queue_arn(
+            "arn:aws:sqs:us-east-1:123456789012:q.fifo"
+        ));
+    }
+
+    #[test]
+    fn shared_constructor_wraps_in_arc() {
+        let arn = "arn:aws:sqs:us-east-1:123456789012:q";
+        let state = state_with_queue(arn, Some("doc"));
+        let arc = SqsResourcePolicyProvider::shared(state);
+        assert_eq!(arc.resource_policy("sqs", arn).as_deref(), Some("doc"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SqsResourcePolicyProvider` mirroring the SNS provider so dispatch's `evaluate_with_resource_policy` path picks up the `Policy` attribute stored on each queue.
- Wired into `MultiResourcePolicyProvider` next to the existing S3/SNS/Lambda/KMS/STS providers.
- Cross-account and same-account callers are now gated by the queue's resource policy (Allow-union with identity policy, explicit-Deny override).

## Test plan
- [x] 9 unit tests in `fakecloud-sqs::resource_policy` cover service-prefix gating, ARN parsing, and state lookup.
- [x] 3 E2E tests in `iam_enforcement.rs`: identity-policy-less Allow via queue policy, explicit-Deny override of identity Allow, and `Principal:*` wildcard grant.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.