### PR TITLE
fix(lambda): emit StateReason and LastUpdateStatusReason fields

### DIFF
--- a/crates/fakecloud-lambda/src/resource_policy.rs
+++ b/crates/fakecloud-lambda/src/resource_policy.rs
@@ -142,6 +142,10 @@ mod tests {
             signing_job_arn: None,
             runtime_version_config: None,
             master_arn: None,
+            state_reason: None,
+            state_reason_code: None,
+            last_update_status_reason: None,
+            last_update_status_reason_code: None,
         }
     }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1018,6 +1018,10 @@ impl LambdaService {
             signing_job_arn: None,
             runtime_version_config: None,
             master_arn: None,
+            state_reason: None,
+            state_reason_code: None,
+            last_update_status_reason: None,
+            last_update_status_reason_code: None,
         };
 
         let response = self.function_config_json(&func);
@@ -1544,6 +1548,18 @@ impl LambdaService {
                 .iter()
                 .map(|l| json!({"Arn": l.arn, "CodeSize": l.code_size}))
                 .collect::<Vec<_>>());
+        }
+        if let Some(ref r) = func.state_reason {
+            config["StateReason"] = json!(r);
+        }
+        if let Some(ref c) = func.state_reason_code {
+            config["StateReasonCode"] = json!(c);
+        }
+        if let Some(ref r) = func.last_update_status_reason {
+            config["LastUpdateStatusReason"] = json!(r);
+        }
+        if let Some(ref c) = func.last_update_status_reason_code {
+            config["LastUpdateStatusReasonCode"] = json!(c);
         }
         config
     }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1241,3 +1241,44 @@ async fn update_function_configuration_rotates_revision_id() {
     let rev_after = v["Configuration"]["RevisionId"].as_str().unwrap();
     assert_ne!(rev_before, rev_after);
 }
+
+#[tokio::test]
+async fn function_config_emits_state_reason_fields_when_populated() {
+    // GetFunctionConfiguration omits StateReason / StateReasonCode and
+    // their LastUpdateStatus counterparts when unset (default), and
+    // surfaces them verbatim once populated. Real AWS leaves these
+    // absent for healthy functions and only attaches them when a
+    // function transitions out of the happy path.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "reason").await;
+
+    // Default (unset) — fields must be absent, not null/empty-string.
+    let req = make_request(Method::GET, "/2015-03-31/functions/reason", "");
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(v["Configuration"]["StateReason"].is_null());
+    assert!(v["Configuration"]["StateReasonCode"].is_null());
+    assert!(v["Configuration"]["LastUpdateStatusReason"].is_null());
+    assert!(v["Configuration"]["LastUpdateStatusReasonCode"].is_null());
+
+    // Mutate state directly — these fields are AWS-internal, no public
+    // API path to set them. Confirm they round-trip into the response.
+    {
+        let mut accts = svc.state.write();
+        let acct = accts.get_or_create("123456789012");
+        let f = acct.functions.get_mut("reason").unwrap();
+        f.state_reason = Some("EFS access point unavailable".into());
+        f.state_reason_code = Some("EFSMountFailure".into());
+        f.last_update_status_reason = Some("Backoff after 3 attempts".into());
+        f.last_update_status_reason_code = Some("EniLimitExceeded".into());
+    }
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/reason", "");
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let cfg = &v["Configuration"];
+    assert_eq!(cfg["StateReason"], "EFS access point unavailable");
+    assert_eq!(cfg["StateReasonCode"], "EFSMountFailure");
+    assert_eq!(cfg["LastUpdateStatusReason"], "Backoff after 3 attempts");
+    assert_eq!(cfg["LastUpdateStatusReasonCode"], "EniLimitExceeded");
+}

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -97,6 +97,23 @@ pub struct LambdaFunction {
     /// `$LATEST` ARN.
     #[serde(default)]
     pub master_arn: Option<String>,
+    /// Free-form `StateReason` populated when the function is not in the
+    /// happy `Active`/`Successful` path (e.g. image scan failed, KMS key
+    /// disabled, code-signing rejection). `None` for normal functions.
+    #[serde(default)]
+    pub state_reason: Option<String>,
+    /// Machine-readable `StateReasonCode` paired with `state_reason`
+    /// (`Idle`, `Creating`, `Restoring`, `EniLimitExceeded`, …).
+    #[serde(default)]
+    pub state_reason_code: Option<String>,
+    /// Free-form `LastUpdateStatusReason` set on the most recent failed
+    /// or in-progress configuration update.
+    #[serde(default)]
+    pub last_update_status_reason: Option<String>,
+    /// Machine-readable code paired with `last_update_status_reason`
+    /// (`EniLimitExceeded`, `InsufficientRolePermissions`, …).
+    #[serde(default)]
+    pub last_update_status_reason_code: Option<String>,
 }
 
 fn default_revision_id() -> String {


### PR DESCRIPTION
## Summary

Phase B2 polish — `GetFunctionConfiguration` was silently dropping four optional AWS-defined fields that real AWS surfaces when a function transitions out of the happy path:

- `StateReason` / `StateReasonCode`
- `LastUpdateStatusReason` / `LastUpdateStatusReasonCode`

Other B2 items called out in the audit (EphemeralStorage, SnapStart, VpcConfig, FileSystemConfigs, DeadLetterConfig, LoggingConfig, KMSKeyArn, SigningProfileVersionArn, SigningJobArn, RuntimeVersionConfig, ImageConfigResponse, stable RevisionId, configurable TracingConfig) were already shipped in earlier batches.

- Adds the four fields to `LambdaFunction`, all defaulting to `None`.
- Emits each field in `function_config_json` only when populated, matching AWS's pattern of leaving them absent rather than emitting nulls.
- Updates the two existing struct constructors.
- New unit test asserts the fields are absent by default and round-trip verbatim once populated.

## Test plan

- [x] `cargo test -p fakecloud-lambda` — 85 passed.
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GetFunctionConfiguration` to emit `StateReason`, `StateReasonCode`, `LastUpdateStatusReason`, and `LastUpdateStatusReasonCode` when set. Omits them when unset to match real AWS Lambda.

- **Bug Fixes**
  - Added the four fields to `LambdaFunction` (default `None`).
  - Updated config JSON to include these keys only when populated.
  - Updated constructors used in create flow and resource-policy tests.
  - Added a unit test to verify absence by default and verbatim round-trip when set.

<sup>Written for commit 44621617816835c2b8d5efd95bd8aa4b4116a6f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

