### PR TITLE
feat(cloudformation): provision AWS::ApiGateway::* resource types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-acm",
+ "fakecloud-apigateway",
  "fakecloud-aws",
  "fakecloud-cloudfront",
  "fakecloud-cloudwatch",

--- a/crates/fakecloud-apigateway/src/lib.rs
+++ b/crates/fakecloud-apigateway/src/lib.rs
@@ -15,11 +15,12 @@ pub mod dispatch;
 pub mod facade;
 pub mod lambda_proxy;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 
 pub use facade::ApiGatewayFacade;
 pub use state::{
-    ApiGatewaySnapshot, ApiGatewayState, RestApi, SharedApiGatewayState,
+    make_id, ApiGatewaySnapshot, ApiGatewayState, ApiKey, Authorizer, Deployment, Integration,
+    Method, Model, Resource, RestApi, SharedApiGatewayState, Stage, UsagePlan,
     APIGATEWAY_SNAPSHOT_SCHEMA_VERSION,
 };
 

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -36,6 +36,7 @@ fakecloud-route53 = { workspace = true }
 fakecloud-cloudfront = { workspace = true }
 fakecloud-stepfunctions = { workspace = true }
 fakecloud-wafv2 = { workspace = true }
+fakecloud-apigateway = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -752,6 +752,7 @@ mod tests {
             cloudfront: Arc::new(RwLock::new(fakecloud_cloudfront::CloudFrontAccounts::new())),
             stepfunctions: shared::<fakecloud_stepfunctions::StepFunctionsState>(),
             wafv2: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
+            apigateway: shared::<fakecloud_apigateway::ApiGatewayState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8,6 +8,12 @@ use fakecloud_acm::{
     CertificateOptions as AcmCertificateOptions, DomainValidation as AcmDomainValidation,
     SharedAcmState, StoredCertificate as AcmStoredCertificate,
 };
+use fakecloud_apigateway::{
+    make_id as apigw_make_id, ApiKey as ApiGwApiKey, Authorizer as ApiGwAuthorizer,
+    Deployment as ApiGwDeployment, Integration as ApiGwIntegration, Method as ApiGwMethod,
+    Model as ApiGwModel, Resource as ApiGwResource, RestApi as ApiGwRestApi, SharedApiGatewayState,
+    Stage as ApiGwStage, UsagePlan as ApiGwUsagePlan,
+};
 use fakecloud_cloudfront::{
     functions::{
         CloudFrontOriginAccessIdentityConfig, FunctionConfig, KeyGroupConfig, KeyGroupItems,
@@ -341,6 +347,7 @@ pub struct ResourceProvisioner {
     pub cloudfront_state: SharedCloudFrontState,
     pub stepfunctions_state: SharedStepFunctionsState,
     pub wafv2_state: SharedWafv2State,
+    pub apigateway_state: SharedApiGatewayState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -466,6 +473,20 @@ impl ResourceProvisioner {
             "AWS::WAFv2::RuleGroup" => self.create_wafv2_rule_group(resource),
             "AWS::WAFv2::LoggingConfiguration" => self.create_wafv2_logging_configuration(resource),
             "AWS::WAFv2::WebACLAssociation" => self.create_wafv2_web_acl_association(resource),
+            "AWS::ApiGateway::RestApi" => self.create_apigw_rest_api(resource),
+            "AWS::ApiGateway::Resource" => self.create_apigw_resource(resource),
+            "AWS::ApiGateway::Method" => self.create_apigw_method(resource),
+            "AWS::ApiGateway::Deployment" => self.create_apigw_deployment(resource),
+            "AWS::ApiGateway::Stage" => self.create_apigw_stage(resource),
+            "AWS::ApiGateway::Authorizer" => self.create_apigw_authorizer(resource),
+            "AWS::ApiGateway::RequestValidator" => self.create_apigw_request_validator(resource),
+            "AWS::ApiGateway::Model" => self.create_apigw_model(resource),
+            "AWS::ApiGateway::GatewayResponse" => self.create_apigw_gateway_response(resource),
+            "AWS::ApiGateway::UsagePlan" => self.create_apigw_usage_plan(resource),
+            "AWS::ApiGateway::ApiKey" => self.create_apigw_api_key(resource),
+            "AWS::ApiGateway::UsagePlanKey" => self.create_apigw_usage_plan_key(resource),
+            "AWS::ApiGateway::DomainName" => self.create_apigw_domain_name(resource),
+            "AWS::ApiGateway::BasePathMapping" => self.create_apigw_base_path_mapping(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -665,6 +686,38 @@ impl ResourceProvisioner {
             }
             "AWS::WAFv2::WebACLAssociation" => {
                 self.delete_wafv2_web_acl_association(&resource.physical_id)
+            }
+            "AWS::ApiGateway::RestApi" => self.delete_apigw_rest_api(&resource.physical_id),
+            "AWS::ApiGateway::Resource" => {
+                self.delete_apigw_resource(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::Method" => self.delete_apigw_method(&resource.physical_id),
+            "AWS::ApiGateway::Deployment" => {
+                self.delete_apigw_deployment(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::Stage" => {
+                self.delete_apigw_stage(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::Authorizer" => {
+                self.delete_apigw_authorizer(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::RequestValidator" => {
+                self.delete_apigw_request_validator(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::Model" => {
+                self.delete_apigw_model(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::GatewayResponse" => {
+                self.delete_apigw_gateway_response(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::UsagePlan" => self.delete_apigw_usage_plan(&resource.physical_id),
+            "AWS::ApiGateway::ApiKey" => self.delete_apigw_api_key(&resource.physical_id),
+            "AWS::ApiGateway::UsagePlanKey" => {
+                self.delete_apigw_usage_plan_key(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::ApiGateway::DomainName" => self.delete_apigw_domain_name(&resource.physical_id),
+            "AWS::ApiGateway::BasePathMapping" => {
+                self.delete_apigw_base_path_mapping(&resource.physical_id, &resource.attributes)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
@@ -8143,6 +8196,1146 @@ impl ResourceProvisioner {
         state.associations.remove(physical_id);
         Ok(())
     }
+
+    // --- API Gateway v1 ---
+
+    fn create_apigw_rest_api(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let api_key_source = props
+            .get("ApiKeySourceType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("HEADER")
+            .to_string();
+        let endpoint_configuration = props
+            .get("EndpointConfiguration")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({"types": ["EDGE"]}));
+        let policy = props
+            .get("Policy")
+            .map(|v| v.to_string().trim_matches('"').to_string());
+        let binary_media_types: Vec<String> = props
+            .get("BinaryMediaTypes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let minimum_compression_size = props.get("MinimumCompressionSize").and_then(|v| v.as_i64());
+        let disable_execute_api_endpoint = props
+            .get("DisableExecuteApiEndpoint")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let id = apigw_make_id();
+        let root_resource_id = apigw_make_id();
+        let now = Utc::now();
+
+        let api = ApiGwRestApi {
+            id: id.clone(),
+            name,
+            description,
+            version: props
+                .get("Version")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            created_date: now,
+            api_key_source,
+            endpoint_configuration,
+            policy,
+            binary_media_types,
+            minimum_compression_size,
+            disable_execute_api_endpoint,
+            root_resource_id: root_resource_id.clone(),
+            tags: BTreeMap::new(),
+            import_source: None,
+        };
+
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.apis.insert(id.clone(), api);
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            root_resource_id.clone(),
+            ApiGwResource {
+                id: root_resource_id.clone(),
+                parent_id: None,
+                path_part: None,
+                path: "/".to_string(),
+            },
+        );
+        state.resources.insert(id.clone(), resources);
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("RestApiId", id.clone())
+            .with("RootResourceId", root_resource_id))
+    }
+
+    fn delete_apigw_rest_api(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.apis.remove(physical_id);
+        state.resources.remove(physical_id);
+        let prefix = format!("{physical_id}/");
+        state.methods.retain(|k, _| !k.starts_with(&prefix));
+        state.integrations.retain(|k, _| !k.starts_with(&prefix));
+        state
+            .integration_responses
+            .retain(|k, _| !k.starts_with(&prefix));
+        state
+            .method_responses
+            .retain(|k, _| !k.starts_with(&prefix));
+        state.deployments.remove(physical_id);
+        state.stages.remove(physical_id);
+        state.models.remove(physical_id);
+        state.request_validators.remove(physical_id);
+        state.authorizers.remove(physical_id);
+        state.gateway_responses.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_apigw_resource(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let parent_id = props
+            .get("ParentId")
+            .and_then(|v| v.as_str())
+            .ok_or("ParentId is required")?
+            .to_string();
+        let path_part = props
+            .get("PathPart")
+            .and_then(|v| v.as_str())
+            .ok_or("PathPart is required")?
+            .to_string();
+
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let api_resources = state
+            .resources
+            .get(&rest_api_id)
+            .ok_or_else(|| format!("RestApi {rest_api_id} not found"))?;
+        let parent = api_resources
+            .get(&parent_id)
+            .ok_or_else(|| format!("Parent resource {parent_id} not found"))?;
+        let parent_path = parent.path.clone();
+        let path = if parent_path == "/" {
+            format!("/{path_part}")
+        } else {
+            format!("{parent_path}/{path_part}")
+        };
+
+        let id = apigw_make_id();
+        let new_resource = ApiGwResource {
+            id: id.clone(),
+            parent_id: Some(parent_id),
+            path_part: Some(path_part),
+            path,
+        };
+        state
+            .resources
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(id.clone(), new_resource);
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("ResourceId", id)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_resource(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.resources.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        let prefix = format!("{rest_api_id}/{physical_id}/");
+        state.methods.retain(|k, _| !k.starts_with(&prefix));
+        state.integrations.retain(|k, _| !k.starts_with(&prefix));
+        Ok(())
+    }
+
+    fn create_apigw_method(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let resource_id = props
+            .get("ResourceId")
+            .and_then(|v| v.as_str())
+            .ok_or("ResourceId is required")?
+            .to_string();
+        let http_method = props
+            .get("HttpMethod")
+            .and_then(|v| v.as_str())
+            .ok_or("HttpMethod is required")?
+            .to_uppercase();
+        let authorization_type = props
+            .get("AuthorizationType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("NONE")
+            .to_string();
+        let authorizer_id = props
+            .get("AuthorizerId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let api_key_required = props
+            .get("ApiKeyRequired")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let operation_name = props
+            .get("OperationName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let request_validator_id = props
+            .get("RequestValidatorId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let request_parameters: BTreeMap<String, bool> = props
+            .get("RequestParameters")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), v.as_bool().unwrap_or(false)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let request_models: BTreeMap<String, String> = props
+            .get("RequestModels")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let authorization_scopes: Vec<String> = props
+            .get("AuthorizationScopes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let composite_key = format!("{rest_api_id}/{resource_id}/{http_method}");
+        let method = ApiGwMethod {
+            rest_api_id: rest_api_id.clone(),
+            resource_id: resource_id.clone(),
+            http_method: http_method.clone(),
+            authorization_type,
+            authorizer_id,
+            api_key_required,
+            operation_name,
+            request_parameters,
+            request_models,
+            request_validator_id,
+            authorization_scopes,
+        };
+
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.apis.contains_key(&rest_api_id) {
+            return Err(format!("RestApi {rest_api_id} not found"));
+        }
+        // Multi-pass provisioning: if `Ref: SomeResource` resolved to the
+        // logical id (because the referenced resource hasn't been
+        // provisioned yet on this pass), bail so CFN retries us next pass.
+        let resource_known = state
+            .resources
+            .get(&rest_api_id)
+            .map(|m| m.contains_key(&resource_id))
+            .unwrap_or(false);
+        if !resource_known {
+            return Err(format!(
+                "Resource {resource_id} not yet provisioned for api {rest_api_id}"
+            ));
+        }
+        state.methods.insert(composite_key.clone(), method);
+
+        if let Some(integ_props) = props.get("Integration").and_then(|v| v.as_object()) {
+            let integration = ApiGwIntegration {
+                rest_api_id: rest_api_id.clone(),
+                resource_id: resource_id.clone(),
+                http_method: http_method.clone(),
+                integration_type: integ_props
+                    .get("Type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("MOCK")
+                    .to_string(),
+                integration_http_method: integ_props
+                    .get("IntegrationHttpMethod")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                uri: integ_props
+                    .get("Uri")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                credentials: integ_props
+                    .get("Credentials")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                request_parameters: integ_props
+                    .get("RequestParameters")
+                    .and_then(|v| v.as_object())
+                    .map(|obj| {
+                        obj.iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                request_templates: integ_props
+                    .get("RequestTemplates")
+                    .and_then(|v| v.as_object())
+                    .map(|obj| {
+                        obj.iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                passthrough_behavior: integ_props
+                    .get("PassthroughBehavior")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("WHEN_NO_MATCH")
+                    .to_string(),
+                timeout_in_millis: integ_props
+                    .get("TimeoutInMillis")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+                cache_namespace: integ_props
+                    .get("CacheNamespace")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                cache_key_parameters: integ_props
+                    .get("CacheKeyParameters")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                content_handling: integ_props
+                    .get("ContentHandling")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                connection_type: integ_props
+                    .get("ConnectionType")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                connection_id: integ_props
+                    .get("ConnectionId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                tls_config: integ_props.get("TlsConfig").cloned(),
+            };
+            state
+                .integrations
+                .insert(composite_key.clone(), integration);
+        }
+
+        Ok(ProvisionResult::new(composite_key.clone())
+            .with("MethodKey", composite_key)
+            .with("RestApiId", rest_api_id)
+            .with("ResourceId", resource_id)
+            .with("HttpMethod", http_method))
+    }
+
+    fn delete_apigw_method(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.methods.remove(physical_id);
+        state.integrations.remove(physical_id);
+        let prefix = format!("{physical_id}/");
+        state
+            .integration_responses
+            .retain(|k, _| !k.starts_with(&prefix));
+        state
+            .method_responses
+            .retain(|k, _| !k.starts_with(&prefix));
+        Ok(())
+    }
+
+    fn create_apigw_deployment(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = apigw_make_id();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.apis.contains_key(&rest_api_id) {
+            return Err(format!("RestApi {rest_api_id} not found"));
+        }
+        let api_summary = serde_json::to_value(
+            state
+                .resources
+                .get(&rest_api_id)
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .unwrap_or(serde_json::Value::Null);
+        let deployment = ApiGwDeployment {
+            id: id.clone(),
+            description,
+            created_date: Utc::now(),
+            api_summary,
+        };
+        state
+            .deployments
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(id.clone(), deployment);
+
+        // CFN inline `StageName` creates a Stage referencing this deployment.
+        if let Some(stage_name) = props
+            .get("StageName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+        {
+            let stage = ApiGwStage {
+                stage_name: stage_name.clone(),
+                deployment_id: id.clone(),
+                description: props
+                    .get("StageDescription")
+                    .and_then(|v| v.get("Description"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                cache_cluster_enabled: false,
+                cache_cluster_size: None,
+                variables: BTreeMap::new(),
+                method_settings: BTreeMap::new(),
+                created_date: Utc::now(),
+                last_updated_date: Utc::now(),
+                tracing_enabled: false,
+                web_acl_arn: None,
+                canary_settings: None,
+                access_log_settings: None,
+                tags: BTreeMap::new(),
+            };
+            state
+                .stages
+                .entry(rest_api_id.clone())
+                .or_default()
+                .insert(stage_name, stage);
+        }
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("DeploymentId", id)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_deployment(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.deployments.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_stage(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let stage_name = props
+            .get("StageName")
+            .and_then(|v| v.as_str())
+            .ok_or("StageName is required")?
+            .to_string();
+        let deployment_id = props
+            .get("DeploymentId")
+            .and_then(|v| v.as_str())
+            .ok_or("DeploymentId is required")?
+            .to_string();
+
+        let variables: BTreeMap<String, String> = props
+            .get("Variables")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tracing_enabled = props
+            .get("TracingEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let cache_cluster_enabled = props
+            .get("CacheClusterEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let cache_cluster_size = props
+            .get("CacheClusterSize")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let stage = ApiGwStage {
+            stage_name: stage_name.clone(),
+            deployment_id,
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            cache_cluster_enabled,
+            cache_cluster_size,
+            variables,
+            method_settings: BTreeMap::new(),
+            created_date: Utc::now(),
+            last_updated_date: Utc::now(),
+            tracing_enabled,
+            web_acl_arn: None,
+            canary_settings: props.get("CanarySetting").cloned(),
+            access_log_settings: props.get("AccessLogSetting").cloned(),
+            tags: BTreeMap::new(),
+        };
+
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.apis.contains_key(&rest_api_id) {
+            return Err(format!("RestApi {rest_api_id} not found"));
+        }
+        let dep_known = state
+            .deployments
+            .get(&rest_api_id)
+            .map(|m| m.contains_key(&stage.deployment_id))
+            .unwrap_or(false);
+        if !dep_known {
+            return Err(format!(
+                "Deployment {} not yet provisioned for api {rest_api_id}",
+                stage.deployment_id
+            ));
+        }
+        state
+            .stages
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(stage_name.clone(), stage);
+
+        Ok(ProvisionResult::new(stage_name.clone())
+            .with("StageName", stage_name)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_stage(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.stages.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_authorizer(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let authorizer_type = props
+            .get("Type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("TOKEN")
+            .to_string();
+        let provider_arns: Vec<String> = props
+            .get("ProviderARNs")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let id = apigw_make_id();
+        let auth = ApiGwAuthorizer {
+            id: id.clone(),
+            name,
+            authorizer_type,
+            provider_arns,
+            auth_type: props
+                .get("AuthType")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            authorizer_uri: props
+                .get("AuthorizerUri")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            authorizer_credentials: props
+                .get("AuthorizerCredentials")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            identity_source: props
+                .get("IdentitySource")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            identity_validation_expression: props
+                .get("IdentityValidationExpression")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            authorizer_result_ttl_in_seconds: props
+                .get("AuthorizerResultTtlInSeconds")
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32),
+        };
+
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.apis.contains_key(&rest_api_id) {
+            return Err(format!("RestApi {rest_api_id} not found"));
+        }
+        state
+            .authorizers
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(id.clone(), auth);
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("AuthorizerId", id)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_authorizer(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.authorizers.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_request_validator(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let name = props.get("Name").and_then(|v| v.as_str()).map(String::from);
+        let validate_body = props
+            .get("ValidateRequestBody")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let validate_params = props
+            .get("ValidateRequestParameters")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let id = apigw_make_id();
+        let body = serde_json::json!({
+            "id": id,
+            "name": name,
+            "validateRequestBody": validate_body,
+            "validateRequestParameters": validate_params,
+        });
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state
+            .request_validators
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(id.clone(), body);
+        Ok(ProvisionResult::new(id.clone())
+            .with("RequestValidatorId", id)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_request_validator(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.request_validators.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_model(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let content_type = props
+            .get("ContentType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("application/json")
+            .to_string();
+        let schema = props.get("Schema").map(|v| {
+            if let Some(s) = v.as_str() {
+                s.to_string()
+            } else {
+                v.to_string()
+            }
+        });
+        let id = apigw_make_id();
+        let model = ApiGwModel {
+            id: id.clone(),
+            name: name.clone(),
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            schema,
+            content_type,
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state
+            .models
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(name.clone(), model);
+        Ok(ProvisionResult::new(name.clone())
+            .with("ModelName", name)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_model(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.models.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_gateway_response(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let response_type = props
+            .get("ResponseType")
+            .and_then(|v| v.as_str())
+            .ok_or("ResponseType is required")?
+            .to_string();
+        let body = serde_json::json!({
+            "responseType": response_type,
+            "statusCode": props.get("StatusCode").and_then(|v| v.as_str()),
+            "responseParameters": props.get("ResponseParameters").cloned().unwrap_or(serde_json::json!({})),
+            "responseTemplates": props.get("ResponseTemplates").cloned().unwrap_or(serde_json::json!({})),
+        });
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state
+            .gateway_responses
+            .entry(rest_api_id.clone())
+            .or_default()
+            .insert(response_type.clone(), body);
+        Ok(ProvisionResult::new(response_type.clone())
+            .with("ResponseType", response_type)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn delete_apigw_gateway_response(
+        &self,
+        physical_id: &str,
+        attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(rest_api_id) = attributes.get("RestApiId") else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.gateway_responses.get_mut(rest_api_id) {
+            map.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_usage_plan(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("UsagePlanName")
+            .and_then(|v| v.as_str())
+            .ok_or("UsagePlanName is required")?
+            .to_string();
+        let id = apigw_make_id();
+        let plan = ApiGwUsagePlan {
+            id: id.clone(),
+            name,
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            api_stages: props
+                .get("ApiStages")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .map(lowercase_first_keys)
+                .collect(),
+            throttle: props.get("Throttle").cloned().map(lowercase_first_keys),
+            quota: props.get("Quota").cloned().map(lowercase_first_keys),
+            product_code: None,
+            tags: BTreeMap::new(),
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.usage_plans.insert(id.clone(), plan);
+        Ok(ProvisionResult::new(id.clone()).with("UsagePlanId", id))
+    }
+
+    fn delete_apigw_usage_plan(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.usage_plans.remove(physical_id);
+        state.usage_plan_keys.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_apigw_api_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-key-{}", resource.logical_id));
+        let value = props
+            .get("Value")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| Uuid::new_v4().simple().to_string());
+        let enabled = props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let id = apigw_make_id();
+        let now = Utc::now();
+        let key = ApiGwApiKey {
+            id: id.clone(),
+            value,
+            name,
+            description: props
+                .get("Description")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            enabled,
+            created_date: now,
+            last_updated_date: now,
+            stage_keys: Vec::new(),
+            tags: BTreeMap::new(),
+            customer_id: props
+                .get("CustomerId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.api_keys.insert(id.clone(), key);
+        Ok(ProvisionResult::new(id.clone()).with("ApiKeyId", id))
+    }
+
+    fn delete_apigw_api_key(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.api_keys.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_apigw_usage_plan_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let usage_plan_id = props
+            .get("UsagePlanId")
+            .and_then(|v| v.as_str())
+            .ok_or("UsagePlanId is required")?
+            .to_string();
+        let key_id = props
+            .get("KeyId")
+            .and_then(|v| v.as_str())
+            .ok_or("KeyId is required")?
+            .to_string();
+        let key_type = props
+            .get("KeyType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("API_KEY")
+            .to_string();
+        let body = serde_json::json!({
+            "id": key_id,
+            "type": key_type,
+        });
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.usage_plans.contains_key(&usage_plan_id) {
+            return Err(format!("UsagePlan {usage_plan_id} not yet provisioned"));
+        }
+        if !state.api_keys.contains_key(&key_id) {
+            return Err(format!("ApiKey {key_id} not yet provisioned"));
+        }
+        state
+            .usage_plan_keys
+            .entry(usage_plan_id.clone())
+            .or_default()
+            .insert(key_id.clone(), body);
+        let physical = format!("{usage_plan_id}/{key_id}");
+        Ok(ProvisionResult::new(physical)
+            .with("UsagePlanId", usage_plan_id)
+            .with("KeyId", key_id))
+    }
+
+    fn delete_apigw_usage_plan_key(
+        &self,
+        physical_id: &str,
+        _attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let mut parts = physical_id.splitn(2, '/');
+        let Some(plan_id) = parts.next() else {
+            return Ok(());
+        };
+        let Some(key_id) = parts.next() else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.usage_plan_keys.get_mut(plan_id) {
+            map.remove(key_id);
+        }
+        Ok(())
+    }
+
+    fn create_apigw_domain_name(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let domain_name = props
+            .get("DomainName")
+            .and_then(|v| v.as_str())
+            .ok_or("DomainName is required")?
+            .to_string();
+        let body = serde_json::json!({
+            "domainName": domain_name,
+            "certificateArn": props.get("CertificateArn").and_then(|v| v.as_str()),
+            "regionalCertificateArn": props.get("RegionalCertificateArn").and_then(|v| v.as_str()),
+            "endpointConfiguration": props.get("EndpointConfiguration").cloned().unwrap_or(serde_json::json!({"types": ["EDGE"]})),
+            "securityPolicy": props.get("SecurityPolicy").and_then(|v| v.as_str()),
+            "ownershipVerificationCertificateArn": props.get("OwnershipVerificationCertificateArn").and_then(|v| v.as_str()),
+            "regionalDomainName": format!("d-{}.execute-api.{}.amazonaws.com", apigw_make_id(), self.region),
+            "regionalHostedZoneId": "Z2FDTNDATAQYW2",
+            "distributionDomainName": format!("d{}.cloudfront.net", apigw_make_id()),
+            "distributionHostedZoneId": "Z2FDTNDATAQYW2",
+        });
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.domain_names.insert(domain_name.clone(), body);
+        Ok(ProvisionResult::new(domain_name.clone())
+            .with("DomainName", domain_name)
+            .with("RegionalHostedZoneId", "Z2FDTNDATAQYW2".to_string())
+            .with("DistributionHostedZoneId", "Z2FDTNDATAQYW2".to_string()))
+    }
+
+    fn delete_apigw_domain_name(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.domain_names.remove(physical_id);
+        state.base_path_mappings.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_apigw_base_path_mapping(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let domain_name = props
+            .get("DomainName")
+            .and_then(|v| v.as_str())
+            .ok_or("DomainName is required")?
+            .to_string();
+        let rest_api_id = props
+            .get("RestApiId")
+            .and_then(|v| v.as_str())
+            .ok_or("RestApiId is required")?
+            .to_string();
+        let base_path = props
+            .get("BasePath")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(none)")
+            .to_string();
+        let stage = props
+            .get("Stage")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let body = serde_json::json!({
+            "basePath": base_path,
+            "restApiId": rest_api_id,
+            "stage": stage,
+        });
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state
+            .base_path_mappings
+            .entry(domain_name.clone())
+            .or_default()
+            .insert(base_path.clone(), body);
+        let physical = format!("{domain_name}/{base_path}");
+        Ok(ProvisionResult::new(physical)
+            .with("DomainName", domain_name)
+            .with("BasePath", base_path))
+    }
+
+    fn delete_apigw_base_path_mapping(
+        &self,
+        physical_id: &str,
+        _attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let mut parts = physical_id.splitn(2, '/');
+        let Some(domain) = parts.next() else {
+            return Ok(());
+        };
+        let Some(base_path) = parts.next() else {
+            return Ok(());
+        };
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(map) = state.base_path_mappings.get_mut(domain) {
+            map.remove(base_path);
+        }
+        Ok(())
+    }
+}
+
+/// Lowercase the first letter of each key in a JSON object, recursively.
+/// CloudFormation property names are PascalCase (`BurstLimit`,
+/// `RateLimit`); the runtime API Gateway service stores values keyed in
+/// camelCase (`burstLimit`, `rateLimit`). Used at the CFN/service
+/// boundary so JSON pulled from the template can flow into the runtime
+/// state without renaming each leaf by hand.
+fn lowercase_first_keys(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                let new_key = if let Some(first) = k.chars().next() {
+                    let mut s = String::with_capacity(k.len());
+                    s.extend(first.to_lowercase());
+                    s.push_str(&k[first.len_utf8()..]);
+                    s
+                } else {
+                    k
+                };
+                out.insert(new_key, lowercase_first_keys(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(lowercase_first_keys).collect())
+        }
+        other => other,
+    }
 }
 
 /// Synthesize the per-domain DNS validation record list for a
@@ -8509,6 +9702,13 @@ mod tests {
                 ),
             )),
             wafv2_state: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
+            apigateway_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),
             region: "us-east-1".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -140,6 +140,7 @@ pub struct CloudFormationDeps {
     pub cloudfront: fakecloud_cloudfront::SharedCloudFrontState,
     pub stepfunctions: fakecloud_stepfunctions::SharedStepFunctionsState,
     pub wafv2: fakecloud_wafv2::SharedWafv2State,
+    pub apigateway: fakecloud_apigateway::SharedApiGatewayState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -215,6 +216,7 @@ impl CloudFormationService {
             cloudfront_state: self.deps.cloudfront.clone(),
             stepfunctions_state: self.deps.stepfunctions.clone(),
             wafv2_state: self.deps.wafv2.clone(),
+            apigateway_state: self.deps.apigateway.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1339,6 +1341,13 @@ mod tests {
                 ),
             )),
             wafv2: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
+            apigateway: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-e2e/tests/cloudformation_apigateway.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_apigateway.rs
@@ -1,0 +1,203 @@
+//! CloudFormation provisioner for AWS::ApiGateway::* (BB9). Exercises
+//! a RestApi with a child Resource, a Method+Integration, a Deployment
+//! that inlines a Stage, plus a UsagePlan/ApiKey. Asserts via the real
+//! API Gateway v1 SDK so the test only passes when both the CFN side
+//! and the runtime API GW side agree on stored shape.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Api": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "cfn-api",
+        "Description": "from cfn",
+        "EndpointConfiguration": {"Types": ["REGIONAL"]}
+      }
+    },
+    "Pets": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ParentId": {"Fn::GetAtt": ["Api", "RootResourceId"]},
+        "PathPart": "pets"
+      }
+    },
+    "GetPets": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ResourceId": {"Ref": "Pets"},
+        "HttpMethod": "GET",
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "Type": "MOCK",
+          "PassthroughBehavior": "WHEN_NO_MATCH",
+          "RequestTemplates": {"application/json": "{\"statusCode\":200}"}
+        }
+      }
+    },
+    "Deploy": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "DependsOn": "GetPets",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "StageName": "prod"
+      }
+    },
+    "Plan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "Properties": {
+        "UsagePlanName": "cfn-plan",
+        "Description": "test plan",
+        "Throttle": {"BurstLimit": 100, "RateLimit": 50}
+      }
+    },
+    "Key": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Name": "cfn-key",
+        "Enabled": true
+      }
+    }
+  },
+  "Outputs": {
+    "ApiId": {"Value": {"Ref": "Api"}},
+    "RootId": {"Value": {"Fn::GetAtt": ["Api", "RootResourceId"]}},
+    "PetsId": {"Value": {"Ref": "Pets"}},
+    "PlanId": {"Value": {"Ref": "Plan"}},
+    "KeyId": {"Value": {"Ref": "Key"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_apigateway_v1() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let agw = server.apigateway_client().await;
+
+    cfn.create_stack()
+        .stack_name("apigw-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("apigw-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    let api_id = outputs.get("ApiId").copied().expect("ApiId output");
+    let root_id = outputs.get("RootId").copied().expect("RootId output");
+    let pets_id = outputs.get("PetsId").copied().expect("PetsId output");
+    let plan_id = outputs.get("PlanId").copied().expect("PlanId output");
+    let key_id = outputs.get("KeyId").copied().expect("KeyId output");
+
+    // Verify RestApi via SDK GetRestApi.
+    let api = agw
+        .get_rest_api()
+        .rest_api_id(api_id)
+        .send()
+        .await
+        .expect("get_rest_api");
+    assert_eq!(api.name(), Some("cfn-api"));
+    assert_eq!(api.description(), Some("from cfn"));
+    assert_eq!(api.root_resource_id(), Some(root_id));
+
+    // Verify Resource via GetResources.
+    let resources = agw
+        .get_resources()
+        .rest_api_id(api_id)
+        .send()
+        .await
+        .expect("get_resources");
+    let pets = resources
+        .items()
+        .iter()
+        .find(|r| r.id() == Some(pets_id))
+        .expect("pets resource present");
+    assert_eq!(pets.path_part(), Some("pets"));
+    assert_eq!(pets.path(), Some("/pets"));
+
+    // Verify Method + Integration.
+    let method = agw
+        .get_method()
+        .rest_api_id(api_id)
+        .resource_id(pets_id)
+        .http_method("GET")
+        .send()
+        .await
+        .expect("get_method");
+    assert_eq!(method.http_method(), Some("GET"));
+    assert_eq!(method.authorization_type(), Some("NONE"));
+
+    let integration = agw
+        .get_integration()
+        .rest_api_id(api_id)
+        .resource_id(pets_id)
+        .http_method("GET")
+        .send()
+        .await
+        .expect("get_integration");
+    assert_eq!(integration.r#type().map(|t| t.as_str()), Some("MOCK"));
+
+    // Verify Stage from inline Deployment.StageName.
+    let stage = agw
+        .get_stage()
+        .rest_api_id(api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("get_stage");
+    assert_eq!(stage.stage_name(), Some("prod"));
+    assert!(!stage.deployment_id().unwrap_or_default().is_empty());
+
+    // Verify UsagePlan.
+    let plan = agw
+        .get_usage_plan()
+        .usage_plan_id(plan_id)
+        .send()
+        .await
+        .expect("get_usage_plan");
+    assert_eq!(plan.name(), Some("cfn-plan"));
+    let throttle = plan.throttle().expect("throttle present");
+    assert_eq!(throttle.burst_limit(), 100);
+    assert!((throttle.rate_limit() - 50.0).abs() < f64::EPSILON);
+
+    // Verify ApiKey.
+    let key = agw
+        .get_api_key()
+        .api_key(key_id)
+        .send()
+        .await
+        .expect("get_api_key");
+    assert_eq!(key.name(), Some("cfn-key"));
+    assert!(key.enabled());
+
+    // Tear down.
+    cfn.delete_stack()
+        .stack_name("apigw-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = agw.get_rest_api().rest_api_id(api_id).send().await;
+    assert!(after.is_err(), "api should be gone after delete");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -738,6 +738,7 @@ async fn main() {
             cloudfront: cloudfront_state.clone(),
             stepfunctions: stepfunctions_state.clone(),
             wafv2: wafv2_state.clone(),
+            apigateway: apigatewayv1_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary
BB9 of the parity gap audit. CloudFormation now provisions the full AWS::ApiGateway::* family — RestApi, Resource, Method (with inline Integration), Deployment (with inline StageName), Stage, Authorizer, RequestValidator, Model, GatewayResponse, UsagePlan, ApiKey, UsagePlanKey, DomainName, BasePathMapping.

Each provisioner writes into the shared `SharedApiGatewayState`, so SDK reads against the runtime API Gateway service see exactly what the stack provisioned. Multi-pass dependency resolution is honored: Method/Stage/UsagePlanKey return `Err` when their referenced resource is still an unresolved logical id, so CFN retries on the next pass.

A `lowercase_first_keys` helper bridges CFN's PascalCase property keys to the runtime API Gateway camelCase JSON storage (Throttle.BurstLimit -> throttle.burstLimit).

## Test plan
- [x] `cargo build -p fakecloud`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-e2e --test cloudformation_apigateway` exercises the full chain via aws-sdk-apigateway against the CFN-provisioned stack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation can now provision the full `AWS::ApiGateway::*` family and writes to `SharedApiGatewayState` so runtime API Gateway reads match what the stack created.

- **New Features**
  - Supports: RestApi, Resource, Method (with inline Integration), Deployment (with inline StageName), Stage, Authorizer, RequestValidator, Model, GatewayResponse, UsagePlan, ApiKey, UsagePlanKey, DomainName, BasePathMapping.
  - Honors multi-pass dependencies. Method/Stage/UsagePlanKey return errors until their refs are provisioned, so CFN retries on the next pass.
  - `lowercase_first_keys` maps CFN PascalCase to API Gateway camelCase JSON.
  - Adds an e2e test (`cloudformation_apigateway.rs`) that validates via `aws-sdk-apigateway`.

<sup>Written for commit 363dfc24a0d15cc9be6d732892256af32d1b8ff6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

