### PR TITLE
feat(iam): real DecodeAuthorizationMessage round-trip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "flate2",
  "http 1.4.0",
  "parking_lot",
  "serde",

--- a/crates/fakecloud-iam/Cargo.toml
+++ b/crates/fakecloud-iam/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
+flate2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fakecloud-iam/src/auth_message.rs
+++ b/crates/fakecloud-iam/src/auth_message.rs
@@ -1,0 +1,121 @@
+//! Encode and decode the opaque deny-reason token returned to clients
+//! when an IAM check denies a request, and consumed by
+//! `sts:DecodeAuthorizationMessage`.
+//!
+//! AWS treats the encoded message as an opaque blob; the documented
+//! contract is "pass it back to DecodeAuthorizationMessage and you'll
+//! get JSON describing why the request was denied". We do the same:
+//! the token is a deflate-compressed JSON document, base64-encoded.
+//! The decoder reverses the transformation, so any deny-time site that
+//! calls [`encode_deny`] gets a real round-trip without needing a
+//! separate state map.
+
+use base64::Engine;
+use flate2::read::ZlibDecoder;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+
+/// Build an encoded authorization message describing a deny decision.
+/// The shape mirrors what AWS returns from
+/// `DecodeAuthorizationMessage`: an `allowed` flag, an `explicitDeny`
+/// flag, and a `matchedStatements.items` array. Optional supplementary
+/// keys (`action`, `principal`, `context`) are included so an operator
+/// inspecting the decoded blob can see why the request failed.
+pub fn encode_deny(
+    explicit: bool,
+    action: Option<&str>,
+    principal_arn: Option<&str>,
+    matched_statements: Vec<Value>,
+    context: Option<Value>,
+) -> String {
+    let mut payload = json!({
+        "allowed": false,
+        "explicitDeny": explicit,
+        "matchedStatements": { "items": matched_statements },
+    });
+    if let Some(a) = action {
+        payload["action"] = json!(a);
+    }
+    if let Some(p) = principal_arn {
+        payload["principal"] = json!(p);
+    }
+    if let Some(c) = context {
+        payload["context"] = c;
+    }
+    let json_bytes = serde_json::to_vec(&payload).unwrap_or_default();
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&json_bytes).ok();
+    let compressed = encoder.finish().unwrap_or_default();
+    base64::engine::general_purpose::STANDARD.encode(compressed)
+}
+
+/// Reverse [`encode_deny`]. Returns the JSON document the encoder
+/// stashed, or an `InvalidAuthorizationMessageException`-shaped error
+/// when the token isn't recognizable. Tokens that decode but don't
+/// look like deny payloads are still returned verbatim — AWS's
+/// behavior is to hand back whatever JSON it finds rather than try to
+/// interpret it.
+pub fn decode_message(encoded: &str) -> Result<String, &'static str> {
+    let compressed = base64::engine::general_purpose::STANDARD
+        .decode(encoded.as_bytes())
+        .map_err(|_| "EncodedMessage is not valid base64")?;
+    let mut decoder = ZlibDecoder::new(&compressed[..]);
+    let mut json_bytes = Vec::new();
+    decoder
+        .read_to_end(&mut json_bytes)
+        .map_err(|_| "EncodedMessage is not a valid deny token")?;
+    String::from_utf8(json_bytes).map_err(|_| "EncodedMessage payload is not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_explicit_deny() {
+        let token = encode_deny(
+            true,
+            Some("s3:GetObject"),
+            Some("arn:aws:iam::111122223333:user/alice"),
+            vec![json!({"sourcePolicyId": "PolicyA"})],
+            Some(json!({"aws:SourceIp": "1.2.3.4"})),
+        );
+        let decoded = decode_message(&token).unwrap();
+        let parsed: Value = serde_json::from_str(&decoded).unwrap();
+        assert_eq!(parsed["allowed"], false);
+        assert_eq!(parsed["explicitDeny"], true);
+        assert_eq!(parsed["action"], "s3:GetObject");
+        assert_eq!(parsed["principal"], "arn:aws:iam::111122223333:user/alice");
+        assert_eq!(
+            parsed["matchedStatements"]["items"][0]["sourcePolicyId"],
+            "PolicyA"
+        );
+    }
+
+    #[test]
+    fn round_trip_implicit_deny_with_no_extras() {
+        let token = encode_deny(false, None, None, Vec::new(), None);
+        let decoded = decode_message(&token).unwrap();
+        let parsed: Value = serde_json::from_str(&decoded).unwrap();
+        assert_eq!(parsed["allowed"], false);
+        assert_eq!(parsed["explicitDeny"], false);
+        assert!(parsed["matchedStatements"]["items"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        assert!(parsed.get("action").is_none());
+    }
+
+    #[test]
+    fn rejects_garbage_base64() {
+        assert!(decode_message("not!!!base64!!").is_err());
+    }
+
+    #[test]
+    fn rejects_base64_that_is_not_zlib() {
+        let token = base64::engine::general_purpose::STANDARD.encode(b"not zlib data");
+        assert!(decode_message(&token).is_err());
+    }
+}

--- a/crates/fakecloud-iam/src/lib.rs
+++ b/crates/fakecloud-iam/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth_message;
 pub mod condition;
 pub mod credential_resolver;
 pub mod evaluator;

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -972,10 +972,20 @@ impl StsService {
         })?;
         validate_string_length("encodedMessage", encoded_message, 1, 10240)?;
 
