### PR TITLE
feat(iam): enforce trust policy on AssumeRole (F1)

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -119,6 +119,10 @@ pub struct ResolvedCredential {
     /// Session policies passed to the STS call that minted this credential.
     /// Empty for IAM user access keys.
     pub session_policies: Vec<String>,
+    /// True iff the underlying STS credential was minted with MFA. Drives
+    /// `aws:MultiFactorAuthPresent` for downstream IAM evaluation. Always
+    /// false for raw IAM user access keys.
+    pub mfa_present: bool,
 }
 
 impl ResolvedCredential {
@@ -815,6 +819,7 @@ mod tests {
                 tags: None,
             },
             session_policies: Vec::new(),
+            mfa_present: false,
         };
         assert_eq!(rc.principal_arn(), "arn:aws:iam::123456789012:user/alice");
         assert_eq!(rc.user_id(), "AIDAALICE");

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -383,6 +383,13 @@ pub async fn dispatch(
                             &aws_request.region,
                             is_secure_transport(&aws_request.headers),
                         );
+                        // MFA flag rides on the resolved credential — STS
+                        // mints it true when AssumeRole supplied
+                        // SerialNumber + TokenCode. IAM user access keys
+                        // never have it, matching AWS.
+                        if let Some(rc) = resolved.as_ref() {
+                            condition_context.aws_mfa_present = Some(rc.mfa_present);
+                        }
                         condition_context.service_keys =
                             service.iam_condition_keys_for(&aws_request, &iam_action);
 

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -50,6 +50,7 @@ impl CredentialResolver for IamCredentialResolver {
                         tags: lookup.principal_tags.map(|m| m.into_iter().collect()),
                     },
                     session_policies: lookup.session_policies,
+                    mfa_present: lookup.mfa_present,
                 });
             }
         }
@@ -138,6 +139,7 @@ mod tests {
                 account_id: "123456789012".into(),
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
         let resolver = IamCredentialResolver::new(shared(state));
@@ -296,6 +298,7 @@ mod tests {
                 account_id: "123456789012".into(),
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
         let resolver = IamCredentialResolver::new(shared(state));

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -225,6 +225,11 @@ pub struct StsTempCredential {
     /// session policies.
     #[serde(default)]
     pub session_policies: Vec<String>,
+    /// True iff the AssumeRole / GetSessionToken call that minted this
+    /// credential supplied MFA (`SerialNumber` + `TokenCode`). Surfaces
+    /// to downstream IAM evaluation as `aws:MultiFactorAuthPresent`.
+    #[serde(default)]
+    pub mfa_present: bool,
 }
 
 /// Result of looking up a set of credentials by access key ID.
@@ -246,6 +251,10 @@ pub struct SecretLookup {
     /// Tags on the principal (IAM user or assumed role) for
     /// `aws:PrincipalTag/<key>` condition evaluation.
     pub principal_tags: Option<BTreeMap<String, String>>,
+    /// True when the underlying STS credential was minted with MFA;
+    /// surfaces as `aws:MultiFactorAuthPresent` to downstream IAM
+    /// evaluation. Always false for raw IAM user access keys.
+    pub mfa_present: bool,
 }
 
 /// Convert a `Vec<Tag>` to a `BTreeMap<String, String>`.
@@ -432,6 +441,7 @@ impl IamState {
                             account_id: self.account_id.clone(),
                             session_policies: Vec::new(),
                             principal_tags: tags_to_hashmap(&user.tags),
+                            mfa_present: false,
                         });
                     }
                 }
@@ -452,6 +462,7 @@ impl IamState {
                     account_id: temp.account_id.clone(),
                     session_policies: temp.session_policies.clone(),
                     principal_tags,
+                    mfa_present: temp.mfa_present,
                 });
             }
             self.sts_temp_credentials.remove(access_key_id);
@@ -475,6 +486,7 @@ impl IamState {
                             account_id: self.account_id.clone(),
                             session_policies: Vec::new(),
                             principal_tags: tags_to_hashmap(&user.tags),
+                            mfa_present: false,
                         });
                     }
                 }
@@ -495,6 +507,7 @@ impl IamState {
             account_id: temp.account_id.clone(),
             session_policies: temp.session_policies.clone(),
             principal_tags,
+            mfa_present: temp.mfa_present,
         })
     }
 
