### PR TITLE
feat(cfn): provision CloudFront metadata resources (8 types)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "chrono",
  "fakecloud-acm",
  "fakecloud-aws",
+ "fakecloud-cloudfront",
  "fakecloud-cloudwatch",
  "fakecloud-cognito",
  "fakecloud-core",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -33,6 +33,7 @@ fakecloud-ecs = { workspace = true }
 fakecloud-acm = { workspace = true }
 fakecloud-elasticache = { workspace = true }
 fakecloud-route53 = { workspace = true }
+fakecloud-cloudfront = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -749,6 +749,7 @@ mod tests {
             acm: Arc::new(RwLock::new(fakecloud_acm::AcmAccounts::new())),
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),
             route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
+            cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8,6 +8,20 @@ use fakecloud_acm::{
     CertificateOptions as AcmCertificateOptions, DomainValidation as AcmDomainValidation,
     SharedAcmState, StoredCertificate as AcmStoredCertificate,
 };
+use fakecloud_cloudfront::{
+    functions::{
+        CloudFrontOriginAccessIdentityConfig, FunctionConfig, KeyGroupConfig, KeyGroupItems,
+        PublicKeyConfig, StoredFunction, StoredKeyGroup, StoredOriginAccessIdentity,
+        StoredPublicKey,
+    },
+    policies::{
+        CachePolicyConfig, OriginAccessControlConfig, OriginRequestPolicyConfig,
+        OriginRequestPolicyCookiesConfig, OriginRequestPolicyHeadersConfig,
+        OriginRequestPolicyQueryStringsConfig, ResponseHeadersPolicyConfig, StoredCachePolicy,
+        StoredOriginAccessControl, StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
+    },
+    SharedCloudFrontState,
+};
 use fakecloud_cloudwatch::{AlarmState, MetricAlarm, SharedCloudWatchState};
 use fakecloud_cognito::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CustomDomainConfig,
