### PR TITLE
feat(cloudformation): provision ECR policies + replication + pull-through cache

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -422,6 +422,12 @@ impl ResourceProvisioner {
             "AWS::KMS::Key" => self.create_kms_key(resource),
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
             "AWS::ECR::Repository" => self.create_ecr_repository(resource),
+            "AWS::ECR::RepositoryPolicy" => self.create_ecr_repository_policy(resource),
+            "AWS::ECR::RegistryPolicy" => self.create_ecr_registry_policy(resource),
+            "AWS::ECR::ReplicationConfiguration" => {
+                self.create_ecr_replication_configuration(resource)
+            }
+            "AWS::ECR::PullThroughCacheRule" => self.create_ecr_pull_through_cache_rule(resource),
             "AWS::CloudWatch::Alarm" => self.create_cloudwatch_alarm(resource),
             "AWS::CloudWatch::Dashboard" => self.create_cloudwatch_dashboard(resource),
             "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
@@ -645,6 +651,14 @@ impl ResourceProvisioner {
             "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
+            "AWS::ECR::RepositoryPolicy" => {
+                self.delete_ecr_repository_policy(&resource.physical_id)
+            }
+            "AWS::ECR::RegistryPolicy" => self.delete_ecr_registry_policy(),
+            "AWS::ECR::ReplicationConfiguration" => self.delete_ecr_replication_configuration(),
+            "AWS::ECR::PullThroughCacheRule" => {
+                self.delete_ecr_pull_through_cache_rule(&resource.physical_id)
+            }
             "AWS::CloudWatch::Alarm" => self.delete_cloudwatch_alarm(&resource.physical_id),
             "AWS::CloudWatch::Dashboard" => self.delete_cloudwatch_dashboard(&resource.physical_id),
             "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
@@ -3860,6 +3874,216 @@ impl ResourceProvisioner {
         let mut accounts = self.ecr_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.repositories.remove(physical_id);
+        Ok(())
+    }
+
+    /// Provision a standalone `AWS::ECR::RepositoryPolicy` against an
+    /// existing repository. Physical id encodes `account/repo` so the
+    /// delete path can find the right repository.
+    fn create_ecr_repository_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let repository_name = props
+            .get("RepositoryName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "RepositoryName is required".to_string())?
+            .to_string();
+        let policy_text = props
+            .get("PolicyText")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .ok_or_else(|| "PolicyText is required".to_string())?;
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let repo = state
+            .repositories
+            .get_mut(&repository_name)
+            .ok_or_else(|| format!("Repository {repository_name} does not exist"))?;
+        repo.policy = Some(policy_text);
+        Ok(ProvisionResult::new(format!(
+            "{}/{}",
+            self.account_id, repository_name
+        )))
+    }
+
+    fn delete_ecr_repository_policy(&self, physical_id: &str) -> Result<(), String> {
+        let repository_name = physical_id
+            .split_once('/')
+            .map(|(_, n)| n.to_string())
+            .unwrap_or_else(|| physical_id.to_string());
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(repo) = state.repositories.get_mut(&repository_name) {
+            repo.policy = None;
+        }
+        Ok(())
+    }
+
+    /// Set the registry-wide policy for the active account. Physical id
+    /// is just the account id since the registry is a singleton.
+    fn create_ecr_registry_policy(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let policy_text = props
+            .get("PolicyText")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .ok_or_else(|| "PolicyText is required".to_string())?;
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.registry_policy = Some(policy_text);
+        Ok(ProvisionResult::new(self.account_id.clone())
+            .with("RegistryId", self.account_id.clone()))
+    }
+
+    fn delete_ecr_registry_policy(&self) -> Result<(), String> {
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.registry_policy = None;
+        Ok(())
+    }
+
+    /// Provision the singleton `AWS::ECR::ReplicationConfiguration`.
+    fn create_ecr_replication_configuration(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        use fakecloud_ecr::state::{
+            ReplicationConfiguration, ReplicationDestination, ReplicationRule, RepositoryFilter,
+        };
+        let cfg = resource
+            .properties
+            .get("ReplicationConfiguration")
+            .ok_or_else(|| "ReplicationConfiguration is required".to_string())?;
+        let rules: Vec<ReplicationRule> = cfg
+            .get("Rules")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .map(|r| {
+                        let destinations: Vec<ReplicationDestination> = r
+                            .get("Destinations")
+                            .and_then(|v| v.as_array())
+                            .map(|d| {
+                                d.iter()
+                                    .map(|dest| ReplicationDestination {
+                                        region: dest
+                                            .get("Region")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                        registry_id: dest
+                                            .get("RegistryId")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        let repository_filters: Vec<RepositoryFilter> = r
+                            .get("RepositoryFilters")
+                            .and_then(|v| v.as_array())
+                            .map(|f| {
+                                f.iter()
+                                    .map(|f| RepositoryFilter {
+                                        filter: f
+                                            .get("Filter")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                        filter_type: f
+                                            .get("FilterType")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        ReplicationRule {
+                            destinations,
+                            repository_filters,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.replication_configuration = Some(ReplicationConfiguration { rules });
+        Ok(ProvisionResult::new(self.account_id.clone()))
+    }
+
+    fn delete_ecr_replication_configuration(&self) -> Result<(), String> {
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.replication_configuration = None;
+        Ok(())
+    }
+
+    fn create_ecr_pull_through_cache_rule(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        use fakecloud_ecr::state::PullThroughCacheRule;
+        let props = &resource.properties;
+        let prefix = props
+            .get("EcrRepositoryPrefix")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "EcrRepositoryPrefix is required".to_string())?
+            .to_string();
+        let upstream_url = props
+            .get("UpstreamRegistryUrl")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "UpstreamRegistryUrl is required".to_string())?
+            .to_string();
+        let upstream_registry = props
+            .get("UpstreamRegistry")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let credential_arn = props
+            .get("CredentialArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let custom_role_arn = props
+            .get("CustomRoleArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let now = Utc::now();
+        let rule = PullThroughCacheRule {
+            ecr_repository_prefix: prefix.clone(),
+            upstream_registry_url: upstream_url,
+            upstream_registry,
+            credential_arn,
+            created_at: now,
+            updated_at: now,
+            custom_role_arn,
+        };
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.pull_through_cache_rules.insert(prefix.clone(), rule);
+        Ok(ProvisionResult::new(prefix))
+    }
+
+    fn delete_ecr_pull_through_cache_rule(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.ecr_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.pull_through_cache_rules.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_ecr.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ecr.rs
@@ -141,3 +141,150 @@ async fn cfn_provisions_and_deletes_ecr_repository() {
         "repository should be gone after stack deletion"
     );
 }
+
+const POLICY_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Repo": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {"RepositoryName": "ecr-cfn-policy-repo"}
+    },
+    "RepoPolicy": {
+      "Type": "AWS::ECR::RepositoryPolicy",
+      "Properties": {
+        "RepositoryName": {"Ref": "Repo"},
+        "PolicyText": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "AllowPull",
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": ["ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage"]
+          }]
+        }
+      }
+    },
+    "RegPolicy": {
+      "Type": "AWS::ECR::RegistryPolicy",
+      "Properties": {
+        "PolicyText": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "ReplicationAccess",
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+            "Action": ["ecr:CreateRepository", "ecr:ReplicateImage"],
+            "Resource": "*"
+          }]
+        }
+      }
+    },
+    "Replication": {
+      "Type": "AWS::ECR::ReplicationConfiguration",
+      "Properties": {
+        "ReplicationConfiguration": {
+          "Rules": [{
+            "Destinations": [{
+              "Region": "us-west-2",
+              "RegistryId": "222222222222"
+            }],
+            "RepositoryFilters": [{
+              "Filter": "ecr-cfn-policy-",
+              "FilterType": "PREFIX_MATCH"
+            }]
+          }]
+        }
+      }
+    },
+    "PtCache": {
+      "Type": "AWS::ECR::PullThroughCacheRule",
+      "Properties": {
+        "EcrRepositoryPrefix": "ecr-public",
+        "UpstreamRegistryUrl": "public.ecr.aws"
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_ecr_policies_and_registry_config() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ecr = aws_sdk_ecr::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("ecr-policy-stack")
+        .template_body(POLICY_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ecr-policy-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    assert_eq!(
+        described
+            .stacks()
+            .first()
+            .unwrap()
+            .stack_status()
+            .unwrap()
+            .as_str(),
+        "CREATE_COMPLETE"
+    );
+
+    let repo_policy = ecr
+        .get_repository_policy()
+        .repository_name("ecr-cfn-policy-repo")
+        .send()
+        .await
+        .expect("get_repository_policy");
+    assert!(repo_policy
+        .policy_text()
+        .map(|s| s.contains("AllowPull"))
+        .unwrap_or(false));
+
+    let reg_policy = ecr
+        .get_registry_policy()
+        .send()
+        .await
+        .expect("get_registry_policy");
+    assert!(reg_policy
+        .policy_text()
+        .map(|s| s.contains("ReplicationAccess"))
+        .unwrap_or(false));
+
+    let replication = ecr
+        .describe_registry()
+        .send()
+        .await
+        .expect("describe_registry");
+    assert_eq!(
+        replication
+            .replication_configuration()
+            .map(|c| c.rules().len()),
+        Some(1)
+    );
+
+    let cache = ecr
+        .describe_pull_through_cache_rules()
+        .send()
+        .await
+        .expect("describe_pull_through_cache_rules");
+    assert!(cache
+        .pull_through_cache_rules()
+        .iter()
+        .any(|r| r.ecr_repository_prefix() == Some("ecr-public")));
+
+    cfn.delete_stack()
+        .stack_name("ecr-policy-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let reg_after = ecr.get_registry_policy().send().await;
+    assert!(reg_after.is_err(), "registry policy should be cleared");
+}

--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -3,10 +3,11 @@ pub(crate) mod pull_through;
 pub mod scanner;
 pub(crate) mod service;
 pub mod signing;
-pub(crate) mod state;
+pub mod state;
 
 pub use service::EcrService;
 pub use state::{
-    EcrSnapshot, EcrState, Image, PullThroughCacheRule, Repository, SharedEcrState,
+    EcrSnapshot, EcrState, Image, PullThroughCacheRule, ReplicationConfiguration,
+    ReplicationDestination, ReplicationRule, Repository, RepositoryFilter, SharedEcrState,
     ECR_SNAPSHOT_SCHEMA_VERSION,
 };


### PR DESCRIPTION
## Summary

Adds four ECR resource types to the CFN provisioner:

- AWS::ECR::RepositoryPolicy — attach/detach a policy on a named repo
- AWS::ECR::RegistryPolicy — registry-wide policy on the account
- AWS::ECR::ReplicationConfiguration — Rules + Destinations + RepositoryFilters
- AWS::ECR::PullThroughCacheRule — upstream cache mapping

Also makes fakecloud-ecr::state public and re-exports ReplicationConfiguration/ReplicationRule/ReplicationDestination/RepositoryFilter so CFN can build them directly.

Closes BB12 (RepositoryPolicy/LifecyclePolicy) plus extras for registry/replication/pull-through gaps.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_ecr
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-ecr -p fakecloud-e2e --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for ECR repository/registry policies, replication, and pull‑through cache so stacks can manage ECR policy and config end to end. Addresses Linear BB12 by adding `AWS::ECR::RepositoryPolicy` and fills gaps for registry, replication, and pull‑through.

- **New Features**
  - Add `AWS::ECR::RepositoryPolicy`, `AWS::ECR::RegistryPolicy`, `AWS::ECR::ReplicationConfiguration`, and `AWS::ECR::PullThroughCacheRule` to the `fakecloud-cloudformation` provisioner (create + delete).
  - Parse and persist replication Rules, Destinations, and RepositoryFilters; store registry-wide and per-repo policies.
  - E2E tests in `fakecloud-e2e` validate with SDK calls: GetRepositoryPolicy, GetRegistryPolicy, DescribeRegistry, DescribePullThroughCacheRules.

- **Refactors**
  - Make `fakecloud-ecr::state` public and re-export `ReplicationConfiguration`, `ReplicationRule`, `ReplicationDestination`, and `RepositoryFilter` for direct CFN construction.

<sup>Written for commit d5359ad67f36bcb7d5ff7b04cd57f0dfcff2c7d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

