### PR TITLE
fix(rds): persist DB instance after bg container start (#914)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -2,6 +2,62 @@ mod helpers;
 
 use helpers::TestServer;
 
+/// DB instances survive a restart. Reproduces issue #914: a DB instance
+/// created with `aws rds create-db-instance` disappeared after restart
+/// because the background container-start task flipped status to
+/// `available` without persisting, and the load path then dropped the
+/// row as a "stuck creating" placeholder.
+///
+/// Uses `start_full` rather than `start_persistent` because the latter
+/// disables the container CLI (most persistence tests cover metadata-
+/// only ops); CreateDBInstance needs real Docker.
+#[tokio::test]
+async fn persistence_round_trip_db_instance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("persist-db")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .unwrap();
+
+    let _ = helpers::wait_for_db_available(&client, "persist-db", 180).await;
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let resp = client
+        .describe_db_instances()
+        .db_instance_identifier("persist-db")
+        .send()
+        .await
+        .unwrap();
+    let instances = resp.db_instances();
+    assert_eq!(instances.len(), 1, "DB instance should survive restart");
+    let inst = &instances[0];
+    assert_eq!(inst.db_instance_identifier(), Some("persist-db"));
+    assert_eq!(inst.engine(), Some("postgres"));
+    assert_eq!(inst.master_username(), Some("admin"));
+    assert_eq!(
+        inst.db_instance_status(),
+        Some("available"),
+        "status should persist as `available`, not be dropped as `creating`",
+    );
+}
+
 /// Parameter groups survive a restart.
 #[tokio::test]
 async fn persistence_round_trip_parameter_group() {

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -289,28 +289,47 @@ impl RdsService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
-            return;
-        };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = RdsSnapshot {
-            schema_version: RDS_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
+        save_snapshot_static(
+            self.state.clone(),
+            self.snapshot_store.clone(),
+            self.snapshot_lock.clone(),
+        )
         .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write rds snapshot"),
-            Err(err) => tracing::error!(%err, "rds snapshot task panicked"),
-        }
     }
+}
 
