### PR TITLE
feat(ecr): execute replication rules on PutImage

### DIFF
--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -746,7 +746,106 @@ impl EcrService {
         if should_scan {
             self.trigger_scan(&account, &name, &digest);
         }
+        self.replicate_image(&account, &name, &digest);
         Ok(response)
+    }
+
+    /// Copy a freshly-pushed image to every destination configured by
+    /// the registry's replication rules, recording the per-destination
+    /// status so DescribeImageReplicationStatus returns real data.
+    /// Synchronous because every destination is in-process.
+    fn replicate_image(&self, source_account: &str, repo_name: &str, digest: &str) {
+        use crate::state::{ImageReplicationStatus, Repository};
+
+        let (rules, image, layer_blobs, source_registry_id, source_uri) = {
+            let accounts = self.state.read();
+            let Some(state) = accounts.get(source_account) else {
+                return;
+            };
+            let Some(cfg) = state.replication_configuration.as_ref() else {
+                return;
+            };
+            let Some(repo) = state.repositories.get(repo_name) else {
+                return;
+            };
+            let Some(image) = repo.images.get(digest).cloned() else {
+                return;
+            };
+            let layers: Vec<crate::state::Layer> = layers_for_image(repo, digest);
+            (
+                cfg.rules.clone(),
+                image,
+                layers,
+                repo.registry_id.clone(),
+                repo.repository_uri.clone(),
+            )
+        };
+
+        // Source URI is `<host>/<repo_name>` — strip the trailing repo
+        // name to recover the host so the destination repo's URI keeps
+        // pointing at the same fakecloud endpoint.
+        let endpoint = source_uri
+            .strip_suffix(&format!("/{repo_name}"))
+            .unwrap_or(&source_uri)
+            .to_string();
+
+        let matching: Vec<_> = rules
+            .into_iter()
+            .filter(|rule| repository_filters_match(&rule.repository_filters, repo_name))
+            .flat_map(|rule| rule.destinations.into_iter())
+            .collect();
+        if matching.is_empty() {
+            return;
+        }
+
+        let mut statuses: Vec<ImageReplicationStatus> = Vec::new();
+        let mut accounts = self.state.write();
+        for dest in matching {
+            // Same registry + same region = no replication target.
+            if dest.registry_id == source_registry_id {
+                continue;
+            }
+            let target_state = accounts.get_or_create(&dest.registry_id);
+            // Provision the mirror repo on demand. Real ECR only
+            // replicates into existing repos; create-on-write keeps the
+            // fakecloud flow honest by mirroring the source repo's
+            // metadata when the target hasn't been pre-provisioned.
+            if !target_state.repositories.contains_key(repo_name) {
+                let arn = format!(
+                    "arn:aws:ecr:{}:{}:repository/{}",
+                    dest.region, dest.registry_id, repo_name
+                );
+                let repo = Repository::new(repo_name, arn, &dest.registry_id, &endpoint);
+                target_state
+                    .repositories
+                    .insert(repo_name.to_string(), repo);
+            }
+            let target_repo = target_state.repositories.get_mut(repo_name).unwrap();
+            target_repo
+                .images
+                .entry(digest.to_string())
+                .or_insert_with(|| image.clone());
+            for layer in &layer_blobs {
+                target_repo
+                    .layers
+                    .entry(layer.digest.clone())
+                    .or_insert_with(|| layer.clone());
+            }
+            statuses.push(ImageReplicationStatus {
+                region: dest.region.clone(),
+                registry_id: dest.registry_id.clone(),
+                status: "COMPLETE".to_string(),
+                failure_code: None,
+            });
+        }
+
+        // Record per-destination replication status on the source repo
+        // so DescribeImageReplicationStatus surfaces real entries.
+        let source_state = accounts.get_or_create(source_account);
+        if let Some(repo) = source_state.repositories.get_mut(repo_name) {
+            repo.replication_statuses
+                .insert(digest.to_string(), statuses);
+        }
     }
 
     /// Mark `digest` as `IN_PROGRESS` and spawn the scanner task.
@@ -2012,13 +2111,32 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        if resolve_image_digest(repo, &image_id).is_none() {
+        let Some(digest) = resolve_image_digest(repo, &image_id) else {
             return Err(image_not_found(&name, &image_id));
-        }
+        };
+        let statuses: Vec<Value> = repo
+            .replication_statuses
+            .get(&digest)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|s| {
+                        let mut obj = serde_json::Map::new();
+                        obj.insert("region".into(), Value::String(s.region.clone()));
+                        obj.insert("registryId".into(), Value::String(s.registry_id.clone()));
+                        obj.insert("status".into(), Value::String(s.status.clone()));
+                        if let Some(ref code) = s.failure_code {
+                            obj.insert("failureCode".into(), Value::String(code.clone()));
+                        }
+                        Value::Object(obj)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         Ok(AwsResponse::ok_json(json!({
             "repositoryName": name,
             "imageId": image_id,
-            "replicationStatuses": [],
+            "replicationStatuses": statuses,
         })))
     }
 

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -692,3 +692,17 @@ pub(crate) fn registry_scan_on_push_matches(
                     .any(|f| registry_filter_matches(f, repo)))
     })
 }
