### PR TITLE
feat(cloudwatch): add Dashboard CRUD ops + CFN provisioner

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -22,7 +22,7 @@ use fakecloud_cloudfront::{
     },
     SharedCloudFrontState,
 };
-use fakecloud_cloudwatch::{AlarmState, MetricAlarm, SharedCloudWatchState};
+use fakecloud_cloudwatch::{AlarmState, Dashboard, MetricAlarm, SharedCloudWatchState};
 use fakecloud_cognito::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CustomDomainConfig,
     EmailConfiguration, PasswordPolicy, PoolPolicies, RecoveryOption, SchemaAttribute,
@@ -400,6 +400,7 @@ impl ResourceProvisioner {
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
             "AWS::ECR::Repository" => self.create_ecr_repository(resource),
             "AWS::CloudWatch::Alarm" => self.create_cloudwatch_alarm(resource),
+            "AWS::CloudWatch::Dashboard" => self.create_cloudwatch_dashboard(resource),
             "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
                 self.create_elbv2_load_balancer(resource)
             }
@@ -567,6 +568,7 @@ impl ResourceProvisioner {
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
             "AWS::CloudWatch::Alarm" => self.delete_cloudwatch_alarm(&resource.physical_id),
+            "AWS::CloudWatch::Dashboard" => self.delete_cloudwatch_dashboard(&resource.physical_id),
             "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
                 self.delete_elbv2_load_balancer(&resource.physical_id)
             }
