### PR TITLE
feat(cloudformation): provision ECS Cluster + TaskDefinition + Service + CapacityProvider (BB11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "fakecloud-core",
  "fakecloud-dynamodb",
  "fakecloud-ecr",
+ "fakecloud-ecs",
  "fakecloud-elbv2",
  "fakecloud-eventbridge",
  "fakecloud-iam",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -29,6 +29,7 @@ fakecloud-elbv2 = { workspace = true }
 fakecloud-organizations = { workspace = true }
 fakecloud-cognito = { workspace = true }
 fakecloud-rds = { workspace = true }
+fakecloud-ecs = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -745,6 +745,7 @@ mod tests {
             organizations: Arc::new(RwLock::new(None)),
             cognito: shared::<fakecloud_cognito::CognitoState>(),
             rds: shared::<fakecloud_rds::RdsState>(),
+            ecs: shared::<fakecloud_ecs::EcsState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -16,6 +16,10 @@ use fakecloud_dynamodb::{
     SharedDynamoDbState,
 };
 use fakecloud_ecr::{Repository, SharedEcrState};
+use fakecloud_ecs::{
+    CapacityProvider as EcsCapacityProvider, Cluster as EcsCluster, Service as EcsService,
+    SharedEcsState, TagEntry as EcsTagEntry, TaskDefinition as EcsTaskDefinition,
+};
 use fakecloud_elbv2::{
     Action as ElbAction, Listener, LoadBalancer, Rule as ElbRule, RuleCondition, SharedElbv2State,
     Tag as ElbTag, TargetGroup, TargetGroupTuple,
@@ -298,6 +302,7 @@ pub struct ResourceProvisioner {
     pub organizations_state: SharedOrganizationsState,
     pub cognito_state: SharedCognitoState,
     pub rds_state: SharedRdsState,
+    pub ecs_state: SharedEcsState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -370,6 +375,10 @@ impl ResourceProvisioner {
             "AWS::RDS::EventSubscription" => self.create_rds_event_subscription(resource),
             "AWS::RDS::DBSecurityGroup" => self.create_rds_security_group(resource),
             "AWS::RDS::DBProxy" => self.create_rds_db_proxy(resource),
+            "AWS::ECS::Cluster" => self.create_ecs_cluster(resource),
+            "AWS::ECS::TaskDefinition" => self.create_ecs_task_definition(resource),
+            "AWS::ECS::Service" => self.create_ecs_service(resource),
+            "AWS::ECS::CapacityProvider" => self.create_ecs_capacity_provider(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -487,6 +496,12 @@ impl ResourceProvisioner {
             }
             "AWS::RDS::DBSecurityGroup" => self.delete_rds_security_group(&resource.physical_id),
             "AWS::RDS::DBProxy" => self.delete_rds_db_proxy(&resource.physical_id),
+            "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
+            "AWS::ECS::TaskDefinition" => self.delete_ecs_task_definition(&resource.physical_id),
+            "AWS::ECS::Service" => self.delete_ecs_service(&resource.physical_id),
+            "AWS::ECS::CapacityProvider" => {
+                self.delete_ecs_capacity_provider(&resource.physical_id)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -4835,6 +4850,416 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- ECS ---
+
+    fn create_ecs_cluster(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cluster_name = props
+            .get("ClusterName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let cluster_arn = format!(
+            "arn:aws:ecs:{}:{}:cluster/{}",
+            self.region, self.account_id, cluster_name
+        );
+        let mut cluster = EcsCluster::new(&cluster_name, cluster_arn.clone());
+        cluster.tags = parse_ecs_tags(props.get("Tags"));
+        cluster.capacity_providers = props
+            .get("CapacityProviders")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if let Some(strategy) = props
+            .get("DefaultCapacityProviderStrategy")
+            .and_then(|v| v.as_array())
+        {
+            cluster.default_capacity_provider_strategy = strategy.clone();
+        }
+        if let Some(cfg) = props.get("Configuration") {
+            cluster.configuration = Some(cfg.clone());
+        }
+        if let Some(settings) = props.get("ClusterSettings").and_then(|v| v.as_array()) {
+            cluster.settings = settings.clone();
+        }
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.clusters.insert(cluster_name.clone(), cluster);
+        Ok(ProvisionResult::new(cluster_name).with("Arn", cluster_arn))
+    }
+
+    fn delete_ecs_cluster(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.clusters.remove(physical_id);
+        // Cascade: drop services + tasks tied to this cluster.
+        state.services.retain(|_, s| s.cluster_name != physical_id);
+        state
+            .tasks
+            .retain(|_, t| t.cluster_arn.split('/').next_back() != Some(physical_id));
+        Ok(())
+    }
+
+    fn create_ecs_task_definition(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let family = props
+            .get("Family")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let container_definitions = props
+            .get("ContainerDefinitions")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let task_role_arn = props
+            .get("TaskRoleArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let execution_role_arn = props
+            .get("ExecutionRoleArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let network_mode = props
+            .get("NetworkMode")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let requires_compatibilities: Vec<String> = props
+            .get("RequiresCompatibilities")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let cpu = props
+            .get("Cpu")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let memory = props
+            .get("Memory")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let volumes = props
+            .get("Volumes")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placement_constraints = props
+            .get("PlacementConstraints")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let tags = parse_ecs_tags(props.get("Tags"));
+
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let revision = state
+            .next_revision
+            .entry(family.clone())
+            .and_modify(|n| *n += 1)
+            .or_insert(1);
+        let revision = *revision;
+        let arn = format!(
+            "arn:aws:ecs:{}:{}:task-definition/{}:{}",
+            self.region, self.account_id, family, revision
+        );
+        let td = EcsTaskDefinition {
+            family: family.clone(),
+            revision,
+            task_definition_arn: arn.clone(),
+            container_definitions,
+            status: "ACTIVE".to_string(),
+            task_role_arn,
+            execution_role_arn,
+            network_mode,
+            requires_compatibilities: requires_compatibilities.clone(),
+            compatibilities: requires_compatibilities,
+            cpu,
+            memory,
+            pid_mode: None,
+            ipc_mode: None,
+            volumes,
+            placement_constraints,
+            proxy_configuration: None,
+            inference_accelerators: Vec::new(),
+            ephemeral_storage: props.get("EphemeralStorage").cloned(),
+            runtime_platform: props.get("RuntimePlatform").cloned(),
+            requires_attributes: Vec::new(),
+            registered_at: Utc::now(),
+            registered_by: None,
+            deregistered_at: None,
+            tags,
+            enable_fault_injection: props.get("EnableFaultInjection").and_then(|v| v.as_bool()),
+        };
+        state
+            .task_definitions
+            .entry(family.clone())
+            .or_default()
+            .insert(revision, td);
+        Ok(ProvisionResult::new(arn.clone()).with("TaskDefinitionArn", arn))
+    }
+
+    fn delete_ecs_task_definition(&self, physical_id: &str) -> Result<(), String> {
+        // physical_id is the full task-definition ARN; family + revision
+        // sit at the trailing segment after `/`.
+        let Some(suffix) = physical_id.rsplit('/').next() else {
+            return Ok(());
+        };
+        let Some((family, rev)) = suffix.split_once(':') else {
+            return Ok(());
+        };
+        let Ok(revision) = rev.parse::<i32>() else {
+            return Ok(());
+        };
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(revs) = state.task_definitions.get_mut(family) {
+            if let Some(td) = revs.get_mut(&revision) {
+                td.status = "INACTIVE".to_string();
+                td.deregistered_at = Some(Utc::now());
+            }
+        }
+        Ok(())
+    }
+
+    fn create_ecs_service(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let service_name = props
+            .get("ServiceName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        // Cluster: default to "default" if missing; accept name or ARN.
+        let cluster_name = props
+            .get("Cluster")
+            .and_then(|v| v.as_str())
+            .map(parse_ecs_cluster_name)
+            .unwrap_or_else(|| "default".to_string());
+        let task_definition_arn = props
+            .get("TaskDefinition")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "TaskDefinition is required".to_string())?
+            .to_string();
+        let desired_count = props
+            .get("DesiredCount")
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32)
+            .unwrap_or(1);
+        let launch_type = props
+            .get("LaunchType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("FARGATE")
+            .to_string();
+        let scheduling_strategy = props
+            .get("SchedulingStrategy")
+            .and_then(|v| v.as_str())
+            .unwrap_or("REPLICA")
+            .to_string();
+        let deployment_controller = props
+            .get("DeploymentController")
+            .and_then(|v| v.get("Type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("ECS")
+            .to_string();
+        let load_balancers = props
+            .get("LoadBalancers")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let service_registries = props
+            .get("ServiceRegistries")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placement_constraints = props
+            .get("PlacementConstraints")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placement_strategy = props
+            .get("PlacementStrategies")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let network_configuration = props.get("NetworkConfiguration").cloned();
+        let role_arn = props
+            .get("Role")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let tags = parse_ecs_tags(props.get("Tags"));
+
+        // Family + revision parsed from the task definition ARN tail.
+        let (family, revision) = parse_td_arn(&task_definition_arn);
+
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.clusters.contains_key(&cluster_name) {
+            return Err(format!(
+                "Cluster {cluster_name} does not exist yet — retry once it has been provisioned"
+            ));
+        }
+        let cluster_arn = state.clusters[&cluster_name].cluster_arn.clone();
+        let service_arn = format!(
+            "arn:aws:ecs:{}:{}:service/{}/{}",
+            self.region, self.account_id, cluster_name, service_name
+        );
+        let key = format!("{cluster_name}/{service_name}");
+        let service = EcsService {
+            service_name: service_name.clone(),
+            service_arn: service_arn.clone(),
+            cluster_name: cluster_name.clone(),
+            cluster_arn,
+            task_definition_arn,
+            family,
+            revision,
+            desired_count,
+            running_count: 0,
+            pending_count: 0,
+            launch_type,
+            status: "ACTIVE".to_string(),
+            scheduling_strategy,
+            deployment_controller,
+            minimum_healthy_percent: props
+                .get("DeploymentConfiguration")
+                .and_then(|v| v.get("MinimumHealthyPercent"))
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32),
+            maximum_percent: props
+                .get("DeploymentConfiguration")
+                .and_then(|v| v.get("MaximumPercent"))
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32),
+            circuit_breaker: None,
+            deployments: Vec::new(),
+            load_balancers,
+            service_registries,
+            placement_constraints,
+            placement_strategy,
+            network_configuration,
+            tags,
+            created_at: Utc::now(),
+            created_by: None,
+            role_arn,
+        };
+        state.services.insert(key.clone(), service);
+        if let Some(c) = state.clusters.get_mut(&cluster_name) {
+            c.active_services_count += 1;
+        }
+        Ok(ProvisionResult::new(service_arn.clone())
+            .with("Name", service_name)
+            .with("ServiceArn", service_arn))
+    }
+
+    fn delete_ecs_service(&self, physical_id: &str) -> Result<(), String> {
+        // physical_id is full Service ARN: .../service/<cluster>/<service>
+        let Some((cluster, service)) = parse_service_arn(physical_id) else {
+            return Ok(());
+        };
+        let key = format!("{cluster}/{service}");
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.services.remove(&key).is_some() {
+            if let Some(c) = state.clusters.get_mut(&cluster) {
+                if c.active_services_count > 0 {
+                    c.active_services_count -= 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn create_ecs_capacity_provider(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let arn = format!(
+            "arn:aws:ecs:{}:{}:capacity-provider/{}",
+            self.region, self.account_id, name
+        );
+        let cp = EcsCapacityProvider {
+            name: name.clone(),
+            arn: arn.clone(),
+            status: "ACTIVE".to_string(),
+            auto_scaling_group_provider: props.get("AutoScalingGroupProvider").cloned(),
+            update_status: None,
+            update_status_reason: None,
+            created_at: Utc::now(),
+            tags: parse_ecs_tags(props.get("Tags")),
+        };
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.capacity_providers.insert(name.clone(), cp);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_ecs_capacity_provider(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.capacity_providers.remove(physical_id);
+        Ok(())
+    }
+}
+
+/// Convert CFN `Tags` array into the ECS `TagEntry` form.
+fn parse_ecs_tags(value: Option<&serde_json::Value>) -> Vec<EcsTagEntry> {
+    let Some(arr) = value.and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|t| {
+            let key = t.get("Key").and_then(|v| v.as_str())?.to_string();
+            let value = t.get("Value").and_then(|v| v.as_str())?.to_string();
+            Some(EcsTagEntry { key, value })
+        })
+        .collect()
+}
+
+/// Strip the cluster ARN prefix when CFN passes a Ref-resolved name or
+/// a GetAtt-resolved ARN; ECS internal state keys clusters by name.
+fn parse_ecs_cluster_name(input: &str) -> String {
+    if let Some(after) = input.split(":cluster/").nth(1) {
+        return after.to_string();
+    }
+    input.to_string()
+}
+
+/// Pull `(family, revision)` out of a task definition ARN tail like
+/// `task-definition/web:3`. Returns `(family, revision)` or
+/// `(input, 1)` for unrecognised shapes.
+fn parse_td_arn(input: &str) -> (String, i32) {
+    let suffix = input.rsplit('/').next().unwrap_or(input);
+    if let Some((family, rev)) = suffix.split_once(':') {
+        if let Ok(revision) = rev.parse::<i32>() {
+            return (family.to_string(), revision);
+        }
+    }
+    (input.to_string(), 1)
+}
+
+/// Pull `(cluster, service)` out of a service ARN like
+/// `arn:aws:ecs:us-east-1:000000000000:service/<cluster>/<service>`.
+fn parse_service_arn(input: &str) -> Option<(String, String)> {
+    let after = input.split(":service/").nth(1)?;
+    let mut parts = after.splitn(2, '/');
+    let cluster = parts.next()?.to_string();
+    let service = parts.next()?.to_string();
+    Some((cluster, service))
 }
 
 /// Parse CFN-shape Tags array into the RDS crate's tag form.
@@ -5089,6 +5514,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             rds_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
+            ecs_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             delivery: Arc::new(DeliveryBus::new()),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -133,6 +133,7 @@ pub struct CloudFormationDeps {
     pub organizations: fakecloud_organizations::SharedOrganizationsState,
     pub cognito: fakecloud_cognito::SharedCognitoState,
     pub rds: fakecloud_rds::SharedRdsState,
+    pub ecs: fakecloud_ecs::SharedEcsState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -201,6 +202,7 @@ impl CloudFormationService {
             organizations_state: self.deps.organizations.clone(),
             cognito_state: self.deps.cognito.clone(),
             rds_state: self.deps.rds.clone(),
+            ecs_state: self.deps.ecs.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1294,6 +1296,13 @@ mod tests {
                 ),
             )),
             rds: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ecs: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
@@ -1,0 +1,176 @@
+//! CloudFormation provisioner for AWS::ECS::Cluster + TaskDefinition + Service + CapacityProvider.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "cfn-ecs-cluster",
+        "ClusterSettings": [{"Name": "containerInsights", "Value": "enhanced"}]
+      }
+    },
+    "CP": {
+      "Type": "AWS::ECS::CapacityProvider",
+      "Properties": {
+        "Name": "cfn-cp"
+      }
+    },
+    "TaskDef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "Family": "cfn-task",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": ["FARGATE"],
+        "Cpu": "256",
+        "Memory": "512",
+        "ContainerDefinitions": [
+          {
+            "Name": "web",
+            "Image": "nginx:alpine",
+            "Essential": true,
+            "PortMappings": [{"ContainerPort": 80, "Protocol": "tcp"}]
+          }
+        ]
+      }
+    },
+    "Svc": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "ServiceName": "cfn-svc",
+        "Cluster": {"Ref": "Cluster"},
+        "TaskDefinition": {"Ref": "TaskDef"},
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "DeploymentConfiguration": {
+          "MinimumHealthyPercent": 50,
+          "MaximumPercent": 200
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ClusterName": {"Value": {"Ref": "Cluster"}},
+    "ClusterArn": {"Value": {"Fn::GetAtt": ["Cluster", "Arn"]}},
+    "CpName": {"Value": {"Ref": "CP"}},
+    "CpArn": {"Value": {"Fn::GetAtt": ["CP", "Arn"]}},
+    "TaskDefArn": {"Value": {"Ref": "TaskDef"}},
+    "ServiceArn": {"Value": {"Fn::GetAtt": ["Svc", "ServiceArn"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_ecs_cluster_taskdef_service_capacity_provider() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ecs = aws_sdk_ecs::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("ecs-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ecs-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut outs = std::collections::HashMap::new();
+    for o in stack.outputs() {
+        if let (Some(k), Some(v)) = (o.output_key(), o.output_value()) {
+            outs.insert(k.to_string(), v.to_string());
+        }
+    }
+    assert_eq!(
+        outs.get("ClusterName").map(|s| s.as_str()),
+        Some("cfn-ecs-cluster")
+    );
+    assert!(outs
+        .get("ClusterArn")
+        .unwrap()
+        .contains(":cluster/cfn-ecs-cluster"));
+    assert_eq!(outs.get("CpName").map(|s| s.as_str()), Some("cfn-cp"));
+    assert!(outs
+        .get("CpArn")
+        .unwrap()
+        .contains(":capacity-provider/cfn-cp"));
+    assert!(outs
+        .get("TaskDefArn")
+        .unwrap()
+        .contains(":task-definition/cfn-task:1"));
+    assert!(outs
+        .get("ServiceArn")
+        .unwrap()
+        .contains(":service/cfn-ecs-cluster/cfn-svc"));
+
+    // Verify cluster + service via SDK.
+    let clusters = ecs
+        .describe_clusters()
+        .clusters("cfn-ecs-cluster")
+        .send()
+        .await
+        .expect("describe_clusters");
+    assert_eq!(
+        clusters.clusters().first().and_then(|c| c.cluster_name()),
+        Some("cfn-ecs-cluster")
+    );
+
+    let svcs = ecs
+        .describe_services()
+        .cluster("cfn-ecs-cluster")
+        .services("cfn-svc")
+        .send()
+        .await
+        .expect("describe_services");
+    assert_eq!(
+        svcs.services().first().and_then(|s| s.service_name()),
+        Some("cfn-svc")
+    );
+    assert_eq!(svcs.services().first().map(|s| s.desired_count()), Some(1));
+
+    let td = ecs
+        .describe_task_definition()
+        .task_definition("cfn-task:1")
+        .send()
+        .await
+        .expect("describe_task_definition");
+    assert_eq!(
+        td.task_definition().and_then(|t| t.family()),
+        Some("cfn-task")
+    );
+
+    cfn.delete_stack()
+        .stack_name("ecs-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    // Cluster gone after stack delete.
+    let after = ecs
+        .describe_clusters()
+        .clusters("cfn-ecs-cluster")
+        .send()
+        .await
+        .expect("describe_clusters after delete");
+    let still_active = after
+        .clusters()
+        .iter()
+        .any(|c| c.cluster_name() == Some("cfn-ecs-cluster") && c.status() == Some("ACTIVE"));
+    assert!(
+        !still_active,
+        "cluster should be gone or non-active after stack deletion"
+    );
+}

--- a/crates/fakecloud-ecs/src/lib.rs
+++ b/crates/fakecloud-ecs/src/lib.rs
@@ -4,5 +4,6 @@ pub(crate) mod state;
 
 pub use service::EcsService;
 pub use state::{
-    Cluster, EcsSnapshot, LifecycleEvent, SharedEcsState, Task, ECS_SNAPSHOT_SCHEMA_VERSION,
+    CapacityProvider, Cluster, EcsSnapshot, EcsState, LifecycleEvent, Service, SharedEcsState,
+    TagEntry, Task, TaskDefinition, ECS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -731,6 +731,7 @@ async fn main() {
             organizations: organizations_state.clone(),
             cognito: cognito_state.clone(),
             rds: rds_state.clone(),
+            ecs: ecs_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
- CFN provisioners for the four core ECS resource types: Cluster, TaskDefinition, Service, CapacityProvider
- TaskDefinition mints next family revision via shared next_revision counter (matches RegisterTaskDefinition)
- Service stored under canonical `{cluster}/{service}` key the runtime uses; returns Err when referenced cluster missing to force CFN multi-pass retry
- Cluster delete cascades through services and tasks; Service create/delete maintain active_services_count
- Ref/GetAtt expose Arn for Cluster/CapacityProvider, TaskDefinitionArn for TaskDefinition, Name/ServiceArn for Service
- New helpers: parse_ecs_tags, parse_ecs_cluster_name (strips ARN prefix), parse_td_arn, parse_service_arn

## Test plan
- [x] cargo test -p fakecloud-cloudformation
- [x] cargo test -p fakecloud-e2e --test cloudformation_ecs (new — full stack exercising all four types end-to-end via ECS SDK)
- [x] cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for ECS Cluster, TaskDefinition, Service, and CapacityProvider with correct Ref/GetAtt outputs, cascading deletes, and revision handling. Addresses BB11 by bringing ECS IaC parity end to end, backed by new e2e tests.

- New Features
  - `AWS::ECS::Cluster`: creates with capacity providers, default strategy, configuration, and settings; delete cascades services/tasks; Ref -> name, GetAtt.Arn -> ARN.
  - `AWS::ECS::TaskDefinition`: mints next family revision, stores full container defs; physical ID and Ref return family:revision; GetAtt.TaskDefinitionArn supported; delete marks INACTIVE.
  - `AWS::ECS::Service`: stored under `{cluster}/{service}`; errors if cluster missing to trigger CFN retry; maintains cluster `active_services_count`; supports desired count, launch type, network config; GetAtt.Name and GetAtt.ServiceArn supported; Ref -> ARN.
  - `AWS::ECS::CapacityProvider`: creates with ASG provider config; Ref -> name, GetAtt.Arn -> ARN.
  - Helpers for ECS tags and ARN parsing; new e2e test provisions all four types and validates via the ECS SDK.

- Dependencies
  - Add `fakecloud-ecs` to `fakecloud-cloudformation` and wire into the server bootstrap.

<sup>Written for commit 41bc0821f74af7bf8e7b3df17523817d032519c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

