### PR TITLE
feat(rds): RestoreDBInstanceFromDBSnapshot carries Tags (M11)

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1495,6 +1495,7 @@ impl RdsService {
         let db_instance_identifier = required_query_param(request, "DBInstanceIdentifier")?;
         let db_snapshot_identifier = required_query_param(request, "DBSnapshotIdentifier")?;
         let vpc_security_group_ids = parse_vpc_security_group_ids(request);
+        let tags = parse_tags(request)?;
 
         let runtime = self.require_runtime()?;
 
@@ -1579,6 +1580,7 @@ impl RdsService {
             vpc_security_group_ids,
             &snapshot,
             &running,
+            tags,
         );
 
         self.state

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -446,6 +446,7 @@ pub(crate) fn build_restored_instance(
     vpc_security_group_ids: Vec<String>,
     snapshot: &DbSnapshot,
     running: &crate::runtime::RunningDbContainer,
+    tags: Vec<RdsTag>,
 ) -> DbInstance {
     DbInstance {
         db_instance_identifier: db_instance_identifier.to_string(),
@@ -466,7 +467,7 @@ pub(crate) fn build_restored_instance(
         master_user_password: snapshot.master_user_password.clone(),
         container_id: running.container_id.clone(),
         host_port: running.host_port,
-        tags: Vec::new(),
+        tags,
         read_replica_source_db_instance_identifier: None,
         read_replica_db_instance_identifiers: Vec::new(),
         vpc_security_group_ids,


### PR DESCRIPTION
## Summary
- RestoreDBInstanceFromDBSnapshot now parses the Tags input parameter
- Tags propagate through build_restored_instance -> stored on the new DBInstance
- DescribeDBInstances surfaces them on the restored instance, matching real RDS

## Test plan
- [x] cargo build -p fakecloud-rds
- [x] cargo clippy -p fakecloud-rds --all-targets -- -D warnings
- [x] cargo test -p fakecloud-rds --lib (123 passing)