+
+/// Replication rule filter check. Empty filter list matches every
+/// repository — that's how AWS treats a rule with no filters.
+pub(crate) fn repository_filters_match(
+    filters: &[crate::state::RepositoryFilter],
+    repo_name: &str,
+) -> bool {
+    if filters.is_empty() {
+        return true;
+    }
+    filters
+        .iter()
+        .any(|f| registry_filter_matches(f, repo_name))
+}

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -267,3 +267,86 @@ fn registry_scan_no_rules_no_match() {
     let cfg = RegistryScanningConfiguration::default();
     assert!(!registry_scan_on_push_matches(&cfg, "x"));
 }
+
+#[test]
+fn repository_filters_match_returns_true_on_empty_list() {
+    use super::repository_filters_match;
+    assert!(repository_filters_match(&[], "any-repo"));
+}
+
+#[test]
+fn repository_filters_match_honours_wildcard() {
+    use super::repository_filters_match;
+    use crate::state::RepositoryFilter;
+    let filters = vec![RepositoryFilter {
+        filter: "team-a/*".to_string(),
+        filter_type: "WILDCARD".to_string(),
+    }];
+    assert!(repository_filters_match(&filters, "team-a/svc"));
+    assert!(!repository_filters_match(&filters, "team-b/svc"));
+}
+
+#[test]
+fn replicate_image_copies_to_destination_account() {
+    use super::EcrService;
+    use crate::state::{
+        EcrState, Image, ReplicationConfiguration, ReplicationDestination, ReplicationRule,
+        Repository,
+    };
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    const SOURCE: &str = "111111111111";
+    const TARGET: &str = "222222222222";
+
+    let mut mas: MultiAccountState<EcrState> =
+        MultiAccountState::new(SOURCE, "us-east-1", "http://fakecloud:4566");
+    let source_state = mas.get_or_create(SOURCE);
+    source_state.replication_configuration = Some(ReplicationConfiguration {
+        rules: vec![ReplicationRule {
+            destinations: vec![ReplicationDestination {
+                region: "us-west-2".to_string(),
+                registry_id: TARGET.to_string(),
+            }],
+            repository_filters: Vec::new(),
+        }],
+    });
+    let arn = source_state.repository_arn("app");
+    let mut repo = Repository::new("app", arn, SOURCE, "fakecloud:4566");
+    repo.images.insert(
+        "sha256:abc".to_string(),
+        Image {
+            image_digest: "sha256:abc".to_string(),
+            image_manifest: "{\"mediaType\":\"x\"}".to_string(),
+            image_manifest_media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+            artifact_media_type: None,
+            image_size_in_bytes: 0,
+            image_pushed_at: chrono::Utc::now(),
+            last_recorded_pull_time: None,
+        },
+    );
+    source_state.repositories.insert("app".to_string(), repo);
+
+    let state: crate::state::SharedEcrState = Arc::new(RwLock::new(mas));
+    let svc = EcrService::new(state.clone());
+    svc.replicate_image(SOURCE, "app", "sha256:abc");
+
+    let accounts = state.read();
+    let target_state = accounts.get(TARGET).expect("target account created");
+    let target_repo = target_state
+        .repositories
+        .get("app")
+        .expect("target repo provisioned");
+    assert!(target_repo.images.contains_key("sha256:abc"));
+
+    let source_state = accounts.get(SOURCE).expect("source account intact");
+    let source_repo = source_state.repositories.get("app").unwrap();
+    let statuses = source_repo
+        .replication_statuses
+        .get("sha256:abc")
+        .expect("status entry recorded");
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].status, "COMPLETE");
+    assert_eq!(statuses[0].registry_id, TARGET);
+}

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -143,6 +143,20 @@ pub struct Repository {
     /// snapshots portable.
     #[serde(default)]
     pub layers: BTreeMap<String, Layer>,
+    /// Per-image replication status entries, keyed by image digest.
+    /// Populated as PutImage fans out to each registered destination.
+    #[serde(default)]
+    pub replication_statuses: BTreeMap<String, Vec<ImageReplicationStatus>>,
+}
+
+/// Outcome of replicating one image to one destination registry/region.
+/// Surfaced through `DescribeImageReplicationStatus`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ImageReplicationStatus {
+    pub region: String,
+    pub registry_id: String,
+    pub status: String,
+    pub failure_code: Option<String>,
 }
 
 impl Repository {
@@ -175,6 +189,7 @@ impl Repository {
             images: BTreeMap::new(),
             image_tags: BTreeMap::new(),
             layers: BTreeMap::new(),
+            replication_statuses: BTreeMap::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- PutImage copies the freshly-pushed image (manifest + layers) into every destination registry/region per the registry's replication rules.
- Mirror repository auto-provisioned at the destination so `docker pull` keeps working without a separate CreateRepository step.
- New `repository.replication_statuses` map records per-destination outcome; DescribeImageReplicationStatus reads from it.
- `repository_filters_match` helper handles empty filter list (treated as match-all).

Closes plan P1 (ECR replication rules execute).

## Test plan

- [x] `cargo test -p fakecloud-ecr --lib` 27 passed (incl. 3 new replication tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Execute ECR replication rules on `PutImage`. When an image is pushed, we copy its manifest and layers to all matching destinations and return real replication statuses via `DescribeImageReplicationStatus`.

- **New Features**
  - Synchronous fan-out to all rule-matching destinations; skip same-registry; auto-provision mirror repo so pulls keep working.
  - Store per-image results in `repository.replication_statuses` with new `ImageReplicationStatus`; `DescribeImageReplicationStatus` returns these entries.
  - Added `repository_filters_match` helper that treats empty filter lists as match-all.

<sup>Written for commit a122d0f175656a3c87c3da1e923b214b3a86fee9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

