### PR TITLE
feat(elasticache): ModifyReplicationGroup accepts auth/encryption/log/multi-AZ fields (N3)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8099,6 +8099,7 @@ impl ResourceProvisioner {
                 .and_then(|v| v.as_str())
                 .map(String::from),
             data_tiering_enabled: props.get("DataTieringEnabled").and_then(|v| v.as_bool()),
+            notification_topic_status: None,
         };
         state.replication_groups.insert(id.clone(), group);
 

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -937,9 +937,14 @@ pub(crate) fn replication_group_xml(g: &ReplicationGroup, region: &str) -> Strin
         .notification_topic_arn
         .as_ref()
         .map(|t| {
+            let status = g
+                .notification_topic_status
+                .as_deref()
+                .unwrap_or("active");
             format!(
-                "<NotificationConfiguration><TopicArn>{}</TopicArn><TopicStatus>active</TopicStatus></NotificationConfiguration>",
-                xml_escape(t)
+                "<NotificationConfiguration><TopicArn>{}</TopicArn><TopicStatus>{}</TopicStatus></NotificationConfiguration>",
+                xml_escape(t),
+                xml_escape(status),
             )
         })
         .unwrap_or_default();

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -1309,6 +1309,7 @@ impl ElastiCacheService {
             notification_topic_arn,
             cluster_mode,
             data_tiering_enabled,
+            notification_topic_status: None,
         };
 
         let xml = replication_group_xml(&group, &region);
@@ -2361,6 +2362,25 @@ impl ElastiCacheService {
             parse_member_list(&request.query_params, "UserGroupIdsToAdd", "member");
         let user_group_ids_to_remove =
             parse_member_list(&request.query_params, "UserGroupIdsToRemove", "member");
+        let new_auth_token = optional_query_param(request, "AuthToken");
+        let new_auth_token_strategy = optional_query_param(request, "AuthTokenUpdateStrategy");
+        let new_transit_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "TransitEncryptionEnabled").as_deref(),
+        )?;
+        let new_multi_az_enabled =
+            parse_optional_bool(optional_query_param(request, "MultiAZEnabled").as_deref())?;
+        let remove_user_groups =
+            parse_optional_bool(optional_query_param(request, "RemoveUserGroups").as_deref())?;
+        let new_log_delivery_configurations = parse_log_delivery_configs(request);
+        let has_log_delivery_input = !new_log_delivery_configurations.is_empty()
+            || request.query_params.keys().any(|k| {
+                k.starts_with("LogDeliveryConfigurations.LogDeliveryConfigurationRequest.")
+            });
+        let new_ip_discovery = optional_query_param(request, "IpDiscovery");
+        let new_network_type = optional_query_param(request, "NetworkType");
+        let new_notification_topic_arn = optional_query_param(request, "NotificationTopicArn");
+        let new_notification_topic_status =
+            optional_query_param(request, "NotificationTopicStatus");
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
@@ -2393,6 +2413,59 @@ impl ElastiCacheService {
         }
         if let Some(window) = new_snapshot_window {
             group.snapshot_window = window;
+        }
+        if let Some(transit) = new_transit_encryption_enabled {
+            group.transit_encryption_enabled = transit;
+        }
+        if let Some(multi_az) = new_multi_az_enabled {
+            group.multi_az_enabled = multi_az;
+        }
+        if let Some(ip_discovery) = new_ip_discovery {
+            group.ip_discovery = Some(ip_discovery);
+        }
+        if let Some(network_type) = new_network_type {
+            group.network_type = Some(network_type);
+        }
+        if let Some(arn) = new_notification_topic_arn {
+            group.notification_topic_arn = Some(arn);
+        }
+        if let Some(status) = new_notification_topic_status {
+            group.notification_topic_status = Some(status);
+        }
+        if has_log_delivery_input {
+            group.log_delivery_configurations = new_log_delivery_configurations;
+        }
+        if remove_user_groups == Some(true) {
+            group.user_group_ids.clear();
+        }
+        // AuthToken rotation: SET / ROTATE store the new token, DELETE clears
+        // it. Default strategy is SET when AuthToken is supplied without one.
+        match new_auth_token_strategy.as_deref() {
+            Some("DELETE") => {
+                group.auth_token = None;
+                group.auth_token_enabled = false;
+            }
+            Some("SET") | Some("ROTATE") => {
+                if let Some(token) = new_auth_token {
+                    group.auth_token = Some(token);
+                    group.auth_token_enabled = true;
+                }
+            }
+            Some(other) => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Invalid value for AuthTokenUpdateStrategy: '{other}'. Valid values: SET, ROTATE, DELETE."
+                    ),
+                ));
+            }
+            None => {
+                if let Some(token) = new_auth_token {
+                    group.auth_token = Some(token);
+                    group.auth_token_enabled = true;
+                }
+            }
         }
 
         // Associate/disassociate user groups

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -940,6 +940,7 @@ fn add_cluster_to_replication_group_updates_members_and_count() {
             notification_topic_arn: None,
             cluster_mode: None,
             data_tiering_enabled: None,
+            notification_topic_status: None,
         },
     );
 
