### PR TITLE
test(kms): EncryptionContext round-trip + AAD-mismatch coverage (G6)

### DIFF
--- a/crates/fakecloud-kms/src/blob.rs
+++ b/crates/fakecloud-kms/src/blob.rs
@@ -248,4 +248,31 @@ mod tests {
         let b = encode(&mk, "k", b"same");
         assert_ne!(a, b, "fresh IV should make ciphertext non-deterministic");
     }
+
+    #[test]
+    fn decode_with_context_round_trips_when_ec_matches() {
+        let mk = fixed_master();
+        let aad = b"{\"app\":\"prod\"}";
+        let blob = encode_with_context(&mk, "k", b"secret", aad);
+        let decoded = decode_with_context(&mk, &blob, aad).expect("matching EC must decode");
+        assert_eq!(decoded.plaintext, b"secret");
+    }
+
+    #[test]
+    fn decode_with_context_rejects_mismatched_ec() {
+        let mk = fixed_master();
+        let blob = encode_with_context(&mk, "k", b"secret", b"{\"app\":\"prod\"}");
+        // Different EC AAD bytes — AEAD verification must fail.
+        assert!(decode_with_context(&mk, &blob, b"{\"app\":\"staging\"}").is_none());
+        // Missing EC at decrypt time — same outcome.
+        assert!(decode_with_context(&mk, &blob, b"").is_none());
+    }
+
+    #[test]
+    fn decode_without_context_rejects_blob_encoded_with_ec() {
+        let mk = fixed_master();
+        let blob = encode_with_context(&mk, "k", b"secret", b"{\"x\":\"y\"}");
+        // Plain `decode` passes empty AAD; EC-bound blob must reject.
+        assert!(decode(&mk, &blob).is_none());
+    }
 }

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -2690,3 +2690,117 @@ fn import_key_material_rejects_garbage_ciphertext() {
     };
     assert!(format!("{:?}", err).contains("InvalidCiphertextException"));
 }
+
+#[test]
+fn encrypt_decrypt_round_trip_with_matching_encryption_context() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"hello-world");
+
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": plaintext,
+                "EncryptionContext": {"app": "prod", "owner": "platform"}
+            }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    let dec = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": ciphertext,
+                // Same EC, different key order — canonicalization sorts.
+                "EncryptionContext": {"owner": "platform", "app": "prod"}
+            }),
+        ))
+        .unwrap();
+    let dec_body: Value = serde_json::from_slice(dec.body.expect_bytes()).unwrap();
+    assert_eq!(dec_body["Plaintext"].as_str().unwrap(), plaintext);
+}
+
+#[test]
+fn decrypt_rejects_mismatched_encryption_context() {
+    use base64::Engine;
+    let svc = make_service();
+    let key_id = create_key(&svc);
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"hello-world");
+
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": plaintext,
+                "EncryptionContext": {"app": "prod"}
+            }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // Different EC at decrypt — must surface InvalidCiphertextException.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": &ciphertext,
+                "EncryptionContext": {"app": "staging"}
+            }),
+        ))
+        .err()
+        .expect("EC mismatch must error");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+
+    // Missing EC at decrypt — same outcome.
+    let err = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({"CiphertextBlob": &ciphertext}),
+        ))
+        .err()
+        .expect("missing EC must error when ciphertext was encrypted with one");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+}
+
+#[test]
+fn re_encrypt_rejects_mismatched_source_encryption_context() {
+    use base64::Engine;
+    let svc = make_service();
+    let src_key = create_key(&svc);
+    let dst_key = create_key(&svc);
+    let plaintext = base64::engine::general_purpose::STANDARD.encode(b"swap-me");
+
+    let enc = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": src_key,
+                "Plaintext": plaintext,
+                "EncryptionContext": {"src": "yes"}
+            }),
+        ))
+        .unwrap();
+    let enc_body: Value = serde_json::from_slice(enc.body.expect_bytes()).unwrap();
+    let ciphertext = enc_body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    let err = svc
+        .re_encrypt(&make_request(
+            "ReEncrypt",
+            json!({
+                "CiphertextBlob": ciphertext,
+                "DestinationKeyId": dst_key,
+                // Wrong source EC.
+                "SourceEncryptionContext": {"src": "no"}
+            }),
+        ))
+        .err()
+        .expect("source EC mismatch must abort ReEncrypt");
+    assert!(format!("{err:?}").contains("InvalidCiphertextException"));
+}


### PR DESCRIPTION
## Summary

The EncryptionContext binding into the AES-GCM AAD has been live since the binary blob landed (\`canonical_encryption_context\` -> \`blob::encode_with_context\`), but there were no tests asserting end-to-end behavior. This PR adds tests at both layers:

**Service-level (\`service::tests\`):**
- \`encrypt_decrypt_round_trip_with_matching_encryption_context\` — round-trip with reordered EC keys (canonicalization sorts)
- \`decrypt_rejects_mismatched_encryption_context\` — different EC + missing EC both surface \`InvalidCiphertextException\`
- \`re_encrypt_rejects_mismatched_source_encryption_context\` — wrong \`SourceEncryptionContext\` aborts ReEncrypt

**Blob-level (\`blob::tests\`):**
- \`decode_with_context_round_trips_when_ec_matches\`
- \`decode_with_context_rejects_mismatched_ec\` (different + empty AAD)
- \`decode_without_context_rejects_blob_encoded_with_ec\` (plain \`decode\` rejects EC-bound blob)

Locks down behavior so a future refactor cannot silently break the EC binding.

## Test plan

- [x] \`cargo test -p fakecloud-kms --lib\` (174 pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end tests in `fakecloud-kms` to validate `EncryptionContext` binding to AES-GCM AAD. Tests cover encrypt/decrypt round-trip with reordered EC keys and reject mismatched or missing context for decrypt and re-encrypt; blob-level decode also rejects EC-bound blobs without matching AAD.

<sup>Written for commit 34b5f93d9279c14fe885f576af262c40192d4392. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

