### PR TITLE
feat(cloudformation): provision AWS::KMS::Key + AWS::KMS::Alias (BB14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "fakecloud-eventbridge",
  "fakecloud-iam",
  "fakecloud-kinesis",
+ "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",
  "fakecloud-persistence",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -22,6 +22,7 @@ fakecloud-logs = { workspace = true }
 fakecloud-lambda = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
 fakecloud-kinesis = { workspace = true }
+fakecloud-kms = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -708,6 +708,7 @@ mod tests {
         use fakecloud_eventbridge::EventBridgeState;
         use fakecloud_iam::IamState;
         use fakecloud_kinesis::KinesisState;
+        use fakecloud_kms::KmsState;
         use fakecloud_lambda::LambdaState;
         use fakecloud_logs::LogsState;
         use fakecloud_s3::S3State;
@@ -736,6 +737,7 @@ mod tests {
             lambda: shared::<LambdaState>(),
             secretsmanager: shared::<SecretsManagerState>(),
             kinesis: shared::<KinesisState>(),
+            kms: shared::<KmsState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -12,6 +12,7 @@ use fakecloud_dynamodb::{
 use fakecloud_eventbridge::{EventRule, SharedEventBridgeState};
 use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
 use fakecloud_kinesis::{build_stream_shards, KinesisStream, SharedKinesisState};
+use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
 use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
 use fakecloud_s3::{S3Bucket, SharedS3State};
@@ -57,6 +58,7 @@ pub struct ResourceProvisioner {
     pub lambda_state: SharedLambdaState,
     pub secretsmanager_state: SharedSecretsManagerState,
     pub kinesis_state: SharedKinesisState,
+    pub kms_state: SharedKmsState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -80,6 +82,8 @@ impl ResourceProvisioner {
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
             "AWS::SecretsManager::Secret" => self.create_secrets_manager_secret(resource),
             "AWS::Kinesis::Stream" => self.create_kinesis_stream(resource),
+            "AWS::KMS::Key" => self.create_kms_key(resource),
+            "AWS::KMS::Alias" => self.create_kms_alias(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -126,6 +130,8 @@ impl ResourceProvisioner {
                 self.delete_secrets_manager_secret(&resource.physical_id)
             }
             "AWS::Kinesis::Stream" => self.delete_kinesis_stream(&resource.physical_id),
+            "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
+            "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -1169,6 +1175,204 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- KMS ---
+
+    fn create_kms_key(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let enabled = props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let key_rotation_enabled = props
+            .get("EnableKeyRotation")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let key_usage = props
+            .get("KeyUsage")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ENCRYPT_DECRYPT")
+            .to_string();
+        let key_spec = props
+            .get("KeySpec")
+            .and_then(|v| v.as_str())
+            .unwrap_or("SYMMETRIC_DEFAULT")
+            .to_string();
+        let multi_region = props
+            .get("MultiRegion")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let origin = props
+            .get("Origin")
+            .and_then(|v| v.as_str())
+            .unwrap_or("AWS_KMS")
+            .to_string();
+        let policy = match props.get("KeyPolicy") {
+            Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
+            Some(v) => serde_json::to_string(v).unwrap_or_default(),
+            None => String::new(),
+        };
+        if !key_spec.starts_with("SYMMETRIC") && !key_spec.starts_with("HMAC") {
+            return Err(format!(
+                "AWS::KMS::Key with KeySpec '{key_spec}' is not yet supported in CloudFormation; only symmetric and HMAC specs are provisioned"
+            ));
+        }
+
+        let mut tags: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            for t in arr {
+                if let (Some(k), Some(v)) = (
+                    t.get("Key").and_then(|x| x.as_str()),
+                    t.get("Value").and_then(|x| x.as_str()),
+                ) {
+                    tags.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let key_id = if multi_region {
+            format!("mrk-{}", Uuid::new_v4().as_simple())
+        } else {
+            Uuid::new_v4().to_string()
+        };
+
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = format!(
+            "arn:aws:kms:{}:{}:key/{}",
+            state.region, state.account_id, key_id
+        );
+        let now = Utc::now().timestamp() as f64;
+
+        // private_key_seed is only consulted for asymmetric KEY_AGREEMENT
+        // specs (ECC DeriveSharedSecret); symmetric and HMAC keys never read
+        // it, so a zero seed is fine for the specs this provisioner accepts.
+        let seed = vec![0u8; 32];
+
+        let encryption_algorithms = if key_usage == "ENCRYPT_DECRYPT" {
+            Some(vec!["SYMMETRIC_DEFAULT".to_string()])
+        } else {
+            None
+        };
+        let mac_algorithms = if key_usage == "GENERATE_VERIFY_MAC" {
+            let alg = match key_spec.as_str() {
+                "HMAC_224" => "HMAC_SHA_224",
+                "HMAC_256" => "HMAC_SHA_256",
+                "HMAC_384" => "HMAC_SHA_384",
+                "HMAC_512" => "HMAC_SHA_512",
+                _ => "HMAC_SHA_256",
+            };
+            Some(vec![alg.to_string()])
+        } else {
+            None
+        };
+
+        let key = KmsKey {
+            key_id: key_id.clone(),
+            arn: arn.clone(),
+            creation_date: now,
+            description,
+            enabled,
+            key_usage,
+            key_spec,
+            key_manager: "CUSTOMER".to_string(),
+            key_state: if enabled { "Enabled" } else { "Disabled" }.to_string(),
+            deletion_date: None,
+            tags,
+            policy,
+            key_rotation_enabled,
+            origin,
+            multi_region,
+            rotations: Vec::new(),
+            signing_algorithms: None,
+            encryption_algorithms,
+            mac_algorithms,
+            custom_key_store_id: None,
+            imported_key_material: false,
+            imported_material_bytes: None,
+            private_key_seed: seed,
+            primary_region: None,
+            asymmetric_private_key_der: None,
+            asymmetric_public_key_der: None,
+        };
+
+        state.keys.insert(key_id.clone(), key);
+
+        Ok(ProvisionResult::new(key_id.clone())
+            .with("Arn", arn)
+            .with("KeyId", key_id))
+    }
+
+    fn delete_kms_key(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.keys.remove(physical_id);
+        state.aliases.retain(|_, a| a.target_key_id != physical_id);
+        Ok(())
+    }
+
+    fn create_kms_alias(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let alias_name = props
+            .get("AliasName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "AliasName is required".to_string())?
+            .to_string();
+        if !alias_name.starts_with("alias/") {
+            return Err(format!(
+                "AliasName must start with 'alias/'; got '{alias_name}'"
+            ));
+        }
+        let target_input = props
+            .get("TargetKeyId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "TargetKeyId is required".to_string())?
+            .to_string();
+
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+
+        let target_key_id = if state.keys.contains_key(&target_input) {
+            target_input.clone()
+        } else if let Some(id) = target_input
+            .strip_prefix("arn:aws:kms:")
+            .and_then(|rest| rest.split(":key/").nth(1))
+        {
+            if state.keys.contains_key(id) {
+                id.to_string()
+            } else {
+                return Err(format!("KMS key '{target_input}' does not exist"));
+            }
+        } else {
+            return Err(format!("KMS key '{target_input}' does not exist"));
+        };
+
+        let alias_arn = format!(
+            "arn:aws:kms:{}:{}:{}",
+            state.region, state.account_id, alias_name
+        );
+        let alias = KmsAlias {
+            alias_name: alias_name.clone(),
+            alias_arn,
+            target_key_id,
+            creation_date: Utc::now().timestamp() as f64,
+        };
+        state.aliases.insert(alias_name.clone(), alias);
+
+        Ok(ProvisionResult::new(alias_name))
+    }
+
+    fn delete_kms_alias(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.aliases.remove(physical_id);
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -1343,6 +1547,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             kinesis_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            kms_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -126,6 +126,7 @@ pub struct CloudFormationDeps {
     pub lambda: fakecloud_lambda::SharedLambdaState,
     pub secretsmanager: fakecloud_secretsmanager::SharedSecretsManagerState,
     pub kinesis: fakecloud_kinesis::SharedKinesisState,
+    pub kms: fakecloud_kms::SharedKmsState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -187,6 +188,7 @@ impl CloudFormationService {
             lambda_state: self.deps.lambda.clone(),
             secretsmanager_state: self.deps.secretsmanager.clone(),
             kinesis_state: self.deps.kinesis.clone(),
+            kms_state: self.deps.kms.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1249,6 +1251,13 @@ mod tests {
                 ),
             )),
             kinesis: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            kms: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_kms.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kms.rs
@@ -1,0 +1,117 @@
+//! CloudFormation provisioner for AWS::KMS::Key + AWS::KMS::Alias.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "AppKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "App data key",
+        "EnableKeyRotation": true,
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "KeySpec": "SYMMETRIC_DEFAULT"
+      }
+    },
+    "AppAlias": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": "alias/cfn-app-key",
+        "TargetKeyId": {"Ref": "AppKey"}
+      }
+    }
+  },
+  "Outputs": {
+    "KeyId": {"Value": {"Ref": "AppKey"}},
+    "KeyArn": {"Value": {"Fn::GetAtt": ["AppKey", "Arn"]}},
+    "AliasName": {"Value": {"Ref": "AppAlias"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_kms_key_and_alias() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kms = server.kms_client().await;
+
+    cfn.create_stack()
+        .stack_name("kms-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("kms-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut key_id = None;
+    let mut key_arn = None;
+    let mut alias_name = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("KeyId") => key_id = o.output_value().map(|s| s.to_string()),
+            Some("KeyArn") => key_arn = o.output_value().map(|s| s.to_string()),
+            Some("AliasName") => alias_name = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let key_id = key_id.expect("KeyId output");
+    let key_arn = key_arn.expect("KeyArn output");
+    let alias_name = alias_name.expect("AliasName output");
+    assert!(
+        key_arn.starts_with("arn:aws:kms:") && key_arn.ends_with(&format!("key/{key_id}")),
+        "unexpected arn {key_arn}"
+    );
+    assert_eq!(alias_name, "alias/cfn-app-key");
+
+    let described_key = kms
+        .describe_key()
+        .key_id(&key_id)
+        .send()
+        .await
+        .expect("describe_key");
+    let metadata = described_key.key_metadata().expect("key metadata");
+    assert_eq!(metadata.key_id(), key_id);
+    assert_eq!(metadata.description(), Some("App data key"));
+    assert_eq!(
+        metadata.key_usage().map(|u| u.as_str()),
+        Some("ENCRYPT_DECRYPT")
+    );
+
+    let listed = kms.list_aliases().send().await.expect("list_aliases");
+    let alias = listed
+        .aliases()
+        .iter()
+        .find(|a| a.alias_name() == Some(&alias_name))
+        .expect("alias present");
+    assert_eq!(alias.target_key_id(), Some(key_id.as_str()));
+
+    cfn.delete_stack()
+        .stack_name("kms-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = kms.describe_key().key_id(&key_id).send().await;
+    assert!(after.is_err(), "key should be gone after stack deletion");
+    let listed_after = kms.list_aliases().send().await.expect("list_aliases after");
+    assert!(
+        !listed_after
+            .aliases()
+            .iter()
+            .any(|a| a.alias_name() == Some(&alias_name)),
+        "alias should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-kms/src/lib.rs
+++ b/crates/fakecloud-kms/src/lib.rs
@@ -6,4 +6,6 @@ pub(crate) mod service;
 pub(crate) mod state;
 
 pub use service::KmsService;
-pub use state::{KmsSnapshot, SharedKmsState, KMS_SNAPSHOT_SCHEMA_VERSION};
+pub use state::{
+    KmsAlias, KmsKey, KmsSnapshot, KmsState, SharedKmsState, KMS_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -720,6 +720,7 @@ async fn main() {
             lambda: lambda_state.clone(),
             secretsmanager: secretsmanager_state.clone(),
             kinesis: kinesis_state.clone(),
+            kms: kms_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- New CloudFormation provisioners for `AWS::KMS::Key` and `AWS::KMS::Alias`.
- `Ref` returns `KeyId` (or `AliasName`); `Fn::GetAtt` exposes `Arn` and `KeyId` on the key.
- Aliases accept the target key as `Ref` (key id) or as a key ARN; aliases pointing at a key that the same stack deletes are also cleaned up.
- Symmetric and HMAC key specs are supported; asymmetric specs return a clear "not yet supported" error rather than silently emitting a broken key.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-e2e --test cloudformation_kms`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::KMS::Key` and `AWS::KMS::Alias`, enabling stacks to create KMS keys and aliases with correct Ref/GetAtt behavior and cleanup. Implements BB14.

- **New Features**
  - Provisioners for `AWS::KMS::Key` and `AWS::KMS::Alias`.
  - `Ref` returns KeyId (keys) and AliasName (aliases); `Fn::GetAtt` exposes `Arn` and `KeyId` for keys.
  - Supports symmetric and HMAC key specs; asymmetric specs return a clear “not yet supported” error.
  - Resolves alias `TargetKeyId` from key ID or ARN and removes aliases when the target key is deleted.
  - Wired `fakecloud-kms` into `fakecloud-cloudformation` and `fakecloud-server`; added e2e test covering provision and deletion.

<sup>Written for commit bb545bcaef81d5bfbca2befddd14a4ded979349c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

