### PR TITLE
feat(logs): metric filters extract metrics on PutLogEvents (Z1)

### DIFF
--- a/crates/fakecloud-cloudwatch/src/delivery.rs
+++ b/crates/fakecloud-cloudwatch/src/delivery.rs
@@ -1,0 +1,88 @@
+//! Cross-service CloudWatch metrics adapter.
+//!
+//! Lets non-cloudwatch services (currently CloudWatch Logs metric
+//! filters) publish metric data points without depending on this crate
+//! directly.
+
+use std::collections::BTreeMap;
+
+use chrono::{TimeZone, Utc};
+
+use fakecloud_core::delivery::CloudwatchDelivery;
+
+use crate::state::{MetricDatum, SharedCloudWatchState};
+
+pub struct CloudwatchDeliveryImpl {
+    state: SharedCloudWatchState,
+}
+
+impl CloudwatchDeliveryImpl {
+    pub fn new(state: SharedCloudWatchState) -> Self {
+        Self { state }
+    }
+}
+
+impl CloudwatchDelivery for CloudwatchDeliveryImpl {
+    fn put_metric(
+        &self,
+        account_id: &str,
+        region: &str,
+        namespace: &str,
+        metric_name: &str,
+        value: f64,
+        unit: Option<&str>,
+        dimensions: BTreeMap<String, String>,
+        timestamp_ms: i64,
+    ) {
+        let timestamp = Utc
+            .timestamp_millis_opt(timestamp_ms)
+            .single()
+            .unwrap_or_else(Utc::now);
+        let mut state = self.state.write();
+        let acct = state.get_or_create(account_id);
+        let metrics_map = acct.metrics_in_mut(region);
+        let bucket = metrics_map.entry(namespace.to_string()).or_default();
+        bucket.push(MetricDatum {
+            metric_name: metric_name.to_string(),
+            dimensions,
+            timestamp,
+            value: Some(value),
+            statistic_values: None,
+            unit: unit.map(|s| s.to_string()),
+            storage_resolution: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::CloudWatchAccounts;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    #[test]
+    fn put_metric_appends_datum_to_namespace() {
+        let state: SharedCloudWatchState = Arc::new(RwLock::new(CloudWatchAccounts::new()));
+        let delivery = CloudwatchDeliveryImpl::new(state.clone());
+
+        delivery.put_metric(
+            "123456789012",
+            "us-east-1",
+            "MyApp",
+            "ErrorCount",
+            1.0,
+            None,
+            BTreeMap::new(),
+            1_700_000_000_000,
+        );
+
+        let guard = state.read();
+        let acct = guard.get("123456789012").unwrap();
+        let metrics = acct.metrics_in("us-east-1").unwrap();
+        let bucket = metrics.get("MyApp").unwrap();
+        assert_eq!(bucket.len(), 1);
+        assert_eq!(bucket[0].metric_name, "ErrorCount");
+        assert_eq!(bucket[0].value, Some(1.0));
+    }
+}

--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod delivery;
 pub mod service;
 pub mod state;
 
+pub use delivery::CloudwatchDeliveryImpl;
 pub use service::CloudWatchService;
 pub use state::{
     AlarmState, CloudWatchAccounts, CloudWatchState, Dashboard, MetricAlarm, MetricDatum,

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -27,6 +27,9 @@ pub struct DeliveryBus {
     ses_dispatcher: Option<Arc<dyn SesSendEmailDispatcher>>,
     /// Run an ECS task on a cluster (cross-service universal target).
     ecs_task_runner: Option<Arc<dyn EcsTaskRunner>>,
+    /// Publish CloudWatch metric data points (CloudWatch Logs metric
+    /// filters extract these on PutLogEvents).
+    cloudwatch_metrics: Option<Arc<dyn CloudwatchDelivery>>,
 }
 
 /// Message attribute for SQS delivery from SNS.
@@ -245,6 +248,24 @@ pub trait EcsTaskRunner: Send + Sync {
     ) -> Result<(), String>;
 }
 
+/// Publish CloudWatch metric data points from outside the cloudwatch
+/// crate. Used by CloudWatch Logs metric filters when an incoming log
+/// event matches their pattern.
+pub trait CloudwatchDelivery: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
+    fn put_metric(
+        &self,
+        account_id: &str,
+        region: &str,
+        namespace: &str,
+        metric_name: &str,
+        value: f64,
+        unit: Option<&str>,
+        dimensions: std::collections::BTreeMap<String, String>,
+        timestamp_ms: i64,
+    );
+}
+
 /// Outbound email dispatch used by services that emulate AWS flows that
 /// route through SES (Cognito verification, etc.) without taking a direct
 /// dependency on the SES crate.
@@ -308,6 +329,41 @@ impl DeliveryBus {
             firehose_sender: None,
             ses_dispatcher: None,
             ecs_task_runner: None,
+            cloudwatch_metrics: None,
+        }
+    }
+
+    pub fn with_cloudwatch_metrics(mut self, sender: Arc<dyn CloudwatchDelivery>) -> Self {
+        self.cloudwatch_metrics = Some(sender);
+        self
+    }
+
+    /// Publish a CloudWatch metric data point. Silently no-ops when no
+    /// CloudWatch sender is wired (in-process tests not exercising the
+    /// metrics path).
+    #[allow(clippy::too_many_arguments)]
+    pub fn put_cloudwatch_metric(
+        &self,
+        account_id: &str,
+        region: &str,
+        namespace: &str,
+        metric_name: &str,
+        value: f64,
+        unit: Option<&str>,
+        dimensions: std::collections::BTreeMap<String, String>,
+        timestamp_ms: i64,
+    ) {
+        if let Some(ref sender) = self.cloudwatch_metrics {
+            sender.put_metric(
+                account_id,
+                region,
+                namespace,
+                metric_name,
+                value,
+                unit,
+                dimensions,
+                timestamp_ms,
+            );
         }
     }
 

--- a/crates/fakecloud-logs/src/filter_pattern.rs
+++ b/crates/fakecloud-logs/src/filter_pattern.rs
@@ -1,0 +1,397 @@
+//! CloudWatch Logs filter pattern evaluator used by metric filters.
+//!
+//! Supports the documented variants:
+//! - Empty pattern matches everything.
+//! - Quoted phrase: substring match of the literal text inside the quotes.
+//! - Plain string (single token): substring match.
+//! - Space-separated terms: AND match (all terms must appear in the message).
+//! - JSON pattern `{ <expr> }`: parses the message as JSON, evaluates a
+//!   boolean expression with `=`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`.
+//!
+//! Independent from the simpler `matches_filter_pattern` helper in
+//! `service/mod.rs`; metric filters need `||` plus JSON-path value
+//! extraction for `MetricValue = $.field`, which the older helper
+//! doesn't expose.
+//!
+//! Array-style patterns (`[a, b, c]`) and `IS NULL` are out of scope and
+//! fail closed.
+
+use serde_json::Value;
+
+/// Returns true when `message` matches the given filter pattern.
+pub fn matches(pattern: &str, message: &str) -> bool {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return true;
+    }
+
+    if pattern.starts_with('{') && pattern.ends_with('}') {
+        return matches_json(pattern, message);
+    }
+
+    // Array-style filters not implemented; fail closed so a bad pattern
+    // doesn't silently extract metrics.
+    if pattern.starts_with('[') {
+        return false;
+    }
+
+    if pattern.starts_with('"') && pattern.ends_with('"') && pattern.len() >= 2 {
+        let inner = &pattern[1..pattern.len() - 1];
+        let unescaped = inner.replace("\\\"", "\"");
+        return message.contains(&unescaped);
+    }
+
+    let terms = tokenize(pattern);
+    if terms.is_empty() {
+        return true;
+    }
+    terms.iter().all(|t| message.contains(t.as_str()))
+}
+
+/// Resolve the literal `MetricValue` from a metric filter transformation.
+///
+/// `metric_value` is either:
+/// - a number literal (e.g. `"1"`, `"42.5"`),
+/// - a JSON path reference (e.g. `"$.bytes"`) extracted from the matched
+///   message,
+/// - empty/missing, falling back to `default_value` or `1.0`.
+pub fn resolve_metric_value(metric_value: &str, default_value: Option<f64>, message: &str) -> f64 {
+    let trimmed = metric_value.trim();
+    if trimmed.is_empty() {
+        return default_value.unwrap_or(1.0);
+    }
+
+    if let Some(path) = trimmed.strip_prefix("$.") {
+        if let Ok(json) = serde_json::from_str::<Value>(message) {
+            if let Some(v) = resolve_path(&json, path) {
+                if let Some(n) = v.as_f64() {
+                    return n;
+                }
+                if let Some(s) = v.as_str() {
+                    if let Ok(n) = s.parse::<f64>() {
+                        return n;
+                    }
+                }
+            }
+        }
+        return default_value.unwrap_or(1.0);
+    }
+
+    trimmed
+        .parse::<f64>()
+        .unwrap_or_else(|_| default_value.unwrap_or(1.0))
+}
+
+fn matches_json(pattern: &str, message: &str) -> bool {
+    let inner = pattern
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or("")
+        .trim();
+    if inner.is_empty() {
+        return true;
+    }
+
+    let json: Value = match serde_json::from_str(message) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    eval_or(inner, &json)
+}
+
+/// Top-level disjunction: `a || b || c` -> any of `a`, `b`, `c`.
+fn eval_or(expr: &str, json: &Value) -> bool {
+    split_top_level(expr, "||")
+        .into_iter()
+        .any(|chunk| eval_and(chunk.trim(), json))
+}
+
+/// Conjunction below `||`: `a && b` -> all of `a`, `b`.
+fn eval_and(expr: &str, json: &Value) -> bool {
+    split_top_level(expr, "&&")
+        .into_iter()
+        .all(|chunk| eval_atom(chunk.trim(), json))
+}
+
+/// Split `expr` on `sep`, ignoring occurrences inside quoted strings.
+fn split_top_level(expr: &str, sep: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let bytes = expr.as_bytes();
+    let sep_bytes = sep.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    let mut in_quotes = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == b'"' {
+            in_quotes = !in_quotes;
+            i += 1;
+            continue;
+        }
+        if !in_quotes && bytes[i..].starts_with(sep_bytes) {
+            parts.push(expr[start..i].to_string());
+            i += sep_bytes.len();
+            start = i;
+            continue;
+        }
+        i += 1;
+    }
+    parts.push(expr[start..].to_string());
+    parts
+}
+
+fn eval_atom(condition: &str, json: &Value) -> bool {
+    let condition = condition.trim();
+    let condition = condition
+        .strip_prefix('(')
+        .and_then(|s| s.strip_suffix(')'))
+        .map(|s| s.trim())
+        .unwrap_or(condition);
+
+    let ops = ["!=", ">=", "<=", "=", ">", "<"];
+    let mut found: Option<(&str, usize)> = None;
+    let bytes = condition.as_bytes();
+    let mut in_quotes = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == b'"' {
+            in_quotes = !in_quotes;
+            i += 1;
+            continue;
+        }
+        if !in_quotes {
+            if let Some(op) = ops
+                .iter()
+                .find(|op| condition[i..].starts_with(*op))
+                .copied()
+            {
+                found = Some((op, i));
+                break;
+            }
+        }
+        i += 1;
+    }
+
+    let Some((op, pos)) = found else {
+        // No comparison: `{ $.field }` matches when field exists.
+        if let Some(path) = condition.strip_prefix("$.") {
+            return resolve_path(json, path).is_some();
+        }
+        return false;
+    };
+
+    let field = condition[..pos].trim();
+    let value = condition[pos + op.len()..].trim();
+
+    let path = match field.strip_prefix("$.") {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let actual = match resolve_path(json, path) {
+        Some(v) => v,
+        // Missing field: only `!=` semantically holds.
+        None => return op == "!=",
+    };
+
+    if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+        let s = &value[1..value.len() - 1];
+        let unescaped = s.replace("\\\"", "\"");
+        return match op {
+            "=" => actual.as_str() == Some(unescaped.as_str()),
+            "!=" => actual.as_str() != Some(unescaped.as_str()),
+            _ => false,
+        };
+    }
+
+    if let Ok(num) = value.parse::<f64>() {
+        let actual_num = actual.as_f64();
+        return match (op, actual_num) {
+            ("=", Some(n)) => (n - num).abs() < f64::EPSILON,
+            ("!=", Some(n)) => (n - num).abs() >= f64::EPSILON,
+            (">", Some(n)) => n > num,
+            ("<", Some(n)) => n < num,
+            (">=", Some(n)) => n >= num,
+            ("<=", Some(n)) => n <= num,
+            _ => false,
+        };
+    }
+
+    if value == "true" || value == "false" {
+        let expected = value == "true";
+        return match op {
+            "=" => actual.as_bool() == Some(expected),
+            "!=" => actual.as_bool() != Some(expected),
+            _ => false,
+        };
+    }
+
+    false
+}
+
+fn resolve_path<'a>(json: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = json;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    if current.is_null() {
+        None
+    } else {
+        Some(current)
+    }
+}
+
+fn tokenize(pattern: &str) -> Vec<String> {
+    let mut terms = Vec::new();
+    let mut chars = pattern.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if c == '"' {
+            chars.next();
+            let mut buf = String::new();
+            loop {
+                match chars.next() {
+                    Some('\\') => {
+                        if let Some(n) = chars.next() {
+                            buf.push(n);
+                        }
+                    }
+                    Some('"') => break,
+                    Some(ch) => buf.push(ch),
+                    None => break,
+                }
+            }
+            terms.push(buf);
+        } else {
+            let mut buf = String::new();
+            while let Some(&ch) = chars.peek() {
+                if ch.is_whitespace() {
+                    break;
+                }
+                buf.push(ch);
+                chars.next();
+            }
+            if !buf.is_empty() {
+                terms.push(buf);
+            }
+        }
+    }
+    terms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_string_pattern_matches_substring() {
+        assert!(matches("ERROR", "service ERROR: timeout"));
+        assert!(!matches("ERROR", "service INFO: ok"));
+    }
+
+    #[test]
+    fn quoted_phrase_pattern_matches_exact() {
+        assert!(matches(
+            "\"connection refused\"",
+            "tcp: connection refused on :8080"
+        ));
+        assert!(!matches(
+            "\"connection refused\"",
+            "tcp: connection was refused"
+        ));
+    }
+
+    #[test]
+    fn space_separated_terms_require_all_to_match() {
+        assert!(matches("ERROR DATABASE", "ERROR: DATABASE down"));
+        assert!(!matches("ERROR DATABASE", "ERROR: cache miss"));
+        assert!(!matches("ERROR DATABASE", "INFO: DATABASE healthy"));
+    }
+
+    #[test]
+    fn json_pattern_equals_predicate() {
+        assert!(matches("{ $.statusCode = 500 }", r#"{"statusCode": 500}"#));
+        assert!(!matches("{ $.statusCode = 500 }", r#"{"statusCode": 200}"#));
+    }
+
+    #[test]
+    fn json_pattern_inequality_predicate() {
+        assert!(matches("{ $.statusCode != 200 }", r#"{"statusCode": 500}"#));
+        assert!(!matches(
+            "{ $.statusCode != 200 }",
+            r#"{"statusCode": 200}"#
+        ));
+    }
+
+    #[test]
+    fn json_pattern_and_predicate() {
+        let p = "{ $.statusCode = 500 && $.method = \"GET\" }";
+        assert!(matches(p, r#"{"statusCode": 500, "method": "GET"}"#));
+        assert!(!matches(p, r#"{"statusCode": 500, "method": "POST"}"#));
+        assert!(!matches(p, r#"{"statusCode": 200, "method": "GET"}"#));
+    }
+
+    #[test]
+    fn json_pattern_or_predicate() {
+        let p = "{ $.statusCode = 500 || $.statusCode = 503 }";
+        assert!(matches(p, r#"{"statusCode": 500}"#));
+        assert!(matches(p, r#"{"statusCode": 503}"#));
+        assert!(!matches(p, r#"{"statusCode": 200}"#));
+    }
+
+    #[test]
+    fn json_pattern_numeric_comparisons() {
+        assert!(matches("{ $.latency > 100 }", r#"{"latency": 250}"#));
+        assert!(!matches("{ $.latency > 100 }", r#"{"latency": 50}"#));
+        assert!(matches("{ $.latency <= 100 }", r#"{"latency": 100}"#));
+    }
+
+    #[test]
+    fn json_pattern_against_non_json_message_fails() {
+        assert!(!matches("{ $.statusCode = 500 }", "plain text, not JSON"));
+    }
+
+    #[test]
+    fn empty_pattern_matches_anything() {
+        assert!(matches("", "anything"));
+        assert!(matches("   ", "anything"));
+    }
+
+    #[test]
+    fn array_pattern_fails_closed() {
+        assert!(!matches("[a, b]", "a b"));
+    }
+
+    #[test]
+    fn resolve_metric_value_literal_number() {
+        assert_eq!(resolve_metric_value("1", None, "msg"), 1.0);
+        assert_eq!(resolve_metric_value("42.5", None, "msg"), 42.5);
+    }
+
+    #[test]
+    fn resolve_metric_value_json_path_extracts_field() {
+        let v = resolve_metric_value("$.bytes", None, r#"{"bytes": 1024}"#);
+        assert_eq!(v, 1024.0);
+    }
+
+    #[test]
+    fn resolve_metric_value_falls_back_when_missing() {
+        let v = resolve_metric_value("$.bytes", Some(7.0), r#"{"other": 1}"#);
+        assert_eq!(v, 7.0);
+        let v = resolve_metric_value("", None, "msg");
+        assert_eq!(v, 1.0);
+    }
+}

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod filter_pattern;
 pub mod ingest;
 pub mod query;
 pub(crate) mod service;

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -442,6 +442,18 @@ impl LogsService {
         let group_name_owned = group_name.to_string();
         let stream_name_owned = stream_name.to_string();
 
+        // Snapshot metric filters bound to this log group; eval happens
+        // after we drop the lock so PutMetricData can re-lock cloudwatch
+        // state without blocking other PutLogEvents calls.
+        let metric_filters_for_group: Vec<crate::state::MetricFilter> = state
+            .metric_filters
+            .iter()
+            .filter(|f| f.log_group_name == group_name_owned)
+            .cloned()
+            .collect();
+        let region_owned = state.region.clone();
+        let account_id_for_metrics = state.account_id.clone();
+
         // Collect delivery pipeline info: find active deliveries whose source
         // resource ARN matches this log group's ARN.
         let group_arn = group.arn.clone();
@@ -526,6 +538,18 @@ impl LogsService {
                     &accepted_events,
                 );
             }
+        }
+
+        // Metric filter eval: per filter, per matching event, publish a
+        // CloudWatch metric data point. Real CloudWatch does this on
+        // ingestion; downstream alarms read those points.
+        if !metric_filters_for_group.is_empty() && !accepted_events.is_empty() {
+            self.publish_metric_filter_data(
+                &account_id_for_metrics,
+                &region_owned,
+                &metric_filters_for_group,
+                &accepted_events,
+            );
         }
 
         let mut response = json!({
@@ -634,6 +658,43 @@ impl LogsService {
             // can decode with the standard CloudWatch-Logs format.
             self.delivery_bus
                 .put_record_to_firehose(destination_arn, encoded.as_bytes());
+        }
+    }
+
+    /// Run each metric filter against the accepted events and publish
+    /// CloudWatch metric data points for matches. Mirrors real
+    /// CloudWatch Logs: one datum per matching event, value resolved
+    /// from the transformation's `MetricValue` (literal or `$.path`).
+    fn publish_metric_filter_data(
+        &self,
+        account_id: &str,
+        region: &str,
+        metric_filters: &[crate::state::MetricFilter],
+        accepted_events: &[LogEvent],
+    ) {
+        for filter in metric_filters {
+            for event in accepted_events {
+                if !crate::filter_pattern::matches(&filter.filter_pattern, &event.message) {
+                    continue;
+                }
+                for tx in &filter.metric_transformations {
+                    let value = crate::filter_pattern::resolve_metric_value(
+                        &tx.metric_value,
+                        tx.default_value,
+                        &event.message,
+                    );
+                    self.delivery_bus.put_cloudwatch_metric(
+                        account_id,
+                        region,
+                        &tx.metric_namespace,
+                        &tx.metric_name,
+                        value,
+                        None,
+                        std::collections::BTreeMap::new(),
+                        event.timestamp,
+                    );
+                }
+            }
         }
     }
 
@@ -2283,6 +2344,142 @@ mod tests {
         let resp = svc.describe_destinations(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["destinations"].is_array());
+    }
+
+    // ---- Metric filter publishes data to CloudWatch ----
+
+    #[derive(Default)]
+    struct MetricRecorder {
+        calls: parking_lot::Mutex<Vec<(String, String, f64, i64)>>,
+    }
+
+    impl fakecloud_core::delivery::CloudwatchDelivery for MetricRecorder {
+        fn put_metric(
+            &self,
+            _account_id: &str,
+            _region: &str,
+            namespace: &str,
+            metric_name: &str,
+            value: f64,
+            _unit: Option<&str>,
+            _dimensions: std::collections::BTreeMap<String, String>,
+            timestamp_ms: i64,
+        ) {
+            self.calls.lock().push((
+                namespace.to_string(),
+                metric_name.to_string(),
+                value,
+                timestamp_ms,
+            ));
+        }
+    }
+
+    fn make_service_with_metrics(recorder: std::sync::Arc<MetricRecorder>) -> LogsService {
+        use fakecloud_core::delivery::DeliveryBus;
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        let bus = DeliveryBus::new().with_cloudwatch_metrics(recorder);
+        LogsService::new(state, std::sync::Arc::new(bus))
+    }
+
+    fn put_metric_filter(
+        svc: &LogsService,
+        group: &str,
+        name: &str,
+        pattern: &str,
+        namespace: &str,
+        metric: &str,
+        value: &str,
+    ) {
+        let req = make_request(
+            "PutMetricFilter",
+            json!({
+                "filterName": name,
+                "filterPattern": pattern,
+                "logGroupName": group,
+                "metricTransformations": [
+                    {
+                        "metricName": metric,
+                        "metricNamespace": namespace,
+                        "metricValue": value,
+                    }
+                ],
+            }),
+        );
+        svc.put_metric_filter(&req).unwrap();
+    }
+
+    #[test]
+    fn put_log_events_publishes_metric_for_matching_filter() {
+        let recorder = std::sync::Arc::new(MetricRecorder::default());
+        let svc = make_service_with_metrics(recorder.clone());
+        create_group(&svc, "mf-publish");
+        create_stream(&svc, "mf-publish", "s1");
+        put_metric_filter(
+            &svc,
+            "mf-publish",
+            "errors-filter",
+            "ERROR",
+            "MyApp",
+            "ErrorCount",
+            "1",
+        );
+
+        put_events(&svc, "mf-publish", "s1", &["ERROR: timeout"]);
+
+        let calls = recorder.calls.lock();
+        assert_eq!(calls.len(), 1, "expected one metric data point");
+        assert_eq!(calls[0].0, "MyApp");
+        assert_eq!(calls[0].1, "ErrorCount");
+        assert_eq!(calls[0].2, 1.0);
+    }
+
+    #[test]
+    fn put_log_events_skips_metric_when_pattern_does_not_match() {
+        let recorder = std::sync::Arc::new(MetricRecorder::default());
+        let svc = make_service_with_metrics(recorder.clone());
+        create_group(&svc, "mf-skip");
+        create_stream(&svc, "mf-skip", "s1");
+        put_metric_filter(
+            &svc,
+            "mf-skip",
+            "errors-filter",
+            "ERROR",
+            "MyApp",
+            "ErrorCount",
+            "1",
+        );
+
+        put_events(&svc, "mf-skip", "s1", &["INFO: ok"]);
+
+        assert!(
+            recorder.calls.lock().is_empty(),
+            "non-matching event must not publish a metric"
+        );
+    }
+
+    #[test]
+    fn put_log_events_extracts_metric_value_from_json_path() {
+        let recorder = std::sync::Arc::new(MetricRecorder::default());
+        let svc = make_service_with_metrics(recorder.clone());
+        create_group(&svc, "mf-json");
+        create_stream(&svc, "mf-json", "s1");
+        put_metric_filter(
+            &svc,
+            "mf-json",
+            "bytes-filter",
+            "{ $.bytes > 0 }",
+            "MyApp",
+            "BytesProcessed",
+            "$.bytes",
+        );
+
+        put_events(&svc, "mf-json", "s1", &[r#"{"bytes": 2048}"#]);
+
+        let calls = recorder.calls.lock();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].2, 2048.0);
     }
 
     #[test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -493,7 +493,14 @@ async fn main() {
         Arc::new(bus)
     };
 
-    // Step 4: Logs delivery (subscription filters can push to SQS, Lambda, and Kinesis)
+    // CloudWatch state must be constructed before logs delivery so
+    // CloudWatch Logs metric filters can publish data points into it.
+    let cloudwatch_state: fakecloud_cloudwatch::SharedCloudWatchState = Arc::new(
+        parking_lot::RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new()),
+    );
+
+    // Step 4: Logs delivery (subscription filters can push to SQS, Lambda, and Kinesis;
+    // metric filters publish CloudWatch metric data points)
     let sqs_delivery_for_ses = sqs_delivery.clone();
     let kinesis_delivery =
         fakecloud_kinesis::delivery::KinesisDeliveryImpl::new(kinesis_state.clone());
@@ -515,11 +522,15 @@ async fn main() {
             firehose_state.clone(),
             s3_state.clone(),
         ));
+    let cloudwatch_delivery_for_logs = Arc::new(fakecloud_cloudwatch::CloudwatchDeliveryImpl::new(
+        cloudwatch_state.clone(),
+    ));
     let mut delivery_for_logs = DeliveryBus::new()
         .with_sqs(sqs_delivery.clone())
         .with_kinesis(kinesis_delivery)
         .with_s3(s3_delivery_for_logs)
-        .with_firehose(firehose_delivery_for_logs);
+        .with_firehose(firehose_delivery_for_logs)
+        .with_cloudwatch_metrics(cloudwatch_delivery_for_logs);
     if let Some(ref ld) = lambda_delivery {
         delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
     }
@@ -604,10 +615,6 @@ async fn main() {
 
     let glue_state: fakecloud_glue::SharedGlueState =
         Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new()));
-
-    let cloudwatch_state: fakecloud_cloudwatch::SharedCloudWatchState = Arc::new(
-        parking_lot::RwLock::new(fakecloud_cloudwatch::CloudWatchAccounts::new()),
-    );
 
     let elbv2_state: fakecloud_elbv2::SharedElbv2State = Arc::new(parking_lot::RwLock::new(
         fakecloud_elbv2::Elbv2Accounts::new(),


### PR DESCRIPTION
## Summary
- CloudWatch Logs metric filters now publish CloudWatch metric data points on PutLogEvents instead of being inert config (`crates/fakecloud-logs/src/service/streams.rs`).
- Added `CloudwatchDelivery` trait + `DeliveryBus::put_cloudwatch_metric` so the logs crate stays decoupled from cloudwatch state, with `CloudwatchDeliveryImpl` wired in `fakecloud-server/src/main.rs`.
- New `filter_pattern` module evaluates plain/quoted/space-separated patterns plus JSON predicates with `=`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, and resolves `MetricValue` literals or `\$.path` extracts.
- Tests: 6 filter_pattern unit tests (all variants required by the task) plus 3 streams integration tests (publishes on match, skips on miss, extracts JSON-path metric value) using a recorder `CloudwatchDelivery` impl.

## Test plan
- [x] `cargo build -p fakecloud-logs -p fakecloud-cloudwatch -p fakecloud-core` clean
- [x] `cargo test -p fakecloud-logs --lib` (277 tests passing)
- [x] `cargo test --workspace --lib` (no regressions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudWatch Logs metric filters now publish CloudWatch metrics on `PutLogEvents`, meeting Z1 by extracting metric values (including from JSON) and sending them via a decoupled delivery path. This improves parity with AWS by recording a datum per matching event.

- **New Features**
  - Emit metric data points for matching events during `PutLogEvents` using `DeliveryBus::put_cloudwatch_metric`.
  - Added `fakecloud-logs::filter_pattern` supporting empty/plain/quoted/space-separated patterns and JSON predicates with `=`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`; resolves `MetricValue` literals or `$.path` with default fallback.
  - Introduced `fakecloud-core::CloudwatchDelivery` and `fakecloud-cloudwatch::CloudwatchDeliveryImpl`; wired into `fakecloud-server` to keep `fakecloud-logs` decoupled from CloudWatch state.

<sup>Written for commit aca5316503b54bf8d219659d13b1eae8cbc0c301. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

