### PR TITLE
feat(cognito): /oauth2/userInfo + /oauth2/revoke (Y5)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -5,7 +5,8 @@ pub mod triggers;
 pub mod user_status;
 
 pub use service::{
-    ensure_pool_signing_key, handle_oauth2_token, oidc_discovery_document, pool_jwks_document,
-    CognitoService, OAuthTokenError, OAuthTokenResponse,
+    ensure_pool_signing_key, handle_oauth2_revoke, handle_oauth2_token, handle_oauth2_userinfo,
+    oidc_discovery_document, pool_jwks_document, CognitoService, OAuthRevokeError, OAuthTokenError,
+    OAuthTokenResponse, OAuthUserInfoError,
 };
 pub use state::{CognitoSnapshot, SharedCognitoState, COGNITO_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1816,9 +1816,23 @@ pub async fn handle_oauth2_token(
             let signing = ensure_pool_signing_key(state, &pool_id).await;
             let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
             let tokens = generate_tokens(&pool_id, client_id, &sub, &username, region, signing_ref);
-            // refresh_token grant returns id+access but not a new
-            // refresh_token (Cognito only rotates refresh tokens when
-            // RefreshTokenRotation is ENABLED — that lands in Y7).
+            {
+                let mut mas = state.write();
+                for (_, account) in mas.iter_mut() {
+                    if account.user_pool_clients.contains_key(client_id) {
+                        account.access_tokens.insert(
+                            tokens.access_token.clone(),
+                            crate::state::AccessTokenData {
+                                user_pool_id: pool_id.clone(),
+                                username: username.clone(),
+                                client_id: client_id.to_string(),
+                                issued_at: Utc::now(),
+                            },
+                        );
+                        break;
+                    }
+                }
+            }
             Ok(OAuthTokenResponse {
                 access_token: tokens.access_token,
                 id_token: Some(tokens.id_token),
@@ -1879,6 +1893,111 @@ fn build_client_credentials_access_token(
         "iat": now,
     });
     sign_jwt(&header, &payload, &b64url, signing.map(|(p, _)| p))
+}
+
+#[derive(Debug, Clone)]
+pub enum OAuthUserInfoError {
+    InvalidToken,
+}
+
+/// RFC 7662-style userInfo. Resolves bearer access token in
+/// state.access_tokens, returns OIDC standard claims sourced from the
+/// user's attributes.
+pub fn handle_oauth2_userinfo(
+    state: &SharedCognitoState,
+    bearer_token: &str,
+) -> Result<Value, OAuthUserInfoError> {
+    let mas = state.read();
+    for (_, account) in mas.iter() {
+        let Some(token_data) = account.access_tokens.get(bearer_token) else {
+            continue;
+        };
+        let user = account
+            .users
+            .get(&token_data.user_pool_id)
+            .and_then(|users| users.get(&token_data.username))
+            .ok_or(OAuthUserInfoError::InvalidToken)?;
+        let mut info = serde_json::Map::new();
+        info.insert("sub".to_string(), Value::String(user.sub.clone()));
+        info.insert("username".to_string(), Value::String(user.username.clone()));
+        for attr in &user.attributes {
+            info.insert(attr.name.clone(), Value::String(attr.value.clone()));
+        }
+        return Ok(Value::Object(info));
+    }
+    Err(OAuthUserInfoError::InvalidToken)
+}
+
+#[derive(Debug, Clone)]
+pub enum OAuthRevokeError {
+    InvalidClient,
+    UnsupportedTokenType,
+}
+
+/// RFC 7009 token revocation. Cognito accepts refresh tokens; revoking a
+/// refresh token also invalidates every access token issued from it
+/// (matched by client_id + username + issued_at >= refresh issued_at).
+/// Per RFC 7009 §2.2, revoking an unknown token is a 200, not an error.
+pub fn handle_oauth2_revoke(
+    state: &SharedCognitoState,
+    params: &BTreeMap<String, String>,
+) -> Result<(), OAuthRevokeError> {
+    let token = match params.get("token") {
+        Some(t) => t.clone(),
+        None => return Ok(()),
+    };
+    if let Some(hint) = params.get("token_type_hint") {
+        if hint != "refresh_token" {
+            return Err(OAuthRevokeError::UnsupportedTokenType);
+        }
+    }
+    let client_id = params
+        .get("client_id")
+        .map(String::as_str)
+        .ok_or(OAuthRevokeError::InvalidClient)?;
+
+    let stored_secret = {
+        let mas = state.read();
+        let mut found = None;
+        for (_, account) in mas.iter() {
+            if let Some(client) = account.user_pool_clients.get(client_id) {
+                found = Some(client.client_secret.clone());
+                break;
+            }
+        }
+        found.ok_or(OAuthRevokeError::InvalidClient)?
+    };
+    if let Some(secret) = stored_secret.as_ref() {
+        let supplied = params.get("client_secret").map(String::as_str);
+        if supplied != Some(secret.as_str()) {
+            return Err(OAuthRevokeError::InvalidClient);
+        }
+    }
+
+    let mut mas = state.write();
+    for (_, account) in mas.iter_mut() {
+        if let Some(rt) = account.refresh_tokens.get(&token).cloned() {
+            if rt.client_id != client_id {
+                return Err(OAuthRevokeError::InvalidClient);
+            }
+            account.refresh_tokens.remove(&token);
+            account.access_tokens.retain(|_, at| {
+                !(at.client_id == rt.client_id
+                    && at.username == rt.username
+                    && at.user_pool_id == rt.user_pool_id
+                    && at.issued_at >= rt.issued_at)
+            });
+            return Ok(());
+        }
+        if let Some(at) = account.access_tokens.get(&token).cloned() {
+            if at.client_id != client_id {
+                return Err(OAuthRevokeError::InvalidClient);
+            }
+            account.access_tokens.remove(&token);
+            return Ok(());
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -5042,3 +5042,284 @@ async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
     let json: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(json["error"], "unsupported_grant_type");
 }
+
+#[tokio::test]
+async fn cognito_oauth2_userinfo_returns_user_attrs() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-userinfo-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-userinfo-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .password("hunter22")
+        .user_attributes(
+            aws_sdk_cognitoidentityprovider::types::AttributeType::builder()
+                .name("email")
+                .value("bob@example.com")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "bob")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let access_token = auth
+        .authentication_result()
+        .unwrap()
+        .access_token()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/userInfo", server.endpoint());
+    let resp = http
+        .get(&url)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["username"], "bob");
+    assert_eq!(json["email"], "bob@example.com");
+    assert!(!json["sub"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cognito_oauth2_userinfo_invalid_token() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/userInfo", server.endpoint());
+    let resp = http
+        .get(&url)
+        .header("Authorization", "Bearer not-a-real-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["error"], "invalid_token");
+}
+
+#[tokio::test]
+async fn cognito_oauth2_userinfo_missing_bearer() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/userInfo", server.endpoint());
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_revoke_refresh_token() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-revoke-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-revoke-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "carol")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let refresh_token = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/revoke", server.endpoint());
+    let body = format!("token={refresh_token}&client_id={client_id}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    let token_body =
+        format!("grant_type=refresh_token&client_id={client_id}&refresh_token={refresh_token}");
+    let token_resp = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(token_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(token_resp.status(), 400);
+    let json: serde_json::Value = token_resp.json().await.unwrap();
+    assert_eq!(json["error"], "invalid_grant");
+}
+
+#[tokio::test]
+async fn cognito_oauth2_revoke_unknown_token_returns_200() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-revoke-unknown-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-revoke-unknown-client")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/revoke", server.endpoint());
+    let body = format!("token=does-not-exist&client_id={client_id}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_revoke_unknown_client_id_401() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/revoke", server.endpoint());
+    let body = "token=foo&client_id=nonexistent-client";
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["error"], "invalid_client");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -581,6 +581,8 @@ async fn main() {
     let cognito_jwks_state = cognito_state.clone();
     let cognito_oidc_state = cognito_state.clone();
     let cognito_token_state = cognito_state.clone();
+    let cognito_userinfo_state = cognito_state.clone();
+    let cognito_revoke_state = cognito_state.clone();
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -3565,6 +3567,127 @@ async fn main() {
                                         serde_json::Value::String(desc.to_string()),
                                     );
                                 }
+                                (status, axum::Json(serde_json::Value::Object(body)))
+                            }
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/oauth2/userInfo",
+            {
+                let cs_get = cognito_userinfo_state.clone();
+                let cs_post = cognito_userinfo_state;
+                axum::routing::get({
+                    move |headers: axum::http::HeaderMap| {
+                        let cs = cs_get.clone();
+                        async move {
+                            let bearer = headers
+                                .get(axum::http::header::AUTHORIZATION)
+                                .and_then(|v| v.to_str().ok())
+                                .and_then(|v| v.strip_prefix("Bearer "))
+                                .map(|s| s.to_string());
+                            let Some(token) = bearer else {
+                                let mut body = serde_json::Map::new();
+                                body.insert(
+                                    "error".into(),
+                                    serde_json::Value::String("invalid_token".to_string()),
+                                );
+                                return (
+                                    axum::http::StatusCode::UNAUTHORIZED,
+                                    axum::Json(serde_json::Value::Object(body)),
+                                );
+                            };
+                            match fakecloud_cognito::handle_oauth2_userinfo(&cs, &token) {
+                                Ok(value) => (axum::http::StatusCode::OK, axum::Json(value)),
+                                Err(_) => {
+                                    let mut body = serde_json::Map::new();
+                                    body.insert(
+                                        "error".into(),
+                                        serde_json::Value::String("invalid_token".to_string()),
+                                    );
+                                    (
+                                        axum::http::StatusCode::UNAUTHORIZED,
+                                        axum::Json(serde_json::Value::Object(body)),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                })
+                .post({
+                    move |headers: axum::http::HeaderMap| {
+                        let cs = cs_post.clone();
+                        async move {
+                            let bearer = headers
+                                .get(axum::http::header::AUTHORIZATION)
+                                .and_then(|v| v.to_str().ok())
+                                .and_then(|v| v.strip_prefix("Bearer "))
+                                .map(|s| s.to_string());
+                            let Some(token) = bearer else {
+                                let mut body = serde_json::Map::new();
+                                body.insert(
+                                    "error".into(),
+                                    serde_json::Value::String("invalid_token".to_string()),
+                                );
+                                return (
+                                    axum::http::StatusCode::UNAUTHORIZED,
+                                    axum::Json(serde_json::Value::Object(body)),
+                                );
+                            };
+                            match fakecloud_cognito::handle_oauth2_userinfo(&cs, &token) {
+                                Ok(value) => (axum::http::StatusCode::OK, axum::Json(value)),
+                                Err(_) => {
+                                    let mut body = serde_json::Map::new();
+                                    body.insert(
+                                        "error".into(),
+                                        serde_json::Value::String("invalid_token".to_string()),
+                                    );
+                                    (
+                                        axum::http::StatusCode::UNAUTHORIZED,
+                                        axum::Json(serde_json::Value::Object(body)),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                })
+            },
+        )
+        .route(
+            "/oauth2/revoke",
+            axum::routing::post({
+                let cs = cognito_revoke_state;
+                move |body: String| {
+                    let cs = cs.clone();
+                    async move {
+                        let params: std::collections::BTreeMap<String, String> =
+                            match serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
+                                Ok(pairs) => pairs.into_iter().collect(),
+                                Err(_) => std::collections::BTreeMap::new(),
+                            };
+                        match fakecloud_cognito::handle_oauth2_revoke(&cs, &params) {
+                            Ok(()) => (
+                                axum::http::StatusCode::OK,
+                                axum::Json(serde_json::Value::Object(serde_json::Map::new())),
+                            ),
+                            Err(err) => {
+                                let (code, status) = match err {
+                                    fakecloud_cognito::OAuthRevokeError::InvalidClient => (
+                                        "invalid_client",
+                                        axum::http::StatusCode::UNAUTHORIZED,
+                                    ),
+                                    fakecloud_cognito::OAuthRevokeError::UnsupportedTokenType => (
+                                        "unsupported_token_type",
+                                        axum::http::StatusCode::BAD_REQUEST,
+                                    ),
+                                };
+                                let mut body = serde_json::Map::new();
+                                body.insert(
+                                    "error".into(),
+                                    serde_json::Value::String(code.to_string()),
+                                );
                                 (status, axum::Json(serde_json::Value::Object(body)))
                             }
                         }


### PR DESCRIPTION
## Summary
- Add `GET`/`POST /oauth2/userInfo` returning OIDC standard claims (sub, username + user attributes) for the bearer access token.
- Add `POST /oauth2/revoke` per RFC 7009: revoking a refresh token also invalidates issued access tokens; unknown token -> 200 (per §2.2); validates client_id+client_secret.
- `handle_oauth2_token` now persists issued access tokens in state so userInfo can resolve them.

## Test plan
- [x] cognito_oauth2_userinfo_returns_user_attrs
- [x] cognito_oauth2_userinfo_invalid_token (401)
- [x] cognito_oauth2_userinfo_missing_bearer (401)
- [x] cognito_oauth2_revoke_refresh_token (200, then refresh re-use -> invalid_grant)
- [x] cognito_oauth2_revoke_unknown_token_returns_200
- [x] cognito_oauth2_revoke_unknown_client_id_401