### PR TITLE
fix(elasticache): emit parameter group, security groups, log delivery, and encryption flags on cache clusters

### DIFF
--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -633,6 +633,55 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
         String::new()
     };
 
+    let cache_parameter_group_xml = match &cluster.cache_parameter_group_name {
+        Some(name) => format!(
+            "<CacheParameterGroup>\
+             <CacheParameterGroupName>{}</CacheParameterGroupName>\
+             <ParameterApplyStatus>in-sync</ParameterApplyStatus>\
+             </CacheParameterGroup>",
+            xml_escape(name)
+        ),
+        None => String::new(),
+    };
+    let security_groups_xml = if cluster.security_group_ids.is_empty() {
+        "<SecurityGroups/>".to_string()
+    } else {
+        format!(
+            "<SecurityGroups>{}</SecurityGroups>",
+            cluster
+                .security_group_ids
+                .iter()
+                .map(|sg| format!(
+                    "<SecurityGroupMembership>\
+                     <SecurityGroupId>{}</SecurityGroupId>\
+                     <Status>active</Status>\
+                     </SecurityGroupMembership>",
+                    xml_escape(sg)
+                ))
+                .collect::<String>()
+        )
+    };
+    let log_delivery_configurations_xml = if cluster.log_delivery_configurations.is_empty() {
+        "<LogDeliveryConfigurations/>".to_string()
+    } else {
+        let entries: String = cluster
+            .log_delivery_configurations
+            .iter()
+            .map(log_delivery_configuration_xml)
+            .collect();
+        format!("<LogDeliveryConfigurations>{entries}</LogDeliveryConfigurations>")
+    };
+    let configuration_endpoint_xml =
+        if cluster.replication_group_id.is_some() && !cluster.endpoint_address.is_empty() {
+            format!(
+            "<ConfigurationEndpoint><Address>{}</Address><Port>{}</Port></ConfigurationEndpoint>",
+            xml_escape(&cluster.endpoint_address),
+            cluster.endpoint_port
+        )
+        } else {
+            String::new()
+        };
+
     format!(
         "<CacheClusterId>{}</CacheClusterId>\
          <CacheNodeType>{}</CacheNodeType>\
@@ -644,6 +693,13 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
          <CacheClusterCreateTime>{}</CacheClusterCreateTime>\
          {cache_subnet_group_name_xml}\
          {cache_nodes_xml}\
+         {cache_parameter_group_xml}\
+         {security_groups_xml}\
+         {log_delivery_configurations_xml}\
+         {configuration_endpoint_xml}\
+         <TransitEncryptionEnabled>{}</TransitEncryptionEnabled>\
+         <AtRestEncryptionEnabled>{}</AtRestEncryptionEnabled>\
+         <AuthTokenEnabled>{}</AuthTokenEnabled>\
          <AutoMinorVersionUpgrade>{}</AutoMinorVersionUpgrade>\
          {replication_group_id_xml}\
          <ARN>{}</ARN>",
@@ -655,6 +711,9 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
         cluster.num_cache_nodes,
         xml_escape(&cluster.preferred_availability_zone),
         xml_escape(&cluster.created_at),
+        cluster.transit_encryption_enabled,
+        cluster.at_rest_encryption_enabled,
+        cluster.auth_token_enabled,
         cluster.auto_minor_version_upgrade,
         xml_escape(&cluster.arn),
     )
@@ -1314,4 +1373,79 @@ pub(crate) fn parameter_xml(p: &EngineDefaultParameter) -> String {
         p.is_modifiable,
         xml_escape(&p.minimum_engine_version),
     )