@@ -3822,6 +3824,58 @@ impl ResourceProvisioner {
         let mut accounts = self.cloudwatch_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.alarms_in_mut(&self.region).remove(physical_id);
+        Ok(())
+    }
+
+    fn create_cloudwatch_dashboard(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let dashboard_name = props
+            .get("DashboardName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                let suffix = Uuid::new_v4().simple().to_string();
+                format!("{}-{}", resource.logical_id, &suffix[..8])
+            });
+        // CFN passes DashboardBody as a JSON string (Fn::Sub friendly).
+        let body = props
+            .get("DashboardBody")
+            .ok_or("DashboardBody is required")?;
+        let body_str = if let Some(s) = body.as_str() {
+            s.to_string()
+        } else {
+            serde_json::to_string(body).map_err(|e| format!("invalid DashboardBody: {e}"))?
+        };
+        // Validate JSON syntax to mirror real PutDashboard behavior.
+        serde_json::from_str::<serde_json::Value>(&body_str)
+            .map_err(|e| format!("DashboardBody must be valid JSON: {e}"))?;
+
+        let arn = format!(
+            "arn:aws:cloudwatch::{}:dashboard/{dashboard_name}",
+            self.account_id
+        );
+        let dashboard = Dashboard {
+            name: dashboard_name.clone(),
+            arn: arn.clone(),
+            size_bytes: body_str.len() as i64,
+            body: body_str,
+            last_modified: Utc::now(),
+        };
+
+        let mut accounts = self.cloudwatch_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.dashboards.insert(dashboard_name.clone(), dashboard);
+
+        Ok(ProvisionResult::new(dashboard_name).with("Arn", arn))
+    }
+
+    fn delete_cloudwatch_dashboard(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudwatch_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.dashboards.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -3,6 +3,6 @@ pub mod state;
 
 pub use service::CloudWatchService;
 pub use state::{
-    AlarmState, CloudWatchAccounts, CloudWatchState, MetricAlarm, MetricDatum,
+    AlarmState, CloudWatchAccounts, CloudWatchState, Dashboard, MetricAlarm, MetricDatum,
     SharedCloudWatchState,
 };

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -9,7 +9,9 @@ use fakecloud_core::query::{
 };
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
-use crate::state::{AlarmState, MetricAlarm, MetricDatum, SharedCloudWatchState, StatisticSet};
+use crate::state::{
+    AlarmState, Dashboard, MetricAlarm, MetricDatum, SharedCloudWatchState, StatisticSet,
+};
 
 const NS: &str = "http://monitoring.amazonaws.com/doc/2010-08-01/";
 
@@ -62,6 +64,10 @@ impl AwsService for CloudWatchService {
             "DisableAlarmActions" => self.disable_alarm_actions(&req),
             "SetAlarmState" => self.set_alarm_state(&req),
             "DescribeAlarmHistory" => self.describe_alarm_history(&req),
+            "PutDashboard" => self.put_dashboard(&req),
+            "GetDashboard" => self.get_dashboard(&req),
+            "DeleteDashboards" => self.delete_dashboards(&req),
+            "ListDashboards" => self.list_dashboards(&req),
             _ => Err(AwsServiceError::action_not_implemented(
                 "monitoring",
                 &req.action,
@@ -836,6 +842,122 @@ impl CloudWatchService {
             &inner,
             &req.request_id,
         ))
+    }
+
+    fn put_dashboard(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let dashboard_name = req
+            .query_params
+            .get("DashboardName")
+            .ok_or_else(|| invalid_param("DashboardName is required"))?
+            .clone();
+        let body = req
+            .query_params
+            .get("DashboardBody")
+            .ok_or_else(|| invalid_param("DashboardBody is required"))?
+            .clone();
+        // AWS validates that DashboardBody parses as JSON; we do the same so
+        // bad bodies surface a useful error before persisting.
+        if serde_json::from_str::<serde_json::Value>(&body).is_err() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterInput",
+                "DashboardBody must be a valid JSON object",
+            ));
+        }
+        let arn = format!(
+            "arn:aws:cloudwatch::{}:dashboard/{dashboard_name}",
+            req.account_id
+        );
+        let dashboard = Dashboard {
+            name: dashboard_name.clone(),
+            arn,
+            size_bytes: body.len() as i64,
+            body,
+            last_modified: Utc::now(),
+        };
+        let mut state = self.state.write();
+        let acct = state.get_or_create(&req.account_id);
+        acct.dashboards.insert(dashboard_name, dashboard);
+        // PutDashboard returns DashboardValidationMessages — empty when the
+        // body parses cleanly.
+        let inner = String::from("<DashboardValidationMessages/>");
+        Ok(xml_response("PutDashboard", &inner, &req.request_id))
+    }
+
+    fn get_dashboard(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let name = req
+            .query_params
+            .get("DashboardName")
+            .ok_or_else(|| invalid_param("DashboardName is required"))?
+            .clone();
+        let state = self.state.read();
+        let dashboard = state
+            .get(&req.account_id)
+            .and_then(|a| a.dashboards.get(&name))
+            .cloned()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFound",
+                    format!("Dashboard {name} does not exist"),
+                )
+            })?;
+        let inner = format!(
+            "<DashboardArn>{}</DashboardArn><DashboardBody>{}</DashboardBody><DashboardName>{}</DashboardName>",
+            xml_escape(&dashboard.arn),
+            xml_escape(&dashboard.body),
+            xml_escape(&dashboard.name),
+        );
+        Ok(xml_response("GetDashboard", &inner, &req.request_id))
+    }
+
+    fn delete_dashboards(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let mut names: Vec<String> = Vec::new();
+        for (k, v) in req.query_params.iter() {
+            if k.starts_with("DashboardNames.member.") {
+                names.push(v.clone());
+            }
+        }
+        if names.is_empty() {
+            return Err(invalid_param(
+                "DashboardNames must contain at least one name",
+            ));
+        }
+        let mut state = self.state.write();
+        let acct = state.get_or_create(&req.account_id);
+        for n in names {
+            acct.dashboards.remove(&n);
+        }
+        Ok(empty_metadata_response("DeleteDashboards", &req.request_id))
+    }
+
+    fn list_dashboards(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let prefix = req.query_params.get("DashboardNamePrefix").cloned();
+        let state = self.state.read();
+        let dashboards: Vec<Dashboard> = state
+            .get(&req.account_id)
+            .map(|a| {
+                a.dashboards
+                    .values()
+                    .filter(|d| prefix.as_ref().is_none_or(|p| d.name.starts_with(p)))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut entries = String::new();
+        for d in &dashboards {
+            entries.push_str("<member>");
+            entries.push_str(&format!(
+                "<DashboardArn>{}</DashboardArn><DashboardName>{}</DashboardName><LastModified>{}</LastModified><Size>{}</Size>",
+                xml_escape(&d.arn),
+                xml_escape(&d.name),
+                d.last_modified.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                d.size_bytes,
+            ));
+            entries.push_str("</member>");
+        }
+        let inner = format!("<DashboardEntries>{entries}</DashboardEntries>");
+        Ok(xml_response("ListDashboards", &inner, &req.request_id))
     }
 }
 

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -35,6 +35,19 @@ pub struct CloudWatchState {
     pub metrics: BTreeMap<String, BTreeMap<String, Vec<MetricDatum>>>,
     /// region -> alarm_name -> MetricAlarm
     pub alarms: BTreeMap<String, BTreeMap<String, MetricAlarm>>,
+    /// Dashboards keyed by name (CloudWatch dashboards are global per
+    /// account, not regional).
+    #[serde(default)]
+    pub dashboards: BTreeMap<String, Dashboard>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Dashboard {
+    pub name: String,
+    pub arn: String,
+    pub body: String,
+    pub last_modified: DateTime<Utc>,
+    pub size_bytes: i64,
 }
 
 impl CloudWatchState {
@@ -43,6 +56,7 @@ impl CloudWatchState {
             account_id: account_id.to_string(),
             metrics: BTreeMap::new(),
             alarms: BTreeMap::new(),
+            dashboards: BTreeMap::new(),
         }
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_cw_dashboard.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_cw_dashboard.rs
@@ -1,0 +1,87 @@
+//! CloudFormation provisioner for AWS::CloudWatch::Dashboard. The
+//! existing CFN provisioner already covers AWS::CloudWatch::Alarm; this
+//! test exercises the dashboard side and rounds out BB18.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Dash": {
+      "Type": "AWS::CloudWatch::Dashboard",
+      "Properties": {
+        "DashboardName": "cfn-dashboard",
+        "DashboardBody": "{\"widgets\":[{\"type\":\"metric\",\"properties\":{\"metrics\":[[\"AWS/Lambda\",\"Invocations\"]],\"region\":\"us-east-1\"}}]}"
+      }
+    }
+  },
+  "Outputs": {
+    "Name": {"Value": {"Ref": "Dash"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_cloudwatch_dashboard() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cw = aws_sdk_cloudwatch::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("cw-dashboard-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("cw-dashboard-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    assert_eq!(outputs.get("Name").copied(), Some("cfn-dashboard"));
+
+    // Verify via SDK GetDashboard.
+    let got = cw
+        .get_dashboard()
+        .dashboard_name("cfn-dashboard")
+        .send()
+        .await
+        .expect("get_dashboard");
+    let body = got.dashboard_body().expect("dashboard body");
+    assert!(body.contains("AWS/Lambda"));
+
+    // Verify ListDashboards picks it up.
+    let listed = cw.list_dashboards().send().await.expect("list_dashboards");
+    assert!(listed
+        .dashboard_entries()
+        .iter()
+        .any(|e| e.dashboard_name() == Some("cfn-dashboard")));
+
+    cfn.delete_stack()
+        .stack_name("cw-dashboard-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    // After teardown, GetDashboard should fail.
+    let after = cw
+        .get_dashboard()
+        .dashboard_name("cfn-dashboard")
+        .send()
+        .await;
+    assert!(after.is_err(), "dashboard should be gone after delete");
+}


### PR DESCRIPTION
## Summary
CloudWatch crate previously had no Dashboard surface. This batch adds it end-to-end:

- New `Dashboard` struct + `dashboards` map on `CloudWatchState` (global per account, not regional)
- 4 new ops: `PutDashboard` (validates body parses as JSON), `GetDashboard`, `DeleteDashboards`, `ListDashboards` (with `DashboardNamePrefix` filter)
- CFN provisioner for `AWS::CloudWatch::Dashboard`

Closes BB18 — `AWS::CloudWatch::Alarm` already shipped previously.

## Test plan
- [x] new e2e `cloudformation_cw_dashboard.rs` exercises CFN -> CW SDK GetDashboard / ListDashboards / verify-gone-after-delete
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo clippy -p fakecloud-cloudformation -p fakecloud-cloudwatch -p fakecloud-e2e --all-targets -- -D warnings`
- [x] `cargo fmt`

Part of Phase BB CloudFormation provisioner expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudWatch Dashboard CRUD and CloudFormation provisioning to support `AWS::CloudWatch::Dashboard`. Completes BB18; `DashboardBody` is validated as JSON and dashboards are global per account.

- **New Features**
  - Added `Dashboard` model and `dashboards` map on `CloudWatchState`.
  - Implemented `PutDashboard`, `GetDashboard`, `DeleteDashboards`, and `ListDashboards`.
  - Added CloudFormation provisioner for `AWS::CloudWatch::Dashboard` with e2e coverage (create, SDK Get/List, delete).

<sup>Written for commit 1231864f85780fd46ee291b66b11a4a3dacfa9f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

