### PR TITLE
feat(cloudformation): provision IAM User/Group/ManagedPolicy/AccessKey/InstanceProfile (BB30)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -14,7 +14,10 @@ use fakecloud_ecr::{Repository, SharedEcrState};
 use fakecloud_eventbridge::{
     ApiDestination, Archive, Connection, EventRule, SharedEventBridgeState,
 };
-use fakecloud_iam::{IamPolicy, IamRole, PolicyVersion, SharedIamState};
+use fakecloud_iam::{
+    IamAccessKey, IamGroup, IamInstanceProfile, IamPolicy, IamRole, IamUser, PolicyVersion,
+    SharedIamState, Tag,
+};
 use fakecloud_kinesis::{build_stream_shards, KinesisConsumer, KinesisStream, SharedKinesisState};
 use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
 use fakecloud_lambda::SharedLambdaState;
@@ -29,6 +32,22 @@ use fakecloud_ssm::{SharedSsmState, SsmParameter};
 
 use crate::state::StackResource;
 use crate::template::ResourceDefinition;
+
+/// Convert a CFN `Tags` property (`[{Key, Value}, ...]`) into the IAM
+/// crate's `Tag` Vec form. Silently skips malformed entries — the same
+/// tolerant behaviour the existing IAM service uses for runtime input.
+fn parse_iam_tags(value: Option<&serde_json::Value>) -> Vec<Tag> {
+    let Some(arr) = value.and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|t| {
+            let key = t.get("Key").and_then(|v| v.as_str())?.to_string();
+            let value = t.get("Value").and_then(|v| v.as_str())?.to_string();
+            Some(Tag { key, value })
+        })
+        .collect()
+}
 
 /// `LogGroupName` properties on Logs CFN resources may carry either a
 /// log-group ARN (when they come from `{Ref: SomeLogGroup}` in the same
