### PR TITLE
feat(kms): bind EncryptionContext into ciphertext AAD (G6)

### DIFF
--- a/crates/fakecloud-e2e/tests/kms.rs
+++ b/crates/fakecloud-e2e/tests/kms.rs
@@ -758,3 +758,137 @@ async fn kms_cancel_key_deletion() {
     let desc = client.describe_key().key_id(&key_id).send().await.unwrap();
     assert!(desc.key_metadata().unwrap().enabled());
 }
+
+#[tokio::test]
+async fn kms_encryption_context_round_trips() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+    let resp = client.create_key().send().await.unwrap();
+    let key_id = resp.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(b"secret-data".to_vec()))
+        .encryption_context("Purpose", "test")
+        .encryption_context("Tenant", "alpha")
+        .send()
+        .await
+        .unwrap();
+    let ciphertext = enc.ciphertext_blob().unwrap().clone();
+
+    let dec = client
+        .decrypt()
+        .ciphertext_blob(ciphertext)
+        .encryption_context("Purpose", "test")
+        .encryption_context("Tenant", "alpha")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dec.plaintext().unwrap().as_ref(), b"secret-data");
+}
+
+#[tokio::test]
+async fn kms_decrypt_with_mismatched_encryption_context_fails() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+    let resp = client.create_key().send().await.unwrap();
+    let key_id = resp.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(b"secret".to_vec()))
+        .encryption_context("Purpose", "encrypt")
+        .send()
+        .await
+        .unwrap();
+    let ciphertext = enc.ciphertext_blob().unwrap().clone();
+
+    let err = client
+        .decrypt()
+        .ciphertext_blob(ciphertext.clone())
+        .encryption_context("Purpose", "different")
+        .send()
+        .await
+        .expect_err("mismatched EC must fail");
+    assert!(format!("{err:?}").contains("InvalidCiphertext"));
+
+    let err2 = client
+        .decrypt()
+        .ciphertext_blob(ciphertext)
+        .send()
+        .await
+        .expect_err("missing EC must fail when EC was supplied at encrypt");
+    assert!(format!("{err2:?}").contains("InvalidCiphertext"));
+}
+
+#[tokio::test]
+async fn kms_decrypt_without_context_round_trips_when_encrypt_had_no_context() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+    let resp = client.create_key().send().await.unwrap();
+    let key_id = resp.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(b"plain".to_vec()))
+        .send()
+        .await
+        .unwrap();
+    let ct = enc.ciphertext_blob().unwrap().clone();
+
+    let dec = client.decrypt().ciphertext_blob(ct).send().await.unwrap();
+    assert_eq!(dec.plaintext().unwrap().as_ref(), b"plain");
+}
+
+#[tokio::test]
+async fn kms_re_encrypt_with_destination_context_changes_required_decrypt_context() {
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+    let k1 = client.create_key().send().await.unwrap();
+    let key1_id = k1.key_metadata().unwrap().key_id().to_string();
+    let k2 = client.create_key().send().await.unwrap();
+    let key2_id = k2.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key1_id)
+        .plaintext(Blob::new(b"x".to_vec()))
+        .encryption_context("src", "1")
+        .send()
+        .await
+        .unwrap();
+    let ct = enc.ciphertext_blob().unwrap().clone();
+
+    let re = client
+        .re_encrypt()
+        .ciphertext_blob(ct)
+        .source_encryption_context("src", "1")
+        .destination_key_id(&key2_id)
+        .destination_encryption_context("dst", "2")
+        .send()
+        .await
+        .unwrap();
+    let new_ct = re.ciphertext_blob().unwrap().clone();
+
+    // Source EC no longer applies after re-encrypt.
+    let err = client
+        .decrypt()
+        .ciphertext_blob(new_ct.clone())
+        .encryption_context("src", "1")
+        .send()
+        .await
+        .expect_err("source EC should not work on re-encrypted ciphertext");
+    assert!(format!("{err:?}").contains("InvalidCiphertext"));
+
+    let dec = client
+        .decrypt()
+        .ciphertext_blob(new_ct)
+        .encryption_context("dst", "2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dec.plaintext().unwrap().as_ref(), b"x");
+}

