### PR TITLE
feat(cloudfront): wall-clock timeout + ComputeUtilization for TestFunction (T1)

### DIFF
--- a/crates/fakecloud-cloudfront/src/cfunctions_service.rs
+++ b/crates/fakecloud-cloudfront/src/cfunctions_service.rs
@@ -294,7 +294,10 @@ impl CloudFrontService {
         body.push_str(XML_DECL);
         body.push_str(&format!("<ConnectionFunctionTestResult xmlns=\"{NS}\">"));
         body.push_str(&render_connection_function_summary_inner(&f));
-        body.push_str("<ComputeUtilization>0</ComputeUtilization>");
+        body.push_str(&format!(
+            "<ComputeUtilization>{}</ComputeUtilization>",
+            exec.compute_utilization
+        ));
         body.push_str("<ConnectionFunctionExecutionLogs>");
         for line in &exec.logs {
             body.push_str(&format!("<member>{}</member>", esc(line)));
@@ -525,5 +528,67 @@ mod tests {
         };
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
         assert_eq!(err.code(), "EntityNotFound");
+    }
+
+    #[tokio::test]
+    async fn test_connection_function_logs_error_and_marks_compute_over_100() {
+        let svc = svc();
+        let etag = create_cfn(
+            &svc,
+            "cfn-throws",
+            r#"function handler() { throw new Error("kaboom"); }"#,
+        )
+        .await;
+        let body = test_cfn_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function/cfn-throws/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(xml.contains("kaboom"), "expected kaboom, got {xml}");
+        assert!(
+            xml.contains("<ConnectionFunctionExecutionLogs>") && xml.contains("ERROR: "),
+            "expected error log, got {xml}"
+        );
+        let cu_open = xml.find("<ComputeUtilization>").unwrap() + "<ComputeUtilization>".len();
+        let cu_close = xml.find("</ComputeUtilization>").unwrap();
+        let pct: u32 = xml[cu_open..cu_close].parse().unwrap();
+        assert!(pct > 100, "expected pct > 100 on error, got {pct}");
+    }
+
+    #[tokio::test]
+    async fn test_connection_function_infinite_loop_is_killed() {
+        let svc = svc();
+        let etag = create_cfn(&svc, "cfn-loop", r#"function handler() { while(1){} }"#).await;
+        let body = test_cfn_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/connection-function/cfn-loop/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("<ConnectionFunctionOutput></ConnectionFunctionOutput>"),
+            "expected empty output after kill, got {xml}"
+        );
+        assert!(
+            xml.contains("ERROR:") && xml.contains("limit"),
+            "expected timeout/limit log, got {xml}"
+        );
+        let cu_open = xml.find("<ComputeUtilization>").unwrap() + "<ComputeUtilization>".len();
+        let cu_close = xml.find("</ComputeUtilization>").unwrap();
+        let pct: u32 = xml[cu_open..cu_close].parse().unwrap();
+        assert!(pct > 100, "expected pct > 100, got {pct}");
     }
 }

