### PR TITLE
feat(cloudformation): provision AWS::Kinesis::StreamConsumer (BB23 followup)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -13,7 +13,7 @@ use fakecloud_dynamodb::{
 use fakecloud_ecr::{Repository, SharedEcrState};
 use fakecloud_eventbridge::{EventRule, SharedEventBridgeState};
 use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
-use fakecloud_kinesis::{build_stream_shards, KinesisStream, SharedKinesisState};
+use fakecloud_kinesis::{build_stream_shards, KinesisConsumer, KinesisStream, SharedKinesisState};
 use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
 use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::SharedLogsState;
@@ -86,6 +86,7 @@ impl ResourceProvisioner {
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
             "AWS::SecretsManager::Secret" => self.create_secrets_manager_secret(resource),
             "AWS::Kinesis::Stream" => self.create_kinesis_stream(resource),
+            "AWS::Kinesis::StreamConsumer" => self.create_kinesis_stream_consumer(resource),
             "AWS::KMS::Key" => self.create_kms_key(resource),
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
             "AWS::ECR::Repository" => self.create_ecr_repository(resource),
@@ -136,6 +137,9 @@ impl ResourceProvisioner {
                 self.delete_secrets_manager_secret(&resource.physical_id)
             }
             "AWS::Kinesis::Stream" => self.delete_kinesis_stream(&resource.physical_id),
+            "AWS::Kinesis::StreamConsumer" => {
+                self.delete_kinesis_stream_consumer(&resource.physical_id)
+            }
             "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
@@ -1180,6 +1184,64 @@ impl ResourceProvisioner {
         let mut accounts = self.kinesis_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.streams.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_kinesis_stream_consumer(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let stream_arn = props
+            .get("StreamARN")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "StreamARN is required".to_string())?
+            .to_string();
+        let consumer_name = props
+            .get("ConsumerName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "ConsumerName is required".to_string())?
+            .to_string();
+
+        let mut accounts = self.kinesis_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state
+            .consumers
+            .values()
+            .any(|c| c.stream_arn == stream_arn && c.consumer_name == consumer_name)
+        {
+            return Err(format!(
+                "Consumer {consumer_name} already exists on stream {stream_arn}"
+            ));
+        }
+        let now = Utc::now();
+        let consumer_arn = format!(
+            "{}/consumer/{}:{}",
+            stream_arn,
+            consumer_name,
+            now.timestamp()
+        );
+        let consumer = KinesisConsumer {
+            consumer_name: consumer_name.clone(),
+            consumer_arn: consumer_arn.clone(),
+            consumer_status: "ACTIVE".to_string(),
+            consumer_creation_timestamp: now,
+            stream_arn: stream_arn.clone(),
+        };
+        state.consumers.insert(consumer_arn.clone(), consumer);
+
+        Ok(ProvisionResult::new(consumer_arn.clone())
+            .with("ConsumerARN", consumer_arn)
+            .with("ConsumerName", consumer_name)
+            .with("ConsumerStatus", "ACTIVE")
+            .with("ConsumerCreationTimestamp", now.timestamp().to_string())
+            .with("StreamARN", stream_arn))
+    }
+
+    fn delete_kinesis_stream_consumer(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.kinesis_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.consumers.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_kinesis_consumer.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kinesis_consumer.rs
@@ -1,0 +1,99 @@
+//! CloudFormation provisioner for AWS::Kinesis::StreamConsumer.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Events": {
+      "Type": "AWS::Kinesis::Stream",
+      "Properties": {"Name": "cfn-consumer-stream", "ShardCount": 1}
+    },
+    "Reader": {
+      "Type": "AWS::Kinesis::StreamConsumer",
+      "Properties": {
+        "ConsumerName": "cfn-reader",
+        "StreamARN": {"Fn::GetAtt": ["Events", "Arn"]}
+      }
+    }
+  },
+  "Outputs": {
+    "ConsumerArn": {"Value": {"Fn::GetAtt": ["Reader", "ConsumerARN"]}},
+    "ConsumerName": {"Value": {"Fn::GetAtt": ["Reader", "ConsumerName"]}},
+    "StreamArn": {"Value": {"Fn::GetAtt": ["Reader", "StreamARN"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_and_deletes_kinesis_stream_consumer() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kinesis = server.kinesis_client().await;
+
+    cfn.create_stack()
+        .stack_name("kinesis-consumer-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("kinesis-consumer-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut consumer_arn = None;
+    let mut consumer_name = None;
+    let mut stream_arn = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("ConsumerArn") => consumer_arn = o.output_value().map(|s| s.to_string()),
+            Some("ConsumerName") => consumer_name = o.output_value().map(|s| s.to_string()),
+            Some("StreamArn") => stream_arn = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let consumer_arn = consumer_arn.expect("ConsumerARN output");
+    let consumer_name = consumer_name.expect("ConsumerName output");
+    let stream_arn = stream_arn.expect("StreamARN output");
+    assert_eq!(consumer_name, "cfn-reader");
+    assert!(consumer_arn.starts_with(&stream_arn));
+    assert!(consumer_arn.contains("/consumer/cfn-reader:"));
+
+    let described_consumer = kinesis
+        .describe_stream_consumer()
+        .consumer_arn(&consumer_arn)
+        .send()
+        .await
+        .expect("describe_stream_consumer");
+    let descr = described_consumer
+        .consumer_description()
+        .expect("description");
+    assert_eq!(descr.consumer_name(), "cfn-reader");
+    assert_eq!(descr.consumer_arn(), &consumer_arn);
+
+    cfn.delete_stack()
+        .stack_name("kinesis-consumer-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = kinesis
+        .describe_stream_consumer()
+        .consumer_arn(&consumer_arn)
+        .send()
+        .await;
+    assert!(
+        after.is_err(),
+        "consumer should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-kinesis/src/lib.rs
+++ b/crates/fakecloud-kinesis/src/lib.rs
@@ -4,6 +4,6 @@ pub(crate) mod state;
 
 pub use service::{build_stream_shards, KinesisService};
 pub use state::{
-    KinesisShard, KinesisSnapshot, KinesisState, KinesisStream, SharedKinesisState,
-    KINESIS_SNAPSHOT_SCHEMA_VERSION,
+    KinesisConsumer, KinesisShard, KinesisSnapshot, KinesisState, KinesisStream,
+    SharedKinesisState, KINESIS_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary

- New CloudFormation provisioner for \`AWS::Kinesis::StreamConsumer\`. Required \`StreamARN\` + \`ConsumerName\`; resolved against the existing \`AWS::Kinesis::Stream\` provisioner via \`Fn::GetAtt: [..., \"Arn\"]\`.
- \`Ref\` returns the full consumer ARN; \`Fn::GetAtt\` exposes \`ConsumerARN\`, \`ConsumerName\`, \`ConsumerStatus\`, \`ConsumerCreationTimestamp\`, \`StreamARN\`.

## Test plan

- [x] \`cargo build -p fakecloud-cloudformation\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_kinesis_consumer\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFormation support for `AWS::Kinesis::StreamConsumer` to create and delete Kinesis consumers tied to a stream.

- **New Features**
  - Provision and deletion for `AWS::Kinesis::StreamConsumer` with required `StreamARN` and `ConsumerName` (stream ARN can come from `Fn::GetAtt` on `AWS::Kinesis::Stream`).
  - `Ref` returns the consumer ARN; `Fn::GetAtt` supports `ConsumerARN`, `ConsumerName`, `ConsumerStatus`, `ConsumerCreationTimestamp`, `StreamARN`.
  - Prevents duplicate consumers on the same stream; adds an e2e test and exports `KinesisConsumer`.

<sup>Written for commit 22b096fc64279d3c6b885c42b7229603b43dca92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

