### PR TITLE
fix(lambda): round-trip advanced EventSourceMapping fields

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -1732,6 +1732,33 @@ impl LambdaService {
         if let Some(p) = body.get("ParallelizationFactor").and_then(|v| v.as_i64()) {
             esm.parallelization_factor = Some(p);
         }
+        if let Some(s) = body.get("KMSKeyArn").and_then(|v| v.as_str()) {
+            esm.kms_key_arn = Some(s.to_string());
+        }
+        if let Some(mc) = body.get("MetricsConfig") {
+            esm.metrics_config = Some(mc.clone());
+        }
+        if let Some(dc) = body.get("DestinationConfig") {
+            esm.destination_config = Some(dc.clone());
+        }
+        if let Some(n) = body.get("MaximumRetryAttempts").and_then(|v| v.as_i64()) {
+            esm.maximum_retry_attempts = Some(n);
+        }
+        if let Some(n) = body
+            .get("MaximumRecordAgeInSeconds")
+            .and_then(|v| v.as_i64())
+        {
+            esm.maximum_record_age_in_seconds = Some(n);
+        }
+        if let Some(b) = body
+            .get("BisectBatchOnFunctionError")
+            .and_then(|v| v.as_bool())
+        {
+            esm.bisect_batch_on_function_error = Some(b);
+        }
+        if let Some(n) = body.get("TumblingWindowInSeconds").and_then(|v| v.as_i64()) {
+            esm.tumbling_window_in_seconds = Some(n);
+        }
         let mut body_json = json!({
             "UUID": esm.uuid,
             "FunctionArn": esm.function_arn,

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -136,6 +136,39 @@ impl LambdaService {
         let maximum_batching_window_in_seconds = body
             .get("MaximumBatchingWindowInSeconds")
             .and_then(|v| v.as_i64());
+        let kms_key_arn = body
+            .get("KMSKeyArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let metrics_config = body.get("MetricsConfig").cloned();
+        let destination_config = body.get("DestinationConfig").cloned();
+        let maximum_retry_attempts = body.get("MaximumRetryAttempts").and_then(|v| v.as_i64());
+        let maximum_record_age_in_seconds = body
+            .get("MaximumRecordAgeInSeconds")
+            .and_then(|v| v.as_i64());
+        let bisect_batch_on_function_error = body
+            .get("BisectBatchOnFunctionError")
+            .and_then(|v| v.as_bool());
+        let tumbling_window_in_seconds =
+            body.get("TumblingWindowInSeconds").and_then(|v| v.as_i64());
+        let topics: Vec<String> = body
+            .get("Topics")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let queues: Vec<String> = body
+            .get("Queues")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let mapping = EventSourceMapping {
             uuid: mapping_uuid.clone(),
@@ -155,6 +188,15 @@ impl LambdaService {
             starting_position_timestamp,
             parallelization_factor,
             function_response_types,
+            kms_key_arn,
+            metrics_config,
+            destination_config,
+            maximum_retry_attempts,
+            maximum_record_age_in_seconds,
+            bisect_batch_on_function_error,
+            tumbling_window_in_seconds,
+            topics,
+            queues,
         };
 
         let response = self.event_source_mapping_json(&mapping);
@@ -245,14 +287,14 @@ impl LambdaService {
             "State": mapping.state,
             "LastModified": mapping.last_modified.timestamp_millis() as f64 / 1000.0,
             "EventSourceMappingArn": esm_arn,
-            // Default fields AWS always returns (zeros / empty arrays / nulls
-            // when unset). Avoids SDK deserialiser breaks on missing keys.
-            "MaximumRetryAttempts": -1,
-            "MaximumRecordAgeInSeconds": -1,
-            "BisectBatchOnFunctionError": false,
-            "TumblingWindowInSeconds": 0,
-            "Topics": [],
-            "Queues": [],
+            // AWS always returns these — emit stored values, falling back to
+            // the documented defaults (-1 = infinite, false, 0).
+            "MaximumRetryAttempts": mapping.maximum_retry_attempts.unwrap_or(-1),
+            "MaximumRecordAgeInSeconds": mapping.maximum_record_age_in_seconds.unwrap_or(-1),
+            "BisectBatchOnFunctionError": mapping.bisect_batch_on_function_error.unwrap_or(false),
+            "TumblingWindowInSeconds": mapping.tumbling_window_in_seconds.unwrap_or(0),
+            "Topics": mapping.topics,
+            "Queues": mapping.queues,
             "SourceAccessConfigurations": [],
             "LastProcessingResult": "No records processed",
             "StateTransitionReason": "User action",
@@ -283,6 +325,15 @@ impl LambdaService {
         }
         if let Some(w) = mapping.maximum_batching_window_in_seconds {
             obj.insert("MaximumBatchingWindowInSeconds".into(), json!(w));
+        }
+        if let Some(ref kms) = mapping.kms_key_arn {
+            obj.insert("KMSKeyArn".into(), json!(kms));
+        }
+        if let Some(ref mc) = mapping.metrics_config {
+            obj.insert("MetricsConfig".into(), mc.clone());
+        }
+        if let Some(ref dc) = mapping.destination_config {
+            obj.insert("DestinationConfig".into(), dc.clone());
         }
         out
     }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1282,3 +1282,70 @@ async fn function_config_emits_state_reason_fields_when_populated() {
     assert_eq!(cfg["LastUpdateStatusReason"], "Backoff after 3 attempts");
     assert_eq!(cfg["LastUpdateStatusReasonCode"], "EniLimitExceeded");
 }
+
+#[tokio::test]
+async fn create_event_source_mapping_round_trips_advanced_fields() {
+    // KMSKeyArn / MetricsConfig / DestinationConfig / MaximumRetryAttempts /
+    // MaximumRecordAgeInSeconds / BisectBatchOnFunctionError /
+    // TumblingWindowInSeconds / Topics / Queues all need to round-trip
+    // through Create → Get so SDK clients can read what they wrote. The
+    // 2024+ AWS shape requires every one of these fields in the response
+    // when the caller supplied them.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "esm-fn").await;
+
+    let body = json!({
+        "FunctionName": "esm-fn",
+        "EventSourceArn": "arn:aws:sqs:us-east-1:123456789012:queue1",
+        "BatchSize": 10,
+        "Enabled": true,
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abc-def",
+        "MetricsConfig": {"Metrics": ["EventCount"]},
+        "DestinationConfig": {"OnFailure": {"Destination": "arn:aws:sqs:us-east-1:123456789012:dlq"}},
+        "MaximumRetryAttempts": 5,
+        "MaximumRecordAgeInSeconds": 3600,
+        "BisectBatchOnFunctionError": true,
+        "TumblingWindowInSeconds": 60,
+        "Topics": ["t1"],
+        "Queues": ["q1"],
+    });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/event-source-mappings",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let uuid = v["UUID"].as_str().unwrap().to_string();
+    assert_eq!(
+        v["KMSKeyArn"],
+        "arn:aws:kms:us-east-1:123456789012:key/abc-def"
+    );
+    assert_eq!(v["MetricsConfig"]["Metrics"][0], "EventCount");
+    assert_eq!(
+        v["DestinationConfig"]["OnFailure"]["Destination"],
+        "arn:aws:sqs:us-east-1:123456789012:dlq"
+    );
+    assert_eq!(v["MaximumRetryAttempts"], 5);
+    assert_eq!(v["MaximumRecordAgeInSeconds"], 3600);
+    assert_eq!(v["BisectBatchOnFunctionError"], true);
+    assert_eq!(v["TumblingWindowInSeconds"], 60);
+    assert_eq!(v["Topics"][0], "t1");
+    assert_eq!(v["Queues"][0], "q1");
+
+    // Get the mapping back and assert all fields survive a round-trip.
+    let req = make_request(
+        Method::GET,
+        &format!("/2015-03-31/event-source-mappings/{uuid}"),
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        v["KMSKeyArn"],
+        "arn:aws:kms:us-east-1:123456789012:key/abc-def"
+    );
+    assert_eq!(v["BisectBatchOnFunctionError"], true);
+    assert_eq!(v["MaximumRetryAttempts"], 5);
+    assert_eq!(v["Topics"][0], "t1");
+}

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -161,6 +161,40 @@ pub struct EventSourceMapping {
     /// semantics. Empty / unset = entire batch is retried on error.
     #[serde(default)]
     pub function_response_types: Vec<String>,
+    /// KMS key for encrypting the filter-criteria document at rest. AWS
+    /// added this in 2024 for Kafka/Kinesis sources whose filters carry
+    /// sensitive selectors.
+    #[serde(default)]
+    pub kms_key_arn: Option<String>,
+    /// `MetricsConfig.Metrics` — set of opted-in CloudWatch metrics
+    /// (`["EventCount"]`). Round-tripped only; fakecloud doesn't yet
+    /// publish these metrics.
+    #[serde(default)]
+    pub metrics_config: Option<serde_json::Value>,
+    /// `DestinationConfig` — `OnFailure.Destination` arn (and rarely
+    /// `OnSuccess.Destination` for self-managed Kafka). Round-tripped.
+    #[serde(default)]
+    pub destination_config: Option<serde_json::Value>,
+    /// `MaximumRetryAttempts` for the source. AWS uses `-1` to mean
+    /// "infinite" so we keep the int rather than a bool.
+    #[serde(default)]
+    pub maximum_retry_attempts: Option<i64>,
+    /// `MaximumRecordAgeInSeconds`. `-1` = infinite.
+    #[serde(default)]
+    pub maximum_record_age_in_seconds: Option<i64>,
+    /// `BisectBatchOnFunctionError` — split the batch in half and retry
+    /// on Lambda invoke failure (Kinesis / DDB streams only).
+    #[serde(default)]
+    pub bisect_batch_on_function_error: Option<bool>,
+    /// `TumblingWindowInSeconds` — Kinesis-only batch aggregation window.
+    #[serde(default)]
+    pub tumbling_window_in_seconds: Option<i64>,
+    /// `Topics` — MSK / self-managed-Kafka topic list.
+    #[serde(default)]
+    pub topics: Vec<String>,
+    /// `Queues` — Amazon MQ broker queue list.
+    #[serde(default)]
+    pub queues: Vec<String>,
 }
 
 /// A recorded Lambda invocation from cross-service delivery.


### PR DESCRIPTION
## Summary

Phase B3 polish — `CreateEventSourceMapping` was silently dropping nine optional fields that the 2024+ AWS shape requires to round-trip via Get/List/Update:

- `KMSKeyArn`, `MetricsConfig`, `DestinationConfig`
- `MaximumRetryAttempts`, `MaximumRecordAgeInSeconds`, `BisectBatchOnFunctionError`
- `TumblingWindowInSeconds`, `Topics`, `Queues`

Pre-fix, callers that wrote these values would read defaults back, and `UpdateEventSourceMapping` couldn't change them at all.

- Adds the nine fields to `EventSourceMapping`, all serde-defaulted.
- Parses them in `create_event_source_mapping` and persists.
- `event_source_mapping_json` reads stored values and conditionally emits the optional fields.
- `update_event_source_mapping_handler` accepts the same fields.
- New unit test asserts every field round-trips through Create → Get.

## Test plan

- [x] `cargo test -p fakecloud-lambda` — 86 passing.
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `CreateEventSourceMapping` and `UpdateEventSourceMapping` to round-trip nine advanced fields so clients read back what they set, matching the 2024+ AWS shape. Prevents silent drops that returned defaults and blocked updates.

- **Bug Fixes**
  - Parse, persist, and emit `KMSKeyArn`, `MetricsConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `MaximumRecordAgeInSeconds`, `BisectBatchOnFunctionError`, `TumblingWindowInSeconds`, `Topics`, and `Queues` across create/get/list/update.
  - Use AWS default fallbacks when unset (-1, false, 0, empty arrays) in responses.
  - Add a unit test to assert full Create → Get round-trip.

<sup>Written for commit 0d99eb17070811345dcc73ce26c24ab2c510546b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

