### PR TITLE
feat(iam): wire MFA + federated provider + token issue time on STS sessions (F3)

### DIFF
--- a/crates/fakecloud-core/src/auth.rs
+++ b/crates/fakecloud-core/src/auth.rs
@@ -123,6 +123,16 @@ pub struct ResolvedCredential {
     /// `aws:MultiFactorAuthPresent` for downstream IAM evaluation. Always
     /// false for raw IAM user access keys.
     pub mfa_present: bool,
+    /// Wall-clock time at which the underlying STS credential was issued.
+    /// Drives `aws:TokenIssueTime` and `aws:MultiFactorAuthAge` (the latter
+    /// computed at evaluation time as `now - token_issued_at` when
+    /// [`Self::mfa_present`] is true). `None` for raw IAM user access keys
+    /// — AWS does not expose `aws:TokenIssueTime` for long-lived credentials.
+    pub token_issued_at: Option<DateTime<Utc>>,
+    /// `aws:FederatedProvider` — SAML provider ARN for AssumeRoleWithSAML,
+    /// OIDC provider ARN for AssumeRoleWithWebIdentity. `None` for raw IAM
+    /// user keys, plain AssumeRole, GetSessionToken, GetFederationToken.
+    pub federated_provider: Option<String>,
 }
 
 impl ResolvedCredential {
@@ -820,6 +830,8 @@ mod tests {
             },
             session_policies: Vec::new(),
             mfa_present: false,
+            token_issued_at: None,
+            federated_provider: None,
         };
         assert_eq!(rc.principal_arn(), "arn:aws:iam::123456789012:user/alice");
         assert_eq!(rc.user_id(), "AIDAALICE");

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -383,12 +383,34 @@ pub async fn dispatch(
                             &aws_request.region,
                             is_secure_transport(&aws_request.headers),
                         );
-                        // MFA flag rides on the resolved credential — STS
-                        // mints it true when AssumeRole supplied
-                        // SerialNumber + TokenCode. IAM user access keys
-                        // never have it, matching AWS.
+                        // F3 keys riding on the resolved credential. STS
+                        // populates these at mint time so subsequent
+                        // requests under the credential can be evaluated
+                        // against `aws:MultiFactorAuthPresent`,
+                        // `aws:MultiFactorAuthAge`, `aws:TokenIssueTime`,
+                        // and `aws:FederatedProvider`. IAM user access
+                        // keys carry none of these, matching AWS.
                         if let Some(rc) = resolved.as_ref() {
                             condition_context.aws_mfa_present = Some(rc.mfa_present);
+                            condition_context.aws_token_issue_time = rc.token_issued_at;
+                            condition_context.aws_federated_provider =
+                                rc.federated_provider.clone();
+                            // `aws:MultiFactorAuthAge` is "seconds since
+                            // MFA was asserted" — computed at evaluation
+                            // time from the token issue moment so the
+                            // value increases monotonically as the session
+                            // ages. Only set when the session was actually
+                            // minted with MFA; otherwise the key is
+                            // absent, matching AWS.
+                            if rc.mfa_present {
+                                if let Some(issued) = rc.token_issued_at {
+                                    let age = chrono::Utc::now()
+                                        .signed_duration_since(issued)
+                                        .num_seconds()
+                                        .max(0);
+                                    condition_context.aws_mfa_age_seconds = Some(age);
+                                }
+                            }
                         }
                         condition_context.service_keys =
                             service.iam_condition_keys_for(&aws_request, &iam_action);

--- a/crates/fakecloud-iam/src/condition.rs
+++ b/crates/fakecloud-iam/src/condition.rs
@@ -27,26 +27,31 @@
 //! Plus the `...IfExists` suffix and the `ForAllValues:` / `ForAnyValue:`
 //! qualifiers on every operator.
 //!
-//! **Implemented global keys** (Phase 2 initial set):
+//! **Implemented global keys**:
 //!
-//! - `aws:username`
-//! - `aws:userid`
-//! - `aws:PrincipalArn`
-//! - `aws:PrincipalAccount`
-//! - `aws:PrincipalType`
-//! - `aws:SourceIp`
-//! - `aws:CurrentTime`
-//! - `aws:EpochTime`
-//! - `aws:SecureTransport`
-//! - `aws:RequestedRegion`
-//! - `aws:MultiFactorAuthPresent`
-//! - `aws:MultiFactorAuthAge`
-//! - `aws:CalledVia`
-//! - `aws:SourceVpc`
-//! - `aws:SourceVpce`
-//! - `aws:VpcSourceIp`
-//! - `aws:FederatedProvider`
-//! - `aws:TokenIssueTime`
+//! - `aws:username` — populated from the IAM user ARN at dispatch time;
+//!   absent for assumed-role / federated-user / root principals,
+//!   matching AWS.
+//! - `aws:userid` — `<role-id>:<RoleSessionName>` for assumed-role
+//!   sessions, the IAM user's `AIDA...` id for IAM users.
+//! - `aws:PrincipalArn`, `aws:PrincipalAccount`, `aws:PrincipalType`
+//! - `aws:SourceIp` — remote-address of the HTTP connection.
+//! - `aws:CurrentTime`, `aws:EpochTime`
+//! - `aws:SecureTransport`, `aws:RequestedRegion`
+//! - `aws:MultiFactorAuthPresent` — `true` iff the underlying STS
+//!   session was minted with `SerialNumber` + `TokenCode`.
+//! - `aws:MultiFactorAuthAge` — seconds since the MFA-asserted session
+//!   was minted; only present when MFA was supplied at mint time.
+//! - `aws:CalledVia` — multi-value chain of service principals that
+//!   re-invoked downstream services on the caller's behalf.
+//! - `aws:SourceVpc`, `aws:SourceVpce`, `aws:VpcSourceIp` — populated
+//!   when the request transited a VPC interface endpoint.
+//! - `aws:FederatedProvider` — SAML provider ARN for
+//!   `AssumeRoleWithSAML`, OIDC provider ARN (or `ProviderId` host)
+//!   for `AssumeRoleWithWebIdentity`. Absent for IAM user keys, plain
+//!   `AssumeRole`, `GetSessionToken`, `GetFederationToken`.
+//! - `aws:TokenIssueTime` — wall-clock time at which the underlying
+//!   STS credential was issued. Absent for IAM user access keys.
 //!
 //! Service-specific keys (`s3:prefix`, `sqs:MessageAttribute`, …) are
 //! deferred to a follow-up batch; the [`ConditionContext::service_keys`]
@@ -931,5 +936,268 @@ mod tests {
         assert!(!cidr_match("10.0.0.0/8", "11.0.0.1"));
         assert!(cidr_match("0.0.0.0/0", "1.2.3.4"));
         assert!(!cidr_match("invalid", "1.2.3.4"));
+    }
+
+    // ---- F3 global condition keys ----
+
+    #[test]
+    fn mfa_present_bool_true() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_present = Some(true);
+        let b = compile(json!({
+            "Bool": { "aws:MultiFactorAuthPresent": "true" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn mfa_present_bool_false_when_absent_session() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_present = Some(false);
+        let b = compile(json!({
+            "Bool": { "aws:MultiFactorAuthPresent": "true" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn mfa_present_missing_key_safe_fails_without_if_exists() {
+        // Long-lived IAM user keys never have MFA; a policy that
+        // requires it must safe-fail.
+        let ctx = ctx_user("alice");
+        let b = compile(json!({
+            "Bool": { "aws:MultiFactorAuthPresent": "true" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn mfa_present_if_exists_passes_when_absent() {
+        let ctx = ctx_user("alice");
+        let b = compile(json!({
+            "BoolIfExists": { "aws:MultiFactorAuthPresent": "true" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn mfa_age_numeric_less_than() {
+        // Session minted 60 seconds ago — policy requires age < 3600.
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_age_seconds = Some(60);
+        let b = compile(json!({
+            "NumericLessThan": { "aws:MultiFactorAuthAge": "3600" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn mfa_age_numeric_greater_than_blocks_old_sessions() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_age_seconds = Some(7200);
+        let b = compile(json!({
+            "NumericLessThan": { "aws:MultiFactorAuthAge": "3600" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn called_via_string_equals_matches_first_hop() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_called_via = vec!["cloudformation.amazonaws.com".into()];
+        let b = compile(json!({
+            "StringEquals": { "aws:CalledVia": "cloudformation.amazonaws.com" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn called_via_for_any_value_matches_in_chain() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_called_via = vec![
+            "cloudformation.amazonaws.com".into(),
+            "athena.amazonaws.com".into(),
+        ];
+        let b = compile(json!({
+            "ForAnyValue:StringEquals": {
+                "aws:CalledVia": ["athena.amazonaws.com", "lambda.amazonaws.com"]
+            }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn called_via_for_all_values_requires_every_hop_in_set() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_called_via = vec![
+            "cloudformation.amazonaws.com".into(),
+            "athena.amazonaws.com".into(),
+        ];
+        let b = compile(json!({
+            "ForAllValues:StringEquals": {
+                "aws:CalledVia": ["cloudformation.amazonaws.com", "athena.amazonaws.com", "lambda.amazonaws.com"]
+            }
+        }));
+        assert!(b.matches(&ctx));
+        // Add a hop not in the policy set; ForAllValues now fails.
+        ctx.aws_called_via.push("ec2.amazonaws.com".into());
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn source_vpce_string_equals() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_source_vpce = Some("vpce-0abcd1234".into());
+        let b = compile(json!({
+            "StringEquals": { "aws:SourceVpce": "vpce-0abcd1234" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn source_vpce_string_not_equals_blocks_other() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_source_vpce = Some("vpce-bad".into());
+        let b = compile(json!({
+            "StringEquals": { "aws:SourceVpce": "vpce-good" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn source_vpc_string_equals() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_source_vpc = Some("vpc-1a2b3c".into());
+        let b = compile(json!({
+            "StringEquals": { "aws:SourceVpc": "vpc-1a2b3c" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn vpc_source_ip_cidr_match() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_vpc_source_ip = Some("172.31.5.10".parse().unwrap());
+        let b = compile(json!({
+            "IpAddress": { "aws:VpcSourceIp": "172.31.0.0/16" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn vpc_source_ip_cidr_outside() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_vpc_source_ip = Some("10.0.0.5".parse().unwrap());
+        let b = compile(json!({
+            "IpAddress": { "aws:VpcSourceIp": "172.31.0.0/16" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn federated_provider_string_equals_saml_arn() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_federated_provider = Some("arn:aws:iam::123456789012:saml-provider/idp".into());
+        let b = compile(json!({
+            "StringEquals": {
+                "aws:FederatedProvider": "arn:aws:iam::123456789012:saml-provider/idp"
+            }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn federated_provider_string_like_oidc_host() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_federated_provider = Some("accounts.google.com".into());
+        let b = compile(json!({
+            "StringLike": { "aws:FederatedProvider": "accounts.*" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn token_issue_time_date_less_than() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_token_issue_time = DateTime::parse_from_rfc3339("2024-06-01T00:00:00Z")
+            .ok()
+            .map(|d| d.with_timezone(&Utc));
+        let b = compile(json!({
+            "DateLessThan": { "aws:TokenIssueTime": "2024-12-31T23:59:59Z" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn token_issue_time_date_greater_than_blocks_old_token() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_token_issue_time = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .ok()
+            .map(|d| d.with_timezone(&Utc));
+        let b = compile(json!({
+            "DateGreaterThan": { "aws:TokenIssueTime": "2024-06-01T00:00:00Z" }
+        }));
+        assert!(!b.matches(&ctx));
+    }
+
+    #[test]
+    fn userid_string_equals_assumed_role_format() {
+        // AWS userid format for assumed roles: <role-id>:<RoleSessionName>
+        let mut ctx = ctx_user("alice");
+        ctx.aws_userid = Some("AROAEXAMPLE:bob-session".into());
+        let b = compile(json!({
+            "StringEquals": { "aws:userid": "AROAEXAMPLE:bob-session" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn userid_string_like_wildcard() {
+        let mut ctx = ctx_user("alice");
+        ctx.aws_userid = Some("AROAEXAMPLE:bob-session".into());
+        let b = compile(json!({
+            "StringLike": { "aws:userid": "AROAEXAMPLE:*" }
+        }));
+        assert!(b.matches(&ctx));
+    }
+
+    #[test]
+    fn username_lookup_case_insensitive_for_f3_keys() {
+        // AWS treats every condition key case-insensitively. Spot-check
+        // each F3 key's lookup with mixed case.
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_present = Some(true);
+        ctx.aws_called_via = vec!["lambda.amazonaws.com".into()];
+        ctx.aws_source_vpc = Some("vpc-x".into());
+        ctx.aws_federated_provider = Some("accounts.google.com".into());
+        ctx.aws_token_issue_time = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .ok()
+            .map(|d| d.with_timezone(&Utc));
+
+        assert!(ctx.lookup("AWS:MULTIFACTORAUTHPRESENT").is_some());
+        assert!(ctx.lookup("aws:multifactorauthpresent").is_some());
+        assert!(ctx.lookup("aws:CalledVia").is_some());
+        assert!(ctx.lookup("AWS:SOURCEVPC").is_some());
+        assert!(ctx.lookup("aws:FederatedProvider").is_some());
+        assert!(ctx.lookup("aws:tokenissuetime").is_some());
+    }
+
+    #[test]
+    fn combined_mfa_and_token_issue_time() {
+        // Realistic policy: only allow when MFA is present AND the
+        // session was minted in the last hour. Combined AND semantics.
+        let mut ctx = ctx_user("alice");
+        ctx.aws_mfa_present = Some(true);
+        ctx.aws_mfa_age_seconds = Some(120);
+        ctx.aws_token_issue_time = Some(Utc::now() - chrono::Duration::seconds(120));
+        let b = compile(json!({
+            "Bool": { "aws:MultiFactorAuthPresent": "true" },
+            "NumericLessThan": { "aws:MultiFactorAuthAge": "3600" }
+        }));
+        assert!(b.matches(&ctx));
+
+        // Bump the age past the policy ceiling — denied.
+        ctx.aws_mfa_age_seconds = Some(7200);
+        assert!(!b.matches(&ctx));
     }
 }

--- a/crates/fakecloud-iam/src/credential_resolver.rs
+++ b/crates/fakecloud-iam/src/credential_resolver.rs
@@ -51,6 +51,8 @@ impl CredentialResolver for IamCredentialResolver {
                     },
                     session_policies: lookup.session_policies,
                     mfa_present: lookup.mfa_present,
+                    token_issued_at: lookup.token_issued_at,
+                    federated_provider: lookup.federated_provider,
                 });
             }
         }
@@ -140,6 +142,8 @@ mod tests {
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
         let resolver = IamCredentialResolver::new(shared(state));
@@ -299,6 +303,8 @@ mod tests {
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
         let resolver = IamCredentialResolver::new(shared(state));

--- a/crates/fakecloud-iam/src/state.rs
+++ b/crates/fakecloud-iam/src/state.rs
@@ -230,6 +230,25 @@ pub struct StsTempCredential {
     /// to downstream IAM evaluation as `aws:MultiFactorAuthPresent`.
     #[serde(default)]
     pub mfa_present: bool,
+    /// Wall-clock time at which the credential was issued. Surfaces to
+    /// downstream IAM evaluation as `aws:TokenIssueTime` and feeds
+    /// `aws:MultiFactorAuthAge` (computed at evaluation time as
+    /// `now - issued_at` in seconds when MFA was asserted).
+    #[serde(default = "default_issued_at")]
+    pub issued_at: DateTime<Utc>,
+    /// `aws:FederatedProvider` — for AssumeRoleWithSAML this is the
+    /// SAML provider ARN; for AssumeRoleWithWebIdentity it is the OIDC
+    /// provider ARN (or a friendly host name like
+    /// `cognito-identity.amazonaws.com`); `None` for plain AssumeRole /
+    /// GetSessionToken / GetFederationToken.
+    #[serde(default)]
+    pub federated_provider: Option<String>,
+}
+
+/// Default for [`StsTempCredential::issued_at`] when deserializing
+/// snapshots written before the field existed.
+fn default_issued_at() -> DateTime<Utc> {
+    Utc::now()
 }
 
 /// Result of looking up a set of credentials by access key ID.
@@ -255,6 +274,17 @@ pub struct SecretLookup {
     /// surfaces as `aws:MultiFactorAuthPresent` to downstream IAM
     /// evaluation. Always false for raw IAM user access keys.
     pub mfa_present: bool,
+    /// Wall-clock time at which the underlying STS credential was
+    /// issued. Surfaces as `aws:TokenIssueTime` and drives
+    /// `aws:MultiFactorAuthAge`. `None` for raw IAM user access keys
+    /// (AWS does not expose `aws:TokenIssueTime` for long-lived
+    /// credentials).
+    pub token_issued_at: Option<DateTime<Utc>>,
+    /// `aws:FederatedProvider` for the underlying credential, when
+    /// applicable. Set by AssumeRoleWithSAML / AssumeRoleWithWebIdentity;
+    /// always `None` for IAM user keys, plain AssumeRole, GetSessionToken,
+    /// and GetFederationToken.
+    pub federated_provider: Option<String>,
 }
 
 /// Convert a `Vec<Tag>` to a `BTreeMap<String, String>`.
@@ -442,6 +472,8 @@ impl IamState {
                             session_policies: Vec::new(),
                             principal_tags: tags_to_hashmap(&user.tags),
                             mfa_present: false,
+                            token_issued_at: None,
+                            federated_provider: None,
                         });
                     }
                 }
@@ -463,6 +495,8 @@ impl IamState {
                     session_policies: temp.session_policies.clone(),
                     principal_tags,
                     mfa_present: temp.mfa_present,
+                    token_issued_at: Some(temp.issued_at),
+                    federated_provider: temp.federated_provider.clone(),
                 });
             }
             self.sts_temp_credentials.remove(access_key_id);
@@ -487,6 +521,8 @@ impl IamState {
                             session_policies: Vec::new(),
                             principal_tags: tags_to_hashmap(&user.tags),
                             mfa_present: false,
+                            token_issued_at: None,
+                            federated_provider: None,
                         });
                     }
                 }
@@ -508,6 +544,8 @@ impl IamState {
             session_policies: temp.session_policies.clone(),
             principal_tags,
             mfa_present: temp.mfa_present,
+            token_issued_at: Some(temp.issued_at),
+            federated_provider: temp.federated_provider.clone(),
         })
     }
 
@@ -615,6 +653,8 @@ mod tests {
                 expiration: Utc::now() + chrono::Duration::minutes(30),
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
         let lookup = state.credential_secret("FSIATEMPKEY").unwrap();
@@ -641,6 +681,8 @@ mod tests {
                 expiration: Utc::now() - chrono::Duration::seconds(1),
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
         assert!(state.credential_secret("FSIAOLD").is_none());
@@ -662,6 +704,8 @@ mod tests {
                 expiration: Utc::now() - chrono::Duration::seconds(1),
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
         assert!(state.credential_secret_readonly("FSIAOLD").is_none());

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -525,6 +525,10 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies,
                 mfa_present: mfa_present_for_session,
+                issued_at: Utc::now(),
+                // Plain AssumeRole does not federate — `aws:FederatedProvider`
+                // stays absent for the resulting session.
+                federated_provider: None,
             },
         );
 
@@ -636,6 +640,20 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
+        // `aws:FederatedProvider` is the OIDC provider ARN (or the
+        // friendly host name when supplied via `ProviderId`). Real AWS
+        // populates it from the registered OIDC provider used during
+        // token validation; this emulator carries the caller-supplied
+        // ProviderId verbatim, falling back to a synthetic OIDC
+        // provider ARN keyed off the role's account when absent so a
+        // policy condition that just checks for "any federated session"
+        // still has a value to bind to.
+        let federated_provider = req.query_params.get("ProviderId").cloned().or_else(|| {
+            Some(format!(
+                "arn:aws:iam::{}:oidc-provider/web-identity",
+                account_id
+            ))
+        });
         target_state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -648,6 +666,8 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies,
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider,
             },
         );
 
@@ -685,7 +705,9 @@ impl StsService {
             )
         })?;
         validate_string_length("principalArn", principal_arn, 20, 2048)?;
-        let _principal_arn = principal_arn.clone();
+        // Snapshot the SAML provider ARN so we can stash it on the
+        // session as `aws:FederatedProvider` after this scope ends.
+        let saml_provider_arn = principal_arn.clone();
 
         // SAMLAssertion is required but we just need to extract session name from it
         let saml_assertion = req.query_params.get("SAMLAssertion").ok_or_else(|| {
@@ -755,6 +777,10 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
+        // SAML federation: the PrincipalArn parameter carries the SAML
+        // provider ARN that vouched for the assertion, and AWS surfaces
+        // exactly that ARN as `aws:FederatedProvider` for the session.
+        let federated_provider = Some(saml_provider_arn);
         target_state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -767,6 +793,8 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies,
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider,
             },
         );
 
@@ -874,6 +902,9 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies: Vec::new(),
                 mfa_present: mfa_present_for_session,
+                issued_at: Utc::now(),
+                // GetSessionToken doesn't federate.
+                federated_provider: None,
             },
         );
 
@@ -953,6 +984,10 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies,
                 mfa_present: false,
+                issued_at: Utc::now(),
+                // GetFederationToken yields a federated user, not a federated
+                // provider — `aws:FederatedProvider` stays absent.
+                federated_provider: None,
             },
         );
 
@@ -1126,6 +1161,8 @@ impl StsService {
                 expiration: expiration_at,
                 session_policies: Vec::new(),
                 mfa_present: false,
+                issued_at: Utc::now(),
+                federated_provider: None,
             },
         );
 
@@ -1839,6 +1876,251 @@ mod tests {
         assert!(
             any_mfa,
             "expected at least one minted credential with mfa_present=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_mfa_resolved_credential_drives_iam_evaluator() {
+        // E2E: assume role with MFA, fetch the issued credential through
+        // the same `CredentialResolver` adapter dispatch uses, then run
+        // the IAM evaluator on a policy that gates on
+        // `aws:MultiFactorAuthPresent: true`. This wires
+        // sts_service -> StsTempCredential -> SecretLookup ->
+        // ResolvedCredential -> ConditionContext end to end and proves
+        // the MFA assertion survives every hop.
+        use crate::credential_resolver::IamCredentialResolver;
+        use crate::evaluator::{
+            evaluate as eval_policies, EvalRequest, PolicyDocument, RequestContext,
+        };
+        use fakecloud_core::auth::{ConditionContext, CredentialResolver};
+
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "mfa-e2e", trust);
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "ops"),
+                ("SerialNumber", "arn:aws:iam::123456789012:mfa/alice"),
+                ("TokenCode", "654321"),
+            ],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        // Pull the AccessKeyId out of the XML response and resolve it.
+        let access_key_id = body
+            .split("<AccessKeyId>")
+            .nth(1)
+            .and_then(|s| s.split("</AccessKeyId>").next())
+            .expect("response should contain AccessKeyId")
+            .to_string();
+        let resolver = IamCredentialResolver::new(state.clone());
+        let resolved = resolver
+            .resolve(&access_key_id)
+            .expect("issued credential must resolve through the resolver");
+        assert!(
+            resolved.mfa_present,
+            "F3: MFA flag must survive the resolver hop"
+        );
+        assert!(
+            resolved.token_issued_at.is_some(),
+            "F3: token_issued_at must be populated for STS sessions"
+        );
+
+        // Mirror what dispatch does: build a ConditionContext from the
+        // resolved credential, then evaluate a permission policy that
+        // requires MFA.
+        let mut ctx: RequestContext = ConditionContext {
+            aws_principal_arn: Some(resolved.principal.arn.clone()),
+            aws_principal_account: Some(resolved.principal.account_id.clone()),
+            aws_userid: Some(resolved.principal.user_id.clone()),
+            aws_mfa_present: Some(resolved.mfa_present),
+            aws_token_issue_time: resolved.token_issued_at,
+            aws_federated_provider: resolved.federated_provider.clone(),
+            ..Default::default()
+        };
+        if resolved.mfa_present {
+            if let Some(issued) = resolved.token_issued_at {
+                ctx.aws_mfa_age_seconds = Some(
+                    Utc::now()
+                        .signed_duration_since(issued)
+                        .num_seconds()
+                        .max(0),
+                );
+            }
+        }
+
+        let policy = PolicyDocument::parse(
+            r#"{"Version":"2012-10-17","Statement":[{
+                "Effect":"Allow",
+                "Action":"s3:GetObject",
+                "Resource":"*",
+                "Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}
+            }]}"#,
+        );
+        let eval = EvalRequest {
+            principal: &resolved.principal,
+            action: "s3:GetObject".to_string(),
+            resource: "arn:aws:s3:::secrets/k".to_string(),
+            context: ctx,
+        };
+        let decision = eval_policies(&[policy], &eval);
+        assert_eq!(
+            decision,
+            crate::evaluator::Decision::Allow,
+            "F3: MFA-gated allow must fire when session was minted with MFA"
+        );
+
+        // Negative control: same evaluator wiring but without MFA on
+        // the resolved credential -> implicit deny.
+        let req_no_mfa = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "no-mfa")],
+        );
+        let resp_no_mfa = svc.handle(req_no_mfa).await.unwrap();
+        let body_no_mfa = std::str::from_utf8(resp_no_mfa.body.expect_bytes()).unwrap();
+        let akid_no_mfa = body_no_mfa
+            .split("<AccessKeyId>")
+            .nth(1)
+            .and_then(|s| s.split("</AccessKeyId>").next())
+            .unwrap()
+            .to_string();
+        let resolved_no_mfa = resolver.resolve(&akid_no_mfa).unwrap();
+        assert!(!resolved_no_mfa.mfa_present);
+        let policy2 = PolicyDocument::parse(
+            r#"{"Version":"2012-10-17","Statement":[{
+                "Effect":"Allow",
+                "Action":"s3:GetObject",
+                "Resource":"*",
+                "Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}
+            }]}"#,
+        );
+        let ctx2 = ConditionContext {
+            aws_principal_arn: Some(resolved_no_mfa.principal.arn.clone()),
+            aws_userid: Some(resolved_no_mfa.principal.user_id.clone()),
+            aws_mfa_present: Some(resolved_no_mfa.mfa_present),
+            aws_token_issue_time: resolved_no_mfa.token_issued_at,
+            ..Default::default()
+        };
+        let eval2 = EvalRequest {
+            principal: &resolved_no_mfa.principal,
+            action: "s3:GetObject".to_string(),
+            resource: "arn:aws:s3:::secrets/k".to_string(),
+            context: ctx2,
+        };
+        assert_eq!(
+            eval_policies(&[policy2], &eval2),
+            crate::evaluator::Decision::ImplicitDeny,
+            "F3: MFA-gated allow must NOT fire when session was minted without MFA"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_saml_populates_federated_provider() {
+        // F3: AssumeRoleWithSAML must surface the SAML provider ARN as
+        // `aws:FederatedProvider` on the resulting session.
+        use crate::credential_resolver::IamCredentialResolver;
+        use base64::Engine;
+        use fakecloud_core::auth::CredentialResolver;
+        let (svc, state) = make_sts_service();
+        let role_arn = create_role_in_state(&state, "saml-role");
+        let saml_xml = r#"<?xml version="1.0"?><samlp:Response><Assertion><AttributeStatement><Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName"><AttributeValue>jane</AttributeValue></Attribute></AttributeStatement></Assertion></samlp:Response>"#;
+        let saml_b64 = base64::engine::general_purpose::STANDARD.encode(saml_xml);
+        let provider_arn = "arn:aws:iam::123456789012:saml-provider/idp";
+        let req = sts_request(
+            "AssumeRoleWithSAML",
+            vec![
+                ("RoleArn", &role_arn),
+                ("PrincipalArn", provider_arn),
+                ("SAMLAssertion", &saml_b64),
+            ],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let access_key_id = body
+            .split("<AccessKeyId>")
+            .nth(1)
+            .and_then(|s| s.split("</AccessKeyId>").next())
+            .unwrap()
+            .to_string();
+        let resolver = IamCredentialResolver::new(state.clone());
+        let resolved = resolver.resolve(&access_key_id).unwrap();
+        assert_eq!(
+            resolved.federated_provider.as_deref(),
+            Some(provider_arn),
+            "AssumeRoleWithSAML must populate aws:FederatedProvider with the SAML provider ARN"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_web_identity_populates_federated_provider() {
+        // F3: AssumeRoleWithWebIdentity must populate
+        // `aws:FederatedProvider`. With ProviderId we carry it verbatim;
+        // without ProviderId we synthesize an OIDC provider ARN keyed
+        // off the role's account so policies that simply check for the
+        // presence of a federated provider still bind.
+        use crate::credential_resolver::IamCredentialResolver;
+        use fakecloud_core::auth::CredentialResolver;
+        let (svc, state) = make_sts_service();
+        let role_arn = create_role_in_state(&state, "oidc-role");
+        let req = sts_request(
+            "AssumeRoleWithWebIdentity",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "oidc-session"),
+                ("WebIdentityToken", "fake-jwt-blob"),
+                ("ProviderId", "accounts.google.com"),
+            ],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let access_key_id = body
+            .split("<AccessKeyId>")
+            .nth(1)
+            .and_then(|s| s.split("</AccessKeyId>").next())
+            .unwrap()
+            .to_string();
+        let resolver = IamCredentialResolver::new(state.clone());
+        let resolved = resolver.resolve(&access_key_id).unwrap();
+        assert_eq!(
+            resolved.federated_provider.as_deref(),
+            Some("accounts.google.com"),
+            "AssumeRoleWithWebIdentity must carry ProviderId as aws:FederatedProvider"
+        );
+    }
+
+    #[tokio::test]
+    async fn assume_role_userid_format_matches_aws() {
+        // AWS userid for assumed-role sessions: <role-id>:<RoleSessionName>.
+        // Verify the resolved credential's user_id matches that shape so
+        // a policy condition `aws:userid` can be matched correctly.
+        use crate::credential_resolver::IamCredentialResolver;
+        use fakecloud_core::auth::CredentialResolver;
+        let (svc, state) = make_sts_service();
+        let role_arn = create_role_in_state(&state, "userid-role");
+        let req = sts_request(
+            "AssumeRole",
+            vec![("RoleArn", &role_arn), ("RoleSessionName", "carol")],
+        );
+        let resp = svc.handle(req).await.unwrap();
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        let access_key_id = body
+            .split("<AccessKeyId>")
+            .nth(1)
+            .and_then(|s| s.split("</AccessKeyId>").next())
+            .unwrap()
+            .to_string();
+        let resolver = IamCredentialResolver::new(state);
+        let resolved = resolver.resolve(&access_key_id).unwrap();
+        let uid = &resolved.principal.user_id;
+        assert!(
+            uid.contains(':'),
+            "assumed-role userid must be `<role-id>:<RoleSessionName>`, got `{uid}`"
+        );
+        assert!(
+            uid.ends_with(":carol"),
+            "assumed-role userid must end with the RoleSessionName, got `{uid}`"
         );
     }
 


### PR DESCRIPTION
## Summary

Phase F3 of the IAM condition-key roadmap. Plumbs the F3 global keys end to end so policies can gate on real session attributes instead of silently ignoring them.

- `StsTempCredential` gains `issued_at` + `federated_provider`; `SecretLookup` and `ResolvedCredential` carry them through to the dispatch layer.
- `AssumeRoleWithSAML` stamps the SAML provider ARN on the session as `aws:FederatedProvider`. `AssumeRoleWithWebIdentity` carries `ProviderId` (with a synthetic OIDC provider ARN fallback so policies that just check for federated provenance still bind).
- Dispatch's `build_condition_context` now populates `aws:TokenIssueTime`, `aws:FederatedProvider`, and computes `aws:MultiFactorAuthAge` as `now - issued_at` whenever MFA was asserted on the session. IAM user access keys keep all four absent, matching AWS.
- `aws:userid` for assumed-role sessions is `<role-id>:<RoleSessionName>`, the AWS shape; verified in a test.

## Test plan

- [x] `cargo test -p fakecloud-iam --tests` (426 passing)
- [x] `cargo test --workspace --lib`
- [x] `cargo clippy --workspace --all-targets --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] New unit tests in `condition.rs`: each F3 key cross-checked against `String*`, `Numeric*`, `Bool`, `Date*`, `IpAddress`, `IfExists`, and `ForAllValues`/`ForAnyValue` qualifiers
- [x] New e2e tests in `sts_service.rs`:
  - `assume_role_with_mfa_resolved_credential_drives_iam_evaluator` -- mints session with MFA, resolves through `IamCredentialResolver`, runs the IAM evaluator on a `Bool: aws:MultiFactorAuthPresent: true` policy, asserts Allow; negative control without MFA asserts ImplicitDeny
  - `assume_role_with_saml_populates_federated_provider`
  - `assume_role_with_web_identity_populates_federated_provider`
  - `assume_role_userid_format_matches_aws`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired IAM F3 condition keys end-to-end so policies can evaluate real STS session attributes: MFA presence/age, token issue time, and federated provider. IAM user access keys keep these keys absent, matching AWS.

- **New Features**
  - `StsTempCredential` adds `issued_at` and `federated_provider`, propagated through `SecretLookup` and `ResolvedCredential` to dispatch.
  - Dispatch now populates `aws:TokenIssueTime` and `aws:FederatedProvider`, and computes `aws:MultiFactorAuthAge` when `aws:MultiFactorAuthPresent` is true.
  - `AssumeRoleWithSAML` sets `aws:FederatedProvider` to the SAML provider ARN; `AssumeRoleWithWebIdentity` uses `ProviderId` or a synthetic OIDC provider ARN fallback.
  - `aws:userid` for assumed roles is `<role-id>:<RoleSessionName>`, matching AWS.

<sup>Written for commit 0e1a6b350428ffb265cd33700c23d5658b553fb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

