### PR TITLE
feat(cloudformation): provision AWS::SecretsManager::Secret (BB13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
  "fakecloud-logs",
  "fakecloud-persistence",
  "fakecloud-s3",
+ "fakecloud-secretsmanager",
  "fakecloud-sns",
  "fakecloud-sqs",
  "fakecloud-ssm",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -20,6 +20,7 @@ fakecloud-eventbridge = { workspace = true }
 fakecloud-dynamodb = { workspace = true }
 fakecloud-logs = { workspace = true }
 fakecloud-lambda = { workspace = true }
+fakecloud-secretsmanager = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -710,6 +710,7 @@ mod tests {
         use fakecloud_lambda::LambdaState;
         use fakecloud_logs::LogsState;
         use fakecloud_s3::S3State;
+        use fakecloud_secretsmanager::SecretsManagerState;
         use fakecloud_sns::SnsState;
         use fakecloud_sqs::SqsState;
         use fakecloud_ssm::SsmState;
@@ -732,6 +733,7 @@ mod tests {
             dynamodb: shared::<DynamoDbState>(),
             logs: shared::<LogsState>(),
             lambda: shared::<LambdaState>(),
+            secretsmanager: shared::<SecretsManagerState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -14,6 +14,7 @@ use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
 use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
 use fakecloud_s3::{S3Bucket, SharedS3State};
+use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
 use fakecloud_sqs::{SharedSqsState, SqsQueue};
 use fakecloud_ssm::{SharedSsmState, SsmParameter};
@@ -53,6 +54,7 @@ pub struct ResourceProvisioner {
     pub dynamodb_state: SharedDynamoDbState,
     pub logs_state: SharedLogsState,
     pub lambda_state: SharedLambdaState,
+    pub secretsmanager_state: SharedSecretsManagerState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -74,6 +76,7 @@ impl ResourceProvisioner {
             "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
+            "AWS::SecretsManager::Secret" => self.create_secrets_manager_secret(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -116,6 +119,9 @@ impl ResourceProvisioner {
             "AWS::DynamoDB::Table" => self.delete_dynamodb_table(&resource.physical_id),
             "AWS::Logs::LogGroup" => self.delete_log_group(&resource.physical_id),
             "AWS::Lambda::Function" => self.delete_lambda_function(&resource.physical_id),
+            "AWS::SecretsManager::Secret" => {
+                self.delete_secrets_manager_secret(&resource.physical_id)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -993,6 +999,103 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- SecretsManager ---
+
+    fn create_secrets_manager_secret(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let kms_key_id = props
+            .get("KmsKeyId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = format!(
+            "arn:aws:secretsmanager:{}:{}:secret:{}",
+            state.region, state.account_id, name
+        );
+
+        if state.secrets.contains_key(&arn) {
+            return Err(format!("Secret {name} already exists"));
+        }
+
+        let now = Utc::now();
+        let mut versions = BTreeMap::new();
+        let mut current_version_id: Option<String> = None;
+        if let Some(secret_string) = props.get("SecretString").and_then(|v| v.as_str()) {
+            let version_id = Uuid::new_v4().to_string();
+            versions.insert(
+                version_id.clone(),
+                SecretVersion {
+                    version_id: version_id.clone(),
+                    secret_string: Some(secret_string.to_string()),
+                    secret_binary: None,
+                    stages: vec!["AWSCURRENT".to_string()],
+                    created_at: now,
+                },
+            );
+            current_version_id = Some(version_id);
+        }
+
+        let mut tags: Vec<(String, String)> = Vec::new();
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            for t in arr {
+                if let (Some(k), Some(v)) = (
+                    t.get("Key").and_then(|x| x.as_str()),
+                    t.get("Value").and_then(|x| x.as_str()),
+                ) {
+                    tags.push((k.to_string(), v.to_string()));
+                }
+            }
+        }
+        let tags_set = !tags.is_empty();
+
+        let secret = Secret {
+            name: name.clone(),
+            arn: arn.clone(),
+            description,
+            kms_key_id,
+            versions,
+            current_version_id,
+            tags,
+            tags_ever_set: tags_set,
+            deleted: false,
+            deletion_date: None,
+            created_at: now,
+            last_changed_at: now,
+            last_accessed_at: None,
+            rotation_enabled: None,
+            rotation_lambda_arn: None,
+            rotation_rules: None,
+            last_rotated_at: None,
+            resource_policy: None,
+        };
+        state.secrets.insert(arn.clone(), secret);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Id", arn.clone())
+            .with("Name", name))
+    }
+
+    fn delete_secrets_manager_secret(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.secrets.remove(physical_id);
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -1161,6 +1264,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             lambda_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            secretsmanager_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -124,6 +124,7 @@ pub struct CloudFormationDeps {
     pub dynamodb: SharedDynamoDbState,
     pub logs: SharedLogsState,
     pub lambda: fakecloud_lambda::SharedLambdaState,
+    pub secretsmanager: fakecloud_secretsmanager::SharedSecretsManagerState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -183,6 +184,7 @@ impl CloudFormationService {
             dynamodb_state: self.deps.dynamodb.clone(),
             logs_state: self.deps.logs.clone(),
             lambda_state: self.deps.lambda.clone(),
+            secretsmanager_state: self.deps.secretsmanager.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1231,6 +1233,13 @@ mod tests {
                 ),
             )),
             lambda: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            secretsmanager: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_secretsmanager.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_secretsmanager.rs
@@ -1,0 +1,80 @@
+//! CloudFormation provisioner for AWS::SecretsManager::Secret.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "ApiToken": {
+      "Type": "AWS::SecretsManager::Secret",
+      "Properties": {
+        "Name": "cfn-test-token",
+        "Description": "Token for the cfn-managed app",
+        "SecretString": "hunter2",
+        "Tags": [
+          {"Key": "Owner", "Value": "platform"}
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "SecretArn": {"Value": {"Ref": "ApiToken"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_secrets_manager_secret() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sm = server.secretsmanager_client().await;
+
+    cfn.create_stack()
+        .stack_name("secret-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("secret-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let arn = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("SecretArn"))
+        .and_then(|o| o.output_value())
+        .expect("SecretArn output")
+        .to_string();
+    assert!(
+        arn.starts_with("arn:aws:secretsmanager:"),
+        "expected ARN, got {arn}"
+    );
+
+    let value = sm
+        .get_secret_value()
+        .secret_id(arn.clone())
+        .send()
+        .await
+        .expect("get_secret_value");
+    assert_eq!(value.secret_string(), Some("hunter2"));
+
+    cfn.delete_stack()
+        .stack_name("secret-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = sm.describe_secret().secret_id(arn).send().await;
+    assert!(after.is_err(), "secret should be gone after stack deletion");
+}

--- a/crates/fakecloud-secretsmanager/src/lib.rs
+++ b/crates/fakecloud-secretsmanager/src/lib.rs
@@ -4,5 +4,6 @@ pub(crate) mod state;
 
 pub use service::SecretsManagerService;
 pub use state::{
-    SecretsManagerSnapshot, SharedSecretsManagerState, SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+    Secret, SecretVersion, SecretsManagerSnapshot, SecretsManagerState, SharedSecretsManagerState,
+    SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -713,6 +713,7 @@ async fn main() {
             dynamodb: dynamodb_state.clone(),
             logs: logs_state.clone(),
             lambda: lambda_state.clone(),
+            secretsmanager: secretsmanager_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- Adds AWS::SecretsManager::Secret support to the CloudFormation provisioner using the existing pattern (state ref on \`CloudFormationDeps\` + \`ResourceProvisioner\`, dispatch in \`create_resource\` / \`delete_resource\`).
- Properties honored: \`Name\` (defaults to logical id), \`Description\`, \`KmsKeyId\`, \`SecretString\`, and \`Tags\`. A SecretString creates a single AWSCURRENT version.
- Stack outputs return the secret ARN via \`Ref\`.
- Re-exports \`Secret\`, \`SecretVersion\`, \`SecretsManagerState\` from \`fakecloud-secretsmanager\` so the provisioner and unit-test harnesses can construct them.

## Test plan

- [x] \`cargo build -p fakecloud\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] e2e \`cloudformation_secretsmanager.rs\`: full lifecycle (CreateStack -> DescribeStacks -> GetSecretValue -> DeleteStack -> describe-secret-fails) passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::SecretsManager::Secret`, so stacks can create and delete secrets and return the secret ARN via `Ref`. Implements BB13.

- **New Features**
  - Supports `Name` (defaults to logical ID), `Description`, `KmsKeyId`, `SecretString`, and `Tags`; creates an `AWSCURRENT` version when `SecretString` is set.
  - Adds `secretsmanager_state` to `CloudFormationDeps` and `ResourceProvisioner`.
  - Re-exports `Secret`, `SecretVersion`, `SecretsManagerState` from `fakecloud-secretsmanager`.
  - Adds an e2e test for create → describe → get → delete through CloudFormation.

- **Migration**
  - When constructing `CloudFormationService`, pass a shared `secretsmanager` state in `CloudFormationDeps`.

<sup>Written for commit e6a612c7ccf918b0bb25df4fcaaf97440a197013. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1000?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

