### PR TITLE
feat(cloudformation): provision Organizations Org + OU + Policy + ResourcePolicy (BB31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,6 +2702,7 @@ dependencies = [
  "fakecloud-kms",
  "fakecloud-lambda",
  "fakecloud-logs",
+ "fakecloud-organizations",
  "fakecloud-persistence",
  "fakecloud-s3",
  "fakecloud-secretsmanager",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -26,6 +26,7 @@ fakecloud-kms = { workspace = true }
 fakecloud-ecr = { workspace = true }
 fakecloud-cloudwatch = { workspace = true }
 fakecloud-elbv2 = { workspace = true }
+fakecloud-organizations = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -742,6 +742,7 @@ mod tests {
             ecr: shared::<EcrState>(),
             cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
+            organizations: Arc::new(RwLock::new(None)),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -28,6 +28,10 @@ use fakecloud_lambda::SharedLambdaState;
 use fakecloud_logs::{
     LogStream, MetricFilter, MetricTransformation, SharedLogsState, SubscriptionFilter,
 };
+use fakecloud_organizations::{
+    OrganizationState, OrganizationalUnit, Policy as OrgPolicy, SharedOrganizationsState,
+    POLICY_TYPE_SCP,
+};
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
@@ -269,6 +273,7 @@ pub struct ResourceProvisioner {
     pub ecr_state: SharedEcrState,
     pub cloudwatch_state: SharedCloudWatchState,
     pub elbv2_state: SharedElbv2State,
+    pub organizations_state: SharedOrganizationsState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -316,6 +321,12 @@ impl ResourceProvisioner {
             "AWS::ElasticLoadBalancingV2::Listener" => self.create_elbv2_listener(resource),
             "AWS::ElasticLoadBalancingV2::ListenerRule" => {
                 self.create_elbv2_listener_rule(resource)
+            }
+            "AWS::Organizations::Organization" => self.create_organization(resource),
+            "AWS::Organizations::OrganizationalUnit" => self.create_organization_unit(resource),
+            "AWS::Organizations::Policy" => self.create_organization_policy(resource),
+            "AWS::Organizations::ResourcePolicy" => {
+                self.create_organization_resource_policy(resource)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
@@ -399,6 +410,14 @@ impl ResourceProvisioner {
             }
             "AWS::ElasticLoadBalancingV2::ListenerRule" => {
                 self.delete_elbv2_listener_rule(&resource.physical_id)
+            }
+            "AWS::Organizations::Organization" => self.delete_organization(&resource.physical_id),
+            "AWS::Organizations::OrganizationalUnit" => {
+                self.delete_organization_unit(&resource.physical_id)
+            }
+            "AWS::Organizations::Policy" => self.delete_organization_policy(&resource.physical_id),
+            "AWS::Organizations::ResourcePolicy" => {
+                self.delete_organization_resource_policy(&resource.physical_id)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
@@ -3052,6 +3071,234 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    // --- Organizations ---
+
+    fn create_organization(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let feature_set = props
+            .get("FeatureSet")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ALL")
+            .to_string();
+
+        let mut org = self.organizations_state.write();
+        if org.is_some() {
+            return Err("Organization already exists; only one per fakecloud process".to_string());
+        }
+        let mut state = OrganizationState::bootstrap(&self.account_id);
+        state.feature_set = feature_set;
+        let org_id = state.org_id.clone();
+        let org_arn = state.org_arn.clone();
+        let mgmt_arn = state.management_account_arn.clone();
+        let root_id = state.root_id.clone();
+        *org = Some(state);
+
+        Ok(ProvisionResult::new(org_id.clone())
+            .with("Id", org_id)
+            .with("Arn", org_arn)
+            .with("ManagementAccountArn", mgmt_arn)
+            .with("RootId", root_id))
+    }
+
+    fn delete_organization(&self, _physical_id: &str) -> Result<(), String> {
+        let mut org = self.organizations_state.write();
+        *org = None;
+        Ok(())
+    }
+
+    fn create_organization_unit(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let parent_id = props
+            .get("ParentId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "ParentId is required".to_string())?
+            .to_string();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        // Accept root id, OU id, or `Ref`-resolved logical id (we map to root).
+        let resolved_parent_id = if parent_id == org.root_id || org.ous.contains_key(&parent_id) {
+            parent_id
+        } else {
+            return Err(format!("Parent {parent_id} does not exist"));
+        };
+        let id_suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(8)
+            .collect();
+        let id = format!("ou-{}-{}", &org.root_id[2..], id_suffix);
+        let arn = format!(
+            "arn:aws:organizations::{}:ou/{}/{}",
+            org.management_account_id, org.org_id, id
+        );
+        org.ous.insert(
+            id.clone(),
+            OrganizationalUnit {
+                id: id.clone(),
+                arn: arn.clone(),
+                name: name.clone(),
+                parent_id: resolved_parent_id,
+            },
+        );
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
+    fn delete_organization_unit(&self, physical_id: &str) -> Result<(), String> {
+        let mut org_lock = self.organizations_state.write();
+        if let Some(org) = org_lock.as_mut() {
+            org.ous.remove(physical_id);
+            org.attachments.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_organization_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let policy_type = props
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .unwrap_or(POLICY_TYPE_SCP)
+            .to_string();
+        let content = props
+            .get("Content")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .unwrap_or_default();
+        let target_ids: Vec<String> = props
+            .get("TargetIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        let id_suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(8)
+            .collect();
+        let id = format!("p-{}", id_suffix);
+        let arn = format!(
+            "arn:aws:organizations::{}:policy/{}/{}/{}",
+            org.management_account_id,
+            org.org_id,
+            policy_type.to_lowercase(),
+            id
+        );
+        org.policies.insert(
+            id.clone(),
+            OrgPolicy {
+                id: id.clone(),
+                arn: arn.clone(),
+                name: name.clone(),
+                description,
+                policy_type,
+                aws_managed: false,
+                content,
+            },
+        );
+        for target in target_ids {
+            org.attachments
+                .entry(target)
+                .or_default()
+                .insert(id.clone());
+        }
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
+    fn delete_organization_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut org_lock = self.organizations_state.write();
+        if let Some(org) = org_lock.as_mut() {
+            org.policies.remove(physical_id);
+            for attachments in org.attachments.values_mut() {
+                attachments.remove(physical_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn create_organization_resource_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let content = props
+            .get("Content")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .ok_or_else(|| "Content is required".to_string())?;
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        org.resource_policy = Some(content);
+        let arn = format!(
+            "arn:aws:organizations::{}:resourcepolicy/{}/rp",
+            org.management_account_id, org.org_id
+        );
+        Ok(ProvisionResult::new(arn.clone()).with("Arn", arn))
+    }
+
+    fn delete_organization_resource_policy(&self, _physical_id: &str) -> Result<(), String> {
+        let mut org_lock = self.organizations_state.write();
+        if let Some(org) = org_lock.as_mut() {
+            org.resource_policy = None;
+        }
+        Ok(())
+    }
+
     fn delete_log_group(&self, physical_id: &str) -> Result<(), String> {
         let mut logs_accounts = self.logs_state.write();
         let state = logs_accounts.default_mut();
@@ -3450,6 +3697,7 @@ mod tests {
             )),
             cloudwatch_state: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2_state: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
+            organizations_state: Arc::new(RwLock::new(None)),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -130,6 +130,7 @@ pub struct CloudFormationDeps {
     pub ecr: fakecloud_ecr::SharedEcrState,
     pub cloudwatch: fakecloud_cloudwatch::SharedCloudWatchState,
     pub elbv2: fakecloud_elbv2::SharedElbv2State,
+    pub organizations: fakecloud_organizations::SharedOrganizationsState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -195,6 +196,7 @@ impl CloudFormationService {
             ecr_state: self.deps.ecr.clone(),
             cloudwatch_state: self.deps.cloudwatch.clone(),
             elbv2_state: self.deps.elbv2.clone(),
+            organizations_state: self.deps.organizations.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1279,6 +1281,7 @@ mod tests {
             )),
             cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
+            organizations: Arc::new(RwLock::new(None)),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_organizations.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_organizations.rs
@@ -1,0 +1,142 @@
+//! CloudFormation provisioner for AWS::Organizations::Organization + OU + Policy + ResourcePolicy.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Org": {
+      "Type": "AWS::Organizations::Organization",
+      "Properties": {"FeatureSet": "ALL"}
+    },
+    "Sandbox": {
+      "Type": "AWS::Organizations::OrganizationalUnit",
+      "Properties": {
+        "Name": "Sandbox",
+        "ParentId": {"Fn::GetAtt": ["Org", "RootId"]}
+      }
+    },
+    "DenyRoot": {
+      "Type": "AWS::Organizations::Policy",
+      "Properties": {
+        "Name": "DenyRootUser",
+        "Description": "Block root sign-in",
+        "Type": "SERVICE_CONTROL_POLICY",
+        "Content": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*", "Condition": {"StringLike": {"aws:PrincipalArn": "*:root"}}}]
+        }
+      }
+    },
+    "OrgPolicy": {
+      "Type": "AWS::Organizations::ResourcePolicy",
+      "Properties": {
+        "Content": {
+          "Version": "2012-10-17",
+          "Statement": [{"Sid": "Allow", "Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "organizations:DescribeOrganization", "Resource": "*"}]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "OrgId": {"Value": {"Ref": "Org"}},
+    "OrgArn": {"Value": {"Fn::GetAtt": ["Org", "Arn"]}},
+    "RootId": {"Value": {"Fn::GetAtt": ["Org", "RootId"]}},
+    "OuId": {"Value": {"Ref": "Sandbox"}},
+    "PolicyId": {"Value": {"Ref": "DenyRoot"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_organization_ou_policy_resource_policy() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let orgs = aws_sdk_organizations::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("orgs-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("orgs-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut org_id = None;
+    let mut ou_id = None;
+    let mut policy_id = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("OrgId") => org_id = o.output_value().map(|s| s.to_string()),
+            Some("OuId") => ou_id = o.output_value().map(|s| s.to_string()),
+            Some("PolicyId") => policy_id = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let org_id = org_id.expect("OrgId");
+    let ou_id = ou_id.expect("OuId");
+    let policy_id = policy_id.expect("PolicyId");
+    assert!(org_id.starts_with("o-"));
+    assert!(ou_id.starts_with("ou-"));
+    assert!(policy_id.starts_with("p-"));
+
+    let described_org = orgs
+        .describe_organization()
+        .send()
+        .await
+        .expect("describe_organization");
+    let org = described_org.organization().expect("organization");
+    assert_eq!(org.id(), Some(org_id.as_str()));
+
+    let described_ou = orgs
+        .describe_organizational_unit()
+        .organizational_unit_id(&ou_id)
+        .send()
+        .await
+        .expect("describe_organizational_unit");
+    let ou = described_ou.organizational_unit().expect("ou");
+    assert_eq!(ou.name(), Some("Sandbox"));
+
+    let described_policy = orgs
+        .describe_policy()
+        .policy_id(&policy_id)
+        .send()
+        .await
+        .expect("describe_policy");
+    let p = described_policy.policy().expect("policy");
+    assert_eq!(
+        p.policy_summary().and_then(|s| s.name()),
+        Some("DenyRootUser")
+    );
+
+    let described_resource_policy = orgs
+        .describe_resource_policy()
+        .send()
+        .await
+        .expect("describe_resource_policy");
+    assert!(described_resource_policy.resource_policy().is_some());
+
+    cfn.delete_stack()
+        .stack_name("orgs-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = orgs.describe_organization().send().await;
+    assert!(
+        after.is_err(),
+        "organization should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-organizations/src/lib.rs
+++ b/crates/fakecloud-organizations/src/lib.rs
@@ -3,4 +3,7 @@ pub(crate) mod service;
 pub(crate) mod state;
 
 pub use service::OrganizationsService;
-pub use state::{SharedOrganizationsState, FEATURE_SET_CONSOLIDATED_BILLING};
+pub use state::{
+    OrganizationState, OrganizationalUnit, Policy, SharedOrganizationsState, FEATURE_SET_ALL,
+    FEATURE_SET_CONSOLIDATED_BILLING, POLICY_TYPE_SCP,
+};

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -728,6 +728,7 @@ async fn main() {
             ecr: ecr_state.clone(),
             cloudwatch: cloudwatch_state.clone(),
             elbv2: elbv2_state.clone(),
+            organizations: organizations_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

- New CloudFormation provisioners for \`AWS::Organizations::Organization\`, \`AWS::Organizations::OrganizationalUnit\`, \`AWS::Organizations::Policy\`, and \`AWS::Organizations::ResourcePolicy\`.
- Organization bootstraps the singleton org with the calling account as management account; \`Fn::GetAtt\` exposes \`Id\`, \`Arn\`, \`ManagementAccountArn\`, and \`RootId\`.
- OU validates \`ParentId\` against the root or an existing OU and assigns a deterministic \`ou-{root}-{rand}\` id.
- Policy provisioner attaches to declared \`TargetIds\` at create time and accepts \`Type=SERVICE_CONTROL_POLICY\` (default), tag, backup, etc.
- ResourcePolicy stores the org-level doc; deletion clears it.

\`AWS::Organizations::Account\` is tracked separately — account creation is asynchronous on real AWS (\`IN_PROGRESS -> SUCCEEDED\`) and warrants its own batch.

## Test plan

- [x] \`cargo build -p fakecloud-cloudformation\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p fakecloud-e2e --test cloudformation_organizations\`
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for AWS Organizations (Organization, OU, Policy, ResourcePolicy) to let stacks create and manage org topologies. Implements BB31.

- **New Features**
  - Organization: bootstraps a singleton org with the caller as management; FeatureSet defaults to ALL; GetAtt exposes Id, Arn, ManagementAccountArn, RootId.
  - OrganizationalUnit: validates ParentId (root or existing OU) and generates ids like ou-{root}-{rand}.
  - Policy: creates policy (Type defaults to SERVICE_CONTROL_POLICY) from Content/Name/Description and attaches to TargetIds at create.
  - ResourcePolicy: stores the org-level policy; deletion clears it.
  - Delete handlers clean up OUs, policies, attachments, and the resource policy.

- **Dependencies**
  - Added `fakecloud-organizations` to `fakecloud-cloudformation` and wired `organizations` state through `CloudFormationDeps` and `fakecloud-server`.

<sup>Written for commit cc046726e7effbb93326959de1022b8a25466548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

