### PR TITLE
fix(s3): emit quoted ETag and ChecksumType in GetObjectAttributes

### DIFF
--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -3506,12 +3506,17 @@ async fn s3_get_object_attributes() {
     );
     let json = output.stdout_json();
 
-    // ETag should match what PutObject returned (without quotes)
+    // ETag must round-trip with the surrounding quote chars AWS itself
+    // emits — SDK clients compare this against PutObject's ETag, which is
+    // also quoted, so unquoted values would fail integrity checks.
     let etag = json["ETag"].as_str().expect("Expected ETag in response");
-    let expected = put_etag.trim_matches('"');
     assert_eq!(
-        etag, expected,
-        "ETag mismatch: got {etag}, expected {expected}"
+        etag, put_etag,
+        "ETag mismatch: got {etag}, expected {put_etag}"
+    );
+    assert!(
+        etag.starts_with('"') && etag.ends_with('"'),
+        "ETag must be quoted: {etag}"
     );
 
     // ObjectSize should match data length
@@ -3523,6 +3528,60 @@ async fn s3_get_object_attributes() {
         .as_str()
         .expect("Expected StorageClass");
     assert_eq!(sc, "STANDARD");
+}
+
+#[tokio::test]
+async fn s3_get_object_attributes_checksum_full_object() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("checksum-attrs")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .put_object()
+        .bucket("checksum-attrs")
+        .key("file.bin")
+        .body(ByteStream::from_static(b"hello world"))
+        .checksum_algorithm(aws_sdk_s3::types::ChecksumAlgorithm::Crc32)
+        .send()
+        .await
+        .unwrap();
+
+    let output = server
+        .aws_cli(&[
+            "s3api",
+            "get-object-attributes",
+            "--bucket",
+            "checksum-attrs",
+            "--key",
+            "file.bin",
+            "--object-attributes",
+            "Checksum",
+        ])
+        .await;
+    assert!(
+        output.success(),
+        "get-object-attributes Checksum failed: {}",
+        output.stderr_text()
+    );
+    let json = output.stdout_json();
+
+    assert!(
+        json["Checksum"]["ChecksumCRC32"].is_string(),
+        "Expected ChecksumCRC32 in response: {json}"
+    );
+    let ct = json["Checksum"]["ChecksumType"]
+        .as_str()
+        .expect("Expected ChecksumType");
+    assert_eq!(
+        ct, "FULL_OBJECT",
+        "Single-part PUT should yield FULL_OBJECT ChecksumType"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -2695,7 +2695,10 @@ impl S3Service {
             let attr = attr.trim();
             match attr {
                 "ETag" => {
-                    body_parts.push(format!("<ETag>{}</ETag>", xml_escape(&obj.etag)));
+                    body_parts.push(format!(
+                        "<ETag>&quot;{}&quot;</ETag>",
+                        xml_escape(&obj.etag)
+                    ));
                 }
                 "StorageClass" => {
                     body_parts.push(format!(
@@ -2709,8 +2712,13 @@ impl S3Service {
                 "Checksum" => {
                     if let (Some(algo), Some(val)) = (&obj.checksum_algorithm, &obj.checksum_value)
                     {
+                        let checksum_type = if obj.parts_count.is_some() {
+                            "COMPOSITE"
+                        } else {
+                            "FULL_OBJECT"
+                        };
                         body_parts.push(format!(
-                            "<Checksum><Checksum{algo}>{val}</Checksum{algo}></Checksum>"
+                            "<Checksum><Checksum{algo}>{val}</Checksum{algo}><ChecksumType>{checksum_type}</ChecksumType></Checksum>"
                         ));
                     }
                 }


### PR DESCRIPTION
## Summary

Phase B1 polish for S3 GetObjectAttributes — closing the two response-field gaps the parity audit flagged. (Other B1 items — `x-amz-bucket-region`, `x-amz-bucket-location-type`, `x-amz-tagging-count`, ListObjects `<Owner>`, CompleteMultipartUpload `<Location>` + checksum, ListBuckets `BucketArn`, ListObjectsV2 `NextContinuationToken` URL-encoding, DeleteObjects `<Quiet>`, etc. — were already shipped in earlier batches.)

- Wrap the `<ETag>` value in surrounding quote chars to match what real AWS emits, so SDK clients that compare against `PutObject`'s (also quoted) ETag get equality.
- Inside `<Checksum>` emit `<ChecksumType>` — `FULL_OBJECT` when the object came from a single-shot PUT, `COMPOSITE` when it was assembled via multipart upload.

## Test plan

- [x] `cargo clippy -p fakecloud-s3 -p fakecloud-e2e --all-targets -- -D warnings` clean.
- [x] Existing `s3_get_object_attributes` updated to assert quoted ETag — passes.
- [x] New `s3_get_object_attributes_checksum_full_object` test exercises the ChecksumType path — passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns S3 GetObjectAttributes with AWS by returning a quoted ETag and including ChecksumType, fixing SDK comparisons and closing a parity gap.

- **Bug Fixes**
  - Return quoted `ETag` in GetObjectAttributes to match AWS and `PutObject`.
  - Emit `ChecksumType` within `Checksum`: `FULL_OBJECT` for single-part PUTs, `COMPOSITE` for multipart uploads.

<sup>Written for commit 458fb7fc2aa461667d0b00502a3622af0a8646af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