@@ -1005,6 +1006,7 @@ async fn delete_cache_cluster_removes_cluster_from_replication_group() {
                 notification_topic_arn: None,
                 cluster_mode: None,
                 data_tiering_enabled: None,
+                notification_topic_status: None,
             },
         );
     }
@@ -1095,6 +1097,7 @@ fn service_with_replication_group(group_id: &str, num_clusters: i32) -> ElastiCa
                 notification_topic_arn: None,
                 cluster_mode: None,
                 data_tiering_enabled: None,
+                notification_topic_status: None,
             },
         );
     }
@@ -1363,6 +1366,7 @@ fn replication_group_xml_emits_dynamic_encryption_and_kms() {
             notification_topic_arn: Some("arn:aws:sns:us-east-1:123:topic-a".to_string()),
             cluster_mode: Some("enabled".to_string()),
             data_tiering_enabled: Some(false),
+            notification_topic_status: None,
         },
     );
     let xml =
@@ -1485,6 +1489,234 @@ fn modify_replication_group_not_found() {
         &[("ReplicationGroupId", "nonexistent")],
     );
     assert!(service.modify_replication_group(&req).is_err());
+}
+
+#[test]
+fn modify_replication_group_updates_auth_token_with_set() {
+    let service = service_with_replication_group("rg-auth", 1);
+    {
+        let mut a = service.state.write();
+        let g = a
+            .default_mut()
+            .replication_groups
+            .get_mut("rg-auth")
+            .unwrap();
+        g.auth_token = Some("a".to_string());
+        g.auth_token_enabled = true;
+    }
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-auth"),
+            ("AuthToken", "b"),
+            ("AuthTokenUpdateStrategy", "SET"),
+        ],
+    );
+    let resp = service.modify_replication_group(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    // Token is never echoed back in the XML payload.
+    assert!(!body.contains("<AuthToken>"));
+    assert!(body.contains("<AuthTokenEnabled>true</AuthTokenEnabled>"));
+
+    let a = service.state.read();
+    let g = a.default_ref().replication_groups.get("rg-auth").unwrap();
+    assert_eq!(g.auth_token.as_deref(), Some("b"));
+    assert!(g.auth_token_enabled);
+}
+
+#[test]
+fn modify_replication_group_delete_auth_token_strategy_clears_token() {
+    let service = service_with_replication_group("rg-del", 1);
+    {
+        let mut a = service.state.write();
+        let g = a
+            .default_mut()
+            .replication_groups
+            .get_mut("rg-del")
+            .unwrap();
+        g.auth_token = Some("secret".to_string());
+        g.auth_token_enabled = true;
+    }
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-del"),
+            ("AuthTokenUpdateStrategy", "DELETE"),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let a = service.state.read();
+    let g = a.default_ref().replication_groups.get("rg-del").unwrap();
+    assert!(g.auth_token.is_none());
+    assert!(!g.auth_token_enabled);
+}
+
+#[test]
+fn modify_replication_group_remove_user_groups_clears_list() {
+    let service = service_with_replication_group("rg-ug", 1);
+    {
+        let mut a = service.state.write();
+        let g = a.default_mut().replication_groups.get_mut("rg-ug").unwrap();
+        g.user_group_ids = vec!["a".to_string(), "b".to_string()];
+    }
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-ug"),
+            ("RemoveUserGroups", "true"),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let a = service.state.read();
+    let g = a.default_ref().replication_groups.get("rg-ug").unwrap();
+    assert!(g.user_group_ids.is_empty());
+}
+
+#[test]
+fn modify_replication_group_persists_log_delivery_changes() {
+    let service = service_with_replication_group("rg-log", 1);
+    {
+        let mut a = service.state.write();
+        let g = a
+            .default_mut()
+            .replication_groups
+            .get_mut("rg-log")
+            .unwrap();
+        g.log_delivery_configurations = vec![crate::state::LogDeliveryConfiguration {
+            log_type: "slow-log".to_string(),
+            destination_type: "cloudwatch-logs".to_string(),
+            destination_details: Some("/aws/orig".to_string()),
+            log_format: "json".to_string(),
+            status: "active".to_string(),
+        }];
+    }
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-log"),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.LogType",
+                "slow-log",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.DestinationType",
+                "cloudwatch-logs",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.DestinationDetails.CloudWatchLogsDetails.LogGroup",
+                "/aws/new-slow",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.1.LogFormat",
+                "json",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.LogType",
+                "engine-log",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.DestinationType",
+                "kinesis-firehose",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.DestinationDetails.KinesisFirehoseDetails.DeliveryStream",
+                "engine-stream",
+            ),
+            (
+                "LogDeliveryConfigurations.LogDeliveryConfigurationRequest.2.LogFormat",
+                "text",
+            ),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let describe = request(
+        "DescribeReplicationGroups",
+        &[("ReplicationGroupId", "rg-log")],
+    );
+    let resp = service.describe_replication_groups(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("/aws/new-slow"));
+    assert!(body.contains("engine-stream"));
+    assert!(!body.contains("/aws/orig"));
+
+    let a = service.state.read();
+    let g = a.default_ref().replication_groups.get("rg-log").unwrap();
+    assert_eq!(g.log_delivery_configurations.len(), 2);
+}
+
+#[test]
+fn modify_replication_group_persists_multi_az_and_network_fields() {
+    let service = service_with_replication_group("rg-net", 1);
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-net"),
+            ("MultiAZEnabled", "true"),
+            ("IpDiscovery", "ipv6"),
+            ("NetworkType", "dual_stack"),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let describe = request(
+        "DescribeReplicationGroups",
+        &[("ReplicationGroupId", "rg-net")],
+    );
+    let resp = service.describe_replication_groups(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<MultiAZ>enabled</MultiAZ>"));
+    assert!(body.contains("<IpDiscovery>ipv6</IpDiscovery>"));
+    assert!(body.contains("<NetworkType>dual_stack</NetworkType>"));
+}
+
+#[test]
+fn modify_replication_group_persists_snapshot_retention_and_window() {
+    let service = service_with_replication_group("rg-snap", 1);
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-snap"),
+            ("SnapshotRetentionLimit", "14"),
+            ("SnapshotWindow", "01:00-03:00"),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let describe = request(
+        "DescribeReplicationGroups",
+        &[("ReplicationGroupId", "rg-snap")],
+    );
+    let resp = service.describe_replication_groups(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<SnapshotRetentionLimit>14</SnapshotRetentionLimit>"));
+    assert!(body.contains("<SnapshotWindow>01:00-03:00</SnapshotWindow>"));
+}
+
+#[test]
+fn modify_replication_group_persists_notification_topic_attrs() {
+    let service = service_with_replication_group("rg-notif", 1);
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:elasticache-events";
+    let req = request(
+        "ModifyReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-notif"),
+            ("NotificationTopicArn", topic_arn),
+            ("NotificationTopicStatus", "inactive"),
+        ],
+    );
+    service.modify_replication_group(&req).unwrap();
+
+    let describe = request(
+        "DescribeReplicationGroups",
+        &[("ReplicationGroupId", "rg-notif")],
+    );
+    let resp = service.describe_replication_groups(&describe).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains(&format!("<TopicArn>{topic_arn}</TopicArn>")));
+    assert!(body.contains("<TopicStatus>inactive</TopicStatus>"));
 }
 
 #[test]