--- a/crates/fakecloud-cloudfront/src/functions_service.rs
+++ b/crates/fakecloud-cloudfront/src/functions_service.rs
@@ -285,7 +285,10 @@ impl CloudFrontService {
         body.push_str(XML_DECL);
         body.push_str(&format!("<TestResult xmlns=\"{NS}\">"));
         body.push_str(&render_function_summary_inner(&f));
-        body.push_str("<ComputeUtilization>0</ComputeUtilization>");
+        body.push_str(&format!(
+            "<ComputeUtilization>{}</ComputeUtilization>",
+            exec.compute_utilization
+        ));
         body.push_str("<FunctionExecutionLogs>");
         for line in &exec.logs {
             body.push_str(&format!("<member>{}</member>", esc(line)));
@@ -1431,5 +1434,112 @@ mod tests {
         };
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
         assert_eq!(err.code(), "NoSuchFunctionExists");
+    }
+
+    #[tokio::test]
+    async fn test_function_modifies_aws_request_shape() {
+        // Mirrors the canonical CloudFront Functions example from the
+        // AWS docs: handler rewrites a request header and returns the
+        // request, fakecloud passes the JSON shape straight through.
+        let svc = svc();
+        let etag = create_function(
+            &svc,
+            "fn-aws-shape",
+            r#"function handler(event) { event.request.headers["x-foo"] = {value: "bar"}; return event.request; }"#,
+        )
+        .await;
+        let body = test_function_request_xml(
+            r#"{"version":"1.0","context":{},"viewer":{},"request":{"method":"GET","uri":"/","querystring":{},"headers":{},"cookies":{}}}"#,
+        );
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/fn-aws-shape/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("x-foo"),
+            "expected request header rewrite in output, got {xml}"
+        );
+        assert!(
+            xml.contains("bar"),
+            "expected header value in output, got {xml}"
+        );
+        assert!(
+            xml.contains("<FunctionErrorMessage></FunctionErrorMessage>"),
+            "expected empty error, got {xml}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_function_logs_error_and_marks_compute_over_100() {
+        let svc = svc();
+        let etag = create_function(
+            &svc,
+            "fn-throws",
+            r#"function handler() { throw new Error("kaboom"); }"#,
+        )
+        .await;
+        let body = test_function_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/fn-throws/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        // Error appears in both the dedicated message and in the logs
+        assert!(xml.contains("kaboom"), "expected kaboom in body, got {xml}");
+        assert!(
+            xml.contains("<FunctionExecutionLogs>")
+                && xml.contains("<member>ERROR: ")
+                && xml.contains("kaboom"),
+            "expected error log line, got {xml}"
+        );
+        // ComputeUtilization is rendered as a plain integer; on failure
+        // we saturate past 100.
+        let cu_open = xml.find("<ComputeUtilization>").unwrap() + "<ComputeUtilization>".len();
+        let cu_close = xml.find("</ComputeUtilization>").unwrap();
+        let pct: u32 = xml[cu_open..cu_close].parse().unwrap();
+        assert!(pct > 100, "expected pct > 100 on error, got {pct}");
+    }
+
+    #[tokio::test]
+    async fn test_function_infinite_loop_is_killed() {
+        let svc = svc();
+        let etag = create_function(&svc, "fn-loop", r#"function handler() { while(1){} }"#).await;
+        let body = test_function_request_xml("{}");
+        let resp = svc
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/function/fn-loop/test",
+                &body,
+                Some(&etag),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK);
+        let xml = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+        assert!(
+            xml.contains("<FunctionOutput></FunctionOutput>"),
+            "expected empty output, got {xml}"
+        );
+        assert!(
+            xml.contains("ERROR:") && xml.contains("limit"),
+            "expected timeout/limit error in logs, got {xml}"
+        );
+        let cu_open = xml.find("<ComputeUtilization>").unwrap() + "<ComputeUtilization>".len();
+        let cu_close = xml.find("</ComputeUtilization>").unwrap();
+        let pct: u32 = xml[cu_open..cu_close].parse().unwrap();
+        assert!(pct > 100, "expected pct > 100 after kill, got {pct}");
     }
 }

--- a/crates/fakecloud-cloudfront/src/js_runtime.rs
+++ b/crates/fakecloud-cloudfront/src/js_runtime.rs
@@ -9,42 +9,114 @@
 //! - JSON.stringify the return value;
 //! - capture `console.log/error` output as execution log lines.
 //!
-//! Limits are enforced via boa's loop iteration + recursion caps and a
-//! hard cap on stringified output size. We intentionally don't try to
-//! emulate every CloudFront builtin — fakecloud only needs the
-//! pass-through shape so callers can validate request/response
-//! transforms in tests.
+//! Limits are enforced in two layers:
+//!
+//! 1. boa's loop iteration + recursion caps trip on hot loops so the
+//!    interpreter eventually returns control even under adversarial
+//!    user JS.
+//! 2. A wall-clock timeout: the actual execution runs on a dedicated
+//!    OS thread; the calling thread waits on a `mpsc::sync_channel` via
+//!    `recv_timeout`. If the JS doesn't finish in time we abandon the
+//!    worker thread (best-effort — boa's iteration limit will eventually
+//!    let it die) and return a timeout error.
+//!
+//! Real CloudFront Functions are bounded at ~1ms of CPU per request and
+//! 2MB of memory. We mirror that with a 10ms wall-clock budget — looser
+//! to avoid flakes on shared CI runners, still tight enough that
+//! `while(1){}` is killed in tests.
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use boa_engine::object::ObjectInitializer;
 use boa_engine::property::Attribute;
 use boa_engine::{js_string, Context, JsValue, NativeFunction, Source};
 
