### PR TITLE
feat(elasticache): CreateCacheCluster accepts all fields (N2)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -7754,11 +7754,106 @@ impl ResourceProvisioner {
             .get("AutoMinorVersionUpgrade")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+        let default_port = if engine == "memcached" { 11211 } else { 6379 };
         let port = props
             .get("Port")
             .and_then(|v| v.as_i64())
             .map(|n| n as u16)
-            .unwrap_or(6379);
+            .unwrap_or(default_port);
+        let cache_parameter_group_name = props
+            .get("CacheParameterGroupName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let security_group_ids: Vec<String> = props
+            .get("VpcSecurityGroupIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let cache_security_group_names: Vec<String> = props
+            .get("CacheSecurityGroupNames")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let preferred_availability_zones: Vec<String> = props
+            .get("PreferredAvailabilityZones")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let snapshot_arns: Vec<String> = props
+            .get("SnapshotArns")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let snapshot_name = props
+            .get("SnapshotName")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let snapshot_retention_limit = props
+            .get("SnapshotRetentionLimit")
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32)
+            .unwrap_or(0);
+        let snapshot_window = props
+            .get("SnapshotWindow")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let preferred_maintenance_window = props
+            .get("PreferredMaintenanceWindow")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let notification_topic_arn = props
+            .get("NotificationTopicArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let transit_encryption_enabled = props
+            .get("TransitEncryptionEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let auth_token = props
+            .get("AuthToken")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        let auth_token_enabled = auth_token.is_some();
+        let network_type = props
+            .get("NetworkType")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| Some("ipv4".to_string()));
+        let ip_discovery = props
+            .get("IpDiscovery")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| Some("ipv4".to_string()));
+        let az_mode = props
+            .get("AZMode")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| Some("single-az".to_string()));
+        let outpost_mode = props
+            .get("OutpostMode")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let preferred_outpost_arn = props
+            .get("PreferredOutpostArn")
+            .and_then(|v| v.as_str())
+            .map(String::from);
 
         let mut accounts = self.elasticache_state.write();
         let state = accounts.get_or_create(&self.account_id);
@@ -7784,12 +7879,27 @@ impl ResourceProvisioner {
             container_id: String::new(),
             host_port: 0,
             replication_group_id: None,
-            cache_parameter_group_name: None,
-            security_group_ids: Vec::new(),
+            cache_parameter_group_name,
+            security_group_ids,
             log_delivery_configurations: Vec::new(),
-            transit_encryption_enabled: false,
+            transit_encryption_enabled,
             at_rest_encryption_enabled: false,
-            auth_token_enabled: false,
+            auth_token_enabled,
+            port,
+            preferred_maintenance_window,
+            preferred_availability_zones,
+            notification_topic_arn,
+            cache_security_group_names,
+            snapshot_arns,
+            snapshot_name,
+            snapshot_retention_limit,
+            snapshot_window,
+            outpost_mode,
+            preferred_outpost_arn,
+            network_type,
+            ip_discovery,
+            az_mode,
+            auth_token,
         };
         state.cache_clusters.insert(id.clone(), cluster);
         Ok(ProvisionResult::new(id.clone())

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -682,6 +682,98 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
             String::new()
         };
 
+    let preferred_maintenance_window_xml = cluster
+        .preferred_maintenance_window
+        .as_ref()
+        .map(|w| {
+            format!(
+                "<PreferredMaintenanceWindow>{}</PreferredMaintenanceWindow>",
+                xml_escape(w)
+            )
+        })
+        .unwrap_or_default();
+    let preferred_outpost_arn_xml = cluster
+        .preferred_outpost_arn
+        .as_ref()
+        .map(|a| {
+            format!(
+                "<PreferredOutpostArn>{}</PreferredOutpostArn>",
+                xml_escape(a)
+            )
+        })
+        .unwrap_or_default();
+    let outpost_mode_xml = cluster
+        .outpost_mode
+        .as_ref()
+        .map(|m| format!("<OutpostMode>{}</OutpostMode>", xml_escape(m)))
+        .unwrap_or_default();
+    let network_type_xml = cluster
+        .network_type
+        .as_ref()
+        .map(|n| format!("<NetworkType>{}</NetworkType>", xml_escape(n)))
+        .unwrap_or_default();
+    let ip_discovery_xml = cluster
+        .ip_discovery
+        .as_ref()
+        .map(|n| format!("<IpDiscovery>{}</IpDiscovery>", xml_escape(n)))
+        .unwrap_or_default();
+    let notification_topic_xml = cluster
+        .notification_topic_arn
+        .as_ref()
+        .map(|t| {
+            format!(
+                "<NotificationConfiguration><TopicArn>{}</TopicArn><TopicStatus>active</TopicStatus></NotificationConfiguration>",
+                xml_escape(t)
+            )
+        })
+        .unwrap_or_default();
+    let snapshot_window_xml = cluster
+        .snapshot_window
+        .as_ref()
+        .map(|w| format!("<SnapshotWindow>{}</SnapshotWindow>", xml_escape(w)))
+        .unwrap_or_default();
+    let snapshot_retention_limit_xml = format!(
+        "<SnapshotRetentionLimit>{}</SnapshotRetentionLimit>",
+        cluster.snapshot_retention_limit
+    );
+    let preferred_azs_xml = if cluster.preferred_availability_zones.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "<PreferredAvailabilityZones>{}</PreferredAvailabilityZones>",
+            cluster
+                .preferred_availability_zones
+                .iter()
+                .map(|az| format!("<AvailabilityZone>{}</AvailabilityZone>", xml_escape(az)))
+                .collect::<String>()
+        )
+    };
+    // Defaults to single-az even if not set; emitted only when known so
+    // older snapshots without the field don't gain a fake value.
+    let az_mode_xml = cluster
+        .az_mode
+        .as_ref()
+        .map(|m| format!("<AZMode>{}</AZMode>", xml_escape(m)))
+        .unwrap_or_default();
+    let cache_security_groups_xml = if cluster.cache_security_group_names.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "<CacheSecurityGroups>{}</CacheSecurityGroups>",
+            cluster
+                .cache_security_group_names
+                .iter()
+                .map(|n| format!(
+                    "<CacheSecurityGroup>\
+                     <CacheSecurityGroupName>{}</CacheSecurityGroupName>\
+                     <Status>active</Status>\
+                     </CacheSecurityGroup>",
+                    xml_escape(n)
+                ))
+                .collect::<String>()
+        )
+    };
+
     format!(
         "<CacheClusterId>{}</CacheClusterId>\
          <CacheNodeType>{}</CacheNodeType>\
@@ -690,13 +782,25 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
          <CacheClusterStatus>{}</CacheClusterStatus>\
          <NumCacheNodes>{}</NumCacheNodes>\
          <PreferredAvailabilityZone>{}</PreferredAvailabilityZone>\
+         {preferred_azs_xml}\
+         {az_mode_xml}\
          <CacheClusterCreateTime>{}</CacheClusterCreateTime>\
+         {preferred_maintenance_window_xml}\
          {cache_subnet_group_name_xml}\
          {cache_nodes_xml}\
          {cache_parameter_group_xml}\
+         {cache_security_groups_xml}\
          {security_groups_xml}\
          {log_delivery_configurations_xml}\
          {configuration_endpoint_xml}\
+         <ClientDownloadLandingPage></ClientDownloadLandingPage>\
+         {notification_topic_xml}\
+         {snapshot_retention_limit_xml}\
+         {snapshot_window_xml}\
+         {outpost_mode_xml}\
+         {preferred_outpost_arn_xml}\
+         {network_type_xml}\
+         {ip_discovery_xml}\
          <TransitEncryptionEnabled>{}</TransitEncryptionEnabled>\
          <AtRestEncryptionEnabled>{}</AtRestEncryptionEnabled>\
          <AuthTokenEnabled>{}</AuthTokenEnabled>\
@@ -1421,6 +1525,21 @@ mod cluster_xml_tests {
             transit_encryption_enabled: false,
             at_rest_encryption_enabled: false,
             auth_token_enabled: false,
+            port: 6379,
+            preferred_maintenance_window: None,
+            preferred_availability_zones: Vec::new(),
+            notification_topic_arn: None,
+            cache_security_group_names: Vec::new(),
+            snapshot_arns: Vec::new(),
+            snapshot_name: None,
+            snapshot_retention_limit: 0,
+            snapshot_window: None,
+            outpost_mode: None,
+            preferred_outpost_arn: None,
+            network_type: None,
+            ip_discovery: None,
+            az_mode: None,
+            auth_token: None,
         }
     }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -840,6 +840,8 @@ impl ElastiCacheService {
         let cache_parameter_group_name = optional_query_param(request, "CacheParameterGroupName");
         let security_group_ids =
             parse_query_list_param(request, "SecurityGroupIds", "SecurityGroupId");
+        let cache_security_group_names =
+            parse_query_list_param(request, "CacheSecurityGroupNames", "CacheSecurityGroupName");
         let log_delivery_configurations = parse_log_delivery_configs(request);
         let transit_encryption_enabled = parse_optional_bool(
             optional_query_param(request, "TransitEncryptionEnabled").as_deref(),
@@ -849,7 +851,37 @@ impl ElastiCacheService {
             optional_query_param(request, "AtRestEncryptionEnabled").as_deref(),
         )?
         .unwrap_or(false);
-        let auth_token_enabled = optional_query_param(request, "AuthToken").is_some();
+        let auth_token = optional_query_param(request, "AuthToken");
+        let auth_token_enabled = auth_token.is_some();
+        // ElastiCache defaults: 6379 redis/valkey, 11211 memcached.
+        let default_port = if engine == ENGINE_MEMCACHED {
+            11211
+        } else {
+            6379
+        };
+        let port = optional_query_param(request, "Port")
+            .and_then(|v| v.parse::<u16>().ok())
+            .unwrap_or(default_port);
+        let preferred_maintenance_window =
+            optional_query_param(request, "PreferredMaintenanceWindow");
+        let preferred_availability_zones =
+            parse_query_list_param(request, "PreferredAvailabilityZones", "AvailabilityZone");
+        let notification_topic_arn = optional_query_param(request, "NotificationTopicArn");
+        let snapshot_arns = parse_query_list_param(request, "SnapshotArns", "SnapshotArn");
+        let snapshot_name = optional_query_param(request, "SnapshotName");
+        let snapshot_retention_limit = optional_query_param(request, "SnapshotRetentionLimit")
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(0);
+        let snapshot_window = optional_query_param(request, "SnapshotWindow");
+        let outpost_mode = optional_query_param(request, "OutpostMode");
+        let preferred_outpost_arn = optional_query_param(request, "PreferredOutpostArn");
+        // Default to ipv4 when unspecified, matching AWS's default network stack.
+        let network_type =
+            Some(optional_query_param(request, "NetworkType").unwrap_or_else(|| "ipv4".into()));
+        let ip_discovery =
+            Some(optional_query_param(request, "IpDiscovery").unwrap_or_else(|| "ipv4".into()));
+        let az_mode =
+            Some(optional_query_param(request, "AZMode").unwrap_or_else(|| "single-az".into()));
 
         let (preferred_availability_zone, arn) = {
             let mut accounts = self.state.write();
@@ -955,6 +987,21 @@ impl ElastiCacheService {
             transit_encryption_enabled,
             at_rest_encryption_enabled,
             auth_token_enabled,
+            port,
+            preferred_maintenance_window,
+            preferred_availability_zones,
+            notification_topic_arn,
+            cache_security_group_names,
+            snapshot_arns,
+            snapshot_name,
+            snapshot_retention_limit,
+            snapshot_window,
+            outpost_mode,
+            preferred_outpost_arn,
+            network_type,
+            ip_discovery,
+            az_mode,
+            auth_token,
         };
 
         let xml = cache_cluster_xml(&cluster, true);

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -153,6 +153,21 @@ fn cache_cluster_xml_contains_expected_fields() {
         transit_encryption_enabled: false,
         at_rest_encryption_enabled: false,
         auth_token_enabled: false,
+        port: 6379,
+        preferred_maintenance_window: None,
+        preferred_availability_zones: Vec::new(),
+        notification_topic_arn: None,
+        cache_security_group_names: Vec::new(),
+        snapshot_arns: Vec::new(),
+        snapshot_name: None,
+        snapshot_retention_limit: 0,
+        snapshot_window: None,
+        outpost_mode: None,
+        preferred_outpost_arn: None,
+        network_type: None,
+        ip_discovery: None,
+        az_mode: None,
+        auth_token: None,
     };
     let xml = cache_cluster_xml(&cluster, true);
     assert!(xml.contains("<CacheClusterId>classic-1</CacheClusterId>"));
@@ -693,6 +708,21 @@ fn service_with_cache_cluster(cluster_id: &str) -> ElastiCacheService {
                 transit_encryption_enabled: false,
                 at_rest_encryption_enabled: false,
                 auth_token_enabled: false,
+                port: 6379,
+                preferred_maintenance_window: None,
+                preferred_availability_zones: Vec::new(),
+                notification_topic_arn: None,
+                cache_security_group_names: Vec::new(),
+                snapshot_arns: Vec::new(),
+                snapshot_name: None,
+                snapshot_retention_limit: 0,
+                snapshot_window: None,
+                outpost_mode: None,
+                preferred_outpost_arn: None,
+                network_type: None,
+                ip_discovery: None,
+                az_mode: None,
+                auth_token: None,
             },
         );
     }
@@ -732,6 +762,21 @@ fn describe_cache_clusters_returns_all() {
                 transit_encryption_enabled: false,
                 at_rest_encryption_enabled: false,
                 auth_token_enabled: false,
+                port: 6380,
+                preferred_maintenance_window: None,
+                preferred_availability_zones: Vec::new(),
+                notification_topic_arn: None,
+                cache_security_group_names: Vec::new(),
+                snapshot_arns: Vec::new(),
+                snapshot_name: None,
+                snapshot_retention_limit: 0,
+                snapshot_window: None,
+                outpost_mode: None,
+                preferred_outpost_arn: None,
+                network_type: None,
+                ip_discovery: None,
+                az_mode: None,
+                auth_token: None,
             },
         );
     }