@@ -96,6 +115,12 @@ impl ResourceProvisioner {
             "AWS::SSM::Parameter" => self.create_ssm_parameter(resource),
             "AWS::IAM::Role" => self.create_iam_role(resource),
             "AWS::IAM::Policy" => self.create_iam_policy(resource),
+            "AWS::IAM::User" => self.create_iam_user(resource),
+            "AWS::IAM::Group" => self.create_iam_group(resource),
+            "AWS::IAM::ManagedPolicy" => self.create_iam_managed_policy(resource),
+            "AWS::IAM::UserToGroupAddition" => self.create_iam_user_to_group_addition(resource),
+            "AWS::IAM::AccessKey" => self.create_iam_access_key(resource),
+            "AWS::IAM::InstanceProfile" => self.create_iam_instance_profile(resource),
             "AWS::S3::Bucket" => self.create_s3_bucket(resource),
             "AWS::Events::Rule" => self.create_eventbridge_rule(resource),
             "AWS::Events::Connection" => self.create_eventbridge_connection(resource),
@@ -151,6 +176,14 @@ impl ResourceProvisioner {
             "AWS::SSM::Parameter" => self.delete_ssm_parameter(&resource.physical_id),
             "AWS::IAM::Role" => self.delete_iam_role(&resource.physical_id),
             "AWS::IAM::Policy" => self.delete_iam_policy(&resource.physical_id),
+            "AWS::IAM::User" => self.delete_iam_user(&resource.physical_id),
+            "AWS::IAM::Group" => self.delete_iam_group(&resource.physical_id),
+            "AWS::IAM::ManagedPolicy" => self.delete_iam_managed_policy(&resource.physical_id),
+            "AWS::IAM::UserToGroupAddition" => {
+                self.delete_iam_user_to_group_addition(&resource.physical_id)
+            }
+            "AWS::IAM::AccessKey" => self.delete_iam_access_key(&resource.physical_id),
+            "AWS::IAM::InstanceProfile" => self.delete_iam_instance_profile(&resource.physical_id),
             "AWS::S3::Bucket" => self.delete_s3_bucket(&resource.physical_id),
             "AWS::Events::Rule" => self.delete_eventbridge_rule(&resource.physical_id),
             "AWS::Events::Connection" => self.delete_eventbridge_connection(&resource.physical_id),
@@ -555,6 +588,493 @@ impl ResourceProvisioner {
         let mut accounts = self.iam_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.policies.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_iam_user(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_name = props
+            .get("UserName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let path = props
+            .get("Path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
+        let permissions_boundary = props
+            .get("PermissionsBoundary")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let tags = parse_iam_tags(props.get("Tags"));
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.users.contains_key(&user_name) {
+            return Err(format!("User {user_name} already exists"));
+        }
+        let arn = format!(
+            "arn:aws:iam::{}:user{}{}",
+            state.account_id, path, user_name
+        );
+        let user_id = format!(
+            "AIDA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let user = IamUser {
+            user_name: user_name.clone(),
+            user_id: user_id.clone(),
+            arn: arn.clone(),
+            path,
+            created_at: Utc::now(),
+            tags,
+            permissions_boundary,
+        };
+        state.users.insert(user_name.clone(), user);
+
+        // Inline + managed policies declared inline on the user.
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            let inline = state
+                .user_inline_policies
+                .entry(user_name.clone())
+                .or_default();
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    inline.insert(n.to_string(), document);
+                }
+            }
+        }
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            let attached = state.user_policies.entry(user_name.clone()).or_default();
+            for a in arns {
+                if let Some(s) = a.as_str() {
+                    if !attached.contains(&s.to_string()) {
+                        attached.push(s.to_string());
+                    }
+                }
+            }
+        }
+        if let Some(groups) = props.get("Groups").and_then(|v| v.as_array()) {
+            for g in groups {
+                if let Some(g_name) = g.as_str() {
+                    if let Some(group) = state.groups.get_mut(g_name) {
+                        if !group.members.iter().any(|m| m == &user_name) {
+                            group.members.push(user_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ProvisionResult::new(user_name).with("Arn", arn))
+    }
+
+    fn delete_iam_user(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.users.remove(physical_id);
+        state.user_inline_policies.remove(physical_id);
+        state.user_policies.remove(physical_id);
+        state.access_keys.remove(physical_id);
+        for group in state.groups.values_mut() {
+            group.members.retain(|m| m != physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_iam_group(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let group_name = props
+            .get("GroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let path = props
+            .get("Path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.groups.contains_key(&group_name) {
+            return Err(format!("Group {group_name} already exists"));
+        }
+        let arn = format!(
+            "arn:aws:iam::{}:group{}{}",
+            state.account_id, path, group_name
+        );
+        let group_id = format!(
+            "AGPA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let mut inline_policies: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    inline_policies.insert(n.to_string(), document);
+                }
+            }
+        }
+        let mut attached_policies: Vec<String> = Vec::new();
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            for a in arns {
+                if let Some(s) = a.as_str() {
+                    attached_policies.push(s.to_string());
+                }
+            }
+        }
+        state.groups.insert(
+            group_name.clone(),
+            IamGroup {
+                group_name: group_name.clone(),
+                group_id,
+                arn: arn.clone(),
+                path,
+                created_at: Utc::now(),
+                members: Vec::new(),
+                inline_policies,
+                attached_policies,
+            },
+        );
+
+        Ok(ProvisionResult::new(group_name).with("Arn", arn))
+    }
+
+    fn delete_iam_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_iam_managed_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // Same shape as AWS::IAM::Policy minus the inline-attach knobs;
+        // ManagedPolicy is a standalone policy, attached separately.
+        let props = &resource.properties;
+        let policy_name = props
+            .get("ManagedPolicyName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let policy_document = props
+            .get("PolicyDocument")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .unwrap_or_default();
+        let path = props
+            .get("Path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = format!(
+            "arn:aws:iam::{}:policy{}{}",
+            state.account_id,
+            if path == "/" { "/" } else { path.as_str() },
+            policy_name
+        );
+        if state.policies.contains_key(&arn) {
+            return Err(format!("Managed policy {policy_name} already exists"));
+        }
+        let policy_id = format!(
+            "ANPA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let now = Utc::now();
+        state.policies.insert(
+            arn.clone(),
+            IamPolicy {
+                policy_name,
+                policy_id,
+                arn: arn.clone(),
+                path,
+                description,
+                created_at: now,
+                tags: Vec::new(),
+                default_version_id: "v1".to_string(),
+                versions: vec![PolicyVersion {
+                    version_id: "v1".to_string(),
+                    document: policy_document,
+                    is_default: true,
+                    created_at: now,
+                }],
+                next_version_num: 2,
+                attachment_count: 0,
+            },
+        );
+
+        // Attach to declared users/groups/roles.
+        if let Some(users) = props.get("Users").and_then(|v| v.as_array()) {
+            for u in users {
+                if let Some(name) = u.as_str() {
+                    let attached = state.user_policies.entry(name.to_string()).or_default();
+                    if !attached.contains(&arn) {
+                        attached.push(arn.clone());
+                    }
+                }
+            }
+        }
+        if let Some(groups) = props.get("Groups").and_then(|v| v.as_array()) {
+            for g in groups {
+                if let Some(name) = g.as_str() {
+                    if let Some(group) = state.groups.get_mut(name) {
+                        if !group.attached_policies.contains(&arn) {
+                            group.attached_policies.push(arn.clone());
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(roles) = props.get("Roles").and_then(|v| v.as_array()) {
+            for r in roles {
+                if let Some(name) = r.as_str() {
+                    let attached = state.role_policies.entry(name.to_string()).or_default();
+                    if !attached.contains(&arn) {
+                        attached.push(arn.clone());
+                    }
+                }
+            }
+        }
+
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
+    }
+
+    fn delete_iam_managed_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.policies.remove(physical_id);
+        for arns in state.user_policies.values_mut() {
+            arns.retain(|a| a != physical_id);
+        }
+        for arns in state.role_policies.values_mut() {
+            arns.retain(|a| a != physical_id);
+        }
+        for group in state.groups.values_mut() {
+            group.attached_policies.retain(|a| a != physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_iam_user_to_group_addition(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let group_name = props
+            .get("GroupName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "GroupName is required".to_string())?
+            .to_string();
+        let users: Vec<String> = props
+            .get("Users")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|u| u.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let group = state
+            .groups
+            .get_mut(&group_name)
+            .ok_or_else(|| format!("Group {group_name} does not exist"))?;
+        for u in &users {
+            if !group.members.iter().any(|m| m == u) {
+                group.members.push(u.clone());
+            }
+        }
+
+        // Encode group + users so delete can revert exactly this addition.
+        let physical_id = format!("{group_name}|{}", users.join(","));
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    fn delete_iam_user_to_group_addition(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some((group_name, users)) = physical_id.split_once('|') {
+            if let Some(group) = state.groups.get_mut(group_name) {
+                let to_remove: Vec<&str> = users.split(',').filter(|s| !s.is_empty()).collect();
+                group.members.retain(|m| !to_remove.iter().any(|u| u == m));
+            }
+        }
+        Ok(())
+    }
+
+    fn create_iam_access_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_name = props
+            .get("UserName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "UserName is required".to_string())?
+            .to_string();
+        let status = props
+            .get("Status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Active")
+            .to_string();
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.users.contains_key(&user_name) {
+            return Err(format!("User {user_name} does not exist"));
+        }
+        let access_key_id = format!(
+            "AKIA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        let secret_access_key: String = Uuid::new_v4()
+            .to_string()
+            .replace('-', "")
+            .chars()
+            .take(40)
+            .collect();
+        state
+            .access_keys
+            .entry(user_name.clone())
+            .or_default()
+            .push(IamAccessKey {
+                access_key_id: access_key_id.clone(),
+                secret_access_key: secret_access_key.clone(),
+                user_name: user_name.clone(),
+                status,
+                created_at: Utc::now(),
+            });
+
+        Ok(ProvisionResult::new(access_key_id.clone()).with("SecretAccessKey", secret_access_key))
+    }
+
+    fn delete_iam_access_key(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        for keys in state.access_keys.values_mut() {
+            keys.retain(|k| k.access_key_id != physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_iam_instance_profile(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("InstanceProfileName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let path = props
+            .get("Path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
+        // Roles[] entries can be plain role names or `Ref`-resolved role
+        // ARNs (which the IAM Role provisioner emits as physical_id);
+        // extract the trailing name segment so DescribeInstanceProfile
+        // round-trips a name list.
+        let roles: Vec<String> = props
+            .get("Roles")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|r| r.as_str())
+                    .map(|s| {
+                        if let Some(rest) = s.strip_prefix("arn:aws:iam::") {
+                            rest.split(":role/")
+                                .nth(1)
+                                .map(|name| name.to_string())
+                                .unwrap_or_else(|| s.to_string())
+                        } else {
+                            s.to_string()
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.instance_profiles.contains_key(&name) {
+            return Err(format!("InstanceProfile {name} already exists"));
+        }
+        // Force a retry pass when role refs haven't been resolved yet: a
+        // logical-id placeholder won't match any real role, and silently
+        // storing it would leave DescribeInstanceProfile returning an
+        // empty Roles array.
+        for role_name in &roles {
+            if !state.roles.contains_key(role_name) {
+                return Err(format!(
+                    "InstanceProfile {name}: referenced role {role_name} not yet provisioned"
+                ));
+            }
+        }
+        let arn = format!(
+            "arn:aws:iam::{}:instance-profile{}{}",
+            state.account_id, path, name
+        );
+        let id = format!(
+            "AIPA{}",
+            &Uuid::new_v4().to_string().replace('-', "").to_uppercase()[..16]
+        );
+        state.instance_profiles.insert(
+            name.clone(),
+            IamInstanceProfile {
+                instance_profile_name: name.clone(),
+                instance_profile_id: id,
+                arn: arn.clone(),
+                path,
+                created_at: Utc::now(),
+                roles,
+                tags: Vec::new(),
+            },
+        );
+
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_iam_instance_profile(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.instance_profiles.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_iam.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_iam.rs
@@ -1,0 +1,154 @@
+//! CloudFormation provisioner for IAM User/Group/ManagedPolicy/AccessKey/InstanceProfile.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Devs": {
+      "Type": "AWS::IAM::Group",
+      "Properties": {"GroupName": "cfn-devs"}
+    },
+    "Alice": {
+      "Type": "AWS::IAM::User",
+      "Properties": {
+        "UserName": "cfn-alice",
+        "Tags": [{"Key": "team", "Value": "platform"}]
+      }
+    },
+    "AliceKey": {
+      "Type": "AWS::IAM::AccessKey",
+      "Properties": {"UserName": {"Ref": "Alice"}}
+    },
+    "Membership": {
+      "Type": "AWS::IAM::UserToGroupAddition",
+      "Properties": {
+        "GroupName": {"Ref": "Devs"},
+        "Users": [{"Ref": "Alice"}]
+      }
+    },
+    "ReadOnly": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": "cfn-readonly",
+        "Description": "read-only policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}]
+        },
+        "Users": [{"Ref": "Alice"}]
+      }
+    },
+    "ServerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": "cfn-ec2-role",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}]
+        }
+      }
+    },
+    "ServerProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "InstanceProfileName": "cfn-ec2-profile",
+        "Roles": [{"Ref": "ServerRole"}]
+      }
+    }
+  },
+  "Outputs": {
+    "AliceArn": {"Value": {"Fn::GetAtt": ["Alice", "Arn"]}},
+    "ProfileArn": {"Value": {"Fn::GetAtt": ["ServerProfile", "Arn"]}},
+    "PolicyArn": {"Value": {"Ref": "ReadOnly"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_iam_user_group_policy_etc() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let iam = server.iam_client().await;
+
+    cfn.create_stack()
+        .stack_name("iam-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityNamedIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("iam-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let user = iam
+        .get_user()
+        .user_name("cfn-alice")
+        .send()
+        .await
+        .expect("get_user");
+    let u = user.user().expect("user");
+    assert_eq!(u.user_name(), "cfn-alice");
+
+    let groups = iam
+        .list_groups_for_user()
+        .user_name("cfn-alice")
+        .send()
+        .await
+        .expect("list_groups_for_user");
+    assert!(
+        groups.groups().iter().any(|g| g.group_name() == "cfn-devs"),
+        "alice should be in cfn-devs"
+    );
+
+    let attached = iam
+        .list_attached_user_policies()
+        .user_name("cfn-alice")
+        .send()
+        .await
+        .expect("list_attached_user_policies");
+    assert!(
+        attached
+            .attached_policies()
+            .iter()
+            .any(|p| p.policy_name() == Some("cfn-readonly")),
+        "managed policy should be attached to alice"
+    );
+
+    let keys = iam
+        .list_access_keys()
+        .user_name("cfn-alice")
+        .send()
+        .await
+        .expect("list_access_keys");
+    assert_eq!(keys.access_key_metadata().len(), 1);
+
+    let profile = iam
+        .get_instance_profile()
+        .instance_profile_name("cfn-ec2-profile")
+        .send()
+        .await
+        .expect("get_instance_profile");
+    let p = profile.instance_profile().expect("profile");
+    assert_eq!(p.instance_profile_name(), "cfn-ec2-profile");
+    assert_eq!(p.roles().len(), 1);
+
+    cfn.delete_stack()
+        .stack_name("iam-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after_user = iam.get_user().user_name("cfn-alice").send().await;
+    assert!(after_user.is_err(), "user should be gone after delete");
+}

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -12,6 +12,6 @@ pub mod sts_service;
 pub mod xml_responses;
 
 pub use state::{
-    IamAccessKey, IamPolicy, IamRole, IamSnapshot, IamState, IamUser, PolicyVersion,
-    SharedIamState, IAM_SNAPSHOT_SCHEMA_VERSION,
+    IamAccessKey, IamGroup, IamInstanceProfile, IamPolicy, IamRole, IamSnapshot, IamState, IamUser,
+    PolicyVersion, SharedIamState, Tag, IAM_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary

- New CloudFormation provisioners for six core IAM resource types beyond Role + Policy: \`User\`, \`Group\`, \`ManagedPolicy\`, \`UserToGroupAddition\`, \`AccessKey\`, \`InstanceProfile\`.
- User and Group provisioners support inline Policies, ManagedPolicyArns attachments, and the user-side Groups membership shorthand in one shot.
- ManagedPolicy attaches inline to \`Users\`/\`Groups\`/\`Roles\` to mirror real AWS behaviour.
- AccessKey emits a synthetic AKIA access key + secret; \`Fn::GetAtt SecretAccessKey\` returns the secret as on real AWS.
- InstanceProfile parses role names from Ref-resolved role ARNs and forces a retry pass when referenced roles haven't been provisioned yet, matching the multi-pass dependency resolver.

OIDCProvider, SAMLProvider, ServiceLinkedRole, VirtualMFADevice are tracked as separate follow-ups.

## Test plan

- [x] \`cargo build -p fakecloud-cloudformation\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_iam\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for six core IAM resources to mirror AWS behavior and unblock stacks using these types. Implements BB30.

- **New Features**
  - `AWS::IAM::User` — supports Path, PermissionsBoundary, Tags, inline `Policies`, `ManagedPolicyArns`, and `Groups` membership; returns Arn.
  - `AWS::IAM::Group` — supports inline policies and `ManagedPolicyArns`; tracks members.
  - `AWS::IAM::ManagedPolicy` — creates standalone policy (v1 default) and attaches to `Users`/`Groups`/`Roles` listed; clean detach on delete.
  - `AWS::IAM::UserToGroupAddition` — adds users to a group; physical ID encodes changes so delete precisely reverts them.
  - `AWS::IAM::AccessKey` — generates AKIA-style key and secret; `Fn::GetAtt: SecretAccessKey` returns the secret.
  - `AWS::IAM::InstanceProfile` — parses role names from `Ref`-resolved ARNs and retries until roles exist; returns Arn.

<sup>Written for commit e477e7c5776d42ca1ef9fd2b7068a128a6aeb140. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

