### PR TITLE
refactor(eventbridge): unify cross-service target dispatch

### DIFF
--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -1,11 +1,13 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
 
 use fakecloud_core::delivery::{DeliveryBus, EventBridgeDelivery};
+use fakecloud_lambda::runtime::ContainerRuntime;
+use fakecloud_lambda::SharedLambdaState;
+use fakecloud_logs::SharedLogsState;
 
-use crate::service::matches_pattern;
+use crate::service::{dispatch_event_target, matches_pattern, EventDispatchContext};
 use crate::state::{PutEvent, SharedEventBridgeState};
 
 /// Implements EventBridgeDelivery so other services (SES) can put events
@@ -13,11 +15,35 @@ use crate::state::{PutEvent, SharedEventBridgeState};
 pub struct EventBridgeDeliveryImpl {
     state: SharedEventBridgeState,
     delivery: Arc<DeliveryBus>,
+    lambda_state: Option<SharedLambdaState>,
+    logs_state: Option<SharedLogsState>,
+    container_runtime: Option<Arc<ContainerRuntime>>,
 }
 
 impl EventBridgeDeliveryImpl {
     pub fn new(state: SharedEventBridgeState, delivery: Arc<DeliveryBus>) -> Self {
-        Self { state, delivery }
+        Self {
+            state,
+            delivery,
+            lambda_state: None,
+            logs_state: None,
+            container_runtime: None,
+        }
+    }
+
+    pub fn with_lambda(mut self, lambda_state: SharedLambdaState) -> Self {
+        self.lambda_state = Some(lambda_state);
+        self
+    }
+
+    pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
+        self.logs_state = Some(logs_state);
+        self
+    }
+
+    pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {
+        self.container_runtime = Some(runtime);
+        self
     }
 }
 
@@ -95,15 +121,23 @@ impl EventBridgeDeliveryImpl {
         });
         let event_str = event_json.to_string();
 
+        let _ = event_str;
+        let resolved_account = if let Some(acct) = target_account_id {
+            acct.to_string()
+        } else {
+            account_id.clone()
+        };
+        let ctx = EventDispatchContext {
+            state: &self.state,
+            delivery: &self.delivery,
+            lambda_state: self.lambda_state.as_ref(),
+            logs_state: self.logs_state.as_ref(),
+            container_runtime: &self.container_runtime,
+            account_id: &resolved_account,
+            region: &region,
+        };
         for target in matching_targets {
-            let arn = &target.arn;
-            if arn.contains(":sqs:") {
-                self.delivery.send_to_sqs(arn, &event_str, &HashMap::new());
-            } else if arn.contains(":sns:") {
-                self.delivery
-                    .publish_to_sns(arn, &event_str, Some(detail_type));
-            }
-            // Lambda and other targets could be added here
+            dispatch_event_target(&ctx, &target, &event_json, &event_id, detail_type);
         }
     }
 }
@@ -138,7 +172,7 @@ mod tests {
     use fakecloud_aws::arn::Arn;
     use fakecloud_core::delivery::{SnsDelivery, SqsDelivery};
     use parking_lot::RwLock;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Mutex;
 
     #[derive(Default)]

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -945,3 +945,198 @@ pub(crate) fn apply_connection_auth(
     }
     builder
 }
