### PR TITLE
feat(cognito): /oauth2/token endpoint (Y3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "tower-http",
  "tracing",

--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -5,6 +5,7 @@ pub mod triggers;
 pub mod user_status;
 
 pub use service::{
-    ensure_pool_signing_key, oidc_discovery_document, pool_jwks_document, CognitoService,
+    ensure_pool_signing_key, handle_oauth2_token, oidc_discovery_document, pool_jwks_document,
+    CognitoService, OAuthTokenError, OAuthTokenResponse,
 };
 pub use state::{CognitoSnapshot, SharedCognitoState, COGNITO_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1682,5 +1682,204 @@ pub fn oidc_discovery_document(pool_id: &str, region: &str, base_url: &str) -> V
     })
 }
 
+/// Result of `/oauth2/token` handling. The HTTP wrapper translates
+/// `Err(OAuthTokenError)` into the OAuth2-shaped JSON `{"error": ...}`
+/// body with the appropriate HTTP status (400 for client errors, 401
+/// for auth failures).
+#[derive(Debug)]
+pub enum OAuthTokenError {
+    InvalidRequest(&'static str),
+    UnsupportedGrantType,
+    InvalidClient,
+    InvalidGrant,
+}
+
+impl OAuthTokenError {
+    pub fn status_code(&self) -> u16 {
+        match self {
+            OAuthTokenError::InvalidClient => 401,
+            _ => 400,
+        }
+    }
+
+    pub fn as_oauth_code(&self) -> &'static str {
+        match self {
+            OAuthTokenError::InvalidRequest(_) => "invalid_request",
+            OAuthTokenError::UnsupportedGrantType => "unsupported_grant_type",
+            OAuthTokenError::InvalidClient => "invalid_client",
+            OAuthTokenError::InvalidGrant => "invalid_grant",
+        }
+    }
+
+    pub fn description(&self) -> Option<&'static str> {
+        match self {
+            OAuthTokenError::InvalidRequest(msg) => Some(msg),
+            _ => None,
+        }
+    }
+}
+
+/// Cognito-shaped `/oauth2/token` response body.
+#[derive(Debug)]
+pub struct OAuthTokenResponse {
+    pub access_token: String,
+    pub id_token: Option<String>,
+    pub refresh_token: Option<String>,
+    pub expires_in: i64,
+    pub token_type: String,
+}
+
+impl OAuthTokenResponse {
+    pub fn to_json(&self) -> Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert("access_token".into(), json!(self.access_token));
+        if let Some(ref id) = self.id_token {
+            obj.insert("id_token".into(), json!(id));
+        }
+        if let Some(ref rt) = self.refresh_token {
+            obj.insert("refresh_token".into(), json!(rt));
+        }
+        obj.insert("expires_in".into(), json!(self.expires_in));
+        obj.insert("token_type".into(), json!(self.token_type));
+        Value::Object(obj)
+    }
+}
+
+/// Handle a Cognito `/oauth2/token` POST. Implements the
+/// `refresh_token` and `client_credentials` grants. The
+/// `authorization_code` grant lands in Y4 alongside the
+/// `/oauth2/authorize` endpoint.
+///
+/// `params` is the form-decoded body (Cognito uses
+/// `application/x-www-form-urlencoded`). `region` is the AWS region
+/// for `iss` claim composition.
+pub async fn handle_oauth2_token(
+    state: &SharedCognitoState,
+    params: &BTreeMap<String, String>,
+    region: &str,
+) -> Result<OAuthTokenResponse, OAuthTokenError> {
+    let grant_type = params
+        .get("grant_type")
+        .map(String::as_str)
+        .ok_or(OAuthTokenError::InvalidRequest("grant_type is required"))?;
+    let client_id = params
+        .get("client_id")
+        .map(String::as_str)
+        .ok_or(OAuthTokenError::InvalidRequest("client_id is required"))?;
+
+    let (pool_id, stored_secret) = {
+        let mas = state.read();
+        let mut found = None;
+        for (_, account) in mas.iter() {
+            if let Some(client) = account.user_pool_clients.get(client_id) {
+                found = Some((client.user_pool_id.clone(), client.client_secret.clone()));
+                break;
+            }
+        }
+        found.ok_or(OAuthTokenError::InvalidClient)?
+    };
+
+    if let Some(secret) = stored_secret.as_ref() {
+        let supplied = params.get("client_secret").map(String::as_str);
+        if supplied != Some(secret.as_str()) {
+            return Err(OAuthTokenError::InvalidClient);
+        }
+    }
+
+    match grant_type {
+        "refresh_token" => {
+            let refresh_token = params
+                .get("refresh_token")
+                .map(String::as_str)
+                .ok_or(OAuthTokenError::InvalidRequest("refresh_token is required"))?;
+            let (username, sub) = {
+                let mas = state.read();
+                let mut found = Err(OAuthTokenError::InvalidGrant);
+                for (_, account) in mas.iter() {
+                    if let Some(rt) = account.refresh_tokens.get(refresh_token) {
+                        if rt.client_id != client_id {
+                            found = Err(OAuthTokenError::InvalidGrant);
+                            break;
+                        }
+                        let sub = account
+                            .users
+                            .get(&rt.user_pool_id)
+                            .and_then(|users| users.get(&rt.username))
+                            .map(|u| u.sub.clone())
+                            .unwrap_or_default();
+                        found = Ok((rt.username.clone(), sub));
+                        break;
+                    }
+                }
+                found?
+            };
+            let signing = ensure_pool_signing_key(state, &pool_id).await;
+            let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+            let tokens = generate_tokens(&pool_id, client_id, &sub, &username, region, signing_ref);
+            // refresh_token grant returns id+access but not a new
+            // refresh_token (Cognito only rotates refresh tokens when
+            // RefreshTokenRotation is ENABLED — that lands in Y7).
+            Ok(OAuthTokenResponse {
+                access_token: tokens.access_token,
+                id_token: Some(tokens.id_token),
+                refresh_token: None,
+                expires_in: 3600,
+                token_type: "Bearer".to_string(),
+            })
+        }
+        "client_credentials" => {
+            // Machine-to-machine: just an access token, no id_token,
+            // no refresh_token. `sub` is the client_id per OIDC core.
+            let signing = ensure_pool_signing_key(state, &pool_id).await;
+            let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+            let scope = params.get("scope").cloned();
+            let access_token = build_client_credentials_access_token(
+                &pool_id,
+                client_id,
+                scope.as_deref(),
+                region,
+                signing_ref,
+            );
+            Ok(OAuthTokenResponse {
+                access_token,
+                id_token: None,
+                refresh_token: None,
+                expires_in: 3600,
+                token_type: "Bearer".to_string(),
+            })
+        }
+        "authorization_code" => Err(OAuthTokenError::UnsupportedGrantType),
+        _ => Err(OAuthTokenError::UnsupportedGrantType),
+    }
+}
+
+fn build_client_credentials_access_token(
+    pool_id: &str,
+    client_id: &str,
+    scope: Option<&str>,
+    region: &str,
+    signing: Option<(&str, &str)>,
+) -> String {
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let now = Utc::now().timestamp();
+    let jti = Uuid::new_v4().to_string();
+    let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
+    let kid = signing
+        .map(|(_, k)| k.to_string())
+        .unwrap_or_else(|| "fakecloud-key-1".to_string());
+    let header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
+    let payload = json!({
+        "sub": client_id,
+        "iss": iss,
+        "client_id": client_id,
+        "token_use": "access",
+        "scope": scope.unwrap_or(""),
+        "jti": jti,
+        "exp": now + 3600,
+        "iat": now,
+    });
+    sign_jwt(&header, &payload, &b64url, signing.map(|(p, _)| p))
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4773,3 +4773,272 @@ async fn cognito_well_known_jwks_404_for_unknown_pool() {
     let resp = http.get(&url).send().await.unwrap();
     assert_eq!(resp.status(), 404);
 }
+
+#[tokio::test]
+async fn cognito_oauth2_token_refresh_grant() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-refresh-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-refresh-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "alice")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let refresh_token = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body =
+        format!("grant_type=refresh_token&client_id={client_id}&refresh_token={refresh_token}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(json["access_token"].as_str().unwrap().split('.').count() == 3);
+    assert!(json["id_token"].as_str().unwrap().split('.').count() == 3);
+    assert_eq!(json["token_type"], "Bearer");
+    assert_eq!(json["expires_in"], 3600);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_client_credentials_grant() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-cc-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-cc-client")
+        .generate_secret(true)
+        .send()
+        .await
+        .expect("create client");
+    let app_client = app.user_pool_client().unwrap();
+    let client_id = app_client.client_id().unwrap().to_string();
+    let client_secret = app_client.client_secret().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = format!(
+        "grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}&scope=api%2Fread"
+    );
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(json["access_token"].as_str().unwrap().split('.').count() == 3);
+    assert!(json.get("id_token").is_none());
+    assert!(json.get("refresh_token").is_none());
+    assert_eq!(json["token_type"], "Bearer");
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_invalid_client_secret() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-bad-secret-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-bad-secret-client")
+        .generate_secret(true)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body =
+        format!("grant_type=client_credentials&client_id={client_id}&client_secret=wrong-secret");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["error"], "invalid_client");
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_unsupported_grant_type() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-ugt-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-ugt-client")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = format!("grant_type=password&client_id={client_id}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["error"], "unsupported_grant_type");
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
+    // /oauth2/authorize lands in Y4; until then authorization_code returns
+    // unsupported_grant_type rather than crashing.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-ac-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-ac-client")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = format!("grant_type=authorization_code&client_id={client_id}&code=abc");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["error"], "unsupported_grant_type");
+}

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -60,6 +60,7 @@ uuid = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_urlencoded = "0.7"
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -580,6 +580,7 @@ async fn main() {
     let cognito_events_state = cognito_state.clone();
     let cognito_jwks_state = cognito_state.clone();
     let cognito_oidc_state = cognito_state.clone();
+    let cognito_token_state = cognito_state.clone();
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -3529,6 +3530,44 @@ async fn main() {
                                 &pool_id, &region, &base_url,
                             )),
                         )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/oauth2/token",
