### PR TITLE
feat(cloudformation): provision Route53 DNSSEC and KeySigningKey

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -479,6 +479,8 @@ impl ResourceProvisioner {
             "AWS::Route53::HostedZone" => self.create_route53_hosted_zone(resource),
             "AWS::Route53::RecordSet" => self.create_route53_record_set(resource),
             "AWS::Route53::HealthCheck" => self.create_route53_health_check(resource),
+            "AWS::Route53::DNSSEC" => self.create_route53_dnssec(resource),
+            "AWS::Route53::KeySigningKey" => self.create_route53_key_signing_key(resource),
             "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
                 self.create_cf_origin_access_identity(resource)
             }
@@ -742,6 +744,10 @@ impl ResourceProvisioner {
                 self.delete_route53_record_set(&resource.physical_id, &resource.attributes)
             }
             "AWS::Route53::HealthCheck" => self.delete_route53_health_check(&resource.physical_id),
+            "AWS::Route53::DNSSEC" => self.delete_route53_dnssec(&resource.physical_id),
+            "AWS::Route53::KeySigningKey" => {
+                self.delete_route53_key_signing_key(&resource.physical_id)
+            }
             "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
                 self.delete_cf_origin_access_identity(&resource.physical_id)
             }
@@ -8229,6 +8235,106 @@ impl ResourceProvisioner {
         // default account bucket so SDK reads land on the same data.
         let state = accounts.entry("000000000000");
         state.health_checks.remove(physical_id);
+        Ok(())
+    }
+
+    /// `AWS::Route53::DNSSEC` flips the hosted zone's `dnssec_status` to
+    /// `SIGNING`. Physical id is the hosted zone id so the delete path can
+    /// flip it back without consulting the template.
+    fn create_route53_dnssec(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let zone_id = resource
+            .properties
+            .get("HostedZoneId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "HostedZoneId is required".to_string())?
+            .trim_start_matches("/hostedzone/")
+            .to_string();
+        let mut accounts = self.route53_state.write();
+        let state = accounts.entry("000000000000");
+        if !state.hosted_zones.contains_key(&zone_id) {
+            return Err(format!("HostedZone {zone_id} does not exist"));
+        }
+        state
+            .dnssec_status
+            .insert(zone_id.clone(), "SIGNING".to_string());
+        Ok(ProvisionResult::new(zone_id))
+    }
+
+    fn delete_route53_dnssec(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.route53_state.write();
+        let state = accounts.entry("000000000000");
+        state.dnssec_status.remove(physical_id);
+        Ok(())
+    }
+
+    /// `AWS::Route53::KeySigningKey` registers a KSK against a hosted
+    /// zone. Physical id encodes `<hosted_zone_id>/<name>` so the delete
+    /// path can find the (zone, name) tuple without re-reading inputs.
+    fn create_route53_key_signing_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let zone_id = props
+            .get("HostedZoneId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "HostedZoneId is required".to_string())?
+            .trim_start_matches("/hostedzone/")
+            .to_string();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Name is required".to_string())?
+            .to_string();
+        let kms_arn = props
+            .get("KeyManagementServiceArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "KeyManagementServiceArn is required".to_string())?
+            .to_string();
+        let status = props
+            .get("Status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ACTIVE")
+            .to_string();
+        let now = Utc::now();
+        let ksk = fakecloud_route53::StoredKeySigningKey {
+            hosted_zone_id: zone_id.clone(),
+            name: name.clone(),
+            kms_arn,
+            status,
+            caller_reference: format!("cfn-{}", Uuid::new_v4()),
+            created_date: now,
+            last_modified_date: now,
+            // Real Route53 derives a deterministic key tag from the KSK
+            // material; we synthesize a stable one from the (zone, name)
+            // tuple so the value round-trips on read without depending on
+            // signing internals.
+            key_tag: ((zone_id.len() + name.len()) % 65536) as i32,
+        };
+        let mut accounts = self.route53_state.write();
+        let state = accounts.entry("000000000000");
+        if !state.hosted_zones.contains_key(&zone_id) {
+            return Err(format!("HostedZone {zone_id} does not exist"));
+        }
+        state
+            .key_signing_keys
+            .insert((zone_id.clone(), name.clone()), ksk);
+        Ok(ProvisionResult::new(format!("{zone_id}/{name}")))
+    }
+
+    fn delete_route53_key_signing_key(&self, physical_id: &str) -> Result<(), String> {
+        let (zone_id, name) = match physical_id.split_once('/') {
+            Some(parts) => parts,
+            None => return Ok(()),
+        };
+        let mut accounts = self.route53_state.write();
+        let state = accounts.entry("000000000000");
+        state
+            .key_signing_keys
+            .remove(&(zone_id.to_string(), name.to_string()));
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_route53.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_route53.rs
@@ -150,3 +150,92 @@ async fn cfn_provisions_route53_resources() {
         .await;
     assert!(hc_after.is_err(), "health check should be gone");
 }
+
+const DNSSEC_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Zone": {
+      "Type": "AWS::Route53::HostedZone",
+      "Properties": {"Name": "dnssec.example.com."}
+    },
+    "Ksk": {
+      "Type": "AWS::Route53::KeySigningKey",
+      "Properties": {
+        "HostedZoneId": {"Ref": "Zone"},
+        "Name": "primary-ksk",
+        "KeyManagementServiceArn": "arn:aws:kms:us-east-1:123456789012:key/dummy",
+        "Status": "ACTIVE"
+      }
+    },
+    "EnableDnssec": {
+      "Type": "AWS::Route53::DNSSEC",
+      "DependsOn": "Ksk",
+      "Properties": {
+        "HostedZoneId": {"Ref": "Zone"}
+      }
+    }
+  },
+  "Outputs": {
+    "ZoneId": {"Value": {"Ref": "Zone"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_route53_dnssec_and_ksk() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let r53 = aws_sdk_route53::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("r53-dnssec-stack")
+        .template_body(DNSSEC_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("r53-dnssec-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().unwrap();
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let zone_id = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("ZoneId"))
+        .and_then(|o| o.output_value())
+        .map(|s| s.to_string())
+        .expect("ZoneId output");
+
+    let dnssec = r53
+        .get_dnssec()
+        .hosted_zone_id(&zone_id)
+        .send()
+        .await
+        .expect("get_dnssec");
+    assert_eq!(
+        dnssec.status().and_then(|s| s.serve_signature()),
+        Some("SIGNING"),
+    );
+    let ksks = dnssec.key_signing_keys();
+    assert!(
+        ksks.iter().any(|k| k.name() == Some("primary-ksk")),
+        "KSK should be present: {ksks:?}"
+    );
+
+    cfn.delete_stack()
+        .stack_name("r53-dnssec-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    // Hosted zone gone -> get_dnssec should error.
+    let after = r53.get_dnssec().hosted_zone_id(&zone_id).send().await;
+    assert!(
+        after.is_err(),
+        "DNSSEC config should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-route53/src/lib.rs
+++ b/crates/fakecloud-route53/src/lib.rs
@@ -18,4 +18,5 @@ pub const NAMESPACE: &str = "https://route53.amazonaws.com/doc/2013-04-01/";
 pub use service::Route53Service;
 pub use state::{
     AccountState, Route53Accounts, SharedRoute53State, StoredHealthCheck, StoredHostedZone,
+    StoredKeySigningKey,
 };


### PR DESCRIPTION
## Summary

Adds two Route53 resource types to the CFN provisioner:

- AWS::Route53::DNSSEC — flips the hosted zone's dnssec_status to SIGNING (clears it on stack delete).
- AWS::Route53::KeySigningKey — stores the KSK keyed by (hosted_zone_id, name) with a deterministic key_tag.

Re-exports StoredKeySigningKey from fakecloud-route53 so the provisioner can construct it directly.

Closes BB20 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_route53
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-route53 --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudFormation support for Route53 DNSSEC and KeySigningKey so stacks can enable DNSSEC and register KSKs for hosted zones. Addresses BB20 in the parity-gap parity plan.

- **New Features**
  - `AWS::Route53::DNSSEC`: sets the hosted zone’s dnssec_status to SIGNING; physical id is the zone id; deletion clears the status.
  - `AWS::Route53::KeySigningKey`: registers a KSK keyed by (hosted_zone_id, name) with a deterministic key_tag; physical id `<zone_id>/<name>`; deletion removes the key.
  - Re-exports `StoredKeySigningKey` from `fakecloud-route53` for direct use in `fakecloud-cloudformation`. E2E test validates create → GetDNSSEC shows SIGNING with the KSK → delete clears state.

<sup>Written for commit 4a2ef51a5d73a6aaf0793ce9a9c61c816356497c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