@@ -601,6 +614,7 @@ mod tests {
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
         let lookup = state.credential_secret("FSIATEMPKEY").unwrap();
@@ -626,6 +640,7 @@ mod tests {
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() - chrono::Duration::seconds(1),
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
         assert!(state.credential_secret("FSIAOLD").is_none());
@@ -646,6 +661,7 @@ mod tests {
                 account_id: "123456789012".to_string(),
                 expiration: Utc::now() - chrono::Duration::seconds(1),
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
         assert!(state.credential_secret_readonly("FSIAOLD").is_none());

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -511,6 +511,8 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
+        let mfa_present_for_session = req.query_params.contains_key("SerialNumber")
+            && req.query_params.contains_key("TokenCode");
         target_state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -522,6 +524,7 @@ impl StsService {
                 account_id: account_id.clone(),
                 expiration: expiration_at,
                 session_policies,
+                mfa_present: mfa_present_for_session,
             },
         );
 
@@ -644,6 +647,7 @@ impl StsService {
                 account_id: account_id.clone(),
                 expiration: expiration_at,
                 session_policies,
+                mfa_present: false,
             },
         );
 
@@ -762,6 +766,7 @@ impl StsService {
                 account_id: account_id.clone(),
                 expiration: expiration_at,
                 session_policies,
+                mfa_present: false,
             },
         );
 
@@ -855,6 +860,8 @@ impl StsService {
         );
         // GetSessionToken does not accept a Policy parameter per AWS
         // docs, so session_policies is always empty for this operation.
+        let mfa_present_for_session = req.query_params.contains_key("SerialNumber")
+            && req.query_params.contains_key("TokenCode");
         state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -866,6 +873,7 @@ impl StsService {
                 account_id,
                 expiration: expiration_at,
                 session_policies: Vec::new(),
+                mfa_present: mfa_present_for_session,
             },
         );
 
@@ -944,6 +952,7 @@ impl StsService {
                 account_id: account_id.clone(),
                 expiration: expiration_at,
                 session_policies,
+                mfa_present: false,
             },
         );
 
@@ -1116,6 +1125,7 @@ impl StsService {
                 account_id: target_account.clone(),
                 expiration: expiration_at,
                 session_policies: Vec::new(),
+                mfa_present: false,
             },
         );
 
@@ -1710,7 +1720,171 @@ mod tests {
         assert_eq!(err.status(), StatusCode::FORBIDDEN);
     }
 
+    #[tokio::test]
+    async fn assume_role_allowed_by_trust_policy_with_principal_match() {
+        // Trust policy names the caller's account explicitly. Per AWS,
+        // `"Principal": { "AWS": "123456789012" }` is shorthand for the
+        // account root and matches any IAM principal in that account.
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "named", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "sess")],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<AccessKeyId>"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn assume_role_blocked_when_principal_not_in_trust_policy() {
+        // Trust policy lists a different account — caller's account
+        // (123456789012) doesn't match, so AssumeRole must 403.
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::999999999999:root"},"Action":"sts:AssumeRole"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "other-account", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "sess")],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected AccessDenied when caller account not in trust policy"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    // ── Trust policy: ExternalId aliases (rename of existing tests for plan) ──
+
+    #[tokio::test]
+    async fn assume_role_blocked_when_external_id_required_but_missing() {
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"hello"}}}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "ext-required", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "sess")],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected AccessDenied when ExternalId required but missing"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn assume_role_succeeds_with_correct_external_id() {
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"hello"}}}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "ext-ok", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "sess"),
+                ("ExternalId", "hello"),
+            ],
+        );
+        svc.handle(req).await.unwrap();
+    }
+
+    // ── Trust policy: MFA enforcement ──
+
+    #[tokio::test]
+    async fn assume_role_blocked_when_mfa_required_but_not_present() {
+        // Trust policy requires `aws:MultiFactorAuthPresent: true`; the
+        // request didn't supply SerialNumber+TokenCode, so the condition
+        // evaluates false and AssumeRole must 403.
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole","Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "mfa-required", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "sess")],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected AccessDenied when MFA required but not supplied"),
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn assume_role_succeeds_with_mfa_supplied() {
+        // Same trust policy as above, but the caller supplied MFA —
+        // condition evaluates true and AssumeRole succeeds. The minted
+        // session credential carries `mfa_present: true` so downstream
+        // Authorize evaluations see `aws:MultiFactorAuthPresent`.
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole","Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "mfa-ok", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "sess"),
+                ("SerialNumber", "arn:aws:iam::123456789012:mfa/alice"),
+                ("TokenCode", "123456"),
+            ],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(body.contains("<AccessKeyId>"), "{body}");
+        // The session credential the resolver hands out must record
+        // mfa_present=true so Authorize sees aws:MultiFactorAuthPresent.
+        let states = state.read();
+        let s = states.get("123456789012").unwrap();
+        let any_mfa = s.sts_temp_credentials.values().any(|c| c.mfa_present);
+        assert!(
+            any_mfa,
+            "expected at least one minted credential with mfa_present=true"
+        );
+    }
+
     // ── Service-linked roles ──
