### PR TITLE
feat(apigatewayv2): @connections management API + connection metadata (S2)

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cors;
 pub mod extras;
 pub mod http_proxy;
 pub mod lambda_proxy;
+pub mod management;
 pub mod mock;
 pub mod router;
 pub(crate) mod service;

--- a/crates/fakecloud-apigatewayv2/src/management.rs
+++ b/crates/fakecloud-apigatewayv2/src/management.rs
@@ -1,0 +1,221 @@
+//! API Gateway v2 `apigatewaymanagementapi` data plane.
+//!
+//! AWS exposes the management API at
+//! `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/@connections/{connectionId}`
+//! and clients use it via the `apigatewaymanagementapi` SDK (PostToConnection,
+//! GetConnection, DeleteConnection). fakecloud serves a single host:port per
+//! process, so we accept the same `@connections/{id}` resource at both
+//! `/@connections/{id}` and `/{stage}/@connections/{id}` — the stage path
+//! prefix that real AWS includes in the URL is stripped by axum and ignored
+//! here, since connection ids are globally unique within a process.
+//!
+//! Errors match AWS's wire shape: 4xx responses carry a JSON `{"message": ...}`
+//! body and an `x-amzn-errortype` header so that botocore / aws-sdk-* clients
+//! surface the right exception class.
+
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde_json::json;
+
+use crate::state::SharedWebSocketRegistry;
+
+/// Build the `@connections/{id}` router served at the root path. AWS SDK
+/// clients usually hit the stage-prefixed form — see
+/// [`router_with_stage_prefix`].
+pub fn router(registry: SharedWebSocketRegistry) -> Router {
+    Router::new()
+        .route(
+            "/@connections/{connection_id}",
+            post(post_to_connection)
+                .get(get_connection)
+                .delete(delete_connection),
+        )
+        .with_state(registry)
+}
+
+/// Build a router that mounts the management routes both at the root and
+/// under a `/{stage}` prefix. AWS SDK clients hit
+/// `/<stage>/@connections/{id}`; tests and ad-hoc callers often hit
+/// `/@connections/{id}` directly.
+pub fn router_with_stage_prefix(registry: SharedWebSocketRegistry) -> Router {
+    Router::new()
+        .route(
+            "/@connections/{connection_id}",
+            post(post_to_connection)
+                .get(get_connection)
+                .delete(delete_connection),
+        )
+        .route(
+            "/{stage}/@connections/{connection_id}",
+            post(post_to_connection_staged)
+                .get(get_connection_staged)
+                .delete(delete_connection_staged),
+        )
+        .with_state(registry)
+}
+
+fn gone_response() -> Response {
+    aws_error_response(
+        StatusCode::GONE,
+        "GoneException",
+        "Connection is no longer available.",
+    )
+}
+
+fn aws_error_response(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = HeaderValue::from_str(error_type) {
+        headers.insert("x-amzn-errortype", v);
+    }
+    (
+        status,
+        headers,
+        Json(json!({ "message": message, "Message": message })),
+    )
+        .into_response()
+}
+
+async fn post_to_connection(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path(connection_id): Path<String>,
+    body: axum::body::Bytes,
+) -> Response {
+    post_to_connection_inner(registry, connection_id, body).await
+}
+
+/// Stage-prefixed variant matches AWS's actual endpoint shape; we ignore the
+/// stage segment because connection ids are unique per process.
+async fn post_to_connection_staged(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path((_stage, connection_id)): Path<(String, String)>,
+    body: axum::body::Bytes,
+) -> Response {
+    post_to_connection_inner(registry, connection_id, body).await
+}
+
+async fn post_to_connection_inner(
+    registry: SharedWebSocketRegistry,
+    connection_id: String,
+    body: axum::body::Bytes,
+) -> Response {
+    let sender = {
+        let r = registry.read();
+        r.get(&connection_id).map(|c| c.sender.clone())
+    };
+    let Some(sender) = sender else {
+        return gone_response();
+    };
+    let msg = match std::str::from_utf8(&body) {
+        Ok(s) => axum::extract::ws::Message::Text(s.to_string().into()),
+        Err(_) => axum::extract::ws::Message::Binary(body),
+    };
+    if sender.send(msg).is_err() {
+        // Receiver dropped between our read and send; clean up the stale
+        // entry and report gone so retries don't keep hitting this branch.
+        registry.write().remove(&connection_id);
+        return gone_response();
+    }
+    // Touch lastActiveAt — outbound traffic counts as activity in AWS too.
+    registry.write().touch(&connection_id);
+    (StatusCode::OK, Json(json!({}))).into_response()
+}
+
+async fn get_connection(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path(connection_id): Path<String>,
+) -> Response {
+    get_connection_inner(registry, connection_id)
+}
+
+async fn get_connection_staged(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path((_stage, connection_id)): Path<(String, String)>,
+) -> Response {
+    get_connection_inner(registry, connection_id)
+}
+
+fn get_connection_inner(registry: SharedWebSocketRegistry, connection_id: String) -> Response {
+    let r = registry.read();
+    let Some(c) = r.get(&connection_id) else {
+        return gone_response();
+    };
+    let mut identity = serde_json::Map::new();
+    identity.insert("sourceIp".to_string(), json!(c.source_ip));
+    if let Some(ua) = c.user_agent.as_deref() {
+        identity.insert("userAgent".to_string(), json!(ua));
+    }
+    (
+        StatusCode::OK,
+        Json(json!({
+            "connectedAt": c.connected_at.to_rfc3339(),
+            "lastActiveAt": c.last_active_at.to_rfc3339(),
+            "identity": serde_json::Value::Object(identity),
+        })),
+    )
+        .into_response()
+}
+
+async fn delete_connection(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path(connection_id): Path<String>,
+) -> Response {
+    delete_connection_inner(registry, connection_id)
+}
+
+async fn delete_connection_staged(
+    State(registry): State<SharedWebSocketRegistry>,
+    Path((_stage, connection_id)): Path<(String, String)>,
+) -> Response {
+    delete_connection_inner(registry, connection_id)
+}
+
+fn delete_connection_inner(registry: SharedWebSocketRegistry, connection_id: String) -> Response {
+    let removed = registry.write().remove(&connection_id);
+    let Some(info) = removed else {
+        return gone_response();
+    };
+    // Drop the sender after sending Close so the lifecycle task wakes up,
+    // forwards the close frame, and exits. Ignored if the receiver is
+    // already gone.
+    let _ = info.sender.send(axum::extract::ws::Message::Close(None));
+    StatusCode::NO_CONTENT.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::WebSocketRegistry;
+    use std::sync::Arc;
+
+    fn empty_registry() -> SharedWebSocketRegistry {
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()))
+    }
+
+    #[tokio::test]
+    async fn get_connection_inner_returns_410_when_missing() {
+        let resp = get_connection_inner(empty_registry(), "nope=".into());
+        assert_eq!(resp.status(), StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn delete_connection_inner_returns_410_when_missing() {
+        let resp = delete_connection_inner(empty_registry(), "nope=".into());
+        assert_eq!(resp.status(), StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn post_to_connection_inner_returns_410_when_missing() {
+        let resp = post_to_connection_inner(
+            empty_registry(),
+            "nope=".into(),
+            axum::body::Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::GONE);
+    }
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -34,6 +34,15 @@ impl WebSocketRegistry {
     pub fn contains(&self, connection_id: &str) -> bool {
         self.connections.contains_key(connection_id)
     }
+
+    /// Bump `last_active_at` to now. AWS updates this whenever traffic flows
+    /// in either direction; we mirror that on inbound frames and outbound
+    /// `PostToConnection` calls.
+    pub fn touch(&mut self, connection_id: &str) {
+        if let Some(info) = self.connections.get_mut(connection_id) {
+            info.last_active_at = Utc::now();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +53,10 @@ pub struct ConnectionInfo {
     pub connected_at: DateTime<Utc>,
     pub last_active_at: DateTime<Utc>,
     pub source_ip: String,
+    /// User-Agent header captured at WebSocket upgrade. Returned via
+    /// `GetConnection.identity.userAgent`. Optional: real AWS omits the
+    /// field entirely when the client didn't send a User-Agent.
+    pub user_agent: Option<String>,
     /// Outbound channel — `axum::extract::ws::Message::Close` triggers a close.
     pub sender: UnboundedSender<axum::extract::ws::Message>,
 }

--- a/crates/fakecloud-apigatewayv2/src/websocket.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket.rs
@@ -14,7 +14,9 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use crate::state::{ConnectionInfo, SharedWebSocketRegistry};
 
 /// Generate a 22-char base64-style connection id, matching AWS's
-/// `<random>=` pattern.
+/// `<random>=` pattern. We use the URL-safe alphabet so the id is a single
+/// path segment — base64 standard's `/` would otherwise be interpreted as
+/// a path separator by HTTP routers (including axum).
 pub fn generate_connection_id() -> String {
     use base64::prelude::*;
     let mut buf = [0u8; 16];
@@ -22,7 +24,7 @@ pub fn generate_connection_id() -> String {
     let uuid = uuid::Uuid::new_v4().as_u128();
     let mixed = nanos.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(uuid);
     buf[..16].copy_from_slice(&mixed.to_le_bytes());
-    let mut s = BASE64_STANDARD_NO_PAD.encode(buf);
+    let mut s = BASE64_URL_SAFE_NO_PAD.encode(buf);
     s.truncate(21);
     s.push('=');
     s
@@ -36,6 +38,7 @@ pub fn register(
     api_id: String,
     stage: String,
     source_ip: String,
+    user_agent: Option<String>,
 ) -> (String, UnboundedReceiver<Message>) {
     let (tx, rx) = unbounded_channel();
     let now = Utc::now();
@@ -47,6 +50,7 @@ pub fn register(
         connected_at: now,
         last_active_at: now,
         source_ip,
+        user_agent,
         sender: tx,
     };
     registry.write().insert(info);
@@ -62,13 +66,53 @@ pub fn deregister(registry: &SharedWebSocketRegistry, connection_id: &str) {
 /// close. `on_message` receives the raw bytes; `is_text` is true for text
 /// frames so dispatchers can preserve framing for `$default` events.
 pub async fn run_lifecycle<F, Fut>(
-    mut socket: WebSocket,
-    mut outbound: UnboundedReceiver<Message>,
+    socket: WebSocket,
+    outbound: UnboundedReceiver<Message>,
     on_message: F,
 ) where
     F: Fn(Vec<u8>, bool) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    run_lifecycle_inner(socket, outbound, on_message, None).await;
+}
+
+/// Same as [`run_lifecycle`] but also bumps `last_active_at` on the registry
+/// entry whenever an inbound frame arrives. This is what the server should
+/// call so that `GetConnection.lastActiveAt` reflects real WebSocket
+/// activity.
+pub async fn run_lifecycle_tracked<F, Fut>(
+    socket: WebSocket,
+    outbound: UnboundedReceiver<Message>,
+    on_message: F,
+    registry: SharedWebSocketRegistry,
+    connection_id: String,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    run_lifecycle_inner(
+        socket,
+        outbound,
+        on_message,
+        Some((registry, connection_id)),
+    )
+    .await;
+}
+
+async fn run_lifecycle_inner<F, Fut>(
+    mut socket: WebSocket,
+    mut outbound: UnboundedReceiver<Message>,
+    on_message: F,
+    activity: Option<(SharedWebSocketRegistry, String)>,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let touch = || {
+        if let Some((reg, id)) = activity.as_ref() {
+            reg.write().touch(id);
+        }
+    };
     loop {
         tokio::select! {
             biased;
@@ -89,9 +133,11 @@ pub async fn run_lifecycle<F, Fut>(
             incoming = socket.recv() => {
                 match incoming {
                     Some(Ok(Message::Text(text))) => {
+                        touch();
                         on_message(text.as_bytes().to_vec(), true).await;
                     }
                     Some(Ok(Message::Binary(bin))) => {
+                        touch();
                         on_message(bin.to_vec(), false).await;
                     }
                     Some(Ok(Message::Close(_))) => break,
@@ -116,6 +162,25 @@ mod tests {
     }
 
     #[test]
+    fn connection_id_is_single_url_path_segment() {
+        // Real AWS connection IDs are url-safe; base64 standard's `/` would
+        // collide with HTTP path separators and break `/@connections/{id}`
+        // routing. Generate enough to catch any accidental regression to
+        // the standard alphabet.
+        for _ in 0..1000 {
+            let id = generate_connection_id();
+            assert!(
+                !id.contains('/'),
+                "connection id contains '/': {id} — would break HTTP path routing"
+            );
+            assert!(
+                !id.contains('+'),
+                "connection id contains '+': {id} — would be percent-encoded by clients"
+            );
+        }
+    }
+
+    #[test]
     fn registry_insert_and_remove() {
         let registry: SharedWebSocketRegistry = Arc::new(parking_lot::RwLock::new(
             crate::state::WebSocketRegistry::default(),
@@ -125,6 +190,7 @@ mod tests {
             "api-1".into(),
             "dev".into(),
             "127.0.0.1".into(),
+            None,
         );
         assert!(registry.read().contains(&id));
         deregister(&registry, &id);
@@ -141,6 +207,7 @@ mod tests {
             "api-1".into(),
             "dev".into(),
             "127.0.0.1".into(),
+            Some("test-agent/1.0".into()),
         );
         let sender = registry.read().get(&id).unwrap().sender.clone();
         sender.send(Message::Text("hello".into())).unwrap();
@@ -162,5 +229,42 @@ mod tests {
         let next = rx.recv().await;
         assert!(matches!(next, Some(Message::Close(_))));
         assert!(rx.recv().await.is_none());
+    }
+
+    #[test]
+    fn register_captures_user_agent_and_source_ip() {
+        let registry: SharedWebSocketRegistry = Arc::new(parking_lot::RwLock::new(
+            crate::state::WebSocketRegistry::default(),
+        ));
+        let (id, _rx) = register(
+            registry.clone(),
+            "api-1".into(),
+            "dev".into(),
+            "203.0.113.7".into(),
+            Some("aws-sdk-go/1.0".into()),
+        );
+        let r = registry.read();
+        let info = r.get(&id).expect("connection registered");
+        assert_eq!(info.source_ip, "203.0.113.7");
+        assert_eq!(info.user_agent.as_deref(), Some("aws-sdk-go/1.0"));
+    }
+
+    #[test]
+    fn touch_updates_last_active_at() {
+        let registry: SharedWebSocketRegistry = Arc::new(parking_lot::RwLock::new(
+            crate::state::WebSocketRegistry::default(),
+        ));
+        let (id, _rx) = register(
+            registry.clone(),
+            "api-1".into(),
+            "dev".into(),
+            "127.0.0.1".into(),
+            None,
+        );
+        let before = registry.read().get(&id).unwrap().last_active_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        registry.write().touch(&id);
+        let after = registry.read().get(&id).unwrap().last_active_at;
+        assert!(after > before, "last_active_at should bump on touch");
     }
 }

--- a/crates/fakecloud-apigatewayv2/tests/websocket_e2e.rs
+++ b/crates/fakecloud-apigatewayv2/tests/websocket_e2e.rs
@@ -1,90 +1,59 @@
 //! End-to-end WebSocket data plane tests.
 //!
-//! Boots a minimal axum app with the same routes the server wires up and
-//! drives them through `tokio-tungstenite` to assert real upgrade -> message
-//! -> close round-trips. Mirrors the server's `/_fakecloud/apigatewayv2/ws/{api_id}`
-//! and `/@connections/{id}` handlers; if the server's wiring drifts, these
-//! tests will pass against the harness but the production server still needs
-//! the same shape — see `crates/fakecloud-server/src/main.rs`.
+//! Boots a minimal axum app that mirrors the server's wiring: the WebSocket
+//! upgrade endpoint at `/_fakecloud/apigatewayv2/ws/{api_id}` plus the
+//! `apigatewaymanagementapi` router at `/@connections/{id}` and
+//! `/{stage}/@connections/{id}`. Drives them through `tokio-tungstenite` and
+//! `reqwest` to exercise the upgrade -> message -> close round-trip and the
+//! PostToConnection / GetConnection / DeleteConnection ops.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::extract::ws::Message;
 use axum::Router;
-use fakecloud_apigatewayv2::{websocket, SharedWebSocketRegistry, WebSocketRegistry};
+use fakecloud_apigatewayv2::{management, websocket, SharedWebSocketRegistry, WebSocketRegistry};
 use futures_util::StreamExt as _;
 use tokio::net::TcpListener;
 
 fn make_app(registry: SharedWebSocketRegistry) -> Router {
-    Router::new()
-        .route(
-            "/_fakecloud/apigatewayv2/ws/{api_id}",
-            axum::routing::get({
-                let reg = registry.clone();
-                move |ws: axum::extract::WebSocketUpgrade,
-                      axum::extract::Path(api_id): axum::extract::Path<String>,
-                      axum::extract::Query(_params): axum::extract::Query<
-                    HashMap<String, String>,
-                >| {
-                    let reg = reg.clone();
-                    async move {
-                        ws.on_upgrade(move |socket| async move {
-                            let (conn_id, rx) = websocket::register(
-                                reg.clone(),
-                                api_id,
-                                "$default".to_string(),
-                                "127.0.0.1".to_string(),
-                            );
-                            websocket::run_lifecycle(socket, rx, |_b, _t| async {}).await;
-                            websocket::deregister(&reg, &conn_id);
-                        })
-                    }
+    let ws_router = Router::new().route(
+        "/_fakecloud/apigatewayv2/ws/{api_id}",
+        axum::routing::get({
+            let reg = registry.clone();
+            move |ws: axum::extract::WebSocketUpgrade,
+                  axum::extract::Path(api_id): axum::extract::Path<String>,
+                  axum::extract::Query(_params): axum::extract::Query<HashMap<String, String>>,
+                  headers: axum::http::HeaderMap| {
+                let reg = reg.clone();
+                async move {
+                    let user_agent = headers
+                        .get(axum::http::header::USER_AGENT)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    ws.on_upgrade(move |socket| async move {
+                        let (conn_id, rx) = websocket::register(
+                            reg.clone(),
+                            api_id,
+                            "$default".to_string(),
+                            "127.0.0.1".to_string(),
+                            user_agent,
+                        );
+                        let conn_id_clone = conn_id.clone();
+                        websocket::run_lifecycle_tracked(
+                            socket,
+                            rx,
+                            |_b, _t| async {},
+                            reg.clone(),
+                            conn_id_clone,
+                        )
+                        .await;
+                        websocket::deregister(&reg, &conn_id);
+                    })
                 }
-            }),
-        )
-        .route(
-            "/@connections/{connection_id}",
-            axum::routing::post({
-                let reg = registry.clone();
-                move |axum::extract::Path(id): axum::extract::Path<String>,
-                      body: axum::body::Bytes| {
-                    let reg = reg.clone();
-                    async move {
-                        let sender = {
-                            let r = reg.read();
-                            r.get(&id).map(|c| c.sender.clone())
-                        };
-                        let Some(sender) = sender else {
-                            return axum::http::StatusCode::GONE;
-                        };
-                        let msg = match std::str::from_utf8(&body) {
-                            Ok(s) => Message::Text(s.to_string().into()),
-                            Err(_) => Message::Binary(body),
-                        };
-                        if sender.send(msg).is_err() {
-                            reg.write().remove(&id);
-                            return axum::http::StatusCode::GONE;
-                        }
-                        axum::http::StatusCode::OK
-                    }
-                }
-            })
-            .delete({
-                let reg = registry.clone();
-                move |axum::extract::Path(id): axum::extract::Path<String>| {
-                    let reg = reg.clone();
-                    async move {
-                        let removed = reg.write().remove(&id);
-                        let Some(info) = removed else {
-                            return axum::http::StatusCode::GONE;
-                        };
-                        let _ = info.sender.send(Message::Close(None));
-                        axum::http::StatusCode::NO_CONTENT
-                    }
-                }
-            }),
-        )
+            }
+        }),
+    );
+    ws_router.merge(management::router_with_stage_prefix(registry))
 }
 
 async fn spawn_app(registry: SharedWebSocketRegistry) -> String {
@@ -103,6 +72,22 @@ async fn open_ws(
 ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
     let url = format!("ws://{}/_fakecloud/apigatewayv2/ws/{}", addr, api_id);
     let (stream, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+    stream
+}
+
+async fn open_ws_with_user_agent(
+    addr: &str,
+    api_id: &str,
+    user_agent: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    let url = format!("ws://{}/_fakecloud/apigatewayv2/ws/{}", addr, api_id);
+    let mut req = url.into_client_request().unwrap();
+    req.headers_mut().insert(
+        "User-Agent",
+        tokio_tungstenite::tungstenite::http::HeaderValue::from_str(user_agent).unwrap(),
+    );
+    let (stream, _) = tokio_tungstenite::connect_async(req).await.unwrap();
     stream
 }
 
@@ -169,6 +154,32 @@ async fn post_to_connections_endpoint_sends_message_to_client() {
 }
 
 #[tokio::test]
+async fn post_to_connections_with_stage_prefix_routes_same_handler() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let mut ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    let client = reqwest::Client::new();
+    // Real AWS SDKs hit `/<stage>/@connections/<id>`. We accept the same
+    // shape and ignore the stage segment.
+    let resp = client
+        .post(format!("http://{}/prod/@connections/{}", addr, id))
+        .body("hello-staged")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let msg = ws.next().await.unwrap().unwrap();
+    match msg {
+        tokio_tungstenite::tungstenite::Message::Text(t) => {
+            assert_eq!(t.as_str(), "hello-staged");
+        }
+        other => panic!("expected text frame, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn post_to_connections_endpoint_returns_410_when_connection_gone() {
     let registry: SharedWebSocketRegistry =
         Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
@@ -181,6 +192,72 @@ async fn post_to_connections_endpoint_returns_410_when_connection_gone() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 410);
+    // AWS SDKs read the error class from the `x-amzn-errortype` header.
+    assert_eq!(
+        resp.headers()
+            .get("x-amzn-errortype")
+            .and_then(|v| v.to_str().ok()),
+        Some("GoneException")
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body
+        .get("message")
+        .and_then(|v| v.as_str())
+        .is_some_and(|m| !m.is_empty()));
+}
+
+#[tokio::test]
+async fn get_connection_returns_metadata() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let _ws = open_ws_with_user_agent(&addr, "api-1", "fakecloud-test/1.0").await;
+    let id = wait_for_connection(&registry).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/@connections/{}", addr, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body
+        .get("connectedAt")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty()));
+    assert!(body
+        .get("lastActiveAt")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty()));
+    let identity = body.get("identity").expect("identity present");
+    assert_eq!(
+        identity.get("sourceIp").and_then(|v| v.as_str()),
+        Some("127.0.0.1")
+    );
+    assert_eq!(
+        identity.get("userAgent").and_then(|v| v.as_str()),
+        Some("fakecloud-test/1.0")
+    );
+}
+
+#[tokio::test]
+async fn get_connection_returns_410_when_missing() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/@connections/{}", addr, "missing="))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 410);
+    assert_eq!(
+        resp.headers()
+            .get("x-amzn-errortype")
+            .and_then(|v| v.to_str().ok()),
+        Some("GoneException")
+    );
 }
 
 #[tokio::test]
@@ -205,4 +282,52 @@ async fn delete_connection_closes_websocket() {
         Some(Ok(other)) => panic!("expected close, got {other:?}"),
         Some(Err(err)) => panic!("ws error: {err}"),
     }
+}
+
+#[tokio::test]
+async fn post_to_connections_after_delete_returns_410() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let _ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    let client = reqwest::Client::new();
+    let del = client
+        .delete(format!("http://{}/@connections/{}", addr, id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(del.status(), 204);
+    let resp = client
+        .post(format!("http://{}/@connections/{}", addr, id))
+        .body("after-delete")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 410);
+}
+
+#[tokio::test]
+async fn inbound_message_bumps_last_active_at() {
+    let registry: SharedWebSocketRegistry =
+        Arc::new(parking_lot::RwLock::new(WebSocketRegistry::default()));
+    let addr = spawn_app(registry.clone()).await;
+    let mut ws = open_ws(&addr, "api-1").await;
+    let id = wait_for_connection(&registry).await;
+    let initial = registry.read().get(&id).unwrap().last_active_at;
+    // Wait a moment so the resolution can show progress, then send a frame.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    use futures_util::SinkExt as _;
+    ws.send(tokio_tungstenite::tungstenite::Message::Text("ping".into()))
+        .await
+        .unwrap();
+    // Give the server a chance to process the inbound frame.
+    for _ in 0..50 {
+        let now = registry.read().get(&id).unwrap().last_active_at;
+        if now > initial {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("last_active_at did not advance after inbound frame");
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -4662,6 +4662,10 @@ async fn main() {
                       axum::extract::Path(api_id): axum::extract::Path<String>,
                       axum::extract::Query(params): axum::extract::Query<
                     std::collections::HashMap<String, String>,
+                >,
+                      headers: axum::http::HeaderMap,
+                      axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<
+                    std::net::SocketAddr,
                 >| {
                     let reg = reg.clone();
                     async move {
@@ -4669,13 +4673,20 @@ async fn main() {
                             .get("stage")
                             .cloned()
                             .unwrap_or_else(|| "$default".to_string());
+                        let user_agent = headers
+                            .get(axum::http::header::USER_AGENT)
+                            .and_then(|v| v.to_str().ok())
+                            .map(|s| s.to_string());
+                        let source_ip = addr.ip().to_string();
                         ws.on_upgrade(move |socket| async move {
                             let (conn_id, rx) = fakecloud_apigatewayv2::websocket::register(
                                 reg.clone(),
                                 api_id,
                                 stage,
-                                "127.0.0.1".to_string(),
+                                source_ip,
+                                user_agent,
                             );
+                            let conn_id_for_lifecycle = conn_id.clone();
                             // Echo dispatcher stub — real Lambda dispatch for
                             // `$default` is wired up in a follow-up; for now
                             // we just log. `@connections` POST exercises the
@@ -4692,8 +4703,12 @@ async fn main() {
                                     );
                                 }
                             };
-                            fakecloud_apigatewayv2::websocket::run_lifecycle(
-                                socket, rx, on_message,
+                            fakecloud_apigatewayv2::websocket::run_lifecycle_tracked(
+                                socket,
+                                rx,
+                                on_message,
+                                reg.clone(),
+                                conn_id_for_lifecycle,
                             )
                             .await;
                             fakecloud_apigatewayv2::websocket::deregister(&reg, &conn_id);
@@ -4702,90 +4717,9 @@ async fn main() {
                 }
             }),
         )
-        .route(
-            "/@connections/{connection_id}",
-            axum::routing::post({
-                let reg = apigatewayv2_ws_registry.clone();
-                move |axum::extract::Path(connection_id): axum::extract::Path<String>,
-                      body: axum::body::Bytes| {
-                    let reg = reg.clone();
-                    async move {
-                        let sender = {
-                            let r = reg.read();
-                            r.get(&connection_id).map(|c| c.sender.clone())
-                        };
-                        let Some(sender) = sender else {
-                            return (
-                                axum::http::StatusCode::GONE,
-                                axum::Json(serde_json::json!({
-                                    "Message": "GoneException",
-                                })),
-                            );
-                        };
-                        let msg = match std::str::from_utf8(&body) {
-                            Ok(s) => axum::extract::ws::Message::Text(s.to_string().into()),
-                            Err(_) => axum::extract::ws::Message::Binary(body.clone()),
-                        };
-                        if sender.send(msg).is_err() {
-                            // Receiver dropped between read and send: treat as
-                            // gone too. Clean up the stale entry while we're
-                            // here so retries don't keep hitting this branch.
-                            reg.write().remove(&connection_id);
-                            return (
-                                axum::http::StatusCode::GONE,
-                                axum::Json(serde_json::json!({
-                                    "Message": "GoneException",
-                                })),
-                            );
-                        }
-                        (
-                            axum::http::StatusCode::OK,
-                            axum::Json(serde_json::json!({})),
-                        )
-                    }
-                }
-            })
-            .get({
-                let reg = apigatewayv2_ws_registry.clone();
-                move |axum::extract::Path(connection_id): axum::extract::Path<String>| {
-                    let reg = reg.clone();
-                    async move {
-                        let r = reg.read();
-                        let Some(c) = r.get(&connection_id) else {
-                            return (
-                                axum::http::StatusCode::GONE,
-                                axum::Json(serde_json::json!({
-                                    "Message": "GoneException",
-                                })),
-                            );
-                        };
-                        (
-                            axum::http::StatusCode::OK,
-                            axum::Json(serde_json::json!({
-                                "ConnectedAt": c.connected_at.to_rfc3339(),
-                                "Identity": { "SourceIp": c.source_ip },
-                                "LastActiveAt": c.last_active_at.to_rfc3339(),
-                            })),
-                        )
-                    }
-                }
-            })
-            .delete({
-                let reg = apigatewayv2_ws_registry.clone();
-                move |axum::extract::Path(connection_id): axum::extract::Path<String>| {
-                    let reg = reg.clone();
-                    async move {
-                        let removed = reg.write().remove(&connection_id);
-                        let Some(info) = removed else {
-                            return axum::http::StatusCode::GONE;
-                        };
-                        // Trigger lifecycle exit on the connection task.
-                        let _ = info.sender.send(axum::extract::ws::Message::Close(None));
-                        axum::http::StatusCode::NO_CONTENT
-                    }
-                }
-            }),
-        )
+        .merge(fakecloud_apigatewayv2::management::router_with_stage_prefix(
+            apigatewayv2_ws_registry.clone(),
+        ))
         .route(
             // Direct injection of an activity task (skipping a state-machine
             // execution). Used by tests that want to exercise the worker

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -112,9 +112,10 @@ curl http://localhost:4566/_fakecloud/health
 
 ## API Gateway v2
 
-| Endpoint                            | Method | Description |
-| ----------------------------------- | ------ | ----------- |
-| `/_fakecloud/apigatewayv2/requests` | GET    | List all HTTP API requests received. |
+| Endpoint                              | Method | Description |
+| ------------------------------------- | ------ | ----------- |
+| `/_fakecloud/apigatewayv2/requests`   | GET    | List all HTTP API requests received. |
+| `/_fakecloud/apigatewayv2/connections` | GET   | List live WebSocket connections (id, api, stage, timestamps, source IP). |
 
 ## RDS
 

--- a/website/content/docs/services/apigatewayv2.md
+++ b/website/content/docs/services/apigatewayv2.md
@@ -9,6 +9,7 @@ fakecloud implements **103 of 103** API Gateway v2 operations at 100% conformanc
 ## Supported features
 
 - **HTTP APIs** — CreateApi, UpdateApi, DeleteApi, GetApis
+- **WebSocket APIs** — CreateApi with `protocolType=WEBSOCKET`, live data plane upgrade endpoint
 - **Routes** — path parameters, wildcards, HTTP method routing
 - **Integrations** — Lambda proxy (v2.0 format), HTTP proxy, Mock integration
 - **Stages** — CRUD, deployments, default stage
@@ -16,14 +17,16 @@ fakecloud implements **103 of 103** API Gateway v2 operations at 100% conformanc
 - **CORS** — configuration on routes and globally
 - **Request history** — every request served is recorded for introspection
 - **Deployments** — CreateDeployment, GetDeployments
+- **Management API** — `apigatewaymanagementapi` ops (PostToConnection, GetConnection, DeleteConnection) at `/@connections/{id}` and `/{stage}/@connections/{id}`
 
 ## Protocol
 
-REST for management, path-based routing for the executed API.
+REST for management, path-based routing for the executed API. WebSocket APIs upgrade at `/_fakecloud/apigatewayv2/ws/{api_id}` and the management API is served on the same host:port — point the AWS SDK's `apigatewaymanagementapi` client at the fakecloud endpoint URL.
 
 ## Introspection
 
 - `GET /_fakecloud/apigatewayv2/requests` — list all HTTP API requests received (method, path, headers, query params, status code, integration response)
+- `GET /_fakecloud/apigatewayv2/connections` — list live WebSocket connections with `connectionId`, `apiId`, `stage`, `connectedAt`, `lastActiveAt`, `sourceIp`
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

- Introduces a `fakecloud_apigatewayv2::management` module hosting the `apigatewaymanagementapi` data plane (`PostToConnection`, `GetConnection`, `DeleteConnection`). Replaces the inline handlers the server carried from S1 and drops AWS-shaped `GoneException` responses (`x-amzn-errortype` header + `{message}` body) on missing connections.
- Accepts both `/@connections/{id}` and the AWS SDK's stage-prefixed `/{stage}/@connections/{id}` so `apigatewaymanagementapi` clients work against the fakecloud endpoint URL with no proxy.
- Extends `ConnectionInfo` with `user_agent`. `GetConnection` returns `identity.{sourceIp,userAgent}`, `connectedAt`, and `lastActiveAt`. `lastActiveAt` is bumped on inbound WS frames (via `run_lifecycle_tracked`) and on outbound `PostToConnection` calls.
- WS upgrade now captures the real client IP via `ConnectInfo<SocketAddr>` instead of hardcoding 127.0.0.1.
- Connection ids switched to base64 url-safe to avoid the standard alphabet's `/` slipping into the path and breaking `/@connections/{id}` routing. 1000-iter regression test covers it.
- Website: `docs/services/apigatewayv2.md` and `docs/reference/introspection.md` updated with the new surface.

## Test plan

- [x] `cargo test -p fakecloud-apigatewayv2` (94 lib + 10 e2e tests including PostToConnection, GetConnection, DeleteConnection, stage-prefixed routing, 410 GoneException flows, and `lastActiveAt` bump)
- [x] `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings`
- [x] `cargo clippy -p fakecloud --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] e2e suite re-run 5x to confirm no flake from the connection-id routing fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the WebSocket `@connections` management API for API Gateway v2 with AWS-compatible behavior and connection metadata. `apigatewaymanagementapi` clients can now call `PostToConnection`, `GetConnection`, and `DeleteConnection` directly against fakecloud.

- **New Features**
  - New `fakecloud_apigatewayv2::management` module implementing `PostToConnection`, `GetConnection`, and `DeleteConnection` at `/@connections/{id}` and `/{stage}/@connections/{id}`.
  - `GetConnection` returns `connectedAt`, `lastActiveAt`, and `identity.{sourceIp,userAgent}`; `lastActiveAt` updates on inbound frames and outbound `PostToConnection`. Real client IP and User-Agent are captured during upgrade.

- **Bug Fixes**
  - Return AWS-shaped 410 `GoneException` for missing connections (`x-amzn-errortype` header and `{"message": ...}` body) for SDK compatibility.
  - Generate base64 URL-safe connection IDs to avoid `/` breaking path routing; covered by a 1000-iter regression test.

<sup>Written for commit 3d5c2fc6cb28b51bc2b5c9a6232504988f5b1828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

