### PR TITLE
feat(rds): ModifyDB[Cluster]ParameterGroup parses + DescribeDB[Cluster]Parameters reads (M2)

### DIFF
--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -221,6 +221,23 @@ impl RdsService {
             }
             "ModifyDBClusterParameterGroup" => {
                 let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
+                let parsed = crate::service::parse_db_parameter_members(req);
+                let mut accounts = write_state!();
+                let state = accounts.get_or_create(&aid);
+                if let Some(map) = state.extras.get_mut("cluster_param_groups") {
+                    if let Some(entry) = map.get_mut(&name) {
+                        if let Some(obj) = entry.as_object_mut() {
+                            if !obj.contains_key("Parameters") {
+                                obj.insert("Parameters".to_string(), json!({}));
+                            }
+                            if let Some(p) = obj.get_mut("Parameters").and_then(|p| p.as_object_mut()) {
+                                for (n, v) in parsed {
+                                    p.insert(n, json!(v));
+                                }
+                            }
+                        }
+                    }
+                }
                 Ok(xml_response("ModifyDBClusterParameterGroup", format!("    <DBClusterParameterGroupName>{}</DBClusterParameterGroupName>", xml_escape(&name)), &rid))
             }
             "ResetDBClusterParameterGroup" => {
@@ -235,7 +252,33 @@ impl RdsService {
                 xml_empty_action(&action, &rid)
             }
             "DescribeDBClusterParameterGroups" => list_extras_xml(self, &aid, "cluster_param_groups", "DBClusterParameterGroups", "DescribeDBClusterParameterGroups", cluster_pg_member_xml, &rid),
-            "DescribeDBClusterParameters" => Ok(xml_response("DescribeDBClusterParameters", "    <Parameters/>".to_string(), &rid)),
+            "DescribeDBClusterParameters" => {
+                let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
+                let source_filter = get_param(req, "Source");
+                let want_user_source = source_filter.as_deref().is_none_or(|s| s == "user");
+                let accounts = self.state_handle().read();
+                let state = accounts.get(&aid);
+                let mut members = String::new();
+                if want_user_source {
+                    if let Some(s) = state {
+                        if let Some(map) = s.extras.get("cluster_param_groups") {
+                            if let Some(entry) = map.get(&name) {
+                                if let Some(params) = entry.get("Parameters").and_then(|p| p.as_object()) {
+                                    for (n, v) in params {
+                                        let value = v.as_str().unwrap_or("").to_string();
+                                        members.push_str(&format!(
+                                            "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
+                                            xml_escape(n),
+                                            xml_escape(&value),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(xml_response("DescribeDBClusterParameters", format!("    <Parameters>\n{members}    </Parameters>"), &rid))
+            }
             "DescribeEngineDefaultClusterParameters" => Ok(xml_response("DescribeEngineDefaultClusterParameters", "    <EngineDefaults>\n      <Parameters/>\n    </EngineDefaults>".to_string(), &rid)),
 
             // ── DB Cluster endpoints ──
@@ -1125,7 +1168,10 @@ mod tests {
             &[("DBClusterParameterGroupName", "cpg")],
         );
         ok("DescribeDBClusterParameterGroups", &[]);
-        ok("DescribeDBClusterParameters", &[]);
+        ok(
+            "DescribeDBClusterParameters",
+            &[("DBClusterParameterGroupName", "cpg")],
+        );
         ok("DescribeEngineDefaultClusterParameters", &[]);
         ok(
             "DeleteDBClusterParameterGroup",

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -368,6 +368,7 @@ impl AwsService for RdsService {
             "DescribeDBEngineVersions" => self.describe_db_engine_versions(&request),
             "DescribeDBInstances" => self.describe_db_instances(&request),
             "DescribeDBParameterGroups" => self.describe_db_parameter_groups(&request),
+            "DescribeDBParameters" => self.describe_db_parameters_real(&request),
             "DescribeDBSnapshots" => self.describe_db_snapshots(&request),
             "DescribeDBSubnetGroups" => self.describe_db_subnet_groups(&request),
             "DescribeOrderableDBInstanceOptions" => {
@@ -2434,6 +2435,12 @@ impl RdsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_query_param(request, "DBParameterGroupName")?;
 
+        // Parse Parameters.member.N.{ParameterName,ParameterValue,ApplyMethod}
+        // before taking the lock so we can validate input independently.
+        // ApplyMethod is accepted (immediate vs pending-reboot) but the
+        // single-state model applies all changes immediately.
+        let parsed_params = parse_db_parameter_members(request);
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
 
@@ -2452,6 +2459,10 @@ impl RdsService {
             parameter_group.description = new_description;
         }
 
+        for (name, value) in parsed_params {
+            parameter_group.parameters.insert(name, value);
+        }
+
         let parameter_group_clone = parameter_group.clone();
 
         Ok(AwsResponse::xml(
@@ -2467,6 +2478,79 @@ impl RdsService {
             ),
         ))
     }
+
+    fn describe_db_parameters_real(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_parameter_group_name = required_query_param(request, "DBParameterGroupName")?;
+        let source_filter = optional_query_param(request, "Source");
+
+        let accounts = self.state.read();
+        let state = match accounts.get(&request.account_id) {
+            Some(s) => s,
+            None => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBParameterGroupNotFound",
+                    format!("DBParameterGroup {db_parameter_group_name} not found."),
+                ));
+            }
+        };
+        let parameter_group = state
+            .parameter_groups
+            .get(&db_parameter_group_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBParameterGroupNotFound",
+                    format!("DBParameterGroup {db_parameter_group_name} not found."),
+                )
+            })?;
+
+        // Modified params surface as Source=user; engine defaults
+        // surface as Source=engine-default. We only persist user-set
+        // values, so we always report `user` and skip when the caller
+        // requested only `engine-default`.
+        let want_user_source = source_filter.as_deref().is_none_or(|s| s == "user");
+        let mut members_xml = String::new();
+        if want_user_source {
+            for (name, value) in &parameter_group.parameters {
+                members_xml.push_str(&format!(
+                    "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
+                    xml_escape(name),
+                    xml_escape(value),
+                ));
+            }
+        }
+        let body = format!("    <Parameters>\n{members_xml}    </Parameters>");
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml("DescribeDBParameters", RDS_NS, &body, &request.request_id),
+        ))
+    }
+}
+
+/// Parse `Parameters.member.N.{ParameterName,ParameterValue,ApplyMethod}`
+/// from a Query-protocol request. Skips members missing a name or value;
+/// ApplyMethod is accepted but ignored (single-state model).
+pub(crate) fn parse_db_parameter_members(request: &AwsRequest) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for index in 1.. {
+        let name_key = format!("Parameters.member.{index}.ParameterName");
+        let value_key = format!("Parameters.member.{index}.ParameterValue");
+        match (
+            optional_query_param(request, &name_key),
+            optional_query_param(request, &value_key),
+        ) {
+            (Some(name), Some(value)) if !name.is_empty() => {
+                out.push((name, value));
+            }
+            (None, None) => break,
+            _ => continue,
+        }
+    }
+    out
 }
 
 pub(crate) struct PaginationResult<T> {

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1022,6 +1022,94 @@ fn modify_db_parameter_group_unknown_errors() {
     );
 }
 
+#[test]
+fn modify_db_parameter_group_persists_parameters() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let req = request(
+        "ModifyDBParameterGroup",
+        &[
+            ("DBParameterGroupName", "pg1"),
+            ("Parameters.member.1.ParameterName", "max_connections"),
+            ("Parameters.member.1.ParameterValue", "200"),
+            ("Parameters.member.1.ApplyMethod", "immediate"),
+            ("Parameters.member.2.ParameterName", "shared_buffers"),
+            ("Parameters.member.2.ParameterValue", "256MB"),
+            ("Parameters.member.2.ApplyMethod", "pending-reboot"),
+        ],
+    );
+    svc.modify_db_parameter_group(&req).unwrap();
+    let __a = svc.state.read();
+    let state = __a.default_ref();
+    let pg = state.parameter_groups.get("pg1").unwrap();
+    assert_eq!(
+        pg.parameters.get("max_connections").map(String::as_str),
+        Some("200")
+    );
+    assert_eq!(
+        pg.parameters.get("shared_buffers").map(String::as_str),
+        Some("256MB")
+    );
+}
+
+#[test]
+fn describe_db_parameters_returns_user_set_values() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let req = request(
+        "ModifyDBParameterGroup",
+        &[
+            ("DBParameterGroupName", "pg1"),
+            ("Parameters.member.1.ParameterName", "max_connections"),
+            ("Parameters.member.1.ParameterValue", "200"),
+        ],
+    );
+    svc.modify_db_parameter_group(&req).unwrap();
+
+    let req = request("DescribeDBParameters", &[("DBParameterGroupName", "pg1")]);
+    let resp = svc.describe_db_parameters_real(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<ParameterName>max_connections</ParameterName>"));
+    assert!(body.contains("<ParameterValue>200</ParameterValue>"));
+    assert!(body.contains("<Source>user</Source>"));
+}
+
+#[test]
+fn describe_db_parameters_with_engine_default_source_omits_user_params() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let req = request(
+        "ModifyDBParameterGroup",
+        &[
+            ("DBParameterGroupName", "pg1"),
+            ("Parameters.member.1.ParameterName", "max_connections"),
+            ("Parameters.member.1.ParameterValue", "200"),
+        ],
+    );
+    svc.modify_db_parameter_group(&req).unwrap();
+
+    let req = request(
+        "DescribeDBParameters",
+        &[
+            ("DBParameterGroupName", "pg1"),
+            ("Source", "engine-default"),
+        ],
+    );
+    let resp = svc.describe_db_parameters_real(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(!body.contains("max_connections"));
+}
+
+#[test]
+fn describe_db_parameters_unknown_group_returns_not_found() {
+    let svc = make_service();
+    let req = request("DescribeDBParameters", &[("DBParameterGroupName", "ghost")]);
+    assert_code(
+        svc.describe_db_parameters_real(&req),
+        "DBParameterGroupNotFound",
+    );
+}
+
 // ── DescribeDBInstances ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Previously:
- ModifyDBParameterGroup ignored \`Parameters.member.N\` entirely; only Description was applied.
- DescribeDBParameters returned an empty \`<Parameters/>\` regardless of what was set.
- Same pattern for the Cluster parameter group ops.

Now:
- ModifyDBParameterGroup parses \`Parameters.member.N.{ParameterName,ParameterValue,ApplyMethod}\` and persists name->value pairs into \`ParameterGroup.parameters\`. ApplyMethod accepted but ignored (single-state model).
- DescribeDBParameters serializes stored params with Source=user. Honors \`Source=user|engine-default|system\` filter — engine-default returns empty (defaults aren't separately tracked yet).
- Same shape for ModifyDBClusterParameterGroup + DescribeDBClusterParameters via the existing cluster_param_groups extras Value (adds a \`Parameters\` sub-object).

Shared parser (\`parse_db_parameter_members\`) used by both instance and cluster paths.

## Test plan

- [x] \`modify_db_parameter_group_persists_parameters\` — multiple params with different ApplyMethods
- [x] \`describe_db_parameters_returns_user_set_values\` — round-trip
- [x] \`describe_db_parameters_with_engine_default_source_omits_user_params\` — Source filter respected
- [x] \`describe_db_parameters_unknown_group_returns_not_found\` — DBParameterGroupNotFound
- [x] all 135 RDS unit tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make RDS parameter groups actually store and return user-set parameters for both instance and cluster groups, with proper parsing and Source filtering. This turns previous no-op Modify/Describe calls into working behavior.

- **New Features**
  - `ModifyDBParameterGroup` parses `Parameters.member.N.{ParameterName,ParameterValue,ApplyMethod}` and saves name→value pairs; `ApplyMethod` is accepted but ignored.
  - `DescribeDBParameters` returns stored params with `Source=user` and respects `Source=user|engine-default|system`; `engine-default` currently returns none (defaults not tracked yet).
  - Mirror the same behavior for clusters: `ModifyDBClusterParameterGroup` and `DescribeDBClusterParameters` (stores under `cluster_param_groups.Parameters`).
  - Shared helper `parse_db_parameter_members` used by both paths.
  - Added tests for parameter persistence, describe filtering, and not-found errors.

<sup>Written for commit 7a6d6d4b3d9ba9a3a86c4cefb7eff78164f0a741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

