### PR TITLE
feat(scheduler): universal targets for SES SendEmail + ECS RunTask + Kinesis (K12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -23,6 +23,10 @@ pub struct DeliveryBus {
     s3_writer: Option<Arc<dyn S3Delivery>>,
     /// Put records into Firehose delivery streams.
     firehose_sender: Option<Arc<dyn FirehoseDelivery>>,
+    /// Send a high-level SES SendEmail call (cross-service universal target).
+    ses_dispatcher: Option<Arc<dyn SesSendEmailDispatcher>>,
+    /// Run an ECS task on a cluster (cross-service universal target).
+    ecs_task_runner: Option<Arc<dyn EcsTaskRunner>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -202,6 +206,39 @@ pub trait S3Delivery: Send + Sync {
     ) -> Result<(), String>;
 }
 
+/// SES SendEmail dispatch for callers that already speak the AWS SES
+/// SendEmail / SendEmailV2 shape (multiple to/cc/bcc, optional subject,
+/// text/html bodies). Distinct from `EmailDispatcher`, which is the
+/// single-recipient cross-service primitive used by Cognito.
+pub trait SesSendEmailDispatcher: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
+    fn send_email(
+        &self,
+        account_id: &str,
+        from: &str,
+        to: Vec<String>,
+        cc: Vec<String>,
+        bcc: Vec<String>,
+        subject: Option<&str>,
+        text_body: Option<&str>,
+        html_body: Option<&str>,
+    ) -> Result<(), String>;
+}
+
+/// Synthesize an ECS RunTask call from outside the ECS crate. Used by
+/// EventBridge Scheduler and EventBridge Rules to start tasks without
+/// depending directly on `fakecloud_ecs`.
+pub trait EcsTaskRunner: Send + Sync {
+    fn run_task(
+        &self,
+        account_id: &str,
+        cluster: &str,
+        task_definition: &str,
+        launch_type: Option<&str>,
+        count: usize,
+    ) -> Result<(), String>;
+}
+
 /// Outbound email dispatch used by services that emulate AWS flows that
 /// route through SES (Cognito verification, etc.) without taking a direct
 /// dependency on the SES crate.
