### PR TITLE
feat(cloudformation): provision AWS::Organizations::Account

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -434,6 +434,7 @@ impl ResourceProvisioner {
             }
             "AWS::Organizations::Organization" => self.create_organization(resource),
             "AWS::Organizations::OrganizationalUnit" => self.create_organization_unit(resource),
+            "AWS::Organizations::Account" => self.create_organization_account(resource),
             "AWS::Organizations::Policy" => self.create_organization_policy(resource),
             "AWS::Organizations::ResourcePolicy" => {
                 self.create_organization_resource_policy(resource)
@@ -661,6 +662,9 @@ impl ResourceProvisioner {
             "AWS::Organizations::Organization" => self.delete_organization(&resource.physical_id),
             "AWS::Organizations::OrganizationalUnit" => {
                 self.delete_organization_unit(&resource.physical_id)
+            }
+            "AWS::Organizations::Account" => {
+                self.delete_organization_account(&resource.physical_id)
             }
             "AWS::Organizations::Policy" => self.delete_organization_policy(&resource.physical_id),
             "AWS::Organizations::ResourcePolicy" => {
@@ -4569,6 +4573,114 @@ impl ResourceProvisioner {
         if let Some(org) = org_lock.as_mut() {
             org.ous.remove(physical_id);
             org.attachments.remove(physical_id);
+        }
+        Ok(())
+    }
+
+    /// Provision an `AWS::Organizations::Account`. Mints a new member
+    /// account synchronously (via Organizations state), optionally moves
+    /// it under the first ParentId when supplied, and persists tags.
+    fn create_organization_account(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let email = props
+            .get("Email")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Email is required".to_string())?
+            .to_string();
+        let name = props
+            .get("AccountName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "AccountName is required".to_string())?
+            .to_string();
+        let parent_ids: Vec<String> = props
+            .get("ParentIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags: Vec<(String, String)> = props
+            .get("Tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t.get("Key").and_then(|v| v.as_str())?;
+                        let val = t.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+                        Some((k.to_string(), val.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        let status = org.create_account(&email, &name, None);
+        let account_id = status
+            .account_id
+            .clone()
+            .ok_or_else(|| "create_account did not return an account id".to_string())?;
+        let account_arn = org
+            .accounts
+            .get(&account_id)
+            .map(|a| a.arn.clone())
+            .unwrap_or_default();
+        let joined_method = org
+            .accounts
+            .get(&account_id)
+            .map(|a| a.joined_method.clone())
+            .unwrap_or_else(|| "CREATED".to_string());
+        let joined_timestamp = org
+            .accounts
+            .get(&account_id)
+            .map(|a| a.joined_timestamp.to_rfc3339())
+            .unwrap_or_default();
+        let acct_status = org
+            .accounts
+            .get(&account_id)
+            .map(|a| a.status.clone())
+            .unwrap_or_else(|| "ACTIVE".to_string());
+
+        if let Some(parent) = parent_ids.first() {
+            let source = org
+                .accounts
+                .get(&account_id)
+                .map(|a| a.parent_id.clone())
+                .unwrap_or_else(|| org.root_id.clone());
+            if parent != &source {
+                org.move_account(&account_id, &source, parent)
+                    .map_err(|e| format!("Failed to move account to parent {parent}: {e:?}"))?;
+            }
+        }
+
+        if !tags.is_empty() {
+            org.set_resource_tags(&account_id, &tags);
+        }
+
+        Ok(ProvisionResult::new(account_id.clone())
+            .with("AccountId", account_id)
+            .with("AccountName", name)
+            .with("Email", email)
+            .with("Arn", account_arn)
+            .with("JoinedMethod", joined_method)
+            .with("JoinedTimestamp", joined_timestamp)
+            .with("Status", acct_status))
+    }
+
+    /// Close the member account on stack delete. Real AWS leaves the
+    /// account in `SUSPENDED` for 90 days; we just flip it via
+    /// `close_account` so subsequent reads see it as suspended.
+    fn delete_organization_account(&self, physical_id: &str) -> Result<(), String> {
+        let mut org_lock = self.organizations_state.write();
+        if let Some(org) = org_lock.as_mut() {
+            let _ = org.close_account(physical_id);
         }
         Ok(())
     }

--- a/crates/fakecloud-e2e/tests/cloudformation_organizations.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_organizations.rs
@@ -140,3 +140,110 @@ async fn cfn_provisions_organization_ou_policy_resource_policy() {
         "organization should be gone after stack deletion"
     );
 }
+
+const ACCOUNT_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Org": {
+      "Type": "AWS::Organizations::Organization",
+      "Properties": {"FeatureSet": "ALL"}
+    },
+    "Sandbox": {
+      "Type": "AWS::Organizations::OrganizationalUnit",
+      "Properties": {
+        "Name": "Sandbox",
+        "ParentId": {"Fn::GetAtt": ["Org", "RootId"]}
+      }
+    },
+    "DevAcct": {
+      "Type": "AWS::Organizations::Account",
+      "Properties": {
+        "AccountName": "DevAccount",
+        "Email": "dev@example.com",
+        "ParentIds": [{"Ref": "Sandbox"}],
+        "Tags": [{"Key": "Env", "Value": "dev"}]
+      }
+    }
+  },
+  "Outputs": {
+    "AcctId": {"Value": {"Ref": "DevAcct"}},
+    "AcctArn": {"Value": {"Fn::GetAtt": ["DevAcct", "Arn"]}},
+    "AcctStatus": {"Value": {"Fn::GetAtt": ["DevAcct", "Status"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_organizations_account() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let orgs = aws_sdk_organizations::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("orgs-account-stack")
+        .template_body(ACCOUNT_TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("orgs-account-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut acct_id = None;
+    let mut acct_arn = None;
+    let mut acct_status = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("AcctId") => acct_id = o.output_value().map(|s| s.to_string()),
+            Some("AcctArn") => acct_arn = o.output_value().map(|s| s.to_string()),
+            Some("AcctStatus") => acct_status = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let acct_id = acct_id.expect("AcctId output");
+    let acct_arn = acct_arn.expect("AcctArn output");
+    assert_eq!(acct_status.as_deref(), Some("ACTIVE"));
+    assert!(acct_arn.starts_with("arn:aws:organizations::"));
+    assert_eq!(acct_id.len(), 12);
+
+    let described_acct = orgs
+        .describe_account()
+        .account_id(&acct_id)
+        .send()
+        .await
+        .expect("describe_account");
+    let acct = described_acct.account().expect("account body");
+    assert_eq!(acct.name(), Some("DevAccount"));
+    assert_eq!(acct.email(), Some("dev@example.com"));
+    assert_eq!(acct.status().map(|s| s.as_str()), Some("ACTIVE"));
+
+    // Confirm parent placement under the Sandbox OU.
+    let parents = orgs
+        .list_parents()
+        .child_id(&acct_id)
+        .send()
+        .await
+        .expect("list_parents");
+    let parent = parents.parents().first().expect("parent present");
+    assert_eq!(
+        parent.r#type().map(|t| t.as_str()),
+        Some("ORGANIZATIONAL_UNIT")
+    );
+
+    cfn.delete_stack()
+        .stack_name("orgs-account-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    // The Organization itself is also torn down — calls should error.
+    let after = orgs.describe_organization().send().await;
+    assert!(after.is_err());
+}


### PR DESCRIPTION
## Summary

Adds the AWS::Organizations::Account resource to the CFN provisioner. Mints a member account synchronously through Organizations state, optionally moves it under the first ParentId, persists tags. Returns AccountId/AccountName/Email/Arn/JoinedMethod/JoinedTimestamp/Status as Fn::GetAtt attributes; stack delete closes the account.

Closes BB31 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_organizations
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `AWS::Organizations::Account` support to the CloudFormation provisioner. Meets Linear BB31 parity goal.

- **New Features**
  - Creates member accounts synchronously; optionally moves to the first `ParentIds` entry; persists `Tags`.
  - Exposes `AccountId`, `AccountName`, `Email`, `Arn`, `JoinedMethod`, `JoinedTimestamp`, `Status` via `Fn::GetAtt`.
  - On stack delete, closes the account (simulates suspension); covered by an e2e test including OU placement and describe/list calls.

<sup>Written for commit 79b31b16e16e37992e3b9743aacf39fb3ad0c7fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