@@ -318,6 +332,7 @@ pub struct ResourceProvisioner {
     pub acm_state: SharedAcmState,
     pub elasticache_state: SharedElastiCacheState,
     pub route53_state: SharedRoute53State,
+    pub cloudfront_state: SharedCloudFrontState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -403,6 +418,22 @@ impl ResourceProvisioner {
             "AWS::Route53::HostedZone" => self.create_route53_hosted_zone(resource),
             "AWS::Route53::RecordSet" => self.create_route53_record_set(resource),
             "AWS::Route53::HealthCheck" => self.create_route53_health_check(resource),
+            "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
+                self.create_cf_origin_access_identity(resource)
+            }
+            "AWS::CloudFront::OriginAccessControl" => {
+                self.create_cf_origin_access_control(resource)
+            }
+            "AWS::CloudFront::PublicKey" => self.create_cf_public_key(resource),
+            "AWS::CloudFront::KeyGroup" => self.create_cf_key_group(resource),
+            "AWS::CloudFront::Function" => self.create_cf_function(resource),
+            "AWS::CloudFront::CachePolicy" => self.create_cf_cache_policy(resource),
+            "AWS::CloudFront::OriginRequestPolicy" => {
+                self.create_cf_origin_request_policy(resource)
+            }
+            "AWS::CloudFront::ResponseHeadersPolicy" => {
+                self.create_cf_response_headers_policy(resource)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -543,6 +574,22 @@ impl ResourceProvisioner {
                 self.delete_route53_record_set(&resource.physical_id, &resource.attributes)
             }
             "AWS::Route53::HealthCheck" => self.delete_route53_health_check(&resource.physical_id),
+            "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
+                self.delete_cf_origin_access_identity(&resource.physical_id)
+            }
+            "AWS::CloudFront::OriginAccessControl" => {
+                self.delete_cf_origin_access_control(&resource.physical_id)
+            }
+            "AWS::CloudFront::PublicKey" => self.delete_cf_public_key(&resource.physical_id),
+            "AWS::CloudFront::KeyGroup" => self.delete_cf_key_group(&resource.physical_id),
+            "AWS::CloudFront::Function" => self.delete_cf_function(&resource.physical_id),
+            "AWS::CloudFront::CachePolicy" => self.delete_cf_cache_policy(&resource.physical_id),
+            "AWS::CloudFront::OriginRequestPolicy" => {
+                self.delete_cf_origin_request_policy(&resource.physical_id)
+            }
+            "AWS::CloudFront::ResponseHeadersPolicy" => {
+                self.delete_cf_response_headers_policy(&resource.physical_id)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -6012,6 +6059,543 @@ impl ResourceProvisioner {
         state.health_checks.remove(physical_id);
         Ok(())
     }
+
+    // --- CloudFront ---
+    //
+    // CloudFront is a global service that stores data under the default
+    // account bucket; mirror that here so SDK reads land on the same data
+    // CFN wrote.
+
+    fn create_cf_origin_access_identity(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("CloudFrontOriginAccessIdentityConfig")
+            .ok_or("CloudFrontOriginAccessIdentityConfig is required")?;
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let caller_reference = format!("cfn-{}", resource.logical_id);
+
+        let id = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+        let s3_canonical_user_id = format!(
+            "{:0<64}",
+            Uuid::new_v4().simple().to_string().to_lowercase()
+        );
+
+        let oai = StoredOriginAccessIdentity {
+            id: id.clone(),
+            etag,
+            s3_canonical_user_id: s3_canonical_user_id.clone(),
+            config: CloudFrontOriginAccessIdentityConfig {
+                caller_reference,
+                comment,
+            },
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_access_identities.insert(id.clone(), oai);
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("S3CanonicalUserId", s3_canonical_user_id))
+    }
+
+    fn delete_cf_origin_access_identity(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_access_identities.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_origin_access_control(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("OriginAccessControlConfig")
+            .ok_or("OriginAccessControlConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginAccessControlConfig.Name is required")?
+            .to_string();
+        let signing_protocol = cfg
+            .get("SigningProtocol")
+            .and_then(|v| v.as_str())
+            .unwrap_or("sigv4")
+            .to_string();
+        let signing_behavior = cfg
+            .get("SigningBehavior")
+            .and_then(|v| v.as_str())
+            .unwrap_or("always")
+            .to_string();
+        let origin_type = cfg
+            .get("OriginAccessControlOriginType")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginAccessControlConfig.OriginAccessControlOriginType is required")?
+            .to_string();
+        let description = cfg
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+        let oac = StoredOriginAccessControl {
+            id: id.clone(),
+            etag,
+            config: OriginAccessControlConfig {
+                name,
+                description,
+                signing_protocol,
+                signing_behavior,
+                origin_access_control_origin_type: origin_type,
+            },
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_access_controls.insert(id.clone(), oac);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_origin_access_control(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_access_controls.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_public_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("PublicKeyConfig")
+            .ok_or("PublicKeyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("PublicKeyConfig.Name is required")?
+            .to_string();
+        let encoded_key = cfg
+            .get("EncodedKey")
+            .and_then(|v| v.as_str())
+            .ok_or("PublicKeyConfig.EncodedKey is required")?
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let caller_reference = cfg
+            .get("CallerReference")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let caller_reference = if caller_reference.is_empty() {
+            format!("cfn-{}", resource.logical_id)
+        } else {
+            caller_reference
+        };
+
+        let id = format!(
+            "K{}",
+            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+
+        let pk = StoredPublicKey {
+            id: id.clone(),
+            etag,
+            created_time: Utc::now(),
+            config: PublicKeyConfig {
+                caller_reference,
+                name,
+                encoded_key,
+                comment,
+            },
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.public_keys.insert(id.clone(), pk);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_public_key(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.public_keys.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_key_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("KeyGroupConfig")
+            .ok_or("KeyGroupConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("KeyGroupConfig.Name is required")?
+            .to_string();
+        let items: Vec<String> = cfg
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "KG{}",
+            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+
+        let kg = StoredKeyGroup {
+            id: id.clone(),
+            etag,
+            last_modified_time: Utc::now(),
+            config: KeyGroupConfig {
+                name,
+                items: KeyGroupItems { public_key: items },
+                comment,
+            },
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.key_groups.insert(id.clone(), kg);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_key_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.key_groups.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_function(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let function_code = props
+            .get("FunctionCode")
+            .and_then(|v| v.as_str())
+            .ok_or("FunctionCode is required")?
+            .to_string();
+        let cfg = props
+            .get("FunctionConfig")
+            .ok_or("FunctionConfig is required")?;
+        let runtime = cfg
+            .get("Runtime")
+            .and_then(|v| v.as_str())
+            .unwrap_or("cloudfront-js-2.0")
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "FN{}",
+            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+        let function_arn = format!("arn:aws:cloudfront::{}:function/{}", self.account_id, name);
+
+        let now = Utc::now();
+        let func = StoredFunction {
+            name: name.clone(),
+            etag,
+            status: "UNPUBLISHED".to_string(),
+            stage: "DEVELOPMENT".to_string(),
+            function_arn: function_arn.clone(),
+            created_time: now,
+            last_modified_time: now,
+            config: FunctionConfig {
+                comment,
+                runtime,
+                key_value_store_associations: None,
+            },
+            function_code,
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        // Use the function's ARN/name as the registry key so subsequent
+        // operations (Get/Update/Delete) keyed by name resolve.
+        state.functions.insert(name.clone(), func);
+
+        Ok(ProvisionResult::new(name.clone())
+            .with("FunctionARN", function_arn)
+            .with("FunctionMetadata.FunctionARN", id)
+            .with("Stage", "DEVELOPMENT"))
+    }
+
+    fn delete_cf_function(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.functions.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_cache_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("CachePolicyConfig")
+            .ok_or("CachePolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("CachePolicyConfig.Name is required")?
+            .to_string();
+        let min_ttl = cfg
+            .get("MinTTL")
+            .and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+            })
+            .unwrap_or(0);
+        let default_ttl = cfg.get("DefaultTTL").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        });
+        let max_ttl = cfg.get("MaxTTL").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        });
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "CP{}",
+            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+
+        let cache_policy = StoredCachePolicy {
+            id: id.clone(),
+            etag,
+            last_modified_time: Utc::now(),
+            config: CachePolicyConfig {
+                comment,
+                name,
+                default_ttl,
+                max_ttl,
+                min_ttl,
+                parameters_in_cache_key_and_forwarded_to_origin: None,
+            },
+            policy_type: "custom".to_string(),
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.cache_policies.insert(id.clone(), cache_policy);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_cache_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.cache_policies.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_origin_request_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("OriginRequestPolicyConfig")
+            .ok_or("OriginRequestPolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginRequestPolicyConfig.Name is required")?
+            .to_string();
+        let header_behavior = cfg
+            .get("HeadersConfig")
+            .and_then(|v| v.get("HeaderBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let cookie_behavior = cfg
+            .get("CookiesConfig")
+            .and_then(|v| v.get("CookieBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let query_string_behavior = cfg
+            .get("QueryStringsConfig")
+            .and_then(|v| v.get("QueryStringBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "ORP{}",
+            Uuid::new_v4().simple().to_string()[..11].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+
+        let policy = StoredOriginRequestPolicy {
+            id: id.clone(),
+            etag,
+            last_modified_time: Utc::now(),
+            config: OriginRequestPolicyConfig {
+                comment,
+                name,
+                headers_config: OriginRequestPolicyHeadersConfig {
+                    header_behavior,
+                    headers: None,
+                },
+                cookies_config: OriginRequestPolicyCookiesConfig {
+                    cookie_behavior,
+                    cookies: None,
+                },
+                query_strings_config: OriginRequestPolicyQueryStringsConfig {
+                    query_string_behavior,
+                    query_strings: None,
+                },
+            },
+            policy_type: "custom".to_string(),
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_request_policies.insert(id.clone(), policy);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_origin_request_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.origin_request_policies.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cf_response_headers_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cfg = props
+            .get("ResponseHeadersPolicyConfig")
+            .ok_or("ResponseHeadersPolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("ResponseHeadersPolicyConfig.Name is required")?
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = format!(
+            "RHP{}",
+            Uuid::new_v4().simple().to_string()[..11].to_uppercase()
+        );
+        let etag = format!(
+            "E{}",
+            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
+        );
+
+        let policy = StoredResponseHeadersPolicy {
+            id: id.clone(),
+            etag,
+            last_modified_time: Utc::now(),
+            config: ResponseHeadersPolicyConfig {
+                comment,
+                name,
+                cors_config: None,
+                security_headers_config: None,
+                server_timing_headers_config: None,
+                custom_headers_config: None,
+                remove_headers_config: None,
+            },
+            policy_type: "custom".to_string(),
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.response_headers_policies.insert(id.clone(), policy);
+
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    fn delete_cf_response_headers_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.response_headers_policies.remove(physical_id);
+        Ok(())
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -6367,6 +6951,9 @@ mod tests {
                 fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             route53_state: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
+            cloudfront_state: Arc::new(RwLock::new(
+                fakecloud_cloudfront::CloudFrontAccounts::new(),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -137,6 +137,7 @@ pub struct CloudFormationDeps {
     pub acm: fakecloud_acm::SharedAcmState,
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
     pub route53: fakecloud_route53::SharedRoute53State,
+    pub cloudfront: fakecloud_cloudfront::SharedCloudFrontState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -209,6 +210,7 @@ impl CloudFormationService {
             acm_state: self.deps.acm.clone(),
             elasticache_state: self.deps.elasticache.clone(),
             route53_state: self.deps.route53.clone(),
+            cloudfront_state: self.deps.cloudfront.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1324,6 +1326,7 @@ mod tests {
                 ),
             )),
             route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
+            cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -20,7 +20,7 @@ pub mod policies;
 pub mod policies_service;
 pub mod router;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 pub mod streaming;
 pub mod streaming_service;
 pub mod tenants;

--- a/crates/fakecloud-e2e/tests/cloudformation_cloudfront.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_cloudfront.rs
@@ -1,0 +1,170 @@
+//! CloudFormation provisioner for AWS::CloudFront::* metadata resources.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "OAI": {
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+      "Properties": {
+        "CloudFrontOriginAccessIdentityConfig": {"Comment": "managed by cfn"}
+      }
+    },
+    "OAC": {
+      "Type": "AWS::CloudFront::OriginAccessControl",
+      "Properties": {
+        "OriginAccessControlConfig": {
+          "Name": "cfn-oac",
+          "OriginAccessControlOriginType": "s3",
+          "SigningBehavior": "always",
+          "SigningProtocol": "sigv4"
+        }
+      }
+    },
+    "PubKey": {
+      "Type": "AWS::CloudFront::PublicKey",
+      "Properties": {
+        "PublicKeyConfig": {
+          "CallerReference": "cfn-pk-1",
+          "Name": "cfn-pubkey",
+          "EncodedKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END PUBLIC KEY-----"
+        }
+      }
+    },
+    "CachePolicy": {
+      "Type": "AWS::CloudFront::CachePolicy",
+      "Properties": {
+        "CachePolicyConfig": {
+          "Name": "cfn-cache",
+          "MinTTL": 1,
+          "DefaultTTL": 60,
+          "MaxTTL": 3600
+        }
+      }
+    },
+    "OriginReqPolicy": {
+      "Type": "AWS::CloudFront::OriginRequestPolicy",
+      "Properties": {
+        "OriginRequestPolicyConfig": {
+          "Name": "cfn-origin-req",
+          "HeadersConfig": {"HeaderBehavior": "none"},
+          "CookiesConfig": {"CookieBehavior": "none"},
+          "QueryStringsConfig": {"QueryStringBehavior": "none"}
+        }
+      }
+    },
+    "RespHdrPolicy": {
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
+      "Properties": {
+        "ResponseHeadersPolicyConfig": {
+          "Name": "cfn-resp-hdr",
+          "Comment": "managed by cfn"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "OAIId": {"Value": {"Ref": "OAI"}},
+    "OACId": {"Value": {"Ref": "OAC"}},
+    "PubKeyId": {"Value": {"Ref": "PubKey"}},
+    "CachePolicyId": {"Value": {"Ref": "CachePolicy"}},
+    "OriginReqPolicyId": {"Value": {"Ref": "OriginReqPolicy"}},
+    "RespHdrPolicyId": {"Value": {"Ref": "RespHdrPolicy"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_cloudfront_resources() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cf = aws_sdk_cloudfront::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("cf-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("cf-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let oai_id = outputs.get("OAIId").expect("OAIId");
+    let oac_id = outputs.get("OACId").expect("OACId");
+    let pk_id = outputs.get("PubKeyId").expect("PubKeyId");
+    let cache_id = outputs.get("CachePolicyId").expect("CachePolicyId");
+    let orp_id = outputs.get("OriginReqPolicyId").expect("OriginReqPolicyId");
+    let rhp_id = outputs.get("RespHdrPolicyId").expect("RespHdrPolicyId");
+
+    assert!(oai_id.starts_with('E'), "OAI id: {oai_id}");
+    assert!(oac_id.starts_with('E'), "OAC id: {oac_id}");
+    assert!(pk_id.starts_with('K'), "PublicKey id: {pk_id}");
+    assert!(cache_id.starts_with("CP"), "CachePolicy id: {cache_id}");
+    assert!(orp_id.starts_with("ORP"), "OriginReqPolicy id: {orp_id}");
+    assert!(rhp_id.starts_with("RHP"), "RespHdrPolicy id: {rhp_id}");
+
+    // Verify a couple via SDK to prove the records are actually retrievable.
+    let oai_get = cf
+        .get_cloud_front_origin_access_identity()
+        .id(*oai_id)
+        .send()
+        .await
+        .expect("get_cloud_front_origin_access_identity");
+    assert!(oai_get.cloud_front_origin_access_identity().is_some());
+
+    let oac_get = cf
+        .get_origin_access_control()
+        .id(*oac_id)
+        .send()
+        .await
+        .expect("get_origin_access_control");
+    let oac_cfg = oac_get
+        .origin_access_control()
+        .and_then(|o| o.origin_access_control_config())
+        .expect("origin access control config");
+    assert_eq!(oac_cfg.name(), "cfn-oac");
+
+    let cache_get = cf
+        .get_cache_policy()
+        .id(*cache_id)
+        .send()
+        .await
+        .expect("get_cache_policy");
+    let cache_cfg = cache_get
+        .cache_policy()
+        .and_then(|p| p.cache_policy_config())
+        .expect("cache policy config");
+    assert_eq!(cache_cfg.name(), "cfn-cache");
+    assert_eq!(cache_cfg.min_ttl(), 1);
+
+    cfn.delete_stack()
+        .stack_name("cf-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let oai_after = cf
+        .get_cloud_front_origin_access_identity()
+        .id(*oai_id)
+        .send()
+        .await;
+    assert!(oai_after.is_err(), "OAI should be gone");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -735,6 +735,7 @@ async fn main() {
             acm: acm_state.clone(),
             elasticache: elasticache_state.clone(),
             route53: route53_state.clone(),
+            cloudfront: cloudfront_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
Provisions 8 AWS::CloudFront::* metadata resource types via CFN:

- `CloudFrontOriginAccessIdentity` — legacy OAI with synthetic S3 canonical user id; Ref returns id, GetAtt exposes `S3CanonicalUserId`.
- `OriginAccessControl` — modern OAC with name/SigningProtocol/SigningBehavior/OriginAccessControlOriginType.
- `PublicKey` — caller-provided EncodedKey, name, comment.
- `KeyGroup` — references a list of public-key ids.
- `Function` — code + runtime + comment, lands as DEVELOPMENT/UNPUBLISHED, function arn exposed via GetAtt.
- `CachePolicy` — name + MinTTL + DefaultTTL + MaxTTL.
- `OriginRequestPolicy` — name + headers/cookies/query-strings behavior.
- `ResponseHeadersPolicy` — name + comment (full sub-config left for follow-up).

CloudFront is global so the provisioner writes into the default-account bucket where the SDK reads.

`AWS::CloudFront::Distribution` itself is deferred to a follow-up batch — DistributionConfig is large and needs its own lifecycle (deployed status transitions, domain name, etag rotation).

## Test plan
- [x] new e2e `cloudformation_cloudfront.rs` exercising all 6 simpler resource types end-to-end via CFN -> CloudFront SDK
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFront metadata provisioning to the CloudFormation provisioner and wire CloudFront state into the server. Resources are stored in the default account to match CloudFront’s global scope.

- **New Features**
  - Provision via CFN: `CloudFrontOriginAccessIdentity`, `OriginAccessControl`, `PublicKey`, `KeyGroup`, `Function`, `CachePolicy`, `OriginRequestPolicy`, `ResponseHeadersPolicy`.
  - Return IDs via Ref and expose attributes like `S3CanonicalUserId` (OAI) and function ARN.
  - `AWS::CloudFront::Distribution` is deferred to a follow-up.

- **Dependencies**
  - Add `fakecloud-cloudfront` to `fakecloud-cloudformation` and inject `cloudfront` state into `fakecloud-server`.

<sup>Written for commit 2701d371a51dd37d11644d97c4987a600a70e4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

