### PR TITLE
feat(ecr): registry-level scan-on-push fallback (GG6)

### DIFF
--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -688,6 +688,8 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        let registry_match =
+            registry_scan_on_push_matches(&state.registry_scanning_configuration, &name);
         let repo = state
             .repositories
             .get_mut(&name)
@@ -724,6 +726,10 @@ impl EcrService {
 
         let snapshot = repo.images.get(&digest).cloned().unwrap();
         let scan_on_push = repo.image_scanning_configuration.scan_on_push;
+        // Registry-level fallback: when the per-repo flag is off but a
+        // registry scanning rule with frequency=SCAN_ON_PUSH matches the
+        // repo's name via its WILDCARD filter, real ECR still scans.
+        let should_scan = scan_on_push || registry_match;
         let tag_ref = supplied_tag.as_deref();
         let response = AwsResponse::ok_json(json!({
             "image": {
@@ -737,7 +743,7 @@ impl EcrService {
         // Drop the lock before kicking the async scan; trigger_scan
         // re-acquires it to mark IN_PROGRESS and spawn the scanner.
         drop(accounts);
-        if scan_on_push {
+        if should_scan {
             self.trigger_scan(&account, &name, &digest);
         }
         Ok(response)

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -665,3 +665,30 @@ pub(crate) fn template_to_json(tpl: &crate::state::RepositoryCreationTemplate) -
     }
     out
 }
+
+/// Match a registry-level scanning rule's WILDCARD `repository_filters`
+/// against a repository name. AWS supports `*` as multi-char wildcard
+/// in `WILDCARD` filters; an empty filter list matches everything.
+pub(crate) fn registry_filter_matches(filter: &crate::state::RepositoryFilter, repo: &str) -> bool {
+    if !filter.filter_type.eq_ignore_ascii_case("WILDCARD") {
+        return false;
+    }
+    wildcard_match(&filter.filter, repo)
+}
+
+/// Decide whether a registry scanning configuration would scan-on-push
+/// for a given repo name. Returns true when any rule has
+/// `scan_frequency=SCAN_ON_PUSH` and at least one of its filters
+/// matches (or the filter list is empty, which AWS treats as "all").
+pub(crate) fn registry_scan_on_push_matches(
+    cfg: &crate::state::RegistryScanningConfiguration,
+    repo: &str,
+) -> bool {
+    cfg.rules.iter().any(|r| {
+        r.scan_frequency.eq_ignore_ascii_case("SCAN_ON_PUSH")
+            && (r.repository_filters.is_empty()
+                || r.repository_filters
+                    .iter()
+                    .any(|f| registry_filter_matches(f, repo)))
+    })
+}

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -205,3 +205,65 @@ fn wildcard_match_basics() {
     assert!(!wildcard_match("exact", "exactly"));
     assert!(!wildcard_match("a*b*c", "a-b"));
 }
+
+// ── Registry-level scan-on-push fallback ───────────────────────
+use super::{registry_filter_matches, registry_scan_on_push_matches};
+use crate::state::{
+    RegistryScanningConfiguration, RegistryScanningRule, RepositoryFilter as RegRepositoryFilter,
+};
+
+fn rule(freq: &str, filters: Vec<(&str, &str)>) -> RegistryScanningRule {
+    RegistryScanningRule {
+        scan_frequency: freq.to_string(),
+        repository_filters: filters
+            .into_iter()
+            .map(|(f, t)| RegRepositoryFilter {
+                filter: f.to_string(),
+                filter_type: t.to_string(),
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn registry_scan_matches_when_filter_wildcards_repo() {
+    let cfg = RegistryScanningConfiguration {
+        scan_type: "BASIC".to_string(),
+        rules: vec![rule("SCAN_ON_PUSH", vec![("prod-*", "WILDCARD")])],
+    };
+    assert!(registry_scan_on_push_matches(&cfg, "prod-api"));
+    assert!(!registry_scan_on_push_matches(&cfg, "dev-api"));
+}
+
+#[test]
+fn registry_scan_matches_when_filter_list_empty() {
+    let cfg = RegistryScanningConfiguration {
+        scan_type: "BASIC".to_string(),
+        rules: vec![rule("SCAN_ON_PUSH", vec![])],
+    };
+    assert!(registry_scan_on_push_matches(&cfg, "anything"));
+}
+
+#[test]
+fn registry_scan_skips_continuous_scan_frequency() {
+    let cfg = RegistryScanningConfiguration {
+        scan_type: "ENHANCED".to_string(),
+        rules: vec![rule("CONTINUOUS_SCAN", vec![("*", "WILDCARD")])],
+    };
+    assert!(!registry_scan_on_push_matches(&cfg, "x"));
+}
+
+#[test]
+fn registry_filter_rejects_unknown_filter_type() {
+    let f = RegRepositoryFilter {
+        filter: "x".to_string(),
+        filter_type: "REGEX".to_string(),
+    };
+    assert!(!registry_filter_matches(&f, "x"));
+}
+
+#[test]
+fn registry_scan_no_rules_no_match() {
+    let cfg = RegistryScanningConfiguration::default();
+    assert!(!registry_scan_on_push_matches(&cfg, "x"));
+}


### PR DESCRIPTION
## Summary
- PutImage falls back to registry-level scanning rules when per-repo scan_on_push=false
- Rules with scan_frequency=SCAN_ON_PUSH and matching WILDCARD filters (or empty filter list) trigger the existing async scan path
- Matches real ECR behavior; previously fakecloud only honored per-repo flag

## Test plan
- [x] cargo build -p fakecloud-ecr
- [x] cargo clippy -p fakecloud-ecr --all-targets -- -D warnings
- [x] unit: prod-* WILDCARD matches prod-api but not dev-api
- [x] unit: empty filter list matches everything
- [x] unit: CONTINUOUS_SCAN frequency does not trigger scan-on-push
- [x] unit: REGEX filter type rejected (only WILDCARD supported)
- [x] unit: empty rules list returns false