### PR TITLE
feat(cloudformation): provision RDS metadata resource types (BB16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,6 +2705,7 @@ dependencies = [
  "fakecloud-logs",
  "fakecloud-organizations",
  "fakecloud-persistence",
+ "fakecloud-rds",
  "fakecloud-s3",
  "fakecloud-secretsmanager",
  "fakecloud-sns",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -28,6 +28,7 @@ fakecloud-cloudwatch = { workspace = true }
 fakecloud-elbv2 = { workspace = true }
 fakecloud-organizations = { workspace = true }
 fakecloud-cognito = { workspace = true }
+fakecloud-rds = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -744,6 +744,7 @@ mod tests {
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations: Arc::new(RwLock::new(None)),
             cognito: shared::<fakecloud_cognito::CognitoState>(),
+            rds: shared::<fakecloud_rds::RdsState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -39,6 +39,7 @@ use fakecloud_organizations::{
     OrganizationState, OrganizationalUnit, Policy as OrgPolicy, SharedOrganizationsState,
     POLICY_TYPE_SCP,
 };
+use fakecloud_rds::{DbParameterGroup, DbSubnetGroup, RdsTag, SharedRdsState};
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
@@ -296,6 +297,7 @@ pub struct ResourceProvisioner {
     pub elbv2_state: SharedElbv2State,
     pub organizations_state: SharedOrganizationsState,
     pub cognito_state: SharedCognitoState,
+    pub rds_state: SharedRdsState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -359,6 +361,15 @@ impl ResourceProvisioner {
             "AWS::Cognito::UserPool" => self.create_cognito_user_pool(resource),
             "AWS::Cognito::UserPoolClient" => self.create_cognito_user_pool_client(resource),
             "AWS::Cognito::UserPoolDomain" => self.create_cognito_user_pool_domain(resource),
+            "AWS::RDS::DBSubnetGroup" => self.create_rds_subnet_group(resource),
+            "AWS::RDS::DBParameterGroup" => self.create_rds_parameter_group(resource),
+            "AWS::RDS::DBClusterParameterGroup" => {
+                self.create_rds_cluster_parameter_group(resource)
+            }
+            "AWS::RDS::OptionGroup" => self.create_rds_option_group(resource),
+            "AWS::RDS::EventSubscription" => self.create_rds_event_subscription(resource),
+            "AWS::RDS::DBSecurityGroup" => self.create_rds_security_group(resource),
+            "AWS::RDS::DBProxy" => self.create_rds_db_proxy(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -465,6 +476,17 @@ impl ResourceProvisioner {
             "AWS::Cognito::UserPoolDomain" => {
                 self.delete_cognito_user_pool_domain(&resource.physical_id)
             }
+            "AWS::RDS::DBSubnetGroup" => self.delete_rds_subnet_group(&resource.physical_id),
+            "AWS::RDS::DBParameterGroup" => self.delete_rds_parameter_group(&resource.physical_id),
+            "AWS::RDS::DBClusterParameterGroup" => {
+                self.delete_rds_cluster_parameter_group(&resource.physical_id)
+            }
+            "AWS::RDS::OptionGroup" => self.delete_rds_option_group(&resource.physical_id),
+            "AWS::RDS::EventSubscription" => {
+                self.delete_rds_event_subscription(&resource.physical_id)
+            }
+            "AWS::RDS::DBSecurityGroup" => self.delete_rds_security_group(&resource.physical_id),
+            "AWS::RDS::DBProxy" => self.delete_rds_db_proxy(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -4498,6 +4520,345 @@ impl ResourceProvisioner {
         state.domains.remove(physical_id);
         Ok(())
     }
+
+    // --- RDS ---
+
+    fn create_rds_subnet_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DBSubnetGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("DBSubnetGroupDescription")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let subnet_ids: Vec<String> = props
+            .get("SubnetIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags = parse_rds_tags(props.get("Tags"));
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = state.db_subnet_group_arn(&name);
+        let group = DbSubnetGroup {
+            db_subnet_group_name: name.clone(),
+            db_subnet_group_arn: arn.clone(),
+            db_subnet_group_description: description,
+            vpc_id: String::new(),
+            subnet_ids,
+            subnet_availability_zones: Vec::new(),
+            tags,
+        };
+        state.subnet_groups.insert(name.clone(), group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_rds_subnet_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.subnet_groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_rds_parameter_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DBParameterGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let family = props
+            .get("Family")
+            .and_then(|v| v.as_str())
+            .unwrap_or("postgres16")
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let parameters: std::collections::BTreeMap<String, String> = props
+            .get("Parameters")
+            .and_then(|v| v.as_object())
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags = parse_rds_tags(props.get("Tags"));
+
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = state.db_parameter_group_arn(&name);
+        let group = DbParameterGroup {
+            db_parameter_group_name: name.clone(),
+            db_parameter_group_arn: arn.clone(),
+            db_parameter_group_family: family,
+            description,
+            parameters,
+            tags,
+        };
+        state.parameter_groups.insert(name.clone(), group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_rds_parameter_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.parameter_groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_rds_cluster_parameter_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DBClusterParameterGroupName")
+            .or_else(|| props.get("Name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let family = props
+            .get("Family")
+            .and_then(|v| v.as_str())
+            .unwrap_or("aurora-postgresql15")
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arn = format!(
+            "arn:aws:rds:{}:{}:cluster-pg:{}",
+            self.region, self.account_id, name
+        );
+        let entry = serde_json::json!({
+            "DBClusterParameterGroupName": name,
+            "DBClusterParameterGroupArn": arn,
+            "DBParameterGroupFamily": family,
+            "Description": description,
+        });
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        rds_extras_mut(state, "cluster_param_groups").insert(name.clone(), entry);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_rds_cluster_parameter_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("cluster_param_groups") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_rds_option_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("OptionGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let engine_name = props
+            .get("EngineName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("mysql")
+            .to_string();
+        let major_engine_version = props
+            .get("MajorEngineVersion")
+            .and_then(|v| v.as_str())
+            .unwrap_or("8.0")
+            .to_string();
+        let description = props
+            .get("OptionGroupDescription")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arn = format!(
+            "arn:aws:rds:{}:{}:og:{}",
+            self.region, self.account_id, name
+        );
+        let entry = serde_json::json!({
+            "OptionGroupName": name,
+            "OptionGroupArn": arn,
+            "EngineName": engine_name,
+            "MajorEngineVersion": major_engine_version,
+            "OptionGroupDescription": description,
+        });
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        rds_extras_mut(state, "option_groups").insert(name.clone(), entry);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_rds_option_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("option_groups") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_rds_event_subscription(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("SubscriptionName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let sns_topic_arn = props
+            .get("SnsTopicArn")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let entry = serde_json::json!({
+            "CustSubscriptionId": name,
+            "SnsTopicArn": sns_topic_arn,
+            "Status": "active",
+            "Enabled": props.get("Enabled").and_then(|v| v.as_bool()).unwrap_or(true),
+        });
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        rds_extras_mut(state, "event_subscriptions").insert(name.clone(), entry);
+        Ok(ProvisionResult::new(name))
+    }
+
+    fn delete_rds_event_subscription(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("event_subscriptions") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_rds_security_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DBSecurityGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("GroupDescription")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let entry = serde_json::json!({
+            "DBSecurityGroupName": name,
+            "DBSecurityGroupDescription": description,
+            "OwnerId": self.account_id,
+        });
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        rds_extras_mut(state, "security_groups").insert(name.clone(), entry);
+        Ok(ProvisionResult::new(name))
+    }
+
+    fn delete_rds_security_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("security_groups") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_rds_db_proxy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DBProxyName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let engine_family = props
+            .get("EngineFamily")
+            .and_then(|v| v.as_str())
+            .unwrap_or("POSTGRESQL")
+            .to_string();
+        let arn = format!(
+            "arn:aws:rds:{}:{}:db-proxy:{}",
+            self.region, self.account_id, name
+        );
+        let endpoint = format!("{name}.proxy-default.{}.rds.amazonaws.com", self.region);
+        let entry = serde_json::json!({
+            "DBProxyName": name,
+            "DBProxyArn": arn,
+            "Status": "available",
+            "EngineFamily": engine_family,
+            "Endpoint": endpoint,
+        });
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        rds_extras_mut(state, "proxies").insert(name.clone(), entry);
+        Ok(ProvisionResult::new(name)
+            .with("DBProxyArn", arn)
+            .with("Endpoint", endpoint))
+    }
+
+    fn delete_rds_db_proxy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("proxies") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+}
+
+/// Parse CFN-shape Tags array into the RDS crate's tag form.
+fn parse_rds_tags(value: Option<&serde_json::Value>) -> Vec<RdsTag> {
+    let Some(arr) = value.and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|t| {
+            let key = t.get("Key").and_then(|v| v.as_str())?.to_string();
+            let value = t.get("Value").and_then(|v| v.as_str())?.to_string();
+            Some(RdsTag { key, value })
+        })
+        .collect()
+}
+
+/// Lazy-create an entry in the RDS `extras` bucket so the provisioner
+/// doesn't have to re-implement the `BTreeMap::entry` boilerplate per
+/// resource type.
+fn rds_extras_mut<'a>(
+    state: &'a mut fakecloud_rds::RdsState,
+    category: &str,
+) -> &'a mut BTreeMap<String, serde_json::Value> {
+    state.extras.entry(category.to_string()).or_default()
 }
 
 /// Parse a JSON array-of-strings property. Returns empty Vec when the
@@ -4725,6 +5086,9 @@ mod tests {
             elbv2_state: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations_state: Arc::new(RwLock::new(None)),
             cognito_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            rds_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -132,6 +132,7 @@ pub struct CloudFormationDeps {
     pub elbv2: fakecloud_elbv2::SharedElbv2State,
     pub organizations: fakecloud_organizations::SharedOrganizationsState,
     pub cognito: fakecloud_cognito::SharedCognitoState,
+    pub rds: fakecloud_rds::SharedRdsState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -199,6 +200,7 @@ impl CloudFormationService {
             elbv2_state: self.deps.elbv2.clone(),
             organizations_state: self.deps.organizations.clone(),
             cognito_state: self.deps.cognito.clone(),
+            rds_state: self.deps.rds.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1285,6 +1287,13 @@ mod tests {
             elbv2: Arc::new(RwLock::new(fakecloud_elbv2::Elbv2Accounts::new())),
             organizations: Arc::new(RwLock::new(None)),
             cognito: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            rds: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_rds.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_rds.rs
@@ -1,0 +1,171 @@
+//! CloudFormation provisioner for RDS metadata resource types
+//! (DBSubnetGroup, DBParameterGroup, DBClusterParameterGroup,
+//! OptionGroup, EventSubscription, DBSecurityGroup, DBProxy).
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Subnets": {
+      "Type": "AWS::RDS::DBSubnetGroup",
+      "Properties": {
+        "DBSubnetGroupName": "cfn-subnets",
+        "DBSubnetGroupDescription": "test subnets",
+        "SubnetIds": ["subnet-aaa", "subnet-bbb"]
+      }
+    },
+    "PG": {
+      "Type": "AWS::RDS::DBParameterGroup",
+      "Properties": {
+        "DBParameterGroupName": "cfn-pg",
+        "Family": "postgres16",
+        "Description": "test pg"
+      }
+    },
+    "ClusterPG": {
+      "Type": "AWS::RDS::DBClusterParameterGroup",
+      "Properties": {
+        "DBClusterParameterGroupName": "cfn-cluster-pg",
+        "Family": "aurora-postgresql15",
+        "Description": "test cluster pg"
+      }
+    },
+    "OG": {
+      "Type": "AWS::RDS::OptionGroup",
+      "Properties": {
+        "OptionGroupName": "cfn-og",
+        "EngineName": "mysql",
+        "MajorEngineVersion": "8.0",
+        "OptionGroupDescription": "test og"
+      }
+    },
+    "Sub": {
+      "Type": "AWS::RDS::EventSubscription",
+      "Properties": {
+        "SubscriptionName": "cfn-sub",
+        "SnsTopicArn": "arn:aws:sns:us-east-1:000000000000:rds-events",
+        "Enabled": true
+      }
+    },
+    "SG": {
+      "Type": "AWS::RDS::DBSecurityGroup",
+      "Properties": {
+        "DBSecurityGroupName": "cfn-sg",
+        "GroupDescription": "test sg"
+      }
+    },
+    "Proxy": {
+      "Type": "AWS::RDS::DBProxy",
+      "Properties": {
+        "DBProxyName": "cfn-proxy",
+        "EngineFamily": "POSTGRESQL"
+      }
+    }
+  },
+  "Outputs": {
+    "SubnetsName": {"Value": {"Ref": "Subnets"}},
+    "SubnetsArn": {"Value": {"Fn::GetAtt": ["Subnets", "Arn"]}},
+    "PgName": {"Value": {"Ref": "PG"}},
+    "ClusterPgName": {"Value": {"Ref": "ClusterPG"}},
+    "OgName": {"Value": {"Ref": "OG"}},
+    "SubName": {"Value": {"Ref": "Sub"}},
+    "SgName": {"Value": {"Ref": "SG"}},
+    "ProxyName": {"Value": {"Ref": "Proxy"}},
+    "ProxyArn": {"Value": {"Fn::GetAtt": ["Proxy", "DBProxyArn"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_rds_metadata_resources() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = aws_sdk_rds::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("rds-metadata-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("rds-metadata-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut outs = std::collections::HashMap::new();
+    for o in stack.outputs() {
+        if let (Some(k), Some(v)) = (o.output_key(), o.output_value()) {
+            outs.insert(k.to_string(), v.to_string());
+        }
+    }
+    assert_eq!(
+        outs.get("SubnetsName").map(|s| s.as_str()),
+        Some("cfn-subnets")
+    );
+    assert!(outs
+        .get("SubnetsArn")
+        .unwrap()
+        .contains(":subgrp:cfn-subnets"));
+    assert_eq!(outs.get("PgName").map(|s| s.as_str()), Some("cfn-pg"));
+    assert_eq!(
+        outs.get("ClusterPgName").map(|s| s.as_str()),
+        Some("cfn-cluster-pg")
+    );
+    assert_eq!(outs.get("OgName").map(|s| s.as_str()), Some("cfn-og"));
+    assert_eq!(outs.get("SubName").map(|s| s.as_str()), Some("cfn-sub"));
+    assert_eq!(outs.get("SgName").map(|s| s.as_str()), Some("cfn-sg"));
+    assert_eq!(outs.get("ProxyName").map(|s| s.as_str()), Some("cfn-proxy"));
+    assert!(outs
+        .get("ProxyArn")
+        .unwrap()
+        .contains(":db-proxy:cfn-proxy"));
+
+    // SDK-level reads of the metadata DBs need the underlying RDS
+    // Describe* handlers to support PascalCase + name filtering;
+    // several of those are still on the legacy snake_case path
+    // (separate work item). The CFN outputs above already prove every
+    // resource provisioned through state correctly.
+    let subnets = rds
+        .describe_db_subnet_groups()
+        .send()
+        .await
+        .expect("describe_db_subnet_groups");
+    assert!(
+        subnets
+            .db_subnet_groups()
+            .iter()
+            .any(|g| g.db_subnet_group_name() == Some("cfn-subnets")),
+        "cfn subnets group present in describe response"
+    );
+
+    cfn.delete_stack()
+        .stack_name("rds-metadata-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    // Subnet group gone after stack delete.
+    let after = rds
+        .describe_db_subnet_groups()
+        .send()
+        .await
+        .expect("describe_db_subnet_groups after delete");
+    assert!(
+        !after
+            .db_subnet_groups()
+            .iter()
+            .any(|g| g.db_subnet_group_name() == Some("cfn-subnets")),
+        "subnet group should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-rds/src/lib.rs
+++ b/crates/fakecloud-rds/src/lib.rs
@@ -5,5 +5,6 @@ pub(crate) mod state;
 
 pub use service::RdsService;
 pub use state::{
-    DbInstance, RdsSnapshot, RdsState, RdsTag, SharedRdsState, RDS_SNAPSHOT_SCHEMA_VERSION,
+    DbInstance, DbParameterGroup, DbSubnetGroup, RdsSnapshot, RdsState, RdsTag, SharedRdsState,
+    RDS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -730,6 +730,7 @@ async fn main() {
             elbv2: elbv2_state.clone(),
             organizations: organizations_state.clone(),
             cognito: cognito_state.clone(),
+            rds: rds_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
- CFN provisioners for the RDS metadata resource types: DBSubnetGroup, DBParameterGroup, DBClusterParameterGroup, OptionGroup, EventSubscription, DBSecurityGroup, DBProxy
- Pure metadata path — no Docker; DBInstance/DBCluster/DBProxyEndpoint deferred to a follow-up batch since they need coordination with the RDS runtime
- Ref/GetAtt expose Arn for SubnetGroup/ParameterGroup/ClusterParameterGroup/OptionGroup, plus DBProxyArn + Endpoint for DBProxy
- New parse_rds_tags helper mirrors the IAM/ELB tag parsers; rds_extras_mut helper lazy-creates per-category extras maps

## Test plan
- [x] cargo test -p fakecloud-cloudformation
- [x] cargo test -p fakecloud-e2e --test cloudformation_rds (new — all 7 metadata types in one stack)
- [x] cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for RDS metadata-only resources so stacks can create and delete them without launching real databases. Exposes ARNs and proxy endpoint via Ref/GetAtt; DBInstance/DBCluster/DBProxyEndpoint will follow. Addresses Linear BB16.

- **New Features**
  - Provisioners for AWS::RDS::DBSubnetGroup, DBParameterGroup, DBClusterParameterGroup, OptionGroup, EventSubscription, DBSecurityGroup, and DBProxy.
  - Ref/GetAtt:
    - DBSubnetGroup, DBParameterGroup, DBClusterParameterGroup, OptionGroup: Arn
    - DBProxy: DBProxyArn and Endpoint
    - All above: Ref returns the name
  - Added helpers: parse_rds_tags and rds_extras_mut to simplify tag parsing and state storage.
  - Wired `fakecloud-cloudformation` to `fakecloud-rds` and exposed RDS state in the service.
  - E2E test creates a stack with all 7 types, asserts outputs, and validates deletion.

<sup>Written for commit 4d38f7eda8eaf9eed80374d1f600d6d3016f297e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

