### PR TITLE
feat(ses): enforce verified-identity gate on SendEmail v1+v2 (X1)

### DIFF
--- a/crates/fakecloud-conformance/tests/ses.rs
+++ b/crates/fakecloud-conformance/tests/ses.rs
@@ -209,6 +209,13 @@ async fn ses_send_email() {
         .send()
         .await
         .unwrap();
+    // Sandbox accounts gate recipients too.
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
 
     let resp = client
         .send_email()
@@ -249,6 +256,12 @@ async fn ses_send_email_with_template() {
     client
         .create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();
@@ -305,6 +318,14 @@ async fn ses_send_bulk_email() {
         .send()
         .await
         .unwrap();
+    for addr in ["a@example.com", "b@example.com"] {
+        client
+            .create_email_identity()
+            .email_identity(addr)
+            .send()
+            .await
+            .unwrap();
+    }
 
     client
         .create_email_template()

--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -315,9 +315,15 @@ async fn sdk_ses_get_emails() {
     let fc = FakeCloud::new(server.endpoint());
     let ses = server.sesv2_client().await;
 
-    // Create identity first
+    // Create identity first (sender + recipient — sandbox accounts gate
+    // both).
     ses.create_email_identity()
         .email_identity("sdk-sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    ses.create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -190,6 +190,13 @@ async fn ses_send_email_simple() {
         .send()
         .await
         .unwrap();
+    // Sandbox accounts must verify recipients too.
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
 
     // Send email with simple content
     let resp = client
@@ -237,6 +244,12 @@ async fn ses_send_email_template() {
     client
         .create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();
@@ -290,6 +303,12 @@ async fn ses_send_email_raw() {
     client
         .create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();
@@ -623,6 +642,12 @@ async fn ses_introspection_endpoint() {
     client
         .create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();
@@ -2338,6 +2363,11 @@ async fn ses_event_fanout_sns_destination() {
         .send()
         .await
         .unwrap();
+    ses.create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
 
     ses.send_email()
         .from_email_address("sender@example.com")
@@ -2470,6 +2500,11 @@ async fn ses_event_fanout_bounce_simulator() {
         .send()
         .await
         .unwrap();
+    ses.create_email_identity()
+        .email_identity("simulator.amazonses.com")
+        .send()
+        .await
+        .unwrap();
 
     // Send to bounce simulator address
     ses.send_email()
@@ -2538,6 +2573,11 @@ async fn ses_event_fanout_suppression_list_simulator() {
 
     ses.create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    ses.create_email_identity()
+        .email_identity("simulator.amazonses.com")
         .send()
         .await
         .unwrap();
@@ -2672,6 +2712,11 @@ async fn ses_event_fanout_eventbridge_destination() {
 
     ses.create_email_identity()
         .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    ses.create_email_identity()
+        .email_identity("recipient@example.com")
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/ses_persistence.rs
+++ b/crates/fakecloud-e2e/tests/ses_persistence.rs
@@ -112,6 +112,11 @@ async fn persistence_suppression_persists_introspection_does_not() {
         .send()
         .await
         .unwrap();
+    ses.create_email_identity()
+        .email_identity("to@example.com")
+        .send()
+        .await
+        .unwrap();
 
     ses.put_suppressed_destination()
         .email_address("blocked@example.com")

--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -333,6 +333,15 @@ async fn test_send_email_v1() {
         .send()
         .await
         .expect("verify identity");
+    // Sandbox accounts also require recipient verification.
+    for addr in ["to@example.com", "cc@example.com"] {
+        client
+            .verify_email_identity()
+            .email_address(addr)
+            .send()
+            .await
+            .expect("verify recipient");
+    }
 
     let resp = client
         .send_email()
@@ -393,6 +402,12 @@ async fn test_send_raw_email_v1() {
     client
         .verify_email_identity()
         .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .verify_email_identity()
+        .email_address("to@example.com")
         .send()
         .await
         .unwrap();
@@ -516,6 +531,12 @@ async fn test_send_templated_email_v1() {
         .send()
         .await
         .expect("verify identity");
+    client
+        .verify_email_identity()
+        .email_address("to@example.com")
+        .send()
+        .await
+        .expect("verify recipient");
 
     // Create template first
     client
@@ -587,6 +608,14 @@ async fn test_send_bulk_templated_email_v1() {
         .send()
         .await
         .unwrap();
+    for addr in ["a@example.com", "b@example.com"] {
+        client
+            .verify_email_identity()
+            .email_address(addr)
+            .send()
+            .await
+            .unwrap();
+    }
 
     client
         .create_template()

--- a/crates/fakecloud-ses/src/service/account.rs
+++ b/crates/fakecloud-ses/src/service/account.rs
@@ -15,11 +15,7 @@ impl SesV2Service {
         let empty = SesState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let acct = &state.account_settings;
-        let production_access = acct
-            .details
-            .as_ref()
-            .and_then(|d| d.production_access_enabled)
-            .unwrap_or(true);
+        let production_access = acct.production_access_enabled;
         let mut response = json!({
             "DedicatedIpAutoWarmupEnabled": acct.dedicated_ip_auto_warmup_enabled,
             "EnforcementStatus": "HEALTHY",
@@ -113,6 +109,11 @@ impl SesV2Service {
             additional_contact_email_addresses: additional,
             production_access_enabled: production_access,
         });
+        // Mirror onto the top-level flag — it's the source of truth for
+        // the SendEmail sandbox-recipient gate.
+        if let Some(flag) = production_access {
+            state.account_settings.production_access_enabled = flag;
+        }
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
 

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -21,6 +21,31 @@ fn extract_email_address(from: &str) -> &str {
     from.trim()
 }
 
+/// Match an email against verified identities: exact email or matching
+/// verified-domain. Shared between sender + sandbox-recipient gates.
+pub(super) fn identity_is_verified(state: &crate::state::SesState, email: &str) -> bool {
+    if state
+        .identities
+        .get(email)
+        .map(|id| id.verified)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if let Some((_, domain)) = email.split_once('@') {
+        if !domain.is_empty()
+            && state
+                .identities
+                .get(domain)
+                .map(|id| id.verified)
+                .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 impl SesV2Service {
     fn render_template_for_send(
         &self,
@@ -88,7 +113,8 @@ impl SesV2Service {
     /// Reject sends where the sender is not a verified identity. Mirrors
     /// real SES: every From address must either match a verified email
     /// identity exactly, or its domain must match a verified domain
-    /// identity.
+    /// identity. Real SES v2 surfaces this as
+    /// `MailFromDomainNotVerifiedException` (HTTP 400).
     pub(super) fn reject_unverified_sender(
         &self,
         account_id: &str,
@@ -102,36 +128,57 @@ impl SesV2Service {
                 "FromEmailAddress is required",
             ));
         }
-        let domain = email.split_once('@').map(|(_, d)| d).unwrap_or("");
 
         let accounts = self.state.read();
-        let Some(state) = accounts.get(account_id) else {
-            return Some(Self::json_error(
-                StatusCode::BAD_REQUEST,
-                "MessageRejected",
-                &format!("Email address is not verified. The following identities failed the check in region {}: {}", "us-east-1", email),
-            ));
-        };
-
-        let email_ok = state
-            .identities
-            .get(email)
-            .map(|id| id.verified)
+        let verified = accounts
+            .get(account_id)
+            .map(|st| identity_is_verified(st, email))
             .unwrap_or(false);
-        let domain_ok = !domain.is_empty()
-            && state
-                .identities
-                .get(domain)
-                .map(|id| id.verified)
-                .unwrap_or(false);
 
-        if email_ok || domain_ok {
+        if verified {
+            None
+        } else {
+            Some(Self::json_error(
+                StatusCode::BAD_REQUEST,
+                "MailFromDomainNotVerifiedException",
+                "Mail-From domain not verified.",
+            ))
+        }
+    }
+
+    /// In sandbox accounts (`production_access_enabled = false`), every
+    /// recipient must also belong to a verified identity. Real SES
+    /// surfaces this as `MessageRejected` listing the failing addresses.
+    pub(super) fn reject_unverified_recipients(
+        &self,
+        account_id: &str,
+        recipients: &[&str],
+    ) -> Option<AwsResponse> {
+        let accounts = self.state.read();
+        let state = accounts.get(account_id)?;
+        if state.account_settings.production_access_enabled {
+            return None;
+        }
+        let mut failing: Vec<String> = Vec::new();
+        for raw in recipients {
+            let addr = extract_email_address(raw);
+            if addr.is_empty() {
+                continue;
+            }
+            if !identity_is_verified(state, addr) {
+                failing.push(addr.to_string());
+            }
+        }
+        if failing.is_empty() {
             None
         } else {
             Some(Self::json_error(
                 StatusCode::BAD_REQUEST,
                 "MessageRejected",
-                &format!("Email address is not verified. The following identities failed the check in region {}: {}", "us-east-1", email),
+                &format!(
+                    "Email address is not verified. The following identities failed the check: {}",
+                    failing.join(", ")
+                ),
             ))
         }
     }
@@ -163,6 +210,16 @@ impl SesV2Service {
         let to = extract_string_array(&body["Destination"]["ToAddresses"]);
         let cc = extract_string_array(&body["Destination"]["CcAddresses"]);
         let bcc = extract_string_array(&body["Destination"]["BccAddresses"]);
+
+        let recipients: Vec<&str> = to
+            .iter()
+            .chain(cc.iter())
+            .chain(bcc.iter())
+            .map(|s| s.as_str())
+            .collect();
+        if let Some(err) = self.reject_unverified_recipients(&req.account_id, &recipients) {
+            return Ok(err);
+        }
 
         let (subject, html_body, text_body, raw_data, template_name, template_data) =
             if body["Content"]["Simple"].is_object() {
@@ -274,6 +331,25 @@ impl SesV2Service {
             let to = extract_string_array(&entry["Destination"]["ToAddresses"]);
             let cc = extract_string_array(&entry["Destination"]["CcAddresses"]);
             let bcc = extract_string_array(&entry["Destination"]["BccAddresses"]);
+
+            let recipients: Vec<&str> = to
+                .iter()
+                .chain(cc.iter())
+                .chain(bcc.iter())
+                .map(|s| s.as_str())
+                .collect();
+            if self
+                .reject_unverified_recipients(&req.account_id, &recipients)
+                .is_some()
+            {
+                // Real SES surfaces unverified recipients per-entry,
+                // not as a whole-batch failure.
+                results.push(json!({
+                    "Status": "MESSAGE_REJECTED",
+                    "Error": "Email address is not verified.",
+                }));
+                continue;
+            }
 
             let message_id = uuid::Uuid::new_v4().to_string();
 

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -16,6 +16,14 @@ fn make_state() -> SharedSesState {
     ))
 }
 
+/// Flip the account out of sandbox so tests focused on send mechanics
+/// don't trip the recipient-verification gate.
+fn enable_production_access(state: &SharedSesState) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    st.account_settings.production_access_enabled = true;
+}
+
 /// Seed a verified identity for the default test account so send tests
 /// don't trip the verified-sender gate.
 fn seed_identity(state: &SharedSesState, name: &str) {
@@ -223,6 +231,7 @@ async fn test_template_lifecycle() {
 #[tokio::test]
 async fn test_send_email() {
     let state = make_state();
+    enable_production_access(&state);
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -273,6 +282,7 @@ async fn test_send_email() {
 async fn test_send_email_skips_dkim_when_signing_disabled() {
     let state = make_state();
     seed_identity(&state, "plain@example.com");
+    enable_production_access(&state);
     {
         let mut accounts = state.write();
         let st = accounts.get_or_create("123456789012");
@@ -353,6 +363,7 @@ async fn test_configuration_set_lifecycle() {
 async fn test_send_email_raw_content() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -389,6 +400,7 @@ async fn test_send_email_raw_content() {
 async fn test_send_email_template_content() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -424,6 +436,7 @@ async fn test_send_email_template_content() {
 async fn test_send_email_template_renders_subject_and_body() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     {
         use crate::state::EmailTemplate;
         let mut accounts = state.write();
@@ -485,6 +498,7 @@ async fn test_send_email_missing_content() {
 async fn test_send_email_with_cc_and_bcc() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -518,6 +532,7 @@ async fn test_send_email_with_cc_and_bcc() {
 async fn test_send_bulk_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -623,7 +638,8 @@ async fn test_send_email_rejects_unverified_sender() {
     let state = make_state();
     let svc = SesV2Service::new(state);
 
-    // No identity registered for sender@example.com → MessageRejected.
+    // No identity registered for sender@example.com → v2 surfaces this
+    // as MailFromDomainNotVerifiedException.
     let req = make_request(
         Method::POST,
         "/v2/email/outbound-emails",
@@ -636,13 +652,14 @@ async fn test_send_email_rejects_unverified_sender() {
     let resp = svc.handle(req).await.unwrap();
     assert_eq!(resp.status, StatusCode::BAD_REQUEST);
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert_eq!(body["__type"], "MessageRejected");
+    assert_eq!(body["__type"], "MailFromDomainNotVerifiedException");
 }
 
 #[tokio::test]
 async fn test_send_email_accepts_verified_domain() {
     let state = make_state();
-    // Verify the domain only → full address should be allowed.
+    // Verify the domain only → both sender and (in sandbox) recipient
+    // resolve through the same verified domain identity.
     seed_identity(&state, "example.com");
     let svc = SesV2Service::new(state);
 
@@ -652,6 +669,110 @@ async fn test_send_email_accepts_verified_domain() {
         r#"{
             "FromEmailAddress": "sender@example.com",
             "Destination": {"ToAddresses": ["recipient@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn send_email_v2_rejects_unverified_from_in_sandbox() {
+    let state = make_state();
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "noreply@example.com",
+            "Destination": {"ToAddresses": ["someone@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "MailFromDomainNotVerifiedException");
+}
+
+#[tokio::test]
+async fn send_email_v2_accepts_verified_from_when_recipient_also_verified_in_sandbox() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    seed_identity(&state, "recipient@example.com");
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["recipient@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn send_email_v2_rejects_unverified_recipient_in_sandbox() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["unverified@elsewhere.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "MessageRejected");
+    assert!(body["message"]
+        .as_str()
+        .unwrap_or("")
+        .contains("unverified@elsewhere.com"));
+}
+
+#[tokio::test]
+async fn send_email_v2_skips_recipient_check_in_production() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["unverified@elsewhere.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn send_email_v2_accepts_verified_domain_when_from_uses_subdomain_or_address() {
+    let state = make_state();
+    seed_identity(&state, "example.com");
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "bot@example.com",
+            "Destination": {"ToAddresses": ["other@example.com"]},
             "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
         }"#,
     );

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -195,6 +195,11 @@ pub struct AccountSettings {
     pub suppressed_reasons: Vec<String>,
     pub vdm_attributes: Option<serde_json::Value>,
     pub details: Option<AccountDetails>,
+    /// Sandbox vs production. New SES accounts default to sandbox
+    /// (`false`), which gates SendEmail on having every recipient also
+    /// verified. Flipped via PutAccountDetails or the admin endpoint.
+    #[serde(default)]
+    pub production_access_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -458,6 +463,7 @@ impl SesState {
                 suppressed_reasons: Vec::new(),
                 vdm_attributes: None,
                 details: None,
+                production_access_enabled: false,
             },
             import_jobs: BTreeMap::new(),
             export_jobs: BTreeMap::new(),

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -98,28 +98,53 @@ pub(crate) fn required_param<'a>(
     })
 }
 
+/// Strip display-name wrappers like `Foo <foo@example.com>`.
+fn extract_email_address(from: &str) -> &str {
+    if let Some(start) = from.rfind('<') {
+        if let Some(end) = from.rfind('>') {
+            if end > start {
+                return from[start + 1..end].trim();
+            }
+        }
+    }
+    from.trim()
+}
+
+/// Match an email against verified identities (exact email or verified
+/// domain match).
+fn identity_is_verified(st: &SesState, email: &str) -> bool {
+    if st
+        .identities
+        .get(email)
+        .map(|id| id.verified)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if let Some((_, domain)) = email.split_once('@') {
+        if !domain.is_empty()
+            && st
+                .identities
+                .get(domain)
+                .map(|id| id.verified)
+                .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Gate every SES v1 send path on a verified sender. Mirrors the v2
-/// `reject_unverified_sender` rule: the From address must match a
-/// verified email identity exactly, or its domain must match a verified
-/// domain identity. Real SES surfaces this as `MessageRejected`.
+/// rule: the From address must match a verified email identity exactly,
+/// or its domain must match a verified domain identity. Real SES v1
+/// surfaces this as `MessageRejected`.
 pub(crate) fn check_v1_verified_sender(
     state: &SharedSesState,
     account_id: &str,
     from: &str,
 ) -> Result<(), AwsServiceError> {
-    let email = if let Some(start) = from.rfind('<') {
-        if let Some(end) = from.rfind('>') {
-            if end > start {
-                from[start + 1..end].trim()
-            } else {
-                from.trim()
-            }
-        } else {
-            from.trim()
-        }
-    } else {
-        from.trim()
-    };
+    let email = extract_email_address(from);
     if email.is_empty() {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
@@ -127,25 +152,11 @@ pub(crate) fn check_v1_verified_sender(
             "Email address is not verified.".to_string(),
         ));
     }
-    let domain = email.split_once('@').map(|(_, d)| d).unwrap_or("");
 
     let accounts = state.read();
     let verified = accounts
         .get(account_id)
-        .map(|st| {
-            let email_ok = st
-                .identities
-                .get(email)
-                .map(|id| id.verified)
-                .unwrap_or(false);
-            let domain_ok = !domain.is_empty()
-                && st
-                    .identities
-                    .get(domain)
-                    .map(|id| id.verified)
-                    .unwrap_or(false);
-            email_ok || domain_ok
-        })
+        .map(|st| identity_is_verified(st, email))
         .unwrap_or(false);
 
     if verified {
@@ -155,6 +166,45 @@ pub(crate) fn check_v1_verified_sender(
             StatusCode::BAD_REQUEST,
             "MessageRejected",
             format!("Email address is not verified. The following identities failed the check in region us-east-1: {email}"),
+        ))
+    }
+}
+
+/// In sandbox accounts, every recipient must also be a verified
+/// identity. Real SES v1 surfaces failures as `MessageRejected` listing
+/// the offending addresses.
+pub(crate) fn check_v1_verified_recipients(
+    state: &SharedSesState,
+    account_id: &str,
+    recipients: &[String],
+) -> Result<(), AwsServiceError> {
+    let accounts = state.read();
+    let Some(st) = accounts.get(account_id) else {
+        return Ok(());
+    };
+    if st.account_settings.production_access_enabled {
+        return Ok(());
+    }
+    let mut failing: Vec<String> = Vec::new();
+    for raw in recipients {
+        let addr = extract_email_address(raw);
+        if addr.is_empty() {
+            continue;
+        }
+        if !identity_is_verified(st, addr) {
+            failing.push(addr.to_string());
+        }
+    }
+    if failing.is_empty() {
+        Ok(())
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MessageRejected",
+            format!(
+                "Email address is not verified. The following identities failed the check: {}",
+                failing.join(", ")
+            ),
         ))
     }
 }
@@ -1024,6 +1074,13 @@ pub(crate) fn send_email(
     let to = parse_member_list(&req.query_params, "Destination.ToAddresses");
     let cc = parse_member_list(&req.query_params, "Destination.CcAddresses");
     let bcc = parse_member_list(&req.query_params, "Destination.BccAddresses");
+    let recipients: Vec<String> = to
+        .iter()
+        .chain(cc.iter())
+        .chain(bcc.iter())
+        .cloned()
+        .collect();
+    check_v1_verified_recipients(state, &req.account_id, &recipients)?;
 
     let subject = req.query_params.get("Message.Subject.Data").cloned();
     let html_body = req.query_params.get("Message.Body.Html.Data").cloned();
@@ -1097,6 +1154,7 @@ pub(crate) fn send_raw_email(
         check_v1_verified_sender(state, &req.account_id, &from)?;
     }
     let to = parse_member_list(&req.query_params, "Destinations");
+    check_v1_verified_recipients(state, &req.account_id, &to)?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1161,6 +1219,14 @@ pub(crate) fn send_templated_email(
             ));
         }
     }
+
+    let recipients: Vec<String> = to
+        .iter()
+        .chain(cc.iter())
+        .chain(bcc.iter())
+        .cloned()
+        .collect();
+    check_v1_verified_recipients(state, &req.account_id, &recipients)?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1234,6 +1300,34 @@ pub(crate) fn send_bulk_templated_email(
             .contains_key(&format!("{dest_prefix}.Destination.ToAddresses.member.1"))
         {
             break;
+        }
+        let to = parse_member_list(
+            &req.query_params,
+            &format!("{dest_prefix}.Destination.ToAddresses"),
+        );
+        let cc = parse_member_list(
+            &req.query_params,
+            &format!("{dest_prefix}.Destination.CcAddresses"),
+        );
+        let bcc = parse_member_list(
+            &req.query_params,
+            &format!("{dest_prefix}.Destination.BccAddresses"),
+        );
+        let recipients: Vec<String> = to
+            .iter()
+            .chain(cc.iter())
+            .chain(bcc.iter())
+            .cloned()
+            .collect();
+        if let Err(err) = check_v1_verified_recipients(state, &req.account_id, &recipients) {
+            // Real SES surfaces unverified recipients per-destination
+            // rather than aborting the whole batch. (From-domain gate is
+            // enforced up-front by `check_v1_verified_sender`.)
+            inner.push_str(&format!(
+                "<member><Status>MessageRejected</Status><Error>{}</Error></member>",
+                xml_escape(&err.message()),
+            ));
+            continue;
         }
         let message_id = send_bulk_destination(
             state,

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -46,6 +46,14 @@ fn seed_identity(state: &SharedSesState, name: &str) {
     );
 }
 
+/// Flip the account out of sandbox so tests focused on send mechanics
+/// don't trip the recipient-verification gate.
+fn enable_production_access(state: &SharedSesState) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    st.account_settings.production_access_enabled = true;
+}
+
 fn make_v1_request(action: &str, params: Vec<(&str, &str)>) -> AwsRequest {
     let mut query_params: HashMap<String, String> = HashMap::new();
     query_params.insert("Action".to_string(), action.to_string());
@@ -1035,6 +1043,7 @@ fn test_get_identity_mail_from_domain_attributes() {
 fn test_send_email_v1() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let req = make_v1_request(
         "SendEmail",
         vec![
@@ -1065,9 +1074,77 @@ fn test_send_email_v1() {
 }
 
 #[test]
+fn send_email_v1_same_path() {
+    // Mirror of `send_email_v2_rejects_unverified_from_in_sandbox` for
+    // SES v1: fresh account, no identities verified, expect the v1
+    // `MessageRejected` error code.
+    let state = make_state();
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "noreply@example.com"),
+            ("Destination.ToAddresses.member.1", "to@example.com"),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => assert_eq!(e.code(), "MessageRejected"),
+        Ok(_) => panic!("expected MessageRejected"),
+    }
+}
+
+#[test]
+fn send_email_v1_rejects_unverified_recipient_in_sandbox() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "sender@example.com"),
+            (
+                "Destination.ToAddresses.member.1",
+                "unverified@elsewhere.com",
+            ),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => {
+            assert_eq!(e.code(), "MessageRejected");
+            assert!(e.message().contains("unverified@elsewhere.com"));
+        }
+        Ok(_) => panic!("expected MessageRejected"),
+    }
+}
+
+#[test]
+fn send_email_v1_skips_recipient_check_in_production() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "sender@example.com"),
+            (
+                "Destination.ToAddresses.member.1",
+                "unverified@elsewhere.com",
+            ),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    let resp = handle_v1_action(&state, &req).unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[test]
 fn test_send_raw_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     let req = make_v1_request(
         "SendRawEmail",
         vec![
@@ -1094,6 +1171,7 @@ fn test_send_raw_email() {
 fn test_send_templated_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     // Create template first
     handle_v1_action(
         &state,
@@ -1154,6 +1232,7 @@ fn test_send_templated_email_missing_template() {
 fn test_send_bulk_templated_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
     handle_v1_action(
         &state,
         &make_v1_request(
@@ -1433,6 +1512,7 @@ fn test_get_send_quota() {
 fn test_get_send_statistics() {
     let state = make_state();
     seed_identity(&state, "a@b.com");
+    enable_production_access(&state);
     // Send an email first
     handle_v1_action(
         &state,


### PR DESCRIPTION
## Summary

- v1 + v2 SendEmail / SendRawEmail / SendTemplatedEmail / SendBulkEmail / SendBulkTemplatedEmail now reject sends whose From address has no matching verified email-or-domain identity. v2 surfaces this as `MailFromDomainNotVerifiedException` (HTTP 400); v1 keeps `MessageRejected` to match real SES.
- Sandbox accounts (the default) additionally gate on every To/CC/BCC being a verified identity. v2 hard-rejects with `MessageRejected`; v1 single-send hard-rejects, and v1 SendBulkTemplatedEmail / v2 SendBulkEmail now emit per-destination `MessageRejected` / `MESSAGE_REJECTED` status entries instead of aborting the batch.
- Adds `account_settings.production_access_enabled: bool` (default `false`) as the source of truth for the sandbox check; PutAccountDetails / GetAccount now read from it. Existing `AccountDetails.production_access_enabled` is mirrored onto the new field for backward compatibility.
- Updates existing SES lib tests (v1 + v2), e2e tests, and conformance tests so send paths verify recipients (or flip to production access) — keeps the new gate observable without papering over it.

## Test plan

- [x] `cargo build -p fakecloud-ses`
- [x] `cargo test -p fakecloud-ses --lib` (215 passed)
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace --tests`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces verified-identity checks on SES send paths. From must be a verified email or domain, and sandbox accounts also require all recipients to be verified.

- **New Features**
  - v2 rejects unverified From with `MailFromDomainNotVerifiedException` (HTTP 400); v1 returns `MessageRejected`.
  - Sandbox: all To/CC/BCC must be verified. Single sends hard-reject with `MessageRejected`; bulk sends report per-destination `MessageRejected`/`MESSAGE_REJECTED` without aborting the batch.
  - Added `production_access_enabled` to account settings (default false) and mirrored via PutAccountDetails/GetAccount. This flag controls the sandbox recipient gate.

- **Migration**
  - In sandbox, verify the sender and each recipient (email or domain) before sending.
  - To disable the recipient gate, enable production access via PutAccountDetails or the admin endpoint.
  - Tests were updated to create recipient identities; update downstream tests similarly if they send in sandbox.

<sup>Written for commit 5f3b5a7b585a2041d30384d8161db36331e7f195. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

