### PR TITLE
feat(kms): real RSA-OAEP unwrap on ImportKeyMaterial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,6 +3191,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "sha1",
  "sha2 0.10.9",
  "signature 2.2.0",
  "thiserror 2.0.18",

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+sha1 = "0.10"
 hmac = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/fakecloud-kms/src/asym.rs
+++ b/crates/fakecloud-kms/src/asym.rs
@@ -218,6 +218,28 @@ fn rsa_verify_prehashed(
     }
 }
 
+/// RSA-OAEP unwrap encrypted key material under the supplied private
+/// key. KMS callers wrap their key material under the public key
+/// returned by GetParametersForImport using one of the documented
+/// `WrappingAlgorithm` values; ImportKeyMaterial reverses the wrap
+/// here to recover the raw key bytes for storage.
+pub fn rsa_oaep_unwrap(
+    priv_der: &[u8],
+    wrapping_algorithm: &str,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, AsymError> {
+    let private = RsaPrivateKey::from_pkcs8_der(priv_der)
+        .map_err(|e| AsymError::CorruptKey(format!("decode pkcs8: {e}")))?;
+    let padding = match wrapping_algorithm {
+        "RSAES_OAEP_SHA_1" => rsa::Oaep::new::<sha1::Sha1>(),
+        "RSAES_OAEP_SHA_256" => rsa::Oaep::new::<Sha256>(),
+        other => return Err(AsymError::UnsupportedAlgorithm(other.to_string())),
+    };
+    private
+        .decrypt(padding, ciphertext)
+        .map_err(|e| AsymError::CryptoFailure(format!("oaep unwrap: {e}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fakecloud-kms/src/service_custom_store.rs
+++ b/crates/fakecloud-kms/src/service_custom_store.rs
@@ -47,19 +47,54 @@ impl KmsService {
             ));
         }
 
+        // Drop the read lock — generating an RSA-2048 keypair is slow
+        // (~50ms) and we'll need a write lock to stash the private half.
+        let key_arn = key.arn.clone();
+        drop(accounts);
+
+        // Real RSA-2048 wrapping keypair. The public half goes back to
+        // the caller as SubjectPublicKeyInfo DER so they can RSA-OAEP
+        // encrypt their key material under it; the private half is
+        // stashed keyed by the import token so ImportKeyMaterial can
+        // unwrap on the way in.
+        let (priv_der, pub_der) = super::asym::generate_keypair("RSA_2048")
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    format!("failed to generate import wrapping key: {e}"),
+                )
+            })?
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    "RSA_2048 keygen returned None",
+                )
+            })?;
+
         let import_token_bytes = rand_bytes(64);
         let import_token_b64 =
             base64::engine::general_purpose::STANDARD.encode(&import_token_bytes);
-        let public_key_bytes = generate_fake_public_key("RSA_2048");
-        let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
+        let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&pub_der);
 
         // Valid for 24 hours
         let parameters_valid_to = Utc::now().timestamp() as f64 + 86400.0;
 
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        state.import_wrapping_keys.insert(
+            import_token_b64.clone(),
+            crate::state::ImportWrapEntry {
+                private_key_der: priv_der,
+                key_id: resolved.clone(),
+            },
+        );
+
         Ok(AwsResponse::json(
             StatusCode::OK,
             serde_json::to_string(&json!({
-                "KeyId": key.arn,
+                "KeyId": key_arn,
                 "ImportToken": import_token_b64,
                 "PublicKey": public_key_b64,
                 "ParametersValidTo": parameters_valid_to,
@@ -75,7 +110,7 @@ impl KmsService {
         let body = req.json_body();
         let key_id = Self::require_key_id(&body)?;
 
-        let _import_token = body["ImportToken"].as_str().ok_or_else(|| {
+        let import_token = body["ImportToken"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -90,6 +125,11 @@ impl KmsService {
                 "EncryptedKeyMaterial is required",
             )
         })?;
+
+        let wrapping_algorithm = body["WrappingAlgorithm"]
+            .as_str()
+            .unwrap_or("RSAES_OAEP_SHA_256")
+            .to_string();
 
         let resolved = self
             .resolve_key_id_for(&req.account_id, &req.region, &key_id)
@@ -119,10 +159,28 @@ impl KmsService {
             ));
         }
 
-        // Store the imported material bytes for use in encrypt/decrypt.
-        // In real AWS, the material is unwrapped with the import RSA key.
-        // Here we treat the EncryptedKeyMaterial as the raw key (base64-decoded).
-        let material_bytes = base64::engine::general_purpose::STANDARD
+        // Look up the wrapping keypair stashed by GetParametersForImport
+        // and verify the token belongs to this CMK.
+        let entry = state
+            .import_wrapping_keys
+            .get(import_token)
+            .cloned()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidImportTokenException",
+                    "ImportToken is invalid or expired",
+                )
+            })?;
+        if entry.key_id != resolved {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidImportTokenException",
+                "ImportToken was issued for a different key",
+            ));
+        }
+
+        let wrapped_bytes = base64::engine::general_purpose::STANDARD
             .decode(encrypted_key_material)
             .map_err(|_| {
                 AwsServiceError::aws_error(
@@ -131,17 +189,37 @@ impl KmsService {
                     "EncryptedKeyMaterial is not valid base64",
                 )
             })?;
-        if material_bytes.is_empty() {
+        if wrapped_bytes.is_empty() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
                 "EncryptedKeyMaterial must not be empty",
             ));
         }
