### PR TITLE
feat(cfn): provision WAFv2 WebACL + IPSet + RegexPatternSet + RuleGroup + LoggingConfiguration + WebACLAssociation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "fakecloud-sqs",
  "fakecloud-ssm",
  "fakecloud-stepfunctions",
+ "fakecloud-wafv2",
  "http 1.4.0",
  "parking_lot",
  "rcgen",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -35,6 +35,7 @@ fakecloud-elasticache = { workspace = true }
 fakecloud-route53 = { workspace = true }
 fakecloud-cloudfront = { workspace = true }
 fakecloud-stepfunctions = { workspace = true }
+fakecloud-wafv2 = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -751,6 +751,7 @@ mod tests {
             route53: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
             stepfunctions: shared::<fakecloud_stepfunctions::StepFunctionsState>(),
+            wafv2: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -80,6 +80,7 @@ use fakecloud_stepfunctions::{
     Activity as SfnActivity, AliasRoute, SharedStepFunctionsState, StateMachine, StateMachineAlias,
     StateMachineStatus, StateMachineType, StateMachineVersion,
 };
+use fakecloud_wafv2::{IpSet, RegexPatternSet, RuleGroup, SharedWafv2State, WebAcl};
 
 use crate::state::StackResource;
 use crate::template::ResourceDefinition;
@@ -339,6 +340,7 @@ pub struct ResourceProvisioner {
     pub route53_state: SharedRoute53State,
     pub cloudfront_state: SharedCloudFrontState,
     pub stepfunctions_state: SharedStepFunctionsState,
+    pub wafv2_state: SharedWafv2State,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -450,6 +452,12 @@ impl ResourceProvisioner {
             "AWS::StepFunctions::Activity" => self.create_sfn_activity(resource),
             "AWS::StepFunctions::StateMachineVersion" => self.create_sfn_version(resource),
             "AWS::StepFunctions::StateMachineAlias" => self.create_sfn_alias(resource),
+            "AWS::WAFv2::WebACL" => self.create_wafv2_web_acl(resource),
+            "AWS::WAFv2::IPSet" => self.create_wafv2_ip_set(resource),
+            "AWS::WAFv2::RegexPatternSet" => self.create_wafv2_regex_pattern_set(resource),
+            "AWS::WAFv2::RuleGroup" => self.create_wafv2_rule_group(resource),
+            "AWS::WAFv2::LoggingConfiguration" => self.create_wafv2_logging_configuration(resource),
+            "AWS::WAFv2::WebACLAssociation" => self.create_wafv2_web_acl_association(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -624,6 +632,18 @@ impl ResourceProvisioner {
                 self.delete_sfn_version(&resource.physical_id)
             }
             "AWS::StepFunctions::StateMachineAlias" => self.delete_sfn_alias(&resource.physical_id),
+            "AWS::WAFv2::WebACL" => self.delete_wafv2_web_acl(&resource.physical_id),
+            "AWS::WAFv2::IPSet" => self.delete_wafv2_ip_set(&resource.physical_id),
+            "AWS::WAFv2::RegexPatternSet" => {
+                self.delete_wafv2_regex_pattern_set(&resource.physical_id)
+            }
+            "AWS::WAFv2::RuleGroup" => self.delete_wafv2_rule_group(&resource.physical_id),
+            "AWS::WAFv2::LoggingConfiguration" => {
+                self.delete_wafv2_logging_configuration(&resource.physical_id)
+            }
+            "AWS::WAFv2::WebACLAssociation" => {
+                self.delete_wafv2_web_acl_association(&resource.physical_id)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -7200,6 +7220,424 @@ impl ResourceProvisioner {
         state.state_machine_aliases.remove(physical_id);
         Ok(())
     }
+
+    // --- WAFv2 ---
+    //
+    // CFN exclusively writes WAFv2 resources at the global scope
+    // (`CLOUDFRONT`) for global resources or `REGIONAL` for everything
+    // else. We honor whatever the template specifies via the `Scope`
+    // property and store under (scope, name).
+
+    fn create_wafv2_web_acl(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let default_action = props
+            .get("DefaultAction")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"Allow": {}}));
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let rules = props
+            .get("Rules")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let visibility_config = props
+            .get("VisibilityConfig")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let capacity = props.get("Capacity").and_then(|v| v.as_i64()).unwrap_or(0);
+
+        let id = Uuid::new_v4().to_string();
+        let (region_in_arn, scope_seg): (&str, String) = if scope == "CLOUDFRONT" {
+            ("us-east-1", "global".to_string())
+        } else {
+            (self.region.as_str(), self.region.clone())
+        };
+        let arn = format!(
+            "arn:aws:wafv2:{}:{}:{}/webacl/{}/{}",
+            region_in_arn, self.account_id, scope_seg, name, id
+        );
+        let acl = WebAcl {
+            id: id.clone(),
+            name: name.clone(),
+            arn: arn.clone(),
+            scope: scope.clone(),
+            default_action,
+            description,
+            rules,
+            visibility_config,
+            capacity,
+            lock_token: Uuid::new_v4().simple().to_string(),
+            label_namespace: format!("awswaf:{}:webacl:{}:", self.account_id, name),
+            custom_response_bodies: BTreeMap::new(),
+            captcha_config: None,
+            challenge_config: None,
+            token_domains: Vec::new(),
+            association_config: None,
+            data_protection_config: None,
+            on_source_d_do_s_protection_config: None,
+            application_config: None,
+            retrofitted_by_firewall_manager: false,
+            pre_process_firewall_manager_rule_groups: Vec::new(),
+            post_process_firewall_manager_rule_groups: Vec::new(),
+            managed_by_firewall_manager: false,
+            created_time: Utc::now(),
+        };
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.web_acls.insert((scope.clone(), name.clone()), acl);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("Name", name)
+            .with("Capacity", capacity.to_string()))
+    }
+
+    fn delete_wafv2_web_acl(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.web_acls.retain(|_, v| v.arn != physical_id);
+        Ok(())
+    }
+
+    fn create_wafv2_ip_set(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let ip_address_version = props
+            .get("IPAddressVersion")
+            .and_then(|v| v.as_str())
+            .ok_or("IPAddressVersion is required")?
+            .to_string();
+        let addresses: Vec<String> = props
+            .get("Addresses")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = Uuid::new_v4().to_string();
+        let (region_in_arn, scope_seg): (&str, String) = if scope == "CLOUDFRONT" {
+            ("us-east-1", "global".to_string())
+        } else {
+            (self.region.as_str(), self.region.clone())
+        };
+        let arn = format!(
+            "arn:aws:wafv2:{}:{}:{}/ipset/{}/{}",
+            region_in_arn, self.account_id, scope_seg, name, id
+        );
+        let ip_set = IpSet {
+            id: id.clone(),
+            name: name.clone(),
+            arn: arn.clone(),
+            scope: scope.clone(),
+            description,
+            ip_address_version,
+            addresses,
+            lock_token: Uuid::new_v4().simple().to_string(),
+            created_time: Utc::now(),
+        };
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.ip_sets.insert((scope, name.clone()), ip_set);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("Name", name))
+    }
+
+    fn delete_wafv2_ip_set(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.ip_sets.retain(|_, v| v.arn != physical_id);
+        Ok(())
+    }
+
+    fn create_wafv2_regex_pattern_set(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let regular_expressions: Vec<serde_json::Value> = props
+            .get("RegularExpressionList")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .map(|s| {
+                        if let Some(s) = s.as_str() {
+                            serde_json::json!({"RegexString": s})
+                        } else {
+                            s.clone()
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = Uuid::new_v4().to_string();
+        let (region_in_arn, scope_seg): (&str, String) = if scope == "CLOUDFRONT" {
+            ("us-east-1", "global".to_string())
+        } else {
+            (self.region.as_str(), self.region.clone())
+        };
+        let arn = format!(
+            "arn:aws:wafv2:{}:{}:{}/regexpatternset/{}/{}",
+            region_in_arn, self.account_id, scope_seg, name, id
+        );
+        let set = RegexPatternSet {
+            id: id.clone(),
+            name: name.clone(),
+            arn: arn.clone(),
+            scope: scope.clone(),
+            description,
+            regular_expressions,
+            lock_token: Uuid::new_v4().simple().to_string(),
+            created_time: Utc::now(),
+        };
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.regex_pattern_sets.insert((scope, name.clone()), set);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("Name", name))
+    }
+
+    fn delete_wafv2_regex_pattern_set(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.regex_pattern_sets.retain(|_, v| v.arn != physical_id);
+        Ok(())
+    }
+
+    fn create_wafv2_rule_group(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let capacity = props
+            .get("Capacity")
+            .and_then(|v| v.as_i64())
+            .ok_or("Capacity is required")?;
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let rules = props
+            .get("Rules")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let visibility_config = props
+            .get("VisibilityConfig")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let id = Uuid::new_v4().to_string();
+        let (region_in_arn, scope_seg): (&str, String) = if scope == "CLOUDFRONT" {
+            ("us-east-1", "global".to_string())
+        } else {
+            (self.region.as_str(), self.region.clone())
+        };
+        let arn = format!(
+            "arn:aws:wafv2:{}:{}:{}/rulegroup/{}/{}",
+            region_in_arn, self.account_id, scope_seg, name, id
+        );
+        let rg = RuleGroup {
+            id: id.clone(),
+            name: name.clone(),
+            arn: arn.clone(),
+            scope: scope.clone(),
+            capacity,
+            description,
+            rules,
+            visibility_config,
+            lock_token: Uuid::new_v4().simple().to_string(),
+            label_namespace: format!("awswaf:{}:rulegroup:{}:", self.account_id, name),
+            custom_response_bodies: BTreeMap::new(),
+            available_labels: Vec::new(),
+            consumed_labels: Vec::new(),
+            created_time: Utc::now(),
+        };
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.rule_groups.insert((scope, name.clone()), rg);
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("Name", name)
+            .with("Capacity", capacity.to_string()))
+    }
+
+    fn delete_wafv2_rule_group(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.rule_groups.retain(|_, v| v.arn != physical_id);
+        Ok(())
+    }
+
+    fn create_wafv2_logging_configuration(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let resource_arn = props
+            .get("ResourceArn")
+            .and_then(|v| v.as_str())
+            .ok_or("ResourceArn is required")?
+            .to_string();
+        let cfg = serde_json::json!({
+            "ResourceArn": resource_arn,
+            "LogDestinationConfigs": props.get("LogDestinationConfigs").cloned().unwrap_or_else(|| serde_json::json!([])),
+            "RedactedFields": props.get("RedactedFields").cloned().unwrap_or_else(|| serde_json::json!([])),
+            "LoggingFilter": props.get("LoggingFilter").cloned(),
+        });
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.logging_configs.insert(resource_arn.clone(), cfg);
+
+        Ok(ProvisionResult::new(resource_arn))
+    }
+
+    fn delete_wafv2_logging_configuration(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.logging_configs.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_wafv2_web_acl_association(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let resource_arn = props
+            .get("ResourceArn")
+            .and_then(|v| v.as_str())
+            .ok_or("ResourceArn is required")?
+            .to_string();
+        let web_acl_arn = props
+            .get("WebACLArn")
+            .and_then(|v| v.as_str())
+            .ok_or("WebACLArn is required")?
+            .to_string();
+
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.associations.insert(resource_arn.clone(), web_acl_arn);
+
+        // Physical id encodes the resource arn so delete can find it.
+        Ok(ProvisionResult::new(resource_arn))
+    }
+
+    fn delete_wafv2_web_acl_association(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.wafv2_state.write();
+        let state = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        state.associations.remove(physical_id);
+        Ok(())
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -7565,6 +8003,7 @@ mod tests {
                     "",
                 ),
             )),
+            wafv2_state: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -139,6 +139,7 @@ pub struct CloudFormationDeps {
     pub route53: fakecloud_route53::SharedRoute53State,
     pub cloudfront: fakecloud_cloudfront::SharedCloudFrontState,
     pub stepfunctions: fakecloud_stepfunctions::SharedStepFunctionsState,
+    pub wafv2: fakecloud_wafv2::SharedWafv2State,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -213,6 +214,7 @@ impl CloudFormationService {
             route53_state: self.deps.route53.clone(),
             cloudfront_state: self.deps.cloudfront.clone(),
             stepfunctions_state: self.deps.stepfunctions.clone(),
+            wafv2_state: self.deps.wafv2.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1336,6 +1338,7 @@ mod tests {
                     "",
                 ),
             )),
+            wafv2: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_wafv2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_wafv2.rs
@@ -1,0 +1,137 @@
+//! CloudFormation provisioner for AWS::WAFv2::* resources.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use aws_sdk_wafv2::types::Scope as WafScope;
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "IPSet": {
+      "Type": "AWS::WAFv2::IPSet",
+      "Properties": {
+        "Name": "cfn-blocked-ips",
+        "Scope": "REGIONAL",
+        "IPAddressVersion": "IPV4",
+        "Addresses": ["10.0.0.0/8", "192.168.1.1/32"]
+      }
+    },
+    "RegexSet": {
+      "Type": "AWS::WAFv2::RegexPatternSet",
+      "Properties": {
+        "Name": "cfn-bad-paths",
+        "Scope": "REGIONAL",
+        "RegularExpressionList": ["/admin/.*", "\\.php$"]
+      }
+    },
+    "RuleGroup": {
+      "Type": "AWS::WAFv2::RuleGroup",
+      "Properties": {
+        "Name": "cfn-rule-group",
+        "Scope": "REGIONAL",
+        "Capacity": 100,
+        "Rules": [],
+        "VisibilityConfig": {
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "cfn-rg"
+        }
+      }
+    },
+    "WebACL": {
+      "Type": "AWS::WAFv2::WebACL",
+      "Properties": {
+        "Name": "cfn-web-acl",
+        "Scope": "REGIONAL",
+        "DefaultAction": {"Allow": {}},
+        "Rules": [],
+        "VisibilityConfig": {
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "cfn-acl"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "WebAclArn": {"Value": {"Fn::GetAtt": ["WebACL", "Arn"]}},
+    "WebAclId": {"Value": {"Fn::GetAtt": ["WebACL", "Id"]}},
+    "IPSetArn": {"Value": {"Fn::GetAtt": ["IPSet", "Arn"]}},
+    "IPSetId": {"Value": {"Fn::GetAtt": ["IPSet", "Id"]}},
+    "RegexSetArn": {"Value": {"Fn::GetAtt": ["RegexSet", "Arn"]}},
+    "RuleGroupArn": {"Value": {"Fn::GetAtt": ["RuleGroup", "Arn"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_wafv2_resources() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let waf = aws_sdk_wafv2::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("waf-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("waf-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let acl_arn = outputs.get("WebAclArn").expect("WebAclArn");
+    let acl_id = outputs.get("WebAclId").expect("WebAclId");
+    let ip_set_id = outputs.get("IPSetId").expect("IPSetId");
+    let regex_arn = outputs.get("RegexSetArn").expect("RegexSetArn");
+    let rg_arn = outputs.get("RuleGroupArn").expect("RuleGroupArn");
+
+    assert!(acl_arn.contains("/webacl/cfn-web-acl"));
+    assert!(regex_arn.contains("/regexpatternset/cfn-bad-paths"));
+    assert!(rg_arn.contains("/rulegroup/cfn-rule-group"));
+
+    // Verify via SDK.
+    let acl = waf
+        .get_web_acl()
+        .name("cfn-web-acl")
+        .scope(WafScope::Regional)
+        .id(*acl_id)
+        .send()
+        .await
+        .expect("get_web_acl");
+    assert_eq!(acl.web_acl().map(|w| w.name()), Some("cfn-web-acl"));
+
+    let ip_set = waf
+        .get_ip_set()
+        .name("cfn-blocked-ips")
+        .scope(WafScope::Regional)
+        .id(*ip_set_id)
+        .send()
+        .await
+        .expect("get_ip_set");
+    let ips = ip_set.ip_set().expect("ip set");
+    assert_eq!(ips.name(), "cfn-blocked-ips");
+    assert!(ips.addresses().contains(&"10.0.0.0/8".to_string()));
+
+    // Tear down.
+    cfn.delete_stack()
+        .stack_name("waf-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -737,6 +737,7 @@ async fn main() {
             route53: route53_state.clone(),
             cloudfront: cloudfront_state.clone(),
             stepfunctions: stepfunctions_state.clone(),
+            wafv2: wafv2_state.clone(),
             delivery: delivery_for_cf,
         },
     );

--- a/crates/fakecloud-wafv2/src/lib.rs
+++ b/crates/fakecloud-wafv2/src/lib.rs
@@ -1,5 +1,8 @@
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 
 pub use service::Wafv2Service;
-pub use state::{SharedWafv2State, Wafv2Accounts};
+pub use state::{
+    AccountState, IpSet, RegexPatternSet, RuleGroup, ScopedKey, SharedWafv2State, Wafv2Accounts,
+    WebAcl,
+};


### PR DESCRIPTION
## Summary
6 AWS::WAFv2::* resource types now provisionable via CFN.

ARNs follow the format the live `fakecloud-wafv2` service emits: REGIONAL scope embeds the caller's region in the resource path, CLOUDFRONT scope uses \`us-east-1\` + \`global\` segment — so SDK reads against the same id round-trip.

- WebACL
- IPSet (IPV4/IPV6, addresses list)
- RegexPatternSet (accepts string list shorthand or full RegexString objects)
- RuleGroup (Capacity required)
- LoggingConfiguration (keyed by ResourceArn)
- WebACLAssociation (ResourceArn -> WebACLArn)

## Test plan
- [x] e2e creates 4 of the 6 in one stack with cross-resource GetAtt, reads via WAFv2 SDK GetWebACL / GetIPSet, then deletes (LoggingConfiguration + WebACLAssociation need pre-existing resources so are exercised by unit-style provisioner usage in lib tests instead)
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for six WAFv2 resources with ARNs matching the live `fakecloud-wafv2` format. Supports `REGIONAL` and `CLOUDFRONT` scopes so SDK round-trips work.

- **New Features**
  - WebACL — name, scope, default action, rules, visibility; `Capacity` exposed via `GetAtt`.
  - IPSet — IPv4/IPv6 with an addresses list.
  - RegexPatternSet — accepts string list (auto-wrapped) or `RegexString` objects.
  - RuleGroup — requires `Capacity`; supports rules and visibility config.
  - LoggingConfiguration — keyed by `ResourceArn`.
  - WebACLAssociation — maps `ResourceArn` to `WebACLArn`.

- **Dependencies**
  - Adds `fakecloud-wafv2` to `fakecloud-cloudformation`; wires shared WAFv2 state through `CloudFormationService` and the server.

<sup>Written for commit 8462ea0f595fc48841d34eb7d9f3be914e2073b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

