### PR TITLE
feat(rds): tag operations multiplex across resource types (M4)

### DIFF
--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1394,8 +1394,9 @@ impl RdsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let instance = find_instance_by_arn_mut(state, &resource_name)?;
-        merge_tags(&mut instance.tags, &tags);
+        let mut target = resolve_tag_target_mut(state, &resource_name)
+            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        target.merge(&tags);
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -1416,8 +1417,9 @@ impl RdsService {
         let accounts = self.state.read();
         let empty = RdsState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let instance = find_instance_by_arn(state, &resource_name)?;
-        let tag_xml = instance.tags.iter().map(tag_xml).collect::<String>();
+        let target = resolve_tag_target(state, &resource_name)
+            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        let tag_xml = target.to_xml();
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -1447,10 +1449,9 @@ impl RdsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let instance = find_instance_by_arn_mut(state, &resource_name)?;
-        instance
-            .tags
-            .retain(|tag| !tag_keys.iter().any(|key| key == &tag.key));
+        let mut target = resolve_tag_target_mut(state, &resource_name)
+            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        target.remove_keys(&tag_keys);
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -1225,36 +1225,6 @@ pub(crate) fn db_snapshot_not_found(identifier: &str) -> AwsServiceError {
     )
 }
 
-pub(crate) fn db_instance_not_found_by_arn(resource_name: &str) -> AwsServiceError {
-    AwsServiceError::aws_error(
-        StatusCode::NOT_FOUND,
-        "DBInstanceNotFound",
-        format!("DBInstance {resource_name} not found."),
-    )
-}
-
-pub(crate) fn find_instance_by_arn<'a>(
-    state: &'a crate::state::RdsState,
-    resource_name: &str,
-) -> Result<&'a DbInstance, AwsServiceError> {
-    state
-        .instances
-        .values()
-        .find(|instance| instance.db_instance_arn == resource_name)
-        .ok_or_else(|| db_instance_not_found_by_arn(resource_name))
-}
-
-pub(crate) fn find_instance_by_arn_mut<'a>(
-    state: &'a mut crate::state::RdsState,
-    resource_name: &str,
-) -> Result<&'a mut DbInstance, AwsServiceError> {
-    state
-        .instances
-        .values_mut()
-        .find(|instance| instance.db_instance_arn == resource_name)
-        .ok_or_else(|| db_instance_not_found_by_arn(resource_name))
-}
-
 pub(crate) fn merge_tags(existing: &mut Vec<RdsTag>, incoming: &[RdsTag]) {
     for tag in incoming {
         if let Some(existing_tag) = existing
@@ -1265,6 +1235,197 @@ pub(crate) fn merge_tags(existing: &mut Vec<RdsTag>, incoming: &[RdsTag]) {
         } else {
             existing.push(tag.clone());
         }
+    }
+}
+
+/// Construct the not-found error for tag operations. AWS returns
+/// `InvalidParameterValue` on a malformed/unknown resource ARN for
+/// AddTags/ListTags/RemoveTags — use that instead of the per-resource
+/// not-found code so the caller's error handling matches.
+pub(crate) fn tag_resource_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidParameterValue",
+        format!("The specified resource name does not match an RDS resource in this region: {arn}"),
+    )
+}
+
+/// Parse an RDS ARN's resource-type segment + name. Returns
+/// `(resource_type, name)` where `resource_type` is the segment AWS
+/// uses to discriminate (`db`, `snapshot`, `cluster`, `pg`, `subgrp`,
+/// `og`, `cluster-pg`, `cluster-snapshot`, `secgrp`, etc.). Returns
+/// `None` on malformed ARNs.
+pub(crate) fn parse_rds_arn(arn: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() < 7 || parts[0] != "arn" || parts[2] != "rds" {
+        return None;
+    }
+    let kind = parts.get(5)?;
+    let name = parts.get(6)?;
+    if kind.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some((kind.to_string(), name.to_string()))
+}
+
+pub(crate) enum TagTargetMut<'a> {
+    Vec(&'a mut Vec<RdsTag>),
+    Json(&'a mut serde_json::Value),
+}
+
+pub(crate) enum TagTargetRef<'a> {
+    Vec(&'a Vec<RdsTag>),
+    Json(&'a serde_json::Value),
+}
+
+impl TagTargetMut<'_> {
+    pub fn merge(&mut self, incoming: &[RdsTag]) {
+        match self {
+            TagTargetMut::Vec(v) => merge_tags(v, incoming),
+            TagTargetMut::Json(entry) => {
+                let obj = match entry.as_object_mut() {
+                    Some(o) => o,
+                    None => return,
+                };
+                if !obj.contains_key("Tags") {
+                    obj.insert("Tags".to_string(), serde_json::json!([]));
+                }
+                let arr = match obj.get_mut("Tags").and_then(|t| t.as_array_mut()) {
+                    Some(a) => a,
+                    None => return,
+                };
+                for t in incoming {
+                    if let Some(existing) = arr
+                        .iter_mut()
+                        .find(|v| v.get("Key").and_then(|k| k.as_str()) == Some(t.key.as_str()))
+                    {
+                        if let Some(o) = existing.as_object_mut() {
+                            o.insert("Value".to_string(), serde_json::json!(t.value));
+                        }
+                    } else {
+                        arr.push(serde_json::json!({"Key": t.key, "Value": t.value}));
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn remove_keys(&mut self, keys: &[String]) {
+        match self {
+            TagTargetMut::Vec(v) => v.retain(|t| !keys.iter().any(|k| k == &t.key)),
+            TagTargetMut::Json(entry) => {
+                if let Some(obj) = entry.as_object_mut() {
+                    if let Some(arr) = obj.get_mut("Tags").and_then(|t| t.as_array_mut()) {
+                        arr.retain(|v| {
+                            v.get("Key")
+                                .and_then(|k| k.as_str())
+                                .is_none_or(|k| !keys.iter().any(|key| key == k))
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl TagTargetRef<'_> {
+    pub fn to_xml(&self) -> String {
+        match self {
+            TagTargetRef::Vec(v) => v.iter().map(tag_xml).collect(),
+            TagTargetRef::Json(entry) => entry
+                .get("Tags")
+                .and_then(|t| t.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| {
+                            let k = v.get("Key").and_then(|k| k.as_str())?;
+                            let val = v.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+                            Some(tag_xml(&RdsTag {
+                                key: k.to_string(),
+                                value: val.to_string(),
+                            }))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+fn extras_bucket_for_resource_type(kind: &str) -> Option<&'static str> {
+    Some(match kind {
+        "cluster" => "clusters",
+        "cluster-snapshot" => "cluster_snapshots",
+        "cluster-pg" => "cluster_param_groups",
+        "og" => "option_groups",
+        "secgrp" => "security_groups",
+        "es" => "event_subscriptions",
+        "proxy" => "db_proxies",
+        _ => return None,
+    })
+}
+
+/// Locate tag storage on whichever RDS resource the ARN points at.
+/// Supports the four state-backed types (db, snapshot, subgrp, pg)
+/// and extras-backed cluster types (cluster, cluster-snapshot,
+/// cluster-pg, og, secgrp, es, proxy) — for those we mutate a `Tags`
+/// array on the stored JSON entry so it survives serde round-trips.
+/// Returns `None` if the ARN doesn't match any known resource.
+pub(crate) fn resolve_tag_target_mut<'a>(
+    state: &'a mut crate::state::RdsState,
+    arn: &str,
+) -> Option<TagTargetMut<'a>> {
+    let (kind, name) = parse_rds_arn(arn)?;
+    match kind.as_str() {
+        "db" => state
+            .instances
+            .get_mut(&name)
+            .map(|i| TagTargetMut::Vec(&mut i.tags)),
+        "snapshot" => state
+            .snapshots
+            .get_mut(&name)
+            .map(|s| TagTargetMut::Vec(&mut s.tags)),
+        "subgrp" => state
+            .subnet_groups
+            .get_mut(&name)
+            .map(|g| TagTargetMut::Vec(&mut g.tags)),
+        "pg" => state
+            .parameter_groups
+            .get_mut(&name)
+            .map(|g| TagTargetMut::Vec(&mut g.tags)),
+        other => extras_bucket_for_resource_type(other)
+            .and_then(|bucket| state.extras.get_mut(bucket))
+            .and_then(|map| map.get_mut(&name))
+            .map(TagTargetMut::Json),
+    }
+}
+
+pub(crate) fn resolve_tag_target<'a>(
+    state: &'a crate::state::RdsState,
+    arn: &str,
+) -> Option<TagTargetRef<'a>> {
+    let (kind, name) = parse_rds_arn(arn)?;
+    match kind.as_str() {
+        "db" => state
+            .instances
+            .get(&name)
+            .map(|i| TagTargetRef::Vec(&i.tags)),
+        "snapshot" => state
+            .snapshots
+            .get(&name)
+            .map(|s| TagTargetRef::Vec(&s.tags)),
+        "subgrp" => state
+            .subnet_groups
+            .get(&name)
+            .map(|g| TagTargetRef::Vec(&g.tags)),
+        "pg" => state
+            .parameter_groups
+            .get(&name)
+            .map(|g| TagTargetRef::Vec(&g.tags)),
+        other => extras_bucket_for_resource_type(other)
+            .and_then(|bucket| state.extras.get(bucket))
+            .and_then(|map| map.get(&name))
+            .map(TagTargetRef::Json),
     }
 }
 

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -699,7 +699,181 @@ fn list_tags_unknown_arn_errors() {
         "ListTagsForResource",
         &[("ResourceName", "arn:aws:rds:us-east-1:123456789012:db:nope")],
     );
-    assert_code(svc.list_tags_for_resource(&req), "DBInstanceNotFound");
+    assert_code(svc.list_tags_for_resource(&req), "InvalidParameterValue");
+}
+
+#[test]
+fn add_tags_to_snapshot_arn_persists() {
+    let svc = make_service();
+    seed_snapshot(&svc, "snap-1", "db1");
+    let arn = {
+        let __a = svc.state.read();
+        __a.default_ref()
+            .snapshots
+            .get("snap-1")
+            .unwrap()
+            .db_snapshot_arn
+            .clone()
+    };
+    let req = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", arn.as_str()),
+            ("Tags.Tag.1.Key", "team"),
+            ("Tags.Tag.1.Value", "platform"),
+        ],
+    );
+    svc.add_tags_to_resource(&req).unwrap();
+    let __a = svc.state.read();
+    let snap = __a.default_ref().snapshots.get("snap-1").unwrap();
+    assert_eq!(snap.tags.len(), 1);
+    assert_eq!(snap.tags[0].key, "team");
+    assert_eq!(snap.tags[0].value, "platform");
+}
+
+#[test]
+fn add_tags_to_parameter_group_arn_persists_and_lists() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let arn = {
+        let __a = svc.state.read();
+        __a.default_ref()
+            .parameter_groups
+            .get("pg1")
+            .unwrap()
+            .db_parameter_group_arn
+            .clone()
+    };
+    let req = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", arn.as_str()),
+            ("Tags.Tag.1.Key", "env"),
+            ("Tags.Tag.1.Value", "prod"),
+        ],
+    );
+    svc.add_tags_to_resource(&req).unwrap();
+
+    let req = request("ListTagsForResource", &[("ResourceName", arn.as_str())]);
+    let resp = svc.list_tags_for_resource(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<Key>env</Key>"));
+    assert!(body.contains("<Value>prod</Value>"));
+}
+
+#[test]
+fn add_tags_to_subnet_group_arn_persists() {
+    let svc = make_service();
+    let arn = {
+        let mut __a = svc.state.write();
+        let state = __a.default_mut();
+        let arn = state.db_subnet_group_arn("sg1");
+        state.subnet_groups.insert(
+            "sg1".to_string(),
+            crate::state::DbSubnetGroup {
+                db_subnet_group_name: "sg1".to_string(),
+                db_subnet_group_arn: arn.clone(),
+                db_subnet_group_description: "desc".to_string(),
+                vpc_id: "vpc-1".to_string(),
+                subnet_ids: Vec::new(),
+                subnet_availability_zones: Vec::new(),
+                tags: Vec::new(),
+            },
+        );
+        arn
+    };
+    let req = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", arn.as_str()),
+            ("Tags.Tag.1.Key", "owner"),
+            ("Tags.Tag.1.Value", "team-a"),
+        ],
+    );
+    svc.add_tags_to_resource(&req).unwrap();
+    let __a = svc.state.read();
+    let g = __a.default_ref().subnet_groups.get("sg1").unwrap();
+    assert_eq!(g.tags.len(), 1);
+    assert_eq!(g.tags[0].key, "owner");
+}
+
+#[test]
+fn remove_tags_from_parameter_group_only_listed_keys() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let arn = {
+        let __a = svc.state.read();
+        __a.default_ref()
+            .parameter_groups
+            .get("pg1")
+            .unwrap()
+            .db_parameter_group_arn
+            .clone()
+    };
+    let add = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", arn.as_str()),
+            ("Tags.Tag.1.Key", "k1"),
+            ("Tags.Tag.1.Value", "v1"),
+            ("Tags.Tag.2.Key", "k2"),
+            ("Tags.Tag.2.Value", "v2"),
+        ],
+    );
+    svc.add_tags_to_resource(&add).unwrap();
+    let remove = request(
+        "RemoveTagsFromResource",
+        &[("ResourceName", arn.as_str()), ("TagKeys.member.1", "k1")],
+    );
+    svc.remove_tags_from_resource(&remove).unwrap();
+    let __a = svc.state.read();
+    let pg = __a.default_ref().parameter_groups.get("pg1").unwrap();
+    assert_eq!(pg.tags.len(), 1);
+    assert_eq!(pg.tags[0].key, "k2");
+}
+
+#[test]
+fn add_tags_to_extras_resource_arn_stores_on_json() {
+    // Cluster ARNs are extras-stored; tags land in a `Tags` array on
+    // the JSON entry so they survive serde round-trips.
+    let svc = make_service();
+    let cluster_arn = {
+        let mut __a = svc.state.write();
+        let state = __a.default_mut();
+        let arn = format!(
+            "arn:aws:rds:us-east-1:{}:cluster:my-cluster",
+            state.account_id
+        );
+        state
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(
+                "my-cluster".to_string(),
+                serde_json::json!({"DBClusterIdentifier": "my-cluster"}),
+            );
+        arn
+    };
+    let req = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", cluster_arn.as_str()),
+            ("Tags.Tag.1.Key", "team"),
+            ("Tags.Tag.1.Value", "data"),
+        ],
+    );
+    svc.add_tags_to_resource(&req).unwrap();
+    let __a = svc.state.read();
+    let entry = __a
+        .default_ref()
+        .extras
+        .get("clusters")
+        .unwrap()
+        .get("my-cluster")
+        .unwrap();
+    let tags = entry.get("Tags").and_then(|t| t.as_array()).unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].get("Key").and_then(|k| k.as_str()), Some("team"));
 }
 
 #[test]