-const LOOP_ITERATION_LIMIT: u64 = 10_000_000;
+/// Hard wall-clock cap on a single TestFunction / TestConnectionFunction
+/// invocation. AWS bounds production traffic at ~1ms of CPU; we set
+/// 250ms so CI runners with noisy neighbours don't false-alarm on
+/// well-formed handlers, while `while(1){}` is still killed well
+/// inside any reasonable test timeout.
+pub(crate) const EXECUTION_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// boa loop iteration cap. Tight enough that `while(1){}` exits the VM
+/// well within the wall-clock budget on any reasonable host, loose
+/// enough that small loops in real handlers run to completion.
+const LOOP_ITERATION_LIMIT: u64 = 200_000;
 const RECURSION_LIMIT: usize = 1_000;
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Result of executing a CloudFront-style function. Either `output`
 /// (the JSON-encoded handler return value) or `error` will be set;
 /// `logs` is always populated (possibly empty) with whatever the user
-/// JS wrote to `console.log` / `console.error`.
+/// JS wrote to `console.log` / `console.error`. On error we also push
+/// a synthetic log line so callers that surface logs alone still see
+/// the failure.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct JsExecution {
     pub output: Option<String>,
     pub error: Option<String>,
     pub logs: Vec<String>,
+    /// Synthetic compute utilisation in percent. Real CloudFront
+    /// returns a number 0..=100 representing the share of the per-
+    /// request CPU budget consumed. We approximate it by linear
+    /// interpolation against `EXECUTION_TIMEOUT` and saturate at 100,
+    /// then deliberately flip past 100 on errors / timeouts so callers
+    /// can detect failure from the metric alone.
+    pub compute_utilization: u32,
 }
 
-/// Run `handler(event)` defined in `code` against `event_json`.
-///
-/// `code` is the raw JavaScript source (already base64-decoded by the
-/// caller). `event_json` is the JSON-encoded event object. Returns a
-/// populated `JsExecution`; this function itself never panics on user
-/// input — JS errors map to `error`, oversized outputs become an
-/// error, and non-JSON event blobs are surfaced as an `error` too.
+/// Run `handler(event)` defined in `code` against `event_json` on a
+/// dedicated worker thread, enforcing `EXECUTION_TIMEOUT`.
 pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
