### PR TITLE
fix(elbv2): allow too_many_arguments on evaluate_waf_outcome

### DIFF
--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -440,6 +440,7 @@ fn evaluate_waf_for_request(
 /// the WAF state for one ALB and returns the resolved
 /// [`WafEvalOutcome`]. Split out so unit tests can drive it without
 /// constructing a full hyper data plane.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_waf_outcome(
     waf_state: &SharedWafv2State,
     lb_arn: &str,


### PR DESCRIPTION
## Summary
- Q2 followup: `evaluate_waf_outcome` takes 8 args (one over clippy's 7-arg threshold), breaking `cargo clippy --workspace --all-targets -- -D warnings` on main.
- All 8 args are needed; refactoring into a struct would just hide the same surface. Allow the lint locally.

## Test plan
- [x] `cargo clippy -p fakecloud-elbv2 --all-targets -- -D warnings` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows `clippy::too_many_arguments` on evaluate_waf_outcome in `fakecloud-elbv2` so `cargo clippy --workspace --all-targets -- -D warnings` passes. The function needs eight inputs; this avoids a pointless struct refactor.

<sup>Written for commit c38ae18017dcba8693f43f033a70d7a45df87bd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