+}
+
+#[cfg(test)]
+mod cluster_xml_tests {
+    use super::*;
+    use crate::state::{CacheCluster, LogDeliveryConfiguration};
+
+    fn fixture() -> CacheCluster {
+        CacheCluster {
+            cache_cluster_id: "c1".into(),
+            cache_node_type: "cache.t3.micro".into(),
+            engine: "redis".into(),
+            engine_version: "7.1".into(),
+            cache_cluster_status: "available".into(),
+            num_cache_nodes: 1,
+            preferred_availability_zone: "us-east-1a".into(),
+            cache_subnet_group_name: None,
+            auto_minor_version_upgrade: true,
+            arn: "arn:aws:elasticache:us-east-1:000000000000:cluster:c1".into(),
+            created_at: "2026-05-02T00:00:00Z".into(),
+            endpoint_address: "127.0.0.1".into(),
+            endpoint_port: 6379,
+            container_id: String::new(),
+            host_port: 6379,
+            replication_group_id: None,
+            cache_parameter_group_name: None,
+            security_group_ids: Vec::new(),
+            log_delivery_configurations: Vec::new(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            auth_token_enabled: false,
+        }
+    }
+
+    #[test]
+    fn defaults_emit_canonical_flags() {
+        let c = fixture();
+        let xml = cache_cluster_xml(&c, false);
+        assert!(xml.contains("<TransitEncryptionEnabled>false</TransitEncryptionEnabled>"));
+        assert!(xml.contains("<AtRestEncryptionEnabled>false</AtRestEncryptionEnabled>"));
+        assert!(xml.contains("<AuthTokenEnabled>false</AuthTokenEnabled>"));
+        // No parameter group / security groups / log destinations set.
+        assert!(!xml.contains("<CacheParameterGroup>"));
+        assert!(xml.contains("<SecurityGroups/>"));
+        assert!(xml.contains("<LogDeliveryConfigurations/>"));
+        // No replication group => no ConfigurationEndpoint emitted.
+        assert!(!xml.contains("<ConfigurationEndpoint>"));
+    }
+
+    #[test]
+    fn populated_fields_round_trip() {
+        let mut c = fixture();
+        c.cache_parameter_group_name = Some("default.redis7".into());
+        c.security_group_ids = vec!["sg-abc".into(), "sg-def".into()];
+        c.transit_encryption_enabled = true;
+        c.at_rest_encryption_enabled = true;
+        c.auth_token_enabled = true;
+        c.log_delivery_configurations = vec![LogDeliveryConfiguration {
+            log_type: "slow-log".into(),
+            destination_type: "cloudwatch-logs".into(),
+            destination_details: Some("my-log-group".into()),
+            log_format: "json".into(),
+            status: "active".into(),
+        }];
+        c.replication_group_id = Some("rg1".into());
+        let xml = cache_cluster_xml(&c, false);
+        assert!(xml.contains("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"));
+        assert!(xml.contains("<SecurityGroupId>sg-abc</SecurityGroupId>"));
+        assert!(xml.contains("<SecurityGroupId>sg-def</SecurityGroupId>"));
+        assert!(xml.contains("<TransitEncryptionEnabled>true</TransitEncryptionEnabled>"));
+        assert!(xml.contains("<AtRestEncryptionEnabled>true</AtRestEncryptionEnabled>"));
+        assert!(xml.contains("<AuthTokenEnabled>true</AuthTokenEnabled>"));
+        assert!(xml.contains("<LogType>slow-log</LogType>"));
+        assert!(xml.contains("<ConfigurationEndpoint>"));
+    }
 }

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -837,6 +837,19 @@ impl ElastiCacheService {
             optional_query_param(request, "AutoMinorVersionUpgrade").as_deref(),
         )?
         .unwrap_or(true);
+        let cache_parameter_group_name = optional_query_param(request, "CacheParameterGroupName");
+        let security_group_ids =
+            parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
+        let log_delivery_configurations = parse_log_delivery_configs(request);
+        let transit_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "TransitEncryptionEnabled").as_deref(),
+        )?
+        .unwrap_or(false);
+        let at_rest_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "AtRestEncryptionEnabled").as_deref(),
+        )?
+        .unwrap_or(false);
+        let auth_token_enabled = optional_query_param(request, "AuthToken").is_some();
 
         let (preferred_availability_zone, arn) = {
             let mut accounts = self.state.write();
@@ -936,6 +949,12 @@ impl ElastiCacheService {
             container_id: running.container_id,
             host_port: running.host_port,
             replication_group_id,
+            cache_parameter_group_name,
+            security_group_ids,
+            log_delivery_configurations,
+            transit_encryption_enabled,
+            at_rest_encryption_enabled,
+            auth_token_enabled,
         };
 
         let xml = cache_cluster_xml(&cluster, true);

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -147,8 +147,13 @@ fn cache_cluster_xml_contains_expected_fields() {
         container_id: "abc123".to_string(),
         host_port: 6379,
         replication_group_id: Some("rg-1".to_string()),
+        cache_parameter_group_name: None,
+        security_group_ids: Vec::new(),
+        log_delivery_configurations: Vec::new(),
+        transit_encryption_enabled: false,
+        at_rest_encryption_enabled: false,
+        auth_token_enabled: false,
     };
-
     let xml = cache_cluster_xml(&cluster, true);
     assert!(xml.contains("<CacheClusterId>classic-1</CacheClusterId>"));
     assert!(xml.contains("<CacheNodeType>cache.t3.micro</CacheNodeType>"));
@@ -682,6 +687,12 @@ fn service_with_cache_cluster(cluster_id: &str) -> ElastiCacheService {
                 container_id: "abc123".to_string(),
                 host_port: 6379,
                 replication_group_id: None,
+                cache_parameter_group_name: None,
+                security_group_ids: Vec::new(),
+                log_delivery_configurations: Vec::new(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                auth_token_enabled: false,
             },
         );
     }