+    let code = code.to_owned();
+    let event = event_json.to_vec();
+    let (tx, rx) = mpsc::sync_channel::<JsExecution>(1);
+
+    // Each call gets its own thread because boa's `Context` holds
+    // `Rc`s and is `!Send`. We can't pre-spawn a worker pool without
+    // marshalling the script + event via channels anyway, so a fresh
+    // thread per call is the simpler shape.
+    let started = Instant::now();
+    let _ = std::thread::Builder::new()
+        .name("cloudfront-js".to_string())
+        // Boa's bytecode VM is recursive so we want a generous stack.
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let result = run_handler_blocking(&code, &event, started);
+            // If the receiver has timed out and gone away the send
+            // simply errors; we don't care — the worker is being
+            // abandoned.
+            let _ = tx.send(result);
+        });
+
+    match rx.recv_timeout(EXECUTION_TIMEOUT) {
+        Ok(mut exec) => {
+            // Floor compute_utilization at 1% on success so callers
+            // don't mistake a successful run for an unrun one.
+            if exec.error.is_none() && exec.compute_utilization == 0 {
+                exec.compute_utilization = 1;
+            }
+            exec
+        }
+        Err(_) => {
+            let msg = format!(
+                "function execution exceeded the {}ms time limit",
+                EXECUTION_TIMEOUT.as_millis()
+            );
+            JsExecution {
+                output: None,
+                error: Some(msg.clone()),
+                logs: vec![format!("ERROR: {msg}")],
+                compute_utilization: 101,
+            }
+        }
+    }
+}
+
+fn run_handler_blocking(code: &str, event_json: &[u8], started: Instant) -> JsExecution {
     let logs: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
     let mut ctx = Context::default();
     ctx.runtime_limits_mut()
@@ -53,29 +125,17 @@ pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
         .set_recursion_limit(RECURSION_LIMIT);
 
     if let Err(err) = install_console(&mut ctx, &logs) {
-        return JsExecution {
-            error: Some(format!("failed to install console: {err}")),
-            logs: logs.borrow().clone(),
-            ..Default::default()
-        };
+        return error_execution(format!("failed to install console: {err}"), &logs, started);
     }
 
     if let Err(err) = ctx.eval(Source::from_bytes(code.as_bytes())) {
-        return JsExecution {
-            error: Some(format!("{}", err)),
-            logs: logs.borrow().clone(),
-            ..Default::default()
-        };
+        return error_execution(format!("{}", err), &logs, started);
     }
 
     let event_str = match std::str::from_utf8(event_json) {
         Ok(s) => s,
         Err(_) => {
-            return JsExecution {
-                error: Some("EventObject is not valid UTF-8".to_string()),
-                logs: logs.borrow().clone(),
-                ..Default::default()
-            };
+            return error_execution("EventObject is not valid UTF-8".to_string(), &logs, started);
         }
     };
     // Wrap in parens so a top-level `{ ... }` object literal parses as
@@ -84,60 +144,52 @@ pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
     let event = match ctx.eval(Source::from_bytes(event_src.as_bytes())) {
         Ok(v) => v,
         Err(err) => {
-            return JsExecution {
-                error: Some(format!("invalid EventObject JSON: {err}")),
-                logs: logs.borrow().clone(),
-                ..Default::default()
-            };
+            return error_execution(format!("invalid EventObject JSON: {err}"), &logs, started);
         }
     };
 
     let handler = match ctx.global_object().get(js_string!("handler"), &mut ctx) {
         Ok(h) => h,
         Err(err) => {
-            return JsExecution {
-                error: Some(format!("function handler is not defined: {err}")),
-                logs: logs.borrow().clone(),
-                ..Default::default()
-            };
+            return error_execution(
+                format!("function handler is not defined: {err}"),
+                &logs,
+                started,
+            );
         }
     };
     let Some(handler_fn) = handler.as_callable() else {
-        return JsExecution {
-            error: Some("function handler is not callable".to_string()),
-            logs: logs.borrow().clone(),
-            ..Default::default()
-        };
+        return error_execution(
+            "function handler is not callable".to_string(),
+            &logs,
+            started,
+        );
     };
 
     let returned = match handler_fn.call(&JsValue::undefined(), &[event], &mut ctx) {
         Ok(v) => v,
         Err(err) => {
-            return JsExecution {
-                error: Some(format!("{}", err)),
-                logs: logs.borrow().clone(),
-                ..Default::default()
-            };
+            return error_execution(format!("{}", err), &logs, started);
         }
     };
 
     let stringified = match stringify(&mut ctx, returned) {
         Ok(s) => s,
         Err(err) => {
-            return JsExecution {
-                error: Some(format!("failed to JSON.stringify result: {err}")),
-                logs: logs.borrow().clone(),
-                ..Default::default()
-            };
+            return error_execution(
+                format!("failed to JSON.stringify result: {err}"),
+                &logs,
+                started,
+            );
         }
     };
 
     if stringified.len() > MAX_OUTPUT_BYTES {
-        return JsExecution {
-            error: Some(format!("function output exceeded {MAX_OUTPUT_BYTES} bytes")),
-            logs: logs.borrow().clone(),
-            ..Default::default()
-        };
+        return error_execution(
+            format!("function output exceeded {MAX_OUTPUT_BYTES} bytes"),
+            &logs,
+            started,
+        );
     }
 
     let captured = logs.borrow().clone();
@@ -145,6 +197,33 @@ pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
         output: Some(stringified),
         error: None,
         logs: captured,
+        compute_utilization: utilization_pct(started.elapsed()),
+    }
+}
+
+fn error_execution(msg: String, logs: &Rc<RefCell<Vec<String>>>, started: Instant) -> JsExecution {
+    let mut captured = logs.borrow().clone();
+    captured.push(format!("ERROR: {msg}"));
+    // Saturate past 100 on any failure so the metric alone signals the
+    // run did not complete cleanly, regardless of how fast it failed.
+    let elapsed_pct = utilization_pct(started.elapsed());
+    let pct = elapsed_pct.max(101);
+    JsExecution {
+        output: None,
+        error: Some(msg),
+        logs: captured,
+        compute_utilization: pct,
+    }
+}
+
+fn utilization_pct(elapsed: Duration) -> u32 {
+    let limit_us = EXECUTION_TIMEOUT.as_micros().max(1);
+    let used_us = elapsed.as_micros();
+    let pct = (used_us * 100) / limit_us;
+    if pct > 100 {
+        100
+    } else {
+        pct as u32
     }
 }
 
