### PR TITLE
feat(cloudformation): provision AWS::ECR::Repository (BB12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-dynamodb",
+ "fakecloud-ecr",
  "fakecloud-eventbridge",
  "fakecloud-iam",
  "fakecloud-kinesis",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -23,6 +23,7 @@ fakecloud-lambda = { workspace = true }
 fakecloud-secretsmanager = { workspace = true }
 fakecloud-kinesis = { workspace = true }
 fakecloud-kms = { workspace = true }
+fakecloud-ecr = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -705,6 +705,7 @@ mod tests {
 
     fn deps() -> CloudFormationDeps {
         use fakecloud_dynamodb::DynamoDbState;
+        use fakecloud_ecr::EcrState;
         use fakecloud_eventbridge::EventBridgeState;
         use fakecloud_iam::IamState;
         use fakecloud_kinesis::KinesisState;
@@ -738,6 +739,7 @@ mod tests {
             secretsmanager: shared::<SecretsManagerState>(),
             kinesis: shared::<KinesisState>(),
             kms: shared::<KmsState>(),
+            ecr: shared::<EcrState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -9,6 +9,7 @@ use fakecloud_dynamodb::{
     AttributeDefinition, DynamoTable, KeySchemaElement, OnDemandThroughput, ProvisionedThroughput,
     SharedDynamoDbState,
 };
+use fakecloud_ecr::{Repository, SharedEcrState};
 use fakecloud_eventbridge::{EventRule, SharedEventBridgeState};
 use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
 use fakecloud_kinesis::{build_stream_shards, KinesisStream, SharedKinesisState};
@@ -59,6 +60,7 @@ pub struct ResourceProvisioner {
     pub secretsmanager_state: SharedSecretsManagerState,
     pub kinesis_state: SharedKinesisState,
     pub kms_state: SharedKmsState,
+    pub ecr_state: SharedEcrState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -84,6 +86,7 @@ impl ResourceProvisioner {
             "AWS::Kinesis::Stream" => self.create_kinesis_stream(resource),
             "AWS::KMS::Key" => self.create_kms_key(resource),
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
+            "AWS::ECR::Repository" => self.create_ecr_repository(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -132,6 +135,7 @@ impl ResourceProvisioner {
             "AWS::Kinesis::Stream" => self.delete_kinesis_stream(&resource.physical_id),
             "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
+            "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -1373,6 +1377,100 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- ECR ---
+
+    fn create_ecr_repository(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let repository_name = props
+            .get("RepositoryName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let image_tag_mutability = props
+            .get("ImageTagMutability")
+            .and_then(|v| v.as_str())
+            .unwrap_or("MUTABLE")
+            .to_string();
+        let scan_on_push = props
+            .get("ImageScanningConfiguration")
+            .and_then(|v| v.get("ScanOnPush"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let encryption_type = props
+            .get("EncryptionConfiguration")
+            .and_then(|v| v.get("EncryptionType"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("AES256")
+            .to_string();
+        let kms_key = props
+            .get("EncryptionConfiguration")
+            .and_then(|v| v.get("KmsKey"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let policy_text = props
+            .get("RepositoryPolicyText")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .filter(|s| !s.is_empty());
+        let lifecycle_policy = props
+            .get("LifecyclePolicy")
+            .and_then(|v| v.get("LifecyclePolicyText"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let mut tags: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            for t in arr {
+                if let (Some(k), Some(v)) = (
+                    t.get("Key").and_then(|x| x.as_str()),
+                    t.get("Value").and_then(|x| x.as_str()),
+                ) {
+                    tags.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.repositories.contains_key(&repository_name) {
+            return Err(format!("Repository {repository_name} already exists"));
+        }
+        let arn = state.repository_arn(&repository_name);
+        let registry_id = state.account_id.clone();
+        let endpoint = format!(
+            "{}.dkr.ecr.{}.amazonaws.com",
+            state.account_id, state.region
+        );
+        let mut repo = Repository::new(&repository_name, arn.clone(), &registry_id, &endpoint);
+        repo.image_tag_mutability = image_tag_mutability;
+        repo.image_scanning_configuration.scan_on_push = scan_on_push;
+        repo.encryption_configuration.encryption_type = encryption_type;
+        repo.encryption_configuration.kms_key = kms_key;
+        repo.policy = policy_text;
+        repo.lifecycle_policy = lifecycle_policy;
+        repo.tags = tags;
+        let uri = repo.repository_uri.clone();
+        state.repositories.insert(repository_name.clone(), repo);
+
+        Ok(ProvisionResult::new(repository_name)
+            .with("Arn", arn)
+            .with("RepositoryUri", uri))
+    }
+
+    fn delete_ecr_repository(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.repositories.remove(physical_id);
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -1550,6 +1648,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             kms_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            ecr_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -127,6 +127,7 @@ pub struct CloudFormationDeps {
     pub secretsmanager: fakecloud_secretsmanager::SharedSecretsManagerState,
     pub kinesis: fakecloud_kinesis::SharedKinesisState,
     pub kms: fakecloud_kms::SharedKmsState,
+    pub ecr: fakecloud_ecr::SharedEcrState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -189,6 +190,7 @@ impl CloudFormationService {
             secretsmanager_state: self.deps.secretsmanager.clone(),
             kinesis_state: self.deps.kinesis.clone(),
             kms_state: self.deps.kms.clone(),
+            ecr_state: self.deps.ecr.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1258,6 +1260,13 @@ mod tests {
                 ),
             )),
             kms: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ecr: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_ecr.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ecr.rs
@@ -1,0 +1,143 @@
+//! CloudFormation provisioner for AWS::ECR::Repository.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "AppRepo": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {
+        "RepositoryName": "cfn-app",
+        "ImageTagMutability": "IMMUTABLE",
+        "ImageScanningConfiguration": {"ScanOnPush": true},
+        "EncryptionConfiguration": {"EncryptionType": "AES256"},
+        "RepositoryPolicyText": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "Pull",
+            "Effect": "Allow",
+            "Principal": {"AWS": "*"},
+            "Action": ["ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage"]
+          }]
+        },
+        "LifecyclePolicy": {
+          "LifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"keep latest 10\",\"selection\":{\"tagStatus\":\"any\",\"countType\":\"imageCountMoreThan\",\"countNumber\":10},\"action\":{\"type\":\"expire\"}}]}"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "RepoName": {"Value": {"Ref": "AppRepo"}},
+    "RepoArn": {"Value": {"Fn::GetAtt": ["AppRepo", "Arn"]}},
+    "RepoUri": {"Value": {"Fn::GetAtt": ["AppRepo", "RepositoryUri"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_ecr_repository() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ecr = server.ecr_client().await;
+
+    cfn.create_stack()
+        .stack_name("ecr-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ecr-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut name = None;
+    let mut arn = None;
+    let mut uri = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("RepoName") => name = o.output_value().map(|s| s.to_string()),
+            Some("RepoArn") => arn = o.output_value().map(|s| s.to_string()),
+            Some("RepoUri") => uri = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let name = name.expect("RepoName output");
+    let arn = arn.expect("RepoArn output");
+    let uri = uri.expect("RepoUri output");
+    assert_eq!(name, "cfn-app");
+    assert!(arn.starts_with("arn:aws:ecr:") && arn.ends_with(":repository/cfn-app"));
+    assert!(uri.ends_with("/cfn-app"));
+
+    let described_repo = ecr
+        .describe_repositories()
+        .repository_names(&name)
+        .send()
+        .await
+        .expect("describe_repositories");
+    let repo = described_repo.repositories().first().expect("repo present");
+    assert_eq!(repo.repository_name(), Some(name.as_str()));
+    assert_eq!(
+        repo.image_tag_mutability().map(|m| m.as_str()),
+        Some("IMMUTABLE")
+    );
+    assert_eq!(
+        repo.image_scanning_configuration()
+            .map(|c| c.scan_on_push()),
+        Some(true)
+    );
+
+    let policy = ecr
+        .get_repository_policy()
+        .repository_name(&name)
+        .send()
+        .await
+        .expect("get_repository_policy");
+    assert!(
+        policy
+            .policy_text()
+            .map(|s| s.contains("ecr:GetDownloadUrlForLayer"))
+            .unwrap_or(false),
+        "policy text should round-trip the inline policy"
+    );
+
+    let lifecycle = ecr
+        .get_lifecycle_policy()
+        .repository_name(&name)
+        .send()
+        .await
+        .expect("get_lifecycle_policy");
+    assert!(
+        lifecycle
+            .lifecycle_policy_text()
+            .map(|s| s.contains("imageCountMoreThan"))
+            .unwrap_or(false),
+        "lifecycle policy text should round-trip"
+    );
+
+    cfn.delete_stack()
+        .stack_name("ecr-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = ecr
+        .describe_repositories()
+        .repository_names(&name)
+        .send()
+        .await;
+    assert!(
+        after.is_err(),
+        "repository should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -7,6 +7,6 @@ pub(crate) mod state;
 
 pub use service::EcrService;
 pub use state::{
-    EcrSnapshot, Image, PullThroughCacheRule, Repository, SharedEcrState,
+    EcrSnapshot, EcrState, Image, PullThroughCacheRule, Repository, SharedEcrState,
     ECR_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -721,6 +721,7 @@ async fn main() {
             secretsmanager: secretsmanager_state.clone(),
             kinesis: kinesis_state.clone(),
             kms: kms_state.clone(),
+            ecr: ecr_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- New CloudFormation provisioner for `AWS::ECR::Repository` with full property surface: `RepositoryName`, `ImageTagMutability`, `ImageScanningConfiguration.ScanOnPush`, `EncryptionConfiguration.{EncryptionType,KmsKey}`, inline `RepositoryPolicyText`, inline `LifecyclePolicy.LifecyclePolicyText`, and `Tags`.
- `Ref` returns the repository name.
- `Fn::GetAtt` exposes `Arn` and `RepositoryUri`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-e2e --test cloudformation_ecr`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for provisioning `AWS::ECR::Repository`, including inline policy and lifecycle configuration. Enables single-resource ECR repo creation and outputs, aligning with BB12.

- **New Features**
  - Provision `AWS::ECR::Repository` with `RepositoryName`, `ImageTagMutability`, `ImageScanningConfiguration.ScanOnPush`, `EncryptionConfiguration.{EncryptionType,KmsKey}`, inline `RepositoryPolicyText`, inline `LifecyclePolicy.LifecyclePolicyText`, and `Tags`.
  - `Ref` returns the repository name; `Fn::GetAtt` exposes `Arn` and `RepositoryUri`.
  - Repositories are cleaned up on stack delete; e2e test covers create, outputs, policy/lifecycle round-trip, and delete.

- **Dependencies**
  - Added `fakecloud-ecr` to `fakecloud-cloudformation` and wired `ecr` into `CloudFormationDeps` and server bootstrap.

<sup>Written for commit 35c44fb113cc565f00b6cf525b286fc1fd3e464a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

