### PR TITLE
feat(elbv2): WAFv2 evaluation in ALB dataplane (Q2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,6 +3296,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "fakecloud-wafv2",
  "http 1.4.0",
  "http-body-util",
  "hyper 1.9.0",

--- a/crates/fakecloud-elbv2/Cargo.toml
+++ b/crates/fakecloud-elbv2/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
+fakecloud-wafv2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -18,6 +18,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use fakecloud_wafv2::evaluator::{
+    evaluate_detailed as waf_evaluate_detailed, WafAction, WafRequest,
+};
+use fakecloud_wafv2::state::{IpSet, RegexPatternSet, SharedWafv2State, WebAcl};
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
@@ -59,6 +63,13 @@ impl Drop for BoundListener {
 #[derive(Clone)]
 struct DataPlane {
     state: SharedElbv2State,
+    /// Optional WAFv2 state. When set, every ALB request is evaluated
+    /// against the WebACL associated with the load balancer (if any)
+    /// before the listener-rule router runs.
+    waf_state: Option<SharedWafv2State>,
+    /// Count of WAF Count-action matches, keyed by `WebACL ARN | rule
+    /// name`. Exposed for tests and future metrics scraping.
+    waf_count_metrics: Arc<Mutex<BTreeMap<String, u64>>>,
     /// Round-robin index per target group ARN (mod target count).
     rr_counters: Arc<Mutex<BTreeMap<String, usize>>>,
     /// Sticky-session map: `AWSALB` cookie value -> `tg_arn|target_id|target_port`.
@@ -66,7 +77,7 @@ struct DataPlane {
     upstream: reqwest::Client,
 }
 
-pub fn spawn_dataplane(state: SharedElbv2State) {
+pub fn spawn_dataplane(state: SharedElbv2State, waf_state: Option<SharedWafv2State>) {
     if !dataplane_enabled() {
         debug!("ELBv2 data plane disabled via {ENV_DISABLE}");
         return;
@@ -87,6 +98,8 @@ pub fn spawn_dataplane(state: SharedElbv2State) {
     };
     let dp = DataPlane {
         state,
+        waf_state,
+        waf_count_metrics: Arc::new(Mutex::new(BTreeMap::new())),
         rr_counters: Arc::new(Mutex::new(BTreeMap::new())),
         sticky_targets: Arc::new(Mutex::new(BTreeMap::new())),
         upstream,
@@ -256,6 +269,22 @@ async fn handle_request(
         .and_then(|p| u16::try_from(p).ok())
         .unwrap_or(80);
 
+    // WAF v2 evaluation: if a WebACL is associated with this LB, run
+    // each request through the evaluator before the listener-rule
+    // router. Block / Captcha / Challenge short-circuit; Count is
+    // recorded but lets the request through.
+    if let Some(waf_resp) = evaluate_waf_for_request(
+        dp,
+        lb_arn,
+        &parts.method,
+        &parts.uri,
+        &parts.headers,
+        &body_bytes,
+        peer_addr,
+    ) {
+        return waf_resp;
+    }
+
     let rules: Vec<&Rule> = snap.rules_for_listener(&listener.arn);
     let actions = select_actions(
         &rules,
@@ -361,6 +390,187 @@ fn snapshot(dp: &DataPlane, lb_arn: &str) -> Option<LbSnapshot> {
                 target_groups,
             });
         }
+    }
+    None
+}
+
+/// Outcome of running the WAFv2 evaluator for one ALB request.
+/// `Allow` means fall through to the listener-rule router; the other
+/// variants short-circuit with a synthetic response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WafEvalOutcome {
+    NoAcl,
+    Allow,
+    Count,
+    Block,
+    Captcha,
+    Challenge,
+}
+
+/// Run the WebACL associated with `lb_arn` (if any) against the
+/// incoming request. Returns `Some(response)` when the resolved
+/// [`WafAction`] is terminal (`Block`, `Captcha`, `Challenge`); returns
+/// `None` when the request should fall through to the listener-rule
+/// router. Count-action matches are recorded in
+/// `dp.waf_count_metrics` and do not short-circuit.
+fn evaluate_waf_for_request(
+    dp: &DataPlane,
+    lb_arn: &str,
+    method: &Method,
+    uri: &http::Uri,
+    headers: &HeaderMap,
+    body: &Bytes,
+    peer_addr: SocketAddr,
+) -> Option<Response<Full<Bytes>>> {
+    let waf_state = dp.waf_state.as_ref()?;
+    let outcome = evaluate_waf_outcome(
+        waf_state,
+        lb_arn,
+        method.as_str(),
+        uri,
+        headers,
+        body.as_ref(),
+        peer_addr,
+        Some(&dp.waf_count_metrics),
+    );
+    waf_outcome_to_response(outcome)
+}
+
+/// Pure-function form of [`evaluate_waf_for_request`] that resolves
+/// the WAF state for one ALB and returns the resolved
+/// [`WafEvalOutcome`]. Split out so unit tests can drive it without
+/// constructing a full hyper data plane.
+pub(crate) fn evaluate_waf_outcome(
+    waf_state: &SharedWafv2State,
+    lb_arn: &str,
+    method: &str,
+    uri: &http::Uri,
+    headers: &HeaderMap,
+    body: &[u8],
+    peer_addr: SocketAddr,
+    count_metrics: Option<&Arc<Mutex<BTreeMap<String, u64>>>>,
+) -> WafEvalOutcome {
+    let Some(snap) = waf_snapshot_for_lb(waf_state, lb_arn) else {
+        return WafEvalOutcome::NoAcl;
+    };
+    let header_pairs: Vec<(String, String)> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|s| (k.as_str().to_lowercase(), s.to_string()))
+        })
+        .collect();
+    let path = uri.path();
+    let query = uri.query().unwrap_or("");
+    let req = WafRequest {
+        method,
+        uri: path,
+        headers: &header_pairs,
+        body,
+        query,
+        source_ip: peer_addr.ip(),
+        country: None,
+    };
+    let detailed = waf_evaluate_detailed(&req, &snap.web_acl, &snap.ipsets, &snap.regex_sets);
+    if !detailed.count_rules.is_empty() {
+        if let Some(metrics) = count_metrics {
+            let mut m = metrics.lock();
+            for rule_name in &detailed.count_rules {
+                let key = format!("{}|{}", snap.web_acl.arn, rule_name);
+                *m.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+    match detailed.action {
+        WafAction::Allow => {
+            if !detailed.count_rules.is_empty() {
+                WafEvalOutcome::Count
+            } else {
+                WafEvalOutcome::Allow
+            }
+        }
+        WafAction::Count => WafEvalOutcome::Count,
+        WafAction::Block => WafEvalOutcome::Block,
+        WafAction::Captcha => WafEvalOutcome::Captcha,
+        WafAction::Challenge => WafEvalOutcome::Challenge,
+    }
+}
+
+fn waf_outcome_to_response(outcome: WafEvalOutcome) -> Option<Response<Full<Bytes>>> {
+    match outcome {
+        WafEvalOutcome::NoAcl | WafEvalOutcome::Allow | WafEvalOutcome::Count => None,
+        WafEvalOutcome::Block => {
+            let body = Bytes::from_static(br#"{"message":"Forbidden"}"#);
+            let mut resp = Response::new(Full::new(body));
+            *resp.status_mut() = StatusCode::FORBIDDEN;
+            resp.headers_mut().insert(
+                http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            Some(resp)
+        }
+        WafEvalOutcome::Captcha => {
+            // AWS WAF emits a 405 Method Not Allowed pseudo-response
+            // when a CAPTCHA challenge fires for an unsupported
+            // request method. The body content is not stable across
+            // versions; an empty JSON object matches the wire
+            // observation.
+            let body = Bytes::from_static(br#"{"message":"Captcha"}"#);
+            let mut resp = Response::new(Full::new(body));
+            *resp.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+            resp.headers_mut().insert(
+                http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            Some(resp)
+        }
+        WafEvalOutcome::Challenge => {
+            let body = Bytes::from_static(br#"{"message":"Challenge"}"#);
+            let mut resp = Response::new(Full::new(body));
+            *resp.status_mut() = StatusCode::ACCEPTED;
+            resp.headers_mut().insert(
+                http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            Some(resp)
+        }
+    }
+}
+
+/// Snapshot of the WAFv2 state needed to evaluate the WebACL
+/// associated with one load balancer. Cloning under the read lock
+/// keeps the per-request handler from re-locking.
+struct WafSnapshot {
+    web_acl: WebAcl,
+    ipsets: std::collections::HashMap<String, IpSet>,
+    regex_sets: std::collections::HashMap<String, RegexPatternSet>,
+}
+
+fn waf_snapshot_for_lb(waf_state: &SharedWafv2State, lb_arn: &str) -> Option<WafSnapshot> {
+    let st = waf_state.read();
+    for account in st.accounts.values() {
+        let Some(acl_arn) = account.associations.get(lb_arn) else {
+            continue;
+        };
+        let Some(web_acl) = account.web_acls.values().find(|a| &a.arn == acl_arn) else {
+            continue;
+        };
+        let ipsets: std::collections::HashMap<String, IpSet> = account
+            .ip_sets
+            .values()
+            .map(|s| (s.arn.clone(), s.clone()))
+            .collect();
+        let regex_sets: std::collections::HashMap<String, RegexPatternSet> = account
+            .regex_pattern_sets
+            .values()
+            .map(|s| (s.arn.clone(), s.clone()))
+            .collect();
+        return Some(WafSnapshot {
+            web_acl: web_acl.clone(),
+            ipsets,
+            regex_sets,
+        });
     }
     None
 }
@@ -758,4 +968,197 @@ fn extract_cookie<'a>(cookies: &'a str, name: &str) -> Option<&'a str> {
 fn short_id() -> String {
     let id = Uuid::new_v4();
     id.simple().to_string()[0..16].to_string()
+}
+
+#[cfg(test)]
+mod waf_tests {
+    use super::*;
+    use chrono::Utc;
+    use fakecloud_wafv2::state::{AccountState, Wafv2Accounts, WebAcl};
+    use http::Uri;
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use std::collections::BTreeMap;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    const ACCOUNT: &str = "123456789012";
+    const LB_ARN: &str =
+        "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/abc";
+    const ACL_ARN: &str = "arn:aws:wafv2:us-east-1:123456789012:regional/webacl/test/xyz";
+
+    fn web_acl_with(default: Value, rules: Vec<Value>) -> WebAcl {
+        WebAcl {
+            id: "xyz".into(),
+            name: "test".into(),
+            arn: ACL_ARN.into(),
+            scope: "REGIONAL".into(),
+            default_action: default,
+            description: None,
+            rules,
+            visibility_config: json!({}),
+            capacity: 0,
+            lock_token: "lt".into(),
+            label_namespace: "awswaf:123456789012:webacl:test:".into(),
+            custom_response_bodies: BTreeMap::new(),
+            captcha_config: None,
+            challenge_config: None,
+            token_domains: Vec::new(),
+            association_config: None,
+            data_protection_config: None,
+            on_source_d_do_s_protection_config: None,
+            application_config: None,
+            retrofitted_by_firewall_manager: false,
+            pre_process_firewall_manager_rule_groups: Vec::new(),
+            post_process_firewall_manager_rule_groups: Vec::new(),
+            managed_by_firewall_manager: false,
+            created_time: Utc::now(),
+        }
+    }
+
+    fn waf_state_with(acl: WebAcl, association: Option<&str>) -> SharedWafv2State {
+        let mut accounts = Wafv2Accounts::new();
+        let mut acct = AccountState::default();
+        acct.web_acls
+            .insert(("REGIONAL".into(), acl.name.clone()), acl);
+        if let Some(resource) = association {
+            acct.associations.insert(resource.into(), ACL_ARN.into());
+        }
+        accounts.accounts.insert(ACCOUNT.into(), acct);
+        Arc::new(RwLock::new(accounts))
+    }
+
+    fn block_path_rule(needle: &str) -> Value {
+        json!({
+            "Name": "block-admin",
+            "Priority": 0,
+            "Action": {"Block": {}},
+            "VisibilityConfig": {},
+            "Statement": {
+                "ByteMatchStatement": {
+                    "SearchString": needle,
+                    "FieldToMatch": {"UriPath": {}},
+                    "TextTransformations": [{"Priority": 0, "Type": "NONE"}],
+                    "PositionalConstraint": "STARTS_WITH",
+                }
+            }
+        })
+    }
+
+    fn count_path_rule(needle: &str) -> Value {
+        json!({
+            "Name": "count-admin",
+            "Priority": 0,
+            "Action": {"Count": {}},
+            "VisibilityConfig": {},
+            "Statement": {
+                "ByteMatchStatement": {
+                    "SearchString": needle,
+                    "FieldToMatch": {"UriPath": {}},
+                    "TextTransformations": [{"Priority": 0, "Type": "NONE"}],
+                    "PositionalConstraint": "STARTS_WITH",
+                }
+            }
+        })
+    }
+
+    fn ip() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0)
+    }
+
+    #[test]
+    fn request_blocked_by_associated_webacl() {
+        let acl = web_acl_with(json!({"Allow": {}}), vec![block_path_rule("/admin")]);
+        let waf = waf_state_with(acl, Some(LB_ARN));
+        let outcome = evaluate_waf_outcome(
+            &waf,
+            LB_ARN,
+            "GET",
+            &"/admin/x".parse::<Uri>().unwrap(),
+            &HeaderMap::new(),
+            b"",
+            ip(),
+            None,
+        );
+        assert_eq!(outcome, WafEvalOutcome::Block);
+        let resp = waf_outcome_to_response(outcome).expect("expected synthetic response");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn request_allowed_when_no_rules_match() {
+        let acl = web_acl_with(json!({"Allow": {}}), vec![block_path_rule("/admin")]);
+        let waf = waf_state_with(acl, Some(LB_ARN));
+        let outcome = evaluate_waf_outcome(
+            &waf,
+            LB_ARN,
+            "GET",
+            &"/public".parse::<Uri>().unwrap(),
+            &HeaderMap::new(),
+            b"",
+            ip(),
+            None,
+        );
+        assert_eq!(outcome, WafEvalOutcome::Allow);
+        assert!(waf_outcome_to_response(outcome).is_none());
+    }
+
+    #[test]
+    fn request_allowed_when_no_webacl_associated() {
+        let acl = web_acl_with(json!({"Block": {}}), vec![]);
+        // Note: we deliberately do NOT associate the ACL with the LB.
+        let waf = waf_state_with(acl, None);
+        let outcome = evaluate_waf_outcome(
+            &waf,
+            LB_ARN,
+            "GET",
+            &"/anything".parse::<Uri>().unwrap(),
+            &HeaderMap::new(),
+            b"",
+            ip(),
+            None,
+        );
+        assert_eq!(outcome, WafEvalOutcome::NoAcl);
+        assert!(waf_outcome_to_response(outcome).is_none());
+    }
+
+    #[test]
+    fn count_action_does_not_block() {
+        let acl = web_acl_with(json!({"Allow": {}}), vec![count_path_rule("/admin")]);
+        let waf = waf_state_with(acl, Some(LB_ARN));
+        let metrics = Arc::new(Mutex::new(BTreeMap::new()));
+        let outcome = evaluate_waf_outcome(
+            &waf,
+            LB_ARN,
+            "GET",
+            &"/admin/x".parse::<Uri>().unwrap(),
+            &HeaderMap::new(),
+            b"",
+            ip(),
+            Some(&metrics),
+        );
+        assert_eq!(outcome, WafEvalOutcome::Count);
+        assert!(waf_outcome_to_response(outcome).is_none());
+        let snap = metrics.lock();
+        let key = format!("{ACL_ARN}|count-admin");
+        assert_eq!(snap.get(&key).copied(), Some(1));
+    }
+
+    #[test]
+    fn webacl_default_block_returns_403() {
+        let acl = web_acl_with(json!({"Block": {}}), vec![]);
+        let waf = waf_state_with(acl, Some(LB_ARN));
+        let outcome = evaluate_waf_outcome(
+            &waf,
+            LB_ARN,
+            "GET",
+            &"/anything".parse::<Uri>().unwrap(),
+            &HeaderMap::new(),
+            b"",
+            ip(),
+            None,
+        );
+        assert_eq!(outcome, WafEvalOutcome::Block);
+        let resp = waf_outcome_to_response(outcome).expect("expected synthetic response");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
 }

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -15,6 +15,8 @@ use fakecloud_core::query::{
 };
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 
+use fakecloud_wafv2::SharedWafv2State;
+
 use crate::state::{AvailabilityZone, LoadBalancer, LoadBalancerAddress, SharedElbv2State, Tag};
 use crate::ELBV2_NAMESPACE;
 
@@ -76,17 +78,52 @@ const ELBV2_SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct Elbv2Service {
     state: SharedElbv2State,
+    waf_state: Option<SharedWafv2State>,
     pub region: String,
 }
 
 impl Elbv2Service {
+    /// Build a service and immediately spin up the prober + dataplane
+    /// supervisor. The dataplane will not perform WAF evaluation unless
+    /// the service is constructed via [`Elbv2Service::with_waf_state`]
+    /// before the dataplane spawns.
     pub fn new(state: SharedElbv2State) -> Self {
         crate::prober::spawn_prober(Arc::clone(&state));
-        crate::dataplane::spawn_dataplane(Arc::clone(&state));
+        crate::dataplane::spawn_dataplane(Arc::clone(&state), None);
         Self {
             state,
+            waf_state: None,
             region: "us-east-1".to_string(),
         }
+    }
+
+    /// Build a service without spawning the dataplane yet. Pair with
+    /// [`Elbv2Service::with_waf_state`] and [`Elbv2Service::start_dataplane`]
+    /// when WAF v2 evaluation should run inside the ALB request path.
+    pub fn new_without_dataplane(state: SharedElbv2State) -> Self {
+        crate::prober::spawn_prober(Arc::clone(&state));
+        Self {
+            state,
+            waf_state: None,
+            region: "us-east-1".to_string(),
+        }
+    }
+
+    /// Plug in the WAFv2 shared state so the ALB dataplane can resolve
+    /// the WebACL associated with each load balancer and evaluate
+    /// incoming requests before the listener-rule router runs.
+    pub fn with_waf_state(mut self, waf_state: SharedWafv2State) -> Self {
+        self.waf_state = Some(waf_state);
+        self
+    }
+
+    /// Spawn the dataplane supervisor. Only needed when the service
+    /// was built with [`Elbv2Service::new_without_dataplane`].
+    pub fn start_dataplane(&self) {
+        crate::dataplane::spawn_dataplane(
+            Arc::clone(&self.state),
+            self.waf_state.as_ref().map(Arc::clone),
+        );
     }
 
     pub fn shared_state(&self) -> SharedElbv2State {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2073,7 +2073,9 @@ async fn main() {
     registry.register(ecs_service);
 
     let elbv2_introspection_state = elbv2_state.clone();
-    let elbv2_service = Elbv2Service::new(elbv2_state.clone());
+    let elbv2_service = Elbv2Service::new_without_dataplane(elbv2_state.clone())
+        .with_waf_state(wafv2_state.clone());
+    elbv2_service.start_dataplane();
     registry.register(Arc::new(elbv2_service));
 
     let cloudfront_service = Arc::new(CloudFrontService::new(cloudfront_state.clone()));

--- a/crates/fakecloud-wafv2/src/evaluator.rs
+++ b/crates/fakecloud-wafv2/src/evaluator.rs
@@ -40,6 +40,17 @@ pub enum WafAction {
     Challenge,
 }
 
+/// Detailed evaluation outcome. `action` is the final resolved
+/// action (same value [`evaluate`] returns); `count_rules` lists the
+/// names of rules whose `Count` action matched on the way to the
+/// terminal decision. Useful for emitting per-rule metrics without
+/// blocking the request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WafEvaluation {
+    pub action: WafAction,
+    pub count_rules: Vec<String>,
+}
+
 /// Evaluate `req` against `web_acl`. Rules are processed in ascending
 /// `Priority`; matching `Count` rules are recorded but do not terminate
 /// evaluation. The first matching non-`Count` rule's action is returned;
@@ -50,10 +61,23 @@ pub fn evaluate(
     ipsets: &HashMap<String, IpSet>,
     regex_sets: &HashMap<String, RegexPatternSet>,
 ) -> WafAction {
+    evaluate_detailed(req, web_acl, ipsets, regex_sets).action
+}
+
+/// Like [`evaluate`] but also reports the names of rules whose
+/// matching `Count` action fired. The returned `action` is the same
+/// value [`evaluate`] would return.
+pub fn evaluate_detailed(
+    req: &WafRequest,
+    web_acl: &WebAcl,
+    ipsets: &HashMap<String, IpSet>,
+    regex_sets: &HashMap<String, RegexPatternSet>,
+) -> WafEvaluation {
     let mut rules: Vec<&Value> = web_acl.rules.iter().collect();
     rules.sort_by_key(|r| r.get("Priority").and_then(Value::as_i64).unwrap_or(0));
 
     let mut labels: HashSet<String> = HashSet::new();
+    let mut count_rules: Vec<String> = Vec::new();
 
     for rule in rules {
         let Some(stmt) = rule.get("Statement") else {
@@ -71,17 +95,27 @@ pub fn evaluate(
             }
         }
         if let Some(action) = rule.get("Action").and_then(rule_action) {
-            // Count is non-terminal: keep evaluating subsequent rules.
+            // Count is non-terminal: keep evaluating subsequent rules but
+            // record the rule for metrics.
             if action == WafAction::Count {
+                if let Some(name) = rule.get("Name").and_then(Value::as_str) {
+                    count_rules.push(name.to_owned());
+                }
                 continue;
             }
-            return action;
+            return WafEvaluation {
+                action,
+                count_rules,
+            };
         }
         // Rule with OverrideAction (rule group reference) doesn't terminate
         // here either since we don't expand rule groups in this batch.
     }
 
-    default_action(web_acl)
+    WafEvaluation {
+        action: default_action(web_acl),
+        count_rules,
+    }
 }
 
 impl WebAcl {
@@ -93,6 +127,17 @@ impl WebAcl {
         regex_sets: &HashMap<String, RegexPatternSet>,
     ) -> WafAction {
         evaluate(req, self, ipsets, regex_sets)
+    }
+
+    /// Convenience wrapper around [`evaluate_detailed`] for callers
+    /// holding a `&WebAcl`.
+    pub fn evaluate_detailed(
+        &self,
+        req: &WafRequest,
+        ipsets: &HashMap<String, IpSet>,
+        regex_sets: &HashMap<String, RegexPatternSet>,
+    ) -> WafEvaluation {
+        evaluate_detailed(req, self, ipsets, regex_sets)
     }
 }
 

--- a/crates/fakecloud-wafv2/src/lib.rs
+++ b/crates/fakecloud-wafv2/src/lib.rs
@@ -2,7 +2,7 @@ pub mod evaluator;
 pub(crate) mod service;
 pub mod state;
 
-pub use evaluator::{evaluate, WafAction, WafRequest};
+pub use evaluator::{evaluate, evaluate_detailed, WafAction, WafEvaluation, WafRequest};
 pub use service::Wafv2Service;
 pub use state::{
     AccountState, IpSet, RegexPatternSet, RuleGroup, ScopedKey, SharedWafv2State, Wafv2Accounts,


### PR DESCRIPTION
ALB dataplane evaluates associated WebACL via wafv2 evaluator before listener-rule resolution. Block returns 403, Captcha 405, Challenge 202, Count passes through. Default action enforced when no rule matches. Workspace tests pass; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable WAFv2 evaluation in the ALB data plane. Each request is checked against the associated WebACL before listener rules; Block/Captcha/Challenge short‑circuit with correct status codes, while Count is recorded and allowed.

- **New Features**
  - ALB requests are evaluated via `fakecloud-wafv2` before listener-rule routing when a WebACL is associated.
  - Actions: Block → 403, Captcha → 405, Challenge → 202. Allow/Count proceed; default action applies when no rule matches.
  - In-memory Count metrics tracked per WebACL rule for tests/metrics.
  - `fakecloud-wafv2` adds `evaluate_detailed` and `WafEvaluation` to expose matched Count rules.

- **Migration**
  - To enable WAF in ELB: build with `new_without_dataplane().with_waf_state(...).start_dataplane()`. Using `new()` keeps previous behavior (no WAF evaluation).
  - `fakecloud-elbv2` now depends on `fakecloud-wafv2`; pass the shared WAF state when enabling WAF.

<sup>Written for commit fd900228cdf07584ae12a0d3b42a82031da092e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

