### PR TITLE
feat(logs): route subscription filter destinations to Firehose

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -21,6 +21,8 @@ pub struct DeliveryBus {
     stepfunctions_starter: Option<Arc<dyn StepFunctionsDelivery>>,
     /// Write objects to S3 buckets.
     s3_writer: Option<Arc<dyn S3Delivery>>,
+    /// Put records into Firehose delivery streams.
+    firehose_sender: Option<Arc<dyn FirehoseDelivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -175,6 +177,15 @@ pub trait StepFunctionsDelivery: Send + Sync {
     fn start_execution(&self, state_machine_arn: &str, input: &str);
 }
 
+/// Cross-service Kinesis Data Firehose dispatch used by services
+/// (CloudWatch Logs subscription filters, EventBridge targets) that
+/// route records into a delivery stream without depending on the
+/// firehose crate directly. ARN form is
+/// `arn:aws:firehose:<region>:<account>:deliverystream/<name>`.
+pub trait FirehoseDelivery: Send + Sync {
+    fn put_record(&self, delivery_stream_arn: &str, data: &[u8]);
+}
+
 /// Cross-service S3 writer used by services that need to deliver
 /// content to S3 buckets without taking a direct dep on the S3 crate
 /// (CloudWatch Logs export tasks, Kinesis Firehose, ELB access logs).
@@ -251,12 +262,27 @@ impl DeliveryBus {
             kinesis_sender: None,
             stepfunctions_starter: None,
             s3_writer: None,
+            firehose_sender: None,
         }
     }
 
     pub fn with_s3(mut self, sender: Arc<dyn S3Delivery>) -> Self {
         self.s3_writer = Some(sender);
         self
+    }
+
+    pub fn with_firehose(mut self, sender: Arc<dyn FirehoseDelivery>) -> Self {
+        self.firehose_sender = Some(sender);
+        self
+    }
+
+    /// Send a single record to a Firehose delivery stream by ARN.
+    /// Silently no-ops when no Firehose sender is wired (in-process
+    /// tests). Production wiring goes through fakecloud_firehose.
+    pub fn put_record_to_firehose(&self, delivery_stream_arn: &str, data: &[u8]) {
+        if let Some(ref sender) = self.firehose_sender {
+            sender.put_record(delivery_stream_arn, data);
+        }
     }
 
     /// Write content to S3. Returns Err when no S3 writer is wired or

