### PR TITLE
feat(cognito): RefreshTokenRotation rotates refresh on grant (Y7)

### DIFF
--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
-    AccessTokenData, CognitoState, CustomDomainConfig, Device, UserImportJob, UserPoolDomain,
+    AccessTokenData, CognitoState, CustomDomainConfig, Device, RefreshTokenData, UserImportJob,
+    UserPoolDomain,
 };
 
 use super::{
@@ -691,8 +692,31 @@ impl CognitoService {
             .map(|(p, k)| (p.as_str(), k.as_str()));
         let tokens = super::generate_tokens(&pool_id, client_id, &sub, &username, &region, signing);
 
-        // Store the new access token
+        let rotation_enabled = state
+            .user_pool_clients
+            .get(client_id)
+            .and_then(|c| c.refresh_token_rotation.as_ref())
+            .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
+            .unwrap_or(false);
+
         let now = Utc::now();
+        let rotated_refresh = if rotation_enabled {
+            let new_token = format!("rt-{}", Uuid::new_v4());
+            state.refresh_tokens.insert(
+                new_token.clone(),
+                RefreshTokenData {
+                    user_pool_id: pool_id.clone(),
+                    username: username.clone(),
+                    client_id: client_id.to_string(),
+                    issued_at: now,
+                },
+            );
+            state.refresh_tokens.remove(refresh_token);
+            Some(new_token)
+        } else {
+            None
+        };
+
         state.access_tokens.insert(
             tokens.access_token.clone(),
             AccessTokenData {
@@ -703,13 +727,17 @@ impl CognitoService {
             },
         );
 
+        let mut auth = json!({
+            "AccessToken": tokens.access_token,
+            "IdToken": tokens.id_token,
+            "TokenType": "Bearer",
+            "ExpiresIn": 3600
+        });
+        if let Some(ref rt) = rotated_refresh {
+            auth["RefreshToken"] = json!(rt);
+        }
         Ok(AwsResponse::ok_json(json!({
-            "AuthenticationResult": {
-                "AccessToken": tokens.access_token,
-                "IdToken": tokens.id_token,
-                "TokenType": "Bearer",
-                "ExpiresIn": 3600
-            }
+            "AuthenticationResult": auth,
         })))
     }
 

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -730,6 +730,17 @@ fn parse_token_validity_units(val: &Value) -> Option<TokenValidityUnits> {
     })
 }
 