+            axum::routing::post({
+                let cs = cognito_token_state;
+                move |body: String| {
+                    let cs = cs.clone();
+                    async move {
+                        let params: std::collections::BTreeMap<String, String> =
+                            match serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
+                                Ok(pairs) => pairs.into_iter().collect(),
+                                Err(_) => std::collections::BTreeMap::new(),
+                            };
+                        let region = std::env::var("AWS_DEFAULT_REGION")
+                            .or_else(|_| std::env::var("AWS_REGION"))
+                            .unwrap_or_else(|_| "us-east-1".to_string());
+                        match fakecloud_cognito::handle_oauth2_token(&cs, &params, &region).await {
+                            Ok(resp) => (axum::http::StatusCode::OK, axum::Json(resp.to_json())),
+                            Err(err) => {
+                                let status = axum::http::StatusCode::from_u16(err.status_code())
+                                    .unwrap_or(axum::http::StatusCode::BAD_REQUEST);
+                                let mut body = serde_json::Map::new();
+                                body.insert(
+                                    "error".into(),
+                                    serde_json::Value::String(err.as_oauth_code().to_string()),
+                                );
+                                if let Some(desc) = err.description() {
+                                    body.insert(
+                                        "error_description".into(),
+                                        serde_json::Value::String(desc.to_string()),
+                                    );
+                                }
+                                (status, axum::Json(serde_json::Value::Object(body)))
+                            }
+                        }
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- POST /oauth2/token (application/x-www-form-urlencoded) per Cognito hosted UI spec
- refresh_token grant: rotates id+access tokens via the pool's RS256 signing key (Y2)
- client_credentials grant: machine-to-machine access token, no id_token, no refresh_token
- OAuth2 error shapes (invalid_request/invalid_client/invalid_grant/unsupported_grant_type) with proper 400/401 status codes
- authorization_code grant returns unsupported_grant_type until /oauth2/authorize lands in Y4

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt
- [x] e2e: refresh_token grant returns valid 3-segment JWTs and id_token
- [x] e2e: client_credentials grant returns access_token only (no id/refresh)
- [x] e2e: invalid client_secret -> 401 invalid_client
- [x] e2e: unknown grant_type -> 400 unsupported_grant_type
- [x] e2e: authorization_code -> 400 unsupported_grant_type (Y4 deferred)