--- a/crates/fakecloud-firehose/src/delivery.rs
+++ b/crates/fakecloud-firehose/src/delivery.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use fakecloud_core::delivery::FirehoseDelivery;
+use fakecloud_s3::SharedS3State;
+
+use crate::service::FirehoseService;
+use crate::state::SharedFirehoseState;
+
+/// Lets non-Firehose services route records into a delivery stream
+/// without taking a direct dep on the firehose crate. CloudWatch Logs
+/// subscription filters use this for `arn:aws:firehose:` destinations.
+pub struct FirehoseDeliveryImpl {
+    inner: Arc<FirehoseService>,
+}
+
+impl FirehoseDeliveryImpl {
+    pub fn new(state: SharedFirehoseState, s3: SharedS3State) -> Self {
+        let svc = FirehoseService::new(state).with_s3(s3);
+        Self {
+            inner: Arc::new(svc),
+        }
+    }
+}
+
+impl FirehoseDelivery for FirehoseDeliveryImpl {
+    fn put_record(&self, delivery_stream_arn: &str, data: &[u8]) {
+        let Some((account, region, stream_name)) = parse_arn(delivery_stream_arn) else {
+            tracing::warn!(arn = %delivery_stream_arn, "invalid firehose ARN");
+            return;
+        };
+        if let Err(err) =
+            self.inner
+                .deliver_records(&account, &region, &stream_name, vec![data.to_vec()])
+        {
+            tracing::warn!(
+                arn = %delivery_stream_arn,
+                error = ?err,
+                "firehose delivery failed"
+            );
+        }
+    }
+}
+
+fn parse_arn(arn: &str) -> Option<(String, String, String)> {
+    // arn:aws:firehose:<region>:<account>:deliverystream/<name>
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    if parts.len() < 6 || parts[0] != "arn" || parts[2] != "firehose" {
+        return None;
+    }
+    let stream_name = parts[5].strip_prefix("deliverystream/")?;
+    Some((
+        parts[4].to_string(),
+        parts[3].to_string(),
+        stream_name.to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_arn_extracts_components() {
+        let parsed = parse_arn("arn:aws:firehose:us-east-1:123456789012:deliverystream/logs-to-s3");
+        assert_eq!(
+            parsed,
+            Some((
+                "123456789012".to_string(),
+                "us-east-1".to_string(),
+                "logs-to-s3".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_arn_rejects_non_firehose_arns() {
+        assert!(parse_arn("arn:aws:s3:::bucket").is_none());
+        assert!(parse_arn("not-an-arn").is_none());
+        assert!(parse_arn("arn:aws:firehose:us-east-1:111:stream/foo").is_none());
+    }
+}

--- a/crates/fakecloud-firehose/src/lib.rs
+++ b/crates/fakecloud-firehose/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod delivery;
 pub mod service;
 pub mod state;
 
+pub use delivery::FirehoseDeliveryImpl;
 pub use service::FirehoseService;
 pub use state::{FirehoseAccounts, SharedFirehoseState};

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -439,7 +439,7 @@ impl FirehoseService {
         Ok(AwsResponse::ok_json(json!({})))
     }
 
-    fn deliver_records(
+    pub fn deliver_records(
         &self,
         account_id: &str,
         region: &str,

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -628,6 +628,12 @@ impl LogsService {
             let partition_key = format!("{}-{}", group_name, stream_name);
             self.delivery_bus
                 .send_to_kinesis(destination_arn, &encoded, &partition_key);
+        } else if destination_arn.contains(":firehose:") {
+            // Firehose subscriptions get the same gzip+base64 envelope
+            // Lambda/Kinesis subscribers see, so a downstream consumer
+            // can decode with the standard CloudWatch-Logs format.
+            self.delivery_bus
+                .put_record_to_firehose(destination_arn, encoded.as_bytes());
         }
     }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -502,10 +502,23 @@ async fn main() {
     let s3_delivery_for_logs = Arc::new(fakecloud_s3::delivery::S3DeliveryImpl::new(
         s3_state.clone(),
     ));
+    // Firehose state is constructed once and shared between the public
+    // FirehoseService (registered later) and the cross-service delivery
+    // hook the Logs subscription dispatch uses for `arn:aws:firehose:`
+    // destinations. Building it here keeps the wiring in one place.
+    let firehose_state: fakecloud_firehose::SharedFirehoseState = Arc::new(
+        parking_lot::RwLock::new(fakecloud_firehose::FirehoseAccounts::new()),
+    );
+    let firehose_delivery_for_logs =
+        Arc::new(fakecloud_firehose::delivery::FirehoseDeliveryImpl::new(
+            firehose_state.clone(),
+            s3_state.clone(),
+        ));
     let mut delivery_for_logs = DeliveryBus::new()
         .with_sqs(sqs_delivery.clone())
         .with_kinesis(kinesis_delivery)
-        .with_s3(s3_delivery_for_logs);
+        .with_s3(s3_delivery_for_logs)
+        .with_firehose(firehose_delivery_for_logs);
     if let Some(ref ld) = lambda_delivery {
         delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
     }
@@ -587,10 +600,6 @@ async fn main() {
     let cognito_token_state = cognito_state.clone();
     let cognito_userinfo_state = cognito_state.clone();
     let cognito_revoke_state = cognito_state.clone();
-
-    let firehose_state: fakecloud_firehose::SharedFirehoseState = Arc::new(
-        parking_lot::RwLock::new(fakecloud_firehose::FirehoseAccounts::new()),
-    );
 
     let glue_state: fakecloud_glue::SharedGlueState =
         Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new()));


### PR DESCRIPTION
## Summary
- Added `FirehoseDelivery` cross-service trait in fakecloud-core + `FirehoseDeliveryImpl` in fakecloud-firehose
- Wired into `DeliveryBus::with_firehose` and exposed via `put_record_to_firehose`
- CloudWatch Logs subscription filters now route `arn:aws:firehose:` destinations through this hook so records land in the Firehose stream (and onward to its S3 destination)

## Test plan
- [x] `cargo test -p fakecloud-firehose --lib` passes (new parse_arn unit tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudWatch Logs subscription filters now deliver to Kinesis Data Firehose when the destination is an `arn:aws:firehose:`. Records use the standard gzip+base64 CloudWatch Logs envelope and flow into the Firehose stream (and then its S3 destination).

- **New Features**
  - Added `FirehoseDelivery` trait in `fakecloud-core` and `FirehoseDeliveryImpl` in `fakecloud-firehose`.
  - Extended `DeliveryBus` with `with_firehose` and `put_record_to_firehose`; wired in `fakecloud-server` with shared Firehose state.
  - `fakecloud-logs` routes subscription data to Firehose destinations; `fakecloud-firehose` handles ARN parsing and record delivery.

<sup>Written for commit 25a74d5e8ce711c90b9cfc179071d3d52ace1b74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

