### PR TITLE
feat(dynamodb): Scan honors IndexName + GSI/LSI projection (L5)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
+use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::state::AttributeValue;
+use crate::state::{AttributeValue, Projection};
 
 use super::{
     build_consumed_capacity, compare_attribute_values, evaluate_filter_expression,
@@ -118,6 +119,35 @@ impl DynamoDbService {
         let is_gsi_query = index_name.is_some()
             && (hash_key_name != table_pk_hash
                 || range_key_name.as_deref() != table_pk_range.as_deref());
+        // Pull the index's Projection + key attributes once, so the
+        // per-item closure below doesn't need to re-walk gsi/lsi.
+        let query_index_projection: Option<(Projection, Vec<String>)> =
+            index_name.and_then(|idx| {
+                table
+                    .gsi
+                    .iter()
+                    .find(|g| g.index_name == idx)
+                    .map(|g| {
+                        (
+                            g.projection.clone(),
+                            g.key_schema
+                                .iter()
+                                .map(|k| k.attribute_name.clone())
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                    .or_else(|| {
+                        table.lsi.iter().find(|l| l.index_name == idx).map(|l| {
+                            (
+                                l.projection.clone(),
+                                l.key_schema
+                                    .iter()
+                                    .map(|k| k.attribute_name.clone())
+                                    .collect::<Vec<_>>(),
+                            )
+                        })
+                    })
+            });
 
         // Apply ExclusiveStartKey: skip items up to and including the start key.
         // For GSI queries the start key contains both index keys and table PK, so
@@ -196,7 +226,16 @@ impl DynamoDbService {
             matched
                 .iter()
                 .map(|item| {
-                    let projected = project_item(item, &body);
+                    let mut projected = project_item(item, &body);
+                    if let Some((proj, key_attrs)) = query_index_projection.as_ref() {
+                        projected = apply_index_projection(
+                            projected,
+                            proj,
+                            key_attrs,
+                            &table_pk_hash,
+                            table_pk_range.as_deref(),
+                        );
+                    }
                     json!(projected)
                 })
                 .collect()
@@ -268,6 +307,39 @@ impl DynamoDbService {
         let exclusive_start_key: Option<HashMap<String, AttributeValue>> =
             parse_key_map(&body["ExclusiveStartKey"]);
 
+        // IndexName: when present, items still come from the base
+        // table (fakecloud doesn't keep separate per-index storage)
+        // but the projection is restricted to what the index defines.
+        let index_name = body["IndexName"].as_str();
+        let (index_projection, index_key_attrs): (Option<Projection>, Vec<String>) =
+            if let Some(idx) = index_name {
+                if let Some(g) = table.gsi.iter().find(|g| g.index_name == idx) {
+                    (
+                        Some(g.projection.clone()),
+                        g.key_schema
+                            .iter()
+                            .map(|k| k.attribute_name.clone())
+                            .collect(),
+                    )
+                } else if let Some(l) = table.lsi.iter().find(|l| l.index_name == idx) {
+                    (
+                        Some(l.projection.clone()),
+                        l.key_schema
+                            .iter()
+                            .map(|k| k.attribute_name.clone())
+                            .collect(),
+                    )
+                } else {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!("Index '{idx}' does not exist on the table"),
+                    ));
+                }
+            } else {
+                (None, Vec::new())
+            };
+
         let hash_key_name = table.hash_key_name().to_string();
         let range_key_name = table.range_key_name().map(|s| s.to_string());
 
@@ -327,7 +399,16 @@ impl DynamoDbService {
             matched
                 .iter()
                 .map(|item| {
-                    let projected = project_item(item, &body);
+                    let mut projected = project_item(item, &body);
+                    if let Some(ref proj) = index_projection {
+                        projected = apply_index_projection(
+                            projected,
+                            proj,
+                            &index_key_attrs,
+                            &hash_key_name,
+                            range_key_name.as_deref(),
+                        );
+                    }
                     json!(projected)
                 })
                 .collect()
@@ -381,4 +462,44 @@ impl DynamoDbService {
 
         Self::ok_json(result)
     }
+}
+
+/// Apply a GSI/LSI projection to an item already projected via the
+/// caller's `ProjectionExpression`. AWS retains the table's primary key
+/// plus the index key; INCLUDE adds the listed non-key attributes;
+/// KEYS_ONLY drops everything else; ALL leaves the item alone.
+fn apply_index_projection(
+    item: HashMap<String, AttributeValue>,
+    projection: &Projection,
+    index_key_attrs: &[String],
+    table_hash_key: &str,
+    table_range_key: Option<&str>,
+) -> HashMap<String, AttributeValue> {
+    if projection.projection_type == "ALL" {
+        return item;
+    }
+    let mut allowed: Vec<String> = Vec::new();
+    allowed.push(table_hash_key.to_string());
+    if let Some(rk) = table_range_key {
+        allowed.push(rk.to_string());
+    }
+    for k in index_key_attrs {
+        if !allowed.contains(k) {
+            allowed.push(k.clone());
+        }
+    }
+    if projection.projection_type == "INCLUDE" {
+        for k in &projection.non_key_attributes {
+            if !allowed.contains(k) {
+                allowed.push(k.clone());
+            }
+        }
+    }
+    let mut out = HashMap::new();
+    for k in &allowed {
+        if let Some(v) = item.get(k) {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    out
 }

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -368,6 +368,121 @@ async fn dynamodb_scan() {
 }
 
 #[tokio::test]
+async fn dynamodb_scan_with_index_name_applies_projection() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    // Table with a GSI on 'category' projecting only KEYS_ONLY.
+    client
+        .create_table()
+        .table_name("ScanIndexTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("category")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .global_secondary_indexes(
+            GlobalSecondaryIndex::builder()
+                .index_name("ByCategory")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("category")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::KeysOnly)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_item()
+        .table_name("ScanIndexTable")
+        .item("id", AttributeValue::S("a".into()))
+        .item("category", AttributeValue::S("books".into()))
+        .item("title", AttributeValue::S("Rust".into()))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .scan()
+        .table_name("ScanIndexTable")
+        .index_name("ByCategory")
+        .send()
+        .await
+        .unwrap();
+
+    let items = resp.items();
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    // KEYS_ONLY projection: table PK ('id') + index PK ('category'); 'title' must be absent.
+    assert!(item.contains_key("id"));
+    assert!(item.contains_key("category"));
+    assert!(!item.contains_key("title"));
+}
+
+#[tokio::test]
+async fn dynamodb_scan_with_unknown_index_name_errors() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    client
+        .create_table()
+        .table_name("NoIdxTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    let err = client
+        .scan()
+        .table_name("NoIdxTable")
+        .index_name("DoesNotExist")
+        .send()
+        .await
+        .expect_err("unknown index must fail");
+    assert!(format!("{err:?}").contains("DoesNotExist"));
+}
+
+#[tokio::test]
 async fn dynamodb_scan_with_filter() {
     let server = TestServer::start().await;
     let client = server.dynamodb_client().await;


### PR DESCRIPTION
## Summary
- Scan with IndexName validates the index exists and applies its projection
- KEYS_ONLY: only table PK + index key attributes
- INCLUDE: those plus the rule's non_key_attributes
- ALL: unchanged
- Unknown IndexName -> ValidationException
- Query already projected; refactored its closure to share the new apply_index_projection helper

## Test plan
- [x] cargo build -p fakecloud-dynamodb
- [x] cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings
- [x] e2e: KEYS_ONLY GSI scan returns only id+category, drops 'title'
- [x] e2e: unknown IndexName -> error