### PR TITLE
feat(logs): write CreateExportTask + CreateDelivery output to real S3

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -19,6 +19,8 @@ pub struct DeliveryBus {
     kinesis_sender: Option<Arc<dyn KinesisDelivery>>,
     /// Start Step Functions executions.
     stepfunctions_starter: Option<Arc<dyn StepFunctionsDelivery>>,
+    /// Write objects to S3 buckets.
+    s3_writer: Option<Arc<dyn S3Delivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -173,6 +175,22 @@ pub trait StepFunctionsDelivery: Send + Sync {
     fn start_execution(&self, state_machine_arn: &str, input: &str);
 }
 
+/// Cross-service S3 writer used by services that need to deliver
+/// content to S3 buckets without taking a direct dep on the S3 crate
+/// (CloudWatch Logs export tasks, Kinesis Firehose, ELB access logs).
+pub trait S3Delivery: Send + Sync {
+    /// Put an object to a bucket. Returns the bucket name on success
+    /// or an error string the caller can surface in tests / logs.
+    fn put_object(
+        &self,
+        account_id: &str,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+        content_type: Option<&str>,
+    ) -> Result<(), String>;
+}
+
 /// Outbound email dispatch used by services that emulate AWS flows that
 /// route through SES (Cognito verification, etc.) without taking a direct
 /// dependency on the SES crate.
@@ -232,6 +250,28 @@ impl DeliveryBus {
             lambda_invoker: None,
             kinesis_sender: None,
             stepfunctions_starter: None,
+            s3_writer: None,
+        }
+    }
+
+    pub fn with_s3(mut self, sender: Arc<dyn S3Delivery>) -> Self {
+        self.s3_writer = Some(sender);
+        self
+    }
+
+    /// Write content to S3. Returns Err when no S3 writer is wired or
+    /// when the underlying impl rejects the bucket / payload.
+    pub fn put_object_to_s3(
+        &self,
+        account_id: &str,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+        content_type: Option<&str>,
+    ) -> Result<(), String> {
+        match self.s3_writer {
+            Some(ref sender) => sender.put_object(account_id, bucket, key, body, content_type),
+            None => Err("S3 writer not configured".to_string()),
         }
     }
 

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -77,32 +77,54 @@ impl LogsService {
             ("RUNNING".to_string(), "Task is running".to_string())
         };
 
