### PR TITLE
feat(rds): ModifyDBInstance accepts all mutable fields (M1)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -6777,6 +6777,7 @@ impl ResourceProvisioner {
             db_parameter_group_name,
             backup_retention_period,
             preferred_backup_window: "03:00-04:00".to_string(),
+            preferred_maintenance_window: None,
             latest_restorable_time: None,
             option_group_name,
             multi_az,

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -534,6 +534,7 @@ impl RdsService {
                 db_parameter_group_name,
                 backup_retention_period,
                 preferred_backup_window,
+                preferred_maintenance_window: None,
                 latest_restorable_time: if backup_retention_period > 0 {
                     Some(created_at)
                 } else {
@@ -897,6 +898,35 @@ impl RdsService {
             parse_optional_bool(optional_query_param(request, "DeletionProtection").as_deref())?;
         let apply_immediately =
             parse_optional_bool(optional_query_param(request, "ApplyImmediately").as_deref())?;
+        let master_user_password = optional_query_param(request, "MasterUserPassword");
+        let backup_retention_period =
+            parse_optional_i32(optional_query_param(request, "BackupRetentionPeriod").as_deref())?;
+        let preferred_backup_window = optional_query_param(request, "PreferredBackupWindow");
+        let preferred_maintenance_window =
+            optional_query_param(request, "PreferredMaintenanceWindow");
+        let engine_version = optional_query_param(request, "EngineVersion");
+        let allocated_storage =
+            parse_optional_i32(optional_query_param(request, "AllocatedStorage").as_deref())?;
+        let db_parameter_group_name = optional_query_param(request, "DBParameterGroupName");
+        let multi_az = parse_optional_bool(optional_query_param(request, "MultiAZ").as_deref())?;
+        let iops = parse_optional_i32(optional_query_param(request, "Iops").as_deref())?;
+        let storage_type = optional_query_param(request, "StorageType");
+        let master_user_secret_kms_key_id =
+            optional_query_param(request, "MasterUserSecretKmsKeyId");
+        let ca_certificate_identifier = optional_query_param(request, "CACertificateIdentifier");
+        let monitoring_interval =
+            parse_optional_i32(optional_query_param(request, "MonitoringInterval").as_deref())?;
+        let performance_insights_enabled = parse_optional_bool(
+            optional_query_param(request, "EnablePerformanceInsights").as_deref(),
+        )?;
+
+        // CloudWatch logs exports — AWS lets callers both opt-in to and
+        // opt-out of specific log types in the same call. We compute the
+        // resulting set per AWS semantics: start from current, remove
+        // DisableLogTypes, then union with EnableLogTypes.
+        let cloudwatch_enable = collect_cloudwatch_log_types(request, "EnableLogTypes");
+        let cloudwatch_disable = collect_cloudwatch_log_types(request, "DisableLogTypes");
+        let cloudwatch_changed = !cloudwatch_enable.is_empty() || !cloudwatch_disable.is_empty();
 
         // Parse VPC security group IDs - only if at least one is provided
         let vpc_security_group_ids = {
@@ -915,9 +945,25 @@ impl RdsService {
             }
         };
 
+        // At-least-one-field validation: every supported mutable input.
         if db_instance_class.is_none()
             && deletion_protection.is_none()
             && vpc_security_group_ids.is_none()
+            && master_user_password.is_none()
+            && backup_retention_period.is_none()
+            && preferred_backup_window.is_none()
+            && preferred_maintenance_window.is_none()
+            && engine_version.is_none()
+            && allocated_storage.is_none()
+            && db_parameter_group_name.is_none()
+            && multi_az.is_none()
+            && iops.is_none()
+            && storage_type.is_none()
+            && master_user_secret_kms_key_id.is_none()
+            && ca_certificate_identifier.is_none()
+            && monitoring_interval.is_none()
+            && performance_insights_enabled.is_none()
+            && !cloudwatch_changed
         {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -936,32 +982,135 @@ impl RdsService {
             .get_mut(&db_instance_identifier)
             .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
 
-        // If ApplyImmediately is false, stage changes as pending
-        if apply_immediately == Some(false) {
-            let pending = instance
-                .pending_modified_values
-                .get_or_insert(Default::default());
-            if let Some(class) = db_instance_class {
-                pending.db_instance_class = Some(class);
+        // Fields AWS always applies immediately (per AWS RDS docs),
+        // regardless of ApplyImmediately:
+        //   deletion_protection, vpc_security_group_ids,
+        //   ca_certificate_identifier, master_user_secret_kms_key_id,
+        //   enabled_cloudwatch_logs_exports.
+        if let Some(deletion_protection) = deletion_protection {
+            instance.deletion_protection = deletion_protection;
+        }
+        if let Some(security_group_ids) = vpc_security_group_ids {
+            instance.vpc_security_group_ids = security_group_ids;
+        }
+        if let Some(ca_id) = ca_certificate_identifier {
+            instance.ca_certificate_identifier = Some(ca_id);
+        }
+        if let Some(kms_key) = master_user_secret_kms_key_id {
+            instance.master_user_secret_kms_key_id = Some(kms_key);
+        }
+        if cloudwatch_changed {
+            let mut current: Vec<String> = instance.enabled_cloudwatch_logs_exports.clone();
+            current.retain(|t| !cloudwatch_disable.contains(t));
+            for t in &cloudwatch_enable {
+                if !current.contains(t) {
+                    current.push(t.clone());
+                }
             }
-            // Note: deletion_protection and vpc_security_group_ids are applied immediately
-            // regardless of ApplyImmediately flag (per AWS behavior)
-            if let Some(deletion_protection) = deletion_protection {
-                instance.deletion_protection = deletion_protection;
-            }
-            if let Some(security_group_ids) = vpc_security_group_ids {
-                instance.vpc_security_group_ids = security_group_ids;
-            }
-        } else {
-            // Apply immediately (default behavior)
+            instance.enabled_cloudwatch_logs_exports = current;
+        }
+
+        // Fields gated on ApplyImmediately. Default (None or true) is
+        // immediate; false stages to pending_modified_values.
+        let immediate = apply_immediately != Some(false);
+        if immediate {
             if let Some(class) = db_instance_class {
                 instance.db_instance_class = class;
             }
-            if let Some(deletion_protection) = deletion_protection {
-                instance.deletion_protection = deletion_protection;
+            if let Some(pwd) = master_user_password {
+                instance.master_user_password = pwd;
             }
-            if let Some(security_group_ids) = vpc_security_group_ids {
-                instance.vpc_security_group_ids = security_group_ids;
+            if let Some(retention) = backup_retention_period {
+                instance.backup_retention_period = retention;
+            }
+            if let Some(window) = preferred_backup_window {
+                instance.preferred_backup_window = window;
+            }
+            if let Some(window) = preferred_maintenance_window {
+                instance.preferred_maintenance_window = Some(window);
+            }
+            if let Some(version) = engine_version {
+                instance.engine_version = version;
+            }
+            if let Some(storage) = allocated_storage {
+                instance.allocated_storage = storage;
+            }
+            if let Some(name) = db_parameter_group_name {
+                instance.db_parameter_group_name = Some(name);
+            }
+            if let Some(az) = multi_az {
+                instance.multi_az = az;
+            }
+            if let Some(iops_val) = iops {
+                instance.iops = Some(iops_val);
+            }
+            if let Some(stype) = storage_type {
+                instance.storage_type = Some(stype);
+            }
+            if let Some(interval) = monitoring_interval {
+                instance.monitoring_interval = Some(interval);
+            }
+            if let Some(pi) = performance_insights_enabled {
+                instance.performance_insights_enabled = pi;
+            }
+        } else {
+            // Stage only if at least one deferrable field was supplied.
+            let any_deferred = db_instance_class.is_some()
+                || master_user_password.is_some()
+                || backup_retention_period.is_some()
+                || preferred_backup_window.is_some()
+                || preferred_maintenance_window.is_some()
+                || engine_version.is_some()
+                || allocated_storage.is_some()
+                || db_parameter_group_name.is_some()
+                || multi_az.is_some()
+                || iops.is_some()
+                || storage_type.is_some()
+                || monitoring_interval.is_some()
+                || performance_insights_enabled.is_some();
+            if any_deferred {
+                let pending = instance
+                    .pending_modified_values
+                    .get_or_insert(Default::default());
+                if let Some(class) = db_instance_class {
+                    pending.db_instance_class = Some(class);
+                }
+                if let Some(pwd) = master_user_password {
+                    pending.master_user_password = Some(pwd);
+                }
+                if let Some(retention) = backup_retention_period {
+                    pending.backup_retention_period = Some(retention);
+                }
+                if let Some(window) = preferred_backup_window {
+                    pending.preferred_backup_window = Some(window);
+                }
+                if let Some(window) = preferred_maintenance_window {
+                    pending.preferred_maintenance_window = Some(window);
+                }
+                if let Some(version) = engine_version {
+                    pending.engine_version = Some(version);
+                }
+                if let Some(storage) = allocated_storage {
+                    pending.allocated_storage = Some(storage);
+                }
+                if let Some(name) = db_parameter_group_name {
+                    pending.db_parameter_group_name = Some(name);
+                }
+                if let Some(az) = multi_az {
+                    pending.multi_az = Some(az);
+                }
+                if let Some(iops_val) = iops {
+                    pending.iops = Some(iops_val);
+                }
+                if let Some(stype) = storage_type {
+                    pending.storage_type = Some(stype);
+                }
+                if let Some(interval) = monitoring_interval {
+                    pending.monitoring_interval = Some(interval);
+                }
+                if let Some(pi) = performance_insights_enabled {
+                    pending.performance_insights_enabled = Some(pi);
+                }
             }
         }
         let instance_arn = instance.db_instance_arn.clone();

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -173,6 +173,29 @@ pub(crate) fn parse_cloudwatch_logs_exports(req: &AwsRequest, base: &str) -> Vec
     parse_string_member_list(req, base)
 }
 
+pub(crate) fn parse_optional_i32(value: Option<&str>) -> Result<Option<i32>, AwsServiceError> {
+    value
+        .map(|raw| {
+            raw.parse::<i32>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("Integer parameter value '{raw}' is invalid."),
+                )
+            })
+        })
+        .transpose()
+}
+
+/// Collect the `member.N` values for a Query-protocol log-types list
+/// nested under `CloudwatchLogsExportConfiguration` (e.g.
+/// `CloudwatchLogsExportConfiguration.EnableLogTypes.member.1`). Returns
+/// an empty vec when no values are present.
+pub(crate) fn collect_cloudwatch_log_types(req: &AwsRequest, list_name: &str) -> Vec<String> {
+    let base = format!("CloudwatchLogsExportConfiguration.{list_name}");
+    parse_string_member_list(req, &base)
+}
+
 pub(crate) fn parse_optional_bool(value: Option<&str>) -> Result<Option<bool>, AwsServiceError> {
     value
         .map(|raw| match raw {
@@ -474,6 +497,7 @@ pub(crate) fn build_restored_instance(
         db_parameter_group_name: None,
         backup_retention_period: 1,
         preferred_backup_window: "03:00-04:00".to_string(),
+        preferred_maintenance_window: None,
         latest_restorable_time: Some(created_at),
         option_group_name: None,
         multi_az: false,
@@ -535,6 +559,7 @@ pub(crate) fn build_read_replica_instance(
         db_parameter_group_name: source.db_parameter_group_name.clone(),
         backup_retention_period: source.backup_retention_period,
         preferred_backup_window: source.preferred_backup_window.clone(),
+        preferred_maintenance_window: source.preferred_maintenance_window.clone(),
         latest_restorable_time: if source.backup_retention_period > 0 {
             Some(created_at)
         } else {

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -170,6 +170,7 @@ fn db_instance_xml_renders_endpoint_and_status() {
         db_parameter_group_name: Some("default.postgres16".to_string()),
         backup_retention_period: 1,
         preferred_backup_window: "03:00-04:00".to_string(),
+        preferred_maintenance_window: None,
         latest_restorable_time: Some(created_at),
         option_group_name: None,
         multi_az: false,
@@ -337,6 +338,7 @@ fn make_instance_with_defaults(id: &str) -> DbInstance {
         db_parameter_group_name: None,
         backup_retention_period: 0,
         preferred_backup_window: String::new(),
+        preferred_maintenance_window: None,
         latest_restorable_time: None,
         option_group_name: None,
         multi_az: false,
@@ -600,6 +602,7 @@ fn seed_instance(svc: &RdsService, identifier: &str) -> String {
             db_parameter_group_name: Some("default.postgres16".to_string()),
             backup_retention_period: 1,
             preferred_backup_window: "03:00-04:00".to_string(),
+            preferred_maintenance_window: None,
             latest_restorable_time: None,
             option_group_name: None,
             multi_az: false,
@@ -1125,6 +1128,144 @@ fn modify_db_instance_pending_when_not_apply_immediately() {
     );
 }
 
+#[test]
+fn modify_db_instance_apply_immediately_updates_engine_and_storage() {
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("EngineVersion", "16.4"),
+            ("AllocatedStorage", "100"),
+            ("Iops", "3000"),
+            ("StorageType", "io2"),
+            ("PreferredMaintenanceWindow", "Mon:00:00-Mon:01:00"),
+            ("MultiAZ", "true"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let inst = state.instances.get("db1").unwrap();
+    assert_eq!(inst.engine_version, "16.4");
+    assert_eq!(inst.allocated_storage, 100);
+    assert_eq!(inst.iops, Some(3000));
+    assert_eq!(inst.storage_type.as_deref(), Some("io2"));
+    assert_eq!(
+        inst.preferred_maintenance_window.as_deref(),
+        Some("Mon:00:00-Mon:01:00")
+    );
+    assert!(inst.multi_az);
+    assert!(inst.pending_modified_values.is_none());
+}
+
+#[test]
+fn modify_db_instance_pending_stages_extended_fields() {
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("EngineVersion", "16.4"),
+            ("AllocatedStorage", "100"),
+            ("PreferredBackupWindow", "04:00-05:00"),
+            ("DBParameterGroupName", "custom-pg"),
+            ("MultiAZ", "true"),
+            ("ApplyImmediately", "false"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let inst = state.instances.get("db1").unwrap();
+    let pending = inst.pending_modified_values.as_ref().unwrap();
+    assert_eq!(pending.engine_version.as_deref(), Some("16.4"));
+    assert_eq!(pending.allocated_storage, Some(100));
+    assert_eq!(
+        pending.preferred_backup_window.as_deref(),
+        Some("04:00-05:00")
+    );
+    assert_eq!(
+        pending.db_parameter_group_name.as_deref(),
+        Some("custom-pg")
+    );
+    assert_eq!(pending.multi_az, Some(true));
+    // Live values unchanged.
+    assert_eq!(inst.engine_version, "16.3");
+    assert_eq!(inst.allocated_storage, 20);
+}
+
+#[test]
+fn modify_db_instance_immediate_only_fields_apply_with_apply_immediately_false() {
+    // CACertificateIdentifier, MasterUserSecretKmsKeyId, and the
+    // CloudwatchLogsExportConfiguration are AWS-immediate fields:
+    // ApplyImmediately=false must not stage them.
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            ("CACertificateIdentifier", "rds-ca-2024"),
+            ("MasterUserSecretKmsKeyId", "alias/aws/rds"),
+            (
+                "CloudwatchLogsExportConfiguration.EnableLogTypes.member.1",
+                "postgresql",
+            ),
+            ("ApplyImmediately", "false"),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let inst = state.instances.get("db1").unwrap();
+    assert_eq!(
+        inst.ca_certificate_identifier.as_deref(),
+        Some("rds-ca-2024")
+    );
+    assert_eq!(
+        inst.master_user_secret_kms_key_id.as_deref(),
+        Some("alias/aws/rds")
+    );
+    assert!(inst
+        .enabled_cloudwatch_logs_exports
+        .iter()
+        .any(|t| t == "postgresql"));
+    // No pending values for these — they were applied directly.
+    assert!(inst.pending_modified_values.is_none());
+}
+
+#[test]
+fn modify_db_instance_cloudwatch_disable_log_types_removes_existing() {
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    {
+        let mut __a = svc.state.write();
+        let state = __a.default_mut();
+        let inst = state.instances.get_mut("db1").unwrap();
+        inst.enabled_cloudwatch_logs_exports =
+            vec!["postgresql".to_string(), "upgrade".to_string()];
+    }
+    let req = request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db1"),
+            (
+                "CloudwatchLogsExportConfiguration.DisableLogTypes.member.1",
+                "upgrade",
+            ),
+        ],
+    );
+    svc.modify_db_instance(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let inst = state.instances.get("db1").unwrap();
+    assert_eq!(inst.enabled_cloudwatch_logs_exports, vec!["postgresql"]);
+}
+
 // ── Snapshots (sync ops only) ────────────────────────────────────
 
 fn seed_snapshot(svc: &RdsService, snapshot_id: &str, instance_id: &str) {
@@ -1257,7 +1398,15 @@ fn modify_db_instance_not_found() {
             ("AllocatedStorage", "20"),
         ],
     );
-    // Validation fires before existence check
+    // AllocatedStorage is a valid mutable field — validation passes
+    // and the existence check fires next.
+    assert_code(svc.modify_db_instance(&req), "DBInstanceNotFound");
+}
+
+#[test]
+fn modify_db_instance_no_fields_returns_invalid_combination() {
+    let svc = make_service();
+    let req = request("ModifyDBInstance", &[("DBInstanceIdentifier", "anyone")]);
     assert_code(svc.modify_db_instance(&req), "InvalidParameterCombination");
 }
 
@@ -1762,6 +1911,7 @@ async fn save_snapshot_static_persists_status_flip_from_bg_task() {
             db_parameter_group_name: None,
             backup_retention_period: 1,
             preferred_backup_window: "03:00-04:00".to_string(),
+            preferred_maintenance_window: None,
             latest_restorable_time: Some(now),
             option_group_name: None,
             multi_az: false,

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -53,6 +53,8 @@ pub struct DbInstance {
     pub db_parameter_group_name: Option<String>,
     pub backup_retention_period: i32,
     pub preferred_backup_window: String,
+    #[serde(default)]
+    pub preferred_maintenance_window: Option<String>,
     pub latest_restorable_time: Option<DateTime<Utc>>,
     pub option_group_name: Option<String>,
     pub multi_az: bool,
@@ -107,6 +109,22 @@ pub struct PendingModifiedValues {
     pub multi_az: Option<bool>,
     pub engine_version: Option<String>,
     pub master_user_password: Option<String>,
+    #[serde(default)]
+    pub preferred_backup_window: Option<String>,
+    #[serde(default)]
+    pub preferred_maintenance_window: Option<String>,
+    #[serde(default)]
+    pub db_parameter_group_name: Option<String>,
+    #[serde(default)]
+    pub iops: Option<i32>,
+    #[serde(default)]
+    pub storage_type: Option<String>,
+    #[serde(default)]
+    pub monitoring_interval: Option<i32>,
+    #[serde(default)]
+    pub performance_insights_enabled: Option<bool>,
+    #[serde(default)]
+    pub enabled_cloudwatch_logs_exports: Option<Vec<String>>,
 }
 
 impl fmt::Debug for PendingModifiedValues {
@@ -120,6 +138,23 @@ impl fmt::Debug for PendingModifiedValues {
             .field(
                 "master_user_password",
                 &self.master_user_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field("preferred_backup_window", &self.preferred_backup_window)
+            .field(
+                "preferred_maintenance_window",
+                &self.preferred_maintenance_window,
+            )
+            .field("db_parameter_group_name", &self.db_parameter_group_name)
+            .field("iops", &self.iops)
+            .field("storage_type", &self.storage_type)
+            .field("monitoring_interval", &self.monitoring_interval)
+            .field(
+                "performance_insights_enabled",
+                &self.performance_insights_enabled,
+            )
+            .field(
+                "enabled_cloudwatch_logs_exports",
+                &self.enabled_cloudwatch_logs_exports,
             )
             .finish()
     }
@@ -697,6 +732,7 @@ mod tests {
                 db_parameter_group_name: None,
                 backup_retention_period: 1,
                 preferred_backup_window: "03:00-04:00".to_string(),
+                preferred_maintenance_window: None,
                 latest_restorable_time: Some(created_at),
                 option_group_name: None,
                 multi_az: false,
@@ -828,6 +864,7 @@ mod tests {
             db_parameter_group_name: None,
             backup_retention_period: 0,
             preferred_backup_window: String::new(),
+            preferred_maintenance_window: None,
             latest_restorable_time: None,
             option_group_name: None,
             multi_az: false,

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -355,6 +355,7 @@ mod tests {
             db_parameter_group_name: None,
             backup_retention_period: 1,
             preferred_backup_window: "03:00-04:00".to_string(),
+            preferred_maintenance_window: None,
             latest_restorable_time: Some(created_at),
             option_group_name: None,
             multi_az: false,

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -610,6 +610,7 @@ mod tests {
                 db_parameter_group_name: None,
                 backup_retention_period: 1,
                 preferred_backup_window: "03:00-04:00".to_string(),
+                preferred_maintenance_window: None,
                 latest_restorable_time: Some(created_at),
                 option_group_name: None,
                 multi_az: false,


### PR DESCRIPTION
## Summary

ModifyDBInstance previously gated on a 3-field check (\`DBInstanceClass\` / \`DeletionProtection\` / \`VpcSecurityGroupIds\`), so callers passing AllocatedStorage, EngineVersion, MultiAZ, Iops, etc. got InvalidParameterCombination even when those fields are valid.

Now accepts and applies the full set of mutable fields documented in the AWS RDS API:

- **Always-immediate** (per AWS docs): DeletionProtection, VpcSecurityGroupIds, CACertificateIdentifier, MasterUserSecretKmsKeyId, CloudwatchLogsExportConfiguration
- **Gated on ApplyImmediately**: MasterUserPassword, BackupRetentionPeriod, PreferredBackupWindow, PreferredMaintenanceWindow, EngineVersion, AllocatedStorage, DBParameterGroupName, MultiAZ, Iops, StorageType, MonitoringInterval, EnablePerformanceInsights, DBInstanceClass

## Implementation

- Extended \`PendingModifiedValues\` with the new deferrable fields.
- Added a \`preferred_maintenance_window\` slot to \`DbInstance\` to round-trip the value (state-only — no maintenance scheduler).
- New \`parse_optional_i32\` and \`collect_cloudwatch_log_types\` helpers.
- CloudwatchLogsExportConfiguration handled per AWS semantics: starting from current set, remove \`DisableLogTypes\`, then union with \`EnableLogTypes\` in a single call.

## Test plan

- [x] \`modify_db_instance_apply_immediately_updates_engine_and_storage\` — covers EngineVersion / AllocatedStorage / Iops / StorageType / PreferredMaintenanceWindow / MultiAZ all applied immediately, no pending values
- [x] \`modify_db_instance_pending_stages_extended_fields\` — same set staged when ApplyImmediately=false
- [x] \`modify_db_instance_immediate_only_fields_apply_with_apply_immediately_false\` — CACertificateIdentifier + MasterUserSecretKmsKeyId + CloudWatch logs apply directly even with ApplyImmediately=false; no pending created
- [x] \`modify_db_instance_cloudwatch_disable_log_types_removes_existing\` — DisableLogTypes prunes existing entries
- [x] \`modify_db_instance_no_fields_returns_invalid_combination\` — no fields → InvalidParameterCombination
- [x] all 131 RDS unit tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ModifyDBInstance in `fakecloud-rds` now accepts and applies all AWS RDS mutable fields. This fixes false InvalidParameterCombination errors and aligns behavior with ApplyImmediately semantics.

- **New Features**
  - Supports all mutable fields. Immediate-only: DeletionProtection, VpcSecurityGroupIds, CACertificateIdentifier, MasterUserSecretKmsKeyId, CloudWatch logs.
  - ApplyImmediately gating for EngineVersion, AllocatedStorage, DBInstanceClass, MultiAZ, Iops, StorageType, DBParameterGroupName, Backup/maintenance windows, MonitoringInterval, EnablePerformanceInsights, MasterUserPassword.
  - CloudWatch logs follow AWS rules: remove DisableLogTypes, then add EnableLogTypes in one call.
  - Added `preferred_maintenance_window` to instance state; no scheduler changes.
  - Extended `PendingModifiedValues` to stage all deferrable fields.
  - New helpers: `parse_optional_i32`, `collect_cloudwatch_log_types`.
  - Validation now checks for at least one mutable field; otherwise returns InvalidParameterCombination.

<sup>Written for commit 203f36df27cb5b37d0f51267210bafd89f5cabad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