@@ -2667,6 +2899,7 @@ fn replication_group_from_request(req: &AwsRequest) -> crate::state::Replication
         notification_topic_arn,
         cluster_mode,
         data_tiering_enabled,
+        notification_topic_status: None,
     }
 }
 

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -259,6 +259,10 @@ pub struct ReplicationGroup {
     /// `enabled`/`disabled` projection.
     #[serde(default)]
     pub data_tiering_enabled: Option<bool>,
+    /// `NotificationTopicStatus` from the most recent ModifyReplicationGroup
+    /// call. Defaults to `active` when emitting describe XML if unset.
+    #[serde(default)]
+    pub notification_topic_status: Option<String>,
 }
 
 /// AWS's LogDeliveryConfiguration shape, retained verbatim so we can
@@ -1233,6 +1237,7 @@ mod tests {
                 notification_topic_arn: None,
                 cluster_mode: None,
                 data_tiering_enabled: None,
+                notification_topic_status: None,
             },
         );
         assert_eq!(state.replication_groups.len(), 1);


### PR DESCRIPTION
## Summary
- Wire `ModifyReplicationGroup` to parse `AuthToken`/`AuthTokenUpdateStrategy` (SET/ROTATE/DELETE), `TransitEncryptionEnabled`, `MultiAZEnabled`, `RemoveUserGroups`, `LogDeliveryConfigurations`, `IpDiscovery`, `NetworkType`, `NotificationTopicArn`/`Status` — fields that already lived on the state struct from N1 but were dropped on the floor.
- Add `notification_topic_status` to `ReplicationGroup` so the topic status round-trips through Describe instead of always emitting hardcoded `active`.
- `AuthTokenUpdateStrategy=DELETE` clears the stored auth token and flips `auth_token_enabled` off; `SET`/`ROTATE` (and the no-strategy default) store the new value.
- Log delivery configs are replaced wholesale when the request supplies any `LogDeliveryConfigurations.LogDeliveryConfigurationRequest.N.*` keys, mirroring the N1 create-time parser.

