### PR TITLE
feat(lambda): AddPermission action prefix + tag store unified (D3)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -293,7 +293,9 @@ async fn lambda_add_get_remove_permission_roundtrip() {
     let statement: serde_json::Value = serde_json::from_str(statement_str).unwrap();
     assert_eq!(statement["Sid"], "events-invoke");
     assert_eq!(statement["Principal"]["Service"], "events.amazonaws.com");
-    assert_eq!(statement["Action"], "lambda:InvokeFunction");
+    // Action is stored verbatim — caller passed `InvokeFunction`, so
+    // the round-trip preserves that, matching real AWS behavior.
+    assert_eq!(statement["Action"], "InvokeFunction");
     assert_eq!(
         statement["Condition"]["ArnLike"]["aws:SourceArn"],
         "arn:aws:events:us-east-1:123456789012:rule/my-rule"

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -72,8 +72,9 @@ fn body(req: &AwsRequest) -> Value {
 /// Extract the function name from a Lambda function ARN, ignoring any
 /// trailing `:version` / `:alias` qualifier. Returns `None` for ARNs
 /// that name a different resource type (event-source mapping,
-/// code-signing config, layer, …) so the caller can fall through to
-/// the keyed tag bag.
+/// code-signing config, layer, …) — Lambda only supports tags on
+/// function ARNs in this implementation, so non-function ARNs are
+/// rejected by callers as `InvalidParameterValueException`.
 fn function_name_from_arn(arn: &str) -> Option<String> {
     let rest = arn.strip_prefix("arn:aws:lambda:")?;
     let mut parts = rest.splitn(5, ':');
@@ -91,6 +92,34 @@ fn function_name_from_arn(arn: &str) -> Option<String> {
             .unwrap_or(name_with_qualifier)
             .to_string(),
     )
+}
+
+/// Parse a raw query string into key/value pairs preserving repeats.
+/// `req.query_params` is a `HashMap<String, String>` and so collapses
+/// `tagKeys=A&tagKeys=B` to a single entry; this lets the
+/// `UntagResource` handler see every value the caller actually sent.
+/// Percent-decodes both key and value with the same lossy fallback the
+/// rest of the dispatch path uses.
+fn parse_query_pairs(raw_query: &str) -> Vec<(String, String)> {
+    raw_query
+        .split('&')
+        .filter(|s| !s.is_empty())
+        .map(|pair| {
+            let mut it = pair.splitn(2, '=');
+            let k = it.next().unwrap_or("");
+            let v = it.next().unwrap_or("");
+            (decode_query_segment(k), decode_query_segment(v))
+        })
+        .collect()
+}
+
+fn decode_query_segment(s: &str) -> String {
+    // Replace `+` with space to match `application/x-www-form-urlencoded`,
+    // then percent-decode. SDKs hit both shapes for path/query data.
+    let plus_decoded = s.replace('+', " ");
+    percent_encoding::percent_decode_str(&plus_decoded)
+        .decode_utf8_lossy()
+        .into_owned()
 }
 
 /// Build a fakecloud-hosted download URL for a layer version's ZIP. The URL
@@ -1707,24 +1736,26 @@ impl LambdaService {
                     .collect()
             })
             .unwrap_or_default();
+        let name = function_name_from_arn(resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                format!("Resource ARN is not a Lambda function: {resource_arn}"),
+            )
+        })?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        // For function ARNs, write directly onto the function's `tags`
-        // map so `GetFunction` and `ListTagsForResource` agree without
-        // a second lookup. Non-function ARNs (event source mappings,
-        // code-signing configs) fall back to the keyed bag.
-        if let Some(name) = function_name_from_arn(resource_arn) {
-            if let Some(func) = state.functions.get_mut(&name) {
-                for (k, v) in &new_tags {
-                    func.tags.insert(k.clone(), v.clone());
-                }
-                return empty();
-            }
-        }
-        let entry = state.tags.entry(resource_arn.to_string()).or_default();
+        let func = state.functions.get_mut(&name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Function not found: {name}"),
+            )
+        })?;
+        // Single source of truth: per-function `tags`. `GetFunction`,
+        // `ListTagsForResource`, and `UntagResource` all read here.
         for (k, v) in new_tags {
-            entry.retain(|(ek, _)| ek != &k);
-            entry.push((k, v));
+            func.tags.insert(k, v);
         }
         empty()
     }
