### PR TITLE
feat(cloudformation): provision AWS::SES::* resource types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "fakecloud-route53",
  "fakecloud-s3",
  "fakecloud-secretsmanager",
+ "fakecloud-ses",
  "fakecloud-sns",
  "fakecloud-sqs",
  "fakecloud-ssm",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -38,6 +38,7 @@ fakecloud-stepfunctions = { workspace = true }
 fakecloud-wafv2 = { workspace = true }
 fakecloud-apigateway = { workspace = true }
 fakecloud-apigatewayv2 = { workspace = true }
+fakecloud-ses = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -754,6 +754,7 @@ mod tests {
             wafv2: Arc::new(RwLock::new(fakecloud_wafv2::Wafv2Accounts::default())),
             apigateway: shared::<fakecloud_apigateway::ApiGatewayState>(),
             apigatewayv2: shared::<fakecloud_apigatewayv2::ApiGatewayV2State>(),
+            ses: shared::<fakecloud_ses::SesState>(),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -85,6 +85,13 @@ use fakecloud_route53::{
 };
 use fakecloud_s3::{S3Bucket, SharedS3State};
 use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
+use fakecloud_ses::{
+    ConfigurationSet as SesConfigurationSet, ContactList as SesContactList,
+    DedicatedIpPool as SesDedicatedIpPool, EmailIdentity as SesEmailIdentity,
+    EmailTemplate as SesEmailTemplate, EventDestination as SesEventDestination,
+    IpFilter as SesIpFilter, ReceiptAction as SesReceiptAction, ReceiptFilter as SesReceiptFilter,
+    ReceiptRule as SesReceiptRule, ReceiptRuleSet as SesReceiptRuleSet, SharedSesState,
+};
 use fakecloud_sns::{SharedSnsState, SnsSubscription, SnsTopic};
 use fakecloud_sqs::{SharedSqsState, SqsQueue};
 use fakecloud_ssm::{SharedSsmState, SsmParameter};
@@ -355,6 +362,7 @@ pub struct ResourceProvisioner {
     pub wafv2_state: SharedWafv2State,
     pub apigateway_state: SharedApiGatewayState,
     pub apigatewayv2_state: SharedApiGatewayV2State,
+    pub ses_state: SharedSesState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -508,6 +516,18 @@ impl ResourceProvisioner {
             "AWS::ApiGatewayV2::ApiMapping" => self.create_apigwv2_api_mapping(resource),
             "AWS::ApiGatewayV2::VpcLink" => self.create_apigwv2_vpc_link(resource),
             "AWS::ApiGatewayV2::Model" => self.create_apigwv2_model(resource),
+            "AWS::SES::ConfigurationSet" => self.create_ses_configuration_set(resource),
+            "AWS::SES::ConfigurationSetEventDestination" => {
+                self.create_ses_event_destination(resource)
+            }
+            "AWS::SES::EmailIdentity" => self.create_ses_email_identity(resource),
+            "AWS::SES::Template" => self.create_ses_template(resource),
+            "AWS::SES::ContactList" => self.create_ses_contact_list(resource),
+            "AWS::SES::DedicatedIpPool" => self.create_ses_dedicated_ip_pool(resource),
+            "AWS::SES::ReceiptRule" => self.create_ses_receipt_rule(resource),
+            "AWS::SES::ReceiptRuleSet" => self.create_ses_receipt_rule_set(resource),
+            "AWS::SES::ReceiptFilter" => self.create_ses_receipt_filter(resource),
+            "AWS::SES::VdmAttributes" => self.create_ses_vdm_attributes(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -771,6 +791,22 @@ impl ResourceProvisioner {
             "AWS::ApiGatewayV2::Model" => {
                 self.delete_apigwv2_model(&resource.physical_id, &resource.attributes)
             }
+            "AWS::SES::ConfigurationSet" => {
+                self.delete_ses_configuration_set(&resource.physical_id)
+            }
+            "AWS::SES::ConfigurationSetEventDestination" => {
+                self.delete_ses_event_destination(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::SES::EmailIdentity" => self.delete_ses_email_identity(&resource.physical_id),
+            "AWS::SES::Template" => self.delete_ses_template(&resource.physical_id),
+            "AWS::SES::ContactList" => self.delete_ses_contact_list(&resource.physical_id),
+            "AWS::SES::DedicatedIpPool" => self.delete_ses_dedicated_ip_pool(&resource.physical_id),
+            "AWS::SES::ReceiptRule" => {
+                self.delete_ses_receipt_rule(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::SES::ReceiptRuleSet" => self.delete_ses_receipt_rule_set(&resource.physical_id),
+            "AWS::SES::ReceiptFilter" => self.delete_ses_receipt_filter(&resource.physical_id),
+            "AWS::SES::VdmAttributes" => Ok(()),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -10137,6 +10173,612 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // --- SES ---
+
+    fn create_ses_configuration_set(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-cs-{}", resource.logical_id));
+        let sending_enabled = props
+            .get("SendingOptions")
+            .and_then(|v| v.get("SendingEnabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let tls_policy = props
+            .get("DeliveryOptions")
+            .and_then(|v| v.get("TlsPolicy"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("OPTIONAL")
+            .to_string();
+        let sending_pool_name = props
+            .get("DeliveryOptions")
+            .and_then(|v| v.get("SendingPoolName"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let custom_redirect_domain = props
+            .get("TrackingOptions")
+            .and_then(|v| v.get("CustomRedirectDomain"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let suppressed_reasons: Vec<String> = props
+            .get("SuppressionOptions")
+            .and_then(|v| v.get("SuppressedReasons"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let reputation_metrics_enabled = props
+            .get("ReputationOptions")
+            .and_then(|v| v.get("ReputationMetricsEnabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let cs = SesConfigurationSet {
+            name: name.clone(),
+            sending_enabled,
+            tls_policy,
+            sending_pool_name,
+            custom_redirect_domain,
+            https_policy: props
+                .get("TrackingOptions")
+                .and_then(|v| v.get("HttpsPolicy"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            suppressed_reasons,
+            reputation_metrics_enabled,
+            vdm_options: props.get("VdmOptions").cloned(),
+            archive_arn: props
+                .get("ArchivingOptions")
+                .and_then(|v| v.get("ArchiveArn"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.configuration_sets.insert(name.clone(), cs);
+        Ok(ProvisionResult::new(name.clone()).with("Name", name))
+    }
+
+    fn delete_ses_configuration_set(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.configuration_sets.remove(physical_id);
+        state.event_destinations.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_event_destination(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cs_name = props
+            .get("ConfigurationSetName")
+            .and_then(|v| v.as_str())
+            .ok_or("ConfigurationSetName is required")?
+            .to_string();
+        let dest_props = props
+            .get("EventDestination")
+            .and_then(|v| v.as_object())
+            .ok_or("EventDestination is required")?;
+        let name = dest_props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-ed-{}", resource.logical_id));
+        let enabled = dest_props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let matching_event_types: Vec<String> = dest_props
+            .get("MatchingEventTypes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let dest = SesEventDestination {
+            name: name.clone(),
+            enabled,
+            matching_event_types,
+            kinesis_firehose_destination: dest_props.get("KinesisFirehoseDestination").cloned(),
+            cloud_watch_destination: dest_props.get("CloudWatchDestination").cloned(),
+            sns_destination: dest_props.get("SnsDestination").cloned(),
+            event_bridge_destination: dest_props.get("EventBridgeDestination").cloned(),
+            pinpoint_destination: dest_props.get("PinpointDestination").cloned(),
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if !state.configuration_sets.contains_key(&cs_name) {
+            return Err(format!("ConfigurationSet {cs_name} not yet provisioned"));
+        }
+        let dests = state.event_destinations.entry(cs_name.clone()).or_default();
+        dests.retain(|d| d.name != name);
+        dests.push(dest);
+        let physical = format!("{cs_name}|{name}");
+        Ok(ProvisionResult::new(physical)
+            .with("Name", name)
+            .with("ConfigurationSetName", cs_name))
+    }
+
+    fn delete_ses_event_destination(
+        &self,
+        physical_id: &str,
+        _attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let mut parts = physical_id.splitn(2, '|');
+        let Some(cs) = parts.next() else {
+            return Ok(());
+        };
+        let Some(name) = parts.next() else {
+            return Ok(());
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(dests) = state.event_destinations.get_mut(cs) {
+            dests.retain(|d| d.name != name);
+        }
+        Ok(())
+    }
+
+    fn create_ses_email_identity(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let identity_name = props
+            .get("EmailIdentity")
+            .and_then(|v| v.as_str())
+            .ok_or("EmailIdentity is required")?
+            .to_string();
+        let identity_type = if identity_name.contains('@') {
+            "EMAIL_ADDRESS"
+        } else {
+            "DOMAIN"
+        }
+        .to_string();
+        let dkim_signing_enabled = props
+            .get("DkimAttributes")
+            .and_then(|v| v.get("SigningEnabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let dkim_signing_attributes_origin = props
+            .get("DkimSigningAttributes")
+            .map(|_| "EXTERNAL")
+            .unwrap_or("AWS_SES")
+            .to_string();
+        let mail_from_domain = props
+            .get("MailFromAttributes")
+            .and_then(|v| v.get("MailFromDomain"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let mail_from_behavior = props
+            .get("MailFromAttributes")
+            .and_then(|v| v.get("BehaviorOnMxFailure"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("USE_DEFAULT_VALUE")
+            .to_string();
+        let configuration_set_name = props
+            .get("ConfigurationSetAttributes")
+            .and_then(|v| v.get("ConfigurationSetName"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let email_forwarding_enabled = props
+            .get("FeedbackAttributes")
+            .and_then(|v| v.get("EmailForwardingEnabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let identity = SesEmailIdentity {
+            identity_name: identity_name.clone(),
+            identity_type,
+            verified: true,
+            created_at: Utc::now(),
+            dkim_signing_enabled,
+            dkim_signing_attributes_origin,
+            dkim_domain_signing_private_key: None,
+            dkim_domain_signing_selector: None,
+            dkim_next_signing_key_length: None,
+            dkim_public_key_b64: None,
+            email_forwarding_enabled,
+            mail_from_domain,
+            mail_from_behavior_on_mx_failure: mail_from_behavior,
+            mail_from_domain_status: "Success".to_string(),
+            configuration_set_name,
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.identities.insert(identity_name.clone(), identity);
+        Ok(ProvisionResult::new(identity_name.clone()).with("EmailIdentity", identity_name))
+    }
+
+    fn delete_ses_email_identity(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.identities.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_template(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let template_block = props
+            .get("Template")
+            .and_then(|v| v.as_object())
+            .ok_or("Template is required")?;
+        let template_name = template_block
+            .get("TemplateName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-tpl-{}", resource.logical_id));
+        let tpl = SesEmailTemplate {
+            template_name: template_name.clone(),
+            subject: template_block
+                .get("SubjectPart")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            html_body: template_block
+                .get("HtmlPart")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            text_body: template_block
+                .get("TextPart")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            created_at: Utc::now(),
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.templates.insert(template_name.clone(), tpl);
+        Ok(ProvisionResult::new(template_name.clone()).with("TemplateName", template_name))
+    }
+
+    fn delete_ses_template(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.templates.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_contact_list(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("ContactListName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-cl-{}", resource.logical_id));
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let now = Utc::now();
+        let cl = SesContactList {
+            contact_list_name: name.clone(),
+            description,
+            topics: Vec::new(),
+            created_at: now,
+            last_updated_at: now,
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.contact_lists.insert(name.clone(), cl);
+        Ok(ProvisionResult::new(name.clone()).with("ContactListName", name))
+    }
+
+    fn delete_ses_contact_list(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.contact_lists.remove(physical_id);
+        state.contacts.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_dedicated_ip_pool(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("PoolName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-pool-{}", resource.logical_id));
+        let scaling_mode = props
+            .get("ScalingMode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("STANDARD")
+            .to_string();
+        let pool = SesDedicatedIpPool {
+            pool_name: name.clone(),
+            scaling_mode,
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.dedicated_ip_pools.insert(name.clone(), pool);
+        Ok(ProvisionResult::new(name.clone()).with("PoolName", name))
+    }
+
+    fn delete_ses_dedicated_ip_pool(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.dedicated_ip_pools.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_receipt_rule_set(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("RuleSetName")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-rs-{}", resource.logical_id));
+        let rs = SesReceiptRuleSet {
+            name: name.clone(),
+            rules: Vec::new(),
+            created_at: Utc::now(),
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.receipt_rule_sets.insert(name.clone(), rs);
+        Ok(ProvisionResult::new(name.clone()).with("RuleSetName", name))
+    }
+
+    fn delete_ses_receipt_rule_set(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.receipt_rule_sets.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_receipt_rule(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rule_set_name = props
+            .get("RuleSetName")
+            .and_then(|v| v.as_str())
+            .ok_or("RuleSetName is required")?
+            .to_string();
+        let rule_block = props
+            .get("Rule")
+            .and_then(|v| v.as_object())
+            .ok_or("Rule is required")?;
+        let name = rule_block
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-rule-{}", resource.logical_id));
+        let enabled = rule_block
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let scan_enabled = rule_block
+            .get("ScanEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let tls_policy = rule_block
+            .get("TlsPolicy")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Optional")
+            .to_string();
+        let recipients: Vec<String> = rule_block
+            .get("Recipients")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let actions: Vec<SesReceiptAction> = rule_block
+            .get("Actions")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(parse_ses_receipt_action).collect())
+            .unwrap_or_default();
+
+        let rule = SesReceiptRule {
+            name: name.clone(),
+            enabled,
+            scan_enabled,
+            tls_policy,
+            recipients,
+            actions,
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let rs = state
+            .receipt_rule_sets
+            .get_mut(&rule_set_name)
+            .ok_or_else(|| format!("ReceiptRuleSet {rule_set_name} not yet provisioned"))?;
+        rs.rules.retain(|r| r.name != name);
+        rs.rules.push(rule);
+        let physical = format!("{rule_set_name}|{name}");
+        Ok(ProvisionResult::new(physical)
+            .with("Name", name)
+            .with("RuleSetName", rule_set_name))
+    }
+
+    fn delete_ses_receipt_rule(
+        &self,
+        physical_id: &str,
+        _attributes: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let mut parts = physical_id.splitn(2, '|');
+        let Some(rs_name) = parts.next() else {
+            return Ok(());
+        };
+        let Some(rule_name) = parts.next() else {
+            return Ok(());
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(rs) = state.receipt_rule_sets.get_mut(rs_name) {
+            rs.rules.retain(|r| r.name != rule_name);
+        }
+        Ok(())
+    }
+
+    fn create_ses_receipt_filter(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let filter_block = props
+            .get("Filter")
+            .and_then(|v| v.as_object())
+            .ok_or("Filter is required")?;
+        let name = filter_block
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("cfn-filter-{}", resource.logical_id));
+        let ip_block = filter_block
+            .get("IpFilter")
+            .and_then(|v| v.as_object())
+            .ok_or("Filter.IpFilter is required")?;
+        let cidr = ip_block
+            .get("Cidr")
+            .and_then(|v| v.as_str())
+            .ok_or("Filter.IpFilter.Cidr is required")?
+            .to_string();
+        let policy = ip_block
+            .get("Policy")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Block")
+            .to_string();
+        let filter = SesReceiptFilter {
+            name: name.clone(),
+            ip_filter: SesIpFilter { cidr, policy },
+        };
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.receipt_filters.insert(name.clone(), filter);
+        Ok(ProvisionResult::new(name.clone()).with("Name", name))
+    }
+
+    fn delete_ses_receipt_filter(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.receipt_filters.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_ses_vdm_attributes(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let mut accounts = self.ses_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.account_settings.vdm_attributes = Some(props.clone());
+        Ok(ProvisionResult::new(format!("vdm-{}", resource.logical_id)))
+    }
+}
+
+fn parse_ses_receipt_action(value: &serde_json::Value) -> Option<SesReceiptAction> {
+    let obj = value.as_object()?;
+    if let Some(s3) = obj.get("S3Action").and_then(|v| v.as_object()) {
+        let bucket_name = s3.get("BucketName").and_then(|v| v.as_str())?.to_string();
+        return Some(SesReceiptAction::S3 {
+            bucket_name,
+            object_key_prefix: s3
+                .get("ObjectKeyPrefix")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            topic_arn: s3
+                .get("TopicArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            kms_key_arn: s3
+                .get("KmsKeyArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        });
+    }
+    if let Some(sns) = obj.get("SNSAction").and_then(|v| v.as_object()) {
+        return Some(SesReceiptAction::Sns {
+            topic_arn: sns.get("TopicArn").and_then(|v| v.as_str())?.to_string(),
+            encoding: sns
+                .get("Encoding")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        });
+    }
+    if let Some(la) = obj.get("LambdaAction").and_then(|v| v.as_object()) {
+        return Some(SesReceiptAction::Lambda {
+            function_arn: la.get("FunctionArn").and_then(|v| v.as_str())?.to_string(),
+            invocation_type: la
+                .get("InvocationType")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            topic_arn: la
+                .get("TopicArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        });
+    }
+    if let Some(b) = obj.get("BounceAction").and_then(|v| v.as_object()) {
+        return Some(SesReceiptAction::Bounce {
+            smtp_reply_code: b
+                .get("SmtpReplyCode")
+                .and_then(|v| v.as_str())
+                .unwrap_or("550")
+                .to_string(),
+            message: b
+                .get("Message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            sender: b
+                .get("Sender")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            status_code: b
+                .get("StatusCode")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            topic_arn: b.get("TopicArn").and_then(|v| v.as_str()).map(String::from),
+        });
+    }
+    if let Some(ah) = obj.get("AddHeaderAction").and_then(|v| v.as_object()) {
+        return Some(SesReceiptAction::AddHeader {
+            header_name: ah.get("HeaderName").and_then(|v| v.as_str())?.to_string(),
+            header_value: ah.get("HeaderValue").and_then(|v| v.as_str())?.to_string(),
+        });
+    }
+    if let Some(s) = obj.get("StopAction").and_then(|v| v.as_object()) {
+        return Some(SesReceiptAction::Stop {
+            scope: s
+                .get("Scope")
+                .and_then(|v| v.as_str())
+                .unwrap_or("RuleSet")
+                .to_string(),
+            topic_arn: s.get("TopicArn").and_then(|v| v.as_str()).map(String::from),
+        });
+    }
+    None
 }
 
 /// Generate an N-character alphanumeric id for API Gateway v2 resources.
@@ -10549,6 +11191,13 @@ mod tests {
                 ),
             )),
             apigatewayv2_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ses_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -142,6 +142,7 @@ pub struct CloudFormationDeps {
     pub wafv2: fakecloud_wafv2::SharedWafv2State,
     pub apigateway: fakecloud_apigateway::SharedApiGatewayState,
     pub apigatewayv2: fakecloud_apigatewayv2::SharedApiGatewayV2State,
+    pub ses: fakecloud_ses::SharedSesState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -219,6 +220,7 @@ impl CloudFormationService {
             wafv2_state: self.deps.wafv2.clone(),
             apigateway_state: self.deps.apigateway.clone(),
             apigatewayv2_state: self.deps.apigatewayv2.clone(),
+            ses_state: self.deps.ses.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1351,6 +1353,13 @@ mod tests {
                 ),
             )),
             apigatewayv2: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new(
+                    "123456789012",
+                    "us-east-1",
+                    "",
+                ),
+            )),
+            ses: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(
                     "123456789012",
                     "us-east-1",

--- a/crates/fakecloud-e2e/tests/cloudformation_ses.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ses.rs
@@ -1,0 +1,190 @@
+//! CloudFormation provisioner for AWS::SES::* (BB27). Provisions a
+//! ConfigurationSet, EmailIdentity, Template, ContactList, DedicatedIpPool,
+//! ReceiptRuleSet+ReceiptRule and asserts via the real SES v2 + v1 SDKs.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cs": {
+      "Type": "AWS::SES::ConfigurationSet",
+      "Properties": {
+        "Name": "cfn-cs",
+        "SendingOptions": {"SendingEnabled": true},
+        "DeliveryOptions": {"TlsPolicy": "REQUIRE"},
+        "ReputationOptions": {"ReputationMetricsEnabled": true}
+      }
+    },
+    "Identity": {
+      "Type": "AWS::SES::EmailIdentity",
+      "Properties": {
+        "EmailIdentity": "cfn-domain.example.com",
+        "DkimAttributes": {"SigningEnabled": true},
+        "MailFromAttributes": {
+          "MailFromDomain": "mail.cfn-domain.example.com",
+          "BehaviorOnMxFailure": "USE_DEFAULT_VALUE"
+        }
+      }
+    },
+    "Tpl": {
+      "Type": "AWS::SES::Template",
+      "Properties": {
+        "Template": {
+          "TemplateName": "cfn-tpl",
+          "SubjectPart": "Hi {{name}}",
+          "TextPart": "Hello {{name}}",
+          "HtmlPart": "<p>Hello {{name}}</p>"
+        }
+      }
+    },
+    "Cl": {
+      "Type": "AWS::SES::ContactList",
+      "Properties": {
+        "ContactListName": "cfn-cl",
+        "Description": "from cfn"
+      }
+    },
+    "Pool": {
+      "Type": "AWS::SES::DedicatedIpPool",
+      "Properties": {
+        "PoolName": "cfn-pool",
+        "ScalingMode": "STANDARD"
+      }
+    },
+    "Rs": {
+      "Type": "AWS::SES::ReceiptRuleSet",
+      "Properties": {
+        "RuleSetName": "cfn-rs"
+      }
+    },
+    "Rule": {
+      "Type": "AWS::SES::ReceiptRule",
+      "DependsOn": "Rs",
+      "Properties": {
+        "RuleSetName": "cfn-rs",
+        "Rule": {
+          "Name": "cfn-rule",
+          "Enabled": true,
+          "ScanEnabled": false,
+          "TlsPolicy": "Optional",
+          "Recipients": ["test@cfn-domain.example.com"],
+          "Actions": [
+            {"AddHeaderAction": {"HeaderName": "X-CFN", "HeaderValue": "yes"}}
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "CsName": {"Value": {"Ref": "Cs"}},
+    "IdName": {"Value": {"Ref": "Identity"}},
+    "TplName": {"Value": {"Ref": "Tpl"}},
+    "ClName": {"Value": {"Ref": "Cl"}},
+    "PoolName": {"Value": {"Ref": "Pool"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_ses() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ses = aws_sdk_sesv2::Client::new(&server.aws_config().await);
+    let ses_v1 = aws_sdk_ses::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("ses-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ses-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let cs = ses
+        .get_configuration_set()
+        .configuration_set_name("cfn-cs")
+        .send()
+        .await
+        .expect("get_configuration_set");
+    assert_eq!(cs.configuration_set_name(), Some("cfn-cs"));
+    assert_eq!(
+        cs.delivery_options()
+            .and_then(|d| d.tls_policy())
+            .map(|t| t.as_str()),
+        Some("REQUIRE")
+    );
+
+    let id = ses
+        .get_email_identity()
+        .email_identity("cfn-domain.example.com")
+        .send()
+        .await
+        .expect("get_email_identity");
+    assert_eq!(id.identity_type().map(|t| t.as_str()), Some("DOMAIN"));
+    assert!(id.verified_for_sending_status());
+
+    let tpl = ses
+        .get_email_template()
+        .template_name("cfn-tpl")
+        .send()
+        .await
+        .expect("get_email_template");
+    assert_eq!(tpl.template_name(), "cfn-tpl");
+
+    let cl = ses
+        .get_contact_list()
+        .contact_list_name("cfn-cl")
+        .send()
+        .await
+        .expect("get_contact_list");
+    assert_eq!(cl.contact_list_name(), Some("cfn-cl"));
+
+    let pool = ses
+        .get_dedicated_ip_pool()
+        .pool_name("cfn-pool")
+        .send()
+        .await
+        .expect("get_dedicated_ip_pool");
+    assert_eq!(
+        pool.dedicated_ip_pool().map(|p| p.scaling_mode().as_str()),
+        Some("STANDARD")
+    );
+
+    // Use SES v1 for receipt rule readback.
+    let rule = ses_v1
+        .describe_receipt_rule()
+        .rule_set_name("cfn-rs")
+        .rule_name("cfn-rule")
+        .send()
+        .await
+        .expect("describe_receipt_rule");
+    let r = rule.rule().expect("rule present");
+    assert_eq!(r.name(), "cfn-rule");
+    assert!(r.enabled());
+
+    cfn.delete_stack()
+        .stack_name("ses-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = ses
+        .get_configuration_set()
+        .configuration_set_name("cfn-cs")
+        .send()
+        .await;
+    assert!(after.is_err(), "configuration set should be gone");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -740,6 +740,7 @@ async fn main() {
             wafv2: wafv2_state.clone(),
             apigateway: apigatewayv1_state.clone(),
             apigatewayv2: apigatewayv2_state.clone(),
+            ses: ses_state.clone(),
             delivery: delivery_for_cf,
         },
     );

--- a/crates/fakecloud-ses/src/lib.rs
+++ b/crates/fakecloud-ses/src/lib.rs
@@ -2,10 +2,12 @@ pub mod dkim;
 pub mod fanout;
 pub mod mime;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 pub mod v1;
 
 pub use service::SesV2Service;
 pub use state::{
-    ReceiptAction, SentEmail, SesSnapshot, SharedSesState, SES_SNAPSHOT_SCHEMA_VERSION,
+    ConfigurationSet, ContactList, DedicatedIpPool, EmailIdentity, EmailTemplate, EventDestination,
+    IpFilter, ReceiptAction, ReceiptFilter, ReceiptRule, ReceiptRuleSet, SentEmail, SesSnapshot,
+    SesState, SharedSesState, SES_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary
BB27 of the parity gap audit. CloudFormation now provisions AWS::SES::* — ConfigurationSet, ConfigurationSetEventDestination, EmailIdentity (with DKIM + MailFrom), Template, ContactList, DedicatedIpPool, ReceiptRuleSet, ReceiptRule (with S3/SNS/Lambda/Bounce/AddHeader/Stop actions), ReceiptFilter, VdmAttributes.

Each provisioner writes into the shared SharedSesState so SDK reads against the runtime SES v1+v2 services see the same data the stack provisioned.

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all
- [x] cargo test -p fakecloud-e2e --test cloudformation_ses exercises ConfigurationSet, EmailIdentity, Template, ContactList, DedicatedIpPool, ReceiptRule via aws-sdk-sesv2 + aws-sdk-ses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFormation support for AWS::SES::* resources. Resources are stored in SharedSesState so sesv2 and ses runtime services reflect stack state.

- New Features
  - Provisioners for ConfigurationSet (+ConfigurationSetEventDestination), EmailIdentity (DKIM + MailFrom), Template, ContactList, DedicatedIpPool, ReceiptRuleSet/ReceiptRule (S3/SNS/Lambda/Bounce/AddHeader/Stop actions), ReceiptFilter, and VdmAttributes.
  - E2E test validates via `aws-sdk-sesv2` and `aws-sdk-ses`.

- Dependencies
  - Add `fakecloud-ses` to `fakecloud-cloudformation`.
  - Expose `fakecloud-ses::state` types publicly for provisioners.
  - Wire SES state into CloudFormation deps and the server.

<sup>Written for commit 9ba9e851a247cad96f635d92acc65cda0256f93e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