+
+/// Context shared by both put_events (direct) and put_event_in_account
+/// (cross-service) when dispatching matched targets. Optional state
+/// handles let cross-service callers (which may not be wired with full
+/// service plumbing) gracefully degrade — e.g. Lambda dispatch becomes
+/// a fire-and-forget log unless `lambda_state` is wired.
+pub(crate) struct EventDispatchContext<'a> {
+    pub(crate) state: &'a crate::state::SharedEventBridgeState,
+    pub(crate) delivery: &'a std::sync::Arc<fakecloud_core::delivery::DeliveryBus>,
+    pub(crate) lambda_state: Option<&'a fakecloud_lambda::SharedLambdaState>,
+    pub(crate) logs_state: Option<&'a fakecloud_logs::SharedLogsState>,
+    pub(crate) container_runtime:
+        &'a Option<std::sync::Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
+    pub(crate) account_id: &'a str,
+    pub(crate) region: &'a str,
+}
+
+/// Single-target dispatch shared by direct PutEvents and cross-service
+/// put_event_in_account so both honour the same target shape (SQS/SNS/
+/// Lambda/Logs/Kinesis/StepFunctions/ApiDestination/HTTP) and the same
+/// InputTransformer + InputPath body resolution.
+pub(crate) fn dispatch_event_target(
+    ctx: &EventDispatchContext,
+    target: &crate::state::EventTarget,
+    event_json: &Value,
+    event_id: &str,
+    detail_type: &str,
+) {
+    let arn = &target.arn;
+    let event_str = event_json.to_string();
+    let body_str = if let Some(ref transformer) = target.input_transformer {
+        apply_input_transformer(transformer, event_json)
+    } else if let Some(ref input) = target.input {
+        input.clone()
+    } else if let Some(ref input_path) = target.input_path {
+        resolve_json_path(event_json, input_path)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| event_str.clone())
+    } else {
+        event_str.clone()
+    };
+
+    if arn.contains(":sqs:") {
+        let group_id = target
+            .sqs_parameters
+            .as_ref()
+            .and_then(|p| p["MessageGroupId"].as_str())
+            .map(|s| s.to_string());
+        if group_id.is_some() {
+            ctx.delivery.send_to_sqs_with_attrs(
+                arn,
+                &body_str,
+                &HashMap::new(),
+                group_id.as_deref(),
+                None,
+            );
+        } else {
+            ctx.delivery.send_to_sqs(arn, &body_str, &HashMap::new());
+        }
+    } else if arn.contains(":sns:") {
+        ctx.delivery
+            .publish_to_sns(arn, &body_str, Some(detail_type));
+    } else if arn.contains(":lambda:") {
+        tracing::info!(
+            function_arn = %arn,
+            payload = %body_str,
+            "EventBridge delivering to Lambda function"
+        );
+        let now = chrono::Utc::now();
+        {
+            let mut accounts = ctx.state.write();
+            let s = accounts.get_or_create(ctx.account_id);
+            s.lambda_invocations.push(crate::state::LambdaInvocation {
+                function_arn: arn.clone(),
+                payload: body_str.clone(),
+                timestamp: now,
+            });
+        }
+        if let Some(ls) = ctx.lambda_state {
+            ls.write()
+                .default_mut()
+                .invocations
+                .push(fakecloud_lambda::LambdaInvocation {
+                    function_arn: arn.clone(),
+                    payload: body_str.clone(),
+                    timestamp: now,
+                    source: "aws:events".to_string(),
+                });
+        }
+        invoke_lambda_async(
+            ctx.container_runtime,
+            &ctx.lambda_state.cloned(),
+            arn,
+            &body_str,
+        );
+    } else if arn.contains(":logs:") {
+        tracing::info!(
+            log_group_arn = %arn,
+            payload = %body_str,
+            "EventBridge delivering to CloudWatch Logs"
+        );
+        let now = chrono::Utc::now();
+        {
+            let mut accounts = ctx.state.write();
+            let s = accounts.get_or_create(ctx.account_id);
+            s.log_deliveries.push(crate::state::LogDelivery {
+                log_group_arn: arn.clone(),
+                payload: body_str.clone(),
+                timestamp: now,
+            });
+        }
+        if let Some(log_state) = ctx.logs_state {
+            deliver_to_logs(log_state, arn, &body_str, now);
+        }
+    } else if arn.contains(":kinesis:") {
+        tracing::info!(
+            stream_arn = %arn,
+            "EventBridge delivering to Kinesis stream"
+        );
+        ctx.delivery.send_to_kinesis(arn, &body_str, event_id);
+    } else if arn.contains(":states:") {
+        tracing::info!(
+            state_machine_arn = %arn,
+            "EventBridge delivering to Step Functions"
+        );
+        ctx.delivery.start_stepfunctions_execution(arn, &body_str);
+        let mut accounts = ctx.state.write();
+        let s = accounts.get_or_create(ctx.account_id);
+        s.step_function_executions
+            .push(crate::state::StepFunctionExecution {
+                state_machine_arn: arn.clone(),
+                payload: body_str.clone(),
+                timestamp: chrono::Utc::now(),
+            });
+    } else if arn.contains(":api-destination/") {
+        let accounts = ctx.state.read();
+        let empty = crate::state::EventBridgeState::new(ctx.account_id, ctx.region);
+        let s = accounts.get(ctx.account_id).unwrap_or(&empty);
+        let dest = s.api_destinations.values().find(|d| d.arn == *arn).cloned();
+        let conn = dest.as_ref().and_then(|d| {
+            s.connections
+                .values()
+                .find(|c| c.arn == d.connection_arn)
+                .cloned()
+        });
+        drop(accounts);
+        if let Some(dest) = dest {
+            let url = dest.invocation_endpoint;
+            let method = dest.http_method;
+            let payload = body_str.clone();
+            tokio::spawn(async move {
+                let client = reqwest::Client::new();
+                let mut req_builder = match method.as_str() {
+                    "GET" => client.get(&url),
+                    "PUT" => client.put(&url),
+                    "DELETE" => client.delete(&url),
+                    "PATCH" => client.patch(&url),
+                    "HEAD" => client.head(&url),
+                    _ => client.post(&url),
+                };
+                req_builder = req_builder.header("Content-Type", "application/json");
+                if let Some(conn) = conn {
+                    req_builder = apply_connection_auth(req_builder, &conn);
+                }
+                let result = req_builder.body(payload).send().await;
+                if let Err(e) = result {
+                    tracing::warn!(
+                        endpoint = %url,
+                        error = %e,
+                        "EventBridge ApiDestination delivery failed"
+                    );
+                }
+            });
+        }
+    } else if arn.starts_with("https://") || arn.starts_with("http://") {
+        let url = arn.clone();
+        let payload = body_str.clone();
+        tokio::spawn(async move {
+            let client = reqwest::Client::new();
+            let result = client
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .body(payload)
+                .send()
+                .await;
+            if let Err(e) = result {
+                tracing::warn!(
+                    endpoint = %url,
+                    error = %e,
+                    "EventBridge HTTP target delivery failed"
+                );
+            }
+        });
+    }
+}

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -1300,7 +1300,10 @@ impl EventBridgeService {
         // Drop the lock before delivering
         drop(accounts);
 
-        // Deliver to targets
+        // Deliver to targets — single-target dispatch lives in the
+        // shared helper so cross-service callers (delivery.rs) honor the
+        // same target shape (SQS/SNS/Lambda/Logs/Kinesis/StepFunctions/
+        // ApiDestination/HTTP) and the same InputTransformer rules.
         for (event_id, source, detail_type, detail, time, resources, targets) in events_to_deliver {
             let detail_value: Value = serde_json::from_str(&detail).unwrap_or(json!({}));
             let event_json = json!({
@@ -1314,186 +1317,18 @@ impl EventBridgeService {
                 "region": req.region,
                 "resources": resources,
             });
-            let event_str = event_json.to_string();
 
+            let ctx = EventDispatchContext {
+                state: &self.state,
+                delivery: &self.delivery,
+                lambda_state: self.lambda_state.as_ref(),
+                logs_state: self.logs_state.as_ref(),
+                container_runtime: &self.container_runtime,
+                account_id: &req.account_id,
+                region: &req.region,
+            };
             for target in targets {
-                let arn = &target.arn;
-                // Compute the message body, applying InputTransformer if present
-                let body_str = if let Some(ref transformer) = target.input_transformer {
-                    apply_input_transformer(transformer, &event_json)
-                } else if let Some(ref input) = target.input {
-                    input.clone()
-                } else if let Some(ref input_path) = target.input_path {
-                    resolve_json_path(&event_json, input_path)
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| event_str.clone())
-                } else {
-                    event_str.clone()
-                };
-
-                if arn.contains(":sqs:") {
-                    // Extract FIFO parameters (MessageGroupId)
-                    let group_id = target
-                        .sqs_parameters
-                        .as_ref()
-                        .and_then(|p| p["MessageGroupId"].as_str())
-                        .map(|s| s.to_string());
-                    if group_id.is_some() {
-                        // FIFO queue: send with group ID but no dedup ID.
-                        // Queues with content-based dedup will auto-generate one;
-                        // queues without it will reject the message.
-                        self.delivery.send_to_sqs_with_attrs(
-                            arn,
-                            &body_str,
-                            &HashMap::new(),
-                            group_id.as_deref(),
-                            None,
-                        );
-                    } else {
-                        self.delivery.send_to_sqs(arn, &body_str, &HashMap::new());
-                    }
-                } else if arn.contains(":sns:") {
-                    self.delivery
-                        .publish_to_sns(arn, &body_str, Some(&detail_type));
-                } else if arn.contains(":lambda:") {
-                    tracing::info!(
-                        function_arn = %arn,
-                        payload = %body_str,
-                        "EventBridge delivering to Lambda function"
-                    );
-                    let now = Utc::now();
-                    let mut accounts = self.state.write();
-                    let state = accounts.get_or_create(&req.account_id);
-                    state
-                        .lambda_invocations
-                        .push(crate::state::LambdaInvocation {
-                            function_arn: arn.clone(),
-                            payload: body_str.clone(),
-                            timestamp: now,
-                        });
-                    drop(accounts);
-                    // Record in Lambda state for cross-service visibility
-                    if let Some(ref ls) = self.lambda_state {
-                        ls.write().default_mut().invocations.push(LambdaInvocation {
-                            function_arn: arn.clone(),
-                            payload: body_str.clone(),
-                            timestamp: now,
-                            source: "aws:events".to_string(),
-                        });
-                    }
-                    // Actually invoke the Lambda function if a container runtime is available
-                    invoke_lambda_async(
-                        &self.container_runtime,
-                        &self.lambda_state,
-                        arn,
-                        &body_str,
-                    );
-                } else if arn.contains(":logs:") {
-                    tracing::info!(
-                        log_group_arn = %arn,
-                        payload = %body_str,
-                        "EventBridge delivering to CloudWatch Logs"
-                    );
-                    let now = Utc::now();
-                    let mut accounts = self.state.write();
-                    let state = accounts.get_or_create(&req.account_id);
-                    state.log_deliveries.push(crate::state::LogDelivery {
-                        log_group_arn: arn.clone(),
-                        payload: body_str.clone(),
-                        timestamp: now,
-                    });
-                    drop(accounts);
-                    // Write event to CloudWatch Logs state
-                    if let Some(ref log_state) = self.logs_state {
-                        deliver_to_logs(log_state, arn, &body_str, now);
-                    }
-                } else if arn.contains(":kinesis:") {
-                    tracing::info!(
-                        stream_arn = %arn,
-                        "EventBridge delivering to Kinesis stream"
-                    );
-                    // Use event ID as partition key for even distribution
-                    self.delivery.send_to_kinesis(arn, &body_str, &event_id);
-                } else if arn.contains(":states:") {
-                    tracing::info!(
-                        state_machine_arn = %arn,
-                        "EventBridge delivering to Step Functions"
-                    );
-                    self.delivery.start_stepfunctions_execution(arn, &body_str);
-                    let mut accounts = self.state.write();
-                    let state = accounts.get_or_create(&req.account_id);
-                    state
-                        .step_function_executions
-                        .push(crate::state::StepFunctionExecution {
-                            state_machine_arn: arn.clone(),
-                            payload: body_str.clone(),
-                            timestamp: Utc::now(),
-                        });
-                } else if arn.contains(":api-destination/") {
-                    // ApiDestination target: look up destination + connection, then POST
-                    let accounts = self.state.read();
-                    let empty = EventBridgeState::new(&req.account_id, &req.region);
-                    let state = accounts.get(&req.account_id).unwrap_or(&empty);
-                    let dest = state.api_destinations.values().find(|d| d.arn == *arn);
-                    if let Some(dest) = dest {
-                        let url = dest.invocation_endpoint.clone();
-                        let method = dest.http_method.clone();
-                        let conn = state
-                            .connections
-                            .values()
-                            .find(|c| c.arn == dest.connection_arn)
-                            .cloned();
-                        drop(accounts);
-
-                        let payload = body_str.clone();
-                        tokio::spawn(async move {
-                            let client = reqwest::Client::new();
-                            let mut req_builder = match method.as_str() {
-                                "GET" => client.get(&url),
-                                "PUT" => client.put(&url),
-                                "DELETE" => client.delete(&url),
-                                "PATCH" => client.patch(&url),
-                                "HEAD" => client.head(&url),
-                                _ => client.post(&url),
-                            };
-                            req_builder = req_builder.header("Content-Type", "application/json");
-
-                            // Apply auth from connection
-                            if let Some(conn) = conn {
-                                req_builder = apply_connection_auth(req_builder, &conn);
-                            }
-
-                            let result = req_builder.body(payload).send().await;
-                            if let Err(e) = result {
-                                tracing::warn!(
-                                    endpoint = %url,
-                                    error = %e,
-                                    "EventBridge ApiDestination delivery failed"
-                                );
-                            }
-                        });
-                    }
-                } else if arn.starts_with("https://") || arn.starts_with("http://") {
-                    // HTTP target — fire-and-forget POST
-                    let url = arn.clone();
-                    let payload = body_str.clone();
-                    tokio::spawn(async move {
-                        let client = reqwest::Client::new();
-                        let result = client
-                            .post(&url)
-                            .header("Content-Type", "application/json")
-                            .body(payload)
-                            .send()
-                            .await;
-                        if let Err(e) = result {
-                            tracing::warn!(
-                                endpoint = %url,
-                                error = %e,
-                                "EventBridge HTTP target delivery failed"
-                            );
-                        }
-                    });
-                }
+                dispatch_event_target(&ctx, &target, &event_json, &event_id, &detail_type);
             }
         }
 


### PR DESCRIPTION
## Summary

- Both PutEvents (direct) and put_event_in_account (cross-service EventBridgeDelivery) now route through shared `dispatch_event_target` helper.
- Cross-service path (delivery.rs) now fires SQS + SNS + Lambda + Logs + Kinesis + Step Functions + ApiDestination + HTTP targets (was SQS + SNS only).
- New `EventDispatchContext` bundles state + delivery bus + optional lambda/logs/runtime handles for graceful degradation.
- `EventBridgeDeliveryImpl` gains `with_lambda` / `with_logs` / `with_runtime` builders for future wiring.

Closes plan K9 (EventBridge cross-service target unification).

## Test plan

- [x] `cargo test -p fakecloud-eventbridge --lib` 204 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies EventBridge target dispatch so direct `PutEvents` and cross-service puts share the same path, making behavior consistent and expanding cross-service delivery beyond SQS/SNS.

- **New Features**
  - Cross-service `put_event_in_account` now delivers to SQS, SNS, Lambda, Logs, Kinesis, Step Functions, ApiDestination, and HTTP.
  - Applies `InputTransformer`/`InputPath` the same way as direct `PutEvents`.
  - Adds `with_lambda`, `with_logs`, and `with_runtime` builders on `EventBridgeDeliveryImpl` for optional full wiring and graceful fallback.

- **Refactors**
  - Introduces shared `dispatch_event_target` and `EventDispatchContext` used by both code paths.
  - Replaces large per-target logic with a single call, reducing duplication and keeping target behavior in one place.
  - Aligns with plan K9 (cross-service target unification).

<sup>Written for commit 0e106017ee843cc832599ef55f5e7e04ef36c4ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

