### PR TITLE
feat(cloudformation): provision Events Connection + ApiDestination + Archive (BB28)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -11,7 +11,9 @@ use fakecloud_dynamodb::{
     SharedDynamoDbState,
 };
 use fakecloud_ecr::{Repository, SharedEcrState};
-use fakecloud_eventbridge::{EventRule, SharedEventBridgeState};
+use fakecloud_eventbridge::{
+    ApiDestination, Archive, Connection, EventRule, SharedEventBridgeState,
+};
 use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
 use fakecloud_kinesis::{build_stream_shards, KinesisConsumer, KinesisStream, SharedKinesisState};
 use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
@@ -96,6 +98,9 @@ impl ResourceProvisioner {
             "AWS::IAM::Policy" => self.create_iam_policy(resource),
             "AWS::S3::Bucket" => self.create_s3_bucket(resource),
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
+            "AWS::Events::Connection" => self.create_eventbridge_connection(resource),
+            "AWS::Events::ApiDestination" => self.create_eventbridge_api_destination(resource),
+            "AWS::Events::Archive" => self.create_eventbridge_archive(resource),
             "AWS::DynamoDB::Table" => self.create_dynamodb_table(resource),
             "AWS::Logs::LogGroup" => self.create_log_group(resource),
             "AWS::Logs::LogStream" => self.create_log_stream(resource),
@@ -148,6 +153,11 @@ impl ResourceProvisioner {
             "AWS::IAM::Policy" => self.delete_iam_policy(&resource.physical_id),
             "AWS::S3::Bucket" => self.delete_s3_bucket(&resource.physical_id),
             "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
+            "AWS::Events::Connection" => self.delete_eventbridge_connection(&resource.physical_id),
+            "AWS::Events::ApiDestination" => {
+                self.delete_eventbridge_api_destination(&resource.physical_id)
+            }
+            "AWS::Events::Archive" => self.delete_eventbridge_archive(&resource.physical_id),
             "AWS::DynamoDB::Table" => self.delete_dynamodb_table(&resource.physical_id),
             "AWS::Logs::LogGroup" => self.delete_log_group(&resource.physical_id),
             "AWS::Logs::LogStream" => self.delete_log_stream(&resource.physical_id),
@@ -672,6 +682,215 @@ impl ResourceProvisioner {
         if let Some(k) = key {
             state.rules.remove(&k);
         }
+        Ok(())
+    }
+
+    fn create_eventbridge_connection(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let authorization_type = props
+            .get("AuthorizationType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("API_KEY")
+            .to_string();
+        let auth_parameters = props
+            .get("AuthParameters")
+            .cloned()
+            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        if state.connections.contains_key(&name) {
+            return Err(format!("Connection {name} already exists"));
+        }
+        let now = Utc::now();
+        let arn = format!(
+            "arn:aws:events:{}:{}:connection/{}/{}",
+            state.region,
+            state.account_id,
+            name,
+            Uuid::new_v4().as_simple()
+        );
+        let secret_arn = format!(
+            "arn:aws:secretsmanager:{}:{}:secret:events!connection/{}-{}",
+            state.region,
+            state.account_id,
+            name,
+            Uuid::new_v4().as_simple()
+        );
+        let connection = Connection {
+            name: name.clone(),
+            arn: arn.clone(),
+            description,
+            authorization_type,
+            auth_parameters,
+            connection_state: "AUTHORIZED".to_string(),
+            secret_arn: secret_arn.clone(),
+            creation_time: now,
+            last_modified_time: now,
+            last_authorized_time: now,
+        };
+        state.connections.insert(name.clone(), connection);
+
+        Ok(ProvisionResult::new(name)
+            .with("Arn", arn)
+            .with("SecretArn", secret_arn))
+    }
+
+    fn delete_eventbridge_connection(&self, physical_id: &str) -> Result<(), String> {
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        state.connections.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_eventbridge_api_destination(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let connection_arn = props
+            .get("ConnectionArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "ConnectionArn is required".to_string())?
+            .to_string();
+        let invocation_endpoint = props
+            .get("InvocationEndpoint")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "InvocationEndpoint is required".to_string())?
+            .to_string();
+        let http_method = props
+            .get("HttpMethod")
+            .and_then(|v| v.as_str())
+            .unwrap_or("POST")
+            .to_string();
+        let invocation_rate_limit_per_second = props
+            .get("InvocationRateLimitPerSecond")
+            .and_then(|v| v.as_i64());
+
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        if state.api_destinations.contains_key(&name) {
+            return Err(format!("ApiDestination {name} already exists"));
+        }
+        let now = Utc::now();
+        let arn = format!(
+            "arn:aws:events:{}:{}:api-destination/{}/{}",
+            state.region,
+            state.account_id,
+            name,
+            Uuid::new_v4().as_simple()
+        );
+        state.api_destinations.insert(
+            name.clone(),
+            ApiDestination {
+                name: name.clone(),
+                arn: arn.clone(),
+                description,
+                connection_arn,
+                invocation_endpoint,
+                http_method,
+                invocation_rate_limit_per_second,
+                state: "ACTIVE".to_string(),
+                creation_time: now,
+                last_modified_time: now,
+            },
+        );
+
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_eventbridge_api_destination(&self, physical_id: &str) -> Result<(), String> {
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        state.api_destinations.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_eventbridge_archive(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("ArchiveName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let event_source_arn = props
+            .get("SourceArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "SourceArn is required".to_string())?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let event_pattern = props.get("EventPattern").map(|v| {
+            if v.is_string() {
+                v.as_str().unwrap_or("").to_string()
+            } else {
+                serde_json::to_string(v).unwrap_or_default()
+            }
+        });
+        let retention_days = props
+            .get("RetentionDays")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        if state.archives.contains_key(&name) {
+            return Err(format!("Archive {name} already exists"));
+        }
+        let arn = format!(
+            "arn:aws:events:{}:{}:archive/{}",
+            state.region, state.account_id, name
+        );
+        state.archives.insert(
+            name.clone(),
+            Archive {
+                name: name.clone(),
+                arn: arn.clone(),
+                event_source_arn,
+                description,
+                event_pattern,
+                retention_days,
+                state: "ENABLED".to_string(),
+                creation_time: Utc::now(),
+                event_count: 0,
+                size_bytes: 0,
+                events: Vec::new(),
+            },
+        );
+
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_eventbridge_archive(&self, physical_id: &str) -> Result<(), String> {
+        let mut eb_accounts = self.eventbridge_state.write();
+        let state = eb_accounts.get_or_create(&self.account_id);
+        state.archives.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_events.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_events.rs
@@ -1,0 +1,114 @@
+//! CloudFormation provisioner for AWS::Events::Connection + ApiDestination + Archive.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Conn": {
+      "Type": "AWS::Events::Connection",
+      "Properties": {
+        "Name": "cfn-conn",
+        "AuthorizationType": "API_KEY",
+        "AuthParameters": {
+          "ApiKeyAuthParameters": {
+            "ApiKeyName": "X-API-Key",
+            "ApiKeyValue": "secret-shhh"
+          }
+        }
+      }
+    },
+    "Dest": {
+      "Type": "AWS::Events::ApiDestination",
+      "Properties": {
+        "Name": "cfn-dest",
+        "ConnectionArn": {"Fn::GetAtt": ["Conn", "Arn"]},
+        "InvocationEndpoint": "https://example.com/webhook",
+        "HttpMethod": "POST",
+        "InvocationRateLimitPerSecond": 10
+      }
+    },
+    "Arch": {
+      "Type": "AWS::Events::Archive",
+      "Properties": {
+        "ArchiveName": "cfn-archive",
+        "SourceArn": "arn:aws:events:us-east-1:123456789012:event-bus/default",
+        "RetentionDays": 30
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_events_connection_apidest_archive() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let eb = server.eventbridge_client().await;
+
+    cfn.create_stack()
+        .stack_name("events-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("events-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let conn = eb
+        .describe_connection()
+        .name("cfn-conn")
+        .send()
+        .await
+        .expect("describe_connection");
+    assert_eq!(conn.name(), Some("cfn-conn"));
+    assert_eq!(
+        conn.authorization_type().map(|a| a.as_str()),
+        Some("API_KEY")
+    );
+
+    let dest = eb
+        .describe_api_destination()
+        .name("cfn-dest")
+        .send()
+        .await
+        .expect("describe_api_destination");
+    assert_eq!(dest.name(), Some("cfn-dest"));
+    assert_eq!(
+        dest.invocation_endpoint(),
+        Some("https://example.com/webhook")
+    );
+    assert_eq!(dest.invocation_rate_limit_per_second(), Some(10));
+
+    let archive = eb
+        .describe_archive()
+        .archive_name("cfn-archive")
+        .send()
+        .await
+        .expect("describe_archive");
+    assert_eq!(archive.archive_name(), Some("cfn-archive"));
+    assert_eq!(archive.retention_days(), Some(30));
+
+    cfn.delete_stack()
+        .stack_name("events-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = eb.describe_connection().name("cfn-conn").send().await;
+    assert!(
+        after.is_err(),
+        "connection should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-eventbridge/src/lib.rs
+++ b/crates/fakecloud-eventbridge/src/lib.rs
@@ -7,6 +7,6 @@ pub(crate) mod state;
 
 pub use service::EventBridgeService;
 pub use state::{
-    EventBridgeSnapshot, EventBridgeState, EventBus, EventRule, SharedEventBridgeState,
-    EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
+    ApiDestination, Archive, Connection, EventBridgeSnapshot, EventBridgeState, EventBus,
+    EventRule, SharedEventBridgeState, EVENTBRIDGE_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary

- New CloudFormation provisioners for \`AWS::Events::Connection\`, \`AWS::Events::ApiDestination\`, and \`AWS::Events::Archive\`.
- Connection stores authorization type + parameters and emits a synthetic SecretArn alongside the connection ARN; \`Fn::GetAtt\` exposes \`Arn\` and \`SecretArn\`.
- ApiDestination validates required \`ConnectionArn\` + \`InvocationEndpoint\` and defaults \`HttpMethod\` to POST. \`Fn::GetAtt\` exposes \`Arn\`.
- Archive accepts \`EventPattern\` as either a string or an inline object; RetentionDays + Description round-trip through \`DescribeArchive\`.

\`AWS::Events::EventBus\`, \`AWS::Events::EventBusPolicy\`, and \`AWS::Events::Endpoint\` remain as follow-ups; archives can already point at the default bus by ARN.

## Test plan

- [x] \`cargo build -p fakecloud-cloudformation\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_events\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFormation support for EventBridge `AWS::Events::Connection`, `AWS::Events::ApiDestination`, and `AWS::Events::Archive` with create/delete handlers and `Fn::GetAtt` attributes. Addresses Linear BB28; EventBus, EventBusPolicy, and Endpoint will follow.

- New Features
  - `AWS::Events::Connection`: stores authorization type and parameters, emits synthetic `SecretArn`; `Fn::GetAtt` exposes `Arn` and `SecretArn`.
  - `AWS::Events::ApiDestination`: requires `ConnectionArn` and `InvocationEndpoint`, defaults `HttpMethod` to `POST`; `Fn::GetAtt` exposes `Arn`.
  - `AWS::Events::Archive`: accepts `EventPattern` as string or object, supports `RetentionDays` and `Description`; `Fn::GetAtt` exposes `Arn`.

<sup>Written for commit e3d2311b03b335dfc48c940e18e6e00a47b8acfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

