### PR TITLE
feat(ecr): enforce repository policy on cross-account ops (P2)

### DIFF
--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -695,19 +695,14 @@ impl EcrService {
             .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
 
-        // Cross-account repository policy gate: if the caller belongs
-        // to a different account than the repo owner, an explicit
-        // Allow on `ecr:PutImage` is required.
-        if request.account_id != account
-            && !repository_policy_allows(
-                repo.policy.as_deref(),
-                &request.account_id,
-                &repo.repository_arn,
-                "ecr:PutImage",
-            )
-        {
-            return Err(repository_policy_denied(&name, "ecr:PutImage"));
-        }
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:PutImage",
+        )?;
 
         // Immutable tag guard: if a tag is supplied, it already maps to
         // a different digest, and the repo is IMMUTABLE, reject.
@@ -983,16 +978,14 @@ impl EcrService {
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
 
-        if request.account_id != account
-            && !repository_policy_allows(
-                repo.policy.as_deref(),
-                &request.account_id,
-                &repo.repository_arn,
-                "ecr:BatchGetImage",
-            )
-        {
-            return Err(repository_policy_denied(&name, "ecr:BatchGetImage"));
-        }
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:BatchGetImage",
+        )?;
 
         let mut images: Vec<Value> = Vec::new();
         let mut failures: Vec<Value> = Vec::new();
@@ -1113,6 +1106,14 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:BatchCheckLayerAvailability",
+        )?;
         let mut layers: Vec<Value> = Vec::new();
         let mut failures: Vec<Value> = Vec::new();
         for digest in &digests {
@@ -1299,19 +1300,14 @@ impl EcrService {
             .repositories
             .get(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        if request.account_id != account
-            && !repository_policy_allows(
-                repo.policy.as_deref(),
-                &request.account_id,
-                &repo.repository_arn,
-                "ecr:GetDownloadUrlForLayer",
-            )
-        {
-            return Err(repository_policy_denied(
-                &name,
-                "ecr:GetDownloadUrlForLayer",
-            ));
-        }
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:GetDownloadUrlForLayer",
+        )?;
         if !repo.layers.contains_key(&digest) {
             return Err(layer_not_found(&digest, &name));
         }
@@ -1339,9 +1335,18 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
-        if !state.repositories.contains_key(&name) {
-            return Err(repository_not_found(&name));
-        }
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:InitiateLayerUpload",
+        )?;
         let upload_id = Uuid::new_v4().to_string();
         let spool = crate::oci::create_upload_spool(&upload_id).map_err(|e| {
             AwsServiceError::aws_error(
@@ -1388,6 +1393,18 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:UploadLayerPart",
+        )?;
         let upload = state
             .layer_uploads
             .get_mut(&upload_id)
@@ -1491,6 +1508,18 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        let repo = state
+            .repositories
+            .get(&name)
+            .ok_or_else(|| repository_not_found(&name))?;
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:CompleteLayerUpload",
+        )?;
         // Peek, validate, then commit — so a digest mismatch lets the
         // caller retry CompleteLayerUpload with the correct digest
         // instead of having to re-upload the entire blob.

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -717,6 +717,28 @@ pub(crate) fn repository_filters_match(
         .any(|f| registry_filter_matches(f, repo_name))
 }
 
+/// Enforce the cross-account repo-policy gate at a handler. Returns
+/// Ok(()) when the caller belongs to the same account as the repo
+/// (in which case ECR falls back to the caller's IAM perms — out of
+/// scope for this batch), or when an explicit Allow on `action` exists.
+/// Otherwise returns the canonical AccessDeniedException.
+pub(crate) fn check_repo_policy(
+    repo_owner_account: &str,
+    caller_account: &str,
+    repo_arn: &str,
+    repo_name: &str,
+    policy_doc: Option<&str>,
+    action: &str,
+) -> Result<(), AwsServiceError> {
+    if caller_account == repo_owner_account {
+        return Ok(());
+    }
+    if repository_policy_allows(policy_doc, caller_account, repo_arn, action) {
+        return Ok(());
+    }
+    Err(repository_policy_denied(repo_name, action))
+}
+
 /// Cross-account ECR repository policy gate. When the caller's account
 /// differs from the repository's owning account, the repo must have a
 /// resource policy that explicitly Allows the requested action — empty

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -587,3 +587,185 @@ mod replication_tests {
         assert!(accounts.get(TARGET).is_none());
     }
 }
+
+// ── Cross-account repo policy enforcement on data-plane ops ────
+#[cfg(test)]
+mod repo_policy_enforcement_tests {
+    use super::super::EcrService;
+    use crate::state::{EcrState, Image, Repository, SharedEcrState};
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method, StatusCode};
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const OWNER: &str = "111111111111";
+    const OTHER: &str = "222222222222";
+
+    fn make_request(action: &str, caller_account: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: caller_account.into(),
+            request_id: "req-1".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn fixture(policy: Option<&str>) -> (EcrService, SharedEcrState) {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(OWNER, "us-east-1", "http://fakecloud:4566");
+        let owner = mas.get_or_create(OWNER);
+        let arn = owner.repository_arn("app");
+        let mut repo = Repository::new("app", arn, OWNER, "fakecloud:4566");
+        repo.policy = policy.map(|s| s.to_string());
+        // Seed an image so BatchGetImage has something to look up after the
+        // gate passes; the action under test should reach the body, not
+        // bail early on missing data.
+        repo.images.insert(
+            "sha256:abc".to_string(),
+            Image {
+                image_digest: "sha256:abc".to_string(),
+                image_manifest: "{\"mediaType\":\"x\"}".to_string(),
+                image_manifest_media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+                artifact_media_type: None,
+                image_size_in_bytes: 0,
+                image_pushed_at: chrono::Utc::now(),
+                last_recorded_pull_time: None,
+            },
+        );
+        repo.image_tags
+            .insert("v1".to_string(), "sha256:abc".to_string());
+        owner.repositories.insert("app".to_string(), repo);
+        let state: SharedEcrState = Arc::new(RwLock::new(mas));
+        let svc = EcrService::new(state.clone());
+        (svc, state)
+    }
+
+    fn cross_account_allow_policy(action: &str) -> String {
+        format!(
+            r#"{{
+                "Version": "2012-10-17",
+                "Statement": [{{
+                    "Sid": "CrossAccount",
+                    "Effect": "Allow",
+                    "Principal": {{"AWS": "arn:aws:iam::{OTHER}:root"}},
+                    "Action": ["{action}"],
+                    "Resource": "*"
+                }}]
+            }}"#
+        )
+    }
+
+    #[test]
+    fn batch_get_image_cross_account_blocked_when_no_policy() {
+        let (svc, _state) = fixture(None);
+        let req = make_request(
+            "BatchGetImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageIds": [{"imageTag": "v1"}],
+            }),
+        );
+        let err = match svc.batch_get_image(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected denial"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+
+    #[test]
+    fn batch_get_image_cross_account_allowed_by_policy() {
+        let policy = cross_account_allow_policy("ecr:BatchGetImage");
+        let (svc, _state) = fixture(Some(&policy));
+        let req = make_request(
+            "BatchGetImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageIds": [{"imageTag": "v1"}],
+            }),
+        );
+        let resp = svc.batch_get_image(&req).expect("should succeed");
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["images"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn batch_get_image_same_account_skips_policy_check() {
+        let (svc, _state) = fixture(None);
+        let req = make_request(
+            "BatchGetImage",
+            OWNER,
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{"imageTag": "v1"}],
+            }),
+        );
+        let resp = svc.batch_get_image(&req).expect("same-account allowed");
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["images"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn put_image_cross_account_blocked_when_policy_denies_action() {
+        // Policy allows BatchGetImage but not PutImage.
+        let policy = cross_account_allow_policy("ecr:BatchGetImage");
+        let (svc, _state) = fixture(Some(&policy));
+        let manifest = "{\"mediaType\":\"x\"}";
+        let req = make_request(
+            "PutImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageManifest": manifest,
+                "imageTag": "v2",
+            }),
+        );
+        let err = match svc.put_image(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected denial"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+
+    #[test]
+    fn get_download_url_for_layer_cross_account_blocked_when_no_policy() {
+        let (svc, _state) = fixture(None);
+        let req = make_request(
+            "GetDownloadUrlForLayer",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "layerDigest": "sha256:deadbeef",
+            }),
+        );
+        let err = match svc.get_download_url_for_layer(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected denial"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert_eq!(err.code(), "AccessDeniedException");
+    }
+}


### PR DESCRIPTION
## Summary
- Cross-account `BatchGetImage`, `PutImage`, `GetDownloadUrlForLayer`, `BatchCheckLayerAvailability`, `InitiateLayerUpload`, `UploadLayerPart`, and `CompleteLayerUpload` now consult the target repo's resource policy via the IAM evaluator.
- Missing policy or one without an explicit Allow on the requested action returns `AccessDeniedException` (HTTP 403); same-account callers fall through to the existing handlers.
- New `check_repo_policy` helper dedupes the gate at every call site so future ops can opt in with one line.

## Test plan
- [x] `cargo build -p fakecloud-ecr`
- [x] `cargo test -p fakecloud-ecr --lib`
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce ECR repository resource policy on cross-account image and layer operations. Cross-account requests now require an explicit Allow in the target repo policy; otherwise they return AccessDeniedException (403). Same-account calls are unchanged.

- **New Features**
  - Policy gate added to: BatchGetImage, PutImage, GetDownloadUrlForLayer, BatchCheckLayerAvailability, InitiateLayerUpload, UploadLayerPart, CompleteLayerUpload.
  - Same-account requests skip the repo-policy check and continue through existing handlers.

- **Refactors**
  - Added `check_repo_policy` helper to centralize the gate and remove duplicated checks in `fakecloud-ecr`.

<sup>Written for commit 33ffca3b8980ad8fd23cb7f8015bca169155e57d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