@@ -219,6 +298,28 @@ mod tests {
         assert!(exec.error.is_none(), "unexpected error: {:?}", exec.error);
         let out = exec.output.expect("output");
         assert!(out.contains("\"x\":\"y\""), "got {out}");
+        assert!(
+            exec.compute_utilization <= 100,
+            "got {}",
+            exec.compute_utilization
+        );
+    }
+
+    #[test]
+    fn modifies_request_headers_aws_shape() {
+        // Mirrors the real CloudFront Functions request shape so
+        // callers can validate header rewrites in tests.
+        let exec = run_handler(
+            r#"function handler(event) {
+                event.request.headers["x-foo"] = {value: "bar"};
+                return event.request;
+            }"#,
+            br#"{"version":"1.0","context":{},"viewer":{},"request":{"method":"GET","uri":"/","querystring":{},"headers":{},"cookies":{}}}"#,
+        );
+        assert!(exec.error.is_none(), "unexpected error: {:?}", exec.error);
+        let out = exec.output.expect("output");
+        assert!(out.contains("\"x-foo\""), "got {out}");
+        assert!(out.contains("\"bar\""), "got {out}");
     }
 
     #[test]
@@ -227,6 +328,16 @@ mod tests {
         assert!(exec.output.is_none());
         let err = exec.error.expect("error");
         assert!(err.contains("boom"), "got {err}");
+        assert!(
+            exec.logs.iter().any(|l| l.contains("boom")),
+            "expected error in logs, got {:?}",
+            exec.logs
+        );
+        assert!(
+            exec.compute_utilization > 100,
+            "expected >100 on error, got {}",
+            exec.compute_utilization
+        );
     }
 
     #[test]
@@ -235,19 +346,48 @@ mod tests {
             r#"function handler(e) { console.log("a", "b"); return e; }"#,
             b"{}",
         );
-        assert_eq!(exec.logs, vec!["a b".to_string()]);
         assert!(exec.error.is_none());
+        assert!(exec.logs.iter().any(|l| l == "a b"));
     }
 
     #[test]
     fn errors_when_handler_missing() {
         let exec = run_handler("var x = 1;", b"{}");
         assert!(exec.error.is_some());
+        assert!(
+            exec.compute_utilization > 100,
+            "expected >100 on error, got {}",
+            exec.compute_utilization
+        );
     }
 
     #[test]
     fn errors_when_event_is_invalid_json() {
         let exec = run_handler(r#"function handler(e) { return e; }"#, b"not-json");
         assert!(exec.error.is_some());
+    }
+
+    #[test]
+    fn infinite_loop_is_killed_by_timeout() {
+        let exec = run_handler(r#"function handler() { while(1){} }"#, b"{}");
+        assert!(exec.output.is_none());
+        let err = exec.error.expect("error");
+        // Either the wall-clock recv_timeout fired or boa's iteration
+        // cap tripped — both are acceptable kill signals; in either
+        // case ComputeUtilization saturates past 100 and an error log
+        // is present.
+        assert!(
+            err.contains("time limit") || err.contains("limit") || err.contains("iteration"),
+            "expected timeout/iteration error, got {err}"
+        );
+        assert!(
+            exec.compute_utilization > 100,
+            "expected >100 after timeout, got {}",
+            exec.compute_utilization
+        );
+        assert!(
+            !exec.logs.is_empty(),
+            "expected error log line, got empty logs"
+        );
     }
 }

--- a/crates/fakecloud-cloudfront/src/js_runtime.rs
+++ b/crates/fakecloud-cloudfront/src/js_runtime.rs
@@ -21,9 +21,9 @@
 //!    let it die) and return a timeout error.
 //!
 //! Real CloudFront Functions are bounded at ~1ms of CPU per request and
-//! 2MB of memory. We mirror that with a 10ms wall-clock budget — looser
-//! to avoid flakes on shared CI runners, still tight enough that
-//! `while(1){}` is killed in tests.
+//! 2MB of memory. We mirror that with a 250ms wall-clock budget —
+//! looser than AWS to absorb cold-start jitter on shared CI runners,
+//! still tight enough that `while(1){}` is killed in tests.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -101,11 +101,24 @@ pub(crate) fn run_handler(code: &str, event_json: &[u8]) -> JsExecution {
             }
             exec
         }