## Test plan
- [x] `cargo build -p fakecloud-elasticache`
- [x] `cargo test -p fakecloud-elasticache --lib` (201 pass, including 7 new `modify_replication_group_*` round-trip tests)
- [ ] CI: `cargo test --workspace --lib`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `ModifyReplicationGroup` in `fakecloud-elasticache` to accept and persist auth, encryption, logging, network, and multi-AZ settings, plus `NotificationTopicStatus`. These values now round-trip via `DescribeReplicationGroups`.

- **New Features**
  - `AuthToken` with `AuthTokenUpdateStrategy` (`SET`/`ROTATE`/`DELETE`); `DELETE` clears the token and disables `auth_token_enabled`, others store and enable.
  - Supports `TransitEncryptionEnabled`, `MultiAZEnabled`, `IpDiscovery`, `NetworkType`, and `RemoveUserGroups` (clears `user_group_ids` when true).
  - Replaces `LogDeliveryConfigurations` wholesale when any `LogDeliveryConfigurations.LogDeliveryConfigurationRequest.N.*` keys are provided.
  - Persists `NotificationTopicArn` and `NotificationTopicStatus`; Describe emits the stored status (defaults to `active` when unset).

<sup>Written for commit 659ef5338254659aecf8dac3bcbeb5ef7eb4a841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

