### PR TITLE
feat(cloudformation): provision AWS::KMS::ReplicaKey

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -421,6 +421,7 @@ impl ResourceProvisioner {
             "AWS::Kinesis::StreamConsumer" => self.create_kinesis_stream_consumer(resource),
             "AWS::KMS::Key" => self.create_kms_key(resource),
             "AWS::KMS::Alias" => self.create_kms_alias(resource),
+            "AWS::KMS::ReplicaKey" => self.create_kms_replica_key(resource),
             "AWS::ECR::Repository" => self.create_ecr_repository(resource),
             "AWS::ECR::RepositoryPolicy" => self.create_ecr_repository_policy(resource),
             "AWS::ECR::RegistryPolicy" => self.create_ecr_registry_policy(resource),
@@ -655,6 +656,7 @@ impl ResourceProvisioner {
                 self.delete_kinesis_stream_consumer(&resource.physical_id)
             }
             "AWS::KMS::Key" => self.delete_kms_key(&resource.physical_id),
+            "AWS::KMS::ReplicaKey" => self.delete_kms_replica_key(&resource.physical_id),
             "AWS::KMS::Alias" => self.delete_kms_alias(&resource.physical_id),
             "AWS::ECR::Repository" => self.delete_ecr_repository(&resource.physical_id),
             "AWS::ECR::RepositoryPolicy" => {
@@ -3738,6 +3740,121 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.keys.remove(physical_id);
         state.aliases.retain(|_, a| a.target_key_id != physical_id);
+        Ok(())
+    }
+
+    /// Provision an `AWS::KMS::ReplicaKey`. Looks up the primary key by
+    /// arn and inserts a region-keyed replica into the same account
+    /// state, mirroring the ReplicateKey API contract.
+    fn create_kms_replica_key(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let primary_arn = props
+            .get("PrimaryKeyArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "PrimaryKeyArn is required".to_string())?
+            .to_string();
+        // arn:aws:kms:<region>:<account>:key/<key_id>
+        let parts: Vec<&str> = primary_arn.split(':').collect();
+        if parts.len() < 6 {
+            return Err(format!("Invalid PrimaryKeyArn: {primary_arn}"));
+        }
+        let primary_region = parts[3].to_string();
+        let key_id = parts[5]
+            .strip_prefix("key/")
+            .ok_or_else(|| format!("PrimaryKeyArn missing key/ segment: {primary_arn}"))?
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let enabled = props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let policy = match props.get("KeyPolicy") {
+            Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
+            Some(v) => serde_json::to_string(v).unwrap_or_default(),
+            None => String::new(),
+        };
+        let mut tags: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            for t in arr {
+                if let (Some(k), Some(v)) = (
+                    t.get("Key").and_then(|x| x.as_str()),
+                    t.get("Value").and_then(|x| x.as_str()),
+                ) {
+                    tags.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        // Source must be a multi-region key in the primary account; look
+        // it up either by raw key_id (when the primary lives in this
+        // state's region) or via the region-keyed slot.
+        let source_storage_keys = [key_id.clone(), format!("{primary_region}:{key_id}")];
+        let source = source_storage_keys
+            .iter()
+            .find_map(|k| state.keys.get(k).cloned())
+            .ok_or_else(|| format!("Primary key {primary_arn} does not exist"))?;
+        if !source.multi_region {
+            return Err(format!(
+                "Primary key {primary_arn} is not a multi-region key"
+            ));
+        }
+
+        // Real AWS uses the same `mrk-...` id across regions; fakecloud
+        // is single-region, so colliding the id with the primary would
+        // overwrite the primary in `state.keys`. Mint a distinct
+        // `mrk-replica-` id whose `primary_region` points back at the
+        // source so DescribeKey reports `MultiRegionKeyType=REPLICA`.
+        let replica_key_id = format!("mrk-replica-{}", Uuid::new_v4().as_simple());
+        let replica_arn = format!(
+            "arn:aws:kms:{}:{}:key/{}",
+            self.region, self.account_id, replica_key_id
+        );
+        let mut replica = source;
+        replica.key_id = replica_key_id.clone();
+        replica.arn = replica_arn.clone();
+        if !description.is_empty() {
+            replica.description = description;
+        }
+        replica.enabled = enabled;
+        replica.key_state = if enabled {
+            "Enabled".to_string()
+        } else {
+            "Disabled".to_string()
+        };
+        if !policy.is_empty() {
+            replica.policy = policy;
+        }
+        if !tags.is_empty() {
+            replica.tags.extend(tags);
+        }
+        replica.deletion_date = None;
+        replica.key_rotation_enabled = false;
+        replica.multi_region = true;
+        replica.rotations = Vec::new();
+        replica.custom_key_store_id = None;
+        replica.imported_key_material = false;
+        replica.imported_material_bytes = None;
+        replica.primary_region = Some(primary_region);
+
+        state.keys.insert(replica_key_id.clone(), replica);
+        Ok(ProvisionResult::new(replica_key_id.clone())
+            .with("KeyId", replica_key_id)
+            .with("Arn", replica_arn))
+    }
+
+    fn delete_kms_replica_key(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.kms_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        state.keys.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_kms.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kms.rs
@@ -115,3 +115,106 @@ async fn cfn_provisions_and_deletes_kms_key_and_alias() {
         "alias should be gone after stack deletion"
     );
 }
+
+const REPLICA_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Primary": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "primary mrk",
+        "MultiRegion": true,
+        "KeyPolicy": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Allow", "Principal": {"AWS": "*"}, "Action": "kms:*", "Resource": "*"}]
+        }
+      }
+    },
+    "Replica": {
+      "Type": "AWS::KMS::ReplicaKey",
+      "Properties": {
+        "Description": "replica mrk",
+        "PrimaryKeyArn": {"Fn::GetAtt": ["Primary", "Arn"]},
+        "Enabled": true
+      }
+    }
+  },
+  "Outputs": {
+    "PrimaryArn": {"Value": {"Fn::GetAtt": ["Primary", "Arn"]}},
+    "PrimaryKeyId": {"Value": {"Ref": "Primary"}},
+    "ReplicaArn": {"Value": {"Fn::GetAtt": ["Replica", "Arn"]}},
+    "ReplicaKeyId": {"Value": {"Fn::GetAtt": ["Replica", "KeyId"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_kms_replica_key() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kms = aws_sdk_kms::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("kms-replica-stack")
+        .template_body(REPLICA_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("kms-replica-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().unwrap();
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    let primary_key_id = outputs
+        .get("PrimaryKeyId")
+        .expect("PrimaryKeyId")
+        .to_string();
+    let replica_key_id = outputs
+        .get("ReplicaKeyId")
+        .expect("ReplicaKeyId")
+        .to_string();
+    let replica_arn = outputs.get("ReplicaArn").expect("ReplicaArn").to_string();
+
+    // Both primary and replica are multi-region keys (fakecloud uses a
+    // synthesized replica key_id since it runs in a single region).
+    assert!(primary_key_id.starts_with("mrk-"));
+    assert!(replica_key_id.starts_with("mrk-replica-"));
+    assert!(replica_arn.contains(&replica_key_id));
+
+    // DescribeKey on the replica ARN should report MultiRegion=true.
+    let described = kms
+        .describe_key()
+        .key_id(&replica_arn)
+        .send()
+        .await
+        .expect("describe_key replica");
+    let metadata = described.key_metadata().expect("metadata");
+    assert_eq!(metadata.multi_region(), Some(true));
+    let mrc = metadata
+        .multi_region_configuration()
+        .expect("multi-region config");
+    assert_eq!(
+        mrc.multi_region_key_type().map(|t| t.as_str()),
+        Some("REPLICA"),
+    );
+
+    cfn.delete_stack()
+        .stack_name("kms-replica-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let replica_after = kms.describe_key().key_id(&replica_arn).send().await;
+    assert!(
+        replica_after.is_err(),
+        "replica should be gone after stack deletion"
+    );
+}

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -549,12 +549,30 @@ pub(crate) fn key_metadata_json(key: &KmsKey, account_id: &str) -> Value {
     }
 
     if key.multi_region {
-        // Add MultiRegionConfiguration for primary keys
+        // Distinguish primary vs replica via the stored `primary_region`
+        // pointer — when set, this key is a replica that points back at
+        // its primary's region and arn.
+        let (key_type, primary_arn, primary_region) = match &key.primary_region {
+            Some(region) => {
+                let primary_arn = key
+                    .arn
+                    .splitn(6, ':')
+                    .enumerate()
+                    .map(|(idx, part)| if idx == 3 { region.as_str() } else { part })
+                    .collect::<Vec<&str>>()
+                    .join(":");
+                ("REPLICA", primary_arn, region.clone())
+            }
+            None => {
+                let region = key.arn.split(':').nth(3).unwrap_or("us-east-1").to_string();
+                ("PRIMARY", key.arn.clone(), region)
+            }
+        };
         meta["MultiRegionConfiguration"] = json!({
-            "MultiRegionKeyType": "PRIMARY",
+            "MultiRegionKeyType": key_type,
             "PrimaryKey": {
-                "Arn": key.arn,
-                "Region": key.arn.split(':').nth(3).unwrap_or("us-east-1"),
+                "Arn": primary_arn,
+                "Region": primary_region,
             },
             "ReplicaKeys": [],
         });


### PR DESCRIPTION
## Summary

Adds AWS::KMS::ReplicaKey to the CFN provisioner. Looks up the primary multi-region key by ARN, clones the relevant fields, and inserts a replica with primary_region set so DescribeKey reports MultiRegionKeyType=REPLICA.

Since fakecloud is single-region, the replica gets a distinct 'mrk-replica-' id rather than colliding with the primary id (real AWS reuses the same id across regions, but fakecloud keys by id within one region).

Updates helpers::key_metadata_json so MultiRegionKeyType is computed from the stored primary_region pointer rather than always returning 'PRIMARY'. The PrimaryKey field of the multi-region configuration now points back at the primary's region/arn for replicas.

Closes BB14 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_kms
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-kms --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::KMS::ReplicaKey` so replicas are created from a primary MRK by ARN and report `MultiRegionKeyType=REPLICA`. Meets Linear BB14’s KMS multi-region replica requirement.

- **New Features**
  - Implemented create/delete for `AWS::KMS::ReplicaKey` (copies description, policy, tags, enabled; sets `primary_region`).
  - Updated `key_metadata_json` to compute `MultiRegionKeyType` and `PrimaryKey` from `primary_region`, pointing replicas to the primary’s ARN/region.
  - Added e2e test for a stack with a primary key and a replica.

<sup>Written for commit dbd72f7c0c3eba1b383ac2ad2bf097771a4366bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

