### PR TITLE
feat(ecr): periodic lifecycle policy re-evaluation ticker (P4)

### DIFF
--- a/crates/fakecloud-ecr/src/lib.rs
+++ b/crates/fakecloud-ecr/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod lifecycle_ticker;
 pub mod oci;
 pub(crate) mod pull_through;
 pub mod scanner;
@@ -5,6 +6,7 @@ pub(crate) mod service;
 pub mod signing;
 pub mod state;
 
+pub use lifecycle_ticker::LifecycleTicker;
 pub use service::EcrService;
 pub use state::{
     EcrSnapshot, EcrState, Image, PullThroughCacheRule, ReplicationConfiguration,

--- a/crates/fakecloud-ecr/src/lifecycle_ticker.rs
+++ b/crates/fakecloud-ecr/src/lifecycle_ticker.rs
@@ -1,0 +1,239 @@
+//! Periodic re-evaluation of repository lifecycle policies.
+//!
+//! `PutLifecyclePolicy` runs the policy synchronously once at write
+//! time. AWS ECR also re-runs lifecycle rules on a recurring schedule
+//! so that `sinceImagePushed` time-based selections eventually evict
+//! aging images even when no new push triggers an evaluation. This
+//! ticker provides that re-run loop: every `interval` it walks all
+//! repositories that have a lifecycle policy, applies the prune set,
+//! and stamps `lifecycle_policy_last_evaluated_at`.
+//!
+//! When no repository has a lifecycle policy set the tick is a cheap
+//! read-only scan of `state` and exits without taking the write lock,
+//! so the loop costs almost nothing in idle setups.
+//!
+//! The ticker is wired up at server startup in `fakecloud-server` via
+//! `tokio::spawn(LifecycleTicker::new(state).run())`.
+use std::time::Duration;
+
+use chrono::Utc;
+
+use crate::service::evaluate_lifecycle_policy;
+use crate::state::SharedEcrState;
+
+/// Default tick interval. AWS itself doesn't publish a guaranteed
+/// re-eval cadence; 5 minutes is a balance between picking up
+/// `sinceImagePushed` evictions promptly and not burning CPU walking
+/// idle accounts.
+pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Background task that periodically re-applies lifecycle policies.
+pub struct LifecycleTicker {
+    state: SharedEcrState,
+    interval: Duration,
+}
+
+impl LifecycleTicker {
+    pub fn new(state: SharedEcrState) -> Self {
+        Self {
+            state,
+            interval: DEFAULT_TICK_INTERVAL,
+        }
+    }
+
+    /// Override the tick interval. Tests use a tiny value; production
+    /// uses the default.
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    pub async fn run(self) {
+        let mut ticker = tokio::time::interval(self.interval);
+        // First tick fires immediately by default — skip it so we
+        // don't double-evaluate right after server start (the
+        // synchronous PutLifecyclePolicy path already evaluated).
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            tick_once(&self.state);
+        }
+    }
+}
+
+/// Single pass over all accounts/repositories. Re-evaluates each
+/// lifecycle policy and applies the resulting prune set. Cheap when
+/// no policies are set: a read-only scan that bails before touching
+/// the write lock.
+pub fn tick_once(state: &SharedEcrState) {
+    // Collect (account_id, repo_name, policy) under the read lock so
+    // we don't hold the writer while parsing JSON. Doubles as the
+    // cheap precheck — when no repo has a policy, `plans` is empty
+    // and we bail before touching the write lock.
+    let plans: Vec<(String, String, String)> = {
+        let accounts = state.read();
+        let mut out: Vec<(String, String, String)> = Vec::new();
+        for (acct, s) in accounts.iter() {
+            for (name, repo) in s.repositories.iter() {
+                if let Some(policy) = repo.lifecycle_policy.as_ref() {
+                    out.push((acct.to_string(), name.clone(), policy.clone()));
+                }
+            }
+        }
+        out
+    };
+
+    if plans.is_empty() {
+        return;
+    }
+
+    let mut accounts = state.write();
+    let now = Utc::now();
+    for (account, name, policy) in plans {
+        let Some(s) = accounts.get_mut(&account) else {
+            continue;
+        };
+        let Some(repo) = s.repositories.get_mut(&name) else {
+            continue;
+        };
+        let prune = evaluate_lifecycle_policy(repo, &policy);
+        if !prune.is_empty() {
+            tracing::info!(
+                repository = %name,
+                account = %account,
+                count = prune.len(),
+                "ECR lifecycle: pruning expired images on tick"
+            );
+            for digest in &prune {
+                repo.images.remove(digest);
+                repo.image_tags.retain(|_, d| d != digest);
+            }
+        }
+        repo.lifecycle_policy_last_evaluated_at = Some(now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{EcrState, Image, Repository};
+    use chrono::Duration as ChronoDuration;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "111111111111";
+
+    fn shared_state_with_repo(repo: Repository) -> SharedEcrState {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
+        let s = mas.get_or_create(ACCOUNT);
+        s.repositories.insert(repo.repository_name.clone(), repo);
+        Arc::new(RwLock::new(mas))
+    }
+
+    fn make_repo_with_old_image() -> Repository {
+        let arn = format!("arn:aws:ecr:us-east-1:{ACCOUNT}:repository/svc");
+        let mut repo = Repository::new("svc", arn, ACCOUNT, "fakecloud:4566");
+        repo.images.insert(
+            "sha256:old".to_string(),
+            Image {
+                image_digest: "sha256:old".to_string(),
+                image_manifest: String::new(),
+                image_manifest_media_type: String::new(),
+                artifact_media_type: None,
+                image_size_in_bytes: 0,
+                // Pushed 30 days ago.
+                image_pushed_at: Utc::now() - ChronoDuration::days(30),
+                last_recorded_pull_time: None,
+            },
+        );
+        repo.image_tags
+            .insert("v1".to_string(), "sha256:old".to_string());
+        repo
+    }
+
+    #[test]
+    fn tick_once_no_policy_is_cheap_and_noop() {
+        let state = shared_state_with_repo(make_repo_with_old_image());
+        // No policy set -> no last_evaluated_at, no image removal.
+        tick_once(&state);
+        let accounts = state.read();
+        let repo = accounts
+            .get(ACCOUNT)
+            .unwrap()
+            .repositories
+            .get("svc")
+            .unwrap();
+        assert!(repo.lifecycle_policy_last_evaluated_at.is_none());
+        assert_eq!(repo.images.len(), 1);
+    }
+
+    #[test]
+    fn tick_once_prunes_and_stamps_last_evaluated_at() {
+        let mut repo = make_repo_with_old_image();
+        // Policy: prune images older than 7 days.
+        repo.lifecycle_policy = Some(
+            r#"{"rules":[{
+                "rulePriority":1,
+                "selection":{
+                    "tagStatus":"any",
+                    "countType":"sinceImagePushed",
+                    "countUnit":"days",
+                    "countNumber":7
+                }
+            }]}"#
+                .to_string(),
+        );
+        let state = shared_state_with_repo(repo);
+        tick_once(&state);
+        let accounts = state.read();
+        let repo = accounts
+            .get(ACCOUNT)
+            .unwrap()
+            .repositories
+            .get("svc")
+            .unwrap();
+        assert!(
+            repo.lifecycle_policy_last_evaluated_at.is_some(),
+            "tick should stamp last_evaluated_at"
+        );
+        assert!(
+            repo.images.is_empty(),
+            "old image should have been pruned by tick"
+        );
+        assert!(
+            repo.image_tags.is_empty(),
+            "tags pointing at pruned image should be gone"
+        );
+    }
+
+    #[test]
+    fn tick_once_updates_timestamp_even_when_nothing_to_prune() {
+        let mut repo = make_repo_with_old_image();
+        // Policy that matches but keeps the image (countNumber=10
+        // covers the only image).
+        repo.lifecycle_policy = Some(
+            r#"{"rules":[{
+                "rulePriority":1,
+                "selection":{
+                    "tagStatus":"tagged",
+                    "countType":"imageCountMoreThan",
+                    "countNumber":10
+                }
+            }]}"#
+                .to_string(),
+        );
+        let state = shared_state_with_repo(repo);
+        tick_once(&state);
+        let accounts = state.read();
+        let repo = accounts
+            .get(ACCOUNT)
+            .unwrap()
+            .repositories
+            .get("svc")
+            .unwrap();
+        assert!(repo.lifecycle_policy_last_evaluated_at.is_some());
+        assert_eq!(repo.images.len(), 1);
+    }
+}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1706,17 +1706,23 @@ impl EcrService {
                     .ok_or_else(|| lifecycle_policy_not_found(&name))?
             }
         };
