### PR TITLE
feat(logs): enforce retention on Logs Insights query results

### DIFF
--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -158,8 +158,21 @@ impl LogsService {
                 continue;
             }
             if let Some(group) = state.log_groups.get(&group_name) {
+                let retention_cutoff = group
+                    .retention_in_days
+                    .map(|d| Utc::now().timestamp_millis() - (d as i64) * 86_400_000);
                 for stream in group.log_streams.values() {
-                    stream_events.push((stream.name.clone(), stream.events.clone()));
+                    let events: Vec<LogEvent> = if let Some(cutoff) = retention_cutoff {
+                        stream
+                            .events
+                            .iter()
+                            .filter(|e| e.timestamp >= cutoff)
+                            .cloned()
+                            .collect()
+                    } else {
+                        stream.events.clone()
+                    };
+                    stream_events.push((stream.name.clone(), events));
                 }
             }
         }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -2284,4 +2284,34 @@ mod tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["destinations"].is_array());
     }
+
+    #[test]
+    fn get_query_results_drops_events_older_than_retention() {
+        let svc = make_service();
+        create_group(&svc, "ret-q");
+        create_stream(&svc, "ret-q", "s");
+        let now = chrono::Utc::now().timestamp_millis();
+        put_events_at(&svc, "ret-q", "s", &["stale"], now - 12 * 86_400_000);
+        put_events(&svc, "ret-q", "s", &["recent"]);
+        put_retention(&svc, "ret-q", 1);
+
+        let req = make_request(
+            "StartQuery",
+            json!({
+                "logGroupName": "ret-q",
+                "queryString": "fields @message",
+                "startTime": (now / 1000) - 30 * 86_400,
+                "endTime": now / 1000,
+            }),
+        );
+        let resp = svc.start_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let qid = body["queryId"].as_str().unwrap().to_string();
+
+        let req = make_request("GetQueryResults", json!({"queryId": qid}));
+        let resp = svc.get_query_results(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let scanned = body["statistics"]["recordsScanned"].as_f64().unwrap();
+        assert_eq!(scanned, 1.0, "retention should hide the 12-day-old event");
+    }
 }


### PR DESCRIPTION
## Summary
- Apply the existing retention cutoff (now - retentionInDays * 86400_000) to events returned by `GetQueryResults` so Logs Insights stops surfacing events older than the group's retention policy.
- `GetLogEvents` and `FilterLogEvents` already enforced this; only the query path was missing.

## Test plan
- [x] `cargo test -p fakecloud-logs --lib retention` — 9 retention tests green, including new `get_query_results_drops_events_older_than_retention`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces log group retention on Logs Insights queries so results and stats no longer include events older than the group’s retention. Brings `GetQueryResults` in line with `GetLogEvents` and `FilterLogEvents`.

- **Bug Fixes**
  - Apply retention cutoff in `GetQueryResults` by filtering stream events before query execution.
  - Ensure `recordsScanned` excludes expired events.
  - Add test: `get_query_results_drops_events_older_than_retention`.

<sup>Written for commit 5d4e7c2296ad682458e2a9cf991be635a36fe33e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

