### PR TITLE
feat(ses): account + config-set sending pause + suppression enforcement (X2)

### DIFF
--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -93,7 +93,7 @@ impl SesV2Service {
             return Some(Self::json_error(
                 StatusCode::BAD_REQUEST,
                 "AccountSendingPausedException",
-                "Email sending is disabled for your account.",
+                "Email sending for the account is paused.",
             ));
         }
         if let Some(name) = config_set_name {
@@ -102,12 +102,26 @@ impl SesV2Service {
                     return Some(Self::json_error(
                         StatusCode::BAD_REQUEST,
                         "ConfigurationSetSendingPausedException",
-                        &format!("Email sending is disabled for the configuration set {name}."),
+                        &format!("Email sending for the configuration set {name} is paused."),
                     ));
                 }
             }
         }
         None
+    }
+
+    /// Returns `true` if `address` (or its domain) is on the account's
+    /// suppression list. Mirrors SES behavior where suppression is keyed
+    /// by exact address; we don't currently honor per-config-set
+    /// suppression overrides because the underlying state only tracks
+    /// account-level suppression.
+    pub(super) fn address_is_suppressed(&self, account_id: &str, address: &str) -> bool {
+        let accounts = self.state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return false;
+        };
+        let trimmed = address.trim();
+        state.suppressed_destinations.contains_key(trimmed)
     }
 
     /// Reject sends where the sender is not a verified identity. Mirrors
@@ -219,6 +233,19 @@ impl SesV2Service {
             .collect();
         if let Some(err) = self.reject_unverified_recipients(&req.account_id, &recipients) {
             return Ok(err);
+        }
+
+        // Single-recipient path: any suppressed recipient kills the send.
+        // Real SES surfaces this as `MessageRejected`.
+        for r in &recipients {
+            let addr = extract_email_address(r);
+            if self.address_is_suppressed(&req.account_id, addr) {
+                return Ok(Self::json_error(
+                    StatusCode::BAD_REQUEST,
+                    "MessageRejected",
+                    "Address is on the suppression list",
+                ));
+            }
         }
 
         let (subject, html_body, text_body, raw_data, template_name, template_data) =
@@ -347,6 +374,20 @@ impl SesV2Service {
                 results.push(json!({
                     "Status": "MESSAGE_REJECTED",
                     "Error": "Email address is not verified.",
+                }));
+                continue;
+            }
+
+            // Drop entries with any suppressed recipient. Mirrors SES,
+            // which fails the bulk entry rather than the whole batch.
+            let any_suppressed = recipients.iter().any(|r| {
+                let addr = extract_email_address(r);
+                self.address_is_suppressed(&req.account_id, addr)
+            });
+            if any_suppressed {
+                results.push(json!({
+                    "Status": "MESSAGE_REJECTED",
+                    "Error": "Address is on the suppression list",
                 }));
                 continue;
             }

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -3966,3 +3966,187 @@ async fn test_get_dedicated_ip_pool_unknown() {
     };
     assert_eq!(err.code(), "NotFoundException");
 }
