### PR TITLE
fix(dynamodb): emit real ItemCollectionMetrics on LSI tables

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -137,11 +137,13 @@ impl DynamoDbService {
             })?;
 
             let mut write_count = 0u32;
+            let mut keys_for_icm: Vec<HashMap<String, AttributeValue>> = Vec::new();
             for request in reqs {
                 if let Some(put_req) = request.get("PutRequest") {
                     let item: HashMap<String, AttributeValue> =
                         serde_json::from_value(put_req["Item"].clone()).unwrap_or_default();
                     let key = extract_key(table, &item);
+                    keys_for_icm.push(key.clone());
                     if let Some(idx) = table.find_item_index(&key) {
                         table.items[idx] = item;
                     } else {
@@ -151,6 +153,7 @@ impl DynamoDbService {
                 } else if let Some(del_req) = request.get("DeleteRequest") {
                     let key: HashMap<String, AttributeValue> =
                         serde_json::from_value(del_req["Key"].clone()).unwrap_or_default();
+                    keys_for_icm.push(key.clone());
                     if let Some(idx) = table.find_item_index(&key) {
                         table.items.remove(idx);
                     }
@@ -170,8 +173,15 @@ impl DynamoDbService {
                 consumed_capacity.push(cc);
             }
 
-            if return_icm == "SIZE" {
-                item_collection_metrics.insert(table_name.clone(), vec![]);
+            if return_icm == "SIZE" && !table.lsi.is_empty() {
+                let entries: Vec<Value> = keys_for_icm
+                    .iter()
+                    .map(|k| super::helpers::build_item_collection_metrics(&return_icm, table, k))
+                    .filter(|v| !v.is_null())
+                    .collect();
+                if !entries.is_empty() {
+                    item_collection_metrics.insert(table_name.clone(), entries);
+                }
             }
         }
 
@@ -183,7 +193,7 @@ impl DynamoDbService {
             result["ConsumedCapacity"] = json!(consumed_capacity);
         }
 
-        if return_icm == "SIZE" {
+        if return_icm == "SIZE" && !item_collection_metrics.is_empty() {
             result["ItemCollectionMetrics"] = json!(item_collection_metrics);
         }
 

--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -2614,3 +2614,40 @@ pub(crate) fn return_icm_mode(body: &Value) -> &str {
         .as_str()
         .unwrap_or("NONE")
 }
+
+/// Build the per-write `ItemCollectionMetrics` document AWS emits when the
+/// table has at least one local secondary index and the caller asked for
+/// `ReturnItemCollectionMetrics=SIZE`. Returns `Value::Null` whenever the
+/// document should be omitted.
+///
+/// `ItemCollectionKey` is the partition-key attribute of the affected item
+/// — we look up the key-schema's HASH element and copy that attribute from
+/// `key`. `SizeEstimateRangeGB` reports a coarse [lower, upper] estimate;
+/// real DynamoDB returns 0..1 GB for small collections, so we use the same
+/// range as a stand-in until item-collection sizing is tracked precisely.
+pub(crate) fn build_item_collection_metrics(
+    mode: &str,
+    table: &crate::state::DynamoTable,
+    key: &std::collections::HashMap<String, crate::state::AttributeValue>,
+) -> Value {
+    if mode != "SIZE" || table.lsi.is_empty() {
+        return Value::Null;
+    }
+    let partition_key = table
+        .key_schema
+        .iter()
+        .find(|k| k.key_type == "HASH")
+        .map(|k| k.attribute_name.as_str());
+    let mut item_collection_key = serde_json::Map::new();
+    if let Some(pk_name) = partition_key {
+        if let Some(pk_value) = key.get(pk_name) {
+            if let Ok(serialized) = serde_json::to_value(pk_value) {
+                item_collection_key.insert(pk_name.to_string(), serialized);
+            }
+        }
+    }
+    json!({
+        "ItemCollectionKey": Value::Object(item_collection_key),
+        "SizeEstimateRangeGB": [0.0, 1.0],
+    })
+}

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -6,10 +6,11 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
 use super::{
-    apply_update_expression, build_consumed_capacity, evaluate_condition, extract_key, get_table,
-    get_table_mut, parse_expression_attribute_names, parse_expression_attribute_values,
-    project_item, require_object, require_str, return_consumed_mode, return_icm_mode,
-    validate_key_attributes_in_key, validate_key_in_item, DynamoDbService,
+    apply_update_expression, build_consumed_capacity, build_item_collection_metrics,
+    evaluate_condition, extract_key, get_table, get_table_mut, parse_expression_attribute_names,
+    parse_expression_attribute_values, project_item, require_object, require_str,
+    return_consumed_mode, return_icm_mode, validate_key_attributes_in_key, validate_key_in_item,
+    DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -27,7 +28,7 @@ impl DynamoDbService {
 
         // --- Acquire write lock ONLY for validation + mutation ---
         // Capture kinesis delivery info alongside the return value
-        let (old_item, kinesis_info, kms_audit) = {
+        let (old_item, kinesis_info, kms_audit, icm) = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
             let region = state.region.clone();
@@ -94,7 +95,7 @@ impl DynamoDbService {
                 (
                     target,
                     event_name.to_string(),
-                    key,
+                    key.clone(),
                     old_item_for_stream,
                     Some(item.clone()),
                 )
@@ -108,7 +109,9 @@ impl DynamoDbService {
                 None
             };
 
-            (old_item_for_return, kinesis_info, kms_audit)
+            let icm = build_item_collection_metrics(&return_icm, table, &key);
+
+            (old_item_for_return, kinesis_info, kms_audit, icm)
         };
         // --- Write lock released, build response ---
 
@@ -140,8 +143,8 @@ impl DynamoDbService {
         if !cc.is_null() {
             result["ConsumedCapacity"] = cc;
         }
-        if return_icm == "SIZE" {
-            result["ItemCollectionMetrics"] = json!({});
+        if !icm.is_null() {
+            result["ItemCollectionMetrics"] = icm;
         }
 
         Self::ok_json(result)
@@ -297,8 +300,9 @@ impl DynamoDbService {
                 result["ConsumedCapacity"] = cc;
             }
 
-            if return_icm == "SIZE" {
-                result["ItemCollectionMetrics"] = json!({});
+            let icm = build_item_collection_metrics(return_icm, table, &key);
+            if !icm.is_null() {
+                result["ItemCollectionMetrics"] = icm;
             }
 
             (result, kinesis_info)
@@ -422,6 +426,8 @@ impl DynamoDbService {
 
         table.recalculate_stats();
 
+        let icm = build_item_collection_metrics(&return_icm, table, &key);
+
         // Release the write lock (drop `state`)
         drop(accounts);
 
@@ -446,8 +452,8 @@ impl DynamoDbService {
         if !cc.is_null() {
             result["ConsumedCapacity"] = cc;
         }
-        if return_icm == "SIZE" {
-            result["ItemCollectionMetrics"] = json!({});
+        if !icm.is_null() {
+            result["ItemCollectionMetrics"] = icm;
         }
 
         Self::ok_json(result)

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -3793,3 +3793,148 @@ async fn query_select_count_omits_items_array() {
         resp.items()
     );
 }
+
+#[tokio::test]
+async fn dynamodb_put_item_emits_item_collection_metrics_on_lsi_table() {
+    use aws_sdk_dynamodb::types::{LocalSecondaryIndex, ReturnItemCollectionMetrics};
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("LsiTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("lsiSk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .local_secondary_indexes(
+            LocalSecondaryIndex::builder()
+                .index_name("byLsiSk")
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("pk")
+                        .key_type(KeyType::Hash)
+                        .build()
+                        .unwrap(),
+                )
+                .key_schema(
+                    KeySchemaElement::builder()
+                        .attribute_name("lsiSk")
+                        .key_type(KeyType::Range)
+                        .build()
+                        .unwrap(),
+                )
+                .projection(
+                    Projection::builder()
+                        .projection_type(ProjectionType::All)
+                        .build(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .put_item()
+        .table_name("LsiTable")
+        .item("pk", AttributeValue::S("user1".into()))
+        .item("sk", AttributeValue::S("a".into()))
+        .item("lsiSk", AttributeValue::S("z".into()))
+        .return_item_collection_metrics(ReturnItemCollectionMetrics::Size)
+        .send()
+        .await
+        .unwrap();
+
+    let icm = resp
+        .item_collection_metrics()
+        .expect("LSI table should yield ItemCollectionMetrics");
+    let icm_key = icm
+        .item_collection_key()
+        .expect("LSI table response must carry ItemCollectionKey");
+    let pk = icm_key
+        .get("pk")
+        .expect("ItemCollectionKey must include partition key");
+    assert_eq!(pk.as_s().unwrap(), "user1");
+    let range = icm.size_estimate_range_gb();
+    assert!(
+        range.len() == 2 && range[0] >= 0.0 && range[1] >= range[0],
+        "SizeEstimateRangeGB malformed: {range:?}"
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_put_item_omits_item_collection_metrics_without_lsi() {
+    use aws_sdk_dynamodb::types::ReturnItemCollectionMetrics;
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+
+    client
+        .create_table()
+        .table_name("PlainTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .put_item()
+        .table_name("PlainTable")
+        .item("pk", AttributeValue::S("user1".into()))
+        .return_item_collection_metrics(ReturnItemCollectionMetrics::Size)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(
+        resp.item_collection_metrics().is_none(),
+        "Tables without LSI must omit ItemCollectionMetrics"
+    );
+}


### PR DESCRIPTION
## Summary

Phase B4 polish — DynamoDB write ops were returning empty `ItemCollectionMetrics` documents whenever `ReturnItemCollectionMetrics=SIZE` was set, regardless of whether the affected table had a Local Secondary Index. Real AWS only emits the document for LSI tables and populates `ItemCollectionKey` + `SizeEstimateRangeGB`.

- Helper `build_item_collection_metrics(mode, table, key)` in `service/helpers.rs` returns `Value::Null` when the table has no LSI or the caller didn't request `SIZE`; otherwise emits the partition-key attribute plus a `[0.0, 1.0]` size estimate.
- Wire into `PutItem`, `UpdateItem`, `DeleteItem`, and `BatchWriteItem`. Per-write entries accumulate and emit under the affected table name.

## Test plan

- [x] `cargo clippy -p fakecloud-dynamodb -p fakecloud-e2e --all-targets -- -D warnings` clean.
- [x] New `dynamodb_put_item_emits_item_collection_metrics_on_lsi_table` test asserts populated `ItemCollectionKey` + valid `SizeEstimateRangeGB` on an LSI table — passes.
- [x] New `dynamodb_put_item_omits_item_collection_metrics_without_lsi` asserts the document is absent on a plain (no-LSI) table — passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix DynamoDB write responses to emit ItemCollectionMetrics only on tables with an LSI when ReturnItemCollectionMetrics=SIZE, matching AWS. Removes the empty {} payload and returns ItemCollectionKey + SizeEstimateRangeGB where applicable.

- **Bug Fixes**
  - Added `build_item_collection_metrics(mode, table, key)` to emit metrics only for LSI tables and SIZE requests; includes ItemCollectionKey and [0.0, 1.0] SizeEstimateRangeGB.
  - Wired into PutItem, UpdateItem, DeleteItem, and BatchWriteItem; BatchWriteItem accumulates per-write entries per table and omits the field when empty.
  - Added e2e tests to verify metrics appear for LSI tables and are omitted for tables without LSI.

<sup>Written for commit 8d5086876f65175088496b99c61763bd3b6a33e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

