### PR TITLE
feat(cloudformation): provision AWS::CertificateManager::Account

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -457,6 +457,7 @@ impl ResourceProvisioner {
             "AWS::ECS::Service" => self.create_ecs_service(resource),
             "AWS::ECS::CapacityProvider" => self.create_ecs_capacity_provider(resource),
             "AWS::CertificateManager::Certificate" => self.create_acm_certificate(resource),
+            "AWS::CertificateManager::Account" => self.create_acm_account(resource),
             "AWS::ElastiCache::ParameterGroup" => self.create_ec_parameter_group(resource),
             "AWS::ElastiCache::SubnetGroup" => self.create_ec_subnet_group(resource),
             "AWS::ElastiCache::SecurityGroup" => self.create_ec_security_group(resource),
@@ -694,6 +695,7 @@ impl ResourceProvisioner {
             "AWS::CertificateManager::Certificate" => {
                 self.delete_acm_certificate(&resource.physical_id)
             }
+            "AWS::CertificateManager::Account" => self.delete_acm_account(),
             "AWS::ElastiCache::ParameterGroup" => {
                 self.delete_ec_parameter_group(&resource.physical_id)
             }
@@ -6796,6 +6798,39 @@ impl ResourceProvisioner {
         let mut accounts = self.acm_state.write();
         if let Some(account) = accounts.accounts.get_mut(&self.account_id) {
             account.certificates.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    /// Provision the singleton `AWS::CertificateManager::Account` resource —
+    /// stores `ExpiryEventsConfiguration.DaysBeforeExpiry` on the account
+    /// config so `GetAccountConfiguration` reflects it.
+    fn create_acm_account(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let days = resource
+            .properties
+            .get("ExpiryEventsConfiguration")
+            .and_then(|v| v.get("DaysBeforeExpiry"))
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32);
+        let mut accounts = self.acm_state.write();
+        let account = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        account.account_config.expiry_events_days_before_expiry = days;
+        Ok(ProvisionResult::new(format!(
+            "acm-account-{}",
+            self.account_id
+        )))
+    }
+
+    /// Reset the account config back to the default (no expiry events).
+    /// AWS keeps the account around — the CFN deletion just clears the
+    /// per-account override.
+    fn delete_acm_account(&self) -> Result<(), String> {
+        let mut accounts = self.acm_state.write();
+        if let Some(account) = accounts.accounts.get_mut(&self.account_id) {
+            account.account_config.expiry_events_days_before_expiry = None;
         }
         Ok(())
     }

--- a/crates/fakecloud-e2e/tests/cloudformation_acm.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_acm.rs
@@ -86,3 +86,60 @@ async fn cfn_provisions_acm_certificate() {
         "certificate should be gone after stack deletion"
     );
 }
+
+const ACCOUNT_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "AcmAcct": {
+      "Type": "AWS::CertificateManager::Account",
+      "Properties": {
+        "ExpiryEventsConfiguration": {
+          "DaysBeforeExpiry": 17
+        }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_acm_account_expiry_events() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let acm = aws_sdk_acm::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("acm-account-stack")
+        .template_body(ACCOUNT_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let cfg = acm
+        .get_account_configuration()
+        .send()
+        .await
+        .expect("get_account_configuration");
+    assert_eq!(
+        cfg.expiry_events().and_then(|e| e.days_before_expiry()),
+        Some(17),
+    );
+
+    cfn.delete_stack()
+        .stack_name("acm-account-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let cfg_after = acm
+        .get_account_configuration()
+        .send()
+        .await
+        .expect("get_account_configuration after delete");
+    assert!(
+        cfg_after
+            .expiry_events()
+            .and_then(|e| e.days_before_expiry())
+            .is_none(),
+        "expiry days should reset to default after stack delete",
+    );
+}


### PR DESCRIPTION
## Summary

Adds the singleton AWS::CertificateManager::Account resource to the CloudFormation provisioner. Maps ExpiryEventsConfiguration.DaysBeforeExpiry into the ACM account config so GetAccountConfiguration round-trips, and clears the override on stack deletion.

Closes BB22 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_acm
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `AWS::CertificateManager::Account` to the CloudFormation provisioner (closes Linear BB22). We store ExpiryEventsConfiguration.DaysBeforeExpiry on the account config so GetAccountConfiguration reflects it, and reset the override on stack deletion.

<sup>Written for commit 5074cf0fd6eb1af80a496c25f10c4644098caba2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

