### PR TITLE
feat(cloudformation): provision AWS::RDS::DBInstance and DBCluster

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -78,7 +78,7 @@ use fakecloud_organizations::{
     OrganizationState, OrganizationalUnit, Policy as OrgPolicy, SharedOrganizationsState,
     POLICY_TYPE_SCP,
 };
-use fakecloud_rds::{DbParameterGroup, DbSubnetGroup, RdsTag, SharedRdsState};
+use fakecloud_rds::{DbInstance, DbParameterGroup, DbSubnetGroup, RdsTag, SharedRdsState};
 use fakecloud_route53::{
     model::{HealthCheckConfig, HostedZoneFeatures, ResourceRecordSet},
     SharedRoute53State, StoredHealthCheck, StoredHostedZone,
@@ -449,6 +449,8 @@ impl ResourceProvisioner {
             "AWS::RDS::EventSubscription" => self.create_rds_event_subscription(resource),
             "AWS::RDS::DBSecurityGroup" => self.create_rds_security_group(resource),
             "AWS::RDS::DBProxy" => self.create_rds_db_proxy(resource),
+            "AWS::RDS::DBInstance" => self.create_rds_db_instance(resource),
+            "AWS::RDS::DBCluster" => self.create_rds_db_cluster(resource),
             "AWS::ECS::Cluster" => self.create_ecs_cluster(resource),
             "AWS::ECS::TaskDefinition" => self.create_ecs_task_definition(resource),
             "AWS::ECS::Service" => self.create_ecs_service(resource),
@@ -678,6 +680,8 @@ impl ResourceProvisioner {
             }
             "AWS::RDS::DBSecurityGroup" => self.delete_rds_security_group(&resource.physical_id),
             "AWS::RDS::DBProxy" => self.delete_rds_db_proxy(&resource.physical_id),
+            "AWS::RDS::DBInstance" => self.delete_rds_db_instance(&resource.physical_id),
+            "AWS::RDS::DBCluster" => self.delete_rds_db_cluster(&resource.physical_id),
             "AWS::ECS::Cluster" => self.delete_ecs_cluster(&resource.physical_id),
             "AWS::ECS::TaskDefinition" => self.delete_ecs_task_definition(&resource.physical_id),
             "AWS::ECS::Service" => self.delete_ecs_service(&resource.physical_id),
@@ -5974,6 +5978,326 @@ impl ResourceProvisioner {
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);
         if let Some(m) = state.extras.get_mut("proxies") {
+            m.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    fn create_rds_db_instance(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let identifier = props
+            .get("DBInstanceIdentifier")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                format!(
+                    "cfn-{}-{}",
+                    resource.logical_id.to_lowercase(),
+                    Uuid::new_v4().simple().to_string()[..8].to_lowercase()
+                )
+            });
+        let class = props
+            .get("DBInstanceClass")
+            .and_then(|v| v.as_str())
+            .unwrap_or("db.t4g.micro")
+            .to_string();
+        let engine = props
+            .get("Engine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("postgres")
+            .to_string();
+        let engine_version = props
+            .get("EngineVersion")
+            .and_then(|v| v.as_str())
+            .unwrap_or("16.0")
+            .to_string();
+        let master_username = props
+            .get("MasterUsername")
+            .and_then(|v| v.as_str())
+            .unwrap_or("admin")
+            .to_string();
+        let master_user_password = props
+            .get("MasterUserPassword")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let db_name = props
+            .get("DBName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let port = props
+            .get("Port")
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32)
+            .unwrap_or(5432);
+        let allocated_storage = props
+            .get("AllocatedStorage")
+            .and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+            })
+            .map(|n| n as i32)
+            .unwrap_or(20);
+        let publicly_accessible = props
+            .get("PubliclyAccessible")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let deletion_protection = props
+            .get("DeletionProtection")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let backup_retention_period = props
+            .get("BackupRetentionPeriod")
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32)
+            .unwrap_or(0);
+        let multi_az = props
+            .get("MultiAZ")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let availability_zone = props
+            .get("AvailabilityZone")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let storage_type = props
+            .get("StorageType")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let storage_encrypted = props
+            .get("StorageEncrypted")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let kms_key_id = props
+            .get("KmsKeyId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let iam_database_authentication_enabled = props
+            .get("EnableIAMDatabaseAuthentication")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let db_parameter_group_name = props
+            .get("DBParameterGroupName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let option_group_name = props
+            .get("OptionGroupName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let vpc_security_group_ids: Vec<String> = props
+            .get("VPCSecurityGroups")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let enabled_cloudwatch_logs_exports: Vec<String> = props
+            .get("EnableCloudwatchLogsExports")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags = parse_rds_tags(props.get("Tags"));
+
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = state.db_instance_arn(&identifier);
+        let endpoint_address = format!(
+            "{identifier}.cluster-fakecloud.{}.rds.amazonaws.com",
+            state.region
+        );
+        let dbi_resource_id = format!("db-{}", Uuid::new_v4().simple());
+        let inst = DbInstance {
+            db_instance_identifier: identifier.clone(),
+            db_instance_arn: arn.clone(),
+            db_instance_class: class,
+            engine,
+            engine_version,
+            db_instance_status: "available".to_string(),
+            master_username,
+            db_name,
+            endpoint_address,
+            port,
+            allocated_storage,
+            publicly_accessible,
+            deletion_protection,
+            created_at: Utc::now(),
+            dbi_resource_id,
+            master_user_password,
+            container_id: String::new(),
+            host_port: 0,
+            tags,
+            read_replica_source_db_instance_identifier: None,
+            read_replica_db_instance_identifiers: Vec::new(),
+            vpc_security_group_ids,
+            db_parameter_group_name,
+            backup_retention_period,
+            preferred_backup_window: "03:00-04:00".to_string(),
+            latest_restorable_time: None,
+            option_group_name,
+            multi_az,
+            pending_modified_values: None,
+            availability_zone,
+            storage_type,
+            storage_encrypted,
+            kms_key_id,
+            iam_database_authentication_enabled,
+            iops: props.get("Iops").and_then(|v| v.as_i64()).map(|n| n as i32),
+            monitoring_interval: props
+                .get("MonitoringInterval")
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32),
+            monitoring_role_arn: props
+                .get("MonitoringRoleArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            performance_insights_enabled: props
+                .get("EnablePerformanceInsights")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            performance_insights_kms_key_id: props
+                .get("PerformanceInsightsKMSKeyId")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            performance_insights_retention_period: props
+                .get("PerformanceInsightsRetentionPeriod")
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32),
+            enabled_cloudwatch_logs_exports,
+            ca_certificate_identifier: props
+                .get("CACertificateIdentifier")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            network_type: props
+                .get("NetworkType")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            character_set_name: props
+                .get("CharacterSetName")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            auto_minor_version_upgrade: props
+                .get("AutoMinorVersionUpgrade")
+                .and_then(|v| v.as_bool()),
+            copy_tags_to_snapshot: props.get("CopyTagsToSnapshot").and_then(|v| v.as_bool()),
+            master_user_secret_arn: None,
+            master_user_secret_kms_key_id: props
+                .get("MasterUserSecret")
+                .and_then(|v| v.get("KmsKeyId"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        };
+        let endpoint = inst.endpoint_address.clone();
+        let endpoint_port = inst.port;
+        state.instances.insert(identifier.clone(), inst);
+
+        Ok(ProvisionResult::new(identifier.clone())
+            .with("DBInstanceArn", arn)
+            .with("Endpoint.Address", endpoint)
+            .with("Endpoint.Port", endpoint_port.to_string())
+            .with("DbiResourceId", format!("db-{identifier}")))
+    }
+
+    fn delete_rds_db_instance(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.instances.remove(physical_id);
+        Ok(())
+    }
+
+    fn create_rds_db_cluster(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let identifier = props
+            .get("DBClusterIdentifier")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                format!(
+                    "cfn-cluster-{}-{}",
+                    resource.logical_id.to_lowercase(),
+                    Uuid::new_v4().simple().to_string()[..8].to_lowercase()
+                )
+            });
+        let engine = props
+            .get("Engine")
+            .and_then(|v| v.as_str())
+            .unwrap_or("aurora-postgresql")
+            .to_string();
+        let engine_version = props
+            .get("EngineVersion")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let master_username = props
+            .get("MasterUsername")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let port = props.get("Port").and_then(|v| v.as_i64()).unwrap_or(5432);
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let arn = format!(
+            "arn:aws:rds:{}:{}:cluster:{}",
+            state.region, state.account_id, identifier
+        );
+        let cluster_resource_id = format!("cluster-{}", Uuid::new_v4().simple());
+        let endpoint = format!(
+            "{identifier}.cluster-fakecloud.{}.rds.amazonaws.com",
+            state.region
+        );
+        let reader_endpoint = format!(
+            "{identifier}.cluster-ro-fakecloud.{}.rds.amazonaws.com",
+            state.region
+        );
+        let body = serde_json::json!({
+            "DBClusterIdentifier": identifier,
+            "DBClusterArn": arn,
+            "Engine": engine,
+            "EngineVersion": engine_version,
+            "MasterUsername": master_username,
+            "Status": "available",
+            "DbClusterResourceId": cluster_resource_id,
+            "Endpoint": endpoint,
+            "ReaderEndpoint": reader_endpoint,
+            "Port": port,
+            "AllocatedStorage": props.get("AllocatedStorage").and_then(|v| v.as_i64()).unwrap_or(1),
+            "BackupRetentionPeriod": props.get("BackupRetentionPeriod").and_then(|v| v.as_i64()).unwrap_or(1),
+            "DatabaseName": props.get("DatabaseName").and_then(|v| v.as_str()),
+            "DBSubnetGroup": props.get("DBSubnetGroupName").and_then(|v| v.as_str()),
+            "VpcSecurityGroupIds": props.get("VpcSecurityGroupIds").cloned().unwrap_or(serde_json::json!([])),
+            "StorageEncrypted": props.get("StorageEncrypted").and_then(|v| v.as_bool()).unwrap_or(false),
+            "KmsKeyId": props.get("KmsKeyId").and_then(|v| v.as_str()),
+            "DeletionProtection": props.get("DeletionProtection").and_then(|v| v.as_bool()).unwrap_or(false),
+            "ClusterCreateTime": Utc::now().to_rfc3339(),
+            "EnabledCloudwatchLogsExports": props.get("EnableCloudwatchLogsExports").cloned().unwrap_or(serde_json::json!([])),
+            "MultiAZ": false,
+            "DBClusterMembers": [],
+        });
+        state
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(identifier.clone(), body);
+        Ok(ProvisionResult::new(identifier.clone())
+            .with("DBClusterArn", arn)
+            .with("Endpoint.Address", endpoint)
+            .with("ReadEndpoint.Address", reader_endpoint)
+            .with("Endpoint.Port", port.to_string())
+            .with("DBClusterResourceId", cluster_resource_id))
+    }
+
+    fn delete_rds_db_cluster(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(m) = state.extras.get_mut("clusters") {
             m.remove(physical_id);
         }
         Ok(())

--- a/crates/fakecloud-e2e/tests/cloudformation_rds_db.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_rds_db.rs
@@ -1,0 +1,117 @@
+//! CloudFormation provisioner for AWS::RDS::DBInstance and AWS::RDS::DBCluster
+//! (BB16). Provisions both and asserts readback via the runtime RDS SDK.
+//! Skips actual Docker container spawn — the CFN provisioner stages the
+//! state record so DescribeDBInstances/DescribeDBClusters returns it; the
+//! Engine/PG init that requires Docker is exercised by the dedicated RDS
+//! e2e tests.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "DbInstance": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "DBInstanceIdentifier": "cfn-instance",
+        "DBInstanceClass": "db.t4g.micro",
+        "Engine": "postgres",
+        "EngineVersion": "16.0",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "hunter2-secret",
+        "AllocatedStorage": "20",
+        "Port": 5432,
+        "PubliclyAccessible": false,
+        "BackupRetentionPeriod": 7,
+        "MultiAZ": true,
+        "StorageEncrypted": true,
+        "EnableIAMDatabaseAuthentication": true
+      }
+    },
+    "DbCluster": {
+      "Type": "AWS::RDS::DBCluster",
+      "Properties": {
+        "DBClusterIdentifier": "cfn-cluster",
+        "Engine": "aurora-postgresql",
+        "EngineVersion": "16.1",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "cluster-secret",
+        "Port": 5432,
+        "BackupRetentionPeriod": 14,
+        "DatabaseName": "appdb",
+        "StorageEncrypted": true,
+        "DeletionProtection": false
+      }
+    }
+  },
+  "Outputs": {
+    "InstanceArn": {"Value": {"Fn::GetAtt": ["DbInstance", "DBInstanceArn"]}},
+    "ClusterArn": {"Value": {"Fn::GetAtt": ["DbCluster", "DBClusterArn"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_rds_db_instance_and_cluster() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = aws_sdk_rds::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("rds-db-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("rds-db-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    // Verify DBInstance via DescribeDBInstances.
+    let inst_resp = rds
+        .describe_db_instances()
+        .db_instance_identifier("cfn-instance")
+        .send()
+        .await
+        .expect("describe_db_instances");
+    let inst = inst_resp.db_instances().first().expect("instance present");
+    assert_eq!(inst.db_instance_identifier(), Some("cfn-instance"));
+    assert_eq!(inst.engine(), Some("postgres"));
+    assert_eq!(inst.engine_version(), Some("16.0"));
+    assert_eq!(inst.master_username(), Some("admin"));
+    assert_eq!(inst.allocated_storage(), Some(20));
+    assert_eq!(inst.multi_az(), Some(true));
+    assert_eq!(inst.storage_encrypted(), Some(true));
+    assert_eq!(inst.iam_database_authentication_enabled(), Some(true));
+    assert_eq!(inst.backup_retention_period(), Some(7));
+
+    // Verify DBCluster via DescribeDBClusters.
+    let cluster_resp = rds
+        .describe_db_clusters()
+        .db_cluster_identifier("cfn-cluster")
+        .send()
+        .await
+        .expect("describe_db_clusters");
+    let cluster = cluster_resp.db_clusters().first().expect("cluster present");
+    assert_eq!(cluster.db_cluster_identifier(), Some("cfn-cluster"));
+    assert_eq!(cluster.engine(), Some("aurora-postgresql"));
+    assert_eq!(cluster.master_username(), Some("admin"));
+    assert_eq!(cluster.database_name(), Some("appdb"));
+    assert_eq!(cluster.backup_retention_period(), Some(14));
+
+    cfn.delete_stack()
+        .stack_name("rds-db-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -148,12 +148,33 @@ impl RdsService {
                 Ok(xml_response(action.as_str(), db_cluster_xml(&id, &arn), &rid))
             }
             "DescribeDBClusters" => {
+                let id_filter = get_param(req, "DBClusterIdentifier");
                 let accounts = self.state_handle().read();
                 let items: Vec<Value> = accounts.get(&aid)
                     .and_then(|s| s.extras.get("clusters"))
-                    .map(|m| m.values().cloned().collect()).unwrap_or_default();
-                let inner = format!("    <DBClusters>\n{}\n    </DBClusters>",
-                    members(&items, db_cluster_member_xml));
+                    .map(|m| {
+                        m.values()
+                            .filter(|v| {
+                                id_filter
+                                    .as_deref()
+                                    .map(|filter| v["DBClusterIdentifier"].as_str() == Some(filter))
+                                    .unwrap_or(true)
+                            })
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let body = items
+                    .iter()
+                    .map(|v| {
+                        format!(
+                            "      <DBCluster>\n{}\n      </DBCluster>",
+                            db_cluster_member_xml(v)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let inner = format!("    <DBClusters>\n{body}\n    </DBClusters>");
                 Ok(xml_response("DescribeDBClusters", inner, &rid))
             }
 
@@ -568,12 +589,104 @@ fn db_cluster_xml(id: &str, arn: &str) -> String {
 }
 
 fn db_cluster_member_xml(v: &Value) -> String {
-    format!(
-        "          <DBClusterIdentifier>{}</DBClusterIdentifier>\n          <DBClusterArn>{}</DBClusterArn>\n          <Status>{}</Status>",
-        xml_escape(v["DBClusterIdentifier"].as_str().unwrap_or("")),
-        xml_escape(v["DBClusterArn"].as_str().unwrap_or("")),
-        xml_escape(v["Status"].as_str().unwrap_or("available")),
-    )
+    let mut out = String::new();
+    out.push_str(&format!(
+        "          <DBClusterIdentifier>{}</DBClusterIdentifier>\n",
+        xml_escape(v["DBClusterIdentifier"].as_str().unwrap_or(""))
+    ));
+    out.push_str(&format!(
+        "          <DBClusterArn>{}</DBClusterArn>\n",
+        xml_escape(v["DBClusterArn"].as_str().unwrap_or(""))
+    ));
+    out.push_str(&format!(
+        "          <Status>{}</Status>\n",
+        xml_escape(v["Status"].as_str().unwrap_or("available"))
+    ));
+    if let Some(s) = v["Engine"].as_str() {
+        out.push_str(&format!("          <Engine>{}</Engine>\n", xml_escape(s)));
+    }
+    if let Some(s) = v["EngineVersion"].as_str() {
+        out.push_str(&format!(
+            "          <EngineVersion>{}</EngineVersion>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["MasterUsername"].as_str() {
+        out.push_str(&format!(
+            "          <MasterUsername>{}</MasterUsername>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["DatabaseName"].as_str() {
+        out.push_str(&format!(
+            "          <DatabaseName>{}</DatabaseName>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["Endpoint"].as_str() {
+        out.push_str(&format!(
+            "          <Endpoint>{}</Endpoint>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["ReaderEndpoint"].as_str() {
+        out.push_str(&format!(
+            "          <ReaderEndpoint>{}</ReaderEndpoint>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(n) = v["Port"].as_i64() {
+        out.push_str(&format!("          <Port>{}</Port>\n", n));
+    }
+    if let Some(n) = v["AllocatedStorage"].as_i64() {
+        out.push_str(&format!(
+            "          <AllocatedStorage>{}</AllocatedStorage>\n",
+            n
+        ));
+    }
+    if let Some(n) = v["BackupRetentionPeriod"].as_i64() {
+        out.push_str(&format!(
+            "          <BackupRetentionPeriod>{}</BackupRetentionPeriod>\n",
+            n
+        ));
+    }
+    if let Some(b) = v["StorageEncrypted"].as_bool() {
+        out.push_str(&format!(
+            "          <StorageEncrypted>{}</StorageEncrypted>\n",
+            b
+        ));
+    }
+    if let Some(s) = v["KmsKeyId"].as_str() {
+        out.push_str(&format!(
+            "          <KmsKeyId>{}</KmsKeyId>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(b) = v["DeletionProtection"].as_bool() {
+        out.push_str(&format!(
+            "          <DeletionProtection>{}</DeletionProtection>\n",
+            b
+        ));
+    }
+    if let Some(s) = v["DBSubnetGroup"].as_str() {
+        out.push_str(&format!(
+            "          <DBSubnetGroup>{}</DBSubnetGroup>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["DbClusterResourceId"].as_str() {
+        out.push_str(&format!(
+            "          <DbClusterResourceId>{}</DbClusterResourceId>\n",
+            xml_escape(s)
+        ));
+    }
+    if let Some(s) = v["ClusterCreateTime"].as_str() {
+        out.push_str(&format!(
+            "          <ClusterCreateTime>{}</ClusterCreateTime>\n",
+            xml_escape(s)
+        ));
+    }
+    out
 }
 
 fn cluster_snapshot_xml(id: &str, arn: &str, cluster: &str) -> String {


### PR DESCRIPTION
## Summary
BB16 of the parity gap audit. CloudFormation now provisions AWS::RDS::DBInstance and AWS::RDS::DBCluster — the two largest remaining RDS gaps.

- DBInstance: full property set (class/engine/version/storage/multi_az/encryption/IAM auth/parameter group/etc.) into the runtime DbInstance state record. Container spawn skipped — CFN only stages the control-plane record so DescribeDBInstances returns it; the engine boot path remains exercised by the dedicated RDS e2e tests.
- DBCluster: stored in extras['clusters'] with full Aurora attribute set, endpoints synthesized.

Also fixes DescribeDBClusters: was wrapping each cluster in <member> tags which the SDK doesn't deserialize, so callers always got empty result sets even with stored clusters. Now wraps in <DBCluster> matching real AWS, emits the full Aurora field set, and honors the DBClusterIdentifier filter.

## Test plan
- [x] cargo build -p fakecloud
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all
- [x] cargo test -p fakecloud-e2e --test cloudformation_rds_db

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation can now provision `AWS::RDS::DBInstance` and `AWS::RDS::DBCluster`, closing major RDS gaps and letting describe calls return staged resources. Also fixes `DescribeDBClusters` XML to match AWS and respect filters.

- **New Features**
  - `AWS::RDS::DBInstance`: maps full properties (class, engine/version, storage, MultiAZ, encryption, IAM auth, parameter group, etc.), creates a control‑plane record only (no container), synthesizes endpoint, and supports delete.
  - `AWS::RDS::DBCluster`: stores Aurora clusters in `extras['clusters']` with key attributes, synthesizes writer/reader endpoints, and supports delete.

- **Bug Fixes**
  - `DescribeDBClusters`: wraps items in `<DBCluster>`, emits full Aurora fields (engine, master user, endpoints, retention, encryption, etc.), and honors the `DBClusterIdentifier` filter to avoid empty result sets.

<sup>Written for commit 30599817cc4f97ef5870924ea52ba1efa3e95981. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