@@ -3257,6 +3302,21 @@ async fn reboot_cache_cluster_marks_rebooting_when_no_runtime() {
                 transit_encryption_enabled: false,
                 at_rest_encryption_enabled: false,
                 auth_token_enabled: false,
+                port: 6379,
+                preferred_maintenance_window: None,
+                preferred_availability_zones: Vec::new(),
+                notification_topic_arn: None,
+                cache_security_group_names: Vec::new(),
+                snapshot_arns: Vec::new(),
+                snapshot_name: None,
+                snapshot_retention_limit: 0,
+                snapshot_window: None,
+                outpost_mode: None,
+                preferred_outpost_arn: None,
+                network_type: None,
+                ip_discovery: None,
+                az_mode: None,
+                auth_token: None,
             },
         );
     }
@@ -3389,4 +3449,379 @@ fn migration_ops_unknown_replication_group_errors() {
         Ok(_) => panic!("expected error"),
     };
     assert_eq!(err.code(), "ReplicationGroupNotFoundFault");
+}
+
+// ── cache cluster create field round-trip (N2) ──
+//
+// Build a CacheCluster as if `CreateCacheCluster` had run, by re-running
+// the same parser the handler uses (sans runtime). The runtime path needs
+// docker, so unit tests skip it by inserting the fully-built struct directly.
+fn cache_cluster_from_request(req: &AwsRequest) -> crate::state::CacheCluster {
+    let cache_cluster_id = required_query_param(req, "CacheClusterId").unwrap();
+    let engine = optional_query_param(req, "Engine").unwrap_or_else(|| ENGINE_REDIS.to_string());
+    let default_version = match engine.as_str() {
+        "valkey" => "8.0",
+        "memcached" => "1.6.22",
+        _ => "7.1",
+    };
+    let engine_version =
+        optional_query_param(req, "EngineVersion").unwrap_or_else(|| default_version.to_string());
+    let cache_node_type =
+        optional_query_param(req, "CacheNodeType").unwrap_or_else(|| "cache.t3.micro".to_string());
+    let num_cache_nodes: i32 = optional_query_param(req, "NumCacheNodes")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let cache_subnet_group_name =
+        optional_query_param(req, "CacheSubnetGroupName").or_else(|| Some("default".to_string()));
+    let auto_minor_version_upgrade =
+        parse_optional_bool(optional_query_param(req, "AutoMinorVersionUpgrade").as_deref())
+            .unwrap()
+            .unwrap_or(true);
+    let cache_parameter_group_name = optional_query_param(req, "CacheParameterGroupName");
+    let security_group_ids = parse_query_list_param(req, "SecurityGroupIds", "SecurityGroupId");
+    let cache_security_group_names =
+        parse_query_list_param(req, "CacheSecurityGroupNames", "CacheSecurityGroupName");
+    let log_delivery_configurations = parse_log_delivery_configs(req);
+    let transit_encryption_enabled =
+        parse_optional_bool(optional_query_param(req, "TransitEncryptionEnabled").as_deref())
+            .unwrap()
+            .unwrap_or(false);
+    let at_rest_encryption_enabled =
+        parse_optional_bool(optional_query_param(req, "AtRestEncryptionEnabled").as_deref())
+            .unwrap()
+            .unwrap_or(false);
+    let auth_token = optional_query_param(req, "AuthToken");
+    let auth_token_enabled = auth_token.is_some();
+    let default_port = if engine == "memcached" { 11211 } else { 6379 };
+    let port: u16 = optional_query_param(req, "Port")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default_port);
+    let preferred_availability_zone = optional_query_param(req, "PreferredAvailabilityZone")
+        .unwrap_or_else(|| "us-east-1a".to_string());
+    let preferred_availability_zones =
+        parse_query_list_param(req, "PreferredAvailabilityZones", "AvailabilityZone");
+    let preferred_maintenance_window = optional_query_param(req, "PreferredMaintenanceWindow");
+    let notification_topic_arn = optional_query_param(req, "NotificationTopicArn");
+    let snapshot_arns = parse_query_list_param(req, "SnapshotArns", "SnapshotArn");
+    let snapshot_name = optional_query_param(req, "SnapshotName");
+    let snapshot_retention_limit = optional_query_param(req, "SnapshotRetentionLimit")
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let snapshot_window = optional_query_param(req, "SnapshotWindow");
+    let outpost_mode = optional_query_param(req, "OutpostMode");
+    let preferred_outpost_arn = optional_query_param(req, "PreferredOutpostArn");
+    let network_type =
+        Some(optional_query_param(req, "NetworkType").unwrap_or_else(|| "ipv4".into()));
+    let ip_discovery =
+        Some(optional_query_param(req, "IpDiscovery").unwrap_or_else(|| "ipv4".into()));
+    let az_mode = Some(optional_query_param(req, "AZMode").unwrap_or_else(|| "single-az".into()));
+    let arn = format!("arn:aws:elasticache:us-east-1:123456789012:cluster:{cache_cluster_id}");
+    crate::state::CacheCluster {
+        cache_cluster_id: cache_cluster_id.clone(),
+        cache_node_type,
+        engine,
+        engine_version,
+        cache_cluster_status: "available".to_string(),
+        num_cache_nodes,
+        preferred_availability_zone,
+        cache_subnet_group_name,
+        auto_minor_version_upgrade,
+        arn,
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        endpoint_address: "127.0.0.1".to_string(),
+        endpoint_port: port,
+        container_id: "test-container".to_string(),
+        host_port: port,
+        replication_group_id: None,
+        cache_parameter_group_name,
+        security_group_ids,
+        log_delivery_configurations,
+        transit_encryption_enabled,
+        at_rest_encryption_enabled,
+        auth_token_enabled,
+        port,
+        preferred_maintenance_window,
+        preferred_availability_zones,
+        notification_topic_arn,
+        cache_security_group_names,
+        snapshot_arns,
+        snapshot_name,
+        snapshot_retention_limit,
+        snapshot_window,
+        outpost_mode,
+        preferred_outpost_arn,
+        network_type,
+        ip_discovery,
+        az_mode,
+        auth_token,
+    }
+}
+
+fn service_with_cache_cluster_from_request(req: &AwsRequest) -> ElastiCacheService {
+    let cluster = cache_cluster_from_request(req);
+    let shared: SharedElastiCacheState = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    {
+        let mut __a = shared.write();
+        let s = __a.default_mut();
+        s.tags.insert(cluster.arn.clone(), Vec::new());
+        s.cache_clusters
+            .insert(cluster.cache_cluster_id.clone(), cluster);
+    }
+    ElastiCacheService::new(shared)
+}
+
+#[test]
+fn create_cache_cluster_persists_log_delivery_configurations() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "log-cc"),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.LogType",
+                "slow-log",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.DestinationType",
+                "cloudwatch-logs",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.DestinationDetails.CloudWatchLogsDetails.LogGroup",
+                "/aws/elasticache/slow",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.LogFormat",
+                "json",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.LogType",
+                "engine-log",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.DestinationType",
+                "kinesis-firehose",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.DestinationDetails.KinesisFirehoseDetails.DeliveryStream",
+                "engine-stream",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.LogFormat",
+                "text",
+            ),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "log-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<LogType>slow-log</LogType>"));
+    assert!(body.contains("<DestinationType>cloudwatch-logs</DestinationType>"));
+    assert!(body.contains("<LogGroup>/aws/elasticache/slow</LogGroup>"));
+    assert!(body.contains("<LogType>engine-log</LogType>"));
+    assert!(body.contains("<DestinationType>kinesis-firehose</DestinationType>"));
+    assert!(body.contains("<DeliveryStream>engine-stream</DeliveryStream>"));
+    assert!(body.contains("<LogFormat>text</LogFormat>"));
+}
+
+#[test]
+fn create_cache_cluster_persists_security_and_subnet_groups() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "sec-cc"),
+            ("CacheSubnetGroupName", "default"),
+            ("SecurityGroupIds.SecurityGroupId.1", "sg-aaa"),
+            ("SecurityGroupIds.SecurityGroupId.2", "sg-bbb"),
+            ("CacheSecurityGroupNames.CacheSecurityGroupName.1", "ec2c-1"),
+            ("CacheSecurityGroupNames.CacheSecurityGroupName.2", "ec2c-2"),
+            ("CacheParameterGroupName", "default.redis7"),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "sec-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<CacheSubnetGroupName>default</CacheSubnetGroupName>"));
+    assert!(body.contains("<SecurityGroupId>sg-aaa</SecurityGroupId>"));
+    assert!(body.contains("<SecurityGroupId>sg-bbb</SecurityGroupId>"));
+    assert!(body.contains("<CacheSecurityGroupName>ec2c-1</CacheSecurityGroupName>"));
+    assert!(body.contains("<CacheSecurityGroupName>ec2c-2</CacheSecurityGroupName>"));
+    assert!(body.contains("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"));
+}
+
+#[test]
+fn create_cache_cluster_persists_snapshot_window_and_retention() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "snap-cc"),
+            ("SnapshotRetentionLimit", "7"),
+            ("SnapshotWindow", "03:00-05:00"),
+            ("SnapshotName", "seed-snapshot"),
+            (
+                "SnapshotArns.SnapshotArn.1",
+                "arn:aws:s3:::my-bucket/snap.rdb",
+            ),
+            ("PreferredMaintenanceWindow", "sun:23:00-mon:01:30"),
+            ("NotificationTopicArn", "arn:aws:sns:us-east-1:123:events"),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "snap-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<SnapshotRetentionLimit>7</SnapshotRetentionLimit>"));
+    assert!(body.contains("<SnapshotWindow>03:00-05:00</SnapshotWindow>"));
+    assert!(body
+        .contains("<PreferredMaintenanceWindow>sun:23:00-mon:01:30</PreferredMaintenanceWindow>"));
+    assert!(body.contains("<TopicArn>arn:aws:sns:us-east-1:123:events</TopicArn>"));
+    // SnapshotName + SnapshotArns are stored on the struct but aren't echoed
+    // by Describe; assert the in-memory state holds them.
+    let state = svc.state.read();
+    let cluster = state
+        .get("123456789012")
+        .unwrap()
+        .cache_clusters
+        .get("snap-cc")
+        .unwrap();
+    assert_eq!(cluster.snapshot_name.as_deref(), Some("seed-snapshot"));
+    assert_eq!(
+        cluster.snapshot_arns,
+        vec!["arn:aws:s3:::my-bucket/snap.rdb".to_string()]
+    );
+}
+
+#[test]
+fn create_cache_cluster_persists_network_fields() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "net-cc"),
+            ("NetworkType", "dual_stack"),
+            ("IpDiscovery", "ipv6"),
+            ("AZMode", "cross-az"),
+            ("OutpostMode", "single-outpost"),
+            (
+                "PreferredOutpostArn",
+                "arn:aws:outposts:us-east-1:123:outpost/op-abc",
+            ),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "net-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<NetworkType>dual_stack</NetworkType>"));
+    assert!(body.contains("<IpDiscovery>ipv6</IpDiscovery>"));
+    assert!(body.contains("<AZMode>cross-az</AZMode>"));
+    assert!(body.contains("<OutpostMode>single-outpost</OutpostMode>"));
+    assert!(body.contains(
+        "<PreferredOutpostArn>arn:aws:outposts:us-east-1:123:outpost/op-abc</PreferredOutpostArn>"
+    ));
+}
+
+#[test]
+fn create_cache_cluster_defaults_port_for_redis() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[("CacheClusterId", "redis-cc"), ("Engine", "redis")],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let state = svc.state.read();
+    let cluster = state
+        .get("123456789012")
+        .unwrap()
+        .cache_clusters
+        .get("redis-cc")
+        .unwrap();
+    assert_eq!(cluster.port, 6379);
+}
+
+#[test]
+fn create_cache_cluster_defaults_port_for_memcached() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[("CacheClusterId", "mc-cc"), ("Engine", "memcached")],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let state = svc.state.read();
+    let cluster = state
+        .get("123456789012")
+        .unwrap()
+        .cache_clusters
+        .get("mc-cc")
+        .unwrap();
+    assert_eq!(cluster.port, 11211);
+}
+
+#[test]
+fn create_cache_cluster_persists_preferred_azs() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "az-cc"),
+            ("Engine", "memcached"),
+            ("NumCacheNodes", "3"),
+            ("PreferredAvailabilityZone", "us-east-1a"),
+            (
+                "PreferredAvailabilityZones.AvailabilityZone.1",
+                "us-east-1a",
+            ),
+            (
+                "PreferredAvailabilityZones.AvailabilityZone.2",
+                "us-east-1b",
+            ),
+            (
+                "PreferredAvailabilityZones.AvailabilityZone.3",
+                "us-east-1c",
+            ),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "az-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<PreferredAvailabilityZone>us-east-1a</PreferredAvailabilityZone>"));
+    assert!(body.contains("<AvailabilityZone>us-east-1a</AvailabilityZone>"));
+    assert!(body.contains("<AvailabilityZone>us-east-1b</AvailabilityZone>"));
+    assert!(body.contains("<AvailabilityZone>us-east-1c</AvailabilityZone>"));
+}
+
+#[test]
+fn create_cache_cluster_does_not_echo_auth_token() {
+    let create_req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "auth-cc"),
+            ("Engine", "redis"),
+            ("AuthToken", "supersecret-token-XYZ"),
+            ("TransitEncryptionEnabled", "true"),
+        ],
+    );
+    let svc = service_with_cache_cluster_from_request(&create_req);
+
+    let describe = request("DescribeCacheClusters", &[("CacheClusterId", "auth-cc")]);
+    let resp = svc.describe_cache_clusters(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<AuthTokenEnabled>true</AuthTokenEnabled>"));
+    // Raw token must never be echoed back in describe XML.
+    assert!(!body.contains("supersecret-token-XYZ"));
+    // But the stored struct keeps it for future ModifyCacheCluster comparisons.
+    let state = svc.state.read();
+    let cluster = state
+        .get("123456789012")
+        .unwrap()
+        .cache_clusters
+        .get("auth-cc")
+        .unwrap();
+    assert_eq!(cluster.auth_token.as_deref(), Some("supersecret-token-XYZ"));
 }

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -128,6 +128,56 @@ pub struct CacheCluster {
     /// `AuthTokenEnabled` — true when an AUTH token was supplied.
     #[serde(default)]
     pub auth_token_enabled: bool,
+    /// Configured `Port` from the create request. Stored separately
+    /// from `endpoint_port`/`host_port` so the engine default
+    /// (6379 redis / 11211 memcached) round-trips even when the
+    /// container listens elsewhere.
+    #[serde(default)]
+    pub port: u16,
+    /// `PreferredMaintenanceWindow` from the request, e.g. `sun:23:00-mon:01:30`.
+    #[serde(default)]
+    pub preferred_maintenance_window: Option<String>,
+    /// `PreferredAvailabilityZones.member.N` — populated for memcached clusters
+    /// pinning each node to a specific AZ.
+    #[serde(default)]
+    pub preferred_availability_zones: Vec<String>,
+    /// `NotificationTopicArn` for cluster events.
+    #[serde(default)]
+    pub notification_topic_arn: Option<String>,
+    /// Legacy EC2-Classic security group names.
+    #[serde(default)]
+    pub cache_security_group_names: Vec<String>,
+    /// `SnapshotArns.member.N` — RDB seed snapshot S3 ARNs (redis only).
+    #[serde(default)]
+    pub snapshot_arns: Vec<String>,
+    /// `SnapshotName` — replication-group / cluster snapshot to seed from.
+    #[serde(default)]
+    pub snapshot_name: Option<String>,
+    /// `SnapshotRetentionLimit` — daily snapshots to keep.
+    #[serde(default)]
+    pub snapshot_retention_limit: i32,
+    /// `SnapshotWindow` — time range when automatic snapshots run.
+    #[serde(default)]
+    pub snapshot_window: Option<String>,
+    /// `OutpostMode` — `single-outpost` or `cross-outpost`.
+    #[serde(default)]
+    pub outpost_mode: Option<String>,
+    /// `PreferredOutpostArn` — ARN of the AWS Outpost the cluster pins to.
+    #[serde(default)]
+    pub preferred_outpost_arn: Option<String>,
+    /// `NetworkType` — `ipv4`, `ipv6`, or `dual_stack`.
+    #[serde(default)]
+    pub network_type: Option<String>,
+    /// `IpDiscovery` — `ipv4` or `ipv6`.
+    #[serde(default)]
+    pub ip_discovery: Option<String>,
+    /// `AZMode` — `single-az` or `cross-az` (memcached multi-node).
+    #[serde(default)]
+    pub az_mode: Option<String>,
+    /// Raw AUTH token. Stored verbatim so a future modify can
+    /// compare/rotate; never echoed back in describe XML.
+    #[serde(default)]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1248,6 +1298,21 @@ mod tests {
                 transit_encryption_enabled: false,
                 at_rest_encryption_enabled: false,
                 auth_token_enabled: false,
+                port: 6379,
+                preferred_maintenance_window: None,
+                preferred_availability_zones: Vec::new(),
+                notification_topic_arn: None,
+                cache_security_group_names: Vec::new(),
+                snapshot_arns: Vec::new(),
+                snapshot_name: None,
+                snapshot_retention_limit: 0,
+                snapshot_window: None,
+                outpost_mode: None,
+                preferred_outpost_arn: None,
+                network_type: None,
+                ip_discovery: None,
+                az_mode: None,
+                auth_token: None,
             },
         );
         assert_eq!(state.cache_clusters.len(), 1);


