### PR TITLE
feat(cloudformation): provision AWS::CloudFront::Distribution

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -26,12 +26,16 @@ use fakecloud_cloudfront::{
         PublicKeyConfig, StoredFunction, StoredKeyGroup, StoredOriginAccessIdentity,
         StoredPublicKey,
     },
+    model::{
+        DefaultCacheBehavior, DistributionConfig, Origin, OriginItems, Origins, ViewerCertificate,
+    },
     policies::{
         CachePolicyConfig, OriginAccessControlConfig, OriginRequestPolicyConfig,
         OriginRequestPolicyCookiesConfig, OriginRequestPolicyHeadersConfig,
         OriginRequestPolicyQueryStringsConfig, ResponseHeadersPolicyConfig, StoredCachePolicy,
         StoredOriginAccessControl, StoredOriginRequestPolicy, StoredResponseHeadersPolicy,
     },
+    state::StoredDistribution,
     SharedCloudFrontState,
 };
 use fakecloud_cloudwatch::{AlarmState, Dashboard, MetricAlarm, SharedCloudWatchState};
@@ -485,6 +489,7 @@ impl ResourceProvisioner {
             "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
                 self.create_cf_origin_access_identity(resource)
             }
+            "AWS::CloudFront::Distribution" => self.create_cf_distribution(resource),
             "AWS::CloudFront::OriginAccessControl" => {
                 self.create_cf_origin_access_control(resource)
             }
