### PR TITLE
feat(cloudformation): provision AWS::SecretsManager::* extras

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -84,7 +84,7 @@ use fakecloud_route53::{
     SharedRoute53State, StoredHealthCheck, StoredHostedZone,
 };
 use fakecloud_s3::{S3Bucket, SharedS3State};
-use fakecloud_secretsmanager::{Secret, SecretVersion, SharedSecretsManagerState};
+use fakecloud_secretsmanager::{RotationRules, Secret, SecretVersion, SharedSecretsManagerState};
 use fakecloud_ses::{
     ConfigurationSet as SesConfigurationSet, ContactList as SesContactList,
     DedicatedIpPool as SesDedicatedIpPool, EmailIdentity as SesEmailIdentity,
@@ -528,6 +528,15 @@ impl ResourceProvisioner {
             "AWS::SES::ReceiptRuleSet" => self.create_ses_receipt_rule_set(resource),
             "AWS::SES::ReceiptFilter" => self.create_ses_receipt_filter(resource),
             "AWS::SES::VdmAttributes" => self.create_ses_vdm_attributes(resource),
+            "AWS::SecretsManager::RotationSchedule" => {
+                self.create_secrets_manager_rotation_schedule(resource)
+            }
+            "AWS::SecretsManager::ResourcePolicy" => {
+                self.create_secrets_manager_resource_policy(resource)
+            }
+            "AWS::SecretsManager::SecretTargetAttachment" => {
+                self.create_secrets_manager_target_attachment(resource)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -807,6 +816,13 @@ impl ResourceProvisioner {
             "AWS::SES::ReceiptRuleSet" => self.delete_ses_receipt_rule_set(&resource.physical_id),
             "AWS::SES::ReceiptFilter" => self.delete_ses_receipt_filter(&resource.physical_id),
             "AWS::SES::VdmAttributes" => Ok(()),
+            "AWS::SecretsManager::RotationSchedule" => {
+                self.delete_secrets_manager_rotation_schedule(&resource.physical_id)
+            }
+            "AWS::SecretsManager::ResourcePolicy" => {
+                self.delete_secrets_manager_resource_policy(&resource.physical_id)
+            }
+            "AWS::SecretsManager::SecretTargetAttachment" => Ok(()),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
             }
@@ -10693,6 +10709,182 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.account_settings.vdm_attributes = Some(props.clone());
         Ok(ProvisionResult::new(format!("vdm-{}", resource.logical_id)))
+    }
+
+    // --- SecretsManager extras ---
+
+    fn create_secrets_manager_rotation_schedule(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let secret_id = props
+            .get("SecretId")
+            .and_then(|v| v.as_str())
+            .ok_or("SecretId is required")?
+            .to_string();
+        let rotation_lambda_arn = props
+            .get("RotationLambdaARN")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let automatically_after_days = props
+            .get("RotationRules")
+            .and_then(|v| v.get("AutomaticallyAfterDays"))
+            .and_then(|v| v.as_i64());
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let secret_arn = if state.secrets.contains_key(&secret_id) {
+            secret_id.clone()
+        } else {
+            let candidate = format!(
+                "arn:aws:secretsmanager:{}:{}:secret:{}",
+                state.region, state.account_id, secret_id
+            );
+            if state.secrets.contains_key(&candidate) {
+                candidate
+            } else {
+                return Err(format!("Secret {secret_id} not yet provisioned"));
+            }
+        };
+        let secret = state
+            .secrets
+            .get_mut(&secret_arn)
+            .ok_or_else(|| format!("Secret {secret_arn} not found"))?;
+        secret.rotation_enabled = Some(true);
+        secret.rotation_lambda_arn = rotation_lambda_arn;
+        secret.rotation_rules = Some(RotationRules {
+            automatically_after_days,
+        });
+        secret.last_changed_at = Utc::now();
+        Ok(ProvisionResult::new(secret_arn.clone()).with("SecretArn", secret_arn))
+    }
+
+    fn delete_secrets_manager_rotation_schedule(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(secret) = state.secrets.get_mut(physical_id) {
+            secret.rotation_enabled = Some(false);
+            secret.rotation_lambda_arn = None;
+            secret.rotation_rules = None;
+            secret.last_changed_at = Utc::now();
+        }
+        Ok(())
+    }
+
+    fn create_secrets_manager_resource_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let secret_id = props
+            .get("SecretId")
+            .and_then(|v| v.as_str())
+            .ok_or("SecretId is required")?
+            .to_string();
+        let policy_doc = props
+            .get("ResourcePolicy")
+            .ok_or("ResourcePolicy is required")?;
+        let policy_str = match policy_doc {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let secret_arn = if state.secrets.contains_key(&secret_id) {
+            secret_id.clone()
+        } else {
+            let candidate = format!(
+                "arn:aws:secretsmanager:{}:{}:secret:{}",
+                state.region, state.account_id, secret_id
+            );
+            if state.secrets.contains_key(&candidate) {
+                candidate
+            } else {
+                return Err(format!("Secret {secret_id} not yet provisioned"));
+            }
+        };
+        let secret = state
+            .secrets
+            .get_mut(&secret_arn)
+            .ok_or_else(|| format!("Secret {secret_arn} not found"))?;
+        secret.resource_policy = Some(policy_str);
+        secret.last_changed_at = Utc::now();
+        Ok(ProvisionResult::new(secret_arn.clone()).with("SecretArn", secret_arn))
+    }
+
+    fn delete_secrets_manager_resource_policy(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(secret) = state.secrets.get_mut(physical_id) {
+            secret.resource_policy = None;
+            secret.last_changed_at = Utc::now();
+        }
+        Ok(())
+    }
+
+    fn create_secrets_manager_target_attachment(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let secret_id = props
+            .get("SecretId")
+            .and_then(|v| v.as_str())
+            .ok_or("SecretId is required")?
+            .to_string();
+        let target_type = props
+            .get("TargetType")
+            .and_then(|v| v.as_str())
+            .ok_or("TargetType is required")?;
+        let target_id = props
+            .get("TargetId")
+            .and_then(|v| v.as_str())
+            .ok_or("TargetId is required")?;
+        let mut accounts = self.secretsmanager_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let secret_arn = if state.secrets.contains_key(&secret_id) {
+            secret_id.clone()
+        } else {
+            let candidate = format!(
+                "arn:aws:secretsmanager:{}:{}:secret:{}",
+                state.region, state.account_id, secret_id
+            );
+            if state.secrets.contains_key(&candidate) {
+                candidate
+            } else {
+                return Err(format!("Secret {secret_id} not yet provisioned"));
+            }
+        };
+        let secret = state
+            .secrets
+            .get_mut(&secret_arn)
+            .ok_or_else(|| format!("Secret {secret_arn} not found"))?;
+        // Update SecretString JSON in current version with engine/host/port
+        // /username/password placeholders so it shows as "attached" via the
+        // RDS-style schema CFN expects.
+        if let Some(version_id) = secret.current_version_id.clone() {
+            if let Some(version) = secret.versions.get_mut(&version_id) {
+                let mut existing: serde_json::Value = version
+                    .secret_string
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                if let Some(obj) = existing.as_object_mut() {
+                    let engine = match target_type {
+                        "AWS::RDS::DBInstance" | "AWS::RDS::DBCluster" => "postgres",
+                        _ => "unknown",
+                    };
+                    obj.entry("engine".to_string())
+                        .or_insert(serde_json::json!(engine));
+                    obj.insert("host".to_string(), serde_json::json!(target_id));
+                    obj.entry("dbInstanceIdentifier".to_string())
+                        .or_insert(serde_json::json!(target_id));
+                }
+                version.secret_string = Some(existing.to_string());
+            }
+        }
+        secret.last_changed_at = Utc::now();
+        Ok(ProvisionResult::new(secret_arn.clone()).with("SecretArn", secret_arn))
     }
 }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_secretsmanager_extras.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_secretsmanager_extras.rs
@@ -1,0 +1,112 @@
+//! CloudFormation provisioner for AWS::SecretsManager::* extras (BB13).
+//! Provisions a Secret + RotationSchedule + ResourcePolicy and asserts via
+//! the real Secrets Manager SDK.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Secret": {
+      "Type": "AWS::SecretsManager::Secret",
+      "Properties": {
+        "Name": "cfn-rot-secret",
+        "Description": "for rotation",
+        "SecretString": "{\"username\":\"admin\",\"password\":\"hunter2\"}"
+      }
+    },
+    "Schedule": {
+      "Type": "AWS::SecretsManager::RotationSchedule",
+      "Properties": {
+        "SecretId": {"Ref": "Secret"},
+        "RotationLambdaARN": "arn:aws:lambda:us-east-1:000000000000:function:rotator",
+        "RotationRules": {"AutomaticallyAfterDays": 30}
+      }
+    },
+    "Policy": {
+      "Type": "AWS::SecretsManager::ResourcePolicy",
+      "Properties": {
+        "SecretId": {"Ref": "Secret"},
+        "ResourcePolicy": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "secretsmanager:DeleteSecret",
+            "Resource": "*"
+          }]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "SecretArn": {"Value": {"Ref": "Secret"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_secrets_manager_extras() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sm = aws_sdk_secretsmanager::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("sm-extras-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sm-extras-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    let secret_arn = outputs.get("SecretArn").copied().expect("SecretArn output");
+
+    // RotationSchedule - DescribeSecret returns rotation fields.
+    let desc = sm
+        .describe_secret()
+        .secret_id(secret_arn)
+        .send()
+        .await
+        .expect("describe_secret");
+    assert_eq!(desc.rotation_enabled(), Some(true));
+    assert_eq!(
+        desc.rotation_lambda_arn(),
+        Some("arn:aws:lambda:us-east-1:000000000000:function:rotator")
+    );
+    let rules = desc.rotation_rules().expect("rotation_rules");
+    assert_eq!(rules.automatically_after_days(), Some(30));
+
+    // ResourcePolicy
+    let policy = sm
+        .get_resource_policy()
+        .secret_id(secret_arn)
+        .send()
+        .await
+        .expect("get_resource_policy");
+    let body = policy.resource_policy().expect("policy body");
+    assert!(body.contains("secretsmanager:DeleteSecret"));
+    assert!(body.contains("Deny"));
+
+    cfn.delete_stack()
+        .stack_name("sm-extras-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-secretsmanager/src/lib.rs
+++ b/crates/fakecloud-secretsmanager/src/lib.rs
@@ -4,6 +4,6 @@ pub(crate) mod state;
 
 pub use service::SecretsManagerService;
 pub use state::{
-    Secret, SecretVersion, SecretsManagerSnapshot, SecretsManagerState, SharedSecretsManagerState,
-    SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
+    RotationRules, Secret, SecretVersion, SecretsManagerSnapshot, SecretsManagerState,
+    SharedSecretsManagerState, SECRETSMANAGER_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary
BB13 of the parity gap audit. Adds the 3 remaining AWS::SecretsManager::* resource types — RotationSchedule, ResourcePolicy, SecretTargetAttachment — on top of the existing Secret provisioner.

- RotationSchedule enables rotation on the target Secret
- ResourcePolicy stores the resource-based policy JSON on the Secret
- SecretTargetAttachment merges engine/host/dbInstanceIdentifier into the Secret's current SecretString JSON for RDS-style targets

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all
- [x] cargo test -p fakecloud-e2e --test cloudformation_secretsmanager_extras

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for the remaining AWS::SecretsManager types—RotationSchedule, ResourcePolicy, and SecretTargetAttachment—to close the BB13 parity gap. Enables rotation, resource policies, and RDS-style target attachments on existing Secrets.

- **New Features**
  - RotationSchedule: enables rotation on the referenced Secret; sets `RotationLambdaARN` and `RotationRules.AutomaticallyAfterDays`; delete disables rotation and clears fields.
  - ResourcePolicy: stores the provided policy JSON on the Secret; delete removes it.
  - SecretTargetAttachment: merges `engine`, `host`, and `dbInstanceIdentifier` into the current `SecretString` for RDS-style targets.
  - All handlers mutate the existing Secret in place and return an error if the Secret is not yet provisioned.

<sup>Written for commit 56245f3cafe085dda753f94c701b7b887bf16e9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

