### PR TITLE
refactor(sns): unify cross-service publish path with direct fan-out

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -108,6 +108,20 @@ pub trait SqsDelivery: Send + Sync {
 /// Trait for publishing messages to SNS topics.
 pub trait SnsDelivery: Send + Sync {
     fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>);
+
+    /// Publish to a FIFO SNS topic carrying the message group/dedup IDs
+    /// that downstream SQS subscribers need for ordering. Default impl
+    /// drops the IDs so non-FIFO callers don't have to override.
+    fn publish_to_topic_fifo(
+        &self,
+        topic_arn: &str,
+        message: &str,
+        subject: Option<&str>,
+        _message_group_id: Option<&str>,
+        _message_dedup_id: Option<&str>,
+    ) {
+        self.publish_to_topic(topic_arn, message, subject);
+    }
 }
 
 /// Trait for putting events onto an EventBridge bus from cross-service integrations.

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -19,8 +19,15 @@ impl SnsDeliveryImpl {
     }
 }
 
-impl SnsDelivery for SnsDeliveryImpl {
-    fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>) {
+impl SnsDeliveryImpl {
+    fn fan_out(
+        &self,
+        topic_arn: &str,
+        message: &str,
+        subject: Option<&str>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) {
         let mut accounts = self.state.write();
 
         // Parse account from topic ARN (arn:aws:sns:region:ACCOUNT:name)
@@ -34,50 +41,29 @@ impl SnsDelivery for SnsDeliveryImpl {
         }
 
         let msg_id = uuid::Uuid::new_v4().to_string();
+        let attrs: BTreeMap<String, crate::state::MessageAttribute> = BTreeMap::new();
         state.published.push(PublishedMessage {
             message_id: msg_id.clone(),
             topic_arn: topic_arn.to_string(),
             message: message.to_string(),
             subject: subject.map(|s| s.to_string()),
-            message_attributes: BTreeMap::new(),
-            message_group_id: None,
-            message_dedup_id: None,
+            message_attributes: attrs.clone(),
+            message_group_id: message_group_id.map(|s| s.to_string()),
+            message_dedup_id: message_dedup_id.map(|s| s.to_string()),
             timestamp: Utc::now(),
         });
 
-        // Fan out to SQS subscribers
-        let sqs_subscribers: Vec<String> = state
-            .subscriptions
-            .values()
-            .filter(|s| s.topic_arn == topic_arn && s.protocol == "sqs" && s.confirmed)
-            .map(|s| s.endpoint.clone())
-            .collect();
+        // Reuse the same subscriber-collection helper the direct
+        // publish() path uses, so filter-policy + confirmation logic is
+        // shared instead of duplicated.
+        let subscribers =
+            crate::service::collect_topic_subscribers(state, topic_arn, &attrs, message);
 
-        // Collect Lambda, email, and SMS subscribers
-        let lambda_subscribers: Vec<(String, String)> = state
-            .subscriptions
-            .values()
-            .filter(|s| s.topic_arn == topic_arn && s.protocol == "lambda" && s.confirmed)
-            .map(|s| (s.endpoint.clone(), s.subscription_arn.clone()))
-            .collect();
-
-        let email_subscribers: Vec<String> = state
-            .subscriptions
-            .values()
-            .filter(|s| {
-                s.topic_arn == topic_arn
-                    && (s.protocol == "email" || s.protocol == "email-json")
-                    && s.confirmed
-            })
-            .map(|s| s.endpoint.clone())
-            .collect();
-
-        let sms_subscribers: Vec<String> = state
-            .subscriptions
-            .values()
-            .filter(|s| s.topic_arn == topic_arn && s.protocol == "sms" && s.confirmed)
-            .map(|s| s.endpoint.clone())
-            .collect();
+        let sqs_subscribers: Vec<(String, bool)> = subscribers.sqs.clone();
+        let lambda_subscribers: Vec<(String, String)> = subscribers.lambda.clone();
+        let email_subscribers: Vec<String> = subscribers.email.clone();
+        let sms_subscribers: Vec<String> = subscribers.sms.clone();
+        let http_subscribers: Vec<crate::service::HttpSubscriber> = subscribers.http.clone();
 
         let endpoint = state.endpoint.clone();
 
@@ -180,9 +166,62 @@ impl SnsDelivery for SnsDeliveryImpl {
         );
         let envelope_str = serde_json::Value::Object(envelope_map).to_string();
 
-        for queue_arn in sqs_subscribers {
-            self.delivery
-                .send_to_sqs(&queue_arn, &envelope_str, &HashMap::new());
+        for (queue_arn, _raw) in sqs_subscribers {
+            self.delivery.send_to_sqs_with_attrs(
+                &queue_arn,
+                &envelope_str,
+                &HashMap::new(),
+                message_group_id,
+                message_dedup_id,
+            );
+        }
+
+        // HTTP/HTTPS subscribers honour DeliveryPolicy + RedrivePolicy
+        // exactly like the direct publish() path.
+        for sub in http_subscribers {
+            let body = envelope_str.clone();
+            let topic = topic_arn.to_string();
+            let delivery = self.delivery.clone();
+            tokio::spawn(async move {
+                let policy =
+                    crate::service::parse_http_delivery_policy(sub.delivery_policy.as_deref());
+                let client = reqwest::Client::new();
+                let mut last_err: Option<String> = None;
+                let attempts = policy.num_retries.saturating_add(1);
+                for attempt in 0..attempts {
+                    if attempt > 0 {
+                        let delay_ms = crate::service::retry_delay_ms(&policy, attempt);
+                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    }
+                    let resp = client
+                        .post(&sub.endpoint)
+                        .header("Content-Type", "application/json")
+                        .header("x-amz-sns-message-type", "Notification")
+                        .header("x-amz-sns-topic-arn", &topic)
+                        .header("x-amz-sns-subscription-arn", &sub.subscription_arn)
+                        .body(body.clone())
+                        .send()
+                        .await;
+                    match resp {
+                        Ok(r) if r.status().is_success() => return,
+                        Ok(r) => last_err = Some(format!("HTTP {}", r.status())),
+                        Err(e) => last_err = Some(e.to_string()),
+                    }
+                }
+                let err = last_err.unwrap_or_else(|| "unknown".to_string());
+                tracing::warn!(
+                    endpoint = %sub.endpoint,
+                    error = %err,
+                    "SNS cross-service HTTP delivery exhausted retries"
+                );
+                if let Some(dlq_arn) =
+                    crate::service::parse_redrive_dlq(sub.redrive_policy.as_deref())
+                {
+                    let dlq_body =
+                        crate::service::build_dlq_envelope(&body, &err, &sub.subscription_arn);
+                    delivery.send_to_sqs(&dlq_arn, &dlq_body, &HashMap::new());
+                }
+            });
         }
 
         // Invoke Lambda subscribers via container runtime
@@ -218,6 +257,29 @@ impl SnsDelivery for SnsDeliveryImpl {
                 }
             });
         }
+    }
+}
+
+impl SnsDelivery for SnsDeliveryImpl {
+    fn publish_to_topic(&self, topic_arn: &str, message: &str, subject: Option<&str>) {
+        self.fan_out(topic_arn, message, subject, None, None);
+    }
+
+    fn publish_to_topic_fifo(
+        &self,
+        topic_arn: &str,
+        message: &str,
+        subject: Option<&str>,
+        message_group_id: Option<&str>,
+        message_dedup_id: Option<&str>,
+    ) {
+        self.fan_out(
+            topic_arn,
+            message,
+            subject,
+            message_group_id,
+            message_dedup_id,
+        );
     }
 }
 

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1605,12 +1605,12 @@ pub(crate) struct SnsLambdaEventInput<'a> {
 /// re-filter the subscriptions map five times inline.
 pub(crate) struct TopicSubscribers {
     /// (queue_arn, raw_message_delivery)
-    sqs: Vec<(String, bool)>,
-    http: Vec<HttpSubscriber>,
+    pub(crate) sqs: Vec<(String, bool)>,
+    pub(crate) http: Vec<HttpSubscriber>,
     /// (function_arn, subscription_arn)
-    lambda: Vec<(String, String)>,
-    email: Vec<String>,
-    sms: Vec<String>,
+    pub(crate) lambda: Vec<(String, String)>,
+    pub(crate) email: Vec<String>,
+    pub(crate) sms: Vec<String>,
 }
 
 /// HTTP/HTTPS subscriber with the per-subscription DeliveryPolicy +