+
+// ── X2: account + config-set sending pause + suppression enforcement ──
+
+#[tokio::test]
+async fn send_email_v2_rejects_when_account_sending_paused() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.account_settings.sending_enabled = false;
+    }
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "AccountSendingPausedException");
+    assert_eq!(body["message"], "Email sending for the account is paused.");
+}
+
+#[tokio::test]
+async fn send_email_v2_succeeds_when_paused_then_resumed() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.account_settings.sending_enabled = false;
+    }
+    let svc = SesV2Service::new(state.clone());
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+
+    // Resume sending
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.account_settings.sending_enabled = true;
+    }
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn send_email_v2_rejects_when_config_set_sending_paused() {
+    use crate::state::ConfigurationSet;
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.configuration_sets.insert(
+            "my-cs".to_string(),
+            ConfigurationSet {
+                name: "my-cs".to_string(),
+                sending_enabled: false,
+                tls_policy: "OPTIONAL".to_string(),
+                sending_pool_name: None,
+                custom_redirect_domain: None,
+                https_policy: None,
+                suppressed_reasons: Vec::new(),
+                reputation_metrics_enabled: false,
+                vdm_options: None,
+                archive_arn: None,
+            },
+        );
+    }
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["r@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}},
+            "ConfigurationSetName": "my-cs"
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "ConfigurationSetSendingPausedException");
+    assert_eq!(
+        body["message"],
+        "Email sending for the configuration set my-cs is paused."
+    );
+}
+
+#[tokio::test]
+async fn send_email_v2_skips_suppressed_recipient() {
+    use crate::state::SuppressedDestination;
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.suppressed_destinations.insert(
+            "blocked@example.com".to_string(),
+            SuppressedDestination {
+                email_address: "blocked@example.com".to_string(),
+                reason: "BOUNCE".to_string(),
+                last_update_time: chrono::Utc::now(),
+            },
+        );
+    }
+    let svc = SesV2Service::new(state);
+
+    // Single-recipient send: a suppressed To address fails the entire
+    // send with MessageRejected.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "Destination": {"ToAddresses": ["blocked@example.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["__type"], "MessageRejected");
+    assert!(body["message"]
+        .as_str()
+        .unwrap_or("")
+        .contains("Address is on the suppression list"));
+
+    // Bulk send: suppressed entry is dropped, others go through.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-bulk-emails",
+        r#"{
+            "FromEmailAddress": "sender@example.com",
+            "DefaultContent": {"Template": {"TemplateName": "t", "TemplateData": "{}"}},
+            "BulkEmailEntries": [
+                {"Destination": {"ToAddresses": ["ok@example.com"]}},
+                {"Destination": {"ToAddresses": ["blocked@example.com"]}}
+            ]
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let results = body["BulkEmailEntryResults"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["Status"], "SUCCESS");
+    assert_eq!(results[1]["Status"], "MESSAGE_REJECTED");
+    assert_eq!(results[1]["Error"], "Address is on the suppression list");
+}

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -209,6 +209,77 @@ pub(crate) fn check_v1_verified_recipients(
     }
 }
 
