### PR TITLE
feat(dynamodb): preserve GSI/LSI/tags/TTL/SSE/Stream across backup; reject ConsistentRead on GSI Scan (L6)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -321,9 +321,17 @@ impl DynamoDbService {
         // table (fakecloud doesn't keep separate per-index storage)
         // but the projection is restricted to what the index defines.
         let index_name = body["IndexName"].as_str();
+        let consistent_read = body["ConsistentRead"].as_bool().unwrap_or(false);
         let (index_projection, index_key_attrs): (Option<Projection>, Vec<String>) =
             if let Some(idx) = index_name {
                 if let Some(g) = table.gsi.iter().find(|g| g.index_name == idx) {
+                    if consistent_read {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "ValidationException",
+                            "Consistent reads are not supported on global secondary indexes",
+                        ));
+                    }
                     (
                         Some(g.projection.clone()),
                         g.key_schema

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -767,6 +767,15 @@ impl DynamoDbService {
             item_count: table.item_count,
             size_bytes: table.size_bytes,
             items: table.items.clone(),
+            gsi: table.gsi.clone(),
+            lsi: table.lsi.clone(),
+            tags: table.tags.clone(),
+            ttl_attribute: table.ttl_attribute.clone(),
+            ttl_enabled: table.ttl_enabled,
+            sse_type: table.sse_type.clone(),
+            sse_kms_key_arn: table.sse_kms_key_arn.clone(),
+            stream_enabled: table.stream_enabled,
+            stream_view_type: table.stream_view_type.clone(),
         };
 
         state.backups.insert(backup_arn.clone(), backup);
@@ -951,6 +960,18 @@ impl DynamoDbService {
             state.region, state.account_id, target_table_name
         );
 
+        // Re-mint the stream ARN against the target table name so it
+        // doesn't collide with the source table's stream ARN; the
+        // view type and enabled flag come straight from the backup.
+        let stream_arn = if backup.stream_enabled {
+            Some(format!(
+                "{arn}/stream/{}",
+                now.format("%Y-%m-%dT%H:%M:%S%.3f")
+            ))
+        } else {
+            None
+        };
+
         let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
@@ -959,27 +980,27 @@ impl DynamoDbService {
             attribute_definitions: backup.attribute_definitions.clone(),
             provisioned_throughput: backup.provisioned_throughput.clone(),
             items: backup.items.clone(),
-            gsi: Vec::new(),
-            lsi: Vec::new(),
-            tags: BTreeMap::new(),
+            gsi: backup.gsi.clone(),
+            lsi: backup.lsi.clone(),
+            tags: backup.tags.clone(),
             created_at: now,
             status: "ACTIVE".to_string(),
             item_count: 0,
             size_bytes: 0,
             billing_mode: backup.billing_mode.clone(),
-            ttl_attribute: None,
-            ttl_enabled: false,
+            ttl_attribute: backup.ttl_attribute.clone(),
+            ttl_enabled: backup.ttl_enabled,
             resource_policy: None,
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
             contributor_insights_counters: BTreeMap::new(),
-            stream_enabled: false,
-            stream_view_type: None,
-            stream_arn: None,
+            stream_enabled: backup.stream_enabled,
+            stream_view_type: backup.stream_view_type.clone(),
+            stream_arn,
             stream_records: Arc::new(RwLock::new(Vec::new())),
-            sse_type: None,
-            sse_kms_key_arn: None,
+            sse_type: backup.sse_type.clone(),
+            sse_kms_key_arn: backup.sse_kms_key_arn.clone(),
 
             deletion_protection_enabled: false,
             on_demand_throughput: None,
@@ -1033,6 +1054,15 @@ impl DynamoDbService {
             state.region, state.account_id, target_table_name
         );
 
+        let stream_arn = if source.stream_enabled {
+            Some(format!(
+                "{arn}/stream/{}",
+                now.format("%Y-%m-%dT%H:%M:%S%.3f")
+            ))
+        } else {
+            None
+        };
+
         let mut table = DynamoTable {
             name: target_table_name.to_string(),
             arn: arn.clone(),
@@ -1041,27 +1071,27 @@ impl DynamoDbService {
             attribute_definitions: source.attribute_definitions.clone(),
             provisioned_throughput: source.provisioned_throughput.clone(),
             items: source.items.clone(),
-            gsi: Vec::new(),
-            lsi: Vec::new(),
-            tags: BTreeMap::new(),
+            gsi: source.gsi.clone(),
+            lsi: source.lsi.clone(),
+            tags: source.tags.clone(),
             created_at: now,
             status: "ACTIVE".to_string(),
             item_count: 0,
             size_bytes: 0,
             billing_mode: source.billing_mode.clone(),
-            ttl_attribute: None,
-            ttl_enabled: false,
+            ttl_attribute: source.ttl_attribute.clone(),
+            ttl_enabled: source.ttl_enabled,
             resource_policy: None,
             pitr_enabled: false,
             kinesis_destinations: Vec::new(),
             contributor_insights_status: "DISABLED".to_string(),
             contributor_insights_counters: BTreeMap::new(),
-            stream_enabled: false,
-            stream_view_type: None,
-            stream_arn: None,
+            stream_enabled: source.stream_enabled,
+            stream_view_type: source.stream_view_type.clone(),
+            stream_arn,
             stream_records: Arc::new(RwLock::new(Vec::new())),
-            sse_type: None,
-            sse_kms_key_arn: None,
+            sse_type: source.sse_type.clone(),
+            sse_kms_key_arn: source.sse_kms_key_arn.clone(),
 
             deletion_protection_enabled: false,
             on_demand_throughput: None,

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3972,6 +3972,136 @@ fn describe_backup_not_found_errors() {
 }
 
 #[test]
+fn create_backup_round_trip_preserves_gsi_lsi_tags_ttl_sse_stream() {
+    let svc = make_service();
+    // Table with GSI + tags + TTL + KMS-encrypted + streams enabled.
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "rich",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_pk", "AttributeType": "S"},
+            ],
+            "BillingMode": "PAY_PER_REQUEST",
+            "GlobalSecondaryIndexes": [{
+                "IndexName": "by-gsi",
+                "KeySchema": [{"AttributeName": "gsi_pk", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }],
+            "Tags": [{"Key": "env", "Value": "prod"}],
+            "SSESpecification": {"Enabled": true, "SSEType": "KMS"},
+            "StreamSpecification": {
+                "StreamEnabled": true,
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            },
+        }),
+    );
+    svc.create_table(&req).unwrap();
+
+    // Enable TTL.
+    svc.update_time_to_live(&make_request(
+        "UpdateTimeToLive",
+        json!({
+            "TableName": "rich",
+            "TimeToLiveSpecification": {"Enabled": true, "AttributeName": "expire_at"},
+        }),
+    ))
+    .unwrap();
+
+    let resp = svc
+        .create_backup(&make_request(
+            "CreateBackup",
+            json!({"TableName": "rich", "BackupName": "snap"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let backup_arn = body["BackupDetails"]["BackupArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    svc.restore_table_from_backup(&make_request(
+        "RestoreTableFromBackup",
+        json!({"TargetTableName": "restored", "BackupArn": backup_arn}),
+    ))
+    .unwrap();
+
+    let desc = svc
+        .describe_table(&make_request(
+            "DescribeTable",
+            json!({"TableName": "restored"}),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(desc.body.expect_bytes()).unwrap();
+    let table = &body["Table"];
+    assert!(
+        table["GlobalSecondaryIndexes"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false),
+        "restored table must keep GSI definitions"
+    );
+    assert!(
+        table["StreamSpecification"]["StreamEnabled"]
+            .as_bool()
+            .unwrap_or(false),
+        "restored table must keep streams enabled"
+    );
+    assert_eq!(
+        table["SSEDescription"]["Status"].as_str(),
+        Some("ENABLED"),
+        "restored table must keep SSE enabled"
+    );
+
+    // Tags survive (returned by ListTagsOfResource).
+    let arn = table["TableArn"].as_str().unwrap().to_string();
+    let tags_resp = svc
+        .list_tags_of_resource(&make_request(
+            "ListTagsOfResource",
+            json!({"ResourceArn": arn}),
+        ))
+        .unwrap();
+    let tags_body: Value = serde_json::from_slice(tags_resp.body.expect_bytes()).unwrap();
+    let tags = tags_body["Tags"].as_array().unwrap();
+    assert!(tags
+        .iter()
+        .any(|t| t["Key"] == "env" && t["Value"] == "prod"));
+}
+
+#[test]
+fn scan_with_consistent_read_on_gsi_rejected() {
+    let svc = make_service();
+    svc.create_table(&make_request(
+        "CreateTable",
+        json!({
+            "TableName": "t",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "gsi_pk", "AttributeType": "S"},
+            ],
+            "BillingMode": "PAY_PER_REQUEST",
+            "GlobalSecondaryIndexes": [{
+                "IndexName": "by-gsi",
+                "KeySchema": [{"AttributeName": "gsi_pk", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }],
+        }),
+    ))
+    .unwrap();
+    let err = svc
+        .scan(&make_request(
+            "Scan",
+            json!({"TableName": "t", "IndexName": "by-gsi", "ConsistentRead": true}),
+        ))
+        .err()
+        .expect("scan with ConsistentRead on GSI must fail");
+    assert!(format!("{err:?}").contains("Consistent reads are not supported"));
+}
+
+#[test]
 fn restore_table_from_backup_not_found_errors() {
     let svc = make_service();
     let req = make_request(

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -170,6 +170,28 @@ pub struct BackupDescription {
     pub size_bytes: i64,
     /// Snapshot of the table items at backup creation time.
     pub items: Vec<HashMap<String, AttributeValue>>,
+    /// Real DDB persists GSI/LSI/tags/TTL/SSE/Stream into the backup
+    /// payload so RestoreTableFromBackup brings the full table back
+    /// up. Older snapshots may not have these fields, so all default
+    /// to empty/false via serde.
+    #[serde(default)]
+    pub gsi: Vec<GlobalSecondaryIndex>,
+    #[serde(default)]
+    pub lsi: Vec<LocalSecondaryIndex>,
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+    #[serde(default)]
+    pub ttl_attribute: Option<String>,
+    #[serde(default)]
+    pub ttl_enabled: bool,
+    #[serde(default)]
+    pub sse_type: Option<String>,
+    #[serde(default)]
+    pub sse_kms_key_arn: Option<String>,
+    #[serde(default)]
+    pub stream_enabled: bool,
+    #[serde(default)]
+    pub stream_view_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

\`CreateBackup\` was discarding the table's secondary indexes, tags, TTL config, encryption settings, and stream config — \`BackupDescription\` simply didn't carry them. \`RestoreTableFromBackup\` then materialized a naked target table, breaking any IaC that backed up + restored expecting full fidelity. \`RestoreTableToPointInTime\` had the same bug at the source-clone step.

Also: \`Scan\` with \`IndexName\` on a GSI silently accepted \`ConsistentRead=true\`. Real DDB rejects with \`ValidationException\`. \`Query\` already rejected; \`Scan\` now matches.

Changes:
- \`BackupDescription\` extended with gsi/lsi/tags/ttl/sse/stream fields (\`#[serde(default)]\` so older snapshots load)
- \`create_backup\` snapshots all of the above
- \`restore_table_from_backup\` rebuilds them onto the target, re-minting the stream ARN
- \`restore_table_to_point_in_time\` does the same from source
- \`Scan\` rejects \`ConsistentRead=true\` on a GSI

## Test plan

- [x] Two new unit tests:
  - \`create_backup_round_trip_preserves_gsi_lsi_tags_ttl_sse_stream\`
  - \`scan_with_consistent_read_on_gsi_rejected\`
- [x] \`cargo test -p fakecloud-dynamodb --lib\` (245 pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backups in `fakecloud-dynamodb` now preserve full table config (GSI/LSI, tags, TTL, SSE, streams) so restore is faithful. Also rejects ConsistentRead on GSI scans to match real DynamoDB. Addresses Linear L6.

- **Bug Fixes**
  - Preserve GSI/LSI, tags, TTL, SSE, and stream settings in backups; restore them and re-mint the stream ARN on target tables.
  - Reject Scan with ConsistentRead=true on a GSI (ValidationException), consistent with Query.
  - Extend BackupDescription with these fields using serde defaults for backward compatibility.

<sup>Written for commit fb01e37771923ed9cc47202db057a8441bf93b97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