+/// Persist the current `RdsState` to the configured snapshot store. Free
+/// function so background tasks (e.g. the create-DB-instance container-start
+/// task) can save without holding a `&RdsService`. Returns immediately when
+/// no store is configured (memory-mode runs).
+async fn save_snapshot_static(
+    state: SharedRdsState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: Arc<AsyncMutex<()>>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = RdsSnapshot {
+        schema_version: RDS_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write rds snapshot"),
+        Err(err) => tracing::error!(%err, "rds snapshot task panicked"),
+    }
+}
+
+impl RdsService {
     /// Return the runtime or a ``ServiceUnavailable`` error if it was not configured.
     ///
     /// RDS operations that start, stop, or reach into a database container fail
@@ -569,6 +588,8 @@ impl RdsService {
             let account_id = request.account_id.clone();
             let region = request.region.clone();
             let arn = instance_arn.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
             tokio::spawn(async move {
                 match runtime
                     .ensure_postgres(
@@ -584,15 +605,27 @@ impl RdsService {
                     .await
                 {
                     Ok(running) => {
-                        let mut accounts = state_handle.write();
-                        let state = accounts.get_or_create(&account_id);
-                        if let Some(inst) = state.instances.get_mut(&id) {
-                            inst.db_instance_status = "available".to_string();
-                            inst.endpoint_address = "127.0.0.1".to_string();
-                            inst.port = i32::from(running.host_port);
-                            inst.host_port = running.host_port;
-                            inst.container_id = running.container_id;
+                        {
+                            let mut accounts = state_handle.write();
+                            let state = accounts.get_or_create(&account_id);
+                            if let Some(inst) = state.instances.get_mut(&id) {
+                                inst.db_instance_status = "available".to_string();
+                                inst.endpoint_address = "127.0.0.1".to_string();
+                                inst.port = i32::from(running.host_port);
+                                inst.host_port = running.host_port;
+                                inst.container_id = running.container_id;
+                            }
                         }
+                        // Persist the flipped status. Without this the
+                        // synchronous CreateDBInstance save captures the
+                        // `creating` placeholder, which the load path
+                        // discards on restart, dropping the instance.
+                        save_snapshot_static(
+                            state_handle.clone(),
+                            snapshot_store.clone(),
+                            snapshot_lock.clone(),
+                        )
+                        .await;
                     }
                     Err(error) => {
                         tracing::error!(%error, db_instance_identifier=%id, "create_db_instance background task failed");
@@ -601,6 +634,12 @@ impl RdsService {
                             let state = accounts.get_or_create(&account_id);
                             state.instances.remove(&id);
                         }
+                        save_snapshot_static(
+                            state_handle.clone(),
+                            snapshot_store.clone(),
+                            snapshot_lock.clone(),
+                        )
+                        .await;
                         emit_event_static(
                             delivery_bus.as_ref(),
                             RdsSourceType::DbInstance,

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -10,12 +10,17 @@ use uuid::Uuid;
 use super::{
     db_instance_xml, default_db_name, default_parameter_group, default_port_for_engine,
     filter_engine_versions, filter_orderable_options, license_model_for_engine, merge_tags,
-    optional_i32_param, parse_tag_keys, parse_tags, validate_create_request, RdsService,
-    RdsSourceType,
+    optional_i32_param, parse_tag_keys, parse_tags, save_snapshot_static, validate_create_request,
+    RdsService, RdsSourceType,
 };
-use crate::state::{default_engine_versions, default_orderable_options, DbInstance, RdsTag};
+use crate::state::{
+    default_engine_versions, default_orderable_options, DbInstance, RdsSnapshot, RdsTag,
+    SharedRdsState, RDS_SNAPSHOT_SCHEMA_VERSION,
+};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsService, AwsServiceError};
+use fakecloud_persistence::{DiskSnapshotStore, SnapshotStore};
+use tokio::sync::Mutex as AsyncMutex;
 
 #[test]
 fn default_port_matches_aws_for_each_engine() {
@@ -1652,4 +1657,125 @@ fn describe_db_subnet_groups_unknown_errors() {
     let svc = make_service();
     let req = request("DescribeDBSubnetGroups", &[("DBSubnetGroupName", "ghost")]);
     assert!(svc.describe_db_subnet_groups(&req).is_err());
+}
+
+/// Issue #914: the bg container-start task flips status from `creating`
+/// to `available`. Without persisting after the flip, a restart loaded a
+/// `creating` placeholder which the load path then dropped, making the
+/// DB instance disappear. `save_snapshot_static` is the free fn the bg
+/// task calls — exercise it directly to lock the contract: the latest
+/// state lands on disk for every caller, not just service handlers.
+#[tokio::test]
+async fn save_snapshot_static_persists_status_flip_from_bg_task() {
+    fn make_instance(id: &str, status: &str) -> DbInstance {
+        let now = Utc::now();
+        DbInstance {
+            db_instance_identifier: id.to_string(),
+            db_instance_arn: format!("arn:aws:rds:us-east-1:123456789012:db:{id}"),
+            db_instance_class: "db.t3.micro".to_string(),
+            engine: "postgres".to_string(),
+            engine_version: "16.3".to_string(),
+            db_instance_status: status.to_string(),
+            master_username: "admin".to_string(),
+            db_name: Some("appdb".to_string()),
+            endpoint_address: String::new(),
+            port: 0,
+            allocated_storage: 20,
+            publicly_accessible: true,
+            deletion_protection: false,
+            created_at: now,
+            dbi_resource_id: format!("db-{id}"),
+            master_user_password: "secret123".to_string(),
+            container_id: String::new(),
+            host_port: 0,
+            tags: Vec::new(),
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids: Vec::new(),
+            db_parameter_group_name: None,
+            backup_retention_period: 1,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: Some(now),
+            option_group_name: None,
+            multi_az: false,
+            pending_modified_values: None,
+            availability_zone: None,
+            storage_type: None,
+            storage_encrypted: false,
+            kms_key_id: None,
+            iam_database_authentication_enabled: false,
+            iops: None,
+            monitoring_interval: None,
+            monitoring_role_arn: None,
+            performance_insights_enabled: false,
+            performance_insights_kms_key_id: None,
+            performance_insights_retention_period: None,
+            enabled_cloudwatch_logs_exports: Vec::new(),
+            ca_certificate_identifier: None,
+            network_type: None,
+            character_set_name: None,
+            auto_minor_version_upgrade: None,
+            copy_tags_to_snapshot: None,
+            master_user_secret_arn: None,
+            master_user_secret_kms_key_id: None,
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("rds.snapshot.json");
+    let store: Arc<dyn SnapshotStore> = Arc::new(DiskSnapshotStore::new(path.clone()));
+    let lock = Arc::new(AsyncMutex::new(()));
+
+    let state: SharedRdsState = Arc::new(RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    {
+        let mut accounts = state.write();
+        let s = accounts.get_or_create("123456789012");
+        s.instances
+            .insert("db-1".to_string(), make_instance("db-1", "creating"));
+    }
+
+    // First save: simulates the synchronous CreateDBInstance handler save.
+    save_snapshot_static(state.clone(), Some(store.clone()), lock.clone()).await;
+    let bytes = std::fs::read(&path).expect("snapshot file should exist");
+    let snap: RdsSnapshot = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(snap.schema_version, RDS_SNAPSHOT_SCHEMA_VERSION);
+    let acc = snap.accounts.expect("multi-account");
+    let s = acc.get("123456789012").expect("account state");
+    assert_eq!(s.instances["db-1"].db_instance_status, "creating");
+
+    // Bg task flips the status and saves again — the regression path.
+    {
+        let mut accounts = state.write();
+        let s = accounts.get_or_create("123456789012");
+        let inst = s.instances.get_mut("db-1").expect("placeholder still here");
+        inst.db_instance_status = "available".to_string();
+        inst.host_port = 15432;
+        inst.port = 15432;
+        inst.endpoint_address = "127.0.0.1".to_string();
+        inst.container_id = "container-id".to_string();
+    }
+    save_snapshot_static(state.clone(), Some(store.clone()), lock.clone()).await;
+
+    let bytes = std::fs::read(&path).unwrap();
+    let snap: RdsSnapshot = serde_json::from_slice(&bytes).unwrap();
+    let acc = snap.accounts.expect("multi-account");
+    let s = acc.get("123456789012").expect("account state");
+    assert_eq!(
+        s.instances["db-1"].db_instance_status, "available",
+        "post-bg-task save must overwrite the `creating` placeholder",
+    );
+    assert_eq!(s.instances["db-1"].host_port, 15432);
+}
+
+/// Memory mode: no store wired, save is a no-op. Guards against
+/// accidentally requiring a store for the bg-task path.
+#[tokio::test]
+async fn save_snapshot_static_is_noop_without_store() {
+    let lock = Arc::new(AsyncMutex::new(()));
+    let state: SharedRdsState = Arc::new(RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    save_snapshot_static(state, None, lock).await;
 }


### PR DESCRIPTION
## Summary

Closes #914. RDS DB instances disappeared across restart even with `--storage-mode persistent`.

`CreateDBInstance` inserts a `creating` placeholder synchronously, then spawns a background task that calls `ensure_postgres` and flips status to `available`. The handler-level snapshot save fired only on the synchronous path, so the persisted snapshot captured `creating`. On reload, the existing stuck-creating cleanup drops every `creating` row, so the DB instance vanished.

Fix: refactor `save_snapshot` into a free `save_snapshot_static` so the background task can persist after the status flip and on the failure-remove path.

## Test plan

- [x] `cargo test -p fakecloud-rds` — new `save_snapshot_static_persists_status_flip_from_bg_task` reproduces the regression at the unit level (creating -> available on disk), plus `save_snapshot_static_is_noop_without_store` for memory mode.
- [x] `cargo clippy -p fakecloud-rds --all-targets -- -D warnings`, `cargo clippy -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [ ] CI runs the new `persistence_round_trip_db_instance` E2E test (CreateDBInstance + restart + DescribeDBInstances). Local Docker daemon was unavailable during authoring; covered by CI which has Docker.