### PR TITLE
feat(cfn): provision Step Functions StateMachine + Activity + Version + Alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,6 +2716,7 @@ dependencies = [
  "fakecloud-sns",
  "fakecloud-sqs",
  "fakecloud-ssm",
+ "fakecloud-stepfunctions",
  "http 1.4.0",
  "parking_lot",
  "rcgen",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -34,6 +34,7 @@ fakecloud-acm = { workspace = true }
 fakecloud-elasticache = { workspace = true }
 fakecloud-route53 = { workspace = true }
 fakecloud-cloudfront = { workspace = true }
+fakecloud-stepfunctions = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -750,6 +750,7 @@ mod tests {
             elasticache: shared::<fakecloud_elasticache::ElastiCacheState>(),
             route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
+            stepfunctions: shared::<fakecloud_stepfunctions::StepFunctionsState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -75,6 +75,10 @@ use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState}
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
 use fakecloud_sqs::{SharedSqsState, SqsQueue};
 use fakecloud_ssm::{SharedSsmState, SsmParameter};
+use fakecloud_stepfunctions::{
+    Activity as SfnActivity, AliasRoute, SharedStepFunctionsState, StateMachine, StateMachineAlias,
+    StateMachineStatus, StateMachineType, StateMachineVersion,
+};
 
 use crate::state::StackResource;
 use crate::template::ResourceDefinition;
@@ -333,6 +337,7 @@ pub struct ResourceProvisioner {
     pub elasticache_state: SharedElastiCacheState,
     pub route53_state: SharedRoute53State,
     pub cloudfront_state: SharedCloudFrontState,
+    pub stepfunctions_state: SharedStepFunctionsState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -434,6 +439,10 @@ impl ResourceProvisioner {
             "AWS::CloudFront::ResponseHeadersPolicy" => {
                 self.create_cf_response_headers_policy(resource)
             }
+            "AWS::StepFunctions::StateMachine" => self.create_sfn_state_machine(resource),
+            "AWS::StepFunctions::Activity" => self.create_sfn_activity(resource),
+            "AWS::StepFunctions::StateMachineVersion" => self.create_sfn_version(resource),
+            "AWS::StepFunctions::StateMachineAlias" => self.create_sfn_alias(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -590,6 +599,14 @@ impl ResourceProvisioner {
             "AWS::CloudFront::ResponseHeadersPolicy" => {
                 self.delete_cf_response_headers_policy(&resource.physical_id)
             }
+            "AWS::StepFunctions::StateMachine" => {
+                self.delete_sfn_state_machine(&resource.physical_id)
+            }
+            "AWS::StepFunctions::Activity" => self.delete_sfn_activity(&resource.physical_id),
+            "AWS::StepFunctions::StateMachineVersion" => {
+                self.delete_sfn_version(&resource.physical_id)
+            }
+            "AWS::StepFunctions::StateMachineAlias" => self.delete_sfn_alias(&resource.physical_id),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -6596,6 +6613,252 @@ impl ResourceProvisioner {
         state.response_headers_policies.remove(physical_id);
         Ok(())
     }
+
+    // --- Step Functions ---
+
+    fn create_sfn_state_machine(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("StateMachineName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                let suffix = Uuid::new_v4().simple().to_string();
+                format!("{}-{}", resource.logical_id, &suffix[..8])
+            });
+        let role_arn = props
+            .get("RoleArn")
+            .and_then(|v| v.as_str())
+            .ok_or("RoleArn is required")?
+            .to_string();
+        let machine_type_str = props
+            .get("StateMachineType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("STANDARD");
+        let machine_type = StateMachineType::parse(machine_type_str)
+            .ok_or_else(|| format!("Invalid StateMachineType: {machine_type_str}"))?;
+        let definition = props
+            .get("DefinitionString")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| {
+                props
+                    .get("Definition")
+                    .map(|v| serde_json::to_string(v).unwrap_or_default())
+            })
+            .ok_or("Definition or DefinitionString is required")?;
+        let logging_configuration = props.get("LoggingConfiguration").cloned();
+        let tracing_configuration = props.get("TracingConfiguration").cloned();
+
+        let arn = format!(
+            "arn:aws:states:{}:{}:stateMachine:{}",
+            self.region, self.account_id, name
+        );
+        let now = Utc::now();
+        let revision_id = Uuid::new_v4().to_string();
+
+        let sm = StateMachine {
+            name: name.clone(),
+            arn: arn.clone(),
+            definition,
+            role_arn,
+            machine_type,
+            status: StateMachineStatus::Active,
+            creation_date: now,
+            update_date: now,
+            tags: BTreeMap::new(),
+            revision_id,
+            logging_configuration,
+            tracing_configuration,
+            description: String::new(),
+        };
+
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.state_machines.insert(arn.clone(), sm);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn.clone())
+            .with("Name", name)
+            .with("StateMachineRevisionId", "INITIAL"))
+    }
+
+    fn delete_sfn_state_machine(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.state_machines.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_sfn_activity(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let arn = format!(
+            "arn:aws:states:{}:{}:activity:{}",
+            self.region, self.account_id, name
+        );
+        let activity = SfnActivity {
+            name: name.clone(),
+            arn: arn.clone(),
+            creation_date: Utc::now(),
+            tags: BTreeMap::new(),
+        };
+
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.activities.insert(arn.clone(), activity);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
+    fn delete_sfn_activity(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.activities.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_sfn_version(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let sm_arn = props
+            .get("StateMachineArn")
+            .and_then(|v| v.as_str())
+            .ok_or("StateMachineArn is required")?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let revision_id = props
+            .get("StateMachineRevisionId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("INITIAL")
+            .to_string();
+
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+
+        // Derive next version number for this state machine.
+        let next_version = state
+            .state_machine_versions
+            .values()
+            .filter(|v| v.state_machine_arn == sm_arn)
+            .map(|v| v.version)
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let version_arn = format!("{sm_arn}:{next_version}");
+
+        let version = StateMachineVersion {
+            state_machine_arn: sm_arn,
+            version: next_version,
+            revision_id,
+            description,
+            creation_date: Utc::now(),
+        };
+        state
+            .state_machine_versions
+            .insert(version_arn.clone(), version);
+
+        Ok(ProvisionResult::new(version_arn.clone()).with("Arn", version_arn))
+    }
+
+    fn delete_sfn_version(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.state_machine_versions.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_sfn_alias(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let routes_value = props
+            .get("RoutingConfiguration")
+            .and_then(|v| v.as_array())
+            .ok_or("RoutingConfiguration is required")?;
+        let routing_configuration: Vec<AliasRoute> = routes_value
+            .iter()
+            .map(|r| AliasRoute {
+                state_machine_version_arn: r
+                    .get("StateMachineVersionArn")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                weight: r
+                    .get("Weight")
+                    .and_then(|x| {
+                        x.as_i64()
+                            .or_else(|| x.as_str().and_then(|s| s.parse::<i64>().ok()))
+                    })
+                    .map(|w| w as i32)
+                    .unwrap_or(0),
+            })
+            .collect();
+
+        let first_version_arn = routing_configuration
+            .first()
+            .map(|r| r.state_machine_version_arn.clone())
+            .unwrap_or_default();
+        // Alias ARN derives from the parent state machine ARN (everything
+        // before `:<version>`) + the alias name.
+        let sm_arn_root = first_version_arn
+            .rsplit_once(':')
+            .map(|(root, _)| root.to_string())
+            .unwrap_or_else(|| {
+                format!(
+                    "arn:aws:states:{}:{}:stateMachine:unknown",
+                    self.region, self.account_id
+                )
+            });
+        let arn = format!("{sm_arn_root}:{name}");
+        let now = Utc::now();
+        let alias = StateMachineAlias {
+            name: name.clone(),
+            arn: arn.clone(),
+            description,
+            routing_configuration,
+            creation_date: now,
+            update_date: now,
+        };
+
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.state_machine_aliases.insert(arn.clone(), alias);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
+    fn delete_sfn_alias(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.stepfunctions_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.state_machine_aliases.remove(physical_id);
+        Ok(())
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -6953,6 +7216,13 @@ mod tests {
             route53_state: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             cloudfront_state: Arc::new(RwLock::new(
                 fakecloud_cloudfront::CloudFrontAccounts::new(),
+            )),
+            stepfunctions_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
             )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -138,6 +138,7 @@ pub struct CloudFormationDeps {
     pub elasticache: fakecloud_elasticache::SharedElastiCacheState,
     pub route53: fakecloud_route53::SharedRoute53State,
     pub cloudfront: fakecloud_cloudfront::SharedCloudFrontState,
+    pub stepfunctions: fakecloud_stepfunctions::SharedStepFunctionsState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -211,6 +212,7 @@ impl CloudFormationService {
             elasticache_state: self.deps.elasticache.clone(),
             route53_state: self.deps.route53.clone(),
             cloudfront_state: self.deps.cloudfront.clone(),
+            stepfunctions_state: self.deps.stepfunctions.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1327,6 +1329,13 @@ mod tests {
             )),
             route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
+            stepfunctions: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_stepfunctions.rs
@@ -1,0 +1,105 @@
+//! CloudFormation provisioner for AWS::StepFunctions::* resources.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Activity": {
+      "Type": "AWS::StepFunctions::Activity",
+      "Properties": {"Name": "cfn-activity"}
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "StateMachineName": "cfn-sm",
+        "RoleArn": "arn:aws:iam::000000000000:role/StepRole",
+        "StateMachineType": "STANDARD",
+        "DefinitionString": "{\"Comment\":\"hello\",\"StartAt\":\"Done\",\"States\":{\"Done\":{\"Type\":\"Succeed\"}}}"
+      }
+    }
+  },
+  "Outputs": {
+    "ActivityArn": {"Value": {"Ref": "Activity"}},
+    "StateMachineArn": {"Value": {"Ref": "StateMachine"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_stepfunctions_resources() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sfn = aws_sdk_sfn::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("sfn-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sfn-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let activity_arn = outputs.get("ActivityArn").expect("ActivityArn");
+    let sm_arn = outputs.get("StateMachineArn").expect("StateMachineArn");
+
+    assert!(
+        activity_arn.contains(":activity:cfn-activity"),
+        "activity arn format: {activity_arn}"
+    );
+    assert!(
+        sm_arn.contains(":stateMachine:cfn-sm"),
+        "state machine arn format: {sm_arn}"
+    );
+
+    // Verify state machine via SDK.
+    let sm = sfn
+        .describe_state_machine()
+        .state_machine_arn(*sm_arn)
+        .send()
+        .await
+        .expect("describe_state_machine");
+    assert_eq!(sm.name(), "cfn-sm");
+    assert_eq!(sm.role_arn(), "arn:aws:iam::000000000000:role/StepRole");
+
+    // Verify activity via SDK.
+    let act = sfn
+        .describe_activity()
+        .activity_arn(*activity_arn)
+        .send()
+        .await
+        .expect("describe_activity");
+    assert_eq!(act.name(), "cfn-activity");
+
+    // Tear down.
+    cfn.delete_stack()
+        .stack_name("sfn-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let sm_after = sfn
+        .describe_state_machine()
+        .state_machine_arn(*sm_arn)
+        .send()
+        .await;
+    assert!(sm_after.is_err(), "state machine should be gone");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -736,6 +736,7 @@ async fn main() {
             elasticache: elasticache_state.clone(),
             route53: route53_state.clone(),
             cloudfront: cloudfront_state.clone(),
+            stepfunctions: stepfunctions_state.clone(),
             delivery: delivery_for_cf,
         },
     );

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -4,10 +4,11 @@ pub mod interpreter;
 pub mod intrinsics;
 pub mod io_processing;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 
 pub use service::{start_execution_from_delivery, StepFunctionsService};
 pub use state::{
-    SharedStepFunctionsState, StepFunctionsSnapshot, TaskTokenState,
-    STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
+    Activity, AliasRoute, SharedStepFunctionsState, StateMachine, StateMachineAlias,
+    StateMachineStatus, StateMachineType, StateMachineVersion, StepFunctionsSnapshot,
+    StepFunctionsState, TaskTokenState, STEPFUNCTIONS_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary
4 AWS::StepFunctions::* resource types now provisionable via CFN:
- `StateMachine` — STANDARD/EXPRESS, accepts DefinitionString or Definition object, RoleArn required, LoggingConfiguration / TracingConfiguration round-tripped
- `Activity` — name -> ARN
- `StateMachineVersion` — auto-increments per state machine, ARN format `<sm-arn>:<version>`
- `StateMachineAlias` — weighted routing across version ARNs; alias ARN derives from the parent state-machine ARN root

## Test plan
- [x] new e2e `cloudformation_stepfunctions.rs` exercises Activity + StateMachine via CFN -> SFN SDK (DescribeActivity, DescribeStateMachine, then delete-and-verify-gone)
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for AWS Step Functions resources: StateMachine, Activity, StateMachineVersion, and StateMachineAlias. Includes an e2e test to create/read/delete via the SFN SDK.

- **New Features**
  - StateMachine: STANDARD/EXPRESS; accepts `DefinitionString` or `Definition`; requires `RoleArn`; preserves logging/tracing; ARN exposed via Ref/GetAtt.
  - Activity: provisions activity ARN from `Name`.
  - StateMachineVersion: auto-increments per SM; ARN `<sm-arn>:<version>`.
  - StateMachineAlias: weighted routing across version ARNs; alias ARN = parent SM root + alias name.

- **Dependencies**
  - Added `fakecloud-stepfunctions` to `fakecloud-cloudformation` and `fakecloud-server`.

<sup>Written for commit 58c4b1d0fd5273302c24065c7613b3af597f9493. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

