### PR TITLE
feat(ses): legacy v1 verified-email aliases (X9)

### DIFF
--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -23,6 +23,11 @@ pub const V1_ACTIONS: &[&str] = &[
     "VerifyEmailIdentity",
     "VerifyDomainIdentity",
     "VerifyDomainDkim",
+    // Legacy v1 email-verification aliases. Real SES still accepts
+    // these; the v2 surface uses the *Identity ops above.
+    "VerifyEmailAddress",
+    "ListVerifiedEmailAddresses",
+    "DeleteVerifiedEmailAddress",
     "ListIdentities",
     "GetIdentityVerificationAttributes",
     "GetIdentityDkimAttributes",

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -16,6 +16,9 @@ pub fn handle_v1_action(
         "VerifyEmailIdentity" => verify_email_identity(state, req),
         "VerifyDomainIdentity" => verify_domain_identity(state, req),
         "VerifyDomainDkim" => verify_domain_dkim(state, req),
+        "VerifyEmailAddress" => verify_email_address(state, req),
+        "ListVerifiedEmailAddresses" => list_verified_email_addresses(state, req),
+        "DeleteVerifiedEmailAddress" => delete_verified_email_address(state, req),
         "ListIdentities" => list_identities(state, req),
         "GetIdentityVerificationAttributes" => get_identity_verification_attributes(state, req),
         "GetIdentityDkimAttributes" => get_identity_dkim_attributes(state, req),
@@ -489,6 +492,88 @@ pub(crate) fn verify_email_identity(
             configuration_set_name: None,
         });
     Ok(xml_metadata_only("VerifyEmailIdentity", &req.request_id))
+}
+
+/// Legacy alias: `VerifyEmailAddress` predates `VerifyEmailIdentity` and
+/// is still accepted by real SES. Same effect: idempotently mark the
+/// supplied email address as a verified identity.
+pub(crate) fn verify_email_address(
+    state: &SharedSesState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let email = required_param(&req.query_params, "EmailAddress")?;
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(&req.account_id);
+    st.identities
+        .entry(email.to_string())
+        .or_insert_with(|| EmailIdentity {
+            identity_name: email.to_string(),
+            identity_type: "EmailAddress".to_string(),
+            verified: true,
+            created_at: Utc::now(),
+            dkim_signing_enabled: false,
+            dkim_signing_attributes_origin: "AWS_SES".to_string(),
+            dkim_domain_signing_private_key: None,
+            dkim_domain_signing_selector: None,
+            dkim_next_signing_key_length: None,
+            dkim_public_key_b64: None,
+            email_forwarding_enabled: true,
+            mail_from_domain: None,
+            mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
+            mail_from_domain_status: "NotStarted".to_string(),
+            configuration_set_name: None,
+        });
+    Ok(xml_metadata_only("VerifyEmailAddress", &req.request_id))
+}
+
+/// Legacy alias: `ListVerifiedEmailAddresses` returns email-type
+/// identities only. New callers should use `ListIdentities` with
+/// `IdentityType=EmailAddress`.
+pub(crate) fn list_verified_email_addresses(
+    state: &SharedSesState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let accounts = state.read();
+    let empty = SesState::new(&req.account_id, &req.region);
+    let st = accounts.get(&req.account_id).unwrap_or(&empty);
+    let mut emails: Vec<&str> = st
+        .identities
+        .values()
+        .filter(|i| i.identity_type == "EmailAddress" && i.verified)
+        .map(|i| i.identity_name.as_str())
+        .collect();
+    emails.sort();
+    let mut inner = String::from("<VerifiedEmailAddresses>");
+    for email in emails {
+        inner.push_str(&format!("<member>{}</member>", xml_escape(email)));
+    }
+    inner.push_str("</VerifiedEmailAddresses>");
+    Ok(AwsResponse::xml(
+        StatusCode::OK,
+        query_response_xml(
+            "ListVerifiedEmailAddresses",
+            SES_NS,
+            &inner,
+            &req.request_id,
+        ),
+    ))
+}
+
+/// Legacy alias for `DeleteIdentity` scoped to email-type identities.
+pub(crate) fn delete_verified_email_address(
+    state: &SharedSesState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let email = required_param(&req.query_params, "EmailAddress")?;
+    state
+        .write()
+        .get_or_create(&req.account_id)
+        .identities
+        .remove(email);
+    Ok(xml_metadata_only(
+        "DeleteVerifiedEmailAddress",
+        &req.request_id,
+    ))
 }
 
 pub(crate) fn verify_domain_identity(

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -698,6 +698,72 @@ fn test_verify_email_identity() {
 }
 
 #[test]
+fn test_verify_email_address_legacy_alias() {
+    let state = make_state();
+    let req = make_v1_request("VerifyEmailAddress", vec![("EmailAddress", "legacy@x.io")]);
+    let resp = handle_v1_action(&state, &req).unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let mas = state.read();
+    let st = mas.default_ref();
+    let identity = st.identities.get("legacy@x.io").unwrap();
+    assert!(identity.verified);
+    assert_eq!(identity.identity_type, "EmailAddress");
+}
+
+#[test]
+fn test_list_verified_email_addresses_returns_only_email_identities() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request("VerifyEmailAddress", vec![("EmailAddress", "u1@x.io")]),
+    )
+    .unwrap();
+    handle_v1_action(
+        &state,
+        &make_v1_request("VerifyEmailAddress", vec![("EmailAddress", "u2@x.io")]),
+    )
+    .unwrap();
+    handle_v1_action(
+        &state,
+        &make_v1_request("VerifyDomainIdentity", vec![("Domain", "x.io")]),
+    )
+    .unwrap();
+
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request("ListVerifiedEmailAddresses", vec![]),
+    )
+    .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("u1@x.io"));
+    assert!(body.contains("u2@x.io"));
+    assert!(body.contains("<VerifiedEmailAddresses>"));
+    // Domain identities don't appear here.
+    assert!(!body.contains("<member>x.io</member>"));
+}
+
+#[test]
+fn test_delete_verified_email_address_legacy_alias() {
+    let state = make_state();
+    handle_v1_action(
+        &state,
+        &make_v1_request("VerifyEmailAddress", vec![("EmailAddress", "drop@x.io")]),
+    )
+    .unwrap();
+    let resp = handle_v1_action(
+        &state,
+        &make_v1_request(
+            "DeleteVerifiedEmailAddress",
+            vec![("EmailAddress", "drop@x.io")],
+        ),
+    )
+    .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let mas = state.read();
+    assert!(!mas.default_ref().identities.contains_key("drop@x.io"));
+}
+
+#[test]
 fn test_verify_domain_identity() {
     let state = make_state();
     let req = make_v1_request("VerifyDomainIdentity", vec![("Domain", "example.com")]);


### PR DESCRIPTION
## Summary
- Add v1 Query aliases: VerifyEmailAddress, ListVerifiedEmailAddresses, DeleteVerifiedEmailAddress
- Same backing identity state as the modern *Identity ops
- Response shapes match real SES legacy XML elements (\`<VerifiedEmailAddresses><member>\`)

## Test plan
- [x] cargo build -p fakecloud-ses
- [x] cargo clippy -p fakecloud-ses --all-targets -- -D warnings
- [x] unit: VerifyEmailAddress idempotently registers an EmailAddress identity
- [x] unit: ListVerifiedEmailAddresses returns email-only identities
- [x] unit: DeleteVerifiedEmailAddress removes the identity