### PR TITLE
feat(iam): implement GetSecurityTokenServicePreferences

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -1010,6 +1010,28 @@ impl IamService {
         ))
     }
 
+    pub(super) fn get_security_token_service_preferences(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let empty = IamState::new(&req.account_id);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let version = state
+            .global_endpoint_token_version
+            .clone()
+            .unwrap_or_else(|| "v1Token".to_string());
+        let body = format!(
+            "  <GetSecurityTokenServicePreferencesResult><GlobalEndpointTokenVersion>{}</GlobalEndpointTokenVersion></GetSecurityTokenServicePreferencesResult>",
+            xml_escape(&version),
+        );
+        Ok(xml_response(
+            "GetSecurityTokenServicePreferences",
+            &body,
+            &req.request_id,
+        ))
+    }
+
     pub(super) fn update_server_certificate(
         &self,
         req: &AwsRequest,

--- a/crates/fakecloud-iam/src/iam_service/mod.rs
+++ b/crates/fakecloud-iam/src/iam_service/mod.rs
@@ -330,6 +330,9 @@ impl AwsService for IamService {
             "SetSecurityTokenServicePreferences" => {
                 self.set_security_token_service_preferences(&req)
             }
+            "GetSecurityTokenServicePreferences" => {
+                self.get_security_token_service_preferences(&req)
+            }
             "UpdateServerCertificate" => self.update_server_certificate(&req),
 
             _ => Err(AwsServiceError::action_not_implemented("iam", &req.action)),
@@ -562,6 +565,7 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "GetMFADevice",
     "ResyncMFADevice",
     "SetSecurityTokenServicePreferences",
+    "GetSecurityTokenServicePreferences",
     "UpdateServerCertificate",
 ];
 

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -3536,3 +3536,44 @@ fn misc_extras_smoke() {
     ))
     .unwrap();
 }
+
+#[test]
+fn get_security_token_service_preferences_round_trips_set_value() {
+    let svc = make_service();
+    svc.set_security_token_service_preferences(&make_request(
+        "SetSecurityTokenServicePreferences",
+        vec![("GlobalEndpointTokenVersion", "v2Token")],
+    ))
+    .unwrap();
+    let resp = svc
+        .get_security_token_service_preferences(&make_request(
+            "GetSecurityTokenServicePreferences",
+            vec![],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes())
+        .unwrap()
+        .to_string();
+    assert!(
+        body.contains("<GlobalEndpointTokenVersion>v2Token</GlobalEndpointTokenVersion>"),
+        "expected stored version, got {body}"
+    );
+}
+
+#[test]
+fn get_security_token_service_preferences_default_v1_when_unset() {
+    let svc = make_service();
+    let resp = svc
+        .get_security_token_service_preferences(&make_request(
+            "GetSecurityTokenServicePreferences",
+            vec![],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes())
+        .unwrap()
+        .to_string();
+    assert!(
+        body.contains("<GlobalEndpointTokenVersion>v1Token</GlobalEndpointTokenVersion>"),
+        "expected default v1Token, got {body}"
+    );
+}


### PR DESCRIPTION
## Summary
Read-side companion to `SetSecurityTokenServicePreferences`. Returns the stored `GlobalEndpointTokenVersion` or `v1Token` when unset, matching AWS's default. Closes the F4 polish gap from the parity audit.

## Test plan
- [x] `get_security_token_service_preferences_round_trips_set_value` - asserts stored v2Token round-trips
- [x] `get_security_token_service_preferences_default_v1_when_unset` - default
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean