### PR TITLE
feat(cloudfront): real JS execution in TestFunction + TestConnectionFunction (T1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,7 +1566,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "rustc_version",
+ "rustc_version 0.4.1",
  "tracing",
 ]
 
@@ -1675,7 +1684,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1727,6 +1736,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boa_ast"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+dependencies = [
+ "bitflags",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap",
+ "num-bigint",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+dependencies = [
+ "aligned-vec",
+ "arrayvec",
+ "bitflags",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
+ "cow-utils",
+ "dashmap",
+ "dynify",
+ "fast-float2",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
+ "indexmap",
+ "intrusive-collections",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "portable-atomic",
+ "rand 0.9.4",
+ "regress",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "small_btree",
+ "static_assertions",
+ "tag_ptr",
+ "tap",
+ "thin-vec",
+ "thiserror 2.0.18",
+ "time",
+ "xsum",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+dependencies = [
+ "boa_macros",
+ "boa_string",
+ "hashbrown 0.16.1",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "once_cell",
+ "phf 0.13.1",
+ "rustc-hash",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+dependencies = [
+ "cfg-if",
+ "cow-utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+dependencies = [
+ "bitflags",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint",
+ "num-traits",
+ "regress",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_string"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+dependencies = [
+ "fast-float2",
+ "itoa",
+ "paste",
+ "rustc-hash",
+ "ryu-js",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1788,6 +1938,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2051,6 +2221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,7 +2278,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -2277,6 +2453,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2568,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2667,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2739,6 +2969,7 @@ version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "boa_engine",
  "bytes",
  "chrono",
  "fakecloud-aws",
@@ -3636,6 +3867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3939,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,6 +3959,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -3810,6 +4069,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,6 +4092,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3999,13 +4284,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -4269,13 +4571,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4289,6 +4590,7 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -4296,43 +4598,48 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -4342,6 +4649,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -4405,6 +4714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4431,6 +4749,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4711,6 +5038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4875,6 +5211,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4927,6 +5264,37 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5051,6 +5419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,6 +5446,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -5123,8 +5503,32 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5231,6 +5635,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-protocol"
@@ -5600,6 +6010,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5760,11 +6180,20 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5890,6 +6319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5988,9 +6423,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -6183,6 +6633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6343,6 +6802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6380,6 +6845,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -6437,7 +6908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -6467,6 +6941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -6879,6 +7354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7073,7 +7554,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -7539,13 +8020,19 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
@@ -7589,6 +8076,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "xz2"
@@ -7701,6 +8194,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -7709,6 +8203,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/crates/fakecloud-cloudfront/Cargo.toml
+++ b/crates/fakecloud-cloudfront/Cargo.toml
@@ -13,6 +13,7 @@ fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+boa_engine = "0.21"
 bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/fakecloud-cloudfront/src/cfunctions_service.rs
+++ b/crates/fakecloud-cloudfront/src/cfunctions_service.rs
@@ -263,27 +263,64 @@ impl CloudFrontService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = route_id(route, "ConnectionFunction")?;
         let if_match = require_if_match(req)?;
+        let parsed: TestConnectionFunctionRequest =
+            xml_io::from_xml_root(&req.body).map_err(|e| {
+                invalid_argument(format!("invalid TestConnectionFunctionRequest XML: {e}"))
+            })?;
+        let event_bytes = base64::engine::general_purpose::STANDARD
+            .decode(parsed.connection_object.trim().as_bytes())
+            .map_err(|e| invalid_argument(format!("ConnectionObject is not valid base64: {e}")))?;
         let state = self.state.read();
         let f = state
             .accounts
             .get(DEFAULT_ACCOUNT)
             .and_then(|a| a.connection_functions.get(&name).cloned())
-            .ok_or_else(|| not_found("ConnectionFunction", &name))?;
+            .ok_or_else(|| {
+                aws_error(
+                    StatusCode::NOT_FOUND,
+                    "EntityNotFound",
+                    format!("ConnectionFunction {name} does not exist"),
+                )
+            })?;
         drop(state);
         if f.etag != if_match {
             return Err(precondition_failed());
         }
-        let mut body = String::with_capacity(512);
+        let code = String::from_utf8(f.code.clone())
+            .map_err(|e| invalid_argument(format!("function code is not valid UTF-8: {e}")))?;
+        let exec = crate::js_runtime::run_handler(&code, &event_bytes);
+
+        let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!("<ConnectionFunctionTestResult xmlns=\"{NS}\">"));
         body.push_str(&render_connection_function_summary_inner(&f));
         body.push_str("<ComputeUtilization>0</ComputeUtilization>");
-        body.push_str("<ConnectionFunctionExecutionLogs></ConnectionFunctionExecutionLogs>");
-        body.push_str("<ConnectionFunctionErrorMessage></ConnectionFunctionErrorMessage>");
-        body.push_str("<ConnectionFunctionOutput>{}</ConnectionFunctionOutput>");
+        body.push_str("<ConnectionFunctionExecutionLogs>");
+        for line in &exec.logs {
+            body.push_str(&format!("<member>{}</member>", esc(line)));
+        }
+        body.push_str("</ConnectionFunctionExecutionLogs>");
+        body.push_str(&format!(
+            "<ConnectionFunctionErrorMessage>{}</ConnectionFunctionErrorMessage>",
+            esc(exec.error.as_deref().unwrap_or(""))
+        ));
+        body.push_str(&format!(
+            "<ConnectionFunctionOutput>{}</ConnectionFunctionOutput>",
+            esc(exec.output.as_deref().unwrap_or(""))
+        ));
         body.push_str("</ConnectionFunctionTestResult>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct TestConnectionFunctionRequest {
+    #[serde(default)]
+    connection_object: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    stage: Option<String>,
 }
 
 fn render_connection_function_summary(f: &StoredConnectionFunction, with_decl: bool) -> String {
@@ -326,4 +363,167 @@ fn push_summary_body(out: &mut String, f: &StoredConnectionFunction) {
     out.push_str(&format!("<Comment>{}</Comment>", esc(&f.comment)));
     out.push_str(&format!("<Runtime>{}</Runtime>", esc(&f.runtime)));
     out.push_str("</ConnectionFunctionConfig>");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::CloudFrontService;
+    use crate::state::CloudFrontAccounts;
+    use bytes::Bytes;
+    use fakecloud_core::service::AwsService;
+    use http::HeaderValue;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn svc() -> CloudFrontService {
+        CloudFrontService::new(Arc::new(RwLock::new(CloudFrontAccounts::new())))
+    }
+
+    fn req(method: http::Method, path: &str, body: &str, if_match: Option<&str>) -> AwsRequest {
+        let mut headers = HeaderMap::new();
+        if let Some(v) = if_match {
+            headers.insert(http::header::IF_MATCH, HeaderValue::from_str(v).unwrap());
+        }
+        AwsRequest {
+            service: "cloudfront".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: DEFAULT_ACCOUNT.into(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            headers,
+            query_params: std::collections::HashMap::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            body: Bytes::from(body.to_string()),
+            path_segments: path
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect(),
+            raw_path: path.into(),
+            raw_query: String::new(),
+            method,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    async fn create_cfn(svc: &CloudFrontService, name: &str, code: &str) -> String {
+        let code_b64 = base64::engine::general_purpose::STANDARD.encode(code.as_bytes());
+        let body = format!(
+            r#"<?xml version="1.0"?>
+<CreateConnectionFunctionRequest xmlns="{NS}">
+  <Name>{name}</Name>
+  <ConnectionFunctionConfig>
+    <Comment>t</Comment>
+    <Runtime>cloudfront-js-2.0</Runtime>
+  </ConnectionFunctionConfig>
+  <ConnectionFunctionCode>{code_b64}</ConnectionFunctionCode>
+</CreateConnectionFunctionRequest>"#
+        );
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function",
+                &body,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        resp.headers
+            .get(ETAG)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn test_cfn_request_xml(event_json: &str) -> String {
+        let event_b64 = base64::engine::general_purpose::STANDARD.encode(event_json.as_bytes());
+        format!(
+            r#"<?xml version="1.0"?>
+<TestConnectionFunctionRequest xmlns="{NS}">
+  <Stage>DEVELOPMENT</Stage>
+  <ConnectionObject>{event_b64}</ConnectionObject>
+</TestConnectionFunctionRequest>"#
+        )
+    }
+
+    #[tokio::test]
+    async fn test_connection_function_executes_handler_and_returns_result() {
+        let svc = svc();
+        let etag = create_cfn(
+            &svc,
+            "cfn-ok",
+            r#"function handler(event) { event.headers.x = "y"; return event; }"#,
+        )
+        .await;
+        let body = test_cfn_request_xml(r#"{"headers":{}}"#);
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function/cfn-ok/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("&quot;x&quot;:&quot;y&quot;"),
+            "expected x:y in output, got {xml}"
+        );
+        assert!(
+            xml.contains("<ConnectionFunctionErrorMessage></ConnectionFunctionErrorMessage>"),
+            "expected empty error, got {xml}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connection_function_propagates_js_error_into_message() {
+        let svc = svc();
+        let etag = create_cfn(
+            &svc,
+            "cfn-err",
+            r#"function handler() { throw new Error("boom"); }"#,
+        )
+        .await;
+        let body = test_cfn_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function/cfn-err/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(xml.contains("boom"), "expected boom, got {xml}");
+        assert!(xml.contains("<ConnectionFunctionOutput></ConnectionFunctionOutput>"));
+    }
+
+    #[tokio::test]
+    async fn test_connection_function_unknown_name_returns_error() {
+        let svc = svc();
+        let body = test_cfn_request_xml("{}");
+        let err = match svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function/missing/test",
+                &body,
+                Some("E0"),
+            ))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("expected EntityNotFound, got Ok"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.code(), "EntityNotFound");
+    }
 }

--- a/crates/fakecloud-cloudfront/src/functions_service.rs
+++ b/crates/fakecloud-cloudfront/src/functions_service.rs
@@ -251,32 +251,54 @@ impl CloudFrontService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = route_id(route, "Function")?;
         let if_match = require_if_match(req)?;
+        let parsed: TestFunctionRequest = xml_io::from_xml_root(&req.body)
+            .map_err(|e| invalid_argument(format!("invalid TestFunctionRequest XML: {e}")))?;
+        let event_bytes = base64::engine::general_purpose::STANDARD
+            .decode(parsed.event_object.trim().as_bytes())
+            .map_err(|e| invalid_argument(format!("EventObject is not valid base64: {e}")))?;
+
         let state = self.state.read();
         let f = state
             .accounts
             .get(DEFAULT_ACCOUNT)
             .and_then(|a| a.functions.get(&name).cloned())
-            .ok_or_else(|| not_found("Function", &name))?;
+            .ok_or_else(|| {
+                aws_error(
+                    StatusCode::NOT_FOUND,
+                    "NoSuchFunctionExists",
+                    format!("The specified function does not exist: {name}"),
+                )
+            })?;
         drop(state);
         if f.etag != if_match {
             return Err(precondition_failed());
         }
 
-        let mut body = String::with_capacity(512);
+        let code_bytes = base64::engine::general_purpose::STANDARD
+            .decode(f.function_code.as_bytes())
+            .unwrap_or_else(|_| f.function_code.as_bytes().to_vec());
+        let code = String::from_utf8(code_bytes)
+            .map_err(|e| invalid_argument(format!("function code is not valid UTF-8: {e}")))?;
+        let exec = crate::js_runtime::run_handler(&code, &event_bytes);
+
+        let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!("<TestResult xmlns=\"{NS}\">"));
-        body.push_str("<TestFunctionResult>");
-        body.push_str(&format!(
-            "<FunctionSummary>{}</FunctionSummary>",
-            render_function_summary_inner(&f)
-                .replacen("<FunctionSummary>", "", 1)
-                .replacen("</FunctionSummary>", "", 1)
-        ));
+        body.push_str(&render_function_summary_inner(&f));
         body.push_str("<ComputeUtilization>0</ComputeUtilization>");
-        body.push_str("<FunctionExecutionLogs></FunctionExecutionLogs>");
-        body.push_str("<FunctionErrorMessage></FunctionErrorMessage>");
-        body.push_str("<FunctionOutput>{}</FunctionOutput>");
-        body.push_str("</TestFunctionResult>");
+        body.push_str("<FunctionExecutionLogs>");
+        for line in &exec.logs {
+            body.push_str(&format!("<member>{}</member>", esc(line)));
+        }
+        body.push_str("</FunctionExecutionLogs>");
+        body.push_str(&format!(
+            "<FunctionErrorMessage>{}</FunctionErrorMessage>",
+            esc(exec.error.as_deref().unwrap_or(""))
+        ));
+        body.push_str(&format!(
+            "<FunctionOutput>{}</FunctionOutput>",
+            esc(exec.output.as_deref().unwrap_or(""))
+        ));
         body.push_str("</TestResult>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }
@@ -1031,6 +1053,16 @@ struct UpdateFunctionRequest {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
+struct TestFunctionRequest {
+    #[serde(default)]
+    event_object: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    stage: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
 struct CreateKeyValueStoreRequest {
     name: String,
     #[serde(default)]
@@ -1242,4 +1274,162 @@ fn render_monitoring(m: &StoredMonitoringSubscription) -> String {
     out.push_str("</RealtimeMetricsSubscriptionConfig>");
     out.push_str("</MonitoringSubscription>");
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::CloudFrontService;
+    use crate::state::CloudFrontAccounts;
+    use bytes::Bytes;
+    use fakecloud_core::service::AwsService;
+    use http::HeaderValue;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn svc() -> CloudFrontService {
+        CloudFrontService::new(Arc::new(RwLock::new(CloudFrontAccounts::new())))
+    }
+
+    fn req(method: http::Method, path: &str, body: &str, if_match: Option<&str>) -> AwsRequest {
+        let mut headers = HeaderMap::new();
+        if let Some(v) = if_match {
+            headers.insert(http::header::IF_MATCH, HeaderValue::from_str(v).unwrap());
+        }
+        AwsRequest {
+            service: "cloudfront".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: DEFAULT_ACCOUNT.into(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            headers,
+            query_params: std::collections::HashMap::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            body: Bytes::from(body.to_string()),
+            path_segments: path
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect(),
+            raw_path: path.into(),
+            raw_query: String::new(),
+            method,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    async fn create_function(svc: &CloudFrontService, name: &str, code: &str) -> String {
+        let code_b64 = base64::engine::general_purpose::STANDARD.encode(code.as_bytes());
+        let body = format!(
+            r#"<?xml version="1.0"?>
+<CreateFunctionRequest xmlns="{NS}">
+  <Name>{name}</Name>
+  <FunctionConfig>
+    <Comment>t</Comment>
+    <Runtime>cloudfront-js-2.0</Runtime>
+  </FunctionConfig>
+  <FunctionCode>{code_b64}</FunctionCode>
+</CreateFunctionRequest>"#
+        );
+        let resp = svc
+            .handle(req(http::Method::POST, "/2020-05-31/function", &body, None))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::CREATED);
+        resp.headers
+            .get(http::header::ETAG)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn test_function_request_xml(event_json: &str) -> String {
+        let event_b64 = base64::engine::general_purpose::STANDARD.encode(event_json.as_bytes());
+        format!(
+            r#"<?xml version="1.0"?>
+<TestFunctionRequest xmlns="{NS}">
+  <Stage>DEVELOPMENT</Stage>
+  <EventObject>{event_b64}</EventObject>
+</TestFunctionRequest>"#
+        )
+    }
+
+    #[tokio::test]
+    async fn test_function_executes_handler_and_returns_result() {
+        let svc = svc();
+        let etag = create_function(
+            &svc,
+            "fn-ok",
+            r#"function handler(event) { event.headers.x = "y"; return event; }"#,
+        )
+        .await;
+        let body = test_function_request_xml(r#"{"headers":{}}"#);
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/fn-ok/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("&quot;x&quot;:&quot;y&quot;"),
+            "expected x:y in FunctionOutput, got {xml}"
+        );
+        assert!(xml.contains("<FunctionErrorMessage></FunctionErrorMessage>"));
+    }
+
+    #[tokio::test]
+    async fn test_function_propagates_js_error_into_message() {
+        let svc = svc();
+        let etag = create_function(
+            &svc,
+            "fn-err",
+            r#"function handler() { throw new Error("boom"); }"#,
+        )
+        .await;
+        let body = test_function_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/fn-err/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("boom"),
+            "expected boom in error msg, got {xml}"
+        );
+        assert!(xml.contains("<FunctionOutput></FunctionOutput>"));
+    }
+
+    #[tokio::test]
+    async fn test_function_unknown_name_returns_error() {
+        let svc = svc();
+        let body = test_function_request_xml("{}");
+        let err = match svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/missing/test",
+                &body,
+                Some("E0"),
+            ))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("expected NoSuchFunctionExists, got Ok"),
+        };
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.code(), "NoSuchFunctionExists");
+    }
 }

--- a/crates/fakecloud-cloudfront/src/js_runtime.rs
+++ b/crates/fakecloud-cloudfront/src/js_runtime.rs
@@ -1,0 +1,253 @@
+//! Minimal JavaScript runtime backing CloudFront Functions and
+//! ConnectionFunctions. We embed `boa_engine` to actually execute the
+//! user's `function handler(event) { ... }` against a caller-provided
+//! event object, mirroring the real AWS shape:
+//!
+//! - decode the function source, eval it in a fresh `Context`;
+//! - parse the event JSON into a JS value (`(<json>)`);
+//! - call `handler(event)`;
+//! - JSON.stringify the return value;
+//! - capture `console.log/error` output as execution log lines.
+//!
+//! Limits are enforced via boa's loop iteration + recursion caps and a
+//! hard cap on stringified output size. We intentionally don't try to
+//! emulate every CloudFront builtin — fakecloud only needs the
+//! pass-through shape so callers can validate request/response
+//! transforms in tests.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use boa_engine::object::ObjectInitializer;
+use boa_engine::property::Attribute;
+use boa_engine::{js_string, Context, JsValue, NativeFunction, Source};
+
+const LOOP_ITERATION_LIMIT: u64 = 10_000_000;
+const RECURSION_LIMIT: usize = 1_000;
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+
+/// Result of executing a CloudFront-style function. Either `output`
+/// (the JSON-encoded handler return value) or `error` will be set;
+/// `logs` is always populated (possibly empty) with whatever the user
+/// JS wrote to `console.log` / `console.error`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct JsExecution {
+    pub output: Option<String>,
+    pub error: Option<String>,
+    pub logs: Vec<String>,
+}
+
+/// Run `handler(event)` defined in `code` against `event_json`.
+///
+/// `code` is the raw JavaScript source (already base64-decoded by the
+/// caller). `event_json` is the JSON-encoded event object. Returns a
+/// populated `JsExecution`; this function itself never panics on user
+/// input — JS errors map to `error`, oversized outputs become an
+/// error, and non-JSON event blobs are surfaced as an `error` too.
+pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
+    let logs: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+    let mut ctx = Context::default();
+    ctx.runtime_limits_mut()
+        .set_loop_iteration_limit(LOOP_ITERATION_LIMIT);
+    ctx.runtime_limits_mut()
+        .set_recursion_limit(RECURSION_LIMIT);
+
+    if let Err(err) = install_console(&mut ctx, &logs) {
+        return JsExecution {
+            error: Some(format!("failed to install console: {err}")),
+            logs: logs.borrow().clone(),
+            ..Default::default()
+        };
+    }
+
+    if let Err(err) = ctx.eval(Source::from_bytes(code.as_bytes())) {
+        return JsExecution {
+            error: Some(format!("{}", err)),
+            logs: logs.borrow().clone(),
+            ..Default::default()
+        };
+    }
+
+    let event_str = match std::str::from_utf8(event_json) {
+        Ok(s) => s,
+        Err(_) => {
+            return JsExecution {
+                error: Some("EventObject is not valid UTF-8".to_string()),
+                logs: logs.borrow().clone(),
+                ..Default::default()
+            };
+        }
+    };
+    // Wrap in parens so a top-level `{ ... }` object literal parses as
+    // an expression rather than a block statement.
+    let event_src = format!("({})", event_str);
+    let event = match ctx.eval(Source::from_bytes(event_src.as_bytes())) {
+        Ok(v) => v,
+        Err(err) => {
+            return JsExecution {
+                error: Some(format!("invalid EventObject JSON: {err}")),
+                logs: logs.borrow().clone(),
+                ..Default::default()
+            };
+        }
+    };
+
+    let handler = match ctx.global_object().get(js_string!("handler"), &mut ctx) {
+        Ok(h) => h,
+        Err(err) => {
+            return JsExecution {
+                error: Some(format!("function handler is not defined: {err}")),
+                logs: logs.borrow().clone(),
+                ..Default::default()
+            };
+        }
+    };
+    let Some(handler_fn) = handler.as_callable() else {
+        return JsExecution {
+            error: Some("function handler is not callable".to_string()),
+            logs: logs.borrow().clone(),
+            ..Default::default()
+        };
+    };
+
+    let returned = match handler_fn.call(&JsValue::undefined(), &[event], &mut ctx) {
+        Ok(v) => v,
+        Err(err) => {
+            return JsExecution {
+                error: Some(format!("{}", err)),
+                logs: logs.borrow().clone(),
+                ..Default::default()
+            };
+        }
+    };
+
+    let stringified = match stringify(&mut ctx, returned) {
+        Ok(s) => s,
+        Err(err) => {
+            return JsExecution {
+                error: Some(format!("failed to JSON.stringify result: {err}")),
+                logs: logs.borrow().clone(),
+                ..Default::default()
+            };
+        }
+    };
+
+    if stringified.len() > MAX_OUTPUT_BYTES {
+        return JsExecution {
+            error: Some(format!("function output exceeded {MAX_OUTPUT_BYTES} bytes")),
+            logs: logs.borrow().clone(),
+            ..Default::default()
+        };
+    }
+
+    let captured = logs.borrow().clone();
+    JsExecution {
+        output: Some(stringified),
+        error: None,
+        logs: captured,
+    }
+}
+
+fn install_console(
+    ctx: &mut Context,
+    logs: &Rc<RefCell<Vec<String>>>,
+) -> Result<(), boa_engine::JsError> {
+    let logs_log = Rc::clone(logs);
+    let log_fn = unsafe {
+        NativeFunction::from_closure(move |_this, args, ctx| {
+            let mut parts: Vec<String> = Vec::with_capacity(args.len());
+            for a in args {
+                let s = a
+                    .to_string(ctx)
+                    .map(|s| s.to_std_string_escaped())
+                    .unwrap_or_default();
+                parts.push(s);
+            }
+            logs_log.borrow_mut().push(parts.join(" "));
+            Ok(JsValue::undefined())
+        })
+    };
+    let logs_err = Rc::clone(logs);
+    let err_fn = unsafe {
+        NativeFunction::from_closure(move |_this, args, ctx| {
+            let mut parts: Vec<String> = Vec::with_capacity(args.len());
+            for a in args {
+                let s = a
+                    .to_string(ctx)
+                    .map(|s| s.to_std_string_escaped())
+                    .unwrap_or_default();
+                parts.push(s);
+            }
+            logs_err.borrow_mut().push(parts.join(" "));
+            Ok(JsValue::undefined())
+        })
+    };
+
+    let console = ObjectInitializer::new(ctx)
+        .function(log_fn, js_string!("log"), 0)
+        .function(err_fn, js_string!("error"), 0)
+        .build();
+    ctx.register_global_property(js_string!("console"), console, Attribute::all())?;
+    Ok(())
+}
+
+fn stringify(ctx: &mut Context, value: JsValue) -> Result<String, boa_engine::JsError> {
+    let stringify = ctx.eval(Source::from_bytes(b"JSON.stringify"))?;
+    let Some(stringify_fn) = stringify.as_callable() else {
+        return Err(boa_engine::JsNativeError::typ()
+            .with_message("JSON.stringify missing")
+            .into());
+    };
+    let result = stringify_fn.call(&JsValue::undefined(), &[value], ctx)?;
+    if result.is_undefined() {
+        // JSON.stringify(undefined) yields undefined; treat as empty.
+        return Ok(String::new());
+    }
+    Ok(result.to_string(ctx)?.to_std_string_escaped())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_modified_event_as_json() {
+        let exec = run_handler(
+            r#"function handler(e) { e.x = "y"; return e; }"#,
+            br#"{"headers":{}}"#,
+        );
+        assert!(exec.error.is_none(), "unexpected error: {:?}", exec.error);
+        let out = exec.output.expect("output");
+        assert!(out.contains("\"x\":\"y\""), "got {out}");
+    }
+
+    #[test]
+    fn surfaces_thrown_error() {
+        let exec = run_handler(r#"function handler() { throw new Error("boom"); }"#, b"{}");
+        assert!(exec.output.is_none());
+        let err = exec.error.expect("error");
+        assert!(err.contains("boom"), "got {err}");
+    }
+
+    #[test]
+    fn captures_console_log() {
+        let exec = run_handler(
+            r#"function handler(e) { console.log("a", "b"); return e; }"#,
+            b"{}",
+        );
+        assert_eq!(exec.logs, vec!["a b".to_string()]);
+        assert!(exec.error.is_none());
+    }
+
+    #[test]
+    fn errors_when_handler_missing() {
+        let exec = run_handler("var x = 1;", b"{}");
+        assert!(exec.error.is_some());
+    }
+
+    #[test]
+    fn errors_when_event_is_invalid_json() {
+        let exec = run_handler(r#"function handler(e) { return e; }"#, b"not-json");
+        assert!(exec.error.is_some());
+    }
+}

--- a/crates/fakecloud-cloudfront/src/lib.rs
+++ b/crates/fakecloud-cloudfront/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fle;
 pub mod fle_service;
 pub mod functions;
 pub mod functions_service;
+pub(crate) mod js_runtime;
 pub mod model;
 pub mod policies;
 pub mod policies_service;


### PR DESCRIPTION
## Summary
- Embed `boa_engine` (0.21) and add `js_runtime.rs` that runs `function handler(event)` against a caller-provided event object, JSON.stringify's the result, and captures `console.log` / `console.error` lines.
- Wire `TestFunction` to decode `EventObject` (base64), execute the stored function code, and emit a real `<TestResult>` with `FunctionOutput` / `FunctionErrorMessage` / `FunctionExecutionLogs` instead of the canned stub.
- Wire `TestConnectionFunction` the same way for `ConnectionObject` and the `ConnectionFunctionTestResult` shape.
- Bound execution with boa's loop-iteration + recursion limits and cap stringified output at 1 MiB; both translate to `FunctionErrorMessage` so callers see a real failure mode.

## Test plan
- [x] `cargo build -p fakecloud-cloudfront`
- [x] `cargo test -p fakecloud-cloudfront --lib` (32 tests, including 6 new: js_runtime + TestFunction + TestConnectionFunction handler-level)
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs real JavaScript in CloudFront TestFunction and TestConnectionFunction using `boa_engine`, so results, errors, and logs now reflect actual handler execution. This improves parity with AWS by executing `handler(event)` against the provided objects with safe limits.

- **New Features**
  - Added `js_runtime.rs` to execute `handler(event)` with loop/recursion limits and a 1 MiB output cap.
  - `TestFunction` and `TestConnectionFunction` now base64-decode the event, run the handler, JSON.stringify the result, capture `console.log`/`console.error`, and surface errors in the ErrorMessage field.
  - Missing function errors now match AWS: `NoSuchFunctionExists` for Function and `EntityNotFound` for ConnectionFunction.

- **Dependencies**
  - Added `boa_engine` 0.21.

<sup>Written for commit a9ed2bd7ae4cc542815c8aae4ac85e4ad7f0634a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