@@ -1656,6 +1656,9 @@ const UPPER_OPS: &[&str] = &["<", "<="];
 mod service_platform;
 #[path = "service_publish.rs"]
 mod service_publish;
+pub(crate) use service_publish::{
+    build_dlq_envelope, parse_http_delivery_policy, parse_redrive_dlq, retry_delay_ms,
+};
 #[path = "service_sms.rs"]
 mod service_sms;
 


### PR DESCRIPTION
## Summary

- Cross-service SNS publish now uses `collect_topic_subscribers` so EventBridge / other callers honor the same filter-policy + subscription-confirmation rules as direct `Publish`.
- Adds HTTP/HTTPS delivery to the cross-service path with DeliveryPolicy retries + RedrivePolicy DLQ routing.
- Adds `publish_to_topic_fifo` trait method so SQS subscribers receive `MessageGroupId` / `MessageDeduplicationId` on FIFO topics.
- TopicSubscribers fields exposed `pub(crate)` so helper module is single source of truth.

Closes plan K5 (SNS cross-service publish unification).

## Test plan

- [x] `cargo test -p fakecloud-sns --lib` 188 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies SNS cross-service publish with the direct fan-out path so filter policies and confirmations match. Adds HTTP/HTTPS delivery with retries + DLQ and a FIFO publish API that passes ordering attributes to SQS.

- **New Features**
  - HTTP/HTTPS delivery in the cross-service path with DeliveryPolicy retries and RedrivePolicy DLQ routing.
  - `publish_to_topic_fifo` in `SnsDelivery` to include `MessageGroupId` and `MessageDeduplicationId` for FIFO topics.

- **Refactors**
  - Cross-service publish now reuses `collect_topic_subscribers` to share filter-policy and subscription confirmation logic.
  - SQS fan-out uses `send_to_sqs_with_attrs` to carry FIFO attributes.
  - `TopicSubscribers` fields exposed as `pub(crate)` to centralize subscriber collection.

<sup>Written for commit 5398be3086a07f7e3fe6f21a420085adf6a8ba22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

