### PR TITLE
feat(kms): real HMAC for GenerateMac/VerifyMac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "hmac 0.12.1",
  "http 1.4.0",
  "k256",
  "p256 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ rcgen = "0.13"
 rsa = { version = "0.9", features = ["sha2", "pem"] }
 sha1 = "0.10"
 sha2 = "0.10"
+hmac = "0.12"
 crc32c = "0.6"
 crc32fast = "1"
 crc64fast-nvme = "1"

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fakecloud-kms/src/mac.rs
+++ b/crates/fakecloud-kms/src/mac.rs
@@ -1,0 +1,134 @@
+//! Real HMAC compute + verify for KMS `GenerateMac` / `VerifyMac`.
+//!
+//! Replaces the prior fake-bytes shim that just stuffed a stringified
+//! `(key_id, alg, message)` triple into the response. Now backs the
+//! response with a real HMAC computed over the message via the key's
+//! stored `master_key_bytes`. Verify uses the underlying crate's
+//! constant-time comparison.
+
+use hmac::{Hmac, Mac};
+use sha2::{Sha256, Sha384, Sha512};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MacError {
+    #[error("unsupported MAC algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+}
+
+/// Compute the MAC of `message` keyed by `key_bytes`. Algorithm names
+/// match KMS's `MacAlgorithmSpec` enum (`HMAC_SHA_224` / `_256` /
+/// `_384` / `_512`). HMAC-SHA-224 is intentionally rejected — the
+/// `sha2::Sha224` digest exists, but AWS dropped HMAC_SHA_224 from
+/// supported MacAlgorithmSpec values, and we mirror that.
+pub fn compute(algorithm: &str, key_bytes: &[u8], message: &[u8]) -> Result<Vec<u8>, MacError> {
+    match algorithm {
+        "HMAC_SHA_256" => {
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.finalize().into_bytes().to_vec())
+        }
+        "HMAC_SHA_384" => {
+            let mut mac = <Hmac<Sha384> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.finalize().into_bytes().to_vec())
+        }
+        "HMAC_SHA_512" => {
+            let mut mac = <Hmac<Sha512> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.finalize().into_bytes().to_vec())
+        }
+        other => Err(MacError::UnsupportedAlgorithm(other.to_string())),
+    }
+}
+
+/// Verify `mac_bytes` matches the expected MAC of `message` under
+/// `key_bytes`. Uses each crate's `verify_slice` for constant-time
+/// comparison so timing leaks don't help an attacker forge MACs.
+pub fn verify(
+    algorithm: &str,
+    key_bytes: &[u8],
+    message: &[u8],
+    mac_bytes: &[u8],
+) -> Result<bool, MacError> {
+    match algorithm {
+        "HMAC_SHA_256" => {
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.verify_slice(mac_bytes).is_ok())
+        }
+        "HMAC_SHA_384" => {
+            let mut mac = <Hmac<Sha384> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.verify_slice(mac_bytes).is_ok())
+        }
+        "HMAC_SHA_512" => {
+            let mut mac = <Hmac<Sha512> as Mac>::new_from_slice(key_bytes)
+                .expect("HMAC accepts any key length");
+            mac.update(message);
+            Ok(mac.verify_slice(mac_bytes).is_ok())
+        }
+        other => Err(MacError::UnsupportedAlgorithm(other.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_sha256() {
+        let key = b"sample-key-material";
+        let msg = b"the quick brown fox";
+        let mac = compute("HMAC_SHA_256", key, msg).unwrap();
+        assert!(verify("HMAC_SHA_256", key, msg, &mac).unwrap());
+    }
+
+    #[test]
+    fn round_trip_sha384() {
+        let key = b"sample-key-material";
+        let msg = b"the quick brown fox";
+        let mac = compute("HMAC_SHA_384", key, msg).unwrap();
+        assert!(verify("HMAC_SHA_384", key, msg, &mac).unwrap());
+    }
+
+    #[test]
+    fn round_trip_sha512() {
+        let key = b"sample-key-material";
+        let msg = b"the quick brown fox";
+        let mac = compute("HMAC_SHA_512", key, msg).unwrap();
+        assert!(verify("HMAC_SHA_512", key, msg, &mac).unwrap());
+    }
+
+    #[test]
+    fn verify_fails_on_tampered_mac() {
+        let key = b"sample-key-material";
+        let msg = b"original";
+        let mac = compute("HMAC_SHA_256", key, msg).unwrap();
+        let mut tampered = mac.clone();
+        tampered[0] ^= 0xff;
+        assert!(!verify("HMAC_SHA_256", key, msg, &tampered).unwrap());
+    }
+
+    #[test]
+    fn verify_fails_on_wrong_key() {
+        let mac = compute("HMAC_SHA_256", b"k1", b"m").unwrap();
+        assert!(!verify("HMAC_SHA_256", b"k2", b"m", &mac).unwrap());
+    }
+
+    #[test]
+    fn unsupported_algorithm_errors() {
+        assert!(compute("HMAC_SHA_999", b"k", b"m").is_err());
+    }
+
+    #[test]
+    fn mac_lengths_match_sha_output() {
+        assert_eq!(compute("HMAC_SHA_256", b"k", b"m").unwrap().len(), 32);
+        assert_eq!(compute("HMAC_SHA_384", b"k", b"m").unwrap().len(), 48);
+        assert_eq!(compute("HMAC_SHA_512", b"k", b"m").unwrap().len(), 64);
+    }
+}

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1299,6 +1299,8 @@ impl KmsService {
 pub(crate) mod asym;
 #[path = "asym_ecdsa.rs"]
 pub(crate) mod asym_ecdsa;
+#[path = "mac.rs"]
+pub(crate) mod mac;
 #[path = "service_aliases.rs"]
 mod service_aliases;
 #[path = "service_crypto.rs"]

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -635,12 +635,27 @@ impl KmsService {
             ));
         }
 
