### PR TITLE
feat(kms): enforce key_state on every crypto op

### DIFF
--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -407,6 +407,35 @@ pub(crate) fn require_non_empty_b64(field: &str, b64: &str) -> Result<(), AwsSer
     Ok(())
 }
 
+/// Reject the request when the key isn't usable for crypto operations.
+/// AWS surfaces `KMSInvalidStateException` for every state other than
+/// `Enabled`; `Disabled` keeps its dedicated `DisabledException` for
+/// backwards compatibility with the old enabled-flag check that the
+/// existing tests assert on. All other lifecycle states
+/// (`PendingDeletion`, `PendingImport`, `Unavailable`, `Updating`,
+/// `Creating`) collapse into `KMSInvalidStateException` so callers
+/// don't see a misleading success when the key is mid-transition.
+pub(crate) fn require_usable_key_state(key: &KmsKey) -> Result<(), AwsServiceError> {
+    if key.key_state == "Enabled" {
+        return Ok(());
+    }
+    if key.key_state == "Disabled" || !key.enabled {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "DisabledException",
+            format!("Key '{}' is disabled", key.arn),
+        ));
+    }
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "KMSInvalidStateException",
+        format!(
+            "Key '{}' is not in a state that allows this operation (current state: {})",
+            key.arn, key.key_state
+        ),
+    ))
+}
+
 pub(crate) fn validate_key_usage_signing(
     key: &KmsKey,
     resolved: &str,

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -42,13 +42,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
         let ciphertext_b64 =
@@ -80,6 +74,14 @@ impl KmsService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let ec_aad = canonical_encryption_context(&body["EncryptionContext"]);
         let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &ec_aad)?;
+
+        // Gate Decrypt on the source key's lifecycle state. AWS rejects
+        // Decrypt against a key in any state other than `Enabled`.
+        if let Some(key_id_only) = decoded.source_arn.rsplit('/').next() {
+            if let Some(source_key) = state.keys.get(key_id_only) {
+                require_usable_key_state(source_key)?;
+            }
+        }
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -132,6 +134,15 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        require_usable_key_state(dest_key)?;
+
+        // Source key gate too — AWS rejects ReEncrypt when either side
+        // is in a non-Enabled state.
+        if let Some(src_key_id) = decoded.source_arn.rsplit('/').next() {
+            if let Some(source_key) = state.keys.get(src_key_id) {
+                require_usable_key_state(source_key)?;
+            }
+        }
 
         let plaintext_bytes = base64::engine::general_purpose::STANDARD
             .decode(&decoded.plaintext_b64)
@@ -200,13 +211,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         let num_bytes = data_key_size_from_body(&body)?;
 
@@ -255,13 +260,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         let num_bytes = data_key_size_from_body(&body)?;
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
@@ -346,6 +345,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        require_usable_key_state(key)?;
 
         // Validate key usage
         if key.key_usage != "SIGN_VERIFY" {
@@ -469,6 +469,7 @@ impl KmsService {
             )
         })?;
 
+        require_usable_key_state(key)?;
         validate_key_usage_signing(key, &resolved)?;
         validate_signing_algorithm(key, signing_algorithm)?;
 
@@ -617,6 +618,8 @@ impl KmsService {
             )
         })?;
 
+        require_usable_key_state(key)?;
+
         // Validate key usage
         if key.key_usage != "GENERATE_VERIFY_MAC" {
             return Err(AwsServiceError::aws_error(
@@ -695,6 +698,8 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+
+        require_usable_key_state(key)?;
 
         // Validate key usage
         if key.key_usage != "GENERATE_VERIFY_MAC" {
@@ -790,13 +795,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         let public_key_bytes = generate_fake_public_key(&key_pair_spec);
         let private_key_bytes = rand_bytes(256);
@@ -852,13 +851,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         let public_key_bytes = generate_fake_public_key(&key_pair_spec);
         let private_key_bytes = rand_bytes(256);
@@ -918,13 +911,7 @@ impl KmsService {
             )
         })?;
 
-        if !key.enabled {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "DisabledException",
-                format!("Key '{}' is disabled", key.arn),
-            ));
-        }
+        require_usable_key_state(key)?;
 
         // Key must be asymmetric (KEY_AGREEMENT usage)
         if key.key_usage != "KEY_AGREEMENT" {

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2373,3 +2373,94 @@ fn tag_resource_on_known_key_succeeds() {
     );
     svc.tag_resource(&req).unwrap();
 }