@@ -1735,26 +1766,34 @@ impl LambdaService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         // AWS sends keys as repeated `tagKeys=K1&tagKeys=K2` query
-        // params. Some SDKs also serialize `tagKeys.member.1=K1` /
-        // `tagKeys.1=K1` — accept both shapes.
+        // params. The dispatcher's deduplicated `query_params` HashMap
+        // collapses repeats, so parse the raw query string for every
+        // occurrence. Also accept `tagKeys.1=K1` / `tagKeys.member.1=K1`
+        // for SDKs that serialize list params indexed-style.
         let mut keys: Vec<String> = Vec::new();
-        for (k, v) in &req.query_params {
+        for (k, v) in parse_query_pairs(&req.raw_query) {
             if k == "tagKeys" || k.starts_with("tagKeys.") {
-                keys.push(v.clone());
+                keys.push(v);
             }
         }
+        let name = function_name_from_arn(resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                format!("Resource ARN is not a Lambda function: {resource_arn}"),
+            )
+        })?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(name) = function_name_from_arn(resource_arn) {
-            if let Some(func) = state.functions.get_mut(&name) {
-                for k in &keys {
-                    func.tags.remove(k);
-                }
-                return empty();
-            }
-        }
-        if let Some(entry) = state.tags.get_mut(resource_arn) {
-            entry.retain(|(k, _)| !keys.contains(k));
+        let func = state.functions.get_mut(&name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!("Function not found: {name}"),
+            )
+        })?;
+        for k in &keys {
+            func.tags.remove(k);
         }
         empty()
     }
@@ -1764,27 +1803,27 @@ impl LambdaService {
         resource_arn: &str,
         account_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let name = function_name_from_arn(resource_arn).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                format!("Resource ARN is not a Lambda function: {resource_arn}"),
+            )
+        })?;
         let region = self.region_for(account_id);
         self.with_state_read(account_id, &region, |state| {
-            if let Some(name) = function_name_from_arn(resource_arn) {
-                if let Some(func) = state.functions.get(&name) {
-                    let tags: serde_json::Map<String, Value> = func
-                        .tags
-                        .iter()
-                        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
-                        .collect();
-                    return ok(json!({"Tags": tags}));
-                }
-            }
-            let tags: serde_json::Map<String, Value> = state
+            let func = state.functions.get(&name).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!("Function not found: {name}"),
+                )
+            })?;
+            let tags: serde_json::Map<String, Value> = func
                 .tags
-                .get(resource_arn)
-                .map(|v| {
-                    v.iter()
-                        .map(|(k, val)| (k.clone(), Value::String(val.clone())))
-                        .collect()
-                })
-                .unwrap_or_default();
+                .iter()
+                .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                .collect();
             ok(json!({"Tags": tags}))
         })
     }

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -140,21 +140,19 @@ impl LambdaService {
             );
         }
 
-        // Normalize Action: callers commonly pass either `InvokeFunction`
-        // or `lambda:InvokeFunction`. Always store as `lambda:<verb>` —
-        // double-prefixing (`lambda:lambda:InvokeFunction`) breaks the
-        // evaluator's resource-action matcher and confuses any client
-        // that round-trips the policy doc.
-        let normalized_action = if action.contains(':') {
-            action.clone()
-        } else {
-            format!("lambda:{action}")
-        };
+        // Store the Action verbatim — AWS round-trips whatever string
+        // the caller sent. Callers that hand in `InvokeFunction` get
+        // `InvokeFunction` back; callers that hand in
+        // `lambda:InvokeFunction` get `lambda:InvokeFunction`; callers
+        // that hand in `s3:PutObject` get `s3:PutObject` (no
+        // `lambda:s3:PutObject` double-prefix). Cross-service evaluator
+        // paths that want a `service:verb` form should already pass
+        // the qualified name; we don't second-guess them here.
         let mut new_statement = serde_json::Map::new();
         new_statement.insert("Sid".to_string(), json!(statement_id));
         new_statement.insert("Effect".to_string(), json!("Allow"));
         new_statement.insert("Principal".to_string(), principal_value);