-        // Generate fake MAC
-        let mac_data = format!(
-            "fakecloud-mac:{}:{}:{}",
-            key.key_id, mac_algorithm, message_b64
-        );
-        let mac_b64 = base64::engine::general_purpose::STANDARD.encode(mac_data.as_bytes());
+        // Real HMAC over the message keyed by master_key_bytes. The
+        // legacy fake-bytes path is gone; tampering with either the
+        // mac, key, or message no longer round-trips.
+        let message_bytes = base64::engine::general_purpose::STANDARD
+            .decode(message_b64)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Message is not valid base64",
+                )
+            })?;
+        let mac_bytes = super::mac::compute(&mac_algorithm, &key.private_key_seed, &message_bytes)
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("GenerateMac failed: {e}"),
+                )
+            })?;
+        let mac_b64 = base64::engine::general_purpose::STANDARD.encode(&mac_bytes);
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -690,15 +705,40 @@ impl KmsService {
             ));
         }
 
-        // Check if MAC matches
-        let expected_mac_data = format!(
-            "fakecloud-mac:{}:{}:{}",
-            key.key_id, mac_algorithm, message_b64
-        );
-        let expected_mac_b64 =
-            base64::engine::general_purpose::STANDARD.encode(expected_mac_data.as_bytes());
-
-        let mac_valid = mac_b64 == expected_mac_b64;
+        // Real HMAC verify with constant-time comparison via the
+        // hmac crate's verify_slice. Replaces the legacy stringified
+        // expected-bytes equality compare.
+        let message_bytes = base64::engine::general_purpose::STANDARD
+            .decode(message_b64)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Message is not valid base64",
+                )
+            })?;
+        let supplied_mac_bytes = base64::engine::general_purpose::STANDARD
+            .decode(mac_b64)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "Mac is not valid base64",
+                )
+            })?;
+        let mac_valid = super::mac::verify(
+            &mac_algorithm,
+            &key.private_key_seed,
+            &message_bytes,
+            &supplied_mac_bytes,
+        )
+        .map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!("VerifyMac failed: {e}"),
+            )
+        })?;
 
         if !mac_valid {
             return Err(AwsServiceError::aws_error(


### PR DESCRIPTION
## Summary
- New `service::mac` module computes HMAC-SHA-256/384/512 via the `hmac` crate keyed by `key.private_key_seed` (per-key 32 bytes).
- `GenerateMac` produces real MACs over the decoded message body; `VerifyMac` uses constant-time `Mac::verify_slice`.
- Replaces the prior fake-bytes shim that base64'd a `(key_id, alg, message)` triple. Tampering with key, message, or MAC now fails verify.

## Test plan
- [x] `cargo test -p fakecloud-kms --lib mac` — 12 tests pass (7 new in `mac::tests` + 5 existing service-level)
- [x] `cargo test -p fakecloud-kms --lib` — 158 tests pass overall
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GenerateMac/VerifyMac to real HMAC using `key.private_key_seed` with constant-time verify. Replaces the placeholder MAC so tampering or wrong keys now correctly fail.

- **New Features**
  - Added `service::mac` with HMAC-SHA-256/384/512 via `hmac`; `GenerateMac` returns a true MAC over the decoded message.
  - `VerifyMac` uses constant-time `Mac::verify_slice` and validates base64 inputs, returning `ValidationException` on errors.

- **Dependencies**
  - Added `hmac` to the workspace.

<sup>Written for commit 3a7775a5a9555ef1b6075f6d5bf28dec6f5d02e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

