### PR TITLE
feat(elbv2): validate Listener Protocol and Port (Q4)

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1074,7 +1074,19 @@ impl Elbv2Service {
     fn create_listener(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let lb_arn = required_query_param(req, "LoadBalancerArn")?;
         let protocol = optional_query_param(req, "Protocol");
-        let port = optional_query_param(req, "Port").and_then(|s| s.parse().ok());
+        if let Some(ref p) = protocol {
+            validate_listener_protocol(p)?;
+        }
+        let port = match optional_query_param(req, "Port") {
+            Some(s) => {
+                let parsed: i32 = s
+                    .parse()
+                    .map_err(|_| invalid_param(format!("Port '{s}' must be a number")))?;
+                validate_listener_port(parsed)?;
+                Some(parsed)
+            }
+            None => None,
+        };
         let ssl_policy = optional_query_param(req, "SslPolicy");
         let alpn_policy = parse_member_list(req, "AlpnPolicy");
         let certificates = parse_certificates(req);
@@ -1186,10 +1198,15 @@ impl Elbv2Service {
             .listeners
             .get_mut(&arn)
             .ok_or_else(|| listener_not_found(&arn))?;
-        if let Some(p) = optional_query_param(req, "Port").and_then(|s| s.parse().ok()) {
-            listener.port = Some(p);
+        if let Some(s) = optional_query_param(req, "Port") {
+            let parsed: i32 = s
+                .parse()
+                .map_err(|_| invalid_param(format!("Port '{s}' must be a number")))?;
+            validate_listener_port(parsed)?;
+            listener.port = Some(parsed);
         }
         if let Some(p) = optional_query_param(req, "Protocol") {
+            validate_listener_protocol(&p)?;
             listener.protocol = Some(p);
         }
         if let Some(p) = optional_query_param(req, "SslPolicy") {

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -111,6 +111,32 @@ pub(crate) fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", msg.into())
 }
 
+/// Listener protocols accepted by ELBv2: HTTP/HTTPS for ALB, TCP/UDP/
+/// TCP_UDP/TLS for NLB, GENEVE for GWLB. Anything else gets rejected
+/// up front rather than silently stored — real ELBv2 returns
+/// ValidationError when callers pass nonsense like "FOO".
+pub(crate) fn validate_listener_protocol(protocol: &str) -> Result<(), AwsServiceError> {
+    const VALID: &[&str] = &["HTTP", "HTTPS", "TCP", "UDP", "TCP_UDP", "TLS", "GENEVE"];
+    if !VALID.contains(&protocol) {
+        return Err(invalid_param(format!(
+            "Protocol '{protocol}' is not valid. Valid values: {}",
+            VALID.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+/// Listener port must be in the TCP/UDP range 1-65535. Real ELBv2
+/// rejects 0 and anything outside u16 with a ValidationError.
+pub(crate) fn validate_listener_port(port: i32) -> Result<(), AwsServiceError> {
+    if !(1..=65535).contains(&port) {
+        return Err(invalid_param(format!(
+            "Port '{port}' must be between 1 and 65535"
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn lb_not_found(arn: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -212,6 +212,187 @@ async fn describe_ssl_policies_includes_tls13() {
     assert!(body_string(&resp).contains("ELBSecurityPolicy-TLS13-1-2-2021-06"));
 }
 
+async fn create_lb_and_tg_for_listener_test(svc: &Elbv2Service) -> (String, String) {
+    let resp = svc
+        .handle(req(
+            "CreateLoadBalancer",
+            &[("Name", "lvb"), ("Subnets.member.1", "subnet-1")],
+        ))
+        .await
+        .unwrap();
+    let lb_arn = {
+        let st = svc.state.read();
+        st.get("123456789012")
+            .unwrap()
+            .load_balancers
+            .keys()
+            .next()
+            .unwrap()
+            .clone()
+    };
+    let _ = resp;
+    let resp = svc
+        .handle(req(
+            "CreateTargetGroup",
+            &[("Name", "tg-1"), ("Protocol", "HTTP"), ("Port", "80")],
+        ))
+        .await
+        .unwrap();
+    let _ = resp;
+    let tg_arn = {
+        let st = svc.state.read();
+        st.get("123456789012")
+            .unwrap()
+            .target_groups
+            .keys()
+            .next()
+            .unwrap()
+            .clone()
+    };
+    (lb_arn, tg_arn)
+}
+
+#[tokio::test]
+async fn create_listener_rejects_invalid_protocol() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "BOGUS"),
+                ("Port", "80"),
+                ("DefaultActions.member.1.Type", "forward"),
+                ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+            ],
+        ))
+        .await
+        .err()
+        .expect("expected validation error");
+    assert_eq!(err.code(), "ValidationError");
+    assert!(format!("{err:?}").contains("BOGUS"));
+}
+
+#[tokio::test]
+async fn create_listener_rejects_port_zero() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "HTTP"),
+                ("Port", "0"),
+                ("DefaultActions.member.1.Type", "forward"),
+                ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+            ],
+        ))
+        .await
+        .err()
+        .expect("expected validation error");
+    assert_eq!(err.code(), "ValidationError");
+}
+
+#[tokio::test]
+async fn create_listener_rejects_port_above_65535() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "HTTP"),
+                ("Port", "70000"),
+                ("DefaultActions.member.1.Type", "forward"),
+                ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+            ],
+        ))
+        .await
+        .err()
+        .expect("expected validation error");
+    assert_eq!(err.code(), "ValidationError");
+}
+
+#[tokio::test]
+async fn create_listener_accepts_valid_protocols() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    for proto in ["HTTP", "HTTPS", "TCP", "UDP", "TCP_UDP", "TLS", "GENEVE"] {
+        // Only HTTP/HTTPS work with the default ALB; for the test we just
+        // need protocol validation to pass, even if downstream rejects.
+        // We assert no ValidationError on the protocol token itself.
+        let res = svc
+            .handle(req(
+                "CreateListener",
+                &[
+                    ("LoadBalancerArn", &lb_arn),
+                    ("Protocol", proto),
+                    ("Port", "80"),
+                    ("DefaultActions.member.1.Type", "forward"),
+                    ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+                ],
+            ))
+            .await;
+        if let Err(e) = res {
+            assert!(
+                !format!("{e:?}").contains("not valid"),
+                "protocol {proto} should be accepted: {e:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn modify_listener_validates_protocol_and_port() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    let resp = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "HTTP"),
+                ("Port", "80"),
+                ("DefaultActions.member.1.Type", "forward"),
+                ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+            ],
+        ))
+        .await
+        .unwrap();
+    let listener_arn = {
+        let st = svc.state.read();
+        st.get("123456789012")
+            .unwrap()
+            .listeners
+            .keys()
+            .next()
+            .unwrap()
+            .clone()
+    };
+    let _ = resp;
+    let err = svc
+        .handle(req(
+            "ModifyListener",
+            &[("ListenerArn", &listener_arn), ("Port", "0")],
+        ))
+        .await
+        .err()
+        .expect("port 0 should fail");
+    assert_eq!(err.code(), "ValidationError");
+    let err = svc
+        .handle(req(
+            "ModifyListener",
+            &[("ListenerArn", &listener_arn), ("Protocol", "BOGUS")],
+        ))
+        .await
+        .err()
+        .expect("bogus protocol should fail");
+    assert_eq!(err.code(), "ValidationError");
+}
+
 #[tokio::test]
 async fn unimplemented_action_errors() {
     let svc = svc();


### PR DESCRIPTION
## Summary
- CreateListener / ModifyListener reject invalid Protocol values (only HTTP/HTTPS/TCP/UDP/TCP_UDP/TLS/GENEVE accepted)
- Reject Port values outside 1-65535 with ValidationError
- Matches real ELBv2 behavior — fakecloud previously stored nonsense like Protocol=FOO silently

## Test plan
- [x] cargo build -p fakecloud-elbv2
- [x] cargo clippy -p fakecloud-elbv2 --all-targets -- -D warnings
- [x] unit: invalid Protocol -> ValidationError
- [x] unit: Port=0 -> ValidationError
- [x] unit: Port>65535 -> ValidationError
- [x] unit: every documented Protocol accepted
- [x] unit: ModifyListener validates same way