### PR TITLE
fix(dynamodb): GetResourcePolicy 404 PolicyNotFoundException (L6)

### DIFF
--- a/crates/fakecloud-conformance/tests/dynamodb.rs
+++ b/crates/fakecloud-conformance/tests/dynamodb.rs
@@ -926,15 +926,14 @@ async fn dynamodb_resource_policy_lifecycle() {
         .await
         .unwrap();
 
-    let resp = client
+    let err = client
         .get_resource_policy()
         .resource_arn(&arn)
         .send()
         .await
-        .unwrap();
-    // After deletion, policy should be absent
-    let policy_val = resp.policy().unwrap_or_default();
-    assert!(policy_val.is_empty() || policy_val == "null");
+        .unwrap_err();
+    let svc_err = err.into_service_error();
+    assert!(svc_err.is_policy_not_found_exception());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -709,7 +709,11 @@ impl DynamoDbService {
                     "RevisionId": revision_id
                 }))
             }
-            None => Self::ok_json(json!({ "Policy": null })),
+            None => Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "PolicyNotFoundException",
+                "No resource-based policy is attached to the resource.",
+            )),
         }
     }
 

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -619,11 +619,12 @@ fn resource_policy_lifecycle() {
     let req = make_request("DeleteResourcePolicy", json!({ "ResourceArn": table_arn }));
     svc.delete_resource_policy(&req).unwrap();
 
-    // Get should return null now
+    // Get should now return PolicyNotFoundException, matching real DynamoDB.
     let req = make_request("GetResourcePolicy", json!({ "ResourceArn": table_arn }));
-    let resp = svc.get_resource_policy(&req).unwrap();
-    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert!(body["Policy"].is_null());
+    match svc.get_resource_policy(&req) {
+        Err(e) => assert_eq!(e.code(), "PolicyNotFoundException"),
+        Ok(_) => panic!("GetResourcePolicy after delete must error"),
+    }
 }
 
 #[test]

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -1146,14 +1146,14 @@ async fn dynamodb_resource_policy_lifecycle() {
         .await
         .unwrap();
 
-    // Get should return no policy
-    let resp = client
+    // Get should now error with PolicyNotFoundException, matching real DynamoDB.
+    let err = client
         .get_resource_policy()
         .resource_arn(&table_arn)
         .send()
         .await
-        .unwrap();
-    assert!(resp.policy().is_none());
+        .expect_err("GetResourcePolicy after delete must error");
+    assert!(format!("{err:?}").contains("PolicyNotFound"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- GetResourcePolicy returns 404 PolicyNotFoundException when table has no resource policy
- Previously returned {Policy: null}, which masks absence vs. real DynamoDB behavior

## Test plan
- [x] cargo build -p fakecloud-dynamodb
- [x] cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings
- [x] unit: resource_policy_lifecycle now expects PolicyNotFoundException after delete
- [x] e2e: dynamodb_resource_policy now expects error after delete