### PR TITLE
feat(s3): add CRC32C and CRC64NVME checksum algorithms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,12 +1986,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crc64fast-nvme"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fe9239af6a04e140c7424d36d1615f37f1804700c17d5339af162add9022e0"
+dependencies = [
+ "crc",
 ]
 
 [[package]]
@@ -3137,7 +3155,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-kms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,9 @@ rcgen = "0.13"
 rsa = { version = "0.9", features = ["sha2", "pem"] }
 sha1 = "0.10"
 sha2 = "0.10"
+crc32c = "0.6"
 crc32fast = "1"
+crc64fast-nvme = "1"
 reqwest = { version = "0.13", features = ["json"] }
 zip = "2"
 tempfile = "3"

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -27,7 +27,9 @@ uuid = { workspace = true }
 base64 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+crc32c = { workspace = true }
 crc32fast = { workspace = true }
+crc64fast-nvme = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2006,6 +2006,28 @@ pub(crate) async fn compute_checksum_streaming(
             }
             Ok(BASE64.encode(hasher.finalize().to_be_bytes()))
         }
+        "CRC32C" => {
+            let mut crc: u32 = 0;
+            loop {
+                let n = file.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                crc = crc32c::crc32c_append(crc, &buf[..n]);
+            }
+            Ok(BASE64.encode(crc.to_be_bytes()))
+        }
+        "CRC64NVME" => {
+            let mut hasher = crc64fast_nvme::Digest::new();
+            loop {
+                let n = file.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                hasher.write(&buf[..n]);
+            }
+            Ok(BASE64.encode(hasher.sum64().to_be_bytes()))
+        }
         "SHA1" => {
             use sha1::Digest as _;
             let mut hasher = sha1::Sha1::new();

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -940,6 +940,10 @@ impl S3Service {
             // Also detect from checksum value headers
             if req.headers.contains_key("x-amz-checksum-crc32") {
                 Some("CRC32".to_string())
+            } else if req.headers.contains_key("x-amz-checksum-crc32c") {
+                Some("CRC32C".to_string())
+            } else if req.headers.contains_key("x-amz-checksum-crc64nvme") {
+                Some("CRC64NVME".to_string())
             } else if req.headers.contains_key("x-amz-checksum-sha1") {
                 Some("SHA1".to_string())
             } else if req.headers.contains_key("x-amz-checksum-sha256") {

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3939,3 +3939,40 @@ fn get_bucket_policy_status_uses_real_json_parse() {
         .unwrap()
         .contains("<IsPublic>true</IsPublic>"));
 }
+
+#[tokio::test]
+async fn compute_checksum_streaming_supports_crc32c() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("data");
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(b"hello world").unwrap();
+    let result = super::compute_checksum_streaming("CRC32C", &path)
+        .await
+        .unwrap();
+    // Reference CRC32C("hello world") = 0xC99465AA, big-endian -> base64
+    let expected = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        0xC99465AAu32.to_be_bytes(),
+    );
+    assert_eq!(result, expected);
+}
+
+#[tokio::test]
+async fn compute_checksum_streaming_supports_crc64nvme() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("data");
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(b"hello world").unwrap();
+    let result = super::compute_checksum_streaming("CRC64NVME", &path)
+        .await
+        .unwrap();
+    // 8-byte digest, base64 = 12 chars
+    let decoded = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        result.as_bytes(),
+    )
+    .unwrap();
+    assert_eq!(decoded.len(), 8);
+}


### PR DESCRIPTION
## Summary
- `compute_checksum_streaming` now handles `CRC32C` (via `crc32c` crate) and `CRC64NVME` (via `crc64fast-nvme` crate) in addition to the existing CRC32 / SHA1 / SHA256.
- PutObject auto-detects the algorithm from `x-amz-checksum-crc32c` / `x-amz-checksum-crc64nvme` value headers, matching the existing CRC32 / SHA1 / SHA256 detection.

## Test plan
- [x] `compute_checksum_streaming_supports_crc32c` verifies the well-known CRC32C("hello world") = 0xC99465AA produces the right base64 digest.
- [x] `compute_checksum_streaming_supports_crc64nvme` round-trips the 8-byte digest.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.