### PR TITLE
feat(dynamodb): atomic ExecuteTransaction + stream/kinesis emit (L3)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -20,7 +20,7 @@ type PendingKinesis = (
 );
 
 use super::{
-    apply_update_expression, build_consumed_capacity, evaluate_condition,
+    apply_update_expression, build_consumed_capacity, evaluate_condition, execute_partiql_in_state,
     execute_partiql_statement, extract_key, get_table, get_table_mut,
     parse_expression_attribute_names, parse_expression_attribute_values, require_str,
     return_consumed_mode, return_icm_mode, DynamoDbService,
@@ -740,37 +740,84 @@ impl DynamoDbService {
             )
         })?;
 
-        // Collect all results; if any fail, return TransactionCanceledException
-        let mut results: Vec<Result<Value, String>> = Vec::new();
-        for stmt_obj in transact_statements {
+        // Snapshot every account state on the default account up-front
+        // so we can revert in one shot if any statement fails. Cheap
+        // because PartiQL targets the default account only (PartiQL has
+        // no per-account scoping), and atomicity is required by the
+        // spec.
+        let mut accounts = self.state.write();
+        let state = accounts.default_mut();
+        let snapshot_tables = state.tables.clone();
+
+        let region = req.region.clone();
+        let mut responses: Vec<Value> = Vec::with_capacity(transact_statements.len());
+        let mut pending_stream: Vec<(String, crate::state::StreamRecord)> = Vec::new();
+        let mut pending_kinesis: Vec<PendingKinesis> = Vec::new();
+        let mut failure: Option<(usize, String)> = None;
+
+        for (i, stmt_obj) in transact_statements.iter().enumerate() {
             let statement = stmt_obj["Statement"].as_str().unwrap_or_default();
             let parameters = stmt_obj["Parameters"]
                 .as_array()
                 .cloned()
                 .unwrap_or_default();
 
-            match execute_partiql_statement(&self.state, statement, &parameters) {
-                Ok(resp) => {
-                    let resp_body: Value =
-                        serde_json::from_slice(resp.body.expect_bytes()).unwrap_or_default();
-                    results.push(Ok(resp_body));
+            match execute_partiql_in_state(state, statement, &parameters) {
+                Ok(outcome) => {
+                    responses.push(outcome.response);
+                    let table_name = match outcome.table_name {
+                        Some(n) => n,
+                        None => continue,
+                    };
+                    let event_name = match outcome.event_name {
+                        Some(e) => e,
+                        None => continue,
+                    };
+                    let keys = outcome.keys.unwrap_or_default();
+                    if let Some(table) = state.tables.get(&table_name) {
+                        if let Some(record) = crate::streams::generate_stream_record(
+                            table,
+                            &event_name,
+                            keys.clone(),
+                            outcome.old_image.clone(),
+                            outcome.new_image.clone(),
+                            &region,
+                        ) {
+                            pending_stream.push((table_name.clone(), record));
+                        }
+                        if let Some(target) = DynamoDbService::kinesis_target(table) {
+                            pending_kinesis.push((
+                                target,
+                                event_name,
+                                keys,
+                                outcome.old_image,
+                                outcome.new_image,
+                            ));
+                        }
+                    }
                 }
                 Err(e) => {
-                    results.push(Err(e.to_string()));
+                    failure = Some((i, e.to_string()));
+                    break;
                 }
             }
         }
 
-        let any_failed = results.iter().any(|r| r.is_err());
-        if any_failed {
-            let reasons: Vec<Value> = results
-                .iter()
-                .map(|r| match r {
-                    Ok(_) => json!({ "Code": "None" }),
-                    Err(msg) => json!({
-                        "Code": "ValidationException",
-                        "Message": msg
-                    }),
+        if let Some((failed_idx, msg)) = failure {
+            // Revert: replace the tables map with the pre-transaction
+            // snapshot so all earlier statements in this transaction
+            // are undone.
+            state.tables = snapshot_tables;
+            let reasons: Vec<Value> = (0..transact_statements.len())
+                .map(|i| {
+                    if i == failed_idx {
+                        json!({
+                            "Code": "ValidationException",
+                            "Message": msg.clone(),
+                        })
+                    } else {
+                        json!({ "Code": "None" })
+                    }
                 })
                 .collect();
             let error_body = json!({
@@ -784,7 +831,24 @@ impl DynamoDbService {
             ));
         }
 
-        let responses: Vec<Value> = results.into_iter().filter_map(|r| r.ok()).collect();
+        // Append pending stream records under each table's lock.
+        for (table_name, record) in pending_stream {
+            if let Some(table) = state.tables.get_mut(&table_name) {
+                crate::streams::add_stream_record(table, record);
+            }
+        }
+
+        drop(accounts);
+        for (target, event_name, keys, old_image, new_image) in pending_kinesis {
+            self.deliver_to_kinesis_destinations(
+                &target,
+                &event_name,
+                &keys,
+                old_image.as_ref(),
+                new_image.as_ref(),
+            );
+        }
+
         Self::ok_json(json!({ "Responses": responses }))
     }
 }
@@ -922,6 +986,64 @@ mod tests {
             table.items.len(),
             0,
             "the Put on Widgets must not commit when a sibling table is missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_transaction_emits_stream_record_per_write() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        let req = req_for(
+            "ExecuteTransaction",
+            json!({
+                "TransactStatements": [
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'b'}"},
+                ]
+            }),
+        );
+        let resp = svc.execute_transaction(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        assert_eq!(table.items.len(), 2);
+        assert_eq!(
+            table.stream_records.read().len(),
+            2,
+            "each PartiQL INSERT must emit one stream record"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_transaction_reverts_on_mid_batch_failure() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        // First INSERT succeeds, second targets a missing table.
+        let req = req_for(
+            "ExecuteTransaction",
+            json!({
+                "TransactStatements": [
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+                    {"Statement": "INSERT INTO \"Missing\" VALUE {'pk': 'b'}"},
+                ]
+            }),
+        );
+        let resp = svc.execute_transaction(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::BAD_REQUEST);
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        assert_eq!(
+            table.items.len(),
+            0,
+            "first INSERT must be reverted when the second statement fails"
         );
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -2179,6 +2179,201 @@ pub(crate) fn execute_partiql_statement(
     }
 }
 
+/// In-place PartiQL executor used by ExecuteTransaction, which must
+/// hold a single write lock across the whole batch so a mid-batch error
+/// can revert. Returns the response body Value plus the touched table
+/// name and (for write ops) the keys + before/after images so the
+/// caller can emit stream + kinesis events after the transaction
+/// commits — mirroring the per-write hooks in items.rs and the
+/// TransactWriteItems path.
+pub(crate) struct PartiqlOutcome {
+    pub response: Value,
+    pub table_name: Option<String>,
+    pub event_name: Option<String>, // INSERT, MODIFY, REMOVE
+    pub keys: Option<HashMap<String, AttributeValue>>,
+    pub old_image: Option<HashMap<String, AttributeValue>>,
+    pub new_image: Option<HashMap<String, AttributeValue>>,
+}
+
+pub(crate) fn execute_partiql_in_state(
+    state: &mut crate::state::DynamoDbState,
+    statement: &str,
+    parameters: &[Value],
+) -> Result<PartiqlOutcome, AwsServiceError> {
+    let trimmed = statement.trim();
+    let upper = trimmed.to_ascii_uppercase();
+
+    if upper.starts_with("SELECT") {
+        let from_pos = upper.find("FROM").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Invalid SELECT statement: missing FROM",
+            )
+        })?;
+        let after_from = trimmed[from_pos + 4..].trim();
+        let (table_name, rest) = parse_partiql_table_name(after_from);
+        let table = get_table(&state.tables, &table_name)?;
+        let rest_upper = rest.trim().to_ascii_uppercase();
+        let items: Vec<Value> = if rest_upper.starts_with("WHERE") {
+            let where_clause = rest.trim()[5..].trim();
+            evaluate_partiql_where(table, where_clause, parameters)?
+                .iter()
+                .map(|item| json!(item))
+                .collect()
+        } else {
+            table.items.iter().map(|item| json!(item)).collect()
+        };
+        Ok(PartiqlOutcome {
+            response: json!({ "Items": items }),
+            table_name: Some(table_name),
+            event_name: None,
+            keys: None,
+            old_image: None,
+            new_image: None,
+        })
+    } else if upper.starts_with("INSERT") {
+        let into_pos = upper.find("INTO").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Invalid INSERT statement: missing INTO",
+            )
+        })?;
+        let after_into = trimmed[into_pos + 4..].trim();
+        let (table_name, rest) = parse_partiql_table_name(after_into);
+        let rest_upper = rest.trim().to_ascii_uppercase();
+        let value_pos = rest_upper.find("VALUE").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Invalid INSERT statement: missing VALUE",
+            )
+        })?;
+        let value_str = rest.trim()[value_pos + 5..].trim();
+        let item = parse_partiql_value_object(value_str, parameters)?;
+        let table = get_table_mut(&mut state.tables, &table_name)?;
+        let key = extract_key(table, &item);
+        if table.find_item_index(&key).is_some() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "DuplicateItemException",
+                "Duplicate primary key exists in table",
+            ));
+        }
+        table.items.push(item.clone());
+        table.recalculate_stats();
+        Ok(PartiqlOutcome {
+            response: json!({}),
+            table_name: Some(table_name),
+            event_name: Some("INSERT".to_string()),
+            keys: Some(key),
+            old_image: None,
+            new_image: Some(item),
+        })
+    } else if upper.starts_with("UPDATE") {
+        let after_update = trimmed[6..].trim();
+        let (table_name, rest) = parse_partiql_table_name(after_update);
+        let rest_upper = rest.trim().to_ascii_uppercase();
+        let set_pos = rest_upper.find("SET").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Invalid UPDATE statement: missing SET",
+            )
+        })?;
+        let after_set = rest.trim()[set_pos + 3..].trim();
+        let where_pos = after_set.to_ascii_uppercase().find("WHERE");
+        let (set_clause, where_clause) = if let Some(wp) = where_pos {
+            (&after_set[..wp], after_set[wp + 5..].trim())
+        } else {
+            (after_set, "")
+        };
+        let table = get_table_mut(&mut state.tables, &table_name)?;
+        let matched_indices = if !where_clause.is_empty() {
+            find_partiql_where_indices(table, where_clause, parameters)?
+        } else {
+            (0..table.items.len()).collect()
+        };
+        let param_offset = count_params_in_str(where_clause);
+        let assignments: Vec<&str> = set_clause.split(',').collect();
+        let mut last_key: Option<HashMap<String, AttributeValue>> = None;
+        let mut last_old: Option<HashMap<String, AttributeValue>> = None;
+        let mut last_new: Option<HashMap<String, AttributeValue>> = None;
+        for idx in &matched_indices {
+            last_old = Some(table.items[*idx].clone());
+            let mut local_offset = param_offset;
+            for assignment in &assignments {
+                let assignment = assignment.trim();
+                if let Some((attr, val_str)) = assignment.split_once('=') {
+                    let attr = attr.trim().trim_matches('"');
+                    let val_str = val_str.trim();
+                    let value = parse_partiql_literal(val_str, parameters, &mut local_offset);
+                    if let Some(v) = value {
+                        table.items[*idx].insert(attr.to_string(), v);
+                    }
+                }
+            }
+            last_key = Some(extract_key(table, &table.items[*idx]));
+            last_new = Some(table.items[*idx].clone());
+        }
+        table.recalculate_stats();
+        Ok(PartiqlOutcome {
+            response: json!({}),
+            table_name: Some(table_name),
+            event_name: last_old.as_ref().map(|_| "MODIFY".to_string()),
+            keys: last_key,
+            old_image: last_old,
+            new_image: last_new,
+        })
+    } else if upper.starts_with("DELETE") {
+        let from_pos = upper.find("FROM").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Invalid DELETE statement: missing FROM",
+            )
+        })?;
+        let after_from = trimmed[from_pos + 4..].trim();
+        let (table_name, rest) = parse_partiql_table_name(after_from);
+        let rest_upper = rest.trim().to_ascii_uppercase();
+        if !rest_upper.starts_with("WHERE") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "DELETE requires a WHERE clause",
+            ));
+        }
+        let where_clause = rest.trim()[5..].trim();
+        let table = get_table_mut(&mut state.tables, &table_name)?;
+        let mut indices = find_partiql_where_indices(table, where_clause, parameters)?;
+        indices.sort_unstable();
+        indices.reverse();
+        let mut last_old: Option<HashMap<String, AttributeValue>> = None;
+        let mut last_key: Option<HashMap<String, AttributeValue>> = None;
+        for idx in indices {
+            let removed = table.items.remove(idx);
+            last_key = Some(extract_key(table, &removed));
+            last_old = Some(removed);
+        }
+        table.recalculate_stats();
+        Ok(PartiqlOutcome {
+            response: json!({}),
+            table_name: Some(table_name),
+            event_name: last_old.as_ref().map(|_| "REMOVE".to_string()),
+            keys: last_key,
+            old_image: last_old,
+            new_image: None,
+        })
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!("Unsupported PartiQL statement: {trimmed}"),
+        ))
+    }
+}
+
 /// Parse a simple `SELECT * FROM tablename WHERE pk = 'value'` or with parameters.
 pub(crate) fn execute_partiql_select(
     state: &SharedDynamoDbState,


### PR DESCRIPTION
## Summary

\`ExecuteTransaction\` (PartiQL transactional batch) was non-atomic and emitted no change-capture events. Each statement called the regular \`execute_partiql_statement\`, which takes its own write lock and commits before returning — so a failure on statement N left statements 0..N-1 already committed. Streams + Kinesis destinations saw nothing.

This PR:

- Adds \`execute_partiql_in_state\` operating on \`&mut DynamoDbState\` (no inner lock), returning a \`PartiqlOutcome\` with table name, event name, keys, before/after images
- Rewrites \`execute_transaction\` to take the write lock once, snapshot \`tables\`, dispatch via the in-state executor, and revert the snapshot on any failure
- Per write, queues a StreamRecord (via existing \`streams::generate_stream_record\`) and Kinesis delivery; appends/dispatches after commit

## Test plan

- [x] \`cargo test -p fakecloud-dynamodb --lib service::batch\` — 4 tests including:
  - \`execute_transaction_emits_stream_record_per_write\`
  - \`execute_transaction_reverts_on_mid_batch_failure\`
- [x] \`cargo test -p fakecloud-dynamodb --lib\` (237 pass)
- [x] \`cargo build -p fakecloud\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ExecuteTransaction` atomic and emit change events. Transactions now either fully commit or fully roll back, and DynamoDB Streams/Kinesis see every write.

- **New Features**
  - Emit one Streams record and Kinesis delivery per write after the transaction commits.
  - Added `execute_partiql_in_state` returning `PartiqlOutcome` with table, event type, keys, and before/after images.
  - Queue events while locked and dispatch Kinesis after releasing the lock to avoid deadlocks.

- **Bug Fixes**
  - `ExecuteTransaction` is now atomic: take one write lock, snapshot tables, revert on any failure.
  - Returns `TransactionCanceledException` with per-statement reasons.
  - Tests cover per-write stream emission and full rollback on mid-batch failure.

<sup>Written for commit 62993c16aa5ae6d6803d951c3badf367aa7d578b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