-        // Collect matching events and write to export storage
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        if from_time < to_time {
-            if let Some(group) = state.log_groups.get(&log_group_name) {
-                let mut exported_lines: Vec<String> = Vec::new();
-                for (stream_name, stream) in &group.log_streams {
-                    // Apply stream name prefix filter if provided
-                    if let Some(ref prefix) = log_stream_name_prefix {
-                        if !stream_name.starts_with(prefix.as_str()) {
-                            continue;
+        // Collect matching events. Render the export payload, then
+        // write it to the destination S3 bucket via the delivery bus
+        // so DescribeLogGroups callers can verify content via real
+        // S3 GetObject. Falls back to the internal export_storage map
+        // when no S3 writer is wired (in-process tests).
+        let mut exported_lines: Vec<String> = Vec::new();
+        {
+            let accounts = self.state.read();
+            let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            if from_time < to_time {
+                if let Some(group) = state.log_groups.get(&log_group_name) {
+                    for (stream_name, stream) in &group.log_streams {
+                        if let Some(ref prefix) = log_stream_name_prefix {
+                            if !stream_name.starts_with(prefix.as_str()) {
+                                continue;
+                            }
                         }
-                    }
-                    for event in &stream.events {
-                        if event.timestamp >= from_time && event.timestamp < to_time {
-                            exported_lines.push(event.message.clone());
+                        for event in &stream.events {
+                            if event.timestamp >= from_time && event.timestamp < to_time {
+                                exported_lines.push(event.message.clone());
+                            }
                         }
                     }
                 }
-                if !exported_lines.is_empty() {
-                    let export_key = format!(
+            }
+        }
+
+        let s3_key = format!("{destination_prefix}/{log_group_name}/{task_id}");
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        if from_time < to_time && !exported_lines.is_empty() {
+            let data = exported_lines.join("\n");
+            let body = data.into_bytes();
+            match self.delivery_bus.put_object_to_s3(
+                &req.account_id,
+                &destination,
+                &s3_key,
+                body.clone(),
+                Some("text/plain"),
+            ) {
+                Ok(()) => {}
+                Err(_) => {
+                    let fallback_key = format!(
                         "{}/{}/{}/{}",
                         destination, destination_prefix, log_group_name, task_id
                     );
-                    let data = exported_lines.join("\n");
-                    state.export_storage.insert(export_key, data.into_bytes());
+                    state.export_storage.insert(fallback_key, body);
                 }
             }
         }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -473,24 +473,43 @@ impl LogsService {
             })
             .collect();
 
-        // Write delivery pipeline events to internal export storage
+        // Write delivery pipeline events to the destination S3 bucket
+        // via the delivery bus so subscribers can read them with real
+        // S3 GetObject. Falls back to the internal export_storage map
+        // when no S3 writer is wired (in-process tests).
         if !delivery_targets.is_empty() && !accepted_events.is_empty() {
             let lines: Vec<String> = accepted_events.iter().map(|e| e.message.clone()).collect();
             let data = lines.join("\n");
             let now_str = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+            let account_id_owned = state.account_id.clone();
             for dest_arn in &delivery_targets {
-                // Extract bucket name from S3 ARN: arn:aws:s3:::bucket-name
                 let bucket = dest_arn.strip_prefix("arn:aws:s3:::").unwrap_or(dest_arn);
-                let key = format!(
-                    "{}/delivery/{}/{}/{}",
-                    bucket, group_name_owned, stream_name_owned, now_str
+                let s3_key = format!(
+                    "delivery/{}/{}/{}",
+                    group_name_owned, stream_name_owned, now_str
                 );
-                // Append to existing data if present
-                let entry = state.export_storage.entry(key).or_default();
-                if !entry.is_empty() {
-                    entry.push(b'\n');
+                let body = data.clone().into_bytes();
+                if self
+                    .delivery_bus
+                    .put_object_to_s3(
+                        &account_id_owned,
+                        bucket,
+                        &s3_key,
+                        body.clone(),
+                        Some("text/plain"),
+                    )
+                    .is_err()
+                {
+                    let fallback_key = format!(
+                        "{}/delivery/{}/{}/{}",
+                        bucket, group_name_owned, stream_name_owned, now_str
+                    );
+                    let entry = state.export_storage.entry(fallback_key).or_default();
+                    if !entry.is_empty() {
+                        entry.push(b'\n');
+                    }
+                    entry.extend_from_slice(data.as_bytes());
                 }
-                entry.extend_from_slice(data.as_bytes());
             }
         }
 

--- a/crates/fakecloud-s3/src/delivery.rs
+++ b/crates/fakecloud-s3/src/delivery.rs
@@ -1,0 +1,109 @@
+use bytes::Bytes;
+use chrono::Utc;
+use fakecloud_core::delivery::S3Delivery;
+use md5::{Digest, Md5};
+
+use crate::state::{memory_body, S3Object, SharedS3State};
+
+/// Lets non-S3 services write objects to buckets without taking a
+/// direct dep on this crate. Used by CloudWatch Logs export tasks,
+/// CloudWatch Logs deliveries, Firehose S3 destinations, ELB access
+/// logs, and similar producers.
+pub struct S3DeliveryImpl {
+    state: SharedS3State,
+}
+
+impl S3DeliveryImpl {
+    pub fn new(state: SharedS3State) -> Self {
+        Self { state }
+    }
+}
+
+impl S3Delivery for S3DeliveryImpl {
+    fn put_object(
+        &self,
+        account_id: &str,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+        content_type: Option<&str>,
+    ) -> Result<(), String> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        let bucket_ref = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| format!("bucket {bucket} not found in account {account_id}"))?;
+
+        let bytes = Bytes::from(body);
+        let size = bytes.len() as u64;
+        let etag = format!("{:x}", Md5::digest(&bytes));
+        let obj = S3Object {
+            key: key.to_string(),
+            body: memory_body(bytes),
+            content_type: content_type
+                .unwrap_or("application/octet-stream")
+                .to_string(),
+            etag,
+            size,
+            last_modified: Utc::now(),
+            ..Default::default()
+        };
+        bucket_ref.objects.insert(key.to_string(), obj);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{S3Bucket, S3State};
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "123456789012";
+
+    fn shared_state() -> SharedS3State {
+        let mut mas: MultiAccountState<S3State> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://localhost");
+        let st = mas.get_or_create(ACCOUNT);
+        st.buckets.insert(
+            "logs-bucket".to_string(),
+            S3Bucket::new("logs-bucket", "us-east-1", "owner-id"),
+        );
+        Arc::new(RwLock::new(mas))
+    }
+
+    #[test]
+    fn put_object_writes_to_bucket() {
+        let state = shared_state();
+        let delivery = S3DeliveryImpl::new(state.clone());
+        delivery
+            .put_object(
+                ACCOUNT,
+                "logs-bucket",
+                "exports/run-1.txt",
+                b"hello world".to_vec(),
+                Some("text/plain"),
+            )
+            .expect("put should succeed");
+        let accounts = state.read();
+        let st = accounts.get(ACCOUNT).unwrap();
+        let bucket = st.buckets.get("logs-bucket").unwrap();
+        let obj = bucket.objects.get("exports/run-1.txt").unwrap();
+        assert_eq!(obj.size, 11);
+        assert_eq!(obj.content_type, "text/plain");
+        assert!(!obj.etag.is_empty());
+    }
+
+    #[test]
+    fn put_object_rejects_missing_bucket() {
+        let state = shared_state();
+        let delivery = S3DeliveryImpl::new(state);
+        let err = delivery
+            .put_object(ACCOUNT, "ghost", "k", b"x".to_vec(), None)
+            .expect_err("missing bucket");
+        assert!(err.contains("not found"));
+    }
+}

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod delivery;
 pub mod inventory;
 pub mod lifecycle;
 pub mod logging;
@@ -8,5 +9,6 @@ pub mod simulation;
 pub(crate) mod state;
 mod xml_util;
 
+pub use delivery::S3DeliveryImpl;
 pub use service::S3Service;
 pub use state::{memory_body, S3Bucket, S3Object, S3State, SharedS3State};

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -499,9 +499,13 @@ async fn main() {
         fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
     let kinesis_delivery_for_dynamodb =
         fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+    let s3_delivery_for_logs = Arc::new(fakecloud_s3::delivery::S3DeliveryImpl::new(
+        s3_state.clone(),
+    ));
     let mut delivery_for_logs = DeliveryBus::new()
         .with_sqs(sqs_delivery.clone())
-        .with_kinesis(kinesis_delivery);
+        .with_kinesis(kinesis_delivery)
+        .with_s3(s3_delivery_for_logs);
     if let Some(ref ld) = lambda_delivery {
         delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
     }


### PR DESCRIPTION
## Summary

- CreateExportTask now writes rendered log payload to destination S3 bucket via new S3Delivery cross-service hook.
- Subscription delivery targets ending in `arn:aws:s3:::<bucket>` route through the same path.
- New `S3Delivery` trait in fakecloud-core + `S3DeliveryImpl` in fakecloud-s3 + `put_object_to_s3` on DeliveryBus.
- Falls back to internal `export_storage` map when no S3 writer wired (in-process tests).

Closes plan Z2 (CreateExportTask / CreateDelivery to real S3).

## Test plan

- [x] `cargo test -p fakecloud-s3 --lib delivery` 2 new unit tests pass
- [x] `cargo test -p fakecloud-logs --lib` 259 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudWatch Logs export tasks and subscription deliveries now write rendered payloads to real S3 via a cross-service S3 writer, so consumers can read exports with S3 GetObject. Falls back to internal `export_storage` when S3 isn’t wired.

- **New Features**
  - Added `S3Delivery` trait in `fakecloud-core` and `put_object_to_s3` on DeliveryBus.
  - Implemented `S3DeliveryImpl` in `fakecloud-s3` that stores objects with computed ETag.
  - Updated `CreateExportTask` and S3-target subscriptions in `fakecloud-logs` to route `arn:aws:s3:::<bucket>` via the delivery bus.
  - Wired `S3DeliveryImpl` into the logs `DeliveryBus` in `fakecloud-server`.

<sup>Written for commit 9075b107f6f92b4dd199c8cc038cf27a73d1da93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