@@ -753,6 +758,7 @@ impl ResourceProvisioner {
             "AWS::CloudFront::CloudFrontOriginAccessIdentity" => {
                 self.delete_cf_origin_access_identity(&resource.physical_id)
             }
+            "AWS::CloudFront::Distribution" => self.delete_cf_distribution(&resource.physical_id),
             "AWS::CloudFront::OriginAccessControl" => {
                 self.delete_cf_origin_access_control(&resource.physical_id)
             }
@@ -8512,6 +8518,165 @@ impl ResourceProvisioner {
         let mut accounts = self.cloudfront_state.write();
         let state = accounts.entry("000000000000");
         state.origin_access_identities.remove(physical_id);
+        Ok(())
+    }
+
+    /// Provision an `AWS::CloudFront::Distribution`. Reads
+    /// DistributionConfig.Origins/DefaultCacheBehavior/etc. and persists
+    /// a StoredDistribution in CloudFront state. CFN's Origins property
+    /// is a flat array, so we wrap it back into the wire shape with a
+    /// quantity + Items.Origin nesting.
+    fn create_cf_distribution(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("DistributionConfig")
+            .ok_or_else(|| "DistributionConfig is required".to_string())?;
+
+        // CFN Origins is a flat JSON array; the wire shape is
+        // { Quantity, Items: { Origin: [...] } }. Translate. CFN's
+        // PascalCase doesn't always match the wire model — Origin's
+        // CustomOriginConfig uses HTTPPort/HTTPSPort while the model
+        // expects HttpPort/HttpsPort, so we patch a few well-known
+        // renames before letting serde finish the parse.
+        let origin_entries: Vec<Origin> = cfg
+            .get("Origins")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| "DistributionConfig.Origins is required".to_string())?
+            .iter()
+            .map(|o| {
+                let mut patched = o.clone();
+                if let Some(custom) = patched
+                    .get_mut("CustomOriginConfig")
+                    .and_then(|v| v.as_object_mut())
+                {
+                    if let Some(v) = custom.remove("HTTPPort") {
+                        custom.insert("HttpPort".to_string(), v);
+                    }
+                    if let Some(v) = custom.remove("HTTPSPort") {
+                        custom.insert("HttpsPort".to_string(), v);
+                    }
+                }
+                serde_json::from_value::<Origin>(patched)
+                    .map_err(|e| format!("Invalid Origin entry: {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if origin_entries.is_empty() {
+            return Err("DistributionConfig.Origins must contain at least one origin".to_string());
+        }
+        let origins = Origins {
+            quantity: origin_entries.len() as i32,
+            items: Some(OriginItems {
+                origin: origin_entries,
+            }),
+        };
+
+        let dcb_value = cfg
+            .get("DefaultCacheBehavior")
+            .ok_or_else(|| "DistributionConfig.DefaultCacheBehavior is required".to_string())?;
+        let default_cache_behavior: DefaultCacheBehavior =
+            serde_json::from_value(dcb_value.clone())
+                .map_err(|e| format!("Invalid DefaultCacheBehavior: {e}"))?;
+
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let enabled = cfg.get("Enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+        let price_class = cfg
+            .get("PriceClass")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let http_version = cfg
+            .get("HttpVersion")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let is_ipv6_enabled = cfg.get("IPV6Enabled").and_then(|v| v.as_bool());
+        let default_root_object = cfg
+            .get("DefaultRootObject")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let web_acl_id = cfg
+            .get("WebACLId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let viewer_certificate: Option<ViewerCertificate> = cfg
+            .get("ViewerCertificate")
+            .map(|v| serde_json::from_value(v.clone()))
+            .transpose()
+            .map_err(|e| format!("Invalid ViewerCertificate: {e}"))?;
+
+        let caller_reference = format!("cfn-{}-{}", resource.logical_id, Uuid::new_v4().simple());
+
+        let mut config = DistributionConfig {
+            caller_reference,
+            comment,
+            enabled,
+            origins,
+            default_cache_behavior,
+            ..Default::default()
+        };
+        config.price_class = price_class;
+        config.http_version = http_version;
+        config.is_ipv6_enabled = is_ipv6_enabled;
+        config.default_root_object = default_root_object;
+        config.web_acl_id = web_acl_id;
+        config.viewer_certificate = viewer_certificate;
+
+        // Mint distribution id + ARN + domain in the same shape the
+        // CloudFront service uses.
+        let id_suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(13)
+            .collect::<String>()
+            .to_uppercase();
+        let id = format!("E{id_suffix}");
+        let etag_suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(7)
+            .collect::<String>()
+            .to_uppercase();
+        let etag = format!("E{etag_suffix}");
+        let domain_name = format!("{}.cloudfront.net", id.to_lowercase());
+        let arn = format!(
+            "arn:aws:cloudfront::{}:distribution/{}",
+            self.account_id, id
+        );
+
+        let stored = StoredDistribution {
+            id: id.clone(),
+            arn: arn.clone(),
+            // CloudFront flips this to Deployed on the first GetDistribution
+            // poll, matching the rest of the service.
+            status: "InProgress".to_string(),
+            last_modified_time: Utc::now(),
+            domain_name: domain_name.clone(),
+            in_progress_invalidation_batches: 0,
+            etag,
+            config,
+        };
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.distributions.insert(id.clone(), stored);
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("DomainName", domain_name)
+            .with("Arn", arn))
+    }
+
+    fn delete_cf_distribution(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        state.distributions.remove(physical_id);
         Ok(())
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_cloudfront.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_cloudfront.rs
@@ -168,3 +168,103 @@ async fn cfn_provisions_cloudfront_resources() {
         .await;
     assert!(oai_after.is_err(), "OAI should be gone");
 }
+
+const DIST_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Dist": {
+      "Type": "AWS::CloudFront::Distribution",
+      "Properties": {
+        "DistributionConfig": {
+          "Comment": "cfn dist",
+          "Enabled": true,
+          "PriceClass": "PriceClass_100",
+          "Origins": [{
+            "Id": "origin-1",
+            "DomainName": "origin.example.com",
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "HTTPPort": 80,
+              "HTTPSPort": 443
+            }
+          }],
+          "DefaultCacheBehavior": {
+            "TargetOriginId": "origin-1",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          }
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "DistId": {"Value": {"Ref": "Dist"}},
+    "DistDomain": {"Value": {"Fn::GetAtt": ["Dist", "DomainName"]}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_cloudfront_distribution() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cf = aws_sdk_cloudfront::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("cf-dist-stack")
+        .template_body(DIST_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("cf-dist-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().unwrap();
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let dist_id = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("DistId"))
+        .and_then(|o| o.output_value())
+        .map(|s| s.to_string())
+        .expect("DistId");
+    let dist_domain = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("DistDomain"))
+        .and_then(|o| o.output_value())
+        .map(|s| s.to_string())
+        .expect("DistDomain");
+    assert!(dist_id.starts_with('E'));
+    assert!(dist_domain.ends_with(".cloudfront.net"));
+
+    let described = cf
+        .get_distribution()
+        .id(&dist_id)
+        .send()
+        .await
+        .expect("get_distribution");
+    let dist = described.distribution().expect("distribution");
+    let dcfg = dist.distribution_config().expect("config");
+    assert_eq!(dcfg.comment(), "cfn dist");
+    assert!(dcfg.enabled());
+    let origins = dcfg.origins().expect("origins");
+    assert_eq!(origins.quantity(), 1);
+    let first_origin = origins.items().first().expect("at least one origin");
+    assert_eq!(first_origin.id(), "origin-1");
+    assert_eq!(first_origin.domain_name(), "origin.example.com");
+    let dcb = dcfg.default_cache_behavior().expect("dcb");
+    assert_eq!(dcb.target_origin_id(), "origin-1");
+
+    cfn.delete_stack()
+        .stack_name("cf-dist-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = cf.get_distribution().id(&dist_id).send().await;
+    assert!(after.is_err(), "distribution should be gone");
+}


### PR DESCRIPTION
## Summary

Adds CloudFront::Distribution to the CFN provisioner. Reads DistributionConfig (Origins, DefaultCacheBehavior, Comment, Enabled, PriceClass, HttpVersion, IPV6Enabled, DefaultRootObject, WebACLId, ViewerCertificate), mints a CloudFront distribution id + ARN + domain name, and persists a StoredDistribution.

Patches CFN/wire casing mismatches:
- CustomOriginConfig HTTPPort/HTTPSPort -> HttpPort/HttpsPort
- IPV6Enabled read manually (wire model uses IsIpv6Enabled)

Returns Id/DomainName/Arn as Fn::GetAtt attributes; stack delete removes from state.

Closes BB21 of the parity-gap plan.

## Test plan

- [x] cargo test -p fakecloud-e2e --test cloudformation_cloudfront
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-cloudfront -p fakecloud-e2e --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::CloudFront::Distribution`. Provisions from `DistributionConfig`, mints Id/ARN/domain, stores distribution state, exposes `Id`, `DomainName`, and `Arn` via `Fn::GetAtt`, and cleans up on stack delete.

- **New Features**
  - Patches CFN/wire casing mismatches: `HTTPPort`/`HTTPSPort` -> `HttpPort`/`HttpsPort`; `IPV6Enabled` mapped to `IsIpv6Enabled`.
  - Adds e2e test for create/get/delete; completes BB21 in the parity-gap plan.

<sup>Written for commit 39e83dcb5194500873d2cf0db13d9d720c271879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

