### PR TITLE
feat(ecr): enforce repository policy on cross-account image ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,6 +2980,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-core",
+ "fakecloud-iam",
  "fakecloud-kms",
  "fakecloud-persistence",
  "http 1.4.0",

--- a/crates/fakecloud-ecr/Cargo.toml
+++ b/crates/fakecloud-ecr/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fakecloud-core = { workspace = true }
+fakecloud-iam = { workspace = true }
 fakecloud-kms = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -695,6 +695,20 @@ impl EcrService {
             .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
 
+        // Cross-account repository policy gate: if the caller belongs
+        // to a different account than the repo owner, an explicit
+        // Allow on `ecr:PutImage` is required.
+        if request.account_id != account
+            && !repository_policy_allows(
+                repo.policy.as_deref(),
+                &request.account_id,
+                &repo.repository_arn,
+                "ecr:PutImage",
+            )
+        {
+            return Err(repository_policy_denied(&name, "ecr:PutImage"));
+        }
+
         // Immutable tag guard: if a tag is supplied, it already maps to
         // a different digest, and the repo is IMMUTABLE, reject.
         if let Some(ref tag) = supplied_tag {
@@ -922,6 +936,17 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
+
+        if request.account_id != account
+            && !repository_policy_allows(
+                repo.policy.as_deref(),
+                &request.account_id,
+                &repo.repository_arn,
+                "ecr:BatchGetImage",
+            )
+        {
+            return Err(repository_policy_denied(&name, "ecr:BatchGetImage"));
+        }
 
         let mut images: Vec<Value> = Vec::new();
         let mut failures: Vec<Value> = Vec::new();
@@ -1228,6 +1253,19 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
+        if request.account_id != account
+            && !repository_policy_allows(
+                repo.policy.as_deref(),
+                &request.account_id,
+                &repo.repository_arn,
+                "ecr:GetDownloadUrlForLayer",
+            )
+        {
+            return Err(repository_policy_denied(
+                &name,
+                "ecr:GetDownloadUrlForLayer",
+            ));
+        }
         if !repo.layers.contains_key(&digest) {
             return Err(layer_not_found(&digest, &name));
         }

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -223,6 +223,16 @@ pub(crate) fn image_not_found(repo: &str, id: &Value) -> AwsServiceError {
     )
 }
 
+pub(crate) fn repository_policy_denied(repo: &str, action: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::FORBIDDEN,
+        "AccessDeniedException",
+        format!(
+            "User is not authorized to perform: {action} on resource: repository {repo} because no resource-based policy allows the {action} action"
+        ),
+    )
+}
+
 pub(crate) fn layer_not_found(digest: &str, repo: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -705,4 +715,41 @@ pub(crate) fn repository_filters_match(
     filters
         .iter()
         .any(|f| registry_filter_matches(f, repo_name))
+}
+
+/// Cross-account ECR repository policy gate. When the caller's account
+/// differs from the repository's owning account, the repo must have a
+/// resource policy that explicitly Allows the requested action — empty
+/// policies implicitly deny, mirroring real AWS.
+pub(crate) fn repository_policy_allows(
+    policy_doc: Option<&str>,
+    caller_account: &str,
+    repo_arn: &str,
+    action: &str,
+) -> bool {
+    let Some(doc) = policy_doc else {
+        return false;
+    };
+    if doc.is_empty() {
+        return false;
+    }
+    use fakecloud_core::auth::{Principal, PrincipalType};
+    use fakecloud_iam::evaluator::{evaluate, Decision, EvalRequest, PolicyDocument};
+    let parsed = PolicyDocument::parse(doc);
+    let principal_arn = format!("arn:aws:iam::{caller_account}:root");
+    let principal = Principal {
+        arn: principal_arn.clone(),
+        user_id: principal_arn,
+        account_id: caller_account.to_string(),
+        principal_type: PrincipalType::User,
+        source_identity: None,
+        tags: None,
+    };
+    let req = EvalRequest {
+        principal: &principal,
+        action: action.to_string(),
+        resource: repo_arn.to_string(),
+        context: Default::default(),
+    };
+    matches!(evaluate(&[parsed], &req), Decision::Allow)
 }

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -350,3 +350,55 @@ fn replicate_image_copies_to_destination_account() {
     assert_eq!(statuses[0].status, "COMPLETE");
     assert_eq!(statuses[0].registry_id, TARGET);
 }
+
+#[test]
+fn repository_policy_allows_explicit_principal() {
+    use super::repository_policy_allows;
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "CrossAccountPull",
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+            "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"],
+            "Resource": "*"
+        }]
+    }"#;
+    assert!(repository_policy_allows(
+        Some(policy),
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "ecr:BatchGetImage",
+    ));
+    // Wrong action -> deny.
+    assert!(!repository_policy_allows(
+        Some(policy),
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "ecr:PutImage",
+    ));
+    // Wrong principal account -> deny.
+    assert!(!repository_policy_allows(
+        Some(policy),
+        "333333333333",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "ecr:BatchGetImage",
+    ));
+}
+
+#[test]
+fn repository_policy_allows_empty_policy_denies() {
+    use super::repository_policy_allows;
+    assert!(!repository_policy_allows(
+        None,
+        "222",
+        "arn",
+        "ecr:PutImage"
+    ));
+    assert!(!repository_policy_allows(
+        Some(""),
+        "222",
+        "arn",
+        "ecr:PutImage"
+    ));
+}


### PR DESCRIPTION
## Summary

- PutImage, BatchGetImage, GetDownloadUrlForLayer now gate cross-account access via the repository's resource policy.
- Empty/missing policies implicitly deny (matches real AWS).
- Uses shared IAM evaluator with a synthetic principal `arn:aws:iam::<caller>:root`.

Closes plan P2 (ECR repository policy enforcement).

## Test plan

- [x] `cargo test -p fakecloud-ecr --lib` 29 passed (incl. 2 new repo policy tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce ECR repository resource policies for cross-account image operations. Cross-account PutImage, BatchGetImage, and GetDownloadUrlForLayer now require an explicit Allow in the repo policy; otherwise access is denied.

- New Features
  - Evaluate repository policy via the shared IAM evaluator using principal `arn:aws:iam::<caller>:root`.
  - Empty or missing policies deny by default; AccessDenied message matches AWS.
  - Added tests for explicit allow and empty policy deny.

- Dependencies
  - Add `fakecloud-iam` to `fakecloud-ecr`.

<sup>Written for commit 091af23fb1c08a40cf1f204a784bf2fd35383424. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