+        // Round-trip the deflated/base64'd token produced by
+        // `auth_message::encode_deny`. Tokens that don't decode are
+        // rejected with `InvalidAuthorizationMessageException`,
+        // matching how AWS reports a corrupted blob.
         let decoded_message =
-            r#"{"allowed":true,"explicitDeny":false,"matchedStatements":{"items":[]}}"#;
+            crate::auth_message::decode_message(encoded_message).map_err(|why| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidAuthorizationMessageException",
+                    why,
+                )
+            })?;
         let xml =
-            xml_responses::decode_authorization_message_response(decoded_message, &req.request_id);
+            xml_responses::decode_authorization_message_response(&decoded_message, &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
 
@@ -1247,18 +1257,48 @@ mod tests {
         ));
         let service = StsService::new(state);
 
-        let mut params = HashMap::new();
-        params.insert(
-            "EncodedMessage".to_string(),
-            "some-encoded-message".to_string(),
+        // Encode a real deny payload, then verify the decode op
+        // round-trips it back through the response body.
+        let token = crate::auth_message::encode_deny(
+            true,
+            Some("s3:GetObject"),
+            Some("arn:aws:iam::123456789012:user/alice"),
+            vec![serde_json::json!({"sourcePolicyId": "deny-bucket-foo"})],
+            None,
         );
+        let mut params = HashMap::new();
+        params.insert("EncodedMessage".to_string(), token);
 
         let req = make_test_request(params);
         let resp = service.decode_authorization_message(&req).unwrap();
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
         assert!(body.contains("DecodedMessage"));
-        assert!(body.contains("allowed"));
-        assert!(body.contains("matchedStatements"));
+        assert!(body.contains("explicitDeny"));
+        assert!(body.contains("s3:GetObject"));
+        assert!(body.contains("deny-bucket-foo"));
+    }
+
+    #[test]
+    fn test_decode_authorization_message_rejects_invalid_token() {
+        use parking_lot::RwLock;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let state: SharedIamState = Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        let service = StsService::new(state);
+
+        let mut params = HashMap::new();
+        params.insert("EncodedMessage".to_string(), "not-a-real-token".to_string());
+        let req = make_test_request(params);
+        let err = match service.decode_authorization_message(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected InvalidAuthorizationMessageException"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        let msg = format!("{:?}", err);
+        assert!(msg.contains("InvalidAuthorizationMessageException"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New `auth_message::encode_deny` builds a deflate+base64 token carrying the deny payload (`allowed`, `explicitDeny`, `matchedStatements.items`, optional `action`/`principal`/`context`).
- New `auth_message::decode_message` reverses it.
- `sts:DecodeAuthorizationMessage` consumes the decoder; tokens that don't decode return `InvalidAuthorizationMessageException` (was: hard-coded canned `{\"allowed\":true,...}` regardless of input).
- Future deny-time call sites can mint encoded blobs through `encode_deny` without state coordination — the token is self-describing.
- Closes plan F4 (DecodeAuthorizationMessage); the rest of F4 (ChangePassword validate, ResyncMFADevice EnableDate refresh, SetSecurityTokenServicePreferences storage) was already in place. Phase F (F1-F4) now done.

## Test plan
- [x] `cargo test -p fakecloud-iam --lib` — 391 tests pass, +5 new (4 round-trip + 1 reject-bad-token)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a real round‑trip for STS DecodeAuthorizationMessage. We now decode the deflate+base64 deny token and return the original JSON, rejecting invalid tokens instead of returning a canned response.

- **New Features**
  - Added `auth_message::encode_deny` to produce a deflate+base64 token with the deny payload (allowed, explicitDeny, matchedStatements; optional action/principal/context). The token is self‑describing for future deny-time call sites.
  - Added `auth_message::decode_message` and wired it into `sts:DecodeAuthorizationMessage` to return the decoded JSON.
  - Return `InvalidAuthorizationMessageException` when the token can't be decoded.

- **Dependencies**
  - Added `flate2` for zlib compression/decompression.

<sup>Written for commit 7c9f0d6d230c9c19bc2e20218e77278f1dd5aaa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