-        let accounts = self.state.read();
+        // Run the preview eval and stamp `last_evaluated_at` so callers
+        // polling `GetLifecyclePolicy` after a preview see the most
+        // recent evaluation marker. Preview is non-destructive — we
+        // don't apply the prune here, just record that it ran.
+        let mut accounts = self.state.write();
         let state = accounts
-            .get(&account)
+            .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
         let repo = state
             .repositories
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
         let _prune = evaluate_lifecycle_policy(repo, &policy);
+        repo.lifecycle_policy_last_evaluated_at = Some(Utc::now());
+        let registry_id = repo.registry_id.clone();
         Ok(AwsResponse::ok_json(json!({
-            "registryId": repo.registry_id,
+            "registryId": registry_id,
             "repositoryName": name,
             "lifecyclePolicyText": policy,
             "status": "COMPLETE",

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -949,3 +949,205 @@ mod scan_on_push_tests {
         );
     }
 }
+
+// ── Lifecycle policy timestamp + ticker integration ─────────────
+#[cfg(test)]
+mod lifecycle_timestamp_tests {
+    use super::super::EcrService;
+    use crate::lifecycle_ticker::tick_once;
+    use crate::state::{EcrState, Image, Repository, SharedEcrState};
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "111111111111";
+
+    fn make_request(action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: ACCOUNT.into(),
+            request_id: "req-1".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn fixture() -> (EcrService, SharedEcrState) {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
+        let s = mas.get_or_create(ACCOUNT);
+        let arn = s.repository_arn("app");
+        let mut repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
+        // Seed an image old enough to be eligible for `sinceImagePushed`.
+        repo.images.insert(
+            "sha256:old".to_string(),
+            Image {
+                image_digest: "sha256:old".to_string(),
+                image_manifest: String::new(),
+                image_manifest_media_type: String::new(),
+                artifact_media_type: None,
+                image_size_in_bytes: 0,
+                image_pushed_at: chrono::Utc::now() - chrono::Duration::days(30),
+                last_recorded_pull_time: None,
+            },
+        );
+        repo.image_tags
+            .insert("v1".to_string(), "sha256:old".to_string());
+        s.repositories.insert("app".to_string(), repo);
+        let state: SharedEcrState = Arc::new(RwLock::new(mas));
+        let svc = EcrService::new(state.clone());
+        (svc, state)
+    }
+
+    fn parse_body(resp: fakecloud_core::service::AwsResponse) -> Value {
+        serde_json::from_slice(resp.body.expect_bytes()).expect("response body is JSON")
+    }
+
+    #[tokio::test]
+    async fn put_lifecycle_policy_then_get_returns_last_evaluated_at() {
+        let (svc, _state) = fixture();
+        let policy = json!({
+            "rules": [{
+                "rulePriority": 1,
+                "selection": {
+                    "tagStatus": "any",
+                    "countType": "imageCountMoreThan",
+                    "countNumber": 100
+                }
+            }]
+        })
+        .to_string();
+        let put_req = make_request(
+            "PutLifecyclePolicy",
+            json!({
+                "repositoryName": "app",
+                "lifecyclePolicyText": policy,
+            }),
+        );
+        let put_resp = <EcrService as fakecloud_core::service::AwsService>::handle(&svc, put_req)
+            .await
+            .expect("PutLifecyclePolicy succeeds");
+        assert!(put_resp.status.is_success());
+
+        let get_req = make_request("GetLifecyclePolicy", json!({"repositoryName": "app"}));
+        let get_resp = <EcrService as fakecloud_core::service::AwsService>::handle(&svc, get_req)
+            .await
+            .expect("GetLifecyclePolicy succeeds");
+        let body = parse_body(get_resp);
+        let ts = body
+            .get("lastEvaluatedAt")
+            .and_then(|v| v.as_i64())
+            .expect("lastEvaluatedAt present");
+        assert!(
+            ts > 0,
+            "lastEvaluatedAt should be a non-zero epoch second after PutLifecyclePolicy"
+        );
+        assert_eq!(
+            body.get("repositoryName").and_then(|v| v.as_str()),
+            Some("app")
+        );
+    }
+
+    #[tokio::test]
+    async fn ticker_tick_once_updates_last_evaluated_at_and_prunes() {
+        let (svc, state) = fixture();
+        // Policy: prune images older than 7 days (the seeded image is 30 days old).
+        let policy = json!({
+            "rules": [{
+                "rulePriority": 1,
+                "selection": {
+                    "tagStatus": "any",
+                    "countType": "sinceImagePushed",
+                    "countUnit": "days",
+                    "countNumber": 7
+                }
+            }]
+        })
+        .to_string();
+        // Install policy with PutLifecyclePolicy (which already prunes
+        // synchronously).
+        let put_req = make_request(
+            "PutLifecyclePolicy",
+            json!({
+                "repositoryName": "app",
+                "lifecyclePolicyText": policy,
+            }),
+        );
+        <EcrService as fakecloud_core::service::AwsService>::handle(&svc, put_req)
+            .await
+            .expect("PutLifecyclePolicy succeeds");
+
+        // Capture the post-Put timestamp; the ticker should advance it.
+        let first_ts = {
+            let accounts = state.read();
+            accounts
+                .get(ACCOUNT)
+                .unwrap()
+                .repositories
+                .get("app")
+                .unwrap()
+                .lifecycle_policy_last_evaluated_at
+                .expect("Put stamped last_evaluated_at")
+        };
+        // Re-seed an old image to verify the ticker prunes it on the
+        // next pass (Put already pruned the original).
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_mut(ACCOUNT).unwrap();
+            let repo = s.repositories.get_mut("app").unwrap();
+            repo.images.insert(
+                "sha256:older".to_string(),
+                Image {
+                    image_digest: "sha256:older".to_string(),
+                    image_manifest: String::new(),
+                    image_manifest_media_type: String::new(),
+                    artifact_media_type: None,
+                    image_size_in_bytes: 0,
+                    image_pushed_at: chrono::Utc::now() - chrono::Duration::days(60),
+                    last_recorded_pull_time: None,
+                },
+            );
+        }
+        // Ensure clock advances at least one second so the new
+        // timestamp is strictly greater.
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+        // Simulate a periodic tick.
+        tick_once(&state);
+
+        let accounts = state.read();
+        let repo = accounts
+            .get(ACCOUNT)
+            .unwrap()
+            .repositories
+            .get("app")
+            .unwrap();
+        let later_ts = repo
+            .lifecycle_policy_last_evaluated_at
+            .expect("tick stamped last_evaluated_at");
+        assert!(
+            later_ts >= first_ts,
+            "tick should not move the timestamp backwards"
+        );
+        assert!(
+            !repo.images.contains_key("sha256:older"),
+            "tick should have pruned the 60-day-old image"
+        );
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2012,6 +2012,14 @@ async fn main() {
     }
     registry.register(Arc::new(ecr_service));
 
+    // Periodic re-evaluation of ECR lifecycle policies. The ticker
+    // re-runs the prune evaluator on every repository with a policy
+    // set so time-based selections (e.g. `sinceImagePushed`) take
+    // effect even when no new push triggers an evaluation. The tick
+    // is a cheap read-only scan when no policies are set.
+    let ecr_lifecycle_ticker = fakecloud_ecr::LifecycleTicker::new(ecr_state.clone());
+    tokio::spawn(ecr_lifecycle_ticker.run());
+
     let ecs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config


### PR DESCRIPTION
## Summary

- Add `LifecycleTicker` background task that re-runs ECR lifecycle policy evaluation every 5 minutes across all accounts/repositories that have a policy, applying prunes and stamping `lifecycle_policy_last_evaluated_at` so `sinceImagePushed` selections actually take effect on idle repos.
- Stamp `last_evaluated_at` on `StartLifecyclePolicyPreview` (non-destructive eval) in addition to `PutLifecyclePolicy` so `GetLifecyclePolicy`'s `lastEvaluatedAt` reflects preview activity.
- Tick is a cheap read-only scan when no repository has a policy set; bails before taking the write lock to avoid burning CPU on idle deployments.

## Test plan

- [x] `cargo build -p fakecloud-ecr` clean
- [x] `cargo build -p fakecloud` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo test -p fakecloud-ecr` -> 47 passed (4 new lifecycle tests)
- [x] New tests:
  - `tick_once_no_policy_is_cheap_and_noop` — no policy -> no timestamp, no prune
  - `tick_once_prunes_and_stamps_last_evaluated_at` — `sinceImagePushed days=7` removes 30-day image
  - `tick_once_updates_timestamp_even_when_nothing_to_prune` — timestamp moves forward on every tick
  - `put_lifecycle_policy_then_get_returns_last_evaluated_at` — round-trip through `EcrService::handle`
  - `ticker_tick_once_updates_last_evaluated_at_and_prunes` — tick prunes a 60-day-old image installed after `PutLifecyclePolicy`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `LifecycleTicker` background task that re-evaluates ECR lifecycle policies every 5 minutes, prunes expired images, and updates `lifecycle_policy_last_evaluated_at` so `sinceImagePushed` rules work on idle repos. Also stamps `last_evaluated_at` on `StartLifecyclePolicyPreview`.

- **New Features**
  - Introduced `LifecycleTicker` in `fakecloud-ecr`; spawned from `fakecloud-server` at startup.
  - On each tick, scans all accounts/repos with a policy, applies prunes, and updates the timestamp.
  - `StartLifecyclePolicyPreview` now updates `last_evaluated_at` (non-destructive preview).
  - Idle setups are cheap: tick exits after a read-only scan when no policies are set (no write lock).

<sup>Written for commit ecc06fb2faec3050851d52ed00c09fc9224b9499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

