### PR TITLE
fix(ecs): emit capacityProviderName on Task

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -2864,6 +2864,10 @@ impl ResourceProvisioner {
             signing_job_arn: None,
             runtime_version_config: None,
             master_arn: None,
+            state_reason: None,
+            state_reason_code: None,
+            last_update_status_reason: None,
+            last_update_status_reason_code: None,
         };
 
         let mut accounts = self.lambda_state.write();
@@ -3096,6 +3100,15 @@ impl ResourceProvisioner {
             starting_position_timestamp,
             parallelization_factor,
             function_response_types,
+            kms_key_arn: None,
+            metrics_config: None,
+            destination_config: None,
+            maximum_retry_attempts: None,
+            maximum_record_age_in_seconds: None,
+            bisect_batch_on_function_error: None,
+            tumbling_window_in_seconds: None,
+            topics: Vec::new(),
+            queues: Vec::new(),
         };
         state.event_source_mappings.insert(uuid.clone(), esm);
         Ok(ProvisionResult::new(uuid.clone()).with("Id", uuid))
@@ -7770,6 +7783,12 @@ impl ResourceProvisioner {
             container_id: String::new(),
             host_port: 0,
             replication_group_id: None,
+            cache_parameter_group_name: None,
+            security_group_ids: Vec::new(),
+            log_delivery_configurations: Vec::new(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            auth_token_enabled: false,
         };
         state.cache_clusters.insert(id.clone(), cluster);
         Ok(ProvisionResult::new(id.clone())

--- a/crates/fakecloud-e2e/tests/ecs_capacity_provider_name.rs
+++ b/crates/fakecloud-e2e/tests/ecs_capacity_provider_name.rs
@@ -1,0 +1,97 @@
+//! Verify Task.capacityProviderName surfaces in DescribeTasks when the
+//! task was launched via a capacity-provider strategy. AWS exposes the
+//! resolved capacity provider on the task itself; SDK clients (CDK,
+//! terraform) match on this field to assert tasks ended up where
+//! intended.
+
+mod helpers;
+
+use aws_sdk_ecs::types::{CapacityProviderStrategyItem, ContainerDefinition};
+use helpers::TestServer;
+
+#[tokio::test]
+async fn run_task_emits_capacity_provider_name_on_task() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("cp-cluster")
+        .capacity_providers("FARGATE_SPOT")
+        .send()
+        .await
+        .unwrap();
+    ecs.register_task_definition()
+        .family("cp-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("true")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let run = ecs
+        .run_task()
+        .cluster("cp-cluster")
+        .task_definition("cp-family")
+        .capacity_provider_strategy(
+            CapacityProviderStrategyItem::builder()
+                .capacity_provider("FARGATE_SPOT")
+                .weight(1)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("run_task");
+
+    let task = &run.tasks()[0];
+    assert_eq!(
+        task.capacity_provider_name(),
+        Some("FARGATE_SPOT"),
+        "Task should carry the strategy's resolved capacityProviderName"
+    );
+}
+
+#[tokio::test]
+async fn run_task_without_strategy_omits_capacity_provider_name() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("plain-cluster")
+        .send()
+        .await
+        .unwrap();
+    ecs.register_task_definition()
+        .family("plain-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("true")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let run = ecs
+        .run_task()
+        .cluster("plain-cluster")
+        .task_definition("plain-family")
+        .send()
+        .await
+        .expect("run_task");
+
+    let task = &run.tasks()[0];
+    assert!(
+        task.capacity_provider_name().is_none(),
+        "RunTask without a CP strategy should not populate capacityProviderName"
+    );
+}

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -500,6 +500,9 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
             .unwrap_or("HEALTHY")),
     );
     map.insert("version".into(), json!(1));
+    if let Some(ref cp) = task.capacity_provider_name {
+        map.insert("capacityProviderName".into(), json!(cp));
+    }
     map.insert(
         "platformFamily".into(),
         match task.launch_type.as_str() {
@@ -711,6 +714,7 @@ pub(crate) fn spawn_service_tasks(
             task_definition_arn: td_arn.clone(),
             family: family.clone(),
             revision,
+            capacity_provider_name: None,
             last_status: "PENDING".into(),
             desired_status: "RUNNING".into(),
             launch_type: launch_type.into(),

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -905,6 +905,7 @@ mod tests {
             task_definition_arn: "arn:aws:ecs:us-east-1:000000000000:task-definition/app:1".into(),
             family: "app".into(),
             revision: 1,
+            capacity_provider_name: None,
             last_status: "PENDING".into(),
             desired_status: "RUNNING".into(),
             launch_type: "FARGATE".into(),

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -151,6 +151,13 @@ impl EcsService {
                     container_name: name,
                 })
             });
+            let capacity_provider_name = body
+                .get("capacityProviderStrategy")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|item| item.get("capacityProvider"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
             let task = Task {
                 task_arn: task_arn.clone(),
                 task_id: task_id.clone(),
@@ -159,6 +166,7 @@ impl EcsService {
                 task_definition_arn: td_arn.clone(),
                 family: td_family.clone(),
                 revision: td_revision,
+                capacity_provider_name,
                 last_status: "PROVISIONING".into(),
                 desired_status: "RUNNING".into(),
                 launch_type: launch_type.clone(),

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -376,6 +376,12 @@ pub struct Task {
     pub task_definition_arn: String,
     pub family: String,
     pub revision: i32,
+    /// Capacity provider this task was placed on. Set when the launch
+    /// went through a `capacityProviderStrategy`; absent for direct
+    /// `launchType=EC2/FARGATE` calls. AWS's Task model emits this at
+    /// the top level next to `launchType`.
+    #[serde(default)]
+    pub capacity_provider_name: Option<String>,
     /// Current lifecycle state: PROVISIONING, PENDING, RUNNING,
     /// DEPROVISIONING, STOPPED.
     pub last_status: String,


### PR DESCRIPTION
## Summary

Phase B8 polish — `DescribeTasks` was omitting the top-level `capacityProviderName` field AWS returns when a task was launched via a capacity-provider strategy. SDK clients (CDK, terraform) match on this to assert that tasks ended up on the intended provider.

- New `capacity_provider_name: Option<String>` on `Task`, serde-defaulted.
- `RunTask` populates it from `capacityProviderStrategy[0].capacityProvider`.
- `task_to_json` emits the field only when populated, matching AWS's "absent when unset" pattern.
- CFN provisioner ctors brought back into sync with `LambdaFunction`, `EventSourceMapping`, and `CacheCluster` field additions from #1043 / #1044 / #1045.

## Test plan

- [x] `cargo test -p fakecloud-ecs --lib` — 33 passing.
- [x] `cargo build --workspace` clean.
- [x] `cargo clippy -p fakecloud-ecs -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings` clean.
- [x] New e2e `ecs_capacity_provider_name` covers strategy-set and unset paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ECS DescribeTasks to include the top-level capacityProviderName when tasks use a capacity-provider strategy, so clients can verify placement. Also syncs CFN provisioner constructors to recent field additions to keep the workspace building.

- **Bug Fixes**
  - `fakecloud-ecs`: add `capacity_provider_name: Option<String>` to `Task`.
  - Populate from the first `capacityProviderStrategy` item during task creation.
  - Emit `capacityProviderName` in DescribeTasks only when set (absent otherwise).
  - New e2e test covers strategy set/unset paths in `fakecloud-e2e`.

- **Refactors**
  - `fakecloud-cloudformation`: update provisioner constructors for LambdaFunction, EventSourceMapping, and CacheCluster to include recently added optional fields.

<sup>Written for commit 0ff5a25d05e7aab5253059affb963c4c3a1aa2cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

