### PR TITLE
feat(lambda): PublishVersion snapshots code+config (D2)

### DIFF
--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -156,7 +156,7 @@ impl LambdaService {
         let res = resource.unwrap_or("");
         match action {
             // Function lifecycle extras
-            "GetFunctionConfiguration" => self.get_function_configuration(res, aid),
+            "GetFunctionConfiguration" => self.get_function_configuration(res, aid, req),
             "UpdateFunctionConfiguration" => self.update_function_configuration(res, req),
             "UpdateFunctionCode" => self.update_function_code(res, req),
             "UpdateEventSourceMapping" => self.update_event_source_mapping_handler(res, req),
@@ -165,7 +165,7 @@ impl LambdaService {
             "InvokeWithResponseStream" => Ok(AwsResponse::json(StatusCode::OK, "{}".to_string())),
 
             // Versions
-            "ListVersionsByFunction" => self.list_versions_by_function(res, aid),
+            "ListVersionsByFunction" => self.list_versions_by_function(res, aid, req),
 
             // Aliases
             "CreateAlias" => self.create_alias(res, req),
@@ -257,14 +257,41 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
+        let qualifier = req.query_params.get("Qualifier").cloned();
         self.with_state_read(account_id, &region, |state| {
-            state
+            let live = state
                 .functions
                 .get(function_name)
-                .map(|f| ok(self.function_config_json(f)))
-                .unwrap_or_else(|| Err(not_found("Function", function_name)))
+                .ok_or_else(|| not_found("Function", function_name))?;
+            // Qualifier resolution mirrors GetFunction: $LATEST or omitted
+            // returns the live config; numeric / alias qualifiers resolve
+            // to a numbered snapshot.
+            let resolved = crate::service::resolve_qualifier_to_version(
+                state,
+                function_name,
+                qualifier.as_deref(),
+            );
+            let (func, version_label) = match resolved {
+                None => (live, "$LATEST".to_string()),
+                Some(v) => {
+                    let snap = state
+                        .function_version_snapshots
+                        .get(function_name)
+                        .and_then(|m| m.get(&v))
+                        .ok_or_else(|| not_found("Function", function_name))?;
+                    (snap, v)
+                }
+            };
+            let mut config = self.function_config_json(func);
+            config["Version"] = json!(version_label);
+            if version_label != "$LATEST" {
+                config["FunctionArn"] = json!(format!("{}:{version_label}", live.function_arn));
+                config["MasterArn"] = json!(live.function_arn);
+            }
+            ok(config)
         })
     }
 
@@ -511,7 +538,7 @@ impl LambdaService {
         // freshly updated $LATEST and returns that version's config.
         if publish {
             drop(accounts);
-            return self.publish_version(function_name, &req.account_id);
+            return self.publish_version(function_name, &req.account_id, req);
         }
 
         ok(self.function_config_json(func))
@@ -554,8 +581,16 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let region = self.region_for(account_id);
+        let max_items: usize = req
+            .query_params
+            .get("MaxItems")
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.clamp(1, 50))
+            .unwrap_or(50);
+        let marker = req.query_params.get("Marker").cloned();
         self.with_state_read(account_id, &region, |state| {
             let func = state
                 .functions
@@ -564,10 +599,10 @@ impl LambdaService {
             // AWS returns $LATEST first, then numbered versions in
             // ascending order. Each numbered version is an immutable
             // snapshot of the function at publish time.
-            let mut versions: Vec<serde_json::Value> = Vec::new();
+            let mut all: Vec<serde_json::Value> = Vec::new();
             let mut latest = self.function_config_json(func);
             latest["Version"] = json!("$LATEST");
-            versions.push(latest);
+            all.push(latest);
             let snapshots = state.function_version_snapshots.get(function_name);
             if let Some(numbered) = state.function_versions.get(function_name) {
                 for v in numbered {
@@ -576,10 +611,29 @@ impl LambdaService {
                     cfg["Version"] = json!(v);
                     cfg["FunctionArn"] = json!(format!("{}:{v}", func.function_arn));
                     cfg["MasterArn"] = json!(func.function_arn);
-                    versions.push(cfg);
+                    all.push(cfg);
                 }
             }
-            ok(json!({ "Versions": versions }))
+            // Pagination: skip past Marker if supplied (Marker is the
+            // Version string of the entry to start *after*), then take
+            // up to MaxItems. Emit a NextMarker when truncated.
+            let start = match marker.as_deref() {
+                Some(m) => all
+                    .iter()
+                    .position(|v| v["Version"].as_str() == Some(m))
+                    .map(|i| i + 1)
+                    .unwrap_or(0),
+                None => 0,
+            };
+            let end = (start + max_items).min(all.len());
+            let page: Vec<serde_json::Value> = all[start..end].to_vec();
+            let mut body = json!({ "Versions": page });
+            if end < all.len() {
+                if let Some(last) = all[end - 1]["Version"].as_str() {
+                    body["NextMarker"] = json!(last);
+                }
+            }
+            ok(body)
         })
     }
 

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1414,7 +1414,16 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // Optional preconditions from the body. Both compare the supplied
+        // value against the live `$LATEST` state; mismatch yields 412
+        // PreconditionFailedException, matching AWS optimistic-concurrency.
+        let body: Value = serde_json::from_slice(&req.body).unwrap_or_default();
+        let supplied_revision = body["RevisionId"].as_str().map(String::from);
+        let supplied_sha = body["CodeSha256"].as_str().map(String::from);
+        let description_override = body["Description"].as_str().map(String::from);
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
         let func = state.functions.get(function_name).ok_or_else(|| {
@@ -1427,6 +1436,25 @@ impl LambdaService {
                 ),
             )
         })?;
+
+        if let Some(ref rev) = supplied_revision {
+            if rev != &func.revision_id {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailedException",
+                    "The RevisionId provided does not match the latest RevisionId for the Lambda function. Call the GetFunction or the GetAlias API to retrieve the latest RevisionId for your resource.",
+                ));
+            }
+        }
+        if let Some(ref sha) = supplied_sha {
+            if sha != &func.code_sha256 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::PRECONDITION_FAILED,
+                    "PreconditionFailedException",
+                    "CodeSha256 does not match the SHA-256 of the function's deployment package.",
+                ));
+            }
+        }
 
         // Pick the next version number per function, monotonic per
         // function arn, never reused. AWS uses sequential decimal
@@ -1448,6 +1476,11 @@ impl LambdaService {
         let mut snapshot = func.clone();
         snapshot.version = next_str.clone();
         snapshot.master_arn = Some(func.function_arn.clone());
+        if let Some(desc) = description_override {
+            snapshot.description = desc;
+        }
+        // Each numbered version gets its own RevisionId, decoupled from $LATEST.
+        snapshot.revision_id = uuid::Uuid::new_v4().to_string();
 
         // Append to numbered list and store the snapshot.
         state
@@ -1670,7 +1703,9 @@ impl AwsService for LambdaService {
                 )
                 .await
             }
-            "PublishVersion" => self.publish_version(resource_name.as_deref().unwrap_or(""), aid),
+            "PublishVersion" => {
+                self.publish_version(resource_name.as_deref().unwrap_or(""), aid, &req)
+            }
             "AddPermission" => self.add_permission(resource_name.as_deref().unwrap_or(""), &req),
             "GetPolicy" => self.get_policy(resource_name.as_deref().unwrap_or(""), aid),
             "RemovePermission" => {

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1108,7 +1108,8 @@ async fn unknown_route_returns_error() {
 #[tokio::test]
 async fn publish_version_unknown_function_errors() {
     let svc = LambdaService::new(make_state());
-    assert!(svc.publish_version("ghost", "123456789012").is_err());
+    let req = make_request(Method::POST, "/2015-03-31/functions/ghost/versions", "{}");
+    assert!(svc.publish_version("ghost", "123456789012", &req).is_err());
 }
 
 #[tokio::test]
@@ -1564,6 +1565,138 @@ async fn update_function_code_dry_run_does_not_mutate() {
     assert_eq!(cfg["CodeSha256"].as_str().unwrap(), pre_sha);
     assert_eq!(cfg["CodeSize"].as_i64().unwrap(), pre_size);
     assert_eq!(cfg["RevisionId"].as_str().unwrap(), pre_rev);
+}
+
+// ── PublishVersion behavior tests (D2) ──
+
+#[tokio::test]
+async fn publish_version_returns_numeric_version_and_versioned_arn() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pv1").await;
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv1/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::CREATED);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Version"], "1");
+    assert!(body["FunctionArn"].as_str().unwrap().ends_with(":1"));
+    assert_eq!(
+        body["MasterArn"].as_str().unwrap(),
+        "arn:aws:lambda:us-east-1:123456789012:function:pv1"
+    );
+}
+
+#[tokio::test]
+async fn publish_version_increments_per_function_counter() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pv2").await;
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv2/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v1["Version"], "1");
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv2/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v2["Version"], "2");
+}
+
+#[tokio::test]
+async fn publish_version_snapshots_code_immutable() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pv3").await;
+
+    // Publish v1 of the seed (empty code).
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv3/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let v1_sha = v1["CodeSha256"].as_str().unwrap().to_string();
+
+    // Push new code into $LATEST.
+    let new_zip_b64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"newer-bytes");
+    let body = json!({ "ZipFile": new_zip_b64 });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/pv3/code",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // GetFunctionConfiguration?Qualifier=1 returns the original snapshot.
+    let mut req = make_request(Method::GET, "/2015-03-31/functions/pv3/configuration", "");
+    req.query_params
+        .insert("Qualifier".to_string(), "1".to_string());
+    let resp = svc.handle(req).await.unwrap();
+    let snap: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(snap["Version"], "1");
+    assert_eq!(snap["CodeSha256"].as_str().unwrap(), v1_sha);
+
+    // $LATEST has the new code SHA.
+    let req = make_request(Method::GET, "/2015-03-31/functions/pv3/configuration", "");
+    let resp = svc.handle(req).await.unwrap();
+    let live: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(live["Version"], "$LATEST");
+    assert_ne!(live["CodeSha256"].as_str().unwrap(), v1_sha);
+}
+
+#[tokio::test]
+async fn list_versions_by_function_returns_all_plus_latest() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pv4").await;
+
+    for _ in 0..2 {
+        let req = make_request(Method::POST, "/2015-03-31/functions/pv4/versions", "{}");
+        svc.handle(req).await.unwrap();
+    }
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/pv4/versions", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let versions: Vec<String> = body["Versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["Version"].as_str().unwrap().to_string())
+        .collect();
+    assert!(versions.contains(&"$LATEST".to_string()));
+    assert!(versions.contains(&"1".to_string()));
+    assert!(versions.contains(&"2".to_string()));
+    assert_eq!(versions.len(), 3);
+}
+
+#[tokio::test]
+async fn publish_version_revision_id_mismatch_returns_412() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pv5").await;
+
+    let body = json!({ "RevisionId": "stale-revision-id-deadbeef" });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/pv5/versions",
+        &body.to_string(),
+    );
+    let err = match svc.handle(req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected PreconditionFailedException"),
+    };
+    assert_eq!(err.status(), StatusCode::PRECONDITION_FAILED);
+    assert!(err.code().contains("PreconditionFailed"));
+}
+
+#[tokio::test]
+async fn publish_version_unknown_function_returns_404() {
+    let svc = LambdaService::new(make_state());
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/missing-fn/versions",
+        "{}",
+    );
+    let err = match svc.handle(req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected ResourceNotFoundException"),
+    };
+    assert_eq!(err.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `PublishVersion` increments a per-function version counter, deep-copies code + config into `versions[<n>]`, returns `Version=<n>` + versioned ARN.
- `ListVersionsByFunction` walks the snapshot map and includes a synthetic `$LATEST` from live function state.
- `GetFunctionConfiguration` with `Qualifier=<numeric-version>` reads the snapshot, not the live function.
- Validates `RevisionId` precondition (412) and `CodeSha256` match (412); rejects unknown function with 404.

Addresses Phase D2 of the parity plan.

## Test plan

- [x] 6 unit tests cover counter increment, snapshot immutability, qualifier read, list+latest, RevisionId mismatch, unknown function.
- [x] `cargo test -p fakecloud-lambda --lib` 99 pass.
- [x] `cargo test --workspace --lib` no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Lambda versioning: `PublishVersion` snapshots code and config into immutable numbered versions and returns a versioned ARN. `ListVersionsByFunction` and `GetFunctionConfiguration` now support `$LATEST` and numeric qualifiers, with pagination where applicable.

- **New Features**
  - `PublishVersion`: increments a per-function counter; deep-copies mutable state; optional `Description` override; validates `RevisionId` and `CodeSha256` (412 on mismatch); 404 for unknown functions; assigns a new `RevisionId` to each version.
  - `GetFunctionConfiguration`: supports `Qualifier` (`$LATEST` or numeric/alias); numeric/alias reads the snapshot; sets `Version`, `FunctionArn` (with suffix), and `MasterArn`.
  - `ListVersionsByFunction`: returns `$LATEST` first, then numbered versions in ascending order; adds `MaxItems` (1–50), `Marker`, and `NextMarker` pagination.

<sup>Written for commit e0e4af86617c153406199e5bcda478553e68efac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

