### PR TITLE
feat(cloudformation): provision AWS::CloudWatch::Alarm (BB18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-aws",
+ "fakecloud-cloudwatch",
  "fakecloud-core",
  "fakecloud-dynamodb",
  "fakecloud-ecr",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -24,6 +24,7 @@ fakecloud-secretsmanager = { workspace = true }
 fakecloud-kinesis = { workspace = true }
 fakecloud-kms = { workspace = true }
 fakecloud-ecr = { workspace = true }
+fakecloud-cloudwatch = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -740,6 +740,7 @@ mod tests {
             kinesis: shared::<KinesisState>(),
             kms: shared::<KmsState>(),
             ecr: shared::<EcrState>(),
+            cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use fakecloud_cloudwatch::{AlarmState, MetricAlarm, SharedCloudWatchState};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_dynamodb::{
     AttributeDefinition, DynamoTable, KeySchemaElement, OnDemandThroughput, ProvisionedThroughput,
@@ -61,6 +62,7 @@ pub struct ResourceProvisioner {
     pub kinesis_state: SharedKinesisState,
     pub kms_state: SharedKmsState,
     pub ecr_state: SharedEcrState,
+    pub cloudwatch_state: SharedCloudWatchState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -87,6 +89,7 @@ impl ResourceProvisioner {
             "AWS::KMS::Key" => self.create_kms_key(resource),
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
             "AWS::ECR::Repository" => self.create_ecr_repository(resource),
+            "AWS::CloudWatch::Alarm" => self.create_cloudwatch_alarm(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -136,6 +139,7 @@ impl ResourceProvisioner {
             "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
+            "AWS::CloudWatch::Alarm" => self.delete_cloudwatch_alarm(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -1471,6 +1475,144 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- CloudWatch ---
+
+    fn create_cloudwatch_alarm(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let alarm_name = props
+            .get("AlarmName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let alarm_description = props
+            .get("AlarmDescription")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let actions_enabled = props
+            .get("ActionsEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let str_array = |key: &str| -> Vec<String> {
+            props
+                .get(key)
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let alarm_actions = str_array("AlarmActions");
+        let ok_actions = str_array("OKActions");
+        let insufficient_data_actions = str_array("InsufficientDataActions");
+
+        let metric_name = props
+            .get("MetricName")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let namespace = props
+            .get("Namespace")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let statistic = props
+            .get("Statistic")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let extended_statistic = props
+            .get("ExtendedStatistic")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let unit = props
+            .get("Unit")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let period = props.get("Period").and_then(|v| v.as_i64());
+        let evaluation_periods = props
+            .get("EvaluationPeriods")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1);
+        let datapoints_to_alarm = props.get("DatapointsToAlarm").and_then(|v| v.as_i64());
+        let threshold = props.get("Threshold").and_then(|v| v.as_f64());
+        let comparison_operator = props
+            .get("ComparisonOperator")
+            .and_then(|v| v.as_str())
+            .unwrap_or("GreaterThanThreshold")
+            .to_string();
+        let treat_missing_data = props
+            .get("TreatMissingData")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let evaluate_low_sample_count_percentile = props
+            .get("EvaluateLowSampleCountPercentile")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let mut dimensions: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arr) = props.get("Dimensions").and_then(|v| v.as_array()) {
+            for d in arr {
+                if let (Some(k), Some(v)) = (
+                    d.get("Name").and_then(|x| x.as_str()),
+                    d.get("Value").and_then(|x| x.as_str()),
+                ) {
+                    dimensions.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let mut accounts = self.cloudwatch_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let alarm_arn = format!(
+            "arn:aws:cloudwatch:{}:{}:alarm:{}",
+            self.region, self.account_id, alarm_name
+        );
+        let now = Utc::now();
+        let alarm = MetricAlarm {
+            alarm_name: alarm_name.clone(),
+            alarm_arn: alarm_arn.clone(),
+            alarm_description,
+            actions_enabled,
+            ok_actions,
+            alarm_actions,
+            insufficient_data_actions,
+            state_value: AlarmState::InsufficientData,
+            state_reason: "Unchecked: Initial alarm creation".to_string(),
+            state_updated_timestamp: now,
+            metric_name,
+            namespace,
+            statistic,
+            extended_statistic,
+            dimensions,
+            period,
+            unit,
+            evaluation_periods,
+            datapoints_to_alarm,
+            threshold,
+            comparison_operator,
+            treat_missing_data,
+            evaluate_low_sample_count_percentile,
+            configuration_updated_timestamp: now,
+            alarm_configuration_updated_timestamp: now,
+        };
+        let region_alarms = state.alarms_in_mut(&self.region);
+        if region_alarms.contains_key(&alarm_name) {
+            return Err(format!("Alarm {alarm_name} already exists"));
+        }
+        region_alarms.insert(alarm_name.clone(), alarm);
+
+        Ok(ProvisionResult::new(alarm_name).with("Arn", alarm_arn))
+    }
+
+    fn delete_cloudwatch_alarm(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudwatch_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.alarms_in_mut(&self.region).remove(physical_id);
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -1653,6 +1795,7 @@ mod tests {
             ecr_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
+            cloudwatch_state: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -128,6 +128,7 @@ pub struct CloudFormationDeps {
     pub kinesis: fakecloud_kinesis::SharedKinesisState,
     pub kms: fakecloud_kms::SharedKmsState,
     pub ecr: fakecloud_ecr::SharedEcrState,
+    pub cloudwatch: fakecloud_cloudwatch::SharedCloudWatchState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -191,6 +192,7 @@ impl CloudFormationService {
             kinesis_state: self.deps.kinesis.clone(),
             kms_state: self.deps.kms.clone(),
             ecr_state: self.deps.ecr.clone(),
+            cloudwatch_state: self.deps.cloudwatch.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1273,6 +1275,7 @@ mod tests {
                     "",
                 ),
             )),
+            cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_cloudwatch_alarm.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_cloudwatch_alarm.rs
@@ -1,0 +1,114 @@
+//! CloudFormation provisioner for AWS::CloudWatch::Alarm.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "HighCpu": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": "cfn-high-cpu",
+        "AlarmDescription": "CPU > 80% for 5 minutes",
+        "Namespace": "AWS/EC2",
+        "MetricName": "CPUUtilization",
+        "Statistic": "Average",
+        "Period": 300,
+        "EvaluationPeriods": 2,
+        "Threshold": 80,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "notBreaching",
+        "Dimensions": [
+          {"Name": "InstanceId", "Value": "i-0123456789abcdef0"}
+        ],
+        "AlarmActions": ["arn:aws:sns:us-east-1:000000000000:alerts"],
+        "OKActions": ["arn:aws:sns:us-east-1:000000000000:recoveries"]
+      }
+    }
+  },
+  "Outputs": {
+    "AlarmName": {"Value": {"Ref": "HighCpu"}},
+    "AlarmArn": {"Value": {"Fn::GetAtt": ["HighCpu", "Arn"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_cloudwatch_alarm() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    cfn.create_stack()
+        .stack_name("alarm-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("alarm-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut name = None;
+    let mut arn = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("AlarmName") => name = o.output_value().map(|s| s.to_string()),
+            Some("AlarmArn") => arn = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let name = name.expect("AlarmName output");
+    let arn = arn.expect("AlarmArn output");
+    assert_eq!(name, "cfn-high-cpu");
+    assert!(arn.starts_with("arn:aws:cloudwatch:") && arn.ends_with(":alarm:cfn-high-cpu"));
+
+    let described_alarms = cw
+        .describe_alarms()
+        .alarm_names(&name)
+        .send()
+        .await
+        .expect("describe_alarms");
+    let alarm = described_alarms
+        .metric_alarms()
+        .first()
+        .expect("alarm present");
+    assert_eq!(alarm.alarm_name(), Some(name.as_str()));
+    assert_eq!(alarm.namespace(), Some("AWS/EC2"));
+    assert_eq!(alarm.metric_name(), Some("CPUUtilization"));
+    assert_eq!(alarm.threshold(), Some(80.0));
+    assert_eq!(alarm.evaluation_periods(), Some(2));
+    assert_eq!(
+        alarm.comparison_operator().map(|c| c.as_str()),
+        Some("GreaterThanThreshold")
+    );
+    assert_eq!(alarm.alarm_actions().len(), 1);
+    assert_eq!(alarm.ok_actions().len(), 1);
+
+    cfn.delete_stack()
+        .stack_name("alarm-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = cw
+        .describe_alarms()
+        .alarm_names(&name)
+        .send()
+        .await
+        .expect("describe_alarms after");
+    assert!(
+        after.metric_alarms().is_empty(),
+        "alarm should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -722,6 +722,7 @@ async fn main() {
             kinesis: kinesis_state.clone(),
             kms: kms_state.clone(),
             ecr: ecr_state.clone(),
+            cloudwatch: cloudwatch_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- New CloudFormation provisioner for \`AWS::CloudWatch::Alarm\`. Full property surface: \`AlarmName\`, \`AlarmDescription\`, \`ActionsEnabled\`, \`AlarmActions\`/\`OKActions\`/\`InsufficientDataActions\`, \`Namespace\`, \`MetricName\`, \`Statistic\`/\`ExtendedStatistic\`, \`Dimensions\`, \`Period\`, \`Unit\`, \`EvaluationPeriods\`, \`DatapointsToAlarm\`, \`Threshold\`, \`ComparisonOperator\`, \`TreatMissingData\`, \`EvaluateLowSampleCountPercentile\`.
- Alarms land in the same per-region keyed structure as \`PutMetricAlarm\` so \`DescribeAlarms\` surfaces them transparently.
- \`Ref\` returns the alarm name; \`Fn::GetAtt\` exposes \`Arn\`.

\`AWS::CloudWatch::Dashboard\` is not yet implemented; the underlying \`fakecloud-cloudwatch\` crate currently only models metrics and alarms. Tracked as future work.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_cloudwatch_alarm\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFormation support for `AWS::CloudWatch::Alarm`, provisioning metric alarms and exposing them via DescribeAlarms like API-created alarms. Aligns with BB18; `Ref` returns the alarm name and `Fn::GetAtt` exposes `Arn`.

- **New Features**
  - Provision `AWS::CloudWatch::Alarm` with full property support (name/description, actions, metric/dimensions, stats, periods/units, evaluation rules, thresholds).
  - Store alarms per region alongside PutMetricAlarm so DescribeAlarms lists stack alarms.
  - Add e2e test for create/delete via stack outputs (name + arn).

- **Dependencies**
  - Wire `fakecloud-cloudwatch` into `fakecloud-cloudformation` and the server.

<sup>Written for commit 5051618ccf6ecf3c2efb60a384cb9317e0294192. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