+
+    #[tokio::test]
+    async fn assume_service_linked_role_blocked_when_caller_not_matching_service() {
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+        let arn = fakecloud_aws::arn::Arn::global(
+            "iam",
+            "123456789012",
+            "role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+        )
+        .to_string();
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create("123456789012");
+            s.roles.insert(
+                "AWSServiceRoleForECS".to_string(),
+                crate::state::IamRole {
+                    role_name: "AWSServiceRoleForECS".to_string(),
+                    role_id: "AROASLRECS".to_string(),
+                    arn: arn.clone(),
+                    path: "/aws-service-role/ecs.amazonaws.com/".to_string(),
+                    assume_role_policy_document: trust.to_string(),
+                    created_at: Utc::now(),
+                    description: None,
+                    max_session_duration: 3600,
+                    tags: Vec::new(),
+                    permissions_boundary: None,
+                },
+            );
+        }
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &arn), ("RoleSessionName", "sess")],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => {
+                panic!("expected AccessDenied for service-linked role with non-service caller")
+            }
+        };
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
 
     #[tokio::test]
     async fn service_linked_role_rejects_non_service_caller() {


### PR DESCRIPTION
## Summary
- AssumeRole runs the role's AssumeRolePolicyDocument through the existing IAM evaluator before minting credentials, populating sts:ExternalId, sts:RoleSessionName, sts:SourceIdentity, and aws:MultiFactorAuthPresent on the trust eval context.
- Service-linked roles under /aws-service-role/<service>/ reject any caller whose principal ARN doesn't match the named service host.
- StsTempCredential, SecretLookup, and ResolvedCredential carry an mfa_present flag; dispatch threads it into ConditionContext.aws_mfa_present so downstream Authorize evaluations see aws:MultiFactorAuthPresent on assumed-role sessions.
- AccessDenied responses match the AWS message format: `User: <caller> is not authorized to perform: sts:AssumeRole on resource: <role-arn>`.
- 7 new test cases cover principal allow/deny, ExternalId required+match, MFA required+supplied, and service-linked role rejection. Existing AssumeRoleWithWebIdentity / AssumeRoleWithSAML paths are untouched (deferred).

## Test plan
- [x] `cargo build -p fakecloud-iam`
- [x] `cargo test -p fakecloud-iam --lib`
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce IAM trust policy evaluation for `sts:AssumeRole`, restrict service‑linked roles to their owning service, and propagate MFA into sessions. This brings `aws:MultiFactorAuthPresent` and AccessDenied behavior in line with AWS.

- **New Features**
  - Run `AssumeRolePolicyDocument` through the IAM evaluator before minting credentials; populate `sts:ExternalId`, `sts:RoleSessionName`, `sts:SourceIdentity`, and `aws:MultiFactorAuthPresent`.
  - Restrict roles under `/aws-service-role/<service>/` to callers matching the service principal.
  - Add `mfa_present` to `StsTempCredential`, `SecretLookup`, and `ResolvedCredential`, and thread it into the condition context so downstream policies see `aws:MultiFactorAuthPresent`.
  - Return AWS-formatted AccessDenied: "User: <caller> is not authorized to perform: sts:AssumeRole on resource: <role-arn>".
  - Add 7 tests covering principal allow/deny, ExternalId required/match, MFA required/supplied, and service-linked role rejection.

<sup>Written for commit 838de5883800eee9144a9fbb6e34087f76f11d3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