--- a/crates/fakecloud-kms/src/blob.rs
+++ b/crates/fakecloud-kms/src/blob.rs
@@ -42,6 +42,22 @@ fn cipher_for(master_key_bytes: &[u8]) -> Option<Aes256Gcm> {
 /// placing in JSON responses. Panics on a master key that isn't 32
 /// bytes; callers control the key, so this is a programming error.
 pub fn encode(master_key_bytes: &[u8], key_id: &str, plaintext: &[u8]) -> Vec<u8> {
+    encode_with_context(master_key_bytes, key_id, plaintext, &[])
+}
+
+/// Variant of [`encode`] that mixes additional bytes into the AEAD AAD.
+/// Used by `Encrypt` / `GenerateDataKey` / `ReEncrypt` to bind the
+/// caller's `EncryptionContext` into the ciphertext: a different EC
+/// supplied at decrypt time fails AES-GCM verification, matching real
+/// KMS behavior. When `extra_aad` is empty the AAD is just `key_id`,
+/// so blobs produced by callers that don't pass EC stay byte-compatible
+/// with the original `encode` output and pre-existing persisted blobs.
+pub fn encode_with_context(
+    master_key_bytes: &[u8],
+    key_id: &str,
+    plaintext: &[u8],
+    extra_aad: &[u8],
+) -> Vec<u8> {
     let cipher =
         cipher_for(master_key_bytes).expect("KMS master key must be 32 bytes for AES-256-GCM");
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
@@ -49,17 +65,19 @@ pub fn encode(master_key_bytes: &[u8], key_id: &str, plaintext: &[u8]) -> Vec<u8
     // AES-GCM in this crate produces ciphertext || tag concatenated; we'll
     // split tag off the back to keep the wire format aligned with the AWS
     // shape (ciphertext segment followed by separate tag segment).
-    // Bind the key-id into the AAD so any tampering with the header
-    // bytes (e.g. flipping a single character of the embedded key-id)
-    // makes AEAD verification fail on decrypt. Without this, the
-    // header is a plain prefix and an attacker could rewrite the
-    // returned KeyId without breaking decryption.
+    // Bind the key-id and supplied EC into the AAD so any tampering
+    // with the header bytes (e.g. flipping a character of the embedded
+    // key-id) or supplying a different EC at decrypt time fails AEAD
+    // verification.
+    let mut aad = Vec::with_capacity(key_id.len() + extra_aad.len());
+    aad.extend_from_slice(key_id.as_bytes());
+    aad.extend_from_slice(extra_aad);
     let combined = cipher
         .encrypt(
             &nonce,
             Payload {
                 msg: plaintext,
-                aad: key_id.as_bytes(),
+                aad: &aad,
             },
         )
         .expect("AES-GCM encrypt with 96-bit nonce never fails on valid key");
@@ -95,6 +113,19 @@ pub struct Decoded {
 /// master key); callers fall back to legacy envelope formats in that
 /// case.
 pub fn decode(master_key_bytes: &[u8], blob: &[u8]) -> Option<Decoded> {
+    decode_with_context(master_key_bytes, blob, &[])
+}
+
+/// Variant of [`decode`] that mixes additional bytes into the AEAD AAD
+/// during verification. Returns `None` when the supplied `extra_aad`
+/// doesn't match what was passed to [`encode_with_context`] at encrypt
+/// time — the caller surfaces this as `InvalidCiphertextException`,
+/// matching the real KMS error for an `EncryptionContext` mismatch.
+pub fn decode_with_context(
+    master_key_bytes: &[u8],
+    blob: &[u8],
+    extra_aad: &[u8],
+) -> Option<Decoded> {
     if blob.len() < VERSION_HEADER.len() + 8 + 12 + 4 + 16 {
         return None;
     }
@@ -124,12 +155,15 @@ pub fn decode(master_key_bytes: &[u8], blob: &[u8]) -> Option<Decoded> {
     let ct_with_tag = &blob[cursor..cursor + ct_len + 16];
 
     let cipher = cipher_for(master_key_bytes)?;
+    let mut aad = Vec::with_capacity(key_id.len() + extra_aad.len());
+    aad.extend_from_slice(key_id.as_bytes());
+    aad.extend_from_slice(extra_aad);
     let plaintext = cipher
         .decrypt(
             nonce,
             Payload {
                 msg: ct_with_tag,
-                aad: key_id.as_bytes(),
+                aad: &aad,
             },
         )
         .ok()?;

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -1,5 +1,24 @@
 use super::*;
 
+/// Canonicalize a KMS `EncryptionContext` (a JSON string-string map)
+/// into a deterministic byte string for use as AEAD AAD. Keys are
+/// sorted via `BTreeMap`'s ordering and the result is JSON-encoded
+/// without whitespace. An empty EC produces zero bytes so blobs
+/// encoded without EC stay byte-compatible with the original AAD shape.
+pub(crate) fn canonical_encryption_context(value: &serde_json::Value) -> Vec<u8> {
+    let Some(obj) = value.as_object() else {
+        return Vec::new();
+    };
+    if obj.is_empty() {
+        return Vec::new();
+    }
+    let sorted: std::collections::BTreeMap<&str, String> = obj
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.as_str(), s.to_string())))
+        .collect();
+    serde_json::to_vec(&sorted).unwrap_or_default()
+}
+
 /// Decode a FakeCloud KMS ciphertext envelope back into its plaintext.
 ///
 /// Ciphertexts come in two flavours: `fakecloud-kms:<key-id>:<b64>`
@@ -9,9 +28,15 @@ use super::*;
 /// flavours look up the source key to return its ARN, so `Decrypt`
 /// and `ReEncrypt` can surface the same `KeyId` / `SourceKeyId` the
 /// real service does.
+///
+/// `encryption_context_aad` is the canonicalized EC bytes
+/// (see [`canonical_encryption_context`]). When the supplied EC
+/// doesn't match what was bound at encrypt time, `crate::blob::decode_with_context`
+/// fails AEAD verification and we surface `InvalidCiphertextException`.
 pub(crate) fn decode_ciphertext_envelope(
     state: &KmsState,
     ciphertext_b64: &str,
+    encryption_context_aad: &[u8],
 ) -> Result<DecodedCiphertext, AwsServiceError> {
     let ciphertext_bytes = base64::engine::general_purpose::STANDARD
         .decode(ciphertext_b64)
@@ -19,7 +44,11 @@ pub(crate) fn decode_ciphertext_envelope(
 
     // Modern AWS-shaped blob (AES-256-GCM under the per-account master
     // key) — try this first. Older textual envelopes fall through.
-    if let Some(decoded) = crate::blob::decode(&state.master_key_bytes, &ciphertext_bytes) {
+    if let Some(decoded) = crate::blob::decode_with_context(
+        &state.master_key_bytes,
+        &ciphertext_bytes,
+        encryption_context_aad,
+    ) {
         let key = state.keys.get(&decoded.key_id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -331,6 +360,7 @@ pub(crate) fn build_encrypt_ciphertext(
     key: &KmsKey,
     plaintext_b64: &str,
     plaintext_bytes: &[u8],
+    encryption_context_aad: &[u8],
 ) -> String {
     let _ = plaintext_b64;
     if let Some(ref material) = key.imported_material_bytes {
@@ -351,7 +381,12 @@ pub(crate) fn build_encrypt_ciphertext(
     // Default path: AWS-shaped binary blob with AES-256-GCM under the
     // per-account master key persisted in `KmsState`. Round-trips through
     // real SDKs and does not leak plaintext to anyone inspecting the bytes.
-    let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, plaintext_bytes);
+    let blob = crate::blob::encode_with_context(
+        &state.master_key_bytes,
+        &key.key_id,
+        plaintext_bytes,
+        encryption_context_aad,
+    );
     base64::engine::general_purpose::STANDARD.encode(&blob)
 }
 

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -50,7 +50,9 @@ impl KmsService {
             ));
         }
 
-        let ciphertext_b64 = build_encrypt_ciphertext(state, key, plaintext_b64, &plaintext_bytes);
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let ciphertext_b64 =
+            build_encrypt_ciphertext(state, key, plaintext_b64, &plaintext_bytes, &ec_aad);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -76,7 +78,8 @@ impl KmsService {
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let decoded = decode_ciphertext_envelope(state, ciphertext_b64)?;
+        let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
+        let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &ec_aad)?;
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -109,7 +112,9 @@ impl KmsService {
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let decoded = decode_ciphertext_envelope(state, ciphertext_b64)?;
+        let source_ec_aad = canonical_encryption_context(&body["SourceEncryptionContext"]);
+        let dest_ec_aad = canonical_encryption_context(&body["DestinationEncryptionContext"]);
+        let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &source_ec_aad)?;
 
         let dest_resolved =
             Self::resolve_key_id_with_state(state, dest_key_id).ok_or_else(|| {
@@ -144,9 +149,14 @@ impl KmsService {
             base64::engine::general_purpose::STANDARD.encode(envelope.as_bytes())
         } else {
             // Default path: wrap the recovered plaintext under the
-            // destination key with the AWS-shaped binary blob.
-            let blob =
-                crate::blob::encode(&state.master_key_bytes, &dest_key.key_id, &plaintext_bytes);
+            // destination key with the AWS-shaped binary blob, binding
+            // the caller's DestinationEncryptionContext into the AAD.
+            let blob = crate::blob::encode_with_context(
+                &state.master_key_bytes,
+                &dest_key.key_id,
+                &plaintext_bytes,
+                &dest_ec_aad,
+            );
             base64::engine::general_purpose::STANDARD.encode(&blob)
         };
 


### PR DESCRIPTION
## Summary
- Encrypt/Decrypt/ReEncrypt now mix the caller's \`EncryptionContext\` into the AES-GCM AAD alongside the key-id
- Decrypt with mismatched EC -> \`InvalidCiphertextException\` (matches real KMS)
- ReEncrypt rebinds dest EC; src EC no longer satisfies decrypt of the re-encrypted blob
- Empty/absent EC encodes to zero AAD bytes -> back-compat with ciphertexts produced before this change

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy -p fakecloud-kms --all-targets -- -D warnings
- [x] cargo test -p fakecloud-kms --lib (151 passing)
- [x] cargo test -p fakecloud-e2e --test kms (23 passing)
- [x] e2e: EC round-trip succeeds
- [x] e2e: mismatched EC at decrypt fails with InvalidCiphertext
- [x] e2e: missing EC at decrypt fails when EC was supplied at encrypt
- [x] e2e: no-EC encrypt/decrypt round-trips (back-compat)
- [x] e2e: ReEncrypt source EC is replaced by dest EC