-        new_statement.insert("Action".to_string(), json!(normalized_action));
+        new_statement.insert("Action".to_string(), json!(action));
         new_statement.insert("Resource".to_string(), json!(func.function_arn));
         if !condition.is_empty() {
             new_statement.insert("Condition".to_string(), Value::Object(condition));

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -769,7 +769,9 @@ async fn add_permission_builds_canonical_statement() {
     assert_eq!(statement["Sid"], "s3-invoke");
     assert_eq!(statement["Effect"], "Allow");
     assert_eq!(statement["Principal"]["Service"], "s3.amazonaws.com");
-    assert_eq!(statement["Action"], "lambda:InvokeFunction");
+    // Verbatim round-trip: caller sent `InvokeFunction`, that's what
+    // AWS keeps in the policy doc.
+    assert_eq!(statement["Action"], "InvokeFunction");
     assert_eq!(
         statement["Resource"],
         "arn:aws:lambda:us-east-1:123456789012:function:f"
@@ -1739,4 +1741,165 @@ async fn update_function_code_publish_creates_new_version() {
         latest["CodeSize"].as_i64().unwrap(),
         b"publish-payload".len() as i64
     );
+}
+
+// ── AddPermission action round-trip (D3) ──────────────────────────
+
+#[tokio::test]
+async fn add_permission_stores_action_verbatim() {
+    // AWS keeps whatever string the caller sent in the policy doc
+    // verbatim — passing `s3:PutObject` should not get re-prefixed to
+    // `lambda:s3:PutObject`.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "f").await;
+    let body = json!({
+        "StatementId": "s3-put",
+        "Action": "s3:PutObject",
+        "Principal": "arn:aws:iam::123456789012:user/u",
+    });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/f/policy",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/f/policy", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let doc: Value = serde_json::from_str(body["Policy"].as_str().unwrap()).unwrap();
+    let stmts = doc["Statement"].as_array().unwrap();
+    assert_eq!(stmts.len(), 1);
+    assert_eq!(stmts[0]["Action"], "s3:PutObject");
+}
+
+#[tokio::test]
+async fn add_permission_action_without_prefix() {
+    // Documented behavior: store verbatim. Caller passed
+    // `InvokeFunction` (no `lambda:` prefix), GetPolicy returns
+    // `InvokeFunction`. The cross-service evaluator path that wants a
+    // qualified `service:verb` is responsible for normalizing on read,
+    // not the storage layer.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "f").await;
+    let body = json!({
+        "StatementId": "raw-verb",
+        "Action": "InvokeFunction",
+        "Principal": "events.amazonaws.com",
+    });
+    let req = make_request(
+        Method::POST,
+        "/2015-03-31/functions/f/policy",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/f/policy", "");
+    let resp = svc.handle(req).await.unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let doc: Value = serde_json::from_str(body["Policy"].as_str().unwrap()).unwrap();
+    let stmts = doc["Statement"].as_array().unwrap();
+    assert_eq!(stmts.len(), 1);
+    assert_eq!(stmts[0]["Action"], "InvokeFunction");
+}
+
+// ── Tag store unification (D3) ────────────────────────────────────
+
+#[tokio::test]
+async fn tag_resource_writes_to_function_tags() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+    let body = json!({"Tags": {"env": "prod", "team": "core"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert!(resp.status.is_success());
+
+    // Read func.tags directly to confirm it landed there.
+    let accounts = svc.state.read();
+    let state = accounts.get("123456789012").unwrap();
+    let func = state.functions.get("tag-fn").unwrap();
+    assert_eq!(func.tags.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(func.tags.get("team").map(String::as_str), Some("core"));
+}
+
+#[tokio::test]
+async fn list_tags_for_resource_reads_from_function_tags() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+
+    // Seed via TagResource.
+    let body = json!({"Tags": {"a": "1", "b": "2"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/2017-03-31/tags/{arn}"), "");
+    let resp = svc.handle(req).await.unwrap();
+    let out: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(out["Tags"]["a"], "1");
+    assert_eq!(out["Tags"]["b"], "2");
+}
+
+#[tokio::test]
+async fn untag_resource_with_multiple_keys() {
+    // AWS sends `tagKeys=A&tagKeys=B`. The dispatcher's deduplicated
+    // `query_params` HashMap collapses repeats, so the handler must
+    // parse `req.raw_query` directly to see both values.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+
+    let body = json!({"Tags": {"A": "1", "B": "2", "C": "3"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let mut req = make_request(Method::DELETE, &format!("/2017-03-31/tags/{arn}"), "");
+    req.raw_query = "tagKeys=A&tagKeys=B".to_string();
+    svc.handle(req).await.unwrap();
+
+    let accounts = svc.state.read();
+    let state = accounts.get("123456789012").unwrap();
+    let func = state.functions.get("tag-fn").unwrap();
+    assert!(!func.tags.contains_key("A"));
+    assert!(!func.tags.contains_key("B"));
+    assert_eq!(func.tags.get("C").map(String::as_str), Some("3"));
+}
+
+#[tokio::test]
+async fn tag_state_unified_no_duplicate_state_tags() {
+    // After D3, `LambdaState::tags` no longer exists — tags live only
+    // on `LambdaFunction::tags`. This test pins the unified shape: a
+    // `TagResource` write puts a single entry in `func.tags` and there
+    // is no parallel `state.tags[arn]` storage to drift out of sync.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+    let body = json!({"Tags": {"only": "here"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let accounts = svc.state.read();
+    let state = accounts.get("123456789012").unwrap();
+    let func = state.functions.get("tag-fn").unwrap();
+    assert_eq!(func.tags.get("only").map(String::as_str), Some("here"));
+    // The fact that this compiles is the structural assertion: there
+    // is no `state.tags` field to read from. The runtime check on
+    // `func.tags` confirms tags actually landed in the unified slot.
 }

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -258,9 +258,6 @@ pub struct LambdaState {
     /// Recursion configs keyed by function name.
     #[serde(default)]
     pub recursion_configs: BTreeMap<String, String>,
-    /// Tags keyed by resource ARN.
-    #[serde(default)]
-    pub tags: BTreeMap<String, Vec<(String, String)>>,
     /// Account settings (single per-account record).
     #[serde(default)]
     pub account_settings: Option<AccountSettings>,
@@ -380,7 +377,6 @@ impl LambdaState {
             runtime_management: BTreeMap::new(),
             scaling_configs: BTreeMap::new(),
             recursion_configs: BTreeMap::new(),
-            tags: BTreeMap::new(),
             account_settings: None,
         }
     }
@@ -402,7 +398,6 @@ impl LambdaState {
         self.runtime_management.clear();
         self.scaling_configs.clear();
         self.recursion_configs.clear();
-        self.tags.clear();
         self.account_settings = None;
     }
 }


### PR DESCRIPTION
AddPermission stores Action verbatim. Tag storage unified onto func.tags (drops dual state.tags). UntagResource accepts both repeated tagKeys=A&tagKeys=B and indexed tagKeys.N forms. 105 lib tests pass; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store Lambda AddPermission “Action” exactly as sent and unify tag storage onto per-function `tags`. Also improve UntagResource to handle repeated and indexed query params.

- **Refactors**
  - AddPermission: keep Action verbatim (no auto `lambda:` prefixing); tests updated to expect the exact value sent.
  - Tags: single source of truth on `LambdaFunction::tags`; removed `LambdaState::tags`; TagResource/ListTagsForResource/UntagResource read/write only here.
  - UntagResource: parse `raw_query` to support `tagKeys=A&tagKeys=B` and `tagKeys.N`/`tagKeys.member.N`; proper percent-decoding and `+` as space.
  - Validation: tag APIs only accept function ARNs; return `InvalidParameterValueException` for non-function ARNs and `ResourceNotFoundException` when the function is missing.

<sup>Written for commit 29b3fac28942104a86c62fb9e7d08983ea0680bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

