### PR TITLE
feat(cloudformation): provision ELBv2 ListenerCertificate and TrustStore

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -438,6 +438,10 @@ impl ResourceProvisioner {
             "AWS::ElasticLoadBalancingV2::ListenerRule" => {
                 self.create_elbv2_listener_rule(resource)
             }
+            "AWS::ElasticLoadBalancingV2::ListenerCertificate" => {
+                self.create_elbv2_listener_certificate(resource)
+            }
+            "AWS::ElasticLoadBalancingV2::TrustStore" => self.create_elbv2_trust_store(resource),
             "AWS::Organizations::Organization" => self.create_organization(resource),
             "AWS::Organizations::OrganizationalUnit" => self.create_organization_unit(resource),
             "AWS::Organizations::Account" => self.create_organization_account(resource),
@@ -672,6 +676,12 @@ impl ResourceProvisioner {
             }
             "AWS::ElasticLoadBalancingV2::ListenerRule" => {
                 self.delete_elbv2_listener_rule(&resource.physical_id)
+            }
+            "AWS::ElasticLoadBalancingV2::ListenerCertificate" => {
+                self.delete_elbv2_listener_certificate(&resource.physical_id)
+            }
+            "AWS::ElasticLoadBalancingV2::TrustStore" => {
+                self.delete_elbv2_trust_store(&resource.physical_id)
             }
             "AWS::Organizations::Organization" => self.delete_organization(&resource.physical_id),
             "AWS::Organizations::OrganizationalUnit" => {
@@ -4699,6 +4709,146 @@ impl ResourceProvisioner {
         let mut accounts = self.elbv2_state.write();
         let state = accounts.get_or_create(&self.account_id);
         state.rules.remove(physical_id);
+        Ok(())
+    }
+
+    /// Provision an `AWS::ElasticLoadBalancingV2::ListenerCertificate`.
+    /// Appends each non-default certificate from `Certificates` to the
+    /// target listener (the default listener cert is set on Listener
+    /// creation, so this resource only manages SNI extras).
+    fn create_elbv2_listener_certificate(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let listener_arn = props
+            .get("ListenerArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "ListenerArn is required".to_string())?
+            .to_string();
+        let certs: Vec<String> = props
+            .get("Certificates")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.get("CertificateArn").and_then(|v| v.as_str()))
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if certs.is_empty() {
+            return Err("Certificates must contain at least one CertificateArn".to_string());
+        }
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let listener = state
+            .listeners
+            .get_mut(&listener_arn)
+            .ok_or_else(|| format!("Listener {listener_arn} does not exist"))?;
+        for arn in &certs {
+            listener.certificates.retain(|c| &c.certificate_arn != arn);
+            listener.certificates.push(fakecloud_elbv2::Certificate {
+                certificate_arn: arn.clone(),
+                is_default: false,
+            });
+        }
+        Ok(ProvisionResult::new(format!(
+            "{}#{}",
+            listener_arn,
+            certs.join(",")
+        )))
+    }
+
+    fn delete_elbv2_listener_certificate(&self, physical_id: &str) -> Result<(), String> {
+        let (listener_arn, cert_list) = match physical_id.split_once('#') {
+            Some(parts) => parts,
+            None => return Ok(()),
+        };
+        let cert_arns: Vec<&str> = cert_list.split(',').collect();
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if let Some(listener) = state.listeners.get_mut(listener_arn) {
+            listener
+                .certificates
+                .retain(|c| !cert_arns.iter().any(|a| *a == c.certificate_arn));
+        }
+        Ok(())
+    }
+
+    /// Provision an `AWS::ElasticLoadBalancingV2::TrustStore`.
+    fn create_elbv2_trust_store(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let bucket = props
+            .get("CaCertificatesBundleS3Bucket")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "CaCertificatesBundleS3Bucket is required".to_string())?;
+        let key = props
+            .get("CaCertificatesBundleS3Key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "CaCertificatesBundleS3Key is required".to_string())?;
+        let tags: Vec<fakecloud_elbv2::Tag> = props
+            .get("Tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t.get("Key").and_then(|v| v.as_str())?;
+                        let val = t.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+                        Some(fakecloud_elbv2::Tag {
+                            key: k.to_string(),
+                            value: val.to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        if state.trust_stores.values().any(|t| t.name == name) {
+            return Err(format!("Trust store {name} already exists"));
+        }
+        let suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(16)
+            .collect();
+        let arn = format!(
+            "arn:aws:elasticloadbalancing:{}:{}:truststore/{}/{}",
+            self.region, self.account_id, name, suffix
+        );
+        let ts = fakecloud_elbv2::TrustStore {
+            arn: arn.clone(),
+            name: name.clone(),
+            status: "ACTIVE".to_string(),
+            number_of_ca_certificates: 1,
+            total_revoked_entries: 0,
+            created_time: Utc::now(),
+            ca_certificates_bundle: Some(format!("s3://{bucket}/{key}").into_bytes()),
+            revocations: BTreeMap::new(),
+            next_revocation_id: 1,
+            tags,
+        };
+        state.trust_stores.insert(arn.clone(), ts);
+        Ok(ProvisionResult::new(arn.clone())
+            .with("TrustStoreArn", arn)
+            .with("Name", name)
+            .with("Status", "ACTIVE".to_string()))
+    }
+
+    fn delete_elbv2_trust_store(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.trust_stores.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_elbv2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_elbv2.rs
@@ -162,3 +162,149 @@ async fn cfn_provisions_elbv2_lb_tg_listener_rule() {
         .await;
     assert!(after.is_err(), "lb should be gone after stack deletion");
 }
+
+const EXTRAS_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Web": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "cfn-extras-web",
+        "Scheme": "internet-facing",
+        "Type": "application",
+        "Subnets": ["subnet-aaa", "subnet-bbb"]
+      }
+    },
+    "ApiTg": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Name": "cfn-extras-api",
+        "Protocol": "HTTPS",
+        "Port": 443,
+        "VpcId": "vpc-1234",
+        "TargetType": "ip"
+      }
+    },
+    "Trust": {
+      "Type": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "Properties": {
+        "Name": "cfn-trust",
+        "CaCertificatesBundleS3Bucket": "ca-bucket",
+        "CaCertificatesBundleS3Key": "bundle.pem",
+        "Tags": [{"Key": "Env", "Value": "prod"}]
+      }
+    },
+    "TlsListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "LoadBalancerArn": {"Ref": "Web"},
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "Certificates": [
+          {"CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/default-cert"}
+        ],
+        "DefaultActions": [
+          {"Type": "forward", "TargetGroupArn": {"Ref": "ApiTg"}}
+        ]
+      }
+    },
+    "ExtraCert": {
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerCertificate",
+      "Properties": {
+        "ListenerArn": {"Ref": "TlsListener"},
+        "Certificates": [
+          {"CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/sni-cert-1"}
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "TrustArn": {"Value": {"Ref": "Trust"}},
+    "ListenerArn": {"Value": {"Ref": "TlsListener"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_elbv2_listener_certificate_and_trust_store() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let elb = server.elbv2_client().await;
+
+    cfn.create_stack()
+        .stack_name("elbv2-extras-stack")
+        .template_body(EXTRAS_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("elbv2-extras-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().unwrap();
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut trust_arn = None;
+    let mut listener_arn = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("TrustArn") => trust_arn = o.output_value().map(|s| s.to_string()),
+            Some("ListenerArn") => listener_arn = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let trust_arn = trust_arn.expect("TrustArn");
+    let listener_arn = listener_arn.expect("ListenerArn");
+    assert!(trust_arn.contains(":truststore/cfn-trust/"));
+
+    let trust_stores = elb
+        .describe_trust_stores()
+        .trust_store_arns(&trust_arn)
+        .send()
+        .await
+        .expect("describe_trust_stores");
+    let ts = trust_stores
+        .trust_stores()
+        .iter()
+        .find(|t| t.trust_store_arn() == Some(&trust_arn))
+        .expect("trust store present");
+    assert_eq!(ts.name(), Some("cfn-trust"));
+    assert_eq!(ts.status().map(|s| s.as_str()), Some("ACTIVE"));
+
+    let listener_certs = elb
+        .describe_listener_certificates()
+        .listener_arn(&listener_arn)
+        .send()
+        .await
+        .expect("describe_listener_certificates");
+    let arns: Vec<&str> = listener_certs
+        .certificates()
+        .iter()
+        .filter_map(|c| c.certificate_arn())
+        .collect();
+    assert!(
+        arns.iter().any(|a| a.contains("sni-cert-1")),
+        "SNI cert should be attached: {arns:?}"
+    );
+
+    cfn.delete_stack()
+        .stack_name("elbv2-extras-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let trust_after = elb
+        .describe_trust_stores()
+        .trust_store_arns(&trust_arn)
+        .send()
+        .await;
+    assert!(
+        trust_after
+            .as_ref()
+            .map(|r| r.trust_stores().is_empty())
+            .unwrap_or(true),
+        "trust store should be deleted",
+    );
+}

--- a/crates/fakecloud-elbv2/src/lib.rs
+++ b/crates/fakecloud-elbv2/src/lib.rs
@@ -2,7 +2,7 @@ pub mod dataplane;
 pub mod prober;
 pub mod router;
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 
 pub const ELBV2_NAMESPACE: &str = "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
 
@@ -10,5 +10,5 @@ pub use service::Elbv2Service;
 pub use state::{
     Action, AvailabilityZone, Certificate, Elbv2Accounts, FixedResponseConfig, ForwardConfig,
     Listener, LoadBalancer, LoadBalancerAddress, RedirectConfig, Rule, RuleCondition,
-    SharedElbv2State, Tag, TargetGroup, TargetGroupTuple,
+    SharedElbv2State, Tag, TargetGroup, TargetGroupTuple, TrustStore,
 };


### PR DESCRIPTION
## Summary

Adds two ELBv2 resource types to the CFN provisioner:

- AWS::ElasticLoadBalancingV2::ListenerCertificate — appends SNI certificates to a target listener; stack delete removes them.
- AWS::ElasticLoadBalancingV2::TrustStore — full TrustStore creation with Name + S3 bundle reference + tags.

Makes fakecloud-elbv2::state public and re-exports TrustStore so the CFN provisioner can construct the struct directly.

Closes BB17 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_elbv2
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-elbv2 --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for ELBv2 `AWS::ElasticLoadBalancingV2::ListenerCertificate` and `AWS::ElasticLoadBalancingV2::TrustStore` to attach SNI certs and create Trust Stores, with clean deletion on stack removal.

- **New Features**
  - `AWS::ElasticLoadBalancingV2::ListenerCertificate`: appends non-default certs to the target listener via `ListenerArn`; stack delete removes those cert ARNs.
  - `AWS::ElasticLoadBalancingV2::TrustStore`: creates a Trust Store with `Name`, S3 bundle (`CaCertificatesBundleS3Bucket`/`CaCertificatesBundleS3Key`), and tags; returns `TrustStoreArn`, `Name`, and `Status`; delete removes it from state.

- **Refactors**
  - Exposed `fakecloud-elbv2::state` publicly and re-exported `TrustStore` so the CFN provisioner can construct it directly.

<sup>Written for commit 409d45f55f9ea22fcf36e65ff055872ae149d948. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

