### PR TITLE
feat(kinesis): honor StreamModeDetails on CreateStream + retention prune on read

### DIFF
--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -185,6 +185,27 @@ impl KinesisService {
         let shard_count = i32::try_from(shard_count)
             .map_err(|_| invalid_argument("ShardCount must be less than or equal to 2147483647"))?;
 
+        // Honor StreamModeDetails.StreamMode if supplied. AWS accepts
+        // PROVISIONED (default) and ON_DEMAND; ON_DEMAND streams ignore
+        // ShardCount entirely. Anything unrecognized is a 400.
+        let stream_mode = body["StreamModeDetails"]["StreamMode"]
+            .as_str()
+            .unwrap_or("PROVISIONED")
+            .to_string();
+        if stream_mode != "PROVISIONED" && stream_mode != "ON_DEMAND" {
+            return Err(invalid_argument(
+                "StreamMode must be PROVISIONED or ON_DEMAND",
+            ));
+        }
+        // ON_DEMAND seeds a small fixed shard count; the surface still
+        // exposes shards through GetShardIterator/GetRecords so callers
+        // can read/write while we no-op the per-shard provisioning.
+        let effective_shard_count = if stream_mode == "ON_DEMAND" {
+            4
+        } else {
+            shard_count
+        };
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
         if state.streams.contains_key(stream_name) {
@@ -204,14 +225,14 @@ impl KinesisService {
             stream_status: "ACTIVE".to_string(),
             stream_creation_timestamp: Utc::now(),
             retention_period_hours: 24,
-            stream_mode: "PROVISIONED".to_string(),
+            stream_mode,
             encryption_type: "NONE".to_string(),
             key_id: None,
-            shard_count,
-            open_shard_count: shard_count,
+            shard_count: effective_shard_count,
+            open_shard_count: effective_shard_count,
             tags: std::collections::BTreeMap::new(),
-            shards: build_stream_shards(shard_count),
-            next_shard_index: shard_count,
+            shards: build_stream_shards(effective_shard_count),
+            next_shard_index: effective_shard_count,
             enhanced_metrics: Vec::new(),
             warm_throughput_mibps: None,
             max_record_size_kib: None,
@@ -433,11 +454,20 @@ impl KinesisService {
             .find(|candidate| candidate.shard_id == lease.shard_id)
             .ok_or_else(|| invalid_argument("ShardId is invalid"))?;
 
-        let end_index = shard
-            .records
-            .len()
-            .min(lease.next_record_index.saturating_add(limit));
-        let records: Vec<Value> = shard.records[lease.next_record_index..end_index]
+        // Drop records past retention. Records are stored in arrival
+        // order so we can stop scanning at the first one within window
+        // — but the iterator slot might point into the expired prefix,
+        // so advance past it before reading.
+        let retention_cutoff =
+            Utc::now() - chrono::Duration::hours(stream.retention_period_hours as i64);
+        let mut start_index = lease.next_record_index;
+        while start_index < shard.records.len()
+            && shard.records[start_index].approximate_arrival_timestamp < retention_cutoff
+        {
+            start_index += 1;
+        }
+        let end_index = shard.records.len().min(start_index.saturating_add(limit));
+        let records: Vec<Value> = shard.records[start_index..end_index]
             .iter()
             .map(|record| {
                 json!({

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -1439,3 +1439,110 @@ fn stop_stream_encryption_unknown_stream_errors() {
     );
     assert!(svc.stop_stream_encryption(&req).is_err());
 }
+
+// ── K13: StreamModeDetails + retention pruning ──
+
+#[test]
+fn create_stream_honors_on_demand_mode() {
+    let (svc, state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({
+            "StreamName": "demand",
+            "StreamModeDetails": {"StreamMode": "ON_DEMAND"}
+        }),
+    ))
+    .unwrap();
+    let _accts = state.read();
+    let st = _accts.default_ref();
+    let stream = st.streams.get("demand").unwrap();
+    assert_eq!(stream.stream_mode, "ON_DEMAND");
+    // ON_DEMAND ignores ShardCount; we seed a small fixed count.
+    assert!(stream.shard_count >= 1);
+}
+
+#[test]
+fn create_stream_rejects_unknown_stream_mode() {
+    let (svc, _) = make_service();
+    let err = svc
+        .create_stream(&request(
+            "CreateStream",
+            json!({
+                "StreamName": "bogus",
+                "StreamModeDetails": {"StreamMode": "TURBO"}
+            }),
+        ))
+        .err()
+        .expect("expected invalid argument");
+    assert!(format!("{:?}", err).contains("StreamMode"));
+}
+
+#[test]
+fn create_stream_defaults_to_provisioned_mode() {
+    let (svc, state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({"StreamName": "default-mode", "ShardCount": 1}),
+    ))
+    .unwrap();
+    let _accts = state.read();
+    let st = _accts.default_ref();
+    let stream = st.streams.get("default-mode").unwrap();
+    assert_eq!(stream.stream_mode, "PROVISIONED");
+}
+
+#[test]
+fn get_records_skips_records_past_retention() {
+    let (svc, state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({"StreamName": "ret", "ShardCount": 1}),
+    ))
+    .unwrap();
+
+    // Push two records: one stale (well past retention), one fresh.
+    {
+        let mut accts = state.write();
+        let st = accts.default_mut();
+        let stream = st.streams.get_mut("ret").unwrap();
+        let shard = &mut stream.shards[0];
+        let stale_ts = chrono::Utc::now() - chrono::Duration::hours(48);
+        shard.records.push(KinesisRecord {
+            sequence_number: "1".to_string(),
+            partition_key: "p".to_string(),
+            data: b"stale".to_vec(),
+            approximate_arrival_timestamp: stale_ts,
+        });
+        shard.records.push(KinesisRecord {
+            sequence_number: "2".to_string(),
+            partition_key: "p".to_string(),
+            data: b"fresh".to_vec(),
+            approximate_arrival_timestamp: chrono::Utc::now(),
+        });
+    }
+
+    let it_resp = svc
+        .get_shard_iterator(&request(
+            "GetShardIterator",
+            json!({
+                "StreamName": "ret",
+                "ShardId": "shardId-000000000000",
+                "ShardIteratorType": "TRIM_HORIZON"
+            }),
+        ))
+        .unwrap();
+    let it_body: Value = serde_json::from_slice(it_resp.body.expect_bytes()).unwrap();
+    let iterator = it_body["ShardIterator"].as_str().unwrap().to_string();
+
+    let resp = svc
+        .get_records(&request("GetRecords", json!({"ShardIterator": iterator})))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let records = body["Records"].as_array().unwrap();
+    assert_eq!(records.len(), 1);
+    let data_b64 = records[0]["Data"].as_str().unwrap();
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(data_b64)
+        .unwrap();
+    assert_eq!(data, b"fresh");
+}


### PR DESCRIPTION
## Summary
- `CreateStream` parses `StreamModeDetails.StreamMode` (`PROVISIONED` default, `ON_DEMAND` accepted, anything else 400). `ON_DEMAND` streams ignore `ShardCount` and seed a small fixed shard count.
- `GetRecords` drops records older than the stream's `retention_period_hours` and advances the iterator past the expired prefix.
- Drive-by: AT_TIMESTAMP shard iterator type confirmed already implemented in an earlier batch.

## Test plan
- [x] `cargo test -p fakecloud-kinesis --lib` — 99 pass; 4 new K13 tests (ON_DEMAND mode, unknown-mode rejection, default PROVISIONED, retention prune)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds StreamMode support and retention-based pruning to `fakecloud-kinesis` Kinesis APIs. Aligns with K13 by honoring `StreamModeDetails` on create and skipping expired records on read.

- **New Features**
  - `CreateStream` validates `StreamModeDetails.StreamMode` (default `PROVISIONED`; accepts `ON_DEMAND`; otherwise 400).
  - `ON_DEMAND` ignores `ShardCount` and seeds a small fixed shard count.
  - `GetRecords` drops records older than `retention_period_hours` and advances the iterator past expired entries.

<sup>Written for commit 167b43c1567831dd7bc12b174915e9ca19ee540d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

