### PR TITLE
feat(iam): real SimulateCustomPolicy + SimulatePrincipalPolicy (F2)

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -148,6 +148,66 @@ fn service_credential_xml(c: &ServiceSpecificCredential, include_password: bool)
     )
 }
 
+/// Walk `ContextEntries.member.N` and route values into the right
+/// bucket on `ctx`. Tag-style keys (`aws:RequestTag/*`,
+/// `aws:ResourceTag/*`, `aws:PrincipalTag/*`) populate the typed maps
+/// the evaluator's tag operators read; everything else lands in
+/// `service_keys` (lowercased), which `ConditionContext::lookup` falls
+/// through to for unrecognized keys.
+fn apply_context_entries(req: &AwsRequest, ctx: &mut fakecloud_core::auth::ConditionContext) {
+    use std::collections::HashMap;
+    for i in 1..=128 {
+        let k = format!("ContextEntries.member.{i}.ContextKeyName");
+        let Some(name) = req.query_params.get(&k) else {
+            break;
+        };
+        let mut values: Vec<String> = Vec::new();
+        for j in 1..=32 {
+            let vk = format!("ContextEntries.member.{i}.ContextKeyValues.member.{j}");
+            if let Some(v) = req.query_params.get(&vk) {
+                values.push(v.clone());
+            } else {
+                break;
+            }
+        }
+        let lower = name.to_ascii_lowercase();
+        // Tag-key prefix lengths: aws:resourcetag/=16, aws:requesttag/=15,
+        // aws:principaltag/=17.
+        let single_value = || values.first().cloned().unwrap_or_default();
+        if let Some(rest) = name
+            .get(..16)
+            .filter(|p| p.eq_ignore_ascii_case("aws:ResourceTag/"))
+            .map(|_| &name[16..])
+        {
+            ctx.resource_tags
+                .get_or_insert_with(HashMap::new)
+                .insert(rest.to_string(), single_value());
+            continue;
+        }
+        if let Some(rest) = name
+            .get(..15)
+            .filter(|p| p.eq_ignore_ascii_case("aws:RequestTag/"))
+            .map(|_| &name[15..])
+        {
+            ctx.request_tags
+                .get_or_insert_with(HashMap::new)
+                .insert(rest.to_string(), single_value());
+            continue;
+        }
+        if let Some(rest) = name
+            .get(..17)
+            .filter(|p| p.eq_ignore_ascii_case("aws:PrincipalTag/"))
+            .map(|_| &name[17..])
+        {
+            ctx.principal_tags
+                .get_or_insert_with(HashMap::new)
+                .insert(rest.to_string(), single_value());
+            continue;
+        }
+        ctx.service_keys.insert(lower, values);
+    }
+}
+
 fn random_id(prefix: &str) -> String {
     format!(
         "{}{}",
@@ -688,7 +748,6 @@ impl IamService {
     ) -> Result<AwsResponse, AwsServiceError> {
         use crate::evaluator::{evaluate_with_gates, Decision, EvalRequest, PolicyDocument};
         use fakecloud_core::auth::{ConditionContext, Principal, PrincipalType};
-        use std::collections::BTreeMap;
 
         let actions = collect_member_list(req, "ActionNames.member.");
         if actions.is_empty() {
@@ -763,27 +822,6 @@ impl IamService {
             _ => {}
         }
 
-        // ContextEntries -> ConditionContext.service_keys (single
-        // bucket; populating typed fields requires per-key dispatch
-        // which the evaluator already handles via lookup).
-        let mut service_keys: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for i in 1..=128 {
-            let k = format!("ContextEntries.member.{i}.ContextKeyName");
-            let Some(name) = req.query_params.get(&k) else {
-                break;
-            };
-            let mut values: Vec<String> = Vec::new();
-            for j in 1..=32 {
-                let vk = format!("ContextEntries.member.{i}.ContextKeyValues.member.{j}");
-                if let Some(v) = req.query_params.get(&vk) {
-                    values.push(v.clone());
-                } else {
-                    break;
-                }
-            }
-            service_keys.insert(name.to_lowercase(), values);
-        }
-
         let principal_arn_str = caller_arn
             .clone()
             .unwrap_or_else(|| format!("arn:aws:iam::{}:root", req.account_id));
@@ -795,12 +833,18 @@ impl IamService {
             source_identity: None,
             tags: None,
         };
-        let ctx = ConditionContext {
+        let mut ctx = ConditionContext {
             aws_principal_arn: Some(principal_arn_str.clone()),
             aws_principal_account: Some(req.account_id.clone()),
-            service_keys,
             ..Default::default()
         };
+        // Route ContextEntries into the typed buckets the evaluator
+        // consults: aws:RequestTag/* / aws:ResourceTag/* /
+        // aws:PrincipalTag/* live in dedicated maps; everything else
+        // (service-specific keys + global scalars) lands in
+        // service_keys, which `ConditionContext::lookup` falls through
+        // to for any key it doesn't recognize.
+        apply_context_entries(req, &mut ctx);
 
         let mut members = String::new();
         for action_name in &actions {
@@ -819,7 +863,7 @@ impl IamService {
                     Decision::ExplicitDeny => "explicitDeny",
                 };
                 members.push_str(&format!(
-                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision></member>",
+                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision><MatchedStatements/><MissingContextValues/></member>",
                     xml_escape(action_name),
                     xml_escape(resource),
                     decision_str

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -3611,6 +3611,116 @@ fn simulate_custom_policy_requires_action_names() {
 }
 
 #[test]
+fn simulate_custom_policy_evaluates_condition_keys() {
+    let svc = make_service();
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*","Condition":{"StringEquals":{"aws:RequestTag/foo":"bar"}}}]}"#;
+
+    // Matching tag value -> allowed.
+    let resp = svc
+        .simulate_custom_policy(&make_request(
+            "SimulateCustomPolicy",
+            vec![
+                ("PolicyInputList.member.1", policy),
+                ("ActionNames.member.1", "s3:PutObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+                (
+                    "ContextEntries.member.1.ContextKeyName",
+                    "aws:RequestTag/foo",
+                ),
+                ("ContextEntries.member.1.ContextKeyValues.member.1", "bar"),
+                ("ContextEntries.member.1.ContextKeyType", "string"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<EvalDecision>allowed</EvalDecision>"),
+        "expected allowed when condition matches, body: {body}"
+    );
+
+    // Different tag value -> implicit deny (Condition false, no Allow matches).
+    let resp = svc
+        .simulate_custom_policy(&make_request(
+            "SimulateCustomPolicy",
+            vec![
+                ("PolicyInputList.member.1", policy),
+                ("ActionNames.member.1", "s3:PutObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+                (
+                    "ContextEntries.member.1.ContextKeyName",
+                    "aws:RequestTag/foo",
+                ),
+                ("ContextEntries.member.1.ContextKeyValues.member.1", "baz"),
+                ("ContextEntries.member.1.ContextKeyType", "string"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<EvalDecision>implicitDeny</EvalDecision>"),
+        "expected implicitDeny when condition fails, body: {body}"
+    );
+}
+
+#[test]
+fn simulate_principal_policy_blocked_by_permission_boundary() {
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "bob")]))
+        .unwrap();
+
+    // Identity policy grants s3:GetObject.
+    let identity_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    svc.create_policy(&make_request(
+        "CreatePolicy",
+        vec![
+            ("PolicyName", "GrantS3Get"),
+            ("PolicyDocument", identity_doc),
+        ],
+    ))
+    .unwrap();
+    let identity_arn = "arn:aws:iam::123456789012:policy/GrantS3Get";
+    svc.attach_user_policy(&make_request(
+        "AttachUserPolicy",
+        vec![("UserName", "bob"), ("PolicyArn", identity_arn)],
+    ))
+    .unwrap();
+
+    // Boundary only allows ec2 actions, so it does not allow s3:GetObject.
+    let boundary_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:Describe*","Resource":"*"}]}"#;
+    svc.create_policy(&make_request(
+        "CreatePolicy",
+        vec![
+            ("PolicyName", "BoundaryEc2Only"),
+            ("PolicyDocument", boundary_doc),
+        ],
+    ))
+    .unwrap();
+    let boundary_arn = "arn:aws:iam::123456789012:policy/BoundaryEc2Only";
+    svc.put_user_permissions_boundary(&make_request(
+        "PutUserPermissionsBoundary",
+        vec![("UserName", "bob"), ("PermissionsBoundary", boundary_arn)],
+    ))
+    .unwrap();
+
+    let user_arn = "arn:aws:iam::123456789012:user/bob";
+    let resp = svc
+        .simulate_principal_policy(&make_request(
+            "SimulatePrincipalPolicy",
+            vec![
+                ("PolicySourceArn", user_arn),
+                ("ActionNames.member.1", "s3:GetObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<EvalDecision>implicitDeny</EvalDecision>"),
+        "expected implicitDeny when boundary blocks, body: {body}"
+    );
+}
+
+#[test]
 fn misc_extras_smoke() {
     let svc = make_service();
     svc.create_user(&make_request("CreateUser", vec![("UserName", "u1")]))


### PR DESCRIPTION
## Summary
- Route ``ContextEntries.member.N`` into the typed ``request_tags`` / ``resource_tags`` / ``principal_tags`` buckets so ``aws:*Tag/<key>`` conditions actually resolve during simulation (previously dumped everything into ``service_keys``, where the typed-key lookup short-circuited before falling through).
- Emit ``<MatchedStatements/>`` and ``<MissingContextValues/>`` inside each ``EvaluationResult`` member to match the AWS XML envelope.
- Add ``simulate_custom_policy_evaluates_condition_keys`` covering matching + non-matching ``aws:RequestTag/foo`` ContextEntries and ``simulate_principal_policy_blocked_by_permission_boundary`` covering the boundary-cap path on a real user.

## Test plan
- [x] ``cargo build -p fakecloud-iam``
- [x] ``cargo test -p fakecloud-iam --lib`` (400 passed)
- [x] ``cargo test --workspace --lib`` (no regressions)
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo fmt --all``

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly evaluates `aws:*Tag/<key>` conditions in SimulateCustomPolicy and SimulatePrincipalPolicy by routing `ContextEntries.member.N` into `request_tags`, `resource_tags`, and `principal_tags` instead of `service_keys`.
Adds `<MatchedStatements/>` and `<MissingContextValues/>` to each `EvaluationResult` to match the AWS XML response shape.

<sup>Written for commit 307eb39ef43739ea93a186c9ad1df29c7d009a46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

