### PR TITLE
feat(cloudformation): provision Logs LogStream + MetricFilter + SubscriptionFilter (BB29)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -16,7 +16,9 @@ use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
 use fakecloud_kinesis::{build_stream_shards, KinesisConsumer, KinesisStream, SharedKinesisState};
 use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
 use fakecloud_lambda::SharedLambdaState;
-use fakecloud_logs::SharedLogsState;
+use fakecloud_logs::{
+    LogStream, MetricFilter, MetricTransformation, SharedLogsState, SubscriptionFilter,
+};
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
@@ -25,6 +27,19 @@ use fakecloud_ssm::{SharedSsmState, SsmParameter};
 
 use crate::state::StackResource;
 use crate::template::ResourceDefinition;
+
+/// `LogGroupName` properties on Logs CFN resources may carry either a
+/// log-group ARN (when they come from `{Ref: SomeLogGroup}` in the same
+/// template) or a plain name. Extract the name in either case.
+fn parse_log_group_name(input: &str) -> String {
+    if let Some(rest) = input.strip_prefix("arn:aws:logs:") {
+        if let Some(after) = rest.split(":log-group:").nth(1) {
+            // ARN ends with `:*`; trim it if present.
+            return after.trim_end_matches(":*").to_string();
+        }
+    }
+    input.to_string()
+}
 
 /// What a resource provisioner returns. The physical id is what `Ref` resolves
 /// to; `attributes` is what `Fn::GetAtt` resolves to (per-resource-type).
