### PR TITLE
feat(kms): real RSA/ECC GenerateDataKeyPair returning parseable PKCS#8 + SPKI (G4)

### DIFF
--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -797,8 +797,7 @@ impl KmsService {
         })?;
         require_usable_key_state(key)?;
 
-        let public_key_bytes = generate_fake_public_key(&key_pair_spec);
-        let private_key_bytes = rand_bytes(256);
+        let (private_key_bytes, public_key_bytes) = generate_data_keypair_bytes(&key_pair_spec)?;
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
         let private_plaintext_b64 =
             base64::engine::general_purpose::STANDARD.encode(&private_key_bytes);
@@ -853,8 +852,7 @@ impl KmsService {
         })?;
         require_usable_key_state(key)?;
 
-        let public_key_bytes = generate_fake_public_key(&key_pair_spec);
-        let private_key_bytes = rand_bytes(256);
+        let (private_key_bytes, public_key_bytes) = generate_data_keypair_bytes(&key_pair_spec)?;
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
 
         let blob = crate::blob::encode(&state.master_key_bytes, &key.key_id, &private_key_bytes);
@@ -950,4 +948,52 @@ impl KmsService {
             .unwrap(),
         ))
     }
+}
+
+/// Generate (private_pkcs8_der, public_spki_der) bytes for a KMS
+/// `KeyPairSpec`. Real keypair via `rsa` for RSA specs and `ecdsa` /
+/// `p256` / `p384` / `k256` for ECC specs — the resulting DER is
+/// parseable with any standard tool, matching real AWS KMS so callers
+/// can sign locally with `PrivateKeyPlaintext` and verify with
+/// `PublicKey` end-to-end.
+fn generate_data_keypair_bytes(key_pair_spec: &str) -> Result<(Vec<u8>, Vec<u8>), AwsServiceError> {
+    if key_pair_spec.starts_with("RSA_") {
+        return super::asym::generate_keypair(key_pair_spec)
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("RSA keypair generation failed: {e}"),
+                )
+            })?
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("Unsupported KeyPairSpec: {key_pair_spec}"),
+                )
+            });
+    }
+    if key_pair_spec.starts_with("ECC_") {
+        return super::asym_ecdsa::generate_keypair(key_pair_spec)
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("ECC keypair generation failed: {e}"),
+                )
+            })?
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("Unsupported KeyPairSpec: {key_pair_spec}"),
+                )
+            });
+    }
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ValidationException",
+        format!("Unsupported KeyPairSpec: {key_pair_spec}"),
+    ))
 }

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -256,6 +256,71 @@ fn generate_data_key_pair_without_plaintext_omits_private_plaintext() {
 }
 
 #[test]
+fn generate_data_key_pair_rsa_returns_parseable_pkcs8_and_spki() {
+    use base64::Engine;
+    use rsa::pkcs8::{DecodePrivateKey, DecodePublicKey};
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let req = make_request(
+        "GenerateDataKeyPair",
+        json!({ "KeyId": key_id, "KeyPairSpec": "RSA_2048" }),
+    );
+    let resp = svc.generate_data_key_pair(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+
+    let priv_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PrivateKeyPlaintext"].as_str().unwrap())
+        .unwrap();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+
+    // Both halves must parse as standards-compliant DER. The fake-bytes
+    // path returned random noise that any real client would reject; the
+    // real path produces a key any standard tool can load.
+    let private = RsaPrivateKey::from_pkcs8_der(&priv_der)
+        .expect("PrivateKeyPlaintext must be parseable PKCS#8 DER");
+    let public = RsaPublicKey::from_public_key_der(&pub_der)
+        .expect("PublicKey must be parseable SubjectPublicKeyInfo DER");
+    // The public half must match the private half; otherwise verify
+    // would reject signatures the caller produced with the private key.
+    assert_eq!(RsaPublicKey::from(&private), public);
+}
+
+#[test]
+fn generate_data_key_pair_ecc_returns_parseable_pkcs8_and_spki() {
+    use base64::Engine;
+    use p256::pkcs8::{DecodePrivateKey, DecodePublicKey};
+    use p256::{PublicKey, SecretKey};
+
+    let svc = make_service();
+    let key_id = create_key(&svc);
+
+    let req = make_request(
+        "GenerateDataKeyPair",
+        json!({ "KeyId": key_id, "KeyPairSpec": "ECC_NIST_P256" }),
+    );
+    let resp = svc.generate_data_key_pair(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+
+    let priv_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PrivateKeyPlaintext"].as_str().unwrap())
+        .unwrap();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(body["PublicKey"].as_str().unwrap())
+        .unwrap();
+
+    let secret = SecretKey::from_pkcs8_der(&priv_der)
+        .expect("PrivateKeyPlaintext must be parseable PKCS#8 DER for P-256");
+    let public = PublicKey::from_public_key_der(&pub_der)
+        .expect("PublicKey must be parseable SubjectPublicKeyInfo DER for P-256");
+    assert_eq!(secret.public_key(), public);
+}
+
+#[test]
 fn derive_shared_secret_success() {
     let svc = make_service();
     let key_id = create_key_with_opts(


### PR DESCRIPTION
## Summary

\`GenerateDataKeyPair\` and \`GenerateDataKeyPairWithoutPlaintext\` were returning fake-bytes payloads from \`generate_fake_public_key\` + \`rand_bytes(256)\`. Real AWS KMS produces standards-compliant PKCS#8 private keys and SubjectPublicKeyInfo public keys; any client feeding our output into a real crypto library would reject both halves.

This wires the existing real keypair generators into the data-key-pair ops:
- RSA_2048 / RSA_3072 / RSA_4096 -> \`super::asym::generate_keypair\` (\`rsa::RsaPrivateKey::new\` -> \`to_pkcs8_der\` + \`to_public_key_der\`)
- ECC_NIST_P256 / P384 / P521 / SECG_P256K1 -> \`super::asym_ecdsa::generate_keypair\`

The private DER goes through the existing envelope wrapper for \`PrivateKeyCiphertextBlob\`. Plaintext form emitted only by the plain \`GenerateDataKeyPair\` op.

## Test plan

- [x] Two new unit tests load the returned bytes back through \`rsa::pkcs8\` and \`p256::pkcs8\` and assert \`public == private.public_key()\`:
  - \`generate_data_key_pair_rsa_returns_parseable_pkcs8_and_spki\`
  - \`generate_data_key_pair_ecc_returns_parseable_pkcs8_and_spki\`
- [x] \`cargo test -p fakecloud-kms --lib\` (168 pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`GenerateDataKeyPair` and `GenerateDataKeyPairWithoutPlaintext` now return real RSA/ECC key pairs that parse as PKCS#8 (private) and SPKI (public), matching AWS KMS. This replaces fake bytes that crypto libraries rejected.

- **Bug Fixes**
  - Return parseable PKCS#8 and SPKI for RSA_2048/3072/4096 and ECC_NIST_P256/P384/P521/SECG_P256K1 using `super::asym::generate_keypair` and `super::asym_ecdsa::generate_keypair`.
  - Wrap private key DER in the existing envelope for `PrivateKeyCiphertextBlob`; add tests using `rsa` and `p256` to validate parsing and public/private match.

<sup>Written for commit e8d9223a66e603bb9118f71eaaf8297b0e469543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