@@ -715,6 +726,12 @@ fn describe_cache_clusters_returns_all() {
                 container_id: "def456".to_string(),
                 host_port: 6380,
                 replication_group_id: None,
+                cache_parameter_group_name: None,
+                security_group_ids: Vec::new(),
+                log_delivery_configurations: Vec::new(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                auth_token_enabled: false,
             },
         );
     }
@@ -2936,6 +2953,12 @@ async fn reboot_cache_cluster_marks_rebooting_when_no_runtime() {
                 container_id: "abc123".to_string(),
                 host_port: 6379,
                 replication_group_id: None,
+                cache_parameter_group_name: None,
+                security_group_ids: Vec::new(),
+                log_delivery_configurations: Vec::new(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                auth_token_enabled: false,
             },
         );
     }

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -105,6 +105,29 @@ pub struct CacheCluster {
     pub container_id: String,
     pub host_port: u16,
     pub replication_group_id: Option<String>,
+    /// `CacheParameterGroup.CacheParameterGroupName` — group bound at
+    /// create / modify time. Real AWS always emits this membership;
+    /// fakecloud previously omitted the element entirely.
+    #[serde(default)]
+    pub cache_parameter_group_name: Option<String>,
+    /// VPC security group ids attached at create time. Echoed via
+    /// `<SecurityGroups>` for parity with AWS DescribeCacheClusters.
+    #[serde(default)]
+    pub security_group_ids: Vec<String>,
+    /// `LogDeliveryConfigurations` — destinations + log types attached
+    /// to the cluster. Round-tripped only.
+    #[serde(default)]
+    pub log_delivery_configurations: Vec<LogDeliveryConfiguration>,
+    /// In-transit encryption flag. Real AWS always emits this; defaults
+    /// to `false` for unencrypted clusters.
+    #[serde(default)]
+    pub transit_encryption_enabled: bool,
+    /// At-rest encryption flag.
+    #[serde(default)]
+    pub at_rest_encryption_enabled: bool,
+    /// `AuthTokenEnabled` — true when an AUTH token was supplied.
+    #[serde(default)]
+    pub auth_token_enabled: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1192,6 +1215,12 @@ mod tests {
                 container_id: "abc123".to_string(),
                 host_port: 12345,
                 replication_group_id: None,
+                cache_parameter_group_name: None,
+                security_group_ids: Vec::new(),
+                log_delivery_configurations: Vec::new(),
+                transit_encryption_enabled: false,
+                at_rest_encryption_enabled: false,
+                auth_token_enabled: false,
             },
         );
         assert_eq!(state.cache_clusters.len(), 1);


### PR DESCRIPTION
## Summary

Phase B6 polish — `cache_cluster_xml` was stripping six fields real AWS always emits. Replication-group XML already covered them; cluster XML didn't.

- Adds 6 fields to `CacheCluster`: `cache_parameter_group_name`, `security_group_ids`, `log_delivery_configurations`, `transit_encryption_enabled`, `at_rest_encryption_enabled`, `auth_token_enabled`. All serde-defaulted.
- `CreateCacheCluster` parses and persists them.
- `cache_cluster_xml` emits the corresponding XML, with empty-list sentinels for parity with AWS's "always present, possibly empty" pattern. `ConfigurationEndpoint` is emitted only for clusters that belong to a replication group.

## Test plan

- [x] `cargo test -p fakecloud-elasticache` — 181 passing.
- [x] `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` clean.
- [x] New `cluster_xml_tests` cover all-defaults and all-populated paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `DescribeCacheClusters` responses with AWS by always emitting parameter group, security groups, log delivery, and encryption/auth flags. Also emits `ConfigurationEndpoint` only for clusters in a replication group, and parses/persists these fields on `CreateCacheCluster`.

- **Bug Fixes**
  - Added six fields to `CacheCluster`: `cache_parameter_group_name`, `security_group_ids`, `log_delivery_configurations`, `transit_encryption_enabled`, `at_rest_encryption_enabled`, `auth_token_enabled` (serde-defaulted for backward compatibility).
  - `cache_cluster_xml` now outputs the new elements, uses empty-list sentinels for `<SecurityGroups/>` and `<LogDeliveryConfigurations/>`, and only emits `<ConfigurationEndpoint>` when `replication_group_id` is set.
  - `CreateCacheCluster` parses `CacheParameterGroupName`, `SecurityGroupIds`, `LogDeliveryConfigurations`, `TransitEncryptionEnabled`, `AtRestEncryptionEnabled`, and `AuthToken` (sets `auth_token_enabled`).
  - Added unit tests for default and populated paths; updated fixtures.

<sup>Written for commit e78a7dd59be84b9aaaeb74ceb2d2879678bdd4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

