### PR TITLE
feat(cloudformation): provision AWS::Kinesis::Stream (BB23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "fakecloud-dynamodb",
  "fakecloud-eventbridge",
  "fakecloud-iam",
+ "fakecloud-kinesis",
  "fakecloud-lambda",
  "fakecloud-logs",
  "fakecloud-persistence",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -21,6 +21,7 @@ fakecloud-dynamodb = { workspace = true }
 fakecloud-logs = { workspace = true }
 fakecloud-lambda = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
+fakecloud-kinesis = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -707,6 +707,7 @@ mod tests {
         use fakecloud_dynamodb::DynamoDbState;
         use fakecloud_eventbridge::EventBridgeState;
         use fakecloud_iam::IamState;
+        use fakecloud_kinesis::KinesisState;
         use fakecloud_lambda::LambdaState;
         use fakecloud_logs::LogsState;
         use fakecloud_s3::S3State;
@@ -734,6 +735,7 @@ mod tests {
             logs: shared::<LogsState>(),
             lambda: shared::<LambdaState>(),
             secretsmanager: shared::<SecretsManagerState>(),
+            kinesis: shared::<KinesisState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -11,6 +11,7 @@ use fakecloud_dynamodb::{
 };
 use fakecloud_eventbridge::{EventRule, SharedEventBridgeState};
 use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
+use fakecloud_kinesis::{build_stream_shards, KinesisStream, SharedKinesisState};
 use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
 use fakecloud_s3::{S3Bucket, SharedS3State};
@@ -55,6 +56,7 @@ pub struct ResourceProvisioner {
     pub logs_state: SharedLogsState,
     pub lambda_state: SharedLambdaState,
     pub secretsmanager_state: SharedSecretsManagerState,
+    pub kinesis_state: SharedKinesisState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -77,6 +79,7 @@ impl ResourceProvisioner {
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
             "AWS::SecretsManager::Secret" => self.create_secrets_manager_secret(resource),
+            "AWS::Kinesis::Stream" => self.create_kinesis_stream(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -122,6 +125,7 @@ impl ResourceProvisioner {
             "AWS::SecretsManager::Secret" => {
                 self.delete_secrets_manager_secret(&resource.physical_id)
             }
+            "AWS::Kinesis::Stream" => self.delete_kinesis_stream(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -1096,6 +1100,75 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- Kinesis ---
+
+    fn create_kinesis_stream(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let stream_name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let shard_count = props
+            .get("ShardCount")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1) as i32;
+        if shard_count <= 0 {
+            return Err("ShardCount must be greater than zero".to_string());
+        }
+        let stream_mode = props
+            .get("StreamModeDetails")
+            .and_then(|v| v.get("StreamMode"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("PROVISIONED")
+            .to_string();
+        let retention_period_hours = props
+            .get("RetentionPeriodHours")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(24) as i32;
+
+        let mut accounts = self.kinesis_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.streams.contains_key(&stream_name) {
+            return Err(format!("Stream {stream_name} already exists"));
+        }
+        let stream_arn = format!(
+            "arn:aws:kinesis:{}:{}:stream/{}",
+            state.region, state.account_id, stream_name
+        );
+        let stream = KinesisStream {
+            stream_name: stream_name.clone(),
+            stream_arn: stream_arn.clone(),
+            stream_status: "ACTIVE".to_string(),
+            stream_creation_timestamp: Utc::now(),
+            retention_period_hours,
+            stream_mode,
+            encryption_type: "NONE".to_string(),
+            key_id: None,
+            shard_count,
+            open_shard_count: shard_count,
+            tags: BTreeMap::new(),
+            shards: build_stream_shards(shard_count),
+            next_shard_index: shard_count,
+            enhanced_metrics: Vec::new(),
+            warm_throughput_mibps: None,
+            max_record_size_kib: None,
+        };
+        state.streams.insert(stream_name.clone(), stream);
+
+        Ok(ProvisionResult::new(stream_name).with("Arn", stream_arn))
+    }
+
+    fn delete_kinesis_stream(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.kinesis_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.streams.remove(physical_id);
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -1267,6 +1340,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             secretsmanager_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            kinesis_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -125,6 +125,7 @@ pub struct CloudFormationDeps {
     pub logs: SharedLogsState,
     pub lambda: fakecloud_lambda::SharedLambdaState,
     pub secretsmanager: fakecloud_secretsmanager::SharedSecretsManagerState,
+    pub kinesis: fakecloud_kinesis::SharedKinesisState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -185,6 +186,7 @@ impl CloudFormationService {
             logs_state: self.deps.logs.clone(),
             lambda_state: self.deps.lambda.clone(),
             secretsmanager_state: self.deps.secretsmanager.clone(),
+            kinesis_state: self.deps.kinesis.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1240,6 +1242,13 @@ mod tests {
                 ),
             )),
             secretsmanager: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            kinesis: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_kinesis.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kinesis.rs
@@ -1,0 +1,82 @@
+//! CloudFormation provisioner for AWS::Kinesis::Stream.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Events": {
+      "Type": "AWS::Kinesis::Stream",
+      "Properties": {
+        "Name": "cfn-events",
+        "ShardCount": 2,
+        "RetentionPeriodHours": 48
+      }
+    }
+  },
+  "Outputs": {
+    "StreamArn": {"Value": {"Fn::GetAtt": ["Events", "Arn"]}},
+    "StreamName": {"Value": {"Ref": "Events"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_kinesis_stream() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kinesis = server.kinesis_client().await;
+
+    cfn.create_stack()
+        .stack_name("kinesis-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("kinesis-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut name = None;
+    let mut arn = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("StreamArn") => arn = o.output_value().map(|s| s.to_string()),
+            Some("StreamName") => name = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let arn = arn.expect("StreamArn output");
+    let name = name.expect("StreamName output");
+    assert!(arn.starts_with("arn:aws:kinesis:"), "unexpected arn {arn}");
+
+    let described_stream = kinesis
+        .describe_stream()
+        .stream_name(&name)
+        .send()
+        .await
+        .expect("describe_stream");
+    let descr = described_stream.stream_description().expect("description");
+    assert_eq!(descr.stream_name(), &name);
+    assert_eq!(descr.shards().len(), 2);
+    assert_eq!(descr.retention_period_hours(), 48);
+
+    cfn.delete_stack()
+        .stack_name("kinesis-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = kinesis.describe_stream().stream_name(&name).send().await;
+    assert!(after.is_err(), "stream should be gone after stack deletion");
+}

--- a/crates/fakecloud-kinesis/src/lib.rs
+++ b/crates/fakecloud-kinesis/src/lib.rs
@@ -2,5 +2,8 @@ pub mod delivery;
 pub(crate) mod service;
 pub(crate) mod state;
 
-pub use service::KinesisService;
-pub use state::{KinesisSnapshot, SharedKinesisState, KINESIS_SNAPSHOT_SCHEMA_VERSION};
+pub use service::{build_stream_shards, KinesisService};
+pub use state::{
+    KinesisShard, KinesisSnapshot, KinesisState, KinesisStream, SharedKinesisState,
+    KINESIS_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -1608,6 +1608,7 @@ const SHARD_LEVEL_METRICS: &[&str] = &[
 
 #[path = "service_helpers.rs"]
 mod service_helpers;
+pub use service_helpers::build_stream_shards;
 pub(crate) use service_helpers::*;
 
 #[cfg(test)]

--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -125,7 +125,7 @@ pub(crate) fn shard_to_json(shard: &KinesisShard) -> Value {
     obj
 }
 
-pub(crate) fn build_stream_shards(shard_count: i32) -> Vec<KinesisShard> {
+pub fn build_stream_shards(shard_count: i32) -> Vec<KinesisShard> {
     let count = shard_count as u128;
     (0..shard_count)
         .map(|index| {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -719,6 +719,7 @@ async fn main() {
             logs: logs_state.clone(),
             lambda: lambda_state.clone(),
             secretsmanager: secretsmanager_state.clone(),
+            kinesis: kinesis_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- Adds AWS::Kinesis::Stream support to the CloudFormation provisioner.
- Properties honored: \`Name\` (defaults to logical id), \`ShardCount\`, \`StreamModeDetails.StreamMode\`, \`RetentionPeriodHours\`.
- Stream is registered in ACTIVE state with shards built via the same \`build_stream_shards\` helper used by the native CreateStream path.
- Re-exports \`KinesisShard\`, \`KinesisState\`, \`KinesisStream\`, and \`build_stream_shards\` from \`fakecloud-kinesis\` so the provisioner and unit-test harnesses can construct them.
- Stack outputs resolve via \`Ref\` (stream name) and \`Fn::GetAtt: [..., Arn]\`.

## Test plan

- [x] \`cargo build -p fakecloud\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] e2e \`cloudformation_kinesis.rs\`: full lifecycle (CreateStack -> DescribeStacks -> describe_stream verifying shard count + retention -> DeleteStack -> describe_stream-fails) passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for provisioning `AWS::Kinesis::Stream`, enabling create/describe/delete via stacks. Implements BB23.

- **New Features**
  - Supports `AWS::Kinesis::Stream` with `Name` (defaults to logical id), `ShardCount`, `StreamModeDetails.StreamMode` (defaults to `PROVISIONED`), and `RetentionPeriodHours` (defaults to 24).
  - Streams are created in ACTIVE with shards from `build_stream_shards`; `ShardCount` must be > 0; stack deletion removes the stream.
  - Stack outputs: `Ref` → stream name; `Fn::GetAtt [..., Arn]` → stream ARN.
  - Wired `fakecloud-kinesis` into the CloudFormation service/server; re-exported `KinesisShard`, `KinesisState`, `KinesisStream`, and `build_stream_shards`. Added e2e test verifying lifecycle, shard count, and retention.

<sup>Written for commit 33fbfc999fbbdb418538293df03d883808702f20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

