### PR TITLE
feat(dynamodb): reject ConsistentRead on GSI + omit Items under Select=COUNT

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -35,12 +35,20 @@ impl DynamoDbService {
         let exclusive_start_key: Option<HashMap<String, AttributeValue>> =
             parse_key_map(&body["ExclusiveStartKey"]);
 
+        let consistent_read = body["ConsistentRead"].as_bool().unwrap_or(false);
         let (items_to_scan, hash_key_name, range_key_name): (
             &[HashMap<String, AttributeValue>],
             String,
             Option<String>,
         ) = if let Some(idx_name) = index_name {
             if let Some(gsi) = table.gsi.iter().find(|g| g.index_name == idx_name) {
+                if consistent_read {
+                    return Err(AwsServiceError::aws_error(
+                        http::StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        "Consistent reads are not supported on global secondary indexes",
+                    ));
+                }
                 let hk = gsi
                     .key_schema
                     .iter()
@@ -180,19 +188,32 @@ impl DynamoDbService {
             Vec::new()
         };
 
-        let items: Vec<Value> = matched
-            .iter()
-            .map(|item| {
-                let projected = project_item(item, &body);
-                json!(projected)
+        let select = body["Select"].as_str();
+        let count_only = matches!(select, Some("COUNT"));
+        let items: Vec<Value> = if count_only {
+            Vec::new()
+        } else {
+            matched
+                .iter()
+                .map(|item| {
+                    let projected = project_item(item, &body);
+                    json!(projected)
+                })
+                .collect()
+        };
+        let count = matched.len();
+        let mut result = if count_only {
+            json!({
+                "Count": count,
+                "ScannedCount": scanned_count,
             })
-            .collect();
-
-        let mut result = json!({
-            "Items": items,
-            "Count": items.len(),
-            "ScannedCount": scanned_count,
-        });
+        } else {
+            json!({
+                "Items": items,
+                "Count": count,
+                "ScannedCount": scanned_count,
+            })
+        };
 
         if let Some(lek) = last_evaluated_key {
             result["LastEvaluatedKey"] = json!(lek);
@@ -298,19 +319,32 @@ impl DynamoDbService {
             Vec::new()
         };
 
-        let items: Vec<Value> = matched
-            .iter()
-            .map(|item| {
-                let projected = project_item(item, &body);
-                json!(projected)
+        let select = body["Select"].as_str();
+        let count_only = matches!(select, Some("COUNT"));
+        let items: Vec<Value> = if count_only {
+            Vec::new()
+        } else {
+            matched
+                .iter()
+                .map(|item| {
+                    let projected = project_item(item, &body);
+                    json!(projected)
+                })
+                .collect()
+        };
+        let count = matched.len();
+        let mut result = if count_only {
+            json!({
+                "Count": count,
+                "ScannedCount": scanned_count,
             })
-            .collect();
-
-        let mut result = json!({
-            "Items": items,
-            "Count": items.len(),
-            "ScannedCount": scanned_count,
-        });
+        } else {
+            json!({
+                "Items": items,
+                "Count": count,
+                "ScannedCount": scanned_count,
+            })
+        };
 
         if let Some(lek) = last_evaluated_key {
             result["LastEvaluatedKey"] = json!(lek);

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -3555,3 +3555,126 @@ async fn dynamodb_update_nested_set_path() {
         "nested SET must not leak a literal dotted-name top-level attribute"
     );
 }
+
+#[tokio::test]
+async fn query_consistent_read_on_gsi_rejected() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("ConsistentGsi")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("gsi_pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("gsi-idx")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("gsi_pk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .query()
+        .table_name("ConsistentGsi")
+        .index_name("gsi-idx")
+        .key_condition_expression("gsi_pk = :v")
+        .expression_attribute_values(":v", AttributeValue::S("a".to_string()))
+        .consistent_read(true)
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("ValidationException"),
+        "expected ValidationException, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn query_select_count_omits_items_array() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("CountOnly")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    for i in 0..3 {
+        client
+            .put_item()
+            .table_name("CountOnly")
+            .item("pk", AttributeValue::S(format!("k{i}")))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let resp = client
+        .query()
+        .table_name("CountOnly")
+        .key_condition_expression("pk = :v")
+        .expression_attribute_values(":v", AttributeValue::S("k0".to_string()))
+        .select(aws_sdk_dynamodb::types::Select::Count)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.count(), 1);
+    // Items array is empty/absent under Select=COUNT
+    assert!(
+        resp.items().is_empty(),
+        "expected empty items under Select=COUNT, got {:?}",
+        resp.items()
+    );
+}


### PR DESCRIPTION
## Summary
Two L6 polish items from the parity audit:
- `Query` with `ConsistentRead=true` against a GSI now returns `ValidationException`. Matches AWS — GSIs are eventually consistent.
- `Query` with `Select=COUNT` returns `Count` + `ScannedCount` (and `ConsumedCapacity` / `LastEvaluatedKey` when applicable), no `Items` array.

## Test plan
- [x] `query_consistent_read_on_gsi_rejected` - asserts ValidationException
- [x] `query_select_count_omits_items_array` - asserts empty items + correct count
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean