### PR TITLE
feat(apigatewayv2): WebSocket support + @connections data plane (S1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1595,8 +1596,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2467,6 +2470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,12 +2829,14 @@ name = "fakecloud-apigatewayv2"
 version = "0.13.3"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "futures-util",
  "http 1.4.0",
  "parking_lot",
  "reqwest",
@@ -2833,6 +2844,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "uuid",
 ]
@@ -7067,6 +7079,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7264,6 +7288,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ version = "0.13.3"
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "signal", "sync", "process", "fs"] }
 tokio-util = { version = "0.7", features = ["io"] }
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 hyper = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fakecloud-apigatewayv2/Cargo.toml
+++ b/crates/fakecloud-apigatewayv2/Cargo.toml
@@ -12,6 +12,7 @@ fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -24,3 +25,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+tokio-tungstenite = "0.29"
+futures-util = "0.3"

--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -6,10 +6,11 @@ pub mod mock;
 pub mod router;
 pub(crate) mod service;
 pub mod state;
+pub mod websocket;
 
 pub use service::ApiGatewayV2Service;
 pub use state::{
-    ApiGatewayV2Snapshot, ApiGatewayV2State, Authorizer, CorsConfiguration, Deployment, HttpApi,
-    Integration, JwtConfiguration, Route, SharedApiGatewayV2State, Stage,
-    APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+    ApiGatewayV2Snapshot, ApiGatewayV2State, Authorizer, ConnectionInfo, CorsConfiguration,
+    Deployment, HttpApi, Integration, JwtConfiguration, Route, SharedApiGatewayV2State,
+    SharedWebSocketRegistry, Stage, WebSocketRegistry, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -523,13 +523,14 @@ impl ApiGatewayV2Service {
             )
         })?;
 
-        if protocol_type != "HTTP" {
+        if protocol_type != "HTTP" && protocol_type != "WEBSOCKET" {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "BadRequestException",
                 format!("Unsupported protocol type: {}", protocol_type),
             ));
         }
+        let protocol_type = protocol_type.to_string();
 
         let description = body["description"].as_str().map(|s| s.to_string());
         let tags = body["tags"].as_object().map(|m| {
@@ -556,6 +557,25 @@ impl ApiGatewayV2Service {
 
         let mut api = HttpApi::new(api_id, name, description, tags, region);
         api.cors_configuration = cors_configuration;
+        api.protocol_type = protocol_type.clone();
+        if protocol_type == "WEBSOCKET" {
+            // WebSocket APIs use a body-based selection expression by default
+            // and have no implicit api-key header selector.
+            api.route_selection_expression = "$request.body.action".to_string();
+            api.api_key_selection_expression = "$request.header.x-api-key".to_string();
+            if let Some(rse) = body
+                .get("routeSelectionExpression")
+                .and_then(|v| v.as_str())
+            {
+                api.route_selection_expression = rse.to_string();
+            }
+            if let Some(akse) = body
+                .get("apiKeySelectionExpression")
+                .and_then(|v| v.as_str())
+            {
+                api.api_key_selection_expression = akse.to_string();
+            }
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -256,10 +256,25 @@ async fn create_api_unsupported_protocol() {
     let state = make_state();
     let svc = ApiGatewayV2Service::new(state);
 
-    let body = serde_json::json!({"name": "ws", "protocolType": "WEBSOCKET"});
+    let body = serde_json::json!({"name": "grpc", "protocolType": "GRPC"});
     let req = make_request(Method::POST, "/v2/apis", &body.to_string());
     let err = expect_err(svc.handle(req).await);
     assert!(err.to_string().contains("BadRequestException"));
+}
+
+#[tokio::test]
+async fn create_api_websocket_protocol_succeeds() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+
+    let body = serde_json::json!({"name": "ws-api", "protocolType": "WEBSOCKET"});
+    let req = make_request(Method::POST, "/v2/apis", &body.to_string());
+    let resp = svc.handle(req).await.unwrap();
+    let b = body_json(&resp);
+    assert_eq!(b["name"], "ws-api");
+    assert_eq!(b["protocolType"], "WEBSOCKET");
+    // Default WS route selection expression follows AWS docs.
+    assert_eq!(b["routeSelectionExpression"], "$request.body.action");
 }
 
 // ── Route CRUD ──

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -1,10 +1,52 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
 
 pub type SharedApiGatewayV2State =
     Arc<parking_lot::RwLock<fakecloud_core::multi_account::MultiAccountState<ApiGatewayV2State>>>;
+
+/// Registry of live WebSocket connections, keyed by AWS-style connection id.
+/// Lives outside the persisted `ApiGatewayV2State` because senders can't be
+/// serialized; a single registry covers all accounts and APIs since connection
+/// ids are globally unique within a fakecloud process.
+pub type SharedWebSocketRegistry = Arc<parking_lot::RwLock<WebSocketRegistry>>;
+
+#[derive(Debug, Default)]
+pub struct WebSocketRegistry {
+    pub connections: HashMap<String, ConnectionInfo>,
+}
+
+impl WebSocketRegistry {
+    pub fn insert(&mut self, info: ConnectionInfo) {
+        self.connections.insert(info.connection_id.clone(), info);
+    }
+
+    pub fn remove(&mut self, connection_id: &str) -> Option<ConnectionInfo> {
+        self.connections.remove(connection_id)
+    }
+
+    pub fn get(&self, connection_id: &str) -> Option<&ConnectionInfo> {
+        self.connections.get(connection_id)
+    }
+
+    pub fn contains(&self, connection_id: &str) -> bool {
+        self.connections.contains_key(connection_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionInfo {
+    pub connection_id: String,
+    pub api_id: String,
+    pub stage: String,
+    pub connected_at: DateTime<Utc>,
+    pub last_active_at: DateTime<Utc>,
+    pub source_ip: String,
+    /// Outbound channel — `axum::extract::ws::Message::Close` triggers a close.
+    pub sender: UnboundedSender<axum::extract::ws::Message>,
+}
 
 impl fakecloud_core::multi_account::AccountState for ApiGatewayV2State {
     fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {

--- a/crates/fakecloud-apigatewayv2/src/websocket.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket.rs
@@ -1,0 +1,166 @@
+//! WebSocket data plane for API Gateway v2 WebSocket APIs.
+//!
+//! Connections are bookkept in a [`WebSocketRegistry`] keyed by AWS-style
+//! connection ids. Inbound frames flow through the websocket task and dispatch
+//! to the API's `$default` route (and `$connect` / `$disconnect` lifecycle
+//! routes when target Lambda integrations are wired up). The control surface
+//! at `/@connections/{id}` lets test code or SigV4 clients post messages back
+//! to a connected client, fetch connection metadata, or close the socket.
+
+use axum::extract::ws::{Message, WebSocket};
+use chrono::Utc;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use crate::state::{ConnectionInfo, SharedWebSocketRegistry};
+
+/// Generate a 22-char base64-style connection id, matching AWS's
+/// `<random>=` pattern.
+pub fn generate_connection_id() -> String {
+    use base64::prelude::*;
+    let mut buf = [0u8; 16];
+    let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0) as u128;
+    let uuid = uuid::Uuid::new_v4().as_u128();
+    let mixed = nanos.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(uuid);
+    buf[..16].copy_from_slice(&mixed.to_le_bytes());
+    let mut s = BASE64_STANDARD_NO_PAD.encode(buf);
+    s.truncate(21);
+    s.push('=');
+    s
+}
+
+/// Register a new WebSocket connection and return its id plus the outbound
+/// `Message` receiver. The caller is responsible for plumbing the receiver
+/// into the upgraded socket.
+pub fn register(
+    registry: SharedWebSocketRegistry,
+    api_id: String,
+    stage: String,
+    source_ip: String,
+) -> (String, UnboundedReceiver<Message>) {
+    let (tx, rx) = unbounded_channel();
+    let now = Utc::now();
+    let connection_id = generate_connection_id();
+    let info = ConnectionInfo {
+        connection_id: connection_id.clone(),
+        api_id,
+        stage,
+        connected_at: now,
+        last_active_at: now,
+        source_ip,
+        sender: tx,
+    };
+    registry.write().insert(info);
+    (connection_id, rx)
+}
+
+pub fn deregister(registry: &SharedWebSocketRegistry, connection_id: &str) {
+    registry.write().remove(connection_id);
+}
+
+/// Drive a websocket lifecycle: bridge inbound frames into `on_message`,
+/// forward outbound frames pushed via the registry sender, and clean up on
+/// close. `on_message` receives the raw bytes; `is_text` is true for text
+/// frames so dispatchers can preserve framing for `$default` events.
+pub async fn run_lifecycle<F, Fut>(
+    mut socket: WebSocket,
+    mut outbound: UnboundedReceiver<Message>,
+    on_message: F,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    loop {
+        tokio::select! {
+            biased;
+            outgoing = outbound.recv() => {
+                match outgoing {
+                    Some(Message::Close(frame)) => {
+                        let _ = socket.send(Message::Close(frame)).await;
+                        break;
+                    }
+                    Some(msg) => {
+                        if socket.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            incoming = socket.recv() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        on_message(text.as_bytes().to_vec(), true).await;
+                    }
+                    Some(Ok(Message::Binary(bin))) => {
+                        on_message(bin.to_vec(), false).await;
+                    }
+                    Some(Ok(Message::Close(_))) => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) | None => break,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn connection_id_format() {
+        let id = generate_connection_id();
+        assert_eq!(id.len(), 22);
+        assert!(id.ends_with('='));
+    }
+
+    #[test]
+    fn registry_insert_and_remove() {
+        let registry: SharedWebSocketRegistry = Arc::new(parking_lot::RwLock::new(
+            crate::state::WebSocketRegistry::default(),
+        ));
+        let (id, _rx) = register(
+            registry.clone(),
+            "api-1".into(),
+            "dev".into(),
+            "127.0.0.1".into(),
+        );
+        assert!(registry.read().contains(&id));
+        deregister(&registry, &id);
+        assert!(!registry.read().contains(&id));
+    }
+
+    #[tokio::test]
+    async fn outbound_send_reaches_receiver() {
+        let registry: SharedWebSocketRegistry = Arc::new(parking_lot::RwLock::new(
+            crate::state::WebSocketRegistry::default(),
+        ));
+        let (id, mut rx) = register(
+            registry.clone(),
+            "api-1".into(),
+            "dev".into(),
+            "127.0.0.1".into(),
+        );
+        let sender = registry.read().get(&id).unwrap().sender.clone();
+        sender.send(Message::Text("hello".into())).unwrap();
+        let msg = rx.recv().await.unwrap();
+        match msg {
+            Message::Text(t) => assert_eq!(t.as_str(), "hello"),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn close_message_breaks_lifecycle() {
+        // Verify that a `Close` outbound message cuts the loop. We use a
+        // `mpsc` directly, swapping in a fake socket would require pulling
+        // tungstenite — keep this as a contract test on the channel side.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        tx.send(Message::Close(None)).unwrap();
+        drop(tx);
+        let next = rx.recv().await;
+        assert!(matches!(next, Some(Message::Close(_))));
+        assert!(rx.recv().await.is_none());
+    }
+}

--- a/crates/fakecloud-apigatewayv2/tests/websocket_e2e.rs
+++ b/crates/fakecloud-apigatewayv2/tests/websocket_e2e.rs
@@ -1,0 +1,208 @@
+//! End-to-end WebSocket data plane tests.
+//!
+//! Boots a minimal axum app with the same routes the server wires up and
+//! drives them through `tokio-tungstenite` to assert real upgrade -> message
+//! -> close round-trips. Mirrors the server's `/_fakecloud/apigatewayv2/ws/{api_id}`
+//! and `/@connections/{id}` handlers; if the server's wiring drifts, these
+//! tests will pass against the harness but the production server still needs
+//! the same shape — see `crates/fakecloud-server/src/main.rs`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::ws::Message;
+use axum::Router;
+use fakecloud_apigatewayv2::{websocket, SharedWebSocketRegistry, WebSocketRegistry};
+use futures_util::StreamExt as _;
+use tokio::net::TcpListener;
+
+fn make_app(registry: SharedWebSocketRegistry) -> Router {
+    Router::new()
+        .route(
+            "/_fakecloud/apigatewayv2/ws/{api_id}",
+            axum::routing::get({
+                let reg = registry.clone();
+                move |ws: axum::extract::WebSocketUpgrade,
+                      axum::extract::Path(api_id): axum::extract::Path<String>,
+                      axum::extract::Query(_params): axum::extract::Query<
+                    HashMap<String, String>,
+                >| {
+                    let reg = reg.clone();
+                    async move {
+                        ws.on_upgrade(move |socket| async move {
+                            let (conn_id, rx) = websocket::register(
+                                reg.clone(),
+                                api_id,
+                                "$default".to_string(),
+                                "127.0.0.1".to_string(),
+                            );
+                            websocket::run_lifecycle(socket, rx, |_b, _t| async {}).await;
+                            websocket::deregister(&reg, &conn_id);
+                        })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/@connections/{connection_id}",
+            axum::routing::post({
+                let reg = registry.clone();
+                move |axum::extract::Path(id): axum::extract::Path<String>,
+                      body: axum::body::Bytes| {
+                    let reg = reg.clone();
+                    async move {
+                        let sender = {
+                            let r = reg.read();
+                            r.get(&id).map(|c| c.sender.clone())
+                        };
+                        let Some(sender) = sender else {
+                            return axum::http::StatusCode::GONE;
+                        };
+                        let msg = match std::str::from_utf8(&body) {
+                            Ok(s) => Message::Text(s.to_string().into()),
+                            Err(_) => Message::Binary(body),
+                        };
+                        if sender.send(msg).is_err() {
+                            reg.write().remove(&id);
+                            return axum::http::StatusCode::GONE;
+                        }
+                        axum::http::StatusCode::OK
+                    }
+                }
+            })
+            .delete({
+                let reg = registry.clone();
+                move |axum::extract::Path(id): axum::extract::Path<String>| {
+                    let reg = reg.clone();
+                    async move {
+                        let removed = reg.write().remove(&id);
+                        let Some(info) = removed else {
+                            return axum::http::StatusCode::GONE;
+                        };
+                        let _ = info.sender.send(Message::Close(None));
+                        axum::http::StatusCode::NO_CONTENT
+                    }
+                }
+            }),
+        )
+}
+
+async fn spawn_app(registry: SharedWebSocketRegistry) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = make_app(registry);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("127.0.0.1:{}", addr.port())
+}
+
+async fn open_ws(
+    addr: &str,
+    api_id: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let url = format!("ws://{}/_fakecloud/apigatewayv2/ws/{}", addr, api_id);
+    let (stream, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+    stream
+}
+
+async fn wait_for_connection(registry: &SharedWebSocketRegistry) -> String {
+    for _ in 0..50 {
+        if let Some(id) = registry.read().connections.keys().next().cloned() {
+            return id;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("no connection registered within timeout");
+}
+
+#[tokio::test]
+async fn websocket_upgrade_creates_connection_record() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let _ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    assert!(registry.read().contains(&id));
+}
+
+#[tokio::test]
+async fn websocket_disconnect_removes_connection() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let mut ws = open_ws(&addr, "api-1").await;
+    let _id = wait_for_connection(&registry).await;
+    ws.close(None).await.unwrap();
+    drop(ws);
+    for _ in 0..50 {
+        if registry.read().connections.is_empty() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("connection not removed within timeout");
+}
+
+#[tokio::test]
+async fn post_to_connections_endpoint_sends_message_to_client() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let mut ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/@connections/{}", addr, id))
+        .body("hello-from-server")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let msg = ws.next().await.unwrap().unwrap();
+    match msg {
+        tokio_tungstenite::tungstenite::Message::Text(t) => {
+            assert_eq!(t.as_str(), "hello-from-server");
+        }
+        other => panic!("expected text frame, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn post_to_connections_endpoint_returns_410_when_connection_gone() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/@connections/{}", addr, "missing="))
+        .body("payload")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 410);
+}
+
+#[tokio::test]
+async fn delete_connection_closes_websocket() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let mut ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!("http://{}/@connections/{}", addr, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    // The server should send a close frame; tungstenite surfaces it as
+    // either a Close message or an end-of-stream.
+    let msg = ws.next().await;
+    match msg {
+        Some(Ok(tokio_tungstenite::tungstenite::Message::Close(_))) | None => {}
+        Some(Ok(other)) => panic!("expected close, got {other:?}"),
+        Some(Err(err)) => panic!("ws error: {err}"),
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -295,6 +295,10 @@ async fn main() {
         ),
     ));
 
+    let apigatewayv2_ws_registry: fakecloud_apigatewayv2::SharedWebSocketRegistry = Arc::new(
+        parking_lot::RwLock::new(fakecloud_apigatewayv2::WebSocketRegistry::default()),
+    );
+
     let apigatewayv1_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,
@@ -4611,6 +4615,165 @@ async fn main() {
                         axum::Json(serde_json::json!({
                             "requests": state.request_history
                         }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/apigatewayv2/connections",
+            axum::routing::get({
+                let reg = apigatewayv2_ws_registry.clone();
+                move || {
+                    let reg = reg.clone();
+                    async move {
+                        let r = reg.read();
+                        let conns: Vec<_> = r
+                            .connections
+                            .values()
+                            .map(|c| {
+                                serde_json::json!({
+                                    "connectionId": c.connection_id,
+                                    "apiId": c.api_id,
+                                    "stage": c.stage,
+                                    "connectedAt": c.connected_at.to_rfc3339(),
+                                    "lastActiveAt": c.last_active_at.to_rfc3339(),
+                                    "sourceIp": c.source_ip,
+                                })
+                            })
+                            .collect();
+                        axum::Json(serde_json::json!({ "connections": conns }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/apigatewayv2/ws/{api_id}",
+            axum::routing::get({
+                let reg = apigatewayv2_ws_registry.clone();
+                move |ws: axum::extract::WebSocketUpgrade,
+                      axum::extract::Path(api_id): axum::extract::Path<String>,
+                      axum::extract::Query(params): axum::extract::Query<
+                    std::collections::HashMap<String, String>,
+                >| {
+                    let reg = reg.clone();
+                    async move {
+                        let stage = params
+                            .get("stage")
+                            .cloned()
+                            .unwrap_or_else(|| "$default".to_string());
+                        ws.on_upgrade(move |socket| async move {
+                            let (conn_id, rx) = fakecloud_apigatewayv2::websocket::register(
+                                reg.clone(),
+                                api_id,
+                                stage,
+                                "127.0.0.1".to_string(),
+                            );
+                            // Echo dispatcher stub — real Lambda dispatch for
+                            // `$default` is wired up in a follow-up; for now
+                            // we just log. `@connections` POST exercises the
+                            // outbound path end-to-end.
+                            let on_message = |bytes: Vec<u8>, is_text: bool| {
+                                let preview =
+                                    String::from_utf8_lossy(&bytes[..bytes.len().min(64)])
+                                        .to_string();
+                                async move {
+                                    tracing::debug!(
+                                        is_text,
+                                        preview = %preview,
+                                        "apigwv2 ws message received"
+                                    );
+                                }
+                            };
+                            fakecloud_apigatewayv2::websocket::run_lifecycle(
+                                socket, rx, on_message,
+                            )
+                            .await;
+                            fakecloud_apigatewayv2::websocket::deregister(&reg, &conn_id);
+                        })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/@connections/{connection_id}",
+            axum::routing::post({
+                let reg = apigatewayv2_ws_registry.clone();
+                move |axum::extract::Path(connection_id): axum::extract::Path<String>,
+                      body: axum::body::Bytes| {
+                    let reg = reg.clone();
+                    async move {
+                        let sender = {
+                            let r = reg.read();
+                            r.get(&connection_id).map(|c| c.sender.clone())
+                        };
+                        let Some(sender) = sender else {
+                            return (
+                                axum::http::StatusCode::GONE,
+                                axum::Json(serde_json::json!({
+                                    "Message": "GoneException",
+                                })),
+                            );
+                        };
+                        let msg = match std::str::from_utf8(&body) {
+                            Ok(s) => axum::extract::ws::Message::Text(s.to_string().into()),
+                            Err(_) => axum::extract::ws::Message::Binary(body.clone()),
+                        };
+                        if sender.send(msg).is_err() {
+                            // Receiver dropped between read and send: treat as
+                            // gone too. Clean up the stale entry while we're
+                            // here so retries don't keep hitting this branch.
+                            reg.write().remove(&connection_id);
+                            return (
+                                axum::http::StatusCode::GONE,
+                                axum::Json(serde_json::json!({
+                                    "Message": "GoneException",
+                                })),
+                            );
+                        }
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::json!({})),
+                        )
+                    }
+                }
+            })
+            .get({
+                let reg = apigatewayv2_ws_registry.clone();
+                move |axum::extract::Path(connection_id): axum::extract::Path<String>| {
+                    let reg = reg.clone();
+                    async move {
+                        let r = reg.read();
+                        let Some(c) = r.get(&connection_id) else {
+                            return (
+                                axum::http::StatusCode::GONE,
+                                axum::Json(serde_json::json!({
+                                    "Message": "GoneException",
+                                })),
+                            );
+                        };
+                        (
+                            axum::http::StatusCode::OK,
+                            axum::Json(serde_json::json!({
+                                "ConnectedAt": c.connected_at.to_rfc3339(),
+                                "Identity": { "SourceIp": c.source_ip },
+                                "LastActiveAt": c.last_active_at.to_rfc3339(),
+                            })),
+                        )
+                    }
+                }
+            })
+            .delete({
+                let reg = apigatewayv2_ws_registry.clone();
+                move |axum::extract::Path(connection_id): axum::extract::Path<String>| {
+                    let reg = reg.clone();
+                    async move {
+                        let removed = reg.write().remove(&connection_id);
+                        let Some(info) = removed else {
+                            return axum::http::StatusCode::GONE;
+                        };
+                        // Trigger lifecycle exit on the connection task.
+                        let _ = info.sender.send(axum::extract::ws::Message::Close(None));
+                        axum::http::StatusCode::NO_CONTENT
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- Accept `protocolType=WEBSOCKET` in `CreateApi` and apply WebSocket defaults (`$request.body.action` route selection, configurable via the request body).
- Add `WebSocketRegistry` to track live connections with an outbound `mpsc` sender; lives outside the persisted `ApiGatewayV2State` since senders aren't serializable.
- Wire an upgrade handler at `/_fakecloud/apigatewayv2/ws/{api_id}` plus a `/@connections/{connection_id}` control surface (POST sends a frame, GET returns metadata, DELETE closes).
- Lambda dispatch for `$connect` / `$disconnect` / `$default` is left as a follow-up; the registry + outbound path are covered end-to-end by 5 `tokio-tungstenite` integration tests.

## Test plan
- [x] `cargo build -p fakecloud-apigatewayv2 -p fakecloud`
- [x] `cargo test -p fakecloud-apigatewayv2 --lib` (88 passed, including 4 new websocket unit tests)
- [x] `cargo test -p fakecloud-apigatewayv2 --tests` (5 new E2E tests pass: upgrade, disconnect, POST send, 410 gone, DELETE close)
- [x] `cargo clippy -p fakecloud-apigatewayv2 -p fakecloud --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WebSocket support to API Gateway v2, including `protocolType=WEBSOCKET` in CreateApi, a live connection registry, a WS upgrade endpoint, and a `/@connections` data plane to send, inspect, and close sockets. Lambda dispatch for `$connect`, `$disconnect`, and `$default` will come later.

- **New Features**
  - Accept `protocolType=WEBSOCKET` in CreateApi with WebSocket defaults (`$request.body.action` route selection; overrides allowed).
  - Add `WebSocketRegistry` to track connections and provide an outbound channel.
  - Server routes:
    - Upgrade at `/_fakecloud/apigatewayv2/ws/{api_id}` (optional `stage` query).
    - Control surface at `/@connections/{connection_id}`: POST sends a frame (text or binary), GET returns metadata, DELETE closes the socket; returns 410 when the connection is gone.

- **Dependencies**
  - Enable `axum` with the `ws` feature.
  - Add `tokio-tungstenite` for end-to-end WebSocket tests.

<sup>Written for commit 516b64170b733a83c9a139ae9d05a377b650e31d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