+/// Reject the send if either account-level sending or the resolved
+/// configuration set's sending flag is paused. Real SES v1 surfaces both
+/// as `MessageRejected` with a message identifying the paused scope.
+pub(crate) fn check_v1_sending_enabled(
+    state: &SharedSesState,
+    account_id: &str,
+    config_set_name: Option<&str>,
+) -> Result<(), AwsServiceError> {
+    let accounts = state.read();
+    let Some(st) = accounts.get(account_id) else {
+        return Ok(());
+    };
+    if !st.account_settings.sending_enabled {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MessageRejected",
+            "Email sending for the account is paused.".to_string(),
+        ));
+    }
+    if let Some(name) = config_set_name {
+        if let Some(cs) = st.configuration_sets.get(name) {
+            if !cs.sending_enabled {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MessageRejected",
+                    format!("Email sending for the configuration set {name} is paused."),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reject sends targeting a recipient on the account suppression list.
+/// Real SES v1 surfaces this as `MessageRejected`.
+pub(crate) fn check_v1_recipients_not_suppressed(
+    state: &SharedSesState,
+    account_id: &str,
+    recipients: &[String],
+) -> Result<(), AwsServiceError> {
+    let accounts = state.read();
+    let Some(st) = accounts.get(account_id) else {
+        return Ok(());
+    };
+    for r in recipients {
+        let addr = extract_email_address(r);
+        if addr.is_empty() {
+            continue;
+        }
+        if st.suppressed_destinations.contains_key(addr) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MessageRejected",
+                "Address is on the suppression list".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// True when `addr` is on the account suppression list. Used by bulk
+/// paths that filter per-destination instead of failing the whole batch.
+pub(crate) fn is_address_suppressed(state: &SharedSesState, account_id: &str, addr: &str) -> bool {
+    let accounts = state.read();
+    let Some(st) = accounts.get(account_id) else {
+        return false;
+    };
+    st.suppressed_destinations
+        .contains_key(extract_email_address(addr))
+}
+
 /// Parse a receipt rule from form parameters (for Create/Update).
 pub(crate) fn parse_receipt_rule(
     params: &HashMap<String, String>,
@@ -1070,6 +1141,8 @@ pub(crate) fn send_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    let config_set_name = req.query_params.get("ConfigurationSetName").cloned();
+    check_v1_sending_enabled(state, &req.account_id, config_set_name.as_deref())?;
     check_v1_verified_sender(state, &req.account_id, from)?;
     let to = parse_member_list(&req.query_params, "Destination.ToAddresses");
     let cc = parse_member_list(&req.query_params, "Destination.CcAddresses");
@@ -1081,6 +1154,7 @@ pub(crate) fn send_email(
         .cloned()
         .collect();
     check_v1_verified_recipients(state, &req.account_id, &recipients)?;
+    check_v1_recipients_not_suppressed(state, &req.account_id, &recipients)?;
 
     let subject = req.query_params.get("Message.Subject.Data").cloned();
     let html_body = req.query_params.get("Message.Body.Html.Data").cloned();
@@ -1150,11 +1224,14 @@ pub(crate) fn send_raw_email(
 ) -> Result<AwsResponse, AwsServiceError> {
     let raw_data = required_param(&req.query_params, "RawMessage.Data")?;
     let from = req.query_params.get("Source").cloned().unwrap_or_default();
+    let config_set_name = req.query_params.get("ConfigurationSetName").cloned();
+    check_v1_sending_enabled(state, &req.account_id, config_set_name.as_deref())?;
     if !from.is_empty() {
         check_v1_verified_sender(state, &req.account_id, &from)?;
     }
     let to = parse_member_list(&req.query_params, "Destinations");
     check_v1_verified_recipients(state, &req.account_id, &to)?;
+    check_v1_recipients_not_suppressed(state, &req.account_id, &to)?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1199,6 +1276,8 @@ pub(crate) fn send_templated_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    let config_set_name = req.query_params.get("ConfigurationSetName").cloned();
+    check_v1_sending_enabled(state, &req.account_id, config_set_name.as_deref())?;
     check_v1_verified_sender(state, &req.account_id, from)?;
     let template_name = required_param(&req.query_params, "Template")?;
     let template_data = required_param(&req.query_params, "TemplateData")?;
@@ -1227,6 +1306,7 @@ pub(crate) fn send_templated_email(
         .cloned()
         .collect();
     check_v1_verified_recipients(state, &req.account_id, &recipients)?;
+    check_v1_recipients_not_suppressed(state, &req.account_id, &recipients)?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1271,6 +1351,8 @@ pub(crate) fn send_bulk_templated_email(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let from = required_param(&req.query_params, "Source")?;
+    let config_set_name = req.query_params.get("ConfigurationSetName").cloned();
+    check_v1_sending_enabled(state, &req.account_id, config_set_name.as_deref())?;
     check_v1_verified_sender(state, &req.account_id, from)?;
     let template_name = required_param(&req.query_params, "Template")?;
     let default_template_data = req
@@ -1327,6 +1409,15 @@ pub(crate) fn send_bulk_templated_email(
                 "<member><Status>MessageRejected</Status><Error>{}</Error></member>",
                 xml_escape(&err.message()),
             ));
+            continue;
+        }
+        let any_suppressed = recipients
+            .iter()
+            .any(|r| is_address_suppressed(state, &req.account_id, r));
+        if any_suppressed {
+            inner.push_str(
+                "<member><Status>MessageRejected</Status><Error>Address is on the suppression list</Error></member>",
+            );
             continue;
         }
         let message_id = send_bulk_destination(

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1541,3 +1541,116 @@ fn test_get_account_sending_enabled() {
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<Enabled>true</Enabled>"));
 }
+
+// ── X2: account + config-set sending pause for v1 ──
+
+#[test]
+fn send_email_v1_account_pause() {
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.account_settings.sending_enabled = false;
+    }
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "sender@example.com"),
+            ("Destination.ToAddresses.member.1", "to@example.com"),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => {
+            assert_eq!(e.code(), "MessageRejected");
+            assert_eq!(e.message(), "Email sending for the account is paused.");
+        }
+        Ok(_) => panic!("expected MessageRejected"),
+    }
+}
+
+#[test]
+fn send_email_v1_config_set_pause() {
+    use crate::state::ConfigurationSet;
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.configuration_sets.insert(
+            "my-cs".to_string(),
+            ConfigurationSet {
+                name: "my-cs".to_string(),
+                sending_enabled: false,
+                tls_policy: "OPTIONAL".to_string(),
+                sending_pool_name: None,
+                custom_redirect_domain: None,
+                https_policy: None,
+                suppressed_reasons: Vec::new(),
+                reputation_metrics_enabled: false,
+                vdm_options: None,
+                archive_arn: None,
+            },
+        );
+    }
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "sender@example.com"),
+            ("Destination.ToAddresses.member.1", "to@example.com"),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+            ("ConfigurationSetName", "my-cs"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => {
+            assert_eq!(e.code(), "MessageRejected");
+            assert_eq!(
+                e.message(),
+                "Email sending for the configuration set my-cs is paused."
+            );
+        }
+        Ok(_) => panic!("expected MessageRejected"),
+    }
+}
+
+#[test]
+fn send_email_v1_skips_suppressed_recipient() {
+    use crate::state::SuppressedDestination;
+    let state = make_state();
+    seed_identity(&state, "sender@example.com");
+    enable_production_access(&state);
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.suppressed_destinations.insert(
+            "blocked@example.com".to_string(),
+            SuppressedDestination {
+                email_address: "blocked@example.com".to_string(),
+                reason: "BOUNCE".to_string(),
+                last_update_time: chrono::Utc::now(),
+            },
+        );
+    }
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "sender@example.com"),
+            ("Destination.ToAddresses.member.1", "blocked@example.com"),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => {
+            assert_eq!(e.code(), "MessageRejected");
+            assert_eq!(e.message(), "Address is on the suppression list");
+        }
+        Ok(_) => panic!("expected MessageRejected"),
+    }
+}


### PR DESCRIPTION
## Summary

- Account-level `sending_enabled=false` rejects every send path (v1 + v2) with the SES-spec exception (`AccountSendingPausedException` v2 / `MessageRejected` v1) and message `Email sending for the account is paused.`
- Config-set-level `sending_enabled=false` rejects sends that reference it with `ConfigurationSetSendingPausedException` v2 / `MessageRejected` v1, message `Email sending for the configuration set <name> is paused.`
- Account suppression-list enforcement at the send paths: single-recipient sends fail with `MessageRejected` (`Address is on the suppression list`); bulk paths drop the entry with `Status: MESSAGE_REJECTED, Error: Address is on the suppression list` and let other entries through.
- Both v1 and v2 `SendEmail` / `SendRawEmail` / `SendTemplatedEmail` / `SendBulk*Email` paths gated.

## Test plan

- [x] `cargo build -p fakecloud-ses`
- [x] `cargo test -p fakecloud-ses --lib` (222 passing, including 9 new X2 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add account- and configuration-set-level sending pause and suppression list enforcement to `fakecloud-ses`, matching SES behavior across v1 and v2 single and bulk send paths.

- **New Features**
  - Account sending pause: v2 returns `AccountSendingPausedException` (“Email sending for the account is paused.”); v1 returns `MessageRejected` with the same message.
  - Configuration set sending pause: v2 returns `ConfigurationSetSendingPausedException` (“Email sending for the configuration set <name> is paused.”); v1 returns `MessageRejected`.
  - Suppression list enforcement: single-recipient sends fail with `MessageRejected` (“Address is on the suppression list”); bulk entries are dropped with `Status: MESSAGE_REJECTED` and `Error: Address is on the suppression list`.
  - Applies to v1 and v2 `SendEmail`, `SendRawEmail`, `SendTemplatedEmail`, and `SendBulk*Email`.

<sup>Written for commit 26f79e01fa946595563afe692ba4f588bf650a44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