+
+// ── G5: key_state enforcement on crypto ops ──
+
+fn force_key_state(svc: &KmsService, key_id: &str, new_state: &str) {
+    let mut accounts = svc.state.write();
+    let s = accounts.get_or_create("123456789012");
+    if let Some(key) = s.keys.get_mut(key_id) {
+        key.key_state = new_state.to_string();
+        if new_state == "Disabled" {
+            key.enabled = false;
+        }
+    }
+}
+
+fn b64(s: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(s.as_bytes())
+}
+
+#[test]
+fn encrypt_rejects_pending_deletion_with_invalid_state() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    force_key_state(&svc, &key_id, "PendingDeletion");
+    let req = make_request(
+        "Encrypt",
+        json!({"KeyId": key_id, "Plaintext": b64("hello")}),
+    );
+    let err = match svc.encrypt(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected KMSInvalidStateException"),
+    };
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("KMSInvalidStateException"), "got: {msg}");
+}
+
+#[test]
+fn encrypt_disabled_still_returns_disabled_exception() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    force_key_state(&svc, &key_id, "Disabled");
+    let req = make_request(
+        "Encrypt",
+        json!({"KeyId": key_id, "Plaintext": b64("hello")}),
+    );
+    let err = match svc.encrypt(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected DisabledException"),
+    };
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("DisabledException"), "got: {msg}");
+}
+
+#[test]
+fn generate_data_key_rejects_unavailable_state() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    force_key_state(&svc, &key_id, "Unavailable");
+    let req = make_request(
+        "GenerateDataKey",
+        json!({"KeyId": key_id, "KeySpec": "AES_256"}),
+    );
+    let err = match svc.generate_data_key(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected KMSInvalidStateException"),
+    };
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("KMSInvalidStateException"), "got: {msg}");
+}
+
+#[test]
+fn decrypt_rejects_when_source_key_is_pending_deletion() {
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    let enc_req = make_request(
+        "Encrypt",
+        json!({"KeyId": key_id, "Plaintext": b64("hello")}),
+    );
+    let enc_resp = svc.encrypt(&enc_req).unwrap();
+    let enc_body: Value = serde_json::from_slice(enc_resp.body.expect_bytes()).unwrap();
+    let ct = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    force_key_state(&svc, &key_id, "PendingDeletion");
+    let dec_req = make_request("Decrypt", json!({"CiphertextBlob": ct}));
+    let err = match svc.decrypt(&dec_req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected KMSInvalidStateException"),
+    };
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("KMSInvalidStateException"), "got: {msg}");
+}


### PR DESCRIPTION
## Summary
- New `require_usable_key_state` helper rejects crypto ops with `KMSInvalidStateException` whenever the key isn't `Enabled`, except `Disabled` (and legacy `enabled=false`) which keep the dedicated `DisabledException` for back-compat.
- Wired into Encrypt, Decrypt, ReEncrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, GenerateDataKeyPair, GenerateDataKeyPairWithoutPlaintext, Sign, Verify, GenerateMac, VerifyMac.
- Decrypt + ReEncrypt also gate on the source key resolved from the ciphertext envelope, so a key flipped to PendingDeletion after Encrypt no longer round-trips.

## Test plan
- [x] `cargo test -p fakecloud-kms --lib` — 162 tests pass (4 new G5 tests covering PendingDeletion/Disabled/Unavailable + Decrypt-after-PendingDeletion)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces key_state checks across all KMS crypto operations so only `Enabled` keys can run. Decrypt/ReEncrypt also validate the source key from the ciphertext, fulfilling G5.

- **Bug Fixes**
  - Return `KMSInvalidStateException` for any state except `Enabled`; keep `DisabledException` for `Disabled` or legacy `enabled=false`.
  - Gate Decrypt/ReEncrypt on the source key resolved from the ciphertext envelope to block round-trips after state changes.
  - Add tests for `PendingDeletion`, `Disabled`, `Unavailable`, and decrypt-after-state-change.

<sup>Written for commit de852ad5a27ea7ecc7ff3314b2eb52924fe7c777. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