### PR DESCRIPTION
## Summary
- Make `CreateCacheCluster` symmetric to N1's `CreateReplicationGroup`: every meaningful input is parsed and persisted.
- New fields on `CacheCluster`: port, preferred maintenance window, preferred-AZ list, notification topic ARN, EC2-Classic + VPC security groups, snapshot ARNs/name/window/retention, outpost mode + ARN, network type, IP discovery, AZ mode, AuthToken.
- Port defaults to 6379 for redis/valkey and 11211 for memcached.
- AuthToken is stored verbatim for future modify/rotate but never echoed in describe XML.
- `cache_cluster_xml` emits the new fields (matching AWS shape) and CFN `AWS::ElastiCache::CacheCluster` provisioner mirrors them.

## Test plan
- [x] `cargo build -p fakecloud-elasticache` clean
- [x] `cargo test -p fakecloud-elasticache --lib` green (194 tests, 8 new)
- [x] `cargo test --workspace --lib` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all`
- [x] New tests round-trip log delivery, security/subnet groups, snapshot window/retention, network fields, port defaults (redis + memcached), preferred AZs, and verify AuthToken is stored but not echoed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends CreateCacheCluster to accept and persist all meaningful inputs, mirroring N1’s CreateReplicationGroup. DescribeCacheClusters XML and the CFN `AWS::ElastiCache::CacheCluster` provisioner now include these fields for accurate round-trips.

- **New Features**
  - CreateCacheCluster now parses and stores: port, preferred maintenance window, preferred AZs, notification topic ARN, VPC SG IDs + cache SG names, snapshot ARNs/name/window/retention, outpost mode + preferred outpost ARN, network type, IP discovery, AZ mode, and AuthToken.
  - Port defaults by engine: 6379 for redis/valkey, 11211 for memcached.
  - AuthToken is stored for future modify/rotate but never returned by Describe.
  - Describe XML emits the new fields (AWS-compatible), and the CFN provisioner mirrors them.
  - Added tests to round-trip these fields, verify port defaults, and ensure the token isn’t echoed.

<sup>Written for commit b3f4571b93d8cf4eb8c939b03e845d0c9a0642fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

