### PR TITLE
feat(cloudformation): provision Cognito UserPool + UserPoolClient + UserPoolDomain (BB15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "chrono",
  "fakecloud-aws",
  "fakecloud-cloudwatch",
+ "fakecloud-cognito",
  "fakecloud-core",
  "fakecloud-dynamodb",
  "fakecloud-ecr",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -27,6 +27,7 @@ fakecloud-ecr = { workspace = true }
 fakecloud-cloudwatch = { workspace = true }
 fakecloud-elbv2 = { workspace = true }
 fakecloud-organizations = { workspace = true }
+fakecloud-cognito = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -743,6 +743,7 @@ mod tests {
             cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations: Arc::new(RwLock::new(None)),
+            cognito: shared::<fakecloud_cognito::CognitoState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -5,6 +5,11 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use fakecloud_cloudwatch::{AlarmState, MetricAlarm, SharedCloudWatchState};
+use fakecloud_cognito::{
+    default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CustomDomainConfig,
+    EmailConfiguration, PasswordPolicy, PoolPolicies, RecoveryOption, SchemaAttribute,
+    SharedCognitoState, SignInPolicy, SmsConfiguration, UserPool, UserPoolClient, UserPoolDomain,
+};
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_dynamodb::{
     AttributeDefinition, DynamoTable, KeySchemaElement, OnDemandThroughput, ProvisionedThroughput,
@@ -274,6 +279,7 @@ pub struct ResourceProvisioner {
     pub cloudwatch_state: SharedCloudWatchState,
     pub elbv2_state: SharedElbv2State,
     pub organizations_state: SharedOrganizationsState,
+    pub cognito_state: SharedCognitoState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -328,6 +334,9 @@ impl ResourceProvisioner {
             "AWS::Organizations::ResourcePolicy" => {
                 self.create_organization_resource_policy(resource)
             }
+            "AWS::Cognito::UserPool" => self.create_cognito_user_pool(resource),
+            "AWS::Cognito::UserPoolClient" => self.create_cognito_user_pool_client(resource),
+            "AWS::Cognito::UserPoolDomain" => self.create_cognito_user_pool_domain(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -418,6 +427,13 @@ impl ResourceProvisioner {
             "AWS::Organizations::Policy" => self.delete_organization_policy(&resource.physical_id),
             "AWS::Organizations::ResourcePolicy" => {
                 self.delete_organization_resource_policy(&resource.physical_id)
+            }
+            "AWS::Cognito::UserPool" => self.delete_cognito_user_pool(&resource.physical_id),
+            "AWS::Cognito::UserPoolClient" => {
+                self.delete_cognito_user_pool_client(&resource.physical_id)
+            }
+            "AWS::Cognito::UserPoolDomain" => {
+                self.delete_cognito_user_pool_domain(&resource.physical_id)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
@@ -3633,6 +3649,483 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- Cognito ---
+
+    fn create_cognito_user_pool(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let pool_name = props
+            .get("PoolName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+
+        let pool_id = format!(
+            "{}_{}",
+            self.region,
+            Uuid::new_v4()
+                .simple()
+                .to_string()
+                .chars()
+                .take(9)
+                .collect::<String>()
+        );
+        let arn = format!(
+            "arn:aws:cognito-idp:{}:{}:userpool/{}",
+            self.region, self.account_id, pool_id
+        );
+        let now = Utc::now();
+
+        let password_policy = parse_cognito_password_policy(props.get("Policies"));
+        let auto_verified = parse_cognito_string_array(props.get("AutoVerifiedAttributes"));
+        let username_attributes = props
+            .get("UsernameAttributes")
+            .and_then(|v| v.as_array())
+            .map(|_| parse_cognito_string_array(props.get("UsernameAttributes")));
+        let alias_attributes = props
+            .get("AliasAttributes")
+            .and_then(|v| v.as_array())
+            .map(|_| parse_cognito_string_array(props.get("AliasAttributes")));
+        let mut schema_attributes = default_schema_attributes();
+        if let Some(arr) = props.get("Schema").and_then(|v| v.as_array()) {
+            for attr in arr {
+                if let Some(parsed) = parse_cognito_schema_attribute(attr) {
+                    if !schema_attributes.iter().any(|a| a.name == parsed.name) {
+                        schema_attributes.push(parsed);
+                    }
+                }
+            }
+        }
+        let mfa_configuration = props
+            .get("MfaConfiguration")
+            .and_then(|v| v.as_str())
+            .unwrap_or("OFF")
+            .to_string();
+        let user_pool_tier = props
+            .get("UserPoolTier")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ESSENTIALS")
+            .to_string();
+        let deletion_protection = props
+            .get("DeletionProtection")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let user_pool_tags = parse_cognito_tags(props.get("UserPoolTags"));
+        let email_configuration =
+            parse_cognito_email_configuration(props.get("EmailConfiguration"));
+        let sms_configuration = parse_cognito_sms_configuration(props.get("SmsConfiguration"));
+        let admin_create_user_config =
+            parse_cognito_admin_create_user_config(props.get("AdminCreateUserConfig"));
+        let account_recovery_setting =
+            parse_cognito_account_recovery(props.get("AccountRecoverySetting"));
+
+        let signing_kid = format!("{pool_id}-key-1");
+        let pool = UserPool {
+            id: pool_id.clone(),
+            name: pool_name,
+            arn: arn.clone(),
+            status: "ACTIVE".to_string(),
+            creation_date: now,
+            last_modified_date: now,
+            policies: PoolPolicies {
+                password_policy,
+                sign_in_policy: SignInPolicy {
+                    allowed_first_auth_factors: vec!["PASSWORD".to_string()],
+                },
+            },
+            auto_verified_attributes: auto_verified,
+            username_attributes,
+            alias_attributes,
+            schema_attributes,
+            lambda_config: None,
+            mfa_configuration,
+            email_configuration,
+            sms_configuration,
+            admin_create_user_config,
+            user_pool_tags,
+            account_recovery_setting,
+            deletion_protection,
+            estimated_number_of_users: 0,
+            software_token_mfa_configuration: None,
+            sms_mfa_configuration: None,
+            user_pool_tier,
+            verification_message_template: None,
+            // Lazy-generate the RSA-2048 keypair on the first JWKS / sign
+            // request — same path the runtime CreateUserPool handler uses
+            // (avoids ~100ms keygen during stack creation).
+            signing_key_pem: None,
+            signing_kid: Some(signing_kid),
+        };
+
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.user_pools.insert(pool_id.clone(), pool);
+
+        let provider_name = format!("cognito-idp.{}.amazonaws.com/{}", self.region, pool_id);
+        let provider_url = format!("https://{provider_name}");
+
+        Ok(ProvisionResult::new(pool_id.clone())
+            .with("Arn", arn)
+            .with("ProviderName", provider_name)
+            .with("ProviderURL", provider_url)
+            .with("UserPoolId", pool_id))
+    }
+
+    fn delete_cognito_user_pool(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.user_pools.remove(physical_id);
+        // Cascade: drop clients tied to this pool, plus per-pool side maps.
+        state
+            .user_pool_clients
+            .retain(|_, c| c.user_pool_id != physical_id);
+        state.users.remove(physical_id);
+        state.groups.remove(physical_id);
+        state.user_groups.remove(physical_id);
+        state.identity_providers.remove(physical_id);
+        state.resource_servers.remove(physical_id);
+        state.import_jobs.remove(physical_id);
+        state.domains.retain(|_, d| d.user_pool_id != physical_id);
+        Ok(())
+    }
+
+    fn create_cognito_user_pool_client(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let pool_id = props
+            .get("UserPoolId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "UserPoolId is required".to_string())?
+            .to_string();
+        let client_name = props
+            .get("ClientName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.user_pools.contains_key(&pool_id) {
+            // Force CFN to retry once UserPool resource provisions.
+            return Err(format!(
+                "User pool {pool_id} does not exist yet — retry once it has been provisioned"
+            ));
+        }
+
+        let client_id: String = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .take(26)
+            .collect::<String>()
+            .to_lowercase();
+        let generate_secret = props
+            .get("GenerateSecret")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let client_secret = if generate_secret {
+            use base64::Engine;
+            let mut bytes = Vec::with_capacity(48);
+            for _ in 0..3 {
+                bytes.extend_from_slice(Uuid::new_v4().as_bytes());
+            }
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .encode(&bytes)
+                    .chars()
+                    .take(51)
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        let now = Utc::now();
+        let client = UserPoolClient {
+            client_id: client_id.clone(),
+            client_name,
+            user_pool_id: pool_id.clone(),
+            client_secret: client_secret.clone(),
+            explicit_auth_flows: parse_cognito_string_array(props.get("ExplicitAuthFlows")),
+            token_validity_units: None,
+            access_token_validity: props.get("AccessTokenValidity").and_then(|v| v.as_i64()),
+            id_token_validity: props.get("IdTokenValidity").and_then(|v| v.as_i64()),
+            refresh_token_validity: props.get("RefreshTokenValidity").and_then(|v| v.as_i64()),
+            callback_urls: parse_cognito_string_array(props.get("CallbackURLs")),
+            logout_urls: parse_cognito_string_array(props.get("LogoutURLs")),
+            supported_identity_providers: parse_cognito_string_array(
+                props.get("SupportedIdentityProviders"),
+            ),
+            allowed_o_auth_flows: parse_cognito_string_array(props.get("AllowedOAuthFlows")),
+            allowed_o_auth_scopes: parse_cognito_string_array(props.get("AllowedOAuthScopes")),
+            allowed_o_auth_flows_user_pool_client: props
+                .get("AllowedOAuthFlowsUserPoolClient")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            prevent_user_existence_errors: props
+                .get("PreventUserExistenceErrors")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            read_attributes: parse_cognito_string_array(props.get("ReadAttributes")),
+            write_attributes: parse_cognito_string_array(props.get("WriteAttributes")),
+            creation_date: now,
+            last_modified_date: now,
+            enable_token_revocation: props
+                .get("EnableTokenRevocation")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true),
+            auth_session_validity: props.get("AuthSessionValidity").and_then(|v| v.as_i64()),
+            client_secrets: Vec::new(),
+            refresh_token_rotation: None,
+        };
+
+        state.user_pool_clients.insert(client_id.clone(), client);
+
+        let mut result = ProvisionResult::new(client_id.clone())
+            .with("ClientId", client_id.clone())
+            .with("Name", client_id);
+        if let Some(secret) = client_secret {
+            result = result.with("ClientSecret", secret);
+        }
+        Ok(result)
+    }
+
+    fn delete_cognito_user_pool_client(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.user_pool_clients.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cognito_user_pool_domain(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let domain = props
+            .get("Domain")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Domain is required".to_string())?
+            .to_string();
+        let pool_id = props
+            .get("UserPoolId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "UserPoolId is required".to_string())?
+            .to_string();
+        let custom_domain_config = props
+            .get("CustomDomainConfig")
+            .and_then(|v| v.as_object())
+            .and_then(|m| {
+                m.get("CertificateArn")
+                    .and_then(|v| v.as_str())
+                    .map(|s| CustomDomainConfig {
+                        certificate_arn: s.to_string(),
+                    })
+            });
+
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.user_pools.contains_key(&pool_id) {
+            return Err(format!(
+                "User pool {pool_id} does not exist yet — retry once it has been provisioned"
+            ));
+        }
+        if state.domains.contains_key(&domain) {
+            return Err(format!("Domain {domain} already exists"));
+        }
+        state.domains.insert(
+            domain.clone(),
+            UserPoolDomain {
+                user_pool_id: pool_id,
+                domain: domain.clone(),
+                status: "ACTIVE".to_string(),
+                custom_domain_config: custom_domain_config.clone(),
+                creation_date: Utc::now(),
+            },
+        );
+
+        let cloudfront_distribution = if custom_domain_config.is_some() {
+            format!("{domain}.cloudfront.net")
+        } else {
+            format!("{domain}.auth.{}.amazoncognito.com", self.region)
+        };
+
+        Ok(ProvisionResult::new(domain.clone())
+            .with("Domain", domain)
+            .with("CloudFrontDistribution", cloudfront_distribution))
+    }
+
+    fn delete_cognito_user_pool_domain(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.domains.remove(physical_id);
+        Ok(())
+    }
+}
+
+/// Parse a JSON array-of-strings property. Returns empty Vec when the
+/// value is missing or shaped wrong; matches the tolerant input handling
+/// used by the runtime Cognito service.
+fn parse_cognito_string_array(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_cognito_password_policy(value: Option<&serde_json::Value>) -> PasswordPolicy {
+    let Some(inner) = value
+        .and_then(|v| v.get("PasswordPolicy"))
+        .and_then(|v| v.as_object())
+    else {
+        return PasswordPolicy::default();
+    };
+    let mut p = PasswordPolicy::default();
+    if let Some(n) = inner.get("MinimumLength").and_then(|v| v.as_i64()) {
+        p.minimum_length = n;
+    }
+    if let Some(b) = inner.get("RequireUppercase").and_then(|v| v.as_bool()) {
+        p.require_uppercase = b;
+    }
+    if let Some(b) = inner.get("RequireLowercase").and_then(|v| v.as_bool()) {
+        p.require_lowercase = b;
+    }
+    if let Some(b) = inner.get("RequireNumbers").and_then(|v| v.as_bool()) {
+        p.require_numbers = b;
+    }
+    if let Some(b) = inner.get("RequireSymbols").and_then(|v| v.as_bool()) {
+        p.require_symbols = b;
+    }
+    if let Some(n) = inner
+        .get("TemporaryPasswordValidityDays")
+        .and_then(|v| v.as_i64())
+    {
+        p.temporary_password_validity_days = n;
+    }
+    p
+}
+
+fn parse_cognito_schema_attribute(value: &serde_json::Value) -> Option<SchemaAttribute> {
+    let name = value.get("Name").and_then(|v| v.as_str())?.to_string();
+    Some(SchemaAttribute {
+        name,
+        attribute_data_type: value
+            .get("AttributeDataType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("String")
+            .to_string(),
+        developer_only_attribute: value
+            .get("DeveloperOnlyAttribute")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        mutable: value
+            .get("Mutable")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        required: value
+            .get("Required")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        string_attribute_constraints: None,
+        number_attribute_constraints: None,
+    })
+}
+
+fn parse_cognito_tags(value: Option<&serde_json::Value>) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    if let Some(obj) = value.and_then(|v| v.as_object()) {
+        for (k, v) in obj {
+            if let Some(s) = v.as_str() {
+                out.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn parse_cognito_email_configuration(
+    value: Option<&serde_json::Value>,
+) -> Option<EmailConfiguration> {
+    let inner = value?.as_object()?;
+    Some(EmailConfiguration {
+        source_arn: inner
+            .get("SourceArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        reply_to_email_address: inner
+            .get("ReplyToEmailAddress")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        email_sending_account: inner
+            .get("EmailSendingAccount")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        from_email_address: inner
+            .get("From")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        configuration_set: inner
+            .get("ConfigurationSet")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
+}
+
+fn parse_cognito_sms_configuration(value: Option<&serde_json::Value>) -> Option<SmsConfiguration> {
+    let inner = value?.as_object()?;
+    Some(SmsConfiguration {
+        sns_caller_arn: inner
+            .get("SnsCallerArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        external_id: inner
+            .get("ExternalId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        sns_region: inner
+            .get("SnsRegion")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
+}
+
+fn parse_cognito_admin_create_user_config(
+    value: Option<&serde_json::Value>,
+) -> Option<AdminCreateUserConfig> {
+    let inner = value?.as_object()?;
+    Some(AdminCreateUserConfig {
+        allow_admin_create_user_only: inner
+            .get("AllowAdminCreateUserOnly")
+            .and_then(|v| v.as_bool()),
+        invite_message_template: None,
+        unused_account_validity_days: inner
+            .get("UnusedAccountValidityDays")
+            .and_then(|v| v.as_i64()),
+    })
+}
+
+fn parse_cognito_account_recovery(
+    value: Option<&serde_json::Value>,
+) -> Option<AccountRecoverySetting> {
+    let arr = value?.get("RecoveryMechanisms")?.as_array()?;
+    Some(AccountRecoverySetting {
+        recovery_mechanisms: arr
+            .iter()
+            .filter_map(|m| {
+                let name = m.get("Name").and_then(|v| v.as_str())?.to_string();
+                let priority = m.get("Priority").and_then(|v| v.as_i64()).unwrap_or(1);
+                Some(RecoveryOption { name, priority })
+            })
+            .collect(),
+    })
 }
 
 #[cfg(test)]
@@ -3698,6 +4191,9 @@ mod tests {
             cloudwatch_state: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2_state: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations_state: Arc::new(RwLock::new(None)),
+            cognito_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -131,6 +131,7 @@ pub struct CloudFormationDeps {
     pub cloudwatch: fakecloud_cloudwatch::SharedCloudWatchState,
     pub elbv2: fakecloud_elbv2::SharedElbv2State,
     pub organizations: fakecloud_organizations::SharedOrganizationsState,
+    pub cognito: fakecloud_cognito::SharedCognitoState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -197,6 +198,7 @@ impl CloudFormationService {
             cloudwatch_state: self.deps.cloudwatch.clone(),
             elbv2_state: self.deps.elbv2.clone(),
             organizations_state: self.deps.organizations.clone(),
+            cognito_state: self.deps.cognito.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1282,6 +1284,13 @@ mod tests {
             cloudwatch: Arc::new(RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new())),
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations: Arc::new(RwLock::new(None)),
+            cognito: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -9,4 +9,9 @@ pub use service::{
     oidc_discovery_document, pool_jwks_document, CognitoService, OAuthRevokeError, OAuthTokenError,
     OAuthTokenResponse, OAuthUserInfoError,
 };
-pub use state::{CognitoSnapshot, SharedCognitoState, COGNITO_SNAPSHOT_SCHEMA_VERSION};
+pub use state::{
+    default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CognitoSnapshot,
+    CognitoState, CustomDomainConfig, EmailConfiguration, PasswordPolicy, PoolPolicies,
+    RecoveryOption, SchemaAttribute, SharedCognitoState, SignInPolicy, SmsConfiguration, UserPool,
+    UserPoolClient, UserPoolDomain, COGNITO_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-e2e/tests/cloudformation_cognito.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_cognito.rs
@@ -1,0 +1,174 @@
+//! CloudFormation provisioner for AWS::Cognito::UserPool + UserPoolClient + UserPoolDomain.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Pool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "PoolName": "cfn-pool",
+        "AutoVerifiedAttributes": ["email"],
+        "Policies": {
+          "PasswordPolicy": {
+            "MinimumLength": 12,
+            "RequireUppercase": true,
+            "RequireLowercase": true,
+            "RequireNumbers": true,
+            "RequireSymbols": false
+          }
+        },
+        "MfaConfiguration": "OFF",
+        "AccountRecoverySetting": {
+          "RecoveryMechanisms": [
+            {"Name": "verified_email", "Priority": 1}
+          ]
+        }
+      }
+    },
+    "Client": {
+      "Type": "AWS::Cognito::UserPoolClient",
+      "Properties": {
+        "ClientName": "cfn-client",
+        "UserPoolId": {"Ref": "Pool"},
+        "GenerateSecret": true,
+        "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+        "CallbackURLs": ["https://example.com/cb"]
+      }
+    },
+    "Domain": {
+      "Type": "AWS::Cognito::UserPoolDomain",
+      "Properties": {
+        "Domain": "cfn-cognito-test",
+        "UserPoolId": {"Ref": "Pool"}
+      }
+    }
+  },
+  "Outputs": {
+    "PoolId": {"Value": {"Ref": "Pool"}},
+    "PoolArn": {"Value": {"Fn::GetAtt": ["Pool", "Arn"]}},
+    "ProviderName": {"Value": {"Fn::GetAtt": ["Pool", "ProviderName"]}},
+    "ClientId": {"Value": {"Ref": "Client"}},
+    "ClientSecret": {"Value": {"Fn::GetAtt": ["Client", "ClientSecret"]}},
+    "DomainName": {"Value": {"Ref": "Domain"}},
+    "CloudFrontDist": {"Value": {"Fn::GetAtt": ["Domain", "CloudFrontDistribution"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_cognito_user_pool_client_domain() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cognito = aws_sdk_cognitoidentityprovider::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("cognito-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("cognito-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut pool_id = None;
+    let mut pool_arn = None;
+    let mut provider_name = None;
+    let mut client_id = None;
+    let mut client_secret = None;
+    let mut domain_name = None;
+    let mut cf_dist = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("PoolId") => pool_id = o.output_value().map(|s| s.to_string()),
+            Some("PoolArn") => pool_arn = o.output_value().map(|s| s.to_string()),
+            Some("ProviderName") => provider_name = o.output_value().map(|s| s.to_string()),
+            Some("ClientId") => client_id = o.output_value().map(|s| s.to_string()),
+            Some("ClientSecret") => client_secret = o.output_value().map(|s| s.to_string()),
+            Some("DomainName") => domain_name = o.output_value().map(|s| s.to_string()),
+            Some("CloudFrontDist") => cf_dist = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let pool_id = pool_id.expect("PoolId");
+    let pool_arn = pool_arn.expect("PoolArn");
+    let provider_name = provider_name.expect("ProviderName");
+    let client_id = client_id.expect("ClientId");
+    let client_secret = client_secret.expect("ClientSecret");
+    let domain_name = domain_name.expect("DomainName");
+    let cf_dist = cf_dist.expect("CloudFrontDist");
+
+    assert!(pool_arn.contains(":userpool/"));
+    assert!(provider_name.starts_with("cognito-idp."));
+    assert!(client_id.len() == 26, "client_id len: {}", client_id.len());
+    assert!(!client_secret.is_empty());
+    assert_eq!(domain_name, "cfn-cognito-test");
+    assert!(cf_dist.contains("cfn-cognito-test"));
+
+    // Pool-level checks via Cognito SDK.
+    let described_pool = cognito
+        .describe_user_pool()
+        .user_pool_id(&pool_id)
+        .send()
+        .await
+        .expect("describe_user_pool");
+    let pool = described_pool.user_pool().expect("pool");
+    assert_eq!(pool.name(), Some("cfn-pool"));
+    assert_eq!(
+        pool.policies()
+            .and_then(|p| p.password_policy())
+            .and_then(|pp| pp.minimum_length()),
+        Some(12)
+    );
+
+    // Client-level checks.
+    let described_client = cognito
+        .describe_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .send()
+        .await
+        .expect("describe_user_pool_client");
+    let client = described_client.user_pool_client().expect("client");
+    assert_eq!(client.client_name(), Some("cfn-client"));
+    assert!(!client.callback_urls().is_empty());
+
+    // Domain check.
+    let described_domain = cognito
+        .describe_user_pool_domain()
+        .domain(&domain_name)
+        .send()
+        .await
+        .expect("describe_user_pool_domain");
+    let domain = described_domain.domain_description().expect("domain");
+    assert_eq!(domain.user_pool_id(), Some(pool_id.as_str()));
+
+    // Stack delete cascades pool + client + domain removal.
+    cfn.delete_stack()
+        .stack_name("cognito-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after_pool = cognito
+        .describe_user_pool()
+        .user_pool_id(&pool_id)
+        .send()
+        .await;
+    assert!(
+        after_pool.is_err(),
+        "pool should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -729,6 +729,7 @@ async fn main() {
             cloudwatch: cloudwatch_state.clone(),
             elbv2: elbv2_state.clone(),
             organizations: organizations_state.clone(),
+            cognito: cognito_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
- CFN provisioners for AWS::Cognito::UserPool, ::UserPoolClient, ::UserPoolDomain
- UserPool stores the full schema attribute set (merged with defaults), PasswordPolicy, MfaConfiguration, EmailConfiguration, SmsConfiguration, AdminCreateUserConfig, AccountRecoverySetting and tags; signing_kid is set up front so the JWKS endpoint resolves while keypair generation stays lazy
- UserPoolClient mints a 26-char lowercase alphanumeric client id; GenerateSecret returns a 51-char base64 secret; returns Err to force CFN retry when the referenced UserPool has not yet been provisioned
- UserPoolDomain populates the domains map and emits the auth.<region>.amazoncognito.com CloudFront distribution unless CertificateArn is provided
- Stack delete cascades pool removal across user_pool_clients, users, groups, identity_providers, resource_servers, import_jobs, and domains
- Ref / GetAtt expose Arn, ProviderName, ProviderURL, ClientId, ClientSecret, Domain, CloudFrontDistribution

## Test plan
- [x] cargo test -p fakecloud-cloudformation
- [x] cargo test -p fakecloud-e2e --test cloudformation_cognito
- [x] cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for Cognito `AWS::Cognito::UserPool`, `::UserPoolClient`, and `::UserPoolDomain`, enabling stack-based provisioning and teardown. Addresses Linear BB15.

- **New Features**
  - Provisioners for UserPool, UserPoolClient, and UserPoolDomain with Ref/GetAtt outputs (Arn/ProviderName/ProviderURL, ClientId/ClientSecret, Domain/CloudFrontDistribution).
  - UserPool persists merged schema, PasswordPolicy, MFA, Email/SMS, AdminCreateUser, AccountRecovery; sets `signing_kid` up front and lazy-generates the JWKS keypair.
  - UserPoolClient mints a 26-char lowercase ID and, when `GenerateSecret=true`, a 51-char base64 secret; returns an error to trigger CFN retry if the pool isn’t ready.
  - UserPoolDomain registers the domain and computes the default `auth.<region>.amazoncognito.com` distribution unless `CertificateArn` is provided.
  - Stack delete cascades to remove related clients, users, groups, identity providers, resource servers, import jobs, and domains.
  - E2E test `cloudformation_cognito.rs` provisions all three resources, validates via SDK, and verifies deletion.

- **Dependencies**
  - Added `fakecloud-cognito` to `fakecloud-cloudformation` and wired Cognito state through the CloudFormation service and server.

<sup>Written for commit 4a53cc20fed85067a52d8cc9e3d1781cc9793c92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

