### PR TITLE
feat(cloudformation): provision ElastiCache metadata resource types (BB24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "fakecloud-dynamodb",
  "fakecloud-ecr",
  "fakecloud-ecs",
+ "fakecloud-elasticache",
  "fakecloud-elbv2",
  "fakecloud-eventbridge",
  "fakecloud-iam",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -31,6 +31,7 @@ fakecloud-cognito = { workspace = true }
 fakecloud-rds = { workspace = true }
 fakecloud-ecs = { workspace = true }
 fakecloud-acm = { workspace = true }
+fakecloud-elasticache = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -747,6 +747,7 @@ mod tests {
             rds: shared::<fakecloud_rds::RdsState>(),
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
+            elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -24,6 +24,10 @@ use fakecloud_ecs::{
     CapacityProvider as EcsCapacityProvider, Cluster as EcsCluster, Service as EcsService,
     SharedEcsState, TagEntry as EcsTagEntry, TaskDefinition as EcsTaskDefinition,
 };
+use fakecloud_elasticache::{
+    CacheParameterGroup, CacheSecurityGroup, CacheSubnetGroup, ElastiCacheUser as EcUser,
+    ElastiCacheUserGroup as EcUserGroup, SharedElastiCacheState,
+};
 use fakecloud_elbv2::{
     Action as ElbAction, Listener, LoadBalancer, Rule as ElbRule, RuleCondition, SharedElbv2State,
     Tag as ElbTag, TargetGroup, TargetGroupTuple,
@@ -308,6 +312,7 @@ pub struct ResourceProvisioner {
     pub rds_state: SharedRdsState,
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
+    pub elasticache_state: SharedElastiCacheState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -385,6 +390,11 @@ impl ResourceProvisioner {
             "AWS::ECS::Service" => self.create_ecs_service(resource),
             "AWS::ECS::CapacityProvider" => self.create_ecs_capacity_provider(resource),
             "AWS::CertificateManager::Certificate" => self.create_acm_certificate(resource),
+            "AWS::ElastiCache::ParameterGroup" => self.create_ec_parameter_group(resource),
+            "AWS::ElastiCache::SubnetGroup" => self.create_ec_subnet_group(resource),
+            "AWS::ElastiCache::SecurityGroup" => self.create_ec_security_group(resource),
+            "AWS::ElastiCache::User" => self.create_ec_user(resource),
+            "AWS::ElastiCache::UserGroup" => self.create_ec_user_group(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -511,6 +521,15 @@ impl ResourceProvisioner {
             "AWS::CertificateManager::Certificate" => {
                 self.delete_acm_certificate(&resource.physical_id)
             }
+            "AWS::ElastiCache::ParameterGroup" => {
+                self.delete_ec_parameter_group(&resource.physical_id)
+            }
+            "AWS::ElastiCache::SubnetGroup" => self.delete_ec_subnet_group(&resource.physical_id),
+            "AWS::ElastiCache::SecurityGroup" => {
+                self.delete_ec_security_group(&resource.physical_id)
+            }
+            "AWS::ElastiCache::User" => self.delete_ec_user(&resource.physical_id),
+            "AWS::ElastiCache::UserGroup" => self.delete_ec_user_group(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -5349,6 +5368,253 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- ElastiCache ---
+
+    fn create_ec_parameter_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("CacheParameterGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let family = props
+            .get("CacheParameterGroupFamily")
+            .and_then(|v| v.as_str())
+            .unwrap_or("redis7")
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:parametergroup:{}",
+            self.region, self.account_id, name
+        );
+        let group = CacheParameterGroup {
+            cache_parameter_group_name: name.clone(),
+            cache_parameter_group_family: family,
+            description,
+            is_global: false,
+            arn: arn.clone(),
+        };
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        // ParameterGroups stored as Vec — replace any existing entry.
+        state
+            .parameter_groups
+            .retain(|p| p.cache_parameter_group_name != name);
+        state.parameter_groups.push(group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_ec_parameter_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state
+            .parameter_groups
+            .retain(|p| p.cache_parameter_group_name != physical_id);
+        Ok(())
+    }
+
+    fn create_ec_subnet_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("CacheSubnetGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let subnet_ids: Vec<String> = props
+            .get("SubnetIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:subnetgroup:{}",
+            self.region, self.account_id, name
+        );
+        let group = CacheSubnetGroup {
+            cache_subnet_group_name: name.clone(),
+            cache_subnet_group_description: description,
+            vpc_id: String::new(),
+            subnet_ids,
+            arn: arn.clone(),
+        };
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.subnet_groups.insert(name.clone(), group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_ec_subnet_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.subnet_groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ec_security_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("CacheSecurityGroupName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:securitygroup:{}",
+            self.region, self.account_id, name
+        );
+        let group = CacheSecurityGroup {
+            cache_security_group_name: name.clone(),
+            description,
+            owner_id: self.account_id.clone(),
+            arn: arn.clone(),
+            ec2_security_groups: Vec::new(),
+        };
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.security_groups.insert(name.clone(), group);
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_ec_security_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.security_groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ec_user(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_id = props
+            .get("UserId")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let user_name = props
+            .get("UserName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&user_id)
+            .to_string();
+        let engine = props
+            .get("Engine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("redis")
+            .to_string();
+        let access_string = props
+            .get("AccessString")
+            .and_then(|v| v.as_str())
+            .unwrap_or("on ~* +@all")
+            .to_string();
+        let authentication_type = props
+            .get("AuthenticationMode")
+            .and_then(|v| v.get("Type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("no-password-required")
+            .to_string();
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:user:{}",
+            self.region, self.account_id, user_id
+        );
+        let user = EcUser {
+            user_id: user_id.clone(),
+            user_name,
+            engine,
+            access_string,
+            status: "active".to_string(),
+            authentication_type,
+            password_count: 0,
+            arn: arn.clone(),
+            minimum_engine_version: "6.0".to_string(),
+            user_group_ids: Vec::new(),
+        };
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.users.insert(user_id.clone(), user);
+        Ok(ProvisionResult::new(user_id).with("Arn", arn))
+    }
+
+    fn delete_ec_user(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.users.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ec_user_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_group_id = props
+            .get("UserGroupId")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let engine = props
+            .get("Engine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("redis")
+            .to_string();
+        let user_ids: Vec<String> = props
+            .get("UserIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let arn = format!(
+            "arn:aws:elasticache:{}:{}:usergroup:{}",
+            self.region, self.account_id, user_group_id
+        );
+        let group = EcUserGroup {
+            user_group_id: user_group_id.clone(),
+            engine,
+            status: "active".to_string(),
+            user_ids,
+            arn: arn.clone(),
+            minimum_engine_version: "6.0".to_string(),
+            pending_changes: None,
+            replication_groups: Vec::new(),
+        };
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.user_groups.insert(user_group_id.clone(), group);
+        Ok(ProvisionResult::new(user_group_id).with("Arn", arn))
+    }
+
+    fn delete_ec_user_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.user_groups.remove(physical_id);
+        Ok(())
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -5700,6 +5966,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             acm_state: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
+            elasticache_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -135,6 +135,7 @@ pub struct CloudFormationDeps {
     pub rds: fakecloud_rds::SharedRdsState,
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
+    pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -205,6 +206,7 @@ impl CloudFormationService {
             rds_state: self.deps.rds.clone(),
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
+            elasticache_state: self.deps.elasticache.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1312,6 +1314,13 @@ mod tests {
                 ),
             )),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
+            elasticache: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_elasticache.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_elasticache.rs
@@ -1,0 +1,168 @@
+//! CloudFormation provisioner for ElastiCache metadata resource types
+//! (ParameterGroup, SubnetGroup, SecurityGroup, User, UserGroup).
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "PG": {
+      "Type": "AWS::ElastiCache::ParameterGroup",
+      "Properties": {
+        "CacheParameterGroupName": "cfn-ec-pg",
+        "CacheParameterGroupFamily": "redis7",
+        "Description": "test pg"
+      }
+    },
+    "SubnetGroup": {
+      "Type": "AWS::ElastiCache::SubnetGroup",
+      "Properties": {
+        "CacheSubnetGroupName": "cfn-ec-subnets",
+        "Description": "test subnets",
+        "SubnetIds": ["subnet-aaa", "subnet-bbb"]
+      }
+    },
+    "SG": {
+      "Type": "AWS::ElastiCache::SecurityGroup",
+      "Properties": {
+        "Description": "test ec sg"
+      }
+    },
+    "User": {
+      "Type": "AWS::ElastiCache::User",
+      "Properties": {
+        "UserId": "cfn-ec-user",
+        "UserName": "cfn-user",
+        "Engine": "redis",
+        "AccessString": "on ~* +@all"
+      }
+    },
+    "UserGroup": {
+      "Type": "AWS::ElastiCache::UserGroup",
+      "Properties": {
+        "UserGroupId": "cfn-ec-usergroup",
+        "Engine": "redis",
+        "UserIds": [{"Ref": "User"}]
+      }
+    }
+  },
+  "Outputs": {
+    "PgName": {"Value": {"Ref": "PG"}},
+    "PgArn": {"Value": {"Fn::GetAtt": ["PG", "Arn"]}},
+    "SubnetGroupName": {"Value": {"Ref": "SubnetGroup"}},
+    "SgName": {"Value": {"Ref": "SG"}},
+    "UserId": {"Value": {"Ref": "User"}},
+    "UserGroupId": {"Value": {"Ref": "UserGroup"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_elasticache_metadata() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ec = aws_sdk_elasticache::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("ec-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ec-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut outs = std::collections::HashMap::new();
+    for o in stack.outputs() {
+        if let (Some(k), Some(v)) = (o.output_key(), o.output_value()) {
+            outs.insert(k.to_string(), v.to_string());
+        }
+    }
+    assert_eq!(outs.get("PgName").map(|s| s.as_str()), Some("cfn-ec-pg"));
+    assert!(outs
+        .get("PgArn")
+        .unwrap()
+        .contains(":parametergroup:cfn-ec-pg"));
+    assert_eq!(
+        outs.get("SubnetGroupName").map(|s| s.as_str()),
+        Some("cfn-ec-subnets")
+    );
+    assert_eq!(outs.get("UserId").map(|s| s.as_str()), Some("cfn-ec-user"));
+    assert_eq!(
+        outs.get("UserGroupId").map(|s| s.as_str()),
+        Some("cfn-ec-usergroup")
+    );
+
+    // Verify SDK reads.
+    let pgs = ec
+        .describe_cache_parameter_groups()
+        .cache_parameter_group_name("cfn-ec-pg")
+        .send()
+        .await
+        .expect("describe_cache_parameter_groups");
+    assert_eq!(
+        pgs.cache_parameter_groups()
+            .first()
+            .and_then(|g| g.cache_parameter_group_name()),
+        Some("cfn-ec-pg")
+    );
+
+    let subnet_groups = ec
+        .describe_cache_subnet_groups()
+        .cache_subnet_group_name("cfn-ec-subnets")
+        .send()
+        .await
+        .expect("describe_cache_subnet_groups");
+    assert_eq!(
+        subnet_groups
+            .cache_subnet_groups()
+            .first()
+            .and_then(|g| g.cache_subnet_group_name()),
+        Some("cfn-ec-subnets")
+    );
+
+    let users = ec
+        .describe_users()
+        .user_id("cfn-ec-user")
+        .send()
+        .await
+        .expect("describe_users");
+    assert_eq!(
+        users.users().first().and_then(|u| u.user_id()),
+        Some("cfn-ec-user")
+    );
+
+    let user_groups = ec
+        .describe_user_groups()
+        .user_group_id("cfn-ec-usergroup")
+        .send()
+        .await
+        .expect("describe_user_groups");
+    assert_eq!(
+        user_groups
+            .user_groups()
+            .first()
+            .and_then(|g| g.user_group_id()),
+        Some("cfn-ec-usergroup")
+    );
+
+    cfn.delete_stack()
+        .stack_name("ec-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = ec.describe_users().user_id("cfn-ec-user").send().await;
+    assert!(after.is_err(), "user should be gone after stack deletion");
+}

--- a/crates/fakecloud-elasticache/src/lib.rs
+++ b/crates/fakecloud-elasticache/src/lib.rs
@@ -4,6 +4,7 @@ pub(crate) mod state;
 
 pub use service::ElastiCacheService;
 pub use state::{
-    CacheCluster, ElastiCacheSnapshot, ReplicationGroup, ServerlessCache, ServiceUpdate,
-    SharedElastiCacheState, UpdateAction, ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
+    CacheCluster, CacheParameterGroup, CacheSecurityGroup, CacheSubnetGroup, ElastiCacheSnapshot,
+    ElastiCacheState, ElastiCacheUser, ElastiCacheUserGroup, ReplicationGroup, ServerlessCache,
+    ServiceUpdate, SharedElastiCacheState, UpdateAction, ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -733,6 +733,7 @@ async fn main() {
             rds: rds_state.clone(),
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
+            elasticache: elasticache_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
- CFN provisioners for ElastiCache metadata: ParameterGroup, SubnetGroup, SecurityGroup, User, UserGroup
- Pure metadata path (no Docker); CacheCluster + ReplicationGroup deferred to a follow-up batch since they need the runtime Redis/Memcached spawn pipeline
- Ref returns canonical name/id; Arn surfaces via GetAtt where applicable; stack delete removes from matching state map

## Test plan
- [x] cargo test -p fakecloud-cloudformation
- [x] cargo test -p fakecloud-e2e --test cloudformation_elasticache (new — five metadata types in one stack)
- [x] cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for ElastiCache metadata resources (ParameterGroup, SubnetGroup, SecurityGroup, User, UserGroup). Implements BB24 and defers CacheCluster/ReplicationGroup to a follow-up.

- **New Features**
  - Provisioners store resources in ElastiCache state maps (parameter_groups, subnet_groups, security_groups, users, user_groups).
  - Ref returns the canonical name/id; Arn is available via GetAtt.
  - Stack delete removes the resource from the matching state map.
  - Pure metadata path only; no Redis/Memcached runtime.
  - New e2e test `cloudformation_elasticache.rs` creates all five types, verifies via CFN outputs and the ElastiCache SDK, then asserts teardown.

- **Dependencies**
  - Added `fakecloud-elasticache` to `fakecloud-cloudformation` and wired `elasticache` shared state into `CloudFormationService` and the server.

<sup>Written for commit f923d1e7f3d8f1c58ecbe65997ecb0f2b7c2e85c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