+fn parse_refresh_token_rotation(val: &Value) -> Option<crate::state::RefreshTokenRotationConfig> {
+    if !val.is_object() {
+        return None;
+    }
+    let feature = val["Feature"].as_str()?.to_string();
+    Some(crate::state::RefreshTokenRotationConfig {
+        feature,
+        retry_grace_period_seconds: val["RetryGracePeriodSeconds"].as_i64(),
+    })
+}
+
 /// Convert a UserPoolClient to the JSON format AWS returns.
 fn user_pool_client_to_json(client: &UserPoolClient) -> Value {
     let mut obj = json!({
@@ -794,6 +805,13 @@ fn user_pool_client_to_json(client: &UserPoolClient) -> Value {
     }
     if let Some(v) = client.auth_session_validity {
         obj["AuthSessionValidity"] = json!(v);
+    }
+    if let Some(ref rot) = client.refresh_token_rotation {
+        let mut r = json!({"Feature": rot.feature});
+        if let Some(g) = rot.retry_grace_period_seconds {
+            r["RetryGracePeriodSeconds"] = json!(g);
+        }
+        obj["RefreshTokenRotation"] = r;
     }
 
     obj
@@ -1816,27 +1834,52 @@ pub async fn handle_oauth2_token(
             let signing = ensure_pool_signing_key(state, &pool_id).await;
             let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
             let tokens = generate_tokens(&pool_id, client_id, &sub, &username, region, signing_ref);
-            {
+            let rotated_refresh = {
                 let mut mas = state.write();
+                let mut new_rt = None;
                 for (_, account) in mas.iter_mut() {
-                    if account.user_pool_clients.contains_key(client_id) {
-                        account.access_tokens.insert(
-                            tokens.access_token.clone(),
-                            crate::state::AccessTokenData {
-                                user_pool_id: pool_id.clone(),
-                                username: username.clone(),
-                                client_id: client_id.to_string(),
-                                issued_at: Utc::now(),
-                            },
-                        );
-                        break;
+                    if !account.user_pool_clients.contains_key(client_id) {
+                        continue;
                     }
+                    let rotation_enabled = account
+                        .user_pool_clients
+                        .get(client_id)
+                        .and_then(|c| c.refresh_token_rotation.as_ref())
+                        .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
+                        .unwrap_or(false);
+                    if rotation_enabled {
+                        if let Some(old) = account.refresh_tokens.get(refresh_token).cloned() {
+                            let token = format!("rt-{}", Uuid::new_v4());
+                            account.refresh_tokens.insert(
+                                token.clone(),
+                                crate::state::RefreshTokenData {
+                                    user_pool_id: old.user_pool_id,
+                                    username: old.username,
+                                    client_id: old.client_id,
+                                    issued_at: Utc::now(),
+                                },
+                            );
+                            account.refresh_tokens.remove(refresh_token);
+                            new_rt = Some(token);
+                        }
+                    }
+                    account.access_tokens.insert(
+                        tokens.access_token.clone(),
+                        crate::state::AccessTokenData {
+                            user_pool_id: pool_id.clone(),
+                            username: username.clone(),
+                            client_id: client_id.to_string(),
+                            issued_at: Utc::now(),
+                        },
+                    );
+                    break;
                 }
-            }
+                new_rt
+            };
             Ok(OAuthTokenResponse {
                 access_token: tokens.access_token,
                 id_token: Some(tokens.id_token),
-                refresh_token: None,
+                refresh_token: rotated_refresh,
                 expires_in: 3600,
                 token_type: "Bearer".to_string(),
             })

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -12,10 +12,11 @@ use crate::state::{
 use super::{
     ensure_user_pool_exists, generate_client_id, generate_client_secret, generate_pool_id,
     parse_account_recovery_setting, parse_admin_create_user_config, parse_email_configuration,
-    parse_password_policy, parse_schema_attribute, parse_sign_in_policy, parse_sms_configuration,
-    parse_string_array, parse_tags, parse_token_validity_units,
-    parse_verification_message_template, require_str, user_pool_client_to_json, user_pool_to_json,
-    validate_enum, validate_range, validate_string_length, CognitoService,
+    parse_password_policy, parse_refresh_token_rotation, parse_schema_attribute,
+    parse_sign_in_policy, parse_sms_configuration, parse_string_array, parse_tags,
+    parse_token_validity_units, parse_verification_message_template, require_str,
+    user_pool_client_to_json, user_pool_to_json, validate_enum, validate_range,
+    validate_string_length, CognitoService,
 };
 
 impl CognitoService {
@@ -503,6 +504,7 @@ impl CognitoService {
             enable_token_revocation: body["EnableTokenRevocation"].as_bool().unwrap_or(true),
             auth_session_validity: body["AuthSessionValidity"].as_i64(),
             client_secrets: Vec::new(),
+            refresh_token_rotation: parse_refresh_token_rotation(&body["RefreshTokenRotation"]),
         };
 
         let response = user_pool_client_to_json(&client);

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -389,6 +389,19 @@ pub struct UserPoolClient {
     pub auth_session_validity: Option<i64>,
     /// Additional client secrets (beyond the primary client_secret)
     pub client_secrets: Vec<ClientSecretDescriptor>,
+    /// "ENABLED" rotates refresh token on every refresh-token grant
+    /// (old token invalidated). Default "DISABLED".
+    #[serde(default)]
+    pub refresh_token_rotation: Option<RefreshTokenRotationConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefreshTokenRotationConfig {
+    /// "ENABLED" or "DISABLED"
+    pub feature: String,
+    /// grace period in seconds during which old token still works
+    #[serde(default)]
+    pub retry_grace_period_seconds: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -5323,3 +5323,299 @@ async fn cognito_oauth2_revoke_unknown_client_id_401() {
     let json: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(json["error"], "invalid_client");
 }
+
+#[tokio::test]
+async fn cognito_refresh_token_rotation_enabled_rotates() {
+    use aws_sdk_cognitoidentityprovider::types::{FeatureType, RefreshTokenRotationType};
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rotation-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("rotation-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .refresh_token_rotation(
+            RefreshTokenRotationType::builder()
+                .feature(FeatureType::Enabled)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("dave")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("dave")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "dave")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let original_refresh = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .get_tokens_from_refresh_token()
+        .client_id(&client_id)
+        .refresh_token(&original_refresh)
+        .send()
+        .await
+        .expect("get tokens");
+    let result = resp.authentication_result().unwrap();
+    let new_refresh = result.refresh_token().expect("rotated refresh present");
+    assert_ne!(new_refresh, original_refresh.as_str());
+
+    let err = client
+        .get_tokens_from_refresh_token()
+        .client_id(&client_id)
+        .refresh_token(&original_refresh)
+        .send()
+        .await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn cognito_refresh_token_rotation_disabled_no_new_token() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("no-rotation-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("no-rotation-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("eve")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("eve")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "eve")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let original_refresh = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
+
+    let resp = client
+        .get_tokens_from_refresh_token()
+        .client_id(&client_id)
+        .refresh_token(&original_refresh)
+        .send()
+        .await
+        .expect("get tokens");
+    let result = resp.authentication_result().unwrap();
+    assert!(result.refresh_token().is_none());
+
+    let resp2 = client
+        .get_tokens_from_refresh_token()
+        .client_id(&client_id)
+        .refresh_token(&original_refresh)
+        .send()
+        .await
+        .expect("get tokens 2nd time");
+    assert!(resp2.authentication_result().is_some());
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_rotates_refresh_when_enabled() {
+    use aws_sdk_cognitoidentityprovider::types::{FeatureType, RefreshTokenRotationType};
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-rotation-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-rotation-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .refresh_token_rotation(
+            RefreshTokenRotationType::builder()
+                .feature(FeatureType::Enabled)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("frank")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("frank")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let auth = client
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "frank")
+        .auth_parameters("PASSWORD", "hunter22")
+        .send()
+        .await
+        .expect("auth");
+    let refresh_token = auth
+        .authentication_result()
+        .unwrap()
+        .refresh_token()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body =
+        format!("grant_type=refresh_token&client_id={client_id}&refresh_token={refresh_token}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    let rotated = json["refresh_token"].as_str().expect("rotated rt present");
+    assert_ne!(rotated, refresh_token.as_str());
+}


### PR DESCRIPTION
## Summary
- New \`RefreshTokenRotationConfig\` field on UserPoolClient ({Feature, RetryGracePeriodSeconds}). Parsed on CreateUserPoolClient + emitted in user_pool_client_to_json.
- \`GetTokensFromRefreshToken\`: when client.refresh_token_rotation.feature == ENABLED, mint a fresh refresh token, drop the old one, return AccessToken+IdToken+RefreshToken. When DISABLED, behavior unchanged.
- \`/oauth2/token\` refresh_token grant: same rotation behavior.

## Test plan
- [x] cognito_refresh_token_rotation_enabled_rotates
- [x] cognito_refresh_token_rotation_disabled_no_new_token
- [x] cognito_oauth2_token_rotates_refresh_when_enabled