### PR TITLE
feat(cfn): provision Route53 HostedZone, RecordSet, HealthCheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "fakecloud-organizations",
  "fakecloud-persistence",
  "fakecloud-rds",
+ "fakecloud-route53",
  "fakecloud-s3",
  "fakecloud-secretsmanager",
  "fakecloud-sns",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -32,6 +32,7 @@ fakecloud-rds = { workspace = true }
 fakecloud-ecs = { workspace = true }
 fakecloud-acm = { workspace = true }
 fakecloud-elasticache = { workspace = true }
+fakecloud-route53 = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -748,6 +748,7 @@ mod tests {
             ecs: shared::<fakecloud_ecs::EcsState>(),
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),
+            route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -52,6 +52,10 @@ use fakecloud_organizations::{
     POLICY_TYPE_SCP,
 };
 use fakecloud_rds::{DbParameterGroup, DbSubnetGroup, RdsTag, SharedRdsState};
+use fakecloud_route53::{
+    model::{HealthCheckConfig, HostedZoneFeatures, ResourceRecordSet},
+    SharedRoute53State, StoredHealthCheck, StoredHostedZone,
+};
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
@@ -313,6 +317,7 @@ pub struct ResourceProvisioner {
     pub ecs_state: SharedEcsState,
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
+    pub route53_state: SharedRoute53State,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -395,6 +400,9 @@ impl ResourceProvisioner {
             "AWS::ElastiCache::SecurityGroup" => self.create_ec_security_group(resource),
             "AWS::ElastiCache::User" => self.create_ec_user(resource),
             "AWS::ElastiCache::UserGroup" => self.create_ec_user_group(resource),
+            "AWS::Route53::HostedZone" => self.create_route53_hosted_zone(resource),
+            "AWS::Route53::RecordSet" => self.create_route53_record_set(resource),
+            "AWS::Route53::HealthCheck" => self.create_route53_health_check(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -530,6 +538,11 @@ impl ResourceProvisioner {
             }
             "AWS::ElastiCache::User" => self.delete_ec_user(&resource.physical_id),
             "AWS::ElastiCache::UserGroup" => self.delete_ec_user_group(&resource.physical_id),
+            "AWS::Route53::HostedZone" => self.delete_route53_hosted_zone(&resource.physical_id),
+            "AWS::Route53::RecordSet" => {
+                self.delete_route53_record_set(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::Route53::HealthCheck" => self.delete_route53_health_check(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -5615,6 +5628,390 @@ impl ResourceProvisioner {
         state.user_groups.remove(physical_id);
         Ok(())
     }
+
+    // --- Route53 ---
+
+    fn create_route53_hosted_zone(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let normalized_name = if name.ends_with('.') {
+            name.clone()
+        } else {
+            format!("{name}.")
+        };
+        let comment = props
+            .get("HostedZoneConfig")
+            .and_then(|v| v.get("Comment"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let private_zone = props
+            .get("VPCs")
+            .and_then(|v| v.as_array())
+            .map(|a| !a.is_empty())
+            .unwrap_or(false);
+        let vpcs: Vec<fakecloud_route53::model::VPC> = props
+            .get("VPCs")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .map(|vpc| fakecloud_route53::model::VPC {
+                        vpc_id: vpc.get("VPCId").and_then(|v| v.as_str()).map(String::from),
+                        vpc_region: vpc
+                            .get("VPCRegion")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let id = format!(
+            "Z{}",
+            Uuid::new_v4().simple().to_string()[..14].to_uppercase()
+        );
+        let name_servers = (1..=4)
+            .map(|i| format!("ns-{}.awsdns-{:02}.com", 100 + i, i))
+            .collect::<Vec<_>>();
+
+        let zone = StoredHostedZone {
+            id: id.clone(),
+            name: normalized_name,
+            caller_reference: format!("cfn-{}", resource.logical_id),
+            comment,
+            private_zone,
+            features: Some(HostedZoneFeatures::default()),
+            vpcs,
+            delegation_set_id: None,
+            name_servers: name_servers.clone(),
+            created_time: Utc::now(),
+            resource_record_sets: Vec::new(),
+        };
+
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        state.hosted_zones.insert(id.clone(), zone);
+
+        let mut result = ProvisionResult::new(id.clone()).with("Id", id);
+        for (i, ns) in name_servers.iter().enumerate() {
+            result = result.with(&format!("NameServers.{i}"), ns.clone());
+        }
+        result = result.with("NameServers", name_servers.join(","));
+        Ok(result)
+    }
+
+    fn delete_route53_hosted_zone(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        state.hosted_zones.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_route53_record_set(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let zone_id = props
+            .get("HostedZoneId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                "HostedZoneId is required (HostedZoneName lookups not supported)".to_string()
+            })?
+            .to_string();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let normalized_name = if name.ends_with('.') {
+            name.clone()
+        } else {
+            format!("{name}.")
+        };
+        let record_type = props
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .ok_or("Type is required")?
+            .to_string();
+        let ttl = props.get("TTL").and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse::<i64>().ok())
+                .or_else(|| v.as_i64())
+        });
+        let resource_records = props
+            .get("ResourceRecords")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                let recs: Vec<fakecloud_route53::model::ResourceRecord> = arr
+                    .iter()
+                    .filter_map(|v| {
+                        v.as_str()
+                            .map(|s| fakecloud_route53::model::ResourceRecord {
+                                value: s.to_string(),
+                            })
+                    })
+                    .collect();
+                fakecloud_route53::model::ResourceRecords {
+                    resource_record: recs,
+                }
+            });
+        let alias_target =
+            props
+                .get("AliasTarget")
+                .map(|v| fakecloud_route53::model::AliasTarget {
+                    hosted_zone_id: v
+                        .get("HostedZoneId")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    dns_name: v
+                        .get("DNSName")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    evaluate_target_health: v
+                        .get("EvaluateTargetHealth")
+                        .and_then(|x| x.as_bool())
+                        .unwrap_or(false),
+                });
+        let set_identifier = props
+            .get("SetIdentifier")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let weight = props.get("Weight").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        });
+        let region = props
+            .get("Region")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let failover = props
+            .get("Failover")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let multi_value_answer = props.get("MultiValueAnswer").and_then(|v| v.as_bool());
+        let health_check_id = props
+            .get("HealthCheckId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let rrset = ResourceRecordSet {
+            name: normalized_name.clone(),
+            record_type: record_type.clone(),
+            set_identifier: set_identifier.clone(),
+            weight,
+            region,
+            geo_location: None,
+            failover,
+            multi_value_answer,
+            ttl,
+            resource_records,
+            alias_target,
+            health_check_id,
+            traffic_policy_instance_id: None,
+            cidr_routing_config: None,
+            geo_proximity_location: None,
+        };
+
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        let zone = state.hosted_zones.get_mut(&zone_id).ok_or_else(|| {
+            format!(
+                "HostedZone {zone_id} not yet provisioned; will retry once it has been provisioned"
+            )
+        })?;
+        // Replace existing record with matching (name, type, set_identifier).
+        zone.resource_record_sets.retain(|r| {
+            !(r.name == rrset.name
+                && r.record_type == rrset.record_type
+                && r.set_identifier == rrset.set_identifier)
+        });
+        zone.resource_record_sets.push(rrset);
+
+        let physical_id = match &set_identifier {
+            Some(sid) => format!("{zone_id}|{normalized_name}|{record_type}|{sid}"),
+            None => format!("{zone_id}|{normalized_name}|{record_type}"),
+        };
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    fn delete_route53_record_set(
+        &self,
+        physical_id: &str,
+        _attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let parts: Vec<&str> = physical_id.split('|').collect();
+        if parts.len() < 3 {
+            return Ok(());
+        }
+        let zone_id = parts[0];
+        let name = parts[1];
+        let record_type = parts[2];
+        let set_identifier = parts.get(3).map(|s| s.to_string());
+
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        if let Some(zone) = state.hosted_zones.get_mut(zone_id) {
+            zone.resource_record_sets.retain(|r| {
+                !(r.name == name
+                    && r.record_type == record_type
+                    && r.set_identifier == set_identifier)
+            });
+        }
+        Ok(())
+    }
+
+    fn create_route53_health_check(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg_value = props
+            .get("HealthCheckConfig")
+            .ok_or("HealthCheckConfig is required")?;
+
+        let health_check_type = cfg_value
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .ok_or("HealthCheckConfig.Type is required")?
+            .to_string();
+
+        let cfg = HealthCheckConfig {
+            ip_address: cfg_value
+                .get("IPAddress")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            port: cfg_value
+                .get("Port")
+                .and_then(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .map(|n| n as i32),
+            health_check_type,
+            resource_path: cfg_value
+                .get("ResourcePath")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            fully_qualified_domain_name: cfg_value
+                .get("FullyQualifiedDomainName")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            search_string: cfg_value
+                .get("SearchString")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            request_interval: cfg_value
+                .get("RequestInterval")
+                .and_then(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .map(|n| n as i32),
+            failure_threshold: cfg_value
+                .get("FailureThreshold")
+                .and_then(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .map(|n| n as i32),
+            measure_latency: cfg_value.get("MeasureLatency").and_then(|v| v.as_bool()),
+            inverted: cfg_value.get("Inverted").and_then(|v| v.as_bool()),
+            disabled: cfg_value.get("Disabled").and_then(|v| v.as_bool()),
+            health_threshold: cfg_value
+                .get("HealthThreshold")
+                .and_then(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .map(|n| n as i32),
+            child_health_checks: cfg_value
+                .get("ChildHealthChecks")
+                .and_then(|v| v.as_array())
+                .map(|arr| fakecloud_route53::model::ChildHealthChecks {
+                    child_health_check: arr
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                }),
+            enable_sni: cfg_value.get("EnableSNI").and_then(|v| v.as_bool()),
+            regions: cfg_value
+                .get("Regions")
+                .and_then(|v| v.as_array())
+                .map(|arr| fakecloud_route53::model::HealthCheckRegions {
+                    region: arr
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                }),
+            alarm_identifier: cfg_value.get("AlarmIdentifier").map(|v| {
+                fakecloud_route53::model::AlarmIdentifier {
+                    region: v
+                        .get("Region")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    name: v
+                        .get("Name")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                }
+            }),
+            insufficient_data_health_status: cfg_value
+                .get("InsufficientDataHealthStatus")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            routing_control_arn: cfg_value
+                .get("RoutingControlArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        };
+
+        let id = Uuid::new_v4().to_string();
+        let hc = StoredHealthCheck {
+            id: id.clone(),
+            caller_reference: format!("cfn-{}", resource.logical_id),
+            version: 1,
+            config: cfg,
+            created_time: Utc::now(),
+            status_line: "Success: HTTP Status Code 200, OK.".to_string(),
+            last_failure_reason: None,
+        };
+
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        state.health_checks.insert(id.clone(), hc);
+
+        Ok(ProvisionResult::new(id.clone()).with("HealthCheckId", id))
+    }
+
+    fn delete_route53_health_check(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        state.health_checks.remove(physical_id);
+        Ok(())
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -5969,6 +6366,7 @@ mod tests {
             elasticache_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
+            route53_state: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -136,6 +136,7 @@ pub struct CloudFormationDeps {
     pub ecs: fakecloud_ecs::SharedEcsState,
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
+    pub route53: fakecloud_route53::SharedRoute53State,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -207,6 +208,7 @@ impl CloudFormationService {
             ecs_state: self.deps.ecs.clone(),
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
+            route53_state: self.deps.route53.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1321,6 +1323,7 @@ mod tests {
                     "",
                 ),
             )),
+            route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_route53.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_route53.rs
@@ -1,0 +1,152 @@
+//! CloudFormation provisioner for AWS::Route53::HostedZone, RecordSet, and HealthCheck.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Zone": {
+      "Type": "AWS::Route53::HostedZone",
+      "Properties": {
+        "Name": "example.com.",
+        "HostedZoneConfig": {"Comment": "managed by cfn"}
+      }
+    },
+    "ApiRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneId": {"Ref": "Zone"},
+        "Name": "api.example.com.",
+        "Type": "A",
+        "TTL": "300",
+        "ResourceRecords": ["10.0.0.1", "10.0.0.2"]
+      }
+    },
+    "HealthCheck": {
+      "Type": "AWS::Route53::HealthCheck",
+      "Properties": {
+        "HealthCheckConfig": {
+          "Type": "HTTP",
+          "FullyQualifiedDomainName": "api.example.com",
+          "Port": 80,
+          "ResourcePath": "/health",
+          "RequestInterval": 30,
+          "FailureThreshold": 3
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ZoneId": {"Value": {"Ref": "Zone"}},
+    "RecordPhysicalId": {"Value": {"Ref": "ApiRecord"}},
+    "HealthCheckId": {"Value": {"Ref": "HealthCheck"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_route53_resources() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let r53 = aws_sdk_route53::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("r53-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("r53-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let zone_id = outputs.get("ZoneId").expect("ZoneId output");
+    let record_pid = outputs.get("RecordPhysicalId").expect("RecordPhysicalId");
+    let health_id = outputs.get("HealthCheckId").expect("HealthCheckId");
+
+    assert!(zone_id.starts_with('Z'), "zone id format: {zone_id}");
+    assert!(
+        record_pid.contains("api.example.com.") && record_pid.contains("|A"),
+        "record physical id format: {record_pid}"
+    );
+    assert!(!health_id.is_empty());
+
+    // Verify hosted zone via SDK.
+    let zone = r53
+        .get_hosted_zone()
+        .id(*zone_id)
+        .send()
+        .await
+        .expect("get_hosted_zone");
+    let hz = zone.hosted_zone().expect("hosted zone");
+    assert_eq!(hz.name(), "example.com.");
+
+    // Verify record set landed in the zone.
+    let records = r53
+        .list_resource_record_sets()
+        .hosted_zone_id(*zone_id)
+        .send()
+        .await
+        .expect("list_resource_record_sets");
+    let api_record = records
+        .resource_record_sets()
+        .iter()
+        .find(|r| r.name() == "api.example.com." && r.r#type().as_str() == "A")
+        .expect("api A record");
+    assert_eq!(api_record.ttl(), Some(300));
+    let values: Vec<&str> = api_record
+        .resource_records()
+        .iter()
+        .map(|rr| rr.value())
+        .collect();
+    assert!(values.contains(&"10.0.0.1"));
+    assert!(values.contains(&"10.0.0.2"));
+
+    // Verify health check.
+    let hc = r53
+        .get_health_check()
+        .health_check_id(*health_id)
+        .send()
+        .await
+        .expect("get_health_check");
+    let cfg = hc
+        .health_check()
+        .and_then(|h| h.health_check_config())
+        .expect("health check config");
+    assert_eq!(cfg.r#type().as_str(), "HTTP");
+    assert_eq!(cfg.fully_qualified_domain_name(), Some("api.example.com"));
+    assert_eq!(cfg.port(), Some(80));
+
+    // Tear down.
+    cfn.delete_stack()
+        .stack_name("r53-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let zone_after = r53.get_hosted_zone().id(*zone_id).send().await;
+    assert!(zone_after.is_err(), "hosted zone should be gone");
+
+    let hc_after = r53
+        .get_health_check()
+        .health_check_id(*health_id)
+        .send()
+        .await;
+    assert!(hc_after.is_err(), "health check should be gone");
+}

--- a/crates/fakecloud-route53/src/lib.rs
+++ b/crates/fakecloud-route53/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod model;
 pub mod router;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 pub mod xml_io;
 
 pub const API_VERSION: &str = "2013-04-01";
@@ -16,4 +16,6 @@ pub const API_PREFIX: &str = "/2013-04-01";
 pub const NAMESPACE: &str = "https://route53.amazonaws.com/doc/2013-04-01/";
 
 pub use service::Route53Service;
-pub use state::{Route53Accounts, SharedRoute53State};
+pub use state::{
+    AccountState, Route53Accounts, SharedRoute53State, StoredHealthCheck, StoredHostedZone,
+};

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -734,6 +734,7 @@ async fn main() {
             ecs: ecs_state.clone(),
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),
+            route53: route53_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
- `AWS::Route53::HostedZone` — mints Z-prefixed id, persists comment + VPCs + 4 synthetic NS records; Ref returns the zone id; GetAtt `NameServers.{0..3}` and a comma-joined `NameServers` are exposed.
- `AWS::Route53::RecordSet` — upserts into the parent hosted zone keyed by `(name, type, set_identifier)`; physical id encodes those parts so delete can pinpoint the record.
- `AWS::Route53::HealthCheck` — stores HealthCheckConfig including IPAddress/Port/ResourcePath/RequestInterval/FailureThreshold/Inverted/Disabled/HealthThreshold/EnableSNI/Regions/AlarmIdentifier.
- All three write into the global default-account bucket so the live Route53 service reads the same data CFN wrote.

## Test plan
- [x] new e2e `cloudformation_route53.rs` exercising the three resource types end-to-end via CFN -> Route53 SDK.
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for Route53: `AWS::Route53::HostedZone`, `AWS::Route53::RecordSet`, and `AWS::Route53::HealthCheck`. Stacks can now create zones, DNS records, and health checks, with data stored in the global Route53 bucket and validated by a new e2e test.

- **New Features**
  - `AWS::Route53::HostedZone`: Z-prefixed id; saves comment and VPCs; adds 4 synthetic NS records. Ref returns zone id; GetAtt `NameServers.{0..3}` and `NameServers` supported.
  - `AWS::Route53::RecordSet`: Upserts into the parent zone keyed by (name, type, set_identifier). Physical id encodes those parts for precise delete.
  - `AWS::Route53::HealthCheck`: Stores full `HealthCheckConfig` (IP/Port/ResourcePath/RequestInterval/FailureThreshold/etc.).
  - Data is written to the global default-account bucket so Route53 SDK reads match CFN writes.

- **Dependencies**
  - Add `fakecloud-route53` and wire `route53_state` into CloudFormation service and server.

<sup>Written for commit 00ee9f00f88be8d9316afe6c39dcadea1f89adc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

