### PR TITLE
feat(cfn): provision Logs Destination + ResourcePolicy + Delivery* + QueryDefinition

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -59,7 +59,8 @@ use fakecloud_lambda::{
     EventSourceMapping, FunctionAlias, FunctionUrlConfig, Layer, LayerVersion, SharedLambdaState,
 };
 use fakecloud_logs::{
-    LogStream, MetricFilter, MetricTransformation, SharedLogsState, SubscriptionFilter,
+    Delivery, DeliveryDestination, DeliverySource, Destination, LogStream, MetricFilter,
+    MetricTransformation, QueryDefinition, ResourcePolicy, SharedLogsState, SubscriptionFilter,
 };
 use fakecloud_organizations::{
     OrganizationState, OrganizationalUnit, Policy as OrgPolicy, SharedOrganizationsState,
@@ -370,6 +371,12 @@ impl ResourceProvisioner {
             "AWS::Logs::LogStream" => self.create_log_stream(resource),
             "AWS::Logs::MetricFilter" => self.create_metric_filter(resource),
             "AWS::Logs::SubscriptionFilter" => self.create_subscription_filter(resource),
+            "AWS::Logs::Destination" => self.create_logs_destination(resource),
+            "AWS::Logs::ResourcePolicy" => self.create_logs_resource_policy(resource),
+            "AWS::Logs::QueryDefinition" => self.create_logs_query_definition(resource),
+            "AWS::Logs::Delivery" => self.create_logs_delivery(resource),
+            "AWS::Logs::DeliveryDestination" => self.create_logs_delivery_destination(resource),
+            "AWS::Logs::DeliverySource" => self.create_logs_delivery_source(resource),
             "AWS::Lambda::Function" => self.create_lambda_function(resource),
             "AWS::Lambda::Permission" => self.create_lambda_permission(resource),
             "AWS::Lambda::EventSourceMapping" => self.create_lambda_event_source_mapping(resource),
@@ -502,6 +509,16 @@ impl ResourceProvisioner {
             "AWS::Logs::SubscriptionFilter" => {
                 self.delete_subscription_filter(&resource.physical_id)
             }
+            "AWS::Logs::Destination" => self.delete_logs_destination(&resource.physical_id),
+            "AWS::Logs::ResourcePolicy" => self.delete_logs_resource_policy(&resource.physical_id),
+            "AWS::Logs::QueryDefinition" => {
+                self.delete_logs_query_definition(&resource.physical_id)
+            }
+            "AWS::Logs::Delivery" => self.delete_logs_delivery(&resource.physical_id),
+            "AWS::Logs::DeliveryDestination" => {
+                self.delete_logs_delivery_destination(&resource.physical_id)
+            }
+            "AWS::Logs::DeliverySource" => self.delete_logs_delivery_source(&resource.physical_id),
             "AWS::Lambda::Function" => self.delete_lambda_function(&resource.physical_id),
             "AWS::Lambda::Permission" => self.delete_lambda_permission(&resource.physical_id),
             "AWS::Lambda::EventSourceMapping" => {
@@ -4216,6 +4233,330 @@ impl ResourceProvisioner {
                     .retain(|f| f.filter_name != filter_name);
             }
         }
+        Ok(())
+    }
+
+    // --- Logs: Destination / ResourcePolicy / QueryDefinition / Delivery* ---
+
+    fn create_logs_destination(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let destination_name = props
+            .get("DestinationName")
+            .and_then(|v| v.as_str())
+            .ok_or("DestinationName is required")?
+            .to_string();
+        let target_arn = props
+            .get("TargetArn")
+            .and_then(|v| v.as_str())
+            .ok_or("TargetArn is required")?
+            .to_string();
+        let role_arn = props
+            .get("RoleArn")
+            .and_then(|v| v.as_str())
+            .ok_or("RoleArn is required")?
+            .to_string();
+        let access_policy = props
+            .get("DestinationPolicy")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let arn = format!(
+            "arn:aws:logs:{}:{}:destination:{destination_name}",
+            self.region, self.account_id
+        );
+        let dest = Destination {
+            destination_name: destination_name.clone(),
+            target_arn,
+            role_arn,
+            arn: arn.clone(),
+            access_policy,
+            creation_time: Utc::now().timestamp_millis(),
+            tags: BTreeMap::new(),
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.destinations.insert(destination_name.clone(), dest);
+
+        Ok(ProvisionResult::new(destination_name).with("Arn", arn))
+    }
+
+    fn delete_logs_destination(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.destinations.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_logs_resource_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let policy_name = props
+            .get("PolicyName")
+            .and_then(|v| v.as_str())
+            .ok_or("PolicyName is required")?
+            .to_string();
+        let policy_document = props
+            .get("PolicyDocument")
+            .map(|v| {
+                if let Some(s) = v.as_str() {
+                    s.to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .ok_or("PolicyDocument is required")?;
+
+        let policy = ResourcePolicy {
+            policy_name: policy_name.clone(),
+            policy_document,
+            last_updated_time: Utc::now().timestamp_millis(),
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.resource_policies.insert(policy_name.clone(), policy);
+
+        Ok(ProvisionResult::new(policy_name))
+    }
+
+    fn delete_logs_resource_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.resource_policies.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_logs_query_definition(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let query_string = props
+            .get("QueryString")
+            .and_then(|v| v.as_str())
+            .ok_or("QueryString is required")?
+            .to_string();
+        let log_group_names: Vec<String> = props
+            .get("LogGroupNames")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let id = Uuid::new_v4().to_string();
+        let qd = QueryDefinition {
+            query_definition_id: id.clone(),
+            name,
+            query_string,
+            log_group_names,
+            last_modified: Utc::now().timestamp_millis(),
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.query_definitions.insert(id.clone(), qd);
+
+        Ok(ProvisionResult::new(id.clone()).with("QueryDefinitionId", id))
+    }
+
+    fn delete_logs_query_definition(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.query_definitions.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_logs_delivery_destination(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let output_format = props
+            .get("OutputFormat")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let mut configuration: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arn) = props.get("DestinationResourceArn").and_then(|v| v.as_str()) {
+            configuration.insert("destinationResourceArn".to_string(), arn.to_string());
+        }
+        if let Some(cfg) = props
+            .get("DeliveryDestinationConfiguration")
+            .and_then(|v| v.as_object())
+        {
+            for (k, v) in cfg {
+                if let Some(s) = v.as_str() {
+                    configuration.insert(k.clone(), s.to_string());
+                }
+            }
+        }
+        let policy = props.get("DeliveryDestinationPolicy").map(|v| {
+            if let Some(s) = v.as_str() {
+                s.to_string()
+            } else {
+                serde_json::to_string(v).unwrap_or_default()
+            }
+        });
+
+        let arn = format!(
+            "arn:aws:logs:{}:{}:delivery-destination:{name}",
+            self.region, self.account_id
+        );
+        let dd = DeliveryDestination {
+            name: name.clone(),
+            arn: arn.clone(),
+            output_format,
+            delivery_destination_configuration: configuration,
+            tags: BTreeMap::new(),
+            delivery_destination_policy: policy,
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.delivery_destinations.insert(name.clone(), dd);
+
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_logs_delivery_destination(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.delivery_destinations.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_logs_delivery_source(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let resource_arns: Vec<String> = props
+            .get("ResourceArn")
+            .and_then(|v| v.as_str())
+            .map(|s| vec![s.to_string()])
+            .or_else(|| {
+                props
+                    .get("ResourceArns")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+            })
+            .unwrap_or_default();
+        let log_type = props
+            .get("LogType")
+            .and_then(|v| v.as_str())
+            .ok_or("LogType is required")?
+            .to_string();
+        let service = props
+            .get("Service")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let arn = format!(
+            "arn:aws:logs:{}:{}:delivery-source:{name}",
+            self.region, self.account_id
+        );
+        let ds = DeliverySource {
+            name: name.clone(),
+            arn: arn.clone(),
+            resource_arns,
+            service,
+            log_type,
+            tags: BTreeMap::new(),
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.delivery_sources.insert(name.clone(), ds);
+
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn delete_logs_delivery_source(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.delivery_sources.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_logs_delivery(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let delivery_source_name = props
+            .get("DeliverySourceName")
+            .and_then(|v| v.as_str())
+            .ok_or("DeliverySourceName is required")?
+            .to_string();
+        let delivery_destination_arn = props
+            .get("DeliveryDestinationArn")
+            .and_then(|v| v.as_str())
+            .ok_or("DeliveryDestinationArn is required")?
+            .to_string();
+        // Infer destination type from the destination ARN service segment.
+        let delivery_destination_type = if delivery_destination_arn.contains(":s3:") {
+            "S3".to_string()
+        } else if delivery_destination_arn.contains(":firehose:") {
+            "FH".to_string()
+        } else {
+            "CWL".to_string()
+        };
+
+        let id = Uuid::new_v4().simple().to_string();
+        let arn = format!(
+            "arn:aws:logs:{}:{}:delivery:{id}",
+            self.region, self.account_id
+        );
+        let delivery = Delivery {
+            id: id.clone(),
+            delivery_source_name,
+            delivery_destination_arn,
+            delivery_destination_type,
+            arn: arn.clone(),
+            tags: BTreeMap::new(),
+        };
+
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.deliveries.insert(id.clone(), delivery);
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("DeliveryId", id)
+            .with("Arn", arn))
+    }
+
+    fn delete_logs_delivery(&self, physical_id: &str) -> Result<(), String> {
+        let mut logs_accounts = self.logs_state.write();
+        let state = logs_accounts.get_or_create(&self.account_id);
+        state.deliveries.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_logs_extras.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_logs_extras.rs
@@ -1,0 +1,155 @@
+//! CloudFormation provisioner for the additional AWS::Logs::* resources
+//! beyond LogGroup/LogStream/MetricFilter/SubscriptionFilter:
+//! Destination, ResourcePolicy, QueryDefinition, Delivery,
+//! DeliveryDestination, DeliverySource.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "LG": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {"LogGroupName": "/cfn/extras", "RetentionInDays": 7}
+    },
+    "Dest": {
+      "Type": "AWS::Logs::Destination",
+      "Properties": {
+        "DestinationName": "cfn-dest",
+        "TargetArn": "arn:aws:kinesis:us-east-1:000000000000:stream/cfn-stream",
+        "RoleArn": "arn:aws:iam::000000000000:role/CfnDestRole"
+      }
+    },
+    "Policy": {
+      "Type": "AWS::Logs::ResourcePolicy",
+      "Properties": {
+        "PolicyName": "cfn-policy",
+        "PolicyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+      }
+    },
+    "Query": {
+      "Type": "AWS::Logs::QueryDefinition",
+      "Properties": {
+        "Name": "cfn-query",
+        "QueryString": "fields @timestamp, @message",
+        "LogGroupNames": ["/cfn/extras"]
+      }
+    },
+    "DeliverySource": {
+      "Type": "AWS::Logs::DeliverySource",
+      "Properties": {
+        "Name": "cfn-source",
+        "ResourceArn": "arn:aws:bedrock:us-east-1:000000000000:knowledgebase/abc",
+        "LogType": "APPLICATION_LOGS"
+      }
+    },
+    "DeliveryDest": {
+      "Type": "AWS::Logs::DeliveryDestination",
+      "Properties": {
+        "Name": "cfn-deliv-dest",
+        "OutputFormat": "json",
+        "DestinationResourceArn": {"Fn::GetAtt": ["LG", "Arn"]}
+      }
+    },
+    "Delivery": {
+      "Type": "AWS::Logs::Delivery",
+      "Properties": {
+        "DeliverySourceName": {"Ref": "DeliverySource"},
+        "DeliveryDestinationArn": {"Fn::GetAtt": ["DeliveryDest", "Arn"]}
+      },
+      "DependsOn": ["DeliverySource", "DeliveryDest"]
+    }
+  },
+  "Outputs": {
+    "DestId": {"Value": {"Ref": "Dest"}},
+    "DestArn": {"Value": {"Fn::GetAtt": ["Dest", "Arn"]}},
+    "PolicyId": {"Value": {"Ref": "Policy"}},
+    "QueryId": {"Value": {"Ref": "Query"}},
+    "DeliverySrcId": {"Value": {"Ref": "DeliverySource"}},
+    "DeliveryDestArn": {"Value": {"Fn::GetAtt": ["DeliveryDest", "Arn"]}},
+    "DeliveryId": {"Value": {"Ref": "Delivery"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_logs_extras() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let logs = aws_sdk_cloudwatchlogs::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("logs-extras-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("logs-extras-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    assert_eq!(outputs.get("DestId").copied(), Some("cfn-dest"));
+    let dest_arn = outputs.get("DestArn").expect("DestArn");
+    assert!(dest_arn.contains(":destination:cfn-dest"));
+    assert_eq!(outputs.get("PolicyId").copied(), Some("cfn-policy"));
+    assert!(!outputs.get("QueryId").expect("QueryId").is_empty());
+    assert_eq!(outputs.get("DeliverySrcId").copied(), Some("cfn-source"));
+    let deliv_dest_arn = outputs.get("DeliveryDestArn").expect("DeliveryDestArn");
+    assert!(deliv_dest_arn.contains(":delivery-destination:cfn-deliv-dest"));
+    let delivery_id = outputs.get("DeliveryId").expect("DeliveryId");
+    assert!(!delivery_id.is_empty());
+
+    // Verify destination + resource policy + query definition via SDK.
+    let dests = logs
+        .describe_destinations()
+        .destination_name_prefix("cfn-dest")
+        .send()
+        .await
+        .expect("describe_destinations");
+    assert!(dests
+        .destinations()
+        .iter()
+        .any(|d| d.destination_name() == Some("cfn-dest")));
+
+    let policies = logs
+        .describe_resource_policies()
+        .send()
+        .await
+        .expect("describe_resource_policies");
+    assert!(policies
+        .resource_policies()
+        .iter()
+        .any(|p| p.policy_name() == Some("cfn-policy")));
+
+    let queries = logs
+        .describe_query_definitions()
+        .send()
+        .await
+        .expect("describe_query_definitions");
+    assert!(queries
+        .query_definitions()
+        .iter()
+        .any(|q| q.name() == Some("cfn-query")));
+
+    cfn.delete_stack()
+        .stack_name("logs-extras-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -6,6 +6,7 @@ pub mod transformer;
 
 pub use service::LogsService;
 pub use state::{
-    LogEvent, LogGroup, LogStream, LogsSnapshot, LogsState, MetricFilter, MetricTransformation,
+    Delivery, DeliveryDestination, DeliverySource, Destination, LogEvent, LogGroup, LogStream,
+    LogsSnapshot, LogsState, MetricFilter, MetricTransformation, QueryDefinition, ResourcePolicy,
     SharedLogsState, SubscriptionFilter, LOGS_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary
Closes the gap between the existing CFN Logs provisioners
(LogGroup/LogStream/MetricFilter/SubscriptionFilter) and the rest of
the Logs CloudFormation surface:

- `AWS::Logs::Destination` — cross-account fanout target (Kinesis ARN + role)
- `AWS::Logs::ResourcePolicy` — accepts inline string OR JSON object PolicyDocument
- `AWS::Logs::QueryDefinition` — saved Logs Insights query
- `AWS::Logs::Delivery` — joins a DeliverySource to a DeliveryDestination; destination type inferred from destination ARN
- `AWS::Logs::DeliveryDestination` — accepts DestinationResourceArn shorthand OR full configuration map + optional policy
- `AWS::Logs::DeliverySource` — single ResourceArn or ResourceArns list

Each Stored* type was already public via `pub mod state`; just exported the missing names.

## Test plan
- [x] new e2e `cloudformation_logs_extras.rs` creates all six in one stack with cross-resource `Fn::GetAtt`, then verifies via CWL SDK DescribeDestinations / DescribeResourcePolicies / DescribeQueryDefinitions
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for the remaining `AWS::Logs` resources: `Destination`, `ResourcePolicy`, `QueryDefinition`, `Delivery`, `DeliveryDestination`, and `DeliverySource`. This completes Logs coverage and exposes ARNs/IDs for use with `Ref` and `GetAtt`.

- **New Features**
  - `AWS::Logs::Destination`: creates fanout target; returns `Arn`.
  - `AWS::Logs::ResourcePolicy`: accepts `PolicyDocument` as string or JSON; stored by `PolicyName`.
  - `AWS::Logs::QueryDefinition`: saves Insights query; returns `QueryDefinitionId`.
  - `AWS::Logs::Delivery`: links source to destination; infers type from destination ARN; returns `DeliveryId` and `Arn`.
  - `AWS::Logs::DeliveryDestination`: supports `DestinationResourceArn` or full `DeliveryDestinationConfiguration`; optional policy.
  - `AWS::Logs::DeliverySource`: supports `ResourceArn` or `ResourceArns`; includes `LogType` and `Service`.

<sup>Written for commit a3bf5d9f0f16fc6f1194211a2f19550cba779a66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