@@ -263,6 +300,56 @@ impl DeliveryBus {
             stepfunctions_starter: None,
             s3_writer: None,
             firehose_sender: None,
+            ses_dispatcher: None,
+            ecs_task_runner: None,
+        }
+    }
+
+    pub fn with_ses_dispatcher(mut self, dispatcher: Arc<dyn SesSendEmailDispatcher>) -> Self {
+        self.ses_dispatcher = Some(dispatcher);
+        self
+    }
+
+    pub fn with_ecs_task_runner(mut self, runner: Arc<dyn EcsTaskRunner>) -> Self {
+        self.ecs_task_runner = Some(runner);
+        self
+    }
+
+    /// Send an email via SES. Returns `Err` when no SES dispatcher is
+    /// wired or the underlying impl rejects (bad source/dest).
+    #[allow(clippy::too_many_arguments)]
+    pub fn send_ses_email(
+        &self,
+        account_id: &str,
+        from: &str,
+        to: Vec<String>,
+        cc: Vec<String>,
+        bcc: Vec<String>,
+        subject: Option<&str>,
+        text_body: Option<&str>,
+        html_body: Option<&str>,
+    ) -> Result<(), String> {
+        match self.ses_dispatcher {
+            Some(ref d) => {
+                d.send_email(account_id, from, to, cc, bcc, subject, text_body, html_body)
+            }
+            None => Err("SES dispatcher not configured".to_string()),
+        }
+    }
+
+    /// Run an ECS task. Returns `Err` when no ECS runner is wired or
+    /// the impl rejects (unknown cluster / task definition).
+    pub fn run_ecs_task(
+        &self,
+        account_id: &str,
+        cluster: &str,
+        task_definition: &str,
+        launch_type: Option<&str>,
+        count: usize,
+    ) -> Result<(), String> {
+        match self.ecs_task_runner {
+            Some(ref r) => r.run_task(account_id, cluster, task_definition, launch_type, count),
+            None => Err("ECS task runner not configured".to_string()),
         }
     }
 

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -16,6 +16,7 @@ fakecloud-secretsmanager = { workspace = true }
 fakecloud-ssm = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -10,7 +10,55 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use super::*;
 
 impl EcsService {
-    pub(super) fn run_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    /// Spawn a task from a cross-service caller (EventBridge Scheduler /
+    /// EventBridge Rules) without going through the AwsRequest dispatch
+    /// path. Builds the JSON body and reuses [`Self::run_task`] so all
+    /// the existing validation / runtime spawn logic runs identically.
+    /// Returns Err with a human-readable message on validation failures —
+    /// the caller decides whether to surface the failure (e.g. DLQ).
+    pub fn run_task_external(
+        &self,
+        account_id: &str,
+        cluster: &str,
+        task_definition: &str,
+        launch_type: Option<&str>,
+        count: usize,
+    ) -> Result<(), String> {
+        use bytes::Bytes;
+        use http::{HeaderMap, Method};
+        use std::collections::HashMap;
+        let body = serde_json::json!({
+            "cluster": cluster,
+            "taskDefinition": task_definition,
+            "launchType": launch_type.unwrap_or("FARGATE"),
+            "count": count.max(1) as i64,
+        });
+        let body_bytes =
+            Bytes::from(serde_json::to_vec(&body).map_err(|e| format!("encode body: {e}"))?);
+        let req = AwsRequest {
+            service: "ecs".into(),
+            action: "RunTask".into(),
+            region: "us-east-1".into(),
+            account_id: account_id.to_string(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: body_bytes,
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        };
+        self.run_task(&req)
+            .map(|_| ())
+            .map_err(|e| format!("{e:?}"))
+    }
+
+    pub fn run_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
         let td_ref = req_str(&body, "taskDefinition")?;
         let cluster_ref = opt_str(&body, "cluster");

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -96,10 +96,249 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
         return Ok(());
     }
 
+    // Templated ECS target: ARN names the cluster, EcsParameters carries
+    // TaskDefinitionArn / LaunchType / TaskCount.
+    if arn.contains(":ecs:") && arn.contains(":cluster/") {
+        return deliver_ecs_templated(bus, schedule, arn);
+    }
+
+    // Universal SDK target (`arn:aws:scheduler:::aws-sdk:<service>:<api>`)
+    // is the AWS-defined shape for arbitrary AWS APIs; we cover SES
+    // SendEmail / SendEmailV2 and ECS RunTask explicitly here, with
+    // remaining services documented as a roadmap item.
+    if let Some((service, action)) = parse_aws_sdk_universal_arn(arn) {
+        return deliver_aws_sdk_universal(bus, schedule, &service, &action, body);
+    }
+
     // Unsupported target type — log and succeed so we don't push it to
     // DLQ (DLQ is for deliverable-target failures, not unknown targets).
     tracing::warn!(target_arn = %arn, schedule = %schedule.name, "scheduler: unsupported target type, skipping");
     Ok(())
+}
+
+/// Deliver to an ECS cluster ARN target. The cluster name is taken from
+/// the ARN segment after `cluster/`; the task definition + launch type +
+/// count come from `Target.EcsParameters`. Missing TaskDefinitionArn is
+/// the failure case — surfaces as `InvalidParameter` so the schedule
+/// routes to its DLQ.
+fn deliver_ecs_templated(
+    bus: &Arc<DeliveryBus>,
+    schedule: &Schedule,
+    cluster_arn: &str,
+) -> Result<(), SqsDeliveryError> {
+    let account_id = account_id_from_arn(cluster_arn).unwrap_or_else(|| "000000000000".to_string());
+    let cluster = cluster_arn
+        .split(":cluster/")
+        .nth(1)
+        .unwrap_or("default")
+        .to_string();
+    let params = match schedule.target.ecs_parameters.as_ref() {
+        Some(p) => p,
+        None => {
+            return Err(SqsDeliveryError::InvalidParameter(
+                "ECS target requires EcsParameters".to_string(),
+            ));
+        }
+    };
+    let task_definition = match params.get("TaskDefinitionArn").and_then(|v| v.as_str()) {
+        Some(td) => td,
+        None => {
+            return Err(SqsDeliveryError::InvalidParameter(
+                "ECS target requires TaskDefinitionArn".to_string(),
+            ));
+        }
+    };
+    let launch_type = params.get("LaunchType").and_then(|v| v.as_str());
+    let count = params
+        .get("TaskCount")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(1)
+        .max(1) as usize;
+    bus.run_ecs_task(&account_id, &cluster, task_definition, launch_type, count)
+        .map_err(SqsDeliveryError::InvalidParameter)
+}
+
+/// Parse `arn:aws:scheduler:::aws-sdk:<service>:<action>` (or the
+/// equivalent with a region/account in slot 3/4) into `(service, action)`.
+fn parse_aws_sdk_universal_arn(arn: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    // Expected layout for the canonical universal target:
+    //   ["arn","aws","scheduler","","","aws-sdk","<service>","<action>"]
+    // AWS also accepts a region+account variant; either way the
+    // resource segment is `aws-sdk:<service>:<action>` and lives in the
+    // tail — find it by name.
+    let aws_sdk_idx = parts.iter().position(|p| *p == "aws-sdk")?;
+    let service = parts.get(aws_sdk_idx + 1)?;
+    let action = parts.get(aws_sdk_idx + 2)?;
+    if service.is_empty() || action.is_empty() {
+        return None;
+    }
+    Some((service.to_lowercase(), action.to_string()))
+}
+
+/// Dispatch a recognized aws-sdk universal target. Unknown service/api
+/// combinations log a warning and succeed (matching the previous
+/// behavior for unsupported targets — DLQ is for deliverable-target
+/// failures, not for unrecognized API combinations).
+fn deliver_aws_sdk_universal(
+    bus: &Arc<DeliveryBus>,
+    schedule: &Schedule,
+    service: &str,
+    action: &str,
+    body: &str,
+) -> Result<(), SqsDeliveryError> {
+    let action_lower = action.to_lowercase();
+    match (service, action_lower.as_str()) {
+        ("sesv2", "sendemail") | ("ses", "sendemail") => {
+            deliver_ses_send_email(bus, schedule, body, service == "sesv2")
+        }
+        ("ecs", "runtask") => deliver_ecs_universal(bus, schedule, body),
+        _ => {
+            tracing::warn!(
+                schedule = %schedule.name,
+                service = %service,
+                action = %action,
+                "scheduler: aws-sdk universal target not implemented for this API"
+            );
+            Ok(())
+        }
+    }
+}
+
+fn deliver_ses_send_email(
+    bus: &Arc<DeliveryBus>,
+    schedule: &Schedule,
+    body: &str,
+    v2: bool,
+) -> Result<(), SqsDeliveryError> {
+    let req: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SqsDeliveryError::InvalidParameter(format!("invalid JSON Input: {e}")))?;
+    let account_id =
+        account_id_from_arn(&schedule.arn).unwrap_or_else(|| "000000000000".to_string());
+
+    // SESv2 SendEmail uses FromEmailAddress/Destination/Content; v1 uses
+    // Source/Destination/Message. Parse both shapes.
+    let from = if v2 {
+        req.get("FromEmailAddress").and_then(|v| v.as_str())
+    } else {
+        req.get("Source").and_then(|v| v.as_str())
+    }
+    .ok_or_else(|| SqsDeliveryError::InvalidParameter("missing source/from".to_string()))?
+    .to_string();
+
+    let dest = req
+        .get("Destination")
+        .cloned()
+        .unwrap_or(serde_json::json!({}));
+    let to = string_array(&dest, "ToAddresses");
+    let cc = string_array(&dest, "CcAddresses");
+    let bcc = string_array(&dest, "BccAddresses");
+    if to.is_empty() && cc.is_empty() && bcc.is_empty() {
+        return Err(SqsDeliveryError::InvalidParameter(
+            "SES SendEmail requires at least one recipient".to_string(),
+        ));
+    }
+
+    // SESv2 message lives at Content.Simple.{Subject,Body}; v1 at Message.
+    let (subject, text, html) = if v2 {
+        let simple = req
+            .get("Content")
+            .and_then(|c| c.get("Simple"))
+            .cloned()
+            .unwrap_or(serde_json::json!({}));
+        (
+            simple
+                .get("Subject")
+                .and_then(|s| s.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+            simple
+                .get("Body")
+                .and_then(|b| b.get("Text"))
+                .and_then(|t| t.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+            simple
+                .get("Body")
+                .and_then(|b| b.get("Html"))
+                .and_then(|h| h.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+        )
+    } else {
+        let msg = req.get("Message").cloned().unwrap_or(serde_json::json!({}));
+        (
+            msg.get("Subject")
+                .and_then(|s| s.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+            msg.get("Body")
+                .and_then(|b| b.get("Text"))
+                .and_then(|t| t.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+            msg.get("Body")
+                .and_then(|b| b.get("Html"))
+                .and_then(|h| h.get("Data"))
+                .and_then(|d| d.as_str())
+                .map(String::from),
+        )
+    };
+
+    bus.send_ses_email(
+        &account_id,
+        &from,
+        to,
+        cc,
+        bcc,
+        subject.as_deref(),
+        text.as_deref(),
+        html.as_deref(),
+    )
+    .map_err(SqsDeliveryError::InvalidParameter)
+}
+
+fn deliver_ecs_universal(
+    bus: &Arc<DeliveryBus>,
+    schedule: &Schedule,
+    body: &str,
+) -> Result<(), SqsDeliveryError> {
+    let req: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SqsDeliveryError::InvalidParameter(format!("invalid JSON Input: {e}")))?;
+    let account_id =
+        account_id_from_arn(&schedule.arn).unwrap_or_else(|| "000000000000".to_string());
+    let cluster = req
+        .get("Cluster")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default")
+        .to_string();
+    let task_definition = req
+        .get("TaskDefinition")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            SqsDeliveryError::InvalidParameter("RunTask requires TaskDefinition".to_string())
+        })?
+        .to_string();
+    let launch_type = req.get("LaunchType").and_then(|v| v.as_str());
+    let count = req
+        .get("Count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(1)
+        .max(1) as usize;
+    bus.run_ecs_task(&account_id, &cluster, &task_definition, launch_type, count)
+        .map_err(SqsDeliveryError::InvalidParameter)
+}
+
+fn string_array(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Route a failed delivery to the schedule's DLQ, if one is
@@ -511,6 +750,202 @@ mod tests {
             None
         );
         assert_eq!(account_id_from_arn("arn:malformed"), None);
+    }
+
+    type EcsRunCall = (String, String, String, Option<String>, usize);
+    struct EcsRunRecorder(Mutex<Vec<EcsRunCall>>);
+    impl fakecloud_core::delivery::EcsTaskRunner for EcsRunRecorder {
+        fn run_task(
+            &self,
+            account_id: &str,
+            cluster: &str,
+            task_definition: &str,
+            launch_type: Option<&str>,
+            count: usize,
+        ) -> Result<(), String> {
+            self.0.lock().unwrap().push((
+                account_id.to_string(),
+                cluster.to_string(),
+                task_definition.to_string(),
+                launch_type.map(String::from),
+                count,
+            ));
+            Ok(())
+        }
+    }
+
+    type SesCall = (
+        String,
+        String,
+        Vec<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    );
+    struct SesRecorder(Mutex<Vec<SesCall>>);
+    impl fakecloud_core::delivery::SesSendEmailDispatcher for SesRecorder {
+        #[allow(clippy::too_many_arguments)]
+        fn send_email(
+            &self,
+            account_id: &str,
+            from: &str,
+            to: Vec<String>,
+            _cc: Vec<String>,
+            _bcc: Vec<String>,
+            subject: Option<&str>,
+            text_body: Option<&str>,
+            html_body: Option<&str>,
+        ) -> Result<(), String> {
+            self.0.lock().unwrap().push((
+                account_id.to_string(),
+                from.to_string(),
+                to,
+                subject.map(String::from),
+                text_body.map(String::from),
+                html_body.map(String::from),
+            ));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn deliver_target_ecs_templated_uses_cluster_arn_and_ecs_parameters() {
+        let runner = Arc::new(EcsRunRecorder(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_ecs_task_runner(runner.clone()));
+        let mut sched = make_schedule(
+            "arn:aws:ecs:us-east-1:111122223333:cluster/prod",
+            None,
+            Some(r#"{}"#),
+        );
+        sched.target.ecs_parameters = Some(serde_json::json!({
+            "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111122223333:task-definition/web:7",
+            "LaunchType": "FARGATE",
+            "TaskCount": 2u64,
+        }));
+        let result = deliver_target(&bus, &sched);
+        assert!(result.is_ok());
+        let calls = runner.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "111122223333");
+        assert_eq!(calls[0].1, "prod");
+        assert_eq!(
+            calls[0].2,
+            "arn:aws:ecs:us-east-1:111122223333:task-definition/web:7"
+        );
+        assert_eq!(calls[0].3.as_deref(), Some("FARGATE"));
+        assert_eq!(calls[0].4, 2);
+    }
+
+    #[test]
+    fn deliver_target_ecs_templated_without_task_definition_returns_invalid_parameter() {
+        let runner = Arc::new(EcsRunRecorder(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_ecs_task_runner(runner));
+        let mut sched = make_schedule("arn:aws:ecs:us-east-1:1:cluster/prod", None, Some(r#"{}"#));
+        sched.target.ecs_parameters = Some(serde_json::json!({"LaunchType": "FARGATE"}));
+        let result = deliver_target(&bus, &sched);
+        assert!(matches!(result, Err(SqsDeliveryError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn aws_sdk_universal_target_dispatches_ses_v2_send_email() {
+        let ses = Arc::new(SesRecorder(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_ses_dispatcher(ses.clone()));
+        let body = serde_json::json!({
+            "FromEmailAddress": "no-reply@example.com",
+            "Destination": {"ToAddresses": ["a@example.com", "b@example.com"]},
+            "Content": {"Simple": {
+                "Subject": {"Data": "hello"},
+                "Body": {"Text": {"Data": "world"}, "Html": {"Data": "<b>hi</b>"}}
+            }}
+        });
+        let sched = make_schedule(
+            "arn:aws:scheduler:::aws-sdk:sesv2:sendEmail",
+            None,
+            Some(&body.to_string()),
+        );
+        let result = deliver_target(&bus, &sched);
+        assert!(result.is_ok(), "got {result:?}");
+        let calls = ses.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "no-reply@example.com");
+        assert_eq!(
+            calls[0].2,
+            vec!["a@example.com".to_string(), "b@example.com".to_string()]
+        );
+        assert_eq!(calls[0].3.as_deref(), Some("hello"));
+        assert_eq!(calls[0].4.as_deref(), Some("world"));
+        assert_eq!(calls[0].5.as_deref(), Some("<b>hi</b>"));
+    }
+
+    #[test]
+    fn aws_sdk_universal_target_dispatches_ses_v1_send_email() {
+        let ses = Arc::new(SesRecorder(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_ses_dispatcher(ses.clone()));
+        let body = serde_json::json!({
+            "Source": "from@example.com",
+            "Destination": {"ToAddresses": ["to@example.com"]},
+            "Message": {"Subject": {"Data": "s"}, "Body": {"Text": {"Data": "t"}}}
+        });
+        let sched = make_schedule(
+            "arn:aws:scheduler:::aws-sdk:ses:sendEmail",
+            None,
+            Some(&body.to_string()),
+        );
+        assert!(deliver_target(&bus, &sched).is_ok());
+        let calls = ses.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "from@example.com");
+        assert_eq!(calls[0].3.as_deref(), Some("s"));
+        assert_eq!(calls[0].4.as_deref(), Some("t"));
+    }
+
+    #[test]
+    fn aws_sdk_universal_target_dispatches_ecs_run_task() {
+        let runner = Arc::new(EcsRunRecorder(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_ecs_task_runner(runner.clone()));
+        let body = serde_json::json!({
+            "Cluster": "prod",
+            "TaskDefinition": "web:9",
+            "LaunchType": "EC2",
+            "Count": 3u64,
+        });
+        let sched = make_schedule(
+            "arn:aws:scheduler:::aws-sdk:ecs:runTask",
+            None,
+            Some(&body.to_string()),
+        );
+        assert!(deliver_target(&bus, &sched).is_ok());
+        let calls = runner.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "prod");
+        assert_eq!(calls[0].2, "web:9");
+        assert_eq!(calls[0].3.as_deref(), Some("EC2"));
+        assert_eq!(calls[0].4, 3);
+    }
+
+    #[test]
+    fn aws_sdk_universal_target_unknown_api_is_ok_no_dlq() {
+        let bus = Arc::new(DeliveryBus::new());
+        let sched = make_schedule("arn:aws:scheduler:::aws-sdk:s3:putObject", None, Some("{}"));
+        // Unknown API → log + succeed (no DLQ; DLQ is for deliverable
+        // failures, not unimplemented surfaces).
+        assert!(deliver_target(&bus, &sched).is_ok());
+    }
+
+    #[test]
+    fn parse_aws_sdk_universal_arn_extracts_service_and_action() {
+        assert_eq!(
+            parse_aws_sdk_universal_arn("arn:aws:scheduler:::aws-sdk:sesv2:sendEmail"),
+            Some(("sesv2".to_string(), "sendEmail".to_string()))
+        );
+        assert_eq!(
+            parse_aws_sdk_universal_arn("arn:aws:scheduler:us-east-1:1:aws-sdk:ecs:runTask"),
+            Some(("ecs".to_string(), "runTask".to_string()))
+        );
+        assert_eq!(
+            parse_aws_sdk_universal_arn("arn:aws:sqs:us-east-1:1:q"),
+            None
+        );
     }
 
     #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2054,7 +2054,9 @@ async fn main() {
     if let Some(ref rt) = ecs_runtime {
         ecs_service = ecs_service.with_runtime(rt.clone());
     }
-    registry.register(Arc::new(ecs_service));
+    let ecs_service = Arc::new(ecs_service);
+    let ecs_service_for_scheduler = ecs_service.clone();
+    registry.register(ecs_service);
 
     let elbv2_introspection_state = elbv2_state.clone();
     let elbv2_service = Elbv2Service::new(elbv2_state.clone());
@@ -2470,11 +2472,25 @@ async fn main() {
         )
     };
     let delivery_for_scheduler = {
+        let kinesis_delivery_for_scheduler =
+            fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
+        let ses_dispatcher_for_scheduler: Arc<
+            dyn fakecloud_core::delivery::SesSendEmailDispatcher,
+        > = Arc::new(SesSendEmailDispatcherImpl {
+            state: ses_state.clone(),
+        });
+        let ecs_runner_for_scheduler: Arc<dyn fakecloud_core::delivery::EcsTaskRunner> =
+            Arc::new(EcsTaskRunnerImpl {
+                service: ecs_service_for_scheduler.clone(),
+            });
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
             .with_sns(sns_delivery_for_scheduler)
             .with_eventbridge(eb_delivery_for_scheduler)
-            .with_stepfunctions(sfn_delivery_for_scheduler);
+            .with_stepfunctions(sfn_delivery_for_scheduler)
+            .with_kinesis(kinesis_delivery_for_scheduler)
+            .with_ses_dispatcher(ses_dispatcher_for_scheduler)
+            .with_ecs_task_runner(ecs_runner_for_scheduler);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }
@@ -5241,6 +5257,74 @@ impl fakecloud_core::delivery::EmailDispatcher for SesEmailDispatcher {
             dkim_signature: None,
             timestamp: chrono::Utc::now(),
         });
+    }
+}
+
+/// SES SendEmail dispatcher for cross-service universal targets
+/// (EventBridge Scheduler `arn:aws:scheduler:::aws-sdk:sesv2:sendEmail`,
+/// EventBridge Rules with SES targets). Distinct from `SesEmailDispatcher`
+/// which is the single-recipient primitive Cognito uses — this one
+/// preserves multi-recipient + subject + html semantics that real callers
+/// pass via the SES API shape.
+struct SesSendEmailDispatcherImpl {
+    state: fakecloud_ses::SharedSesState,
+}
+
+impl fakecloud_core::delivery::SesSendEmailDispatcher for SesSendEmailDispatcherImpl {
+    #[allow(clippy::too_many_arguments)]
+    fn send_email(
+        &self,
+        account_id: &str,
+        from: &str,
+        to: Vec<String>,
+        cc: Vec<String>,
+        bcc: Vec<String>,
+        subject: Option<&str>,
+        text_body: Option<&str>,
+        html_body: Option<&str>,
+    ) -> Result<(), String> {
+        if to.is_empty() && cc.is_empty() && bcc.is_empty() {
+            return Err("at least one recipient required".to_string());
+        }
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        state.sent_emails.push(fakecloud_ses::SentEmail {
+            message_id: format!("scheduler-{}", uuid::Uuid::new_v4()),
+            from: from.to_string(),
+            to,
+            cc,
+            bcc,
+            subject: subject.map(String::from),
+            html_body: html_body.map(String::from),
+            text_body: text_body.map(String::from),
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            dkim_signature: None,
+            timestamp: chrono::Utc::now(),
+        });
+        Ok(())
+    }
+}
+
+/// ECS RunTask runner for cross-service universal targets. Wraps an
+/// `Arc<EcsService>` so the call goes through the same validation +
+/// runtime spawn path as a direct ECS RunTask request.
+struct EcsTaskRunnerImpl {
+    service: Arc<fakecloud_ecs::EcsService>,
+}
+
+impl fakecloud_core::delivery::EcsTaskRunner for EcsTaskRunnerImpl {
+    fn run_task(
+        &self,
+        account_id: &str,
+        cluster: &str,
+        task_definition: &str,
+        launch_type: Option<&str>,
+        count: usize,
+    ) -> Result<(), String> {
+        self.service
+            .run_task_external(account_id, cluster, task_definition, launch_type, count)
     }
 }
 


### PR DESCRIPTION
## Summary

EventBridge Scheduler universal targets now cover SES SendEmail (v1+v2), ECS RunTask, and Kinesis. Three correctness gaps closed:

1. **Templated ECS targets** (`arn:aws:ecs:...:cluster/<name>` + `EcsParameters`) now actually start a task. Previously fell through to the unsupported-target log line.
2. **Universal SDK target shape** (`arn:aws:scheduler:::aws-sdk:<service>:<api>`) recognized for `sesv2:sendEmail`, `ses:sendEmail`, `ecs:runTask`. Unknown service/api combos log + succeed (DLQ is for deliverable-target failures, not unimplemented surfaces).
3. **Kinesis target** was already implemented in `delivery.rs` but the production scheduler `DeliveryBus` didn't carry a `KinesisDelivery` impl — so deliveries silently no-op'd in the actual server. Now wired alongside the new SES/ECS handles.

Failures (missing `TaskDefinitionArn`, missing SES recipient, malformed JSON Input) surface as `SqsDeliveryError::InvalidParameter` so the schedule routes to its DLQ.

## Implementation

- `fakecloud-core/src/delivery.rs` — new `SesSendEmailDispatcher` and `EcsTaskRunner` traits + `with_*` builders + `send_ses_email` / `run_ecs_task` methods.
- `fakecloud-ecs/src/service_tasks.rs` — `pub fn run_task_external(account_id, cluster, task_definition, launch_type, count)` that synthesizes an `AwsRequest` and reuses the existing `run_task` validation + runtime spawn logic.
- `fakecloud-scheduler/src/delivery.rs` — `:ecs:cluster/` branch (templated form), `parse_aws_sdk_universal_arn` + `deliver_aws_sdk_universal` dispatcher, `deliver_ses_send_email` (v1 + v2 shapes), `deliver_ecs_universal`.
- `fakecloud-server/src/main.rs` — `SesSendEmailDispatcherImpl` (writes to `SesState::sent_emails`) + `EcsTaskRunnerImpl` (delegates to `EcsService::run_task_external`); wired into the scheduler delivery bus alongside Kinesis.

## Test plan

- [x] 7 new unit tests covering ECS templated success/failure, aws-sdk SES v1/v2/ECS dispatch, and unknown-API succeed-no-DLQ behavior
- [x] all 80 scheduler unit tests pass (was 73)
- [x] `cargo build --bin fakecloud` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds universal EventBridge Scheduler targets for SES SendEmail (v1/v2) and ECS RunTask, and wires Kinesis so scheduled deliveries actually run. Fixes prior no-ops for templated ECS targets and Kinesis, and routes bad inputs to the DLQ.

- **New Features**
  - ECS: templated cluster ARN + `EcsParameters` now starts tasks; universal `arn:aws:scheduler:::aws-sdk:ecs:runTask` supported via `EcsTaskRunner` and `EcsService::run_task_external`.
  - SES: universal `sesv2:sendEmail` and `ses:sendEmail` supported; parses both payload shapes and sends via `SesSendEmailDispatcher` (records in SES state).
  - Kinesis: scheduler `DeliveryBus` in `fakecloud-server` now includes `KinesisDelivery` so Kinesis targets execute.
  - Errors: missing task definition, missing SES recipient, or malformed JSON → `SqsDeliveryError::InvalidParameter` (DLQ). Unknown aws-sdk service/action combos log and succeed (no DLQ).

<sup>Written for commit 37dce40177e902b528c6c4eca3aa53abda7ccba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