-        Err(_) => {
+        Err(mpsc::RecvTimeoutError::Timeout) => {
             let msg = format!(
                 "function execution exceeded the {}ms time limit",
                 EXECUTION_TIMEOUT.as_millis()
             );
+            JsExecution {
+                output: None,
+                error: Some(msg.clone()),
+                logs: vec![format!("ERROR: {msg}")],
+                compute_utilization: 101,
+            }
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            // The worker thread either failed to spawn (`spawn()` errored
+            // and the sender was dropped) or panicked partway through.
+            // Surface that distinctly so a host-level problem doesn't get
+            // misdiagnosed as adversarial JS.
+            let msg = "function execution worker thread panicked or failed to spawn".to_string();
             JsExecution {
                 output: None,
                 error: Some(msg.clone()),


### PR DESCRIPTION
## Summary

- Move CloudFront Functions / ConnectionFunctions JS execution onto a dedicated worker thread guarded by `mpsc::sync_channel::recv_timeout` so adversarial JS like `while(1){}` is killed by both boa's iteration limit and a hard wall-clock budget (250ms).
- `JsExecution.compute_utilization` is now populated dynamically: proportional to elapsed time on success (saturated at 100), fixed at 101 on errors / timeouts so callers can detect failure from the metric alone. `test_function` / `test_connection_function` emit the value (previously hardcoded 0).
- Errors land on `FunctionExecutionLogs` as `ERROR: ...` lines in addition to `FunctionErrorMessage`, mirroring real CloudFront where the failure shows up in CloudWatch logs.

## Test plan

- [x] `cargo test -p fakecloud-cloudfront --lib` (43 tests, 5 new)
- [x] `cargo clippy -p fakecloud-cloudfront --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Trivial JS: `function handler(event) { event.request.headers["x-foo"] = {value: "bar"}; return event.request; }` returns the modified request (`test_function_modifies_aws_request_shape`)
- [x] Throwing JS: `function handler() { throw new Error("kaboom"); }` returns `FunctionExecutionLogs` containing the error and `ComputeUtilization > 100` (`test_function_logs_error_and_marks_compute_over_100`)
- [x] Infinite loop: `function handler() { while(1){} }` is killed by timeout / iteration cap, `ComputeUtilization > 100`, error logged (`test_function_infinite_loop_is_killed`, mirrored on ConnectionFunction)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CloudFront Function and ConnectionFunction JS on a dedicated worker thread with a 250ms wall-clock timeout to prevent hangs. ComputeUtilization is returned, and errors are mirrored to execution logs.

- **New Features**
  - JS runs on a worker thread guarded by `mpsc::sync_channel::recv_timeout` and Boa’s iteration cap; infinite loops are killed within 250ms.
  - `compute_utilization` is derived from elapsed time (1–100 on success); set to 101 on errors/timeouts so failure is detectable via the metric. Both `test_function` and `test_connection_function` now emit this value.
  - Errors are mirrored to execution logs as `ERROR: ...` in addition to `FunctionErrorMessage`, matching CloudFront behavior.

- **Bug Fixes**
  - Distinguish `recv_timeout` `Disconnected` from `Timeout` so worker spawn/panic errors are reported separately from wall-clock timeouts.
  - Synced module docs to the 250ms timeout.

<sup>Written for commit d34dbcffca26de02c0902be2e759c47ee80b2cc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