@@ -1635,7 +1809,7 @@ fn list_tags_resource_not_found() {
         "ListTagsForResource",
         &[("ResourceName", "arn:aws:rds:us-east-1:123:db:ghost")],
     );
-    assert_code(svc.list_tags_for_resource(&req), "DBInstanceNotFound");
+    assert_code(svc.list_tags_for_resource(&req), "InvalidParameterValue");
 }
 
 // ── snapshot operations ──


### PR DESCRIPTION
## Summary

AddTagsToResource / ListTagsForResource / RemoveTagsFromResource previously only handled instance ARNs (\`arn:aws:rds:...:db:<name>\`). Tagging a snapshot, parameter group, or cluster returned DBInstanceNotFound — silently inaccessible to anything but instances.

Now multiplex on the ARN's resource-type segment:

**State-backed** (\`Vec<RdsTag>\` on the typed entity):
- \`db\` -> instances
- \`snapshot\` -> snapshots
- \`subgrp\` -> subnet_groups
- \`pg\` -> parameter_groups

**Extras-backed** (JSON \`Tags\` array on the stored entry):
- \`cluster\`, \`cluster-snapshot\`, \`cluster-pg\`
- \`og\` (option groups), \`secgrp\`, \`es\` (event subscriptions), \`proxy\`

Unknown ARNs return AWS's actual error code for tag ops (\`InvalidParameterValue\` with the unmatched ARN in the message), not the type-specific not-found code that only made sense for instance-only callers.

## Implementation

- New \`parse_rds_arn\` helper extracts \`(resource_type, name)\` from any RDS ARN.
- \`TagTargetMut\` / \`TagTargetRef\` enums abstract over Vec-backed vs JSON-backed tag storage with shared \`merge\` / \`remove_keys\` / \`to_xml\` operations.
- \`resolve_tag_target_mut\` / \`resolve_tag_target\` map ARN -> the right tag store across all resource types.
- Removed dead \`find_instance_by_arn\` / \`find_instance_by_arn_mut\` helpers.

## Test plan

- [x] \`add_tags_to_snapshot_arn_persists\` — snapshot tags
- [x] \`add_tags_to_parameter_group_arn_persists_and_lists\` — pg tags + list round-trip
- [x] \`add_tags_to_subnet_group_arn_persists\` — subnet group tags
- [x] \`remove_tags_from_parameter_group_only_listed_keys\` — RemoveTags on non-instance type
- [x] \`add_tags_to_extras_resource_arn_stores_on_json\` — cluster ARN -> JSON Tags array
- [x] all 140 RDS unit tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag operations now work across RDS resource types by inspecting the ARN’s resource segment. Unknown or malformed ARNs now return `InvalidParameterValue`, matching AWS.

- **New Features**
  - State-backed: `db`, `snapshot`, `subgrp`, `pg` (tags stored on the entity).
  - Extras-backed: `cluster`, `cluster-snapshot`, `cluster-pg`, `og`, `secgrp`, `es`, `proxy` (tags stored in a `Tags` array on the JSON entry).

- **Bug Fixes**
  - Return `InvalidParameterValue` for tag ops on unknown ARNs instead of `DBInstanceNotFound`.

<sup>Written for commit 88e23fee31b137e755065a3b0d57f8c703d37ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