+
+        // RSA-OAEP unwrap with the wrapping private key. AWS rejects a
+        // bad cipher with InvalidCiphertextException; mirror that.
+        let unwrapped = super::asym::rsa_oaep_unwrap(
+            &entry.private_key_der,
+            &wrapping_algorithm,
+            &wrapped_bytes,
+        )
+        .map_err(|_| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidCiphertextException",
+                "EncryptedKeyMaterial could not be unwrapped",
+            )
+        })?;
+
         key.imported_key_material = true;
-        key.imported_material_bytes = Some(material_bytes);
+        key.imported_material_bytes = Some(unwrapped);
         key.enabled = true;
         key.key_state = "Enabled".to_string();
+        // Token is single-use; drop it now that the import succeeded
+        // so a replay on the same token is rejected with the same
+        // InvalidImportTokenException as an unknown token.
+        state.import_wrapping_keys.remove(import_token);
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -43,6 +43,49 @@ fn create_key(svc: &KmsService) -> String {
     body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string()
 }
 
+/// Helper: run GetParametersForImport, RSA-OAEP-wrap `material` under
+/// the returned public key, and call ImportKeyMaterial. Used by every
+/// import-flow test so they exercise the real OAEP unwrap path
+/// instead of relying on the previous fake-bytes shim.
+fn import_external_material(svc: &KmsService, key_id: &str, material: &[u8]) {
+    use base64::Engine;
+    use rsa::pkcs8::DecodePublicKey;
+
+    let resp = svc
+        .get_parameters_for_import(&make_request(
+            "GetParametersForImport",
+            json!({
+                "KeyId": key_id,
+                "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+                "WrappingKeySpec": "RSA_2048",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let token = body["ImportToken"].as_str().unwrap().to_string();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+    let public = rsa::RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+    let mut rng = rand::thread_rng();
+    let wrapped = public
+        .encrypt(&mut rng, rsa::Oaep::new::<rsa::sha2::Sha256>(), material)
+        .unwrap();
+    let wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&wrapped);
+
+    svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_id,
+            "ImportToken": token,
+            "EncryptedKeyMaterial": wrapped_b64,
+            "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+            "ExpirationModel": "KEY_MATERIAL_DOES_NOT_EXPIRE"
+        }),
+    ))
+    .unwrap();
+}
+
 #[test]
 fn list_keys_pagination_no_duplicates() {
     let svc = make_service();
@@ -289,20 +332,8 @@ fn import_key_material_lifecycle() {
     let svc = make_service();
     let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
 
-    let fake_token = base64::engine::general_purpose::STANDARD.encode(b"token");
-    let fake_material = base64::engine::general_purpose::STANDARD.encode(b"material");
-
-    // Import
-    let req = make_request(
-        "ImportKeyMaterial",
-        json!({
-            "KeyId": key_id,
-            "ImportToken": fake_token,
-            "EncryptedKeyMaterial": fake_material,
-            "ExpirationModel": "KEY_MATERIAL_DOES_NOT_EXPIRE"
-        }),
-    );
-    svc.import_key_material(&req).unwrap();
+    // Real RSA-OAEP wrap+unwrap flow.
+    import_external_material(&svc, &key_id, b"my-secret-aes-key-material!12345");
 
     // Key should be enabled
     {
@@ -333,6 +364,9 @@ fn import_key_material_non_external_fails() {
     let svc = make_service();
     let key_id = create_key(&svc);
 
+    // Non-EXTERNAL key rejects ImportKeyMaterial regardless of token
+    // validity, so the fake token + material here is fine — we never
+    // reach the unwrap step.
     let fake_token = base64::engine::general_purpose::STANDARD.encode(b"token");
     let fake_material = base64::engine::general_purpose::STANDARD.encode(b"material");
 
@@ -662,21 +696,10 @@ fn derive_shared_secret_is_deterministic() {
 fn imported_key_material_encrypt_decrypt_roundtrip() {
     let svc = make_service();
     let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
-
-    let fake_token = base64::engine::general_purpose::STANDARD.encode(b"token");
     let material = b"my-secret-aes-key-material!12345";
-    let fake_material = base64::engine::general_purpose::STANDARD.encode(material);
 
-    // Import key material
-    let req = make_request(
-        "ImportKeyMaterial",
-        json!({
-            "KeyId": key_id,
-            "ImportToken": fake_token,
-            "EncryptedKeyMaterial": fake_material,
-        }),
-    );
-    svc.import_key_material(&req).unwrap();
+    // Real RSA-OAEP wrap+unwrap flow.
+    import_external_material(&svc, &key_id, material);
 
     // Encrypt
     let plaintext = b"Hello imported key!";
@@ -717,21 +740,7 @@ fn imported_key_material_encrypt_decrypt_roundtrip() {
 fn imported_key_material_decrypt_fails_after_deletion() {
     let svc = make_service();
     let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
-
-    let fake_token = base64::engine::general_purpose::STANDARD.encode(b"token");
-    let fake_material =
-        base64::engine::general_purpose::STANDARD.encode(b"some-key-material-32bytes!!");
-
-    // Import and encrypt
-    svc.import_key_material(&make_request(
-        "ImportKeyMaterial",
-        json!({
-            "KeyId": key_id,
-            "ImportToken": fake_token,
-            "EncryptedKeyMaterial": fake_material,
-        }),
-    ))
-    .unwrap();
+    import_external_material(&svc, &key_id, b"some-key-material-32bytes!!");
 
     let plaintext_b64 = base64::engine::general_purpose::STANDARD.encode(b"secret");
     let resp = svc
@@ -2463,4 +2472,156 @@ fn decrypt_rejects_when_source_key_is_pending_deletion() {
     };
     let msg = format!("{:?}", err);
     assert!(msg.contains("KMSInvalidStateException"), "got: {msg}");
+}
+
+// ── G7: ImportKeyMaterial RSA-OAEP unwrap ──
+
+#[test]
+fn import_key_material_rejects_unknown_token() {
+    let svc = make_service();
+    let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+    let bogus_token = base64::engine::general_purpose::STANDARD.encode(b"never-issued");
+    let bogus_material = base64::engine::general_purpose::STANDARD.encode(b"raw-bytes");
+    let err = match svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_id,
+            "ImportToken": bogus_token,
+            "EncryptedKeyMaterial": bogus_material,
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidImportTokenException"),
+    };
+    assert!(format!("{:?}", err).contains("InvalidImportTokenException"));
+}
+
+#[test]
+fn import_key_material_rejects_token_for_other_key() {
+    use base64::Engine;
+    use rsa::pkcs8::DecodePublicKey;
+
+    let svc = make_service();
+    let key_a = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+    let key_b = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+
+    // Token issued for key_a, but caller tries to use it for key_b.
+    let resp = svc
+        .get_parameters_for_import(&make_request(
+            "GetParametersForImport",
+            json!({"KeyId": key_a, "WrappingAlgorithm": "RSAES_OAEP_SHA_256"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let token = body["ImportToken"].as_str().unwrap().to_string();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+    let public = rsa::RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+    let mut rng = rand::thread_rng();
+    let wrapped = public
+        .encrypt(&mut rng, rsa::Oaep::new::<rsa::sha2::Sha256>(), b"material")
+        .unwrap();
+    let wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&wrapped);
+
+    let err = match svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_b,
+            "ImportToken": token,
+            "EncryptedKeyMaterial": wrapped_b64,
+            "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidImportTokenException for cross-key token"),
+    };
+    assert!(format!("{:?}", err).contains("InvalidImportTokenException"));
+}
+
+#[test]
+fn import_key_material_token_is_single_use() {
+    use base64::Engine;
+    use rsa::pkcs8::DecodePublicKey;
+
+    let svc = make_service();
+    let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+
+    let resp = svc
+        .get_parameters_for_import(&make_request(
+            "GetParametersForImport",
+            json!({"KeyId": key_id, "WrappingAlgorithm": "RSAES_OAEP_SHA_256"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let token = body["ImportToken"].as_str().unwrap().to_string();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+    let public = rsa::RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+    let mut rng = rand::thread_rng();
+    let wrapped = public
+        .encrypt(&mut rng, rsa::Oaep::new::<rsa::sha2::Sha256>(), b"material")
+        .unwrap();
+    let wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&wrapped);
+
+    // First import succeeds.
+    svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_id,
+            "ImportToken": token.clone(),
+            "EncryptedKeyMaterial": wrapped_b64.clone(),
+            "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+        }),
+    ))
+    .unwrap();
+
+    // Replay with the same token must fail — the token was single-use.
+    let err = match svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_id,
+            "ImportToken": token,
+            "EncryptedKeyMaterial": wrapped_b64,
+            "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidImportTokenException on token replay"),
+    };
+    assert!(format!("{:?}", err).contains("InvalidImportTokenException"));
+}
+
+#[test]
+fn import_key_material_rejects_garbage_ciphertext() {
+    let svc = make_service();
+    let key_id = create_key_with_opts(&svc, json!({ "Origin": "EXTERNAL" }));
+
+    let resp = svc
+        .get_parameters_for_import(&make_request(
+            "GetParametersForImport",
+            json!({"KeyId": key_id, "WrappingAlgorithm": "RSAES_OAEP_SHA_256"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let token = body["ImportToken"].as_str().unwrap().to_string();
+
+    // Random 256-byte payload — won't OAEP-decrypt under any key.
+    let garbage = vec![0xab_u8; 256];
+    let garbage_b64 = base64::engine::general_purpose::STANDARD.encode(&garbage);
+
+    let err = match svc.import_key_material(&make_request(
+        "ImportKeyMaterial",
+        json!({
+            "KeyId": key_id,
+            "ImportToken": token,
+            "EncryptedKeyMaterial": garbage_b64,
+            "WrappingAlgorithm": "RSAES_OAEP_SHA_256",
+        }),
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("expected InvalidCiphertextException"),
+    };
+    assert!(format!("{:?}", err).contains("InvalidCiphertextException"));
 }

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -26,6 +26,24 @@ pub struct KmsState {
     /// decrypt afterwards.
     #[serde(default = "default_master_key_bytes")]
     pub master_key_bytes: Vec<u8>,
+    /// In-flight RSA wrapping keypairs handed out by GetParametersForImport
+    /// and consumed by ImportKeyMaterial to RSA-OAEP-unwrap the encrypted
+    /// key material. Keyed by the import token bytes returned to the
+    /// caller; entries are removed after a successful import.
+    #[serde(default)]
+    pub import_wrapping_keys: BTreeMap<String, ImportWrapEntry>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct ImportWrapEntry {
+    /// PKCS#8 DER-encoded RSA-2048 private key half of the wrapping
+    /// keypair. The corresponding SubjectPublicKeyInfo DER was returned
+    /// to the caller in `GetParametersForImport.PublicKey` so they can
+    /// RSA-OAEP-encrypt the key material under it.
+    pub private_key_der: Vec<u8>,
+    /// CMK key id this token is bound to. ImportKeyMaterial rejects the
+    /// token when it doesn't match the CMK in the request.
+    pub key_id: String,
 }
 
 fn default_master_key_bytes() -> Vec<u8> {
@@ -46,6 +64,7 @@ impl KmsState {
             grants: Vec::new(),
             custom_key_stores: BTreeMap::new(),
             master_key_bytes: default_master_key_bytes(),
+            import_wrapping_keys: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- `GetParametersForImport` now generates a real RSA-2048 wrapping keypair, returns the SubjectPublicKeyInfo DER as `PublicKey`, and stashes the PKCS#8 private half in state keyed by the issued `ImportToken` (bound to the CMK id).
- `ImportKeyMaterial` looks up the wrapping private key by token, rejects tokens for the wrong CMK with `InvalidImportTokenException`, and RSA-OAEP-unwraps `EncryptedKeyMaterial` under SHA-1 or SHA-256 per `WrappingAlgorithm`. Bad ciphertext -> `InvalidCiphertextException`. Tokens are single-use.
- New `asym::rsa_oaep_unwrap` helper covers `RSAES_OAEP_SHA_1` + `RSAES_OAEP_SHA_256`.

## Test plan
- [x] `cargo test -p fakecloud-kms --lib` — 166 tests pass; existing import-flow tests now exercise the real OAEP wrap+unwrap via a new `import_external_material` helper, plus 4 new G7 tests (unknown token, cross-key token, replay, garbage cipher).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real RSA‑OAEP unwrap for external key imports. GetParametersForImport now returns a real RSA‑2048 public key, and ImportKeyMaterial unwraps the encrypted material with the matching private key; tokens are CMK‑bound and single‑use. Aligns with plan G7.

- **New Features**
  - GetParametersForImport creates an RSA‑2048 pair, returns the SPKI DER public key, and stores the PKCS#8 private key keyed by the issued ImportToken (bound to the CMK).
  - ImportKeyMaterial validates the token/CMK, unwraps with RSA‑OAEP using SHA‑1 or SHA‑256 (per WrappingAlgorithm), and maps failures to InvalidImportTokenException or InvalidCiphertextException; tokens are single‑use.
  - Added `asym::rsa_oaep_unwrap` helper; tests now run a real wrap/unwrap flow and cover unknown token, cross‑key token, replay, and garbage ciphertext.

- **Dependencies**
  - Added `sha1`.

<sup>Written for commit 36143d9e895fb2375fe236b22b9b72d4d8fe9b07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