@@ -83,6 +98,9 @@ impl ResourceProvisioner {
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
             "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
+            "AWS::Logs::LogStream" => self.create_log_stream(resource),
+            "AWS::Logs::MetricFilter" => self.create_metric_filter(resource),
+            "AWS::Logs::SubscriptionFilter" => self.create_subscription_filter(resource),
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
             "AWS::SecretsManager::Secret" => self.create_secrets_manager_secret(resource),
             "AWS::Kinesis::Stream" => self.create_kinesis_stream(resource),
@@ -132,6 +150,11 @@ impl ResourceProvisioner {
             "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
             "AWS::DynamoDB::Table" => self.delete_dynamodb_table(&resource.physical_id),
             "AWS::Logs::LogGroup" => self.delete_log_group(&resource.physical_id),
+            "AWS::Logs::LogStream" => self.delete_log_stream(&resource.physical_id),
+            "AWS::Logs::MetricFilter" => self.delete_metric_filter(&resource.physical_id),
+            "AWS::Logs::SubscriptionFilter" => {
+                self.delete_subscription_filter(&resource.physical_id)
+            }
             "AWS::Lambda::Function" => self.delete_lambda_function(&resource.physical_id),
             "AWS::SecretsManager::Secret" => {
                 self.delete_secrets_manager_secret(&resource.physical_id)
@@ -1686,6 +1709,220 @@ impl ResourceProvisioner {
             .map(|(name, _)| name.clone());
         if let Some(name) = name {
             state.log_groups.remove(&name);
+        }
+        Ok(())
+    }
+
+    fn create_log_stream(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let log_group_name = props
+            .get("LogGroupName")
+            .and_then(|v| v.as_str())
+            .map(parse_log_group_name)
+            .ok_or_else(|| "LogGroupName is required".to_string())?;
+        let log_stream_name = props
+            .get("LogStreamName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        let group = state
+            .log_groups
+            .get_mut(&log_group_name)
+            .ok_or_else(|| format!("Log group {log_group_name} does not exist"))?;
+        let arn = format!(
+            "arn:aws:logs:{}:{}:log-group:{}:log-stream:{}",
+            self.region, self.account_id, log_group_name, log_stream_name
+        );
+        if group.log_streams.contains_key(&log_stream_name) {
+            return Err(format!(
+                "Log stream {log_stream_name} already exists in {log_group_name}"
+            ));
+        }
+        group.log_streams.insert(
+            log_stream_name.clone(),
+            LogStream {
+                name: log_stream_name.clone(),
+                arn,
+                creation_time: Utc::now().timestamp_millis(),
+                first_event_timestamp: None,
+                last_event_timestamp: None,
+                last_ingestion_time: None,
+                upload_sequence_token: String::new(),
+                events: Vec::new(),
+            },
+        );
+
+        // Encode group + stream into the physical id so deletion can target both.
+        let physical_id = format!("{log_group_name}|{log_stream_name}");
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    fn delete_log_stream(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        if let Some((group_name, stream_name)) = physical_id.split_once('|') {
+            if let Some(group) = state.log_groups.get_mut(group_name) {
+                group.log_streams.remove(stream_name);
+            }
+        }
+        Ok(())
+    }
+
+    fn create_metric_filter(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let log_group_name = props
+            .get("LogGroupName")
+            .and_then(|v| v.as_str())
+            .map(parse_log_group_name)
+            .ok_or_else(|| "LogGroupName is required".to_string())?;
+        let filter_name = props
+            .get("FilterName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let filter_pattern = props
+            .get("FilterPattern")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let mut transformations: Vec<MetricTransformation> = Vec::new();
+        if let Some(arr) = props
+            .get("MetricTransformations")
+            .and_then(|v| v.as_array())
+        {
+            for t in arr {
+                let metric_name = t
+                    .get("MetricName")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let metric_namespace = t
+                    .get("MetricNamespace")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let metric_value = t
+                    .get("MetricValue")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("1")
+                    .to_string();
+                let default_value = t.get("DefaultValue").and_then(|v| v.as_f64());
+                transformations.push(MetricTransformation {
+                    metric_name,
+                    metric_namespace,
+                    metric_value,
+                    default_value,
+                });
+            }
+        }
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        if !state.log_groups.contains_key(&log_group_name) {
+            return Err(format!("Log group {log_group_name} does not exist"));
+        }
+        state
+            .metric_filters
+            .retain(|f| !(f.log_group_name == log_group_name && f.filter_name == filter_name));
+        state.metric_filters.push(MetricFilter {
+            filter_name: filter_name.clone(),
+            filter_pattern,
+            log_group_name: log_group_name.clone(),
+            metric_transformations: transformations,
+            creation_time: Utc::now().timestamp_millis(),
+        });
+
+        Ok(ProvisionResult::new(format!(
+            "{log_group_name}|{filter_name}"
+        )))
+    }
+
+    fn delete_metric_filter(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        if let Some((group_name, filter_name)) = physical_id.split_once('|') {
+            state
+                .metric_filters
+                .retain(|f| !(f.log_group_name == group_name && f.filter_name == filter_name));
+        }
+        Ok(())
+    }
+
+    fn create_subscription_filter(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let log_group_name = props
+            .get("LogGroupName")
+            .and_then(|v| v.as_str())
+            .map(parse_log_group_name)
+            .ok_or_else(|| "LogGroupName is required".to_string())?;
+        let filter_name = props
+            .get("FilterName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let filter_pattern = props
+            .get("FilterPattern")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let destination_arn = props
+            .get("DestinationArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "DestinationArn is required".to_string())?
+            .to_string();
+        let role_arn = props
+            .get("RoleArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let distribution = props
+            .get("Distribution")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ByLogStream")
+            .to_string();
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        let group = state
+            .log_groups
+            .get_mut(&log_group_name)
+            .ok_or_else(|| format!("Log group {log_group_name} does not exist"))?;
+        group
+            .subscription_filters
+            .retain(|f| f.filter_name != filter_name);
+        group.subscription_filters.push(SubscriptionFilter {
+            filter_name: filter_name.clone(),
+            log_group_name: log_group_name.clone(),
+            filter_pattern,
+            destination_arn,
+            role_arn,
+            distribution,
+            creation_time: Utc::now().timestamp_millis(),
+        });
+
+        Ok(ProvisionResult::new(format!(
+            "{log_group_name}|{filter_name}"
+        )))
+    }
+
+    fn delete_subscription_filter(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        if let Some((group_name, filter_name)) = physical_id.split_once('|') {
+            if let Some(group) = state.log_groups.get_mut(group_name) {
+                group
+                    .subscription_filters
+                    .retain(|f| f.filter_name != filter_name);
+            }
         }
         Ok(())
     }

--- a/crates/fakecloud-e2e/tests/cloudformation_logs.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_logs.rs
@@ -1,0 +1,128 @@
+//! CloudFormation provisioner for AWS::Logs::LogStream + MetricFilter + SubscriptionFilter.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Group": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {"LogGroupName": "cfn-logs-app"}
+    },
+    "Stream": {
+      "Type": "AWS::Logs::LogStream",
+      "Properties": {
+        "LogGroupName": {"Ref": "Group"},
+        "LogStreamName": "main"
+      }
+    },
+    "Errors": {
+      "Type": "AWS::Logs::MetricFilter",
+      "Properties": {
+        "LogGroupName": {"Ref": "Group"},
+        "FilterName": "error-count",
+        "FilterPattern": "ERROR",
+        "MetricTransformations": [
+          {"MetricName": "Errors", "MetricNamespace": "App", "MetricValue": "1"}
+        ]
+      }
+    },
+    "Subscription": {
+      "Type": "AWS::Logs::SubscriptionFilter",
+      "Properties": {
+        "LogGroupName": {"Ref": "Group"},
+        "FilterName": "kinesis-fanout",
+        "FilterPattern": "",
+        "DestinationArn": "arn:aws:kinesis:us-east-1:000000000000:stream/cfn-fanout"
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_logs_filters_and_streams() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let logs = server.logs_client().await;
+
+    cfn.create_stack()
+        .stack_name("logs-filters-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("logs-filters-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let streams = logs
+        .describe_log_streams()
+        .log_group_name("cfn-logs-app")
+        .send()
+        .await
+        .expect("describe_log_streams");
+    assert!(
+        streams
+            .log_streams()
+            .iter()
+            .any(|s| s.log_stream_name() == Some("main")),
+        "log stream should exist"
+    );
+
+    let metric_filters = logs
+        .describe_metric_filters()
+        .log_group_name("cfn-logs-app")
+        .send()
+        .await
+        .expect("describe_metric_filters");
+    let mf = metric_filters
+        .metric_filters()
+        .iter()
+        .find(|f| f.filter_name() == Some("error-count"))
+        .expect("metric filter present");
+    assert_eq!(mf.filter_pattern(), Some("ERROR"));
+
+    let sub_filters = logs
+        .describe_subscription_filters()
+        .log_group_name("cfn-logs-app")
+        .send()
+        .await
+        .expect("describe_subscription_filters");
+    let sf = sub_filters
+        .subscription_filters()
+        .iter()
+        .find(|f| f.filter_name() == Some("kinesis-fanout"))
+        .expect("subscription filter present");
+    assert_eq!(
+        sf.destination_arn(),
+        Some("arn:aws:kinesis:us-east-1:000000000000:stream/cfn-fanout")
+    );
+
+    cfn.delete_stack()
+        .stack_name("logs-filters-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after_groups = logs
+        .describe_log_groups()
+        .log_group_name_prefix("cfn-logs-app")
+        .send()
+        .await
+        .expect("describe_log_groups after");
+    assert!(
+        after_groups.log_groups().is_empty(),
+        "log group should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -6,6 +6,6 @@ pub mod transformer;
 
 pub use service::LogsService;
 pub use state::{
-    LogEvent, LogGroup, LogStream, LogsSnapshot, LogsState, SharedLogsState,
-    LOGS_SNAPSHOT_SCHEMA_VERSION,
+    LogEvent, LogGroup, LogStream, LogsSnapshot, LogsState, MetricFilter, MetricTransformation,
+    SharedLogsState, SubscriptionFilter, LOGS_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary

- New CloudFormation provisioners for \`AWS::Logs::LogStream\`, \`AWS::Logs::MetricFilter\`, and \`AWS::Logs::SubscriptionFilter\`.
- \`LogGroupName\` accepts either a plain name or an ARN — the latter being what \`{Ref: SomeLogGroup}\` returns — so an in-template stream/filter that points at a sibling log group works without any template gymnastics.
- Composite \`Ref\` values (\`{group}|{stream}\` for streams, \`{group}|{filter}\` for filters) so delete can target both the parent group and the child resource precisely.

Other \`AWS::Logs::*\` types (\`Destination\`, \`ResourcePolicy\`, \`QueryDefinition\`, \`Delivery\`, \`DeliveryDestination\`, \`DeliverySource\`) are tracked as separate follow-ups.

## Test plan

- [x] \`cargo build -p fakecloud-cloudformation\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_logs\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements BB29 by adding CloudFormation support for CloudWatch Logs sub-resources. Enables templates to create streams and filters within a group and cleanly delete them.

- **New Features**
  - Provisioners for `AWS::Logs::LogStream`, `AWS::Logs::MetricFilter`, and `AWS::Logs::SubscriptionFilter`.
  - `LogGroupName` accepts a plain name or a LogGroup ARN (from `Ref`) for easy in-template wiring.
  - Composite physical IDs for deletes: `{group}|{stream}` and `{group}|{filter}`.
  - Exports `MetricFilter`, `MetricTransformation`, and `SubscriptionFilter` from `fakecloud-logs`; adds e2e coverage in `cloudformation_logs.rs`.

<sup>Written for commit 1522ff0a95e27ac295a621e08acd973572e7fd4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

