### PR TITLE
feat(ecr): UpdateImageStorageClass + ListImageReferrers + in-use tracking (P5)

### DIFF
--- a/crates/fakecloud-ecr/src/lifecycle_ticker.rs
+++ b/crates/fakecloud-ecr/src/lifecycle_ticker.rs
@@ -146,6 +146,11 @@ mod tests {
                 // Pushed 30 days ago.
                 image_pushed_at: Utc::now() - ChronoDuration::days(30),
                 last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
             },
         );
         repo.image_tags

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -497,12 +497,16 @@ async fn blob_get(
 ) -> Result<AwsResponse, AwsServiceError> {
     // Snapshot the layer under a write lock so we can bump pull metadata
     // on every image whose manifest references this blob digest.
+    let caller_arn = request.principal.as_ref().map(|p| p.arn.clone());
     let local = {
         let mut accounts = service.state_handle().write();
         let layer = accounts
             .get_mut(&request.account_id)
-            .and_then(|s| s.repositories.get_mut(name))
-            .and_then(|repo| {
+            .and_then(|s| {
+                let exclusions = crate::service::pull_time_exclusion_set(s);
+                s.repositories.get_mut(name).map(|repo| (repo, exclusions))
+            })
+            .and_then(|(repo, exclusions)| {
                 let layer = repo.layers.get(digest).cloned()?;
                 let touched: Vec<String> = repo
                     .images
@@ -521,7 +525,12 @@ async fn blob_get(
                     })
                     .map(|(d, _)| d.clone())
                     .collect();
-                crate::service::touch_image_pull(repo, &touched);
+                crate::service::touch_image_pull(
+                    repo,
+                    &touched,
+                    caller_arn.as_deref(),
+                    &exclusions,
+                );
                 Some(layer)
             });
         layer
@@ -539,6 +548,40 @@ async fn blob_get(
         crate::pull_through::proxy_blob(service, &request.account_id, name, digest).await
     {
         let proxied = outcome?;
+        // Pull-through cached the blob; mirror the local-hit code path
+        // and bump the in-use counters on every image whose manifest
+        // references this layer digest. Honours pull-time exclusions.
+        {
+            let mut accounts = service.state_handle().write();
+            if let Some(state) = accounts.get_mut(&request.account_id) {
+                let exclusions = crate::service::pull_time_exclusion_set(state);
+                if let Some(repo) = state.repositories.get_mut(name) {
+                    let touched: Vec<String> = repo
+                        .images
+                        .iter()
+                        .filter(|(_, img)| {
+                            serde_json::from_str::<serde_json::Value>(&img.image_manifest)
+                                .ok()
+                                .and_then(|v| v.get("layers").cloned())
+                                .and_then(|v| v.as_array().cloned())
+                                .map(|arr| {
+                                    arr.iter().any(|l| {
+                                        l.get("digest").and_then(|d| d.as_str()) == Some(digest)
+                                    })
+                                })
+                                .unwrap_or(false)
+                        })
+                        .map(|(d, _)| d.clone())
+                        .collect();
+                    crate::service::touch_image_pull(
+                        repo,
+                        &touched,
+                        caller_arn.as_deref(),
+                        &exclusions,
+                    );
+                }
+            }
+        }
         return Ok(crate::pull_through::blob_response(&proxied, digest));
     }
     Err(blob_not_found(name, digest))
@@ -894,8 +937,14 @@ async fn manifest_head(
             .insert("Content-Length", HeaderValue::from(size));
         return Ok(resp);
     }
-    if let Some(outcome) =
-        crate::pull_through::proxy_manifest(service, &request.account_id, name, reference).await
+    if let Some(outcome) = crate::pull_through::proxy_manifest(
+        service,
+        &request.account_id,
+        name,
+        reference,
+        request.principal.as_ref().map(|p| p.arn.as_str()),
+    )
+    .await
     {
         let proxied = outcome?;
         let mut resp = crate::pull_through::manifest_response(&proxied);
@@ -917,12 +966,16 @@ async fn manifest_get(
 ) -> Result<AwsResponse, AwsServiceError> {
     // Pull-shaped op: snapshot the manifest under a write lock so we can
     // bump `last_in_use_at`/`in_use_count` on the touched image.
+    let caller_arn = request.principal.as_ref().map(|p| p.arn.clone());
     let local = {
         let mut accounts = service.state_handle().write();
         accounts
             .get_mut(&request.account_id)
-            .and_then(|s| s.repositories.get_mut(name))
-            .and_then(|repo| {
+            .and_then(|s| {
+                let exclusions = crate::service::pull_time_exclusion_set(s);
+                s.repositories.get_mut(name).map(|repo| (repo, exclusions))
+            })
+            .and_then(|(repo, exclusions)| {
                 let digest = resolve_reference(repo, reference)?;
                 let manifest = repo.images.get(&digest).map(|img| {
                     (
@@ -932,7 +985,12 @@ async fn manifest_get(
                     )
                 });
                 if manifest.is_some() {
-                    crate::service::touch_image_pull(repo, &[digest]);
+                    crate::service::touch_image_pull(
+                        repo,
+                        &[digest],
+                        caller_arn.as_deref(),
+                        &exclusions,
+                    );
                 }
                 manifest
             })
@@ -945,8 +1003,14 @@ async fn manifest_get(
         );
         return Ok(resp);
     }
-    if let Some(outcome) =
-        crate::pull_through::proxy_manifest(service, &request.account_id, name, reference).await
+    if let Some(outcome) = crate::pull_through::proxy_manifest(
+        service,
+        &request.account_id,
+        name,
+        reference,
+        request.principal.as_ref().map(|p| p.arn.as_str()),
+    )
+    .await
     {
         let proxied = outcome?;
         return Ok(crate::pull_through::manifest_response(&proxied));

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -943,6 +943,9 @@ async fn manifest_head(
         name,
         reference,
         request.principal.as_ref().map(|p| p.arn.as_str()),
+        // HEAD is an existence check, not a pull — don't bump pull
+        // counters on the freshly cached image.
+        false,
     )
     .await
     {
@@ -1009,6 +1012,8 @@ async fn manifest_get(
         name,
         reference,
         request.principal.as_ref().map(|p| p.arn.as_str()),
+        // GET is a pull — bump in-use counters on the freshly cached image.
+        true,
     )
     .await
     {

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -495,12 +495,36 @@ async fn blob_get(
     name: &str,
     digest: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // Snapshot the layer under a write lock so we can bump pull metadata
+    // on every image whose manifest references this blob digest.
     let local = {
-        let accounts = service.state_handle().read();
-        accounts
-            .get(&request.account_id)
-            .and_then(|s| s.repositories.get(name))
-            .and_then(|r| r.layers.get(digest).cloned())
+        let mut accounts = service.state_handle().write();
+        let layer = accounts
+            .get_mut(&request.account_id)
+            .and_then(|s| s.repositories.get_mut(name))
+            .and_then(|repo| {
+                let layer = repo.layers.get(digest).cloned()?;
+                let touched: Vec<String> = repo
+                    .images
+                    .iter()
+                    .filter(|(_, img)| {
+                        serde_json::from_str::<serde_json::Value>(&img.image_manifest)
+                            .ok()
+                            .and_then(|v| v.get("layers").cloned())
+                            .and_then(|v| v.as_array().cloned())
+                            .map(|arr| {
+                                arr.iter().any(|l| {
+                                    l.get("digest").and_then(|d| d.as_str()) == Some(digest)
+                                })
+                            })
+                            .unwrap_or(false)
+                    })
+                    .map(|(d, _)| d.clone())
+                    .collect();
+                crate::service::touch_image_pull(repo, &touched);
+                Some(layer)
+            });
+        layer
     };
     if let Some(layer) = local {
         let bytes = decrypt_layer_bytes(service, &request.account_id, &layer)?;
@@ -891,21 +915,26 @@ async fn manifest_get(
     name: &str,
     reference: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // Pull-shaped op: snapshot the manifest under a write lock so we can
+    // bump `last_in_use_at`/`in_use_count` on the touched image.
     let local = {
-        let accounts = service.state_handle().read();
+        let mut accounts = service.state_handle().write();
         accounts
-            .get(&request.account_id)
-            .and_then(|s| s.repositories.get(name))
+            .get_mut(&request.account_id)
+            .and_then(|s| s.repositories.get_mut(name))
             .and_then(|repo| {
-                resolve_reference(repo, reference).and_then(|digest| {
-                    repo.images.get(&digest).map(|img| {
-                        (
-                            digest,
-                            img.image_manifest_media_type.clone(),
-                            img.image_manifest.as_bytes().to_vec(),
-                        )
-                    })
-                })
+                let digest = resolve_reference(repo, reference)?;
+                let manifest = repo.images.get(&digest).map(|img| {
+                    (
+                        digest.clone(),
+                        img.image_manifest_media_type.clone(),
+                        img.image_manifest.as_bytes().to_vec(),
+                    )
+                });
+                if manifest.is_some() {
+                    crate::service::touch_image_pull(repo, &[digest]);
+                }
+                manifest
             })
     };
     if let Some((digest, media_type, body)) = local {
@@ -958,6 +987,11 @@ fn manifest_put(
             image_size_in_bytes: body.len() as u64,
             image_pushed_at: Utc::now(),
             last_recorded_pull_time: None,
+            image_status: "ACTIVE".to_string(),
+            last_archived_at: None,
+            last_activated_at: None,
+            last_in_use_at: None,
+            in_use_count: 0,
         },
     );
     // If the reference isn't a digest, treat it as a tag.

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -325,6 +325,11 @@ fn cache_manifest(
             image_size_in_bytes: bytes.len() as u64,
             image_pushed_at: Utc::now(),
             last_recorded_pull_time: Some(Utc::now()),
+            image_status: "ACTIVE".to_string(),
+            last_archived_at: None,
+            last_activated_at: None,
+            last_in_use_at: Some(Utc::now()),
+            in_use_count: 1,
         },
     );
     // A reference can be a tag (alphanumeric) or a digest. Only store

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -187,6 +187,7 @@ pub(crate) async fn proxy_manifest(
     repo_name: &str,
     reference: &str,
     caller_arn: Option<&str>,
+    count_as_pull: bool,
 ) -> Option<Result<ProxiedManifest, AwsServiceError>> {
     let rules = rules_for_account(service, account_id);
     let (rule, upstream_path) = match_rule(&rules, repo_name)?;
@@ -235,6 +236,7 @@ pub(crate) async fn proxy_manifest(
         &media_type,
         &digest,
         caller_arn,
+        count_as_pull,
     );
     Some(Ok(ProxiedManifest {
         bytes,
@@ -297,6 +299,7 @@ fn cache_manifest(
     media_type: &str,
     digest: &str,
     caller_arn: Option<&str>,
+    count_as_pull: bool,
 ) {
     let mut accounts = service.state_handle().write();
     let state = accounts.get_or_create(account_id);
@@ -304,12 +307,13 @@ fn cache_manifest(
     let region = state.region.clone();
     // Honour pull-time exclusions: an excluded principal that triggers
     // a proxy-cache should not bump the in-use counter on the freshly
-    // cached image.
+    // cached image. HEAD requests also opt out via `count_as_pull=false`
+    // — they are existence checks, not pulls.
     let excluded = caller_arn
         .map(|a| state.pull_time_exclusions.contains_key(a))
         .unwrap_or(false);
     let now = Utc::now();
-    let (last_pull, last_in_use, in_use_count) = if excluded {
+    let (last_pull, last_in_use, in_use_count) = if !count_as_pull || excluded {
         (None, None, 0)
     } else {
         (Some(now), Some(now), 1)

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -186,6 +186,7 @@ pub(crate) async fn proxy_manifest(
     account_id: &str,
     repo_name: &str,
     reference: &str,
+    caller_arn: Option<&str>,
 ) -> Option<Result<ProxiedManifest, AwsServiceError>> {
     let rules = rules_for_account(service, account_id);
     let (rule, upstream_path) = match_rule(&rules, repo_name)?;
@@ -233,6 +234,7 @@ pub(crate) async fn proxy_manifest(
         &bytes,
         &media_type,
         &digest,
+        caller_arn,
     );
     Some(Ok(ProxiedManifest {
         bytes,
@@ -285,6 +287,7 @@ pub(crate) async fn proxy_blob(
     Some(Ok(ProxiedBlob { bytes, media_type }))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cache_manifest(
     service: &EcrService,
     account_id: &str,
@@ -293,11 +296,24 @@ fn cache_manifest(
     bytes: &[u8],
     media_type: &str,
     digest: &str,
+    caller_arn: Option<&str>,
 ) {
     let mut accounts = service.state_handle().write();
     let state = accounts.get_or_create(account_id);
     let account_id = state.account_id.clone();
     let region = state.region.clone();
+    // Honour pull-time exclusions: an excluded principal that triggers
+    // a proxy-cache should not bump the in-use counter on the freshly
+    // cached image.
+    let excluded = caller_arn
+        .map(|a| state.pull_time_exclusions.contains_key(a))
+        .unwrap_or(false);
+    let now = Utc::now();
+    let (last_pull, last_in_use, in_use_count) = if excluded {
+        (None, None, 0)
+    } else {
+        (Some(now), Some(now), 1)
+    };
     let repo = state
         .repositories
         .entry(repo_name.to_string())
@@ -323,13 +339,13 @@ fn cache_manifest(
             image_manifest_media_type: media_type.to_string(),
             artifact_media_type: None,
             image_size_in_bytes: bytes.len() as u64,
-            image_pushed_at: Utc::now(),
-            last_recorded_pull_time: Some(Utc::now()),
+            image_pushed_at: now,
+            last_recorded_pull_time: last_pull,
             image_status: "ACTIVE".to_string(),
             last_archived_at: None,
             last_activated_at: None,
-            last_in_use_at: Some(Utc::now()),
-            in_use_count: 1,
+            last_in_use_at: last_in_use,
+            in_use_count,
         },
     );
     // A reference can be a tag (alphanumeric) or a digest. Only store

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -722,6 +722,11 @@ impl EcrService {
             image_size_in_bytes: manifest.len() as u64,
             image_pushed_at: Utc::now(),
             last_recorded_pull_time: None,
+            image_status: "ACTIVE".to_string(),
+            last_archived_at: None,
+            last_activated_at: None,
+            last_in_use_at: None,
+            in_use_count: 0,
         });
         // If the caller re-pushes an existing digest with a new manifest
         // payload (shouldn't happen under sha256 addressing but tolerate
@@ -969,13 +974,17 @@ impl EcrService {
             .cloned()
             .unwrap_or_default();
         let account = target_account_id(request, &body);
-        let accounts = self.state.read();
+        // Take a write lock so pull-time bookkeeping (`lastInUseAt`,
+        // `inUseCount`, `lastRecordedPullTime`) can update in place. Real
+        // ECR records pull time at least every 24 h on the data plane;
+        // fakecloud bumps unconditionally so tests can observe each call.
+        let mut accounts = self.state.write();
         let state = accounts
-            .get(&account)
+            .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
         let repo = state
             .repositories
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
 
         check_repo_policy(
@@ -989,6 +998,7 @@ impl EcrService {
 
         let mut images: Vec<Value> = Vec::new();
         let mut failures: Vec<Value> = Vec::new();
+        let mut hit_digests: Vec<String> = Vec::new();
         for id in &ids {
             match resolve_image_digest(repo, id) {
                 Some(digest) => {
@@ -1001,6 +1011,7 @@ impl EcrService {
                         "imageManifest": img.image_manifest,
                         "imageManifestMediaType": img.image_manifest_media_type,
                     }));
+                    hit_digests.push(digest);
                 }
                 None => failures.push(json!({
                     "imageId": id,
@@ -1009,6 +1020,7 @@ impl EcrService {
                 })),
             }
         }
+        touch_image_pull(repo, &hit_digests);
         Ok(AwsResponse::ok_json(json!({
             "images": images,
             "failures": failures,
@@ -1292,13 +1304,13 @@ impl EcrService {
         let name = req_str(&body, "repositoryName")?.to_string();
         let digest = req_str(&body, "layerDigest")?.to_string();
         let account = target_account_id(request, &body);
-        let accounts = self.state.read();
+        let mut accounts = self.state.write();
         let state = accounts
-            .get(&account)
+            .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
         let repo = state
             .repositories
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
         check_repo_policy(
             &account,
@@ -1311,9 +1323,32 @@ impl EcrService {
         if !repo.layers.contains_key(&digest) {
             return Err(layer_not_found(&digest, &name));
         }
-        // Batch 3 will host `/v2/<name>/blobs/<digest>` — return that
-        // path as a relative URL so callers that trust the endpoint
-        // they're already talking to can resolve it.
+        // Pull bookkeeping: the OCI client requested a layer blob, which
+        // means at least one image whose manifest references that layer
+        // is being pulled. Touch every such image so DescribeImages
+        // reflects the access. Don't touch unrelated images.
+        let mut touched: Vec<String> = Vec::new();
+        for (img_digest, img) in &repo.images {
+            let parsed: Value = match serde_json::from_str(&img.image_manifest) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let references = parsed
+                .get("layers")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .any(|l| l.get("digest").and_then(|d| d.as_str()) == Some(digest.as_str()))
+                })
+                .unwrap_or(false);
+            if references {
+                touched.push(img_digest.clone());
+            }
+        }
+        touch_image_pull(repo, &touched);
+        // The OCI v2 endpoint hosts `/v2/<name>/blobs/<digest>` — return
+        // that absolute URL so callers that trust the endpoint they're
+        // already talking to can resolve it.
         let endpoint = accounts.endpoint();
         let url = format!(
             "{}/v2/{}/blobs/{}",
@@ -2972,6 +3007,22 @@ impl EcrService {
             .and_then(|v| v.as_str())
             .ok_or_else(|| invalid_parameter("subjectId.imageDigest is required"))?
             .to_string();
+        // Optional filter: artifactTypes + artifactStatus. Defaults match
+        // AWS: `artifactStatus = ACTIVE` only when no filter is supplied.
+        let filter = body.get("filter").cloned().unwrap_or(Value::Null);
+        let artifact_type_filter: Option<Vec<String>> = filter
+            .get("artifactTypes")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            });
+        let artifact_status_filter: String = filter
+            .get("artifactStatus")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ACTIVE")
+            .to_string();
         let account = target_account_id(request, &body);
         let accounts = self.state.read();
         let state = accounts
@@ -2988,8 +3039,63 @@ impl EcrService {
                 format!("Subject image {digest} not found in repository '{name}'"),
             ));
         }
+        // Walk every image; include those whose manifest has a
+        // `subject.digest` matching the requested subject. The subject
+        // is the OCI Distribution v1.1 referrer relation.
+        let mut referrers: Vec<Value> = Vec::new();
+        for image in repo.images.values() {
+            let parsed: Value = match serde_json::from_str(&image.image_manifest) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let subject_digest = parsed
+                .get("subject")
+                .and_then(|s| s.get("digest"))
+                .and_then(|d| d.as_str());
+            if subject_digest != Some(digest.as_str()) {
+                continue;
+            }
+            // OCI artifact type lives at `artifactType` (image manifest)
+            // or `config.mediaType` (image-config-as-artifact).
+            let artifact_type = parsed
+                .get("artifactType")
+                .and_then(|v| v.as_str())
+                .or_else(|| {
+                    parsed
+                        .get("config")
+                        .and_then(|c| c.get("mediaType"))
+                        .and_then(|v| v.as_str())
+                })
+                .map(str::to_string);
+            if let Some(ref allowed) = artifact_type_filter {
+                if !allowed.iter().any(|t| Some(t) == artifact_type.as_ref()) {
+                    continue;
+                }
+            }
+            // Status filter: `ANY` matches everything; otherwise the
+            // referrer's `image_status` must equal the filter value.
+            if artifact_status_filter != "ANY" && image.image_status != artifact_status_filter {
+                continue;
+            }
+            // Annotations live on the manifest under `annotations`.
+            let annotations = parsed
+                .get("annotations")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let mut referrer = json!({
+                "digest": image.image_digest,
+                "mediaType": image.image_manifest_media_type,
+                "size": image.image_size_in_bytes,
+                "annotations": annotations,
+                "artifactStatus": image.image_status,
+            });
+            if let Some(t) = artifact_type {
+                referrer["artifactType"] = json!(t);
+            }
+            referrers.push(referrer);
+        }
         Ok(AwsResponse::ok_json(json!({
-            "imageReferrers": [],
+            "referrers": referrers,
         })))
     }
 
@@ -3004,28 +3110,44 @@ impl EcrService {
             .cloned()
             .ok_or_else(|| invalid_parameter("Missing imageId"))?;
         let target_class = req_str(&body, "targetStorageClass")?.to_string();
+        // Smithy `TargetStorageClass` is `STANDARD | ARCHIVE`. Anything
+        // else is rejected the way AWS would reject an enum mismatch.
         if target_class != "STANDARD" && target_class != "ARCHIVE" {
             return Err(invalid_parameter(format!(
                 "Invalid targetStorageClass '{target_class}'. Must be STANDARD or ARCHIVE."
             )));
         }
         let account = target_account_id(request, &body);
-        let accounts = self.state.read();
+        let mut accounts = self.state.write();
         let state = accounts
-            .get(&account)
+            .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
         let repo = state
             .repositories
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
-        if resolve_image_digest(repo, &image_id).is_none() {
-            return Err(image_not_found(&name, &image_id));
-        }
+        let digest = resolve_image_digest(repo, &image_id)
+            .ok_or_else(|| image_not_found(&name, &image_id))?;
+        let registry_id = repo.registry_id.clone();
+        let now = Utc::now();
+        let image = repo.images.get_mut(&digest).expect("digest resolves");
+        let new_status = match target_class.as_str() {
+            "ARCHIVE" => {
+                image.last_archived_at = Some(now);
+                "ARCHIVED"
+            }
+            // STANDARD = restore from archive.
+            _ => {
+                image.last_activated_at = Some(now);
+                "ACTIVE"
+            }
+        };
+        image.image_status = new_status.to_string();
         Ok(AwsResponse::ok_json(json!({
-            "registryId": repo.registry_id,
+            "registryId": registry_id,
             "repositoryName": name,
             "imageId": image_id,
-            "targetStorageClass": target_class,
+            "imageStatus": new_status,
         })))
     }
 }

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -197,10 +197,25 @@ impl AwsService for EcrService {
                 }
             }
             let result = crate::oci::dispatch(self, &request).await;
-            let mutates_oci = matches!(
-                request.method,
-                http::Method::POST | http::Method::PUT | http::Method::PATCH | http::Method::DELETE
-            );
+            // POST/PUT/PATCH/DELETE always mutate. GET to a `blobs/<digest>`
+            // or `manifests/<reference>` endpoint also mutates because those
+            // handlers bump the touched image's `last_in_use_at` /
+            // `in_use_count` / `last_recorded_pull_time`. `tags/list` (also
+            // GET) is read-only and excluded.
+            let is_pull_get = request.method == http::Method::GET
+                && request.path_segments.len() >= 3
+                && matches!(
+                    request.path_segments[request.path_segments.len() - 2].as_str(),
+                    "blobs" | "manifests"
+                );
+            let mutates_oci = is_pull_get
+                || matches!(
+                    request.method,
+                    http::Method::POST
+                        | http::Method::PUT
+                        | http::Method::PATCH
+                        | http::Method::DELETE
+                );
             if mutates_oci && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
                 self.save_snapshot().await;
             }
@@ -982,6 +997,10 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        // Snapshot the registered exclusion ARNs before grabbing the repo
+        // mut so `touch_image_pull` can honour the exclusion contract
+        // without holding two `&mut`s on `EcrState`.
+        let exclusions = pull_time_exclusion_set(state);
         let repo = state
             .repositories
             .get_mut(&name)
@@ -1020,7 +1039,8 @@ impl EcrService {
                 })),
             }
         }
-        touch_image_pull(repo, &hit_digests);
+        let caller_arn = request.principal.as_ref().map(|p| p.arn.as_str());
+        touch_image_pull(repo, &hit_digests, caller_arn, &exclusions);
         Ok(AwsResponse::ok_json(json!({
             "images": images,
             "failures": failures,
@@ -1308,6 +1328,7 @@ impl EcrService {
         let state = accounts
             .get_mut(&account)
             .ok_or_else(|| repository_not_found(&name))?;
+        let exclusions = pull_time_exclusion_set(state);
         let repo = state
             .repositories
             .get_mut(&name)
@@ -1345,7 +1366,8 @@ impl EcrService {
                 touched.push(img_digest.clone());
             }
         }
-        touch_image_pull(repo, &touched);
+        let caller_arn = request.principal.as_ref().map(|p| p.arn.as_str());
+        touch_image_pull(repo, &touched, caller_arn, &exclusions);
         // The OCI v2 endpoint hosts `/v2/<name>/blobs/<digest>` — return
         // that absolute URL so callers that trust the endpoint they're
         // already talking to can resolve it.

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -366,9 +366,25 @@ pub(crate) fn image_to_details(repo: &Repository, image: &Image, registry_id: &s
 /// Used by `BatchGetImage`, `GetDownloadUrlForLayer`, and the OCI manifest /
 /// blob GET handlers so DescribeImages reports a fresh `lastInUseAt` and
 /// the `inUseCount` matches actual pull traffic.
-pub(crate) fn touch_image_pull(repo: &mut Repository, digests: &[String]) {
+///
+/// When `caller_arn` matches a principal registered via
+/// `RegisterPullTimeUpdateExclusion` (passed in `exclusion_arns`), nothing
+/// is touched. The exclusion contract has to apply uniformly across the
+/// `lastRecordedPullTime`, `lastInUseAt`, and `inUseCount` fields — all
+/// three are pull-time bookkeeping.
+pub(crate) fn touch_image_pull(
+    repo: &mut Repository,
+    digests: &[String],
+    caller_arn: Option<&str>,
+    exclusion_arns: &std::collections::HashSet<String>,
+) {
     if digests.is_empty() {
         return;
+    }
+    if let Some(arn) = caller_arn {
+        if exclusion_arns.contains(arn) {
+            return;
+        }
     }
     let now = chrono::Utc::now();
     for digest in digests {
@@ -378,6 +394,16 @@ pub(crate) fn touch_image_pull(repo: &mut Repository, digests: &[String]) {
             image.in_use_count = image.in_use_count.saturating_add(1);
         }
     }
+}
+
+/// Snapshot the registered pull-time-exclusion principal ARNs for the
+/// account. Cheap clone (`String`s in a `HashSet`) intended to be taken
+/// before grabbing a repo `&mut` so `touch_image_pull` can run without
+/// borrowing the surrounding `EcrState`.
+pub(crate) fn pull_time_exclusion_set(
+    state: &crate::state::EcrState,
+) -> std::collections::HashSet<String> {
+    state.pull_time_exclusions.keys().cloned().collect()
 }
 
 /// Return only the layer blobs referenced by the manifest of `image_digest`.

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -1,6 +1,9 @@
 use super::*;
 
 /// Actions that mutate persisted state. Only these trigger a snapshot save.
+/// Pull-shaped reads (`BatchGetImage`, `GetDownloadUrlForLayer`) are listed
+/// because they bump `last_in_use_at`/`in_use_count` on the touched image,
+/// which is persisted state.
 pub(crate) fn is_mutating(action: &str) -> bool {
     matches!(
         action,
@@ -13,7 +16,9 @@ pub(crate) fn is_mutating(action: &str) -> bool {
             | "TagResource"
             | "UntagResource"
             | "PutImage"
+            | "BatchGetImage"
             | "BatchDeleteImage"
+            | "GetDownloadUrlForLayer"
             | "InitiateLayerUpload"
             | "UploadLayerPart"
             | "CompleteLayerUpload"
@@ -302,6 +307,37 @@ pub(crate) fn image_to_details(repo: &Repository, image: &Image, registry_id: &s
     if let Some(t) = image.last_recorded_pull_time {
         out["lastRecordedPullTime"] = json!(t.timestamp());
     }
+    // Storage-class lifecycle fields. `imageStatus` is in the AWS Smithy
+    // model; `lastArchivedAt` / `lastActivatedAt` are too. Real ECR omits
+    // these until they're set, so do the same.
+    out["imageStatus"] = json!(image.image_status);
+    if let Some(t) = image.last_archived_at {
+        out["lastArchivedAt"] = json!(t.timestamp());
+    }
+    if let Some(t) = image.last_activated_at {
+        out["lastActivatedAt"] = json!(t.timestamp());
+    }
+    // fakecloud-extension fields (not in AWS Smithy). `lastInUseAt` is
+    // bumped by every pull-shaped op (BatchGetImage, GetDownloadUrlForLayer,
+    // OCI manifest/blob GET); `inUseCount` is the monotonic counter.
+    // Tests can rely on these to assert pull frequency without scraping
+    // logs. See P5 ECR polish PR.
+    if let Some(t) = image.last_in_use_at {
+        out["lastInUseAt"] = json!(t.timestamp());
+    }
+    out["inUseCount"] = json!(image.in_use_count);
+    // If this image is a referrer (its manifest carries a `subject`),
+    // surface the subject digest the way AWS does. Parse defensively —
+    // not every image is JSON.
+    if let Ok(parsed) = serde_json::from_str::<Value>(&image.image_manifest) {
+        if let Some(subject_digest) = parsed
+            .get("subject")
+            .and_then(|s| s.get("digest"))
+            .and_then(|d| d.as_str())
+        {
+            out["subjectManifestDigest"] = json!(subject_digest);
+        }
+    }
     // Surface scan state on the image itself (real ECR returns these
     // unconditionally; SDK callers that watch scan-on-push completion poll
     // DescribeImages and previously saw nothing).
@@ -324,6 +360,24 @@ pub(crate) fn image_to_details(repo: &Repository, image: &Image, registry_id: &s
         out["imageScanStatus"] = json!({ "status": "PENDING" });
     }
     out
+}
+
+/// Stamp pull metadata on every image whose digest matches one of `digests`.
+/// Used by `BatchGetImage`, `GetDownloadUrlForLayer`, and the OCI manifest /
+/// blob GET handlers so DescribeImages reports a fresh `lastInUseAt` and
+/// the `inUseCount` matches actual pull traffic.
+pub(crate) fn touch_image_pull(repo: &mut Repository, digests: &[String]) {
+    if digests.is_empty() {
+        return;
+    }
+    let now = chrono::Utc::now();
+    for digest in digests {
+        if let Some(image) = repo.images.get_mut(digest) {
+            image.last_in_use_at = Some(now);
+            image.last_recorded_pull_time = Some(now);
+            image.in_use_count = image.in_use_count.saturating_add(1);
+        }
+    }
 }
 
 /// Return only the layer blobs referenced by the manifest of `image_digest`.

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -61,6 +61,11 @@ fn repo_with_images(entries: &[(&str, &[&str], i64)]) -> Repository {
                 image_size_in_bytes: 0,
                 image_pushed_at: pushed,
                 last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
             },
         );
         for t in *tags {
@@ -324,6 +329,11 @@ fn replicate_image_copies_to_destination_account() {
             image_size_in_bytes: 0,
             image_pushed_at: chrono::Utc::now(),
             last_recorded_pull_time: None,
+            image_status: "ACTIVE".to_string(),
+            last_archived_at: None,
+            last_activated_at: None,
+            last_in_use_at: None,
+            in_use_count: 0,
         },
     );
     source_state.repositories.insert("app".to_string(), repo);
@@ -472,6 +482,11 @@ mod replication_tests {
                 image_size_in_bytes: 0,
                 image_pushed_at: chrono::Utc::now(),
                 last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
             },
         );
     }
@@ -646,6 +661,11 @@ mod repo_policy_enforcement_tests {
                 image_size_in_bytes: 0,
                 image_pushed_at: chrono::Utc::now(),
                 last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
             },
         );
         repo.image_tags
@@ -1005,6 +1025,11 @@ mod lifecycle_timestamp_tests {
                 image_size_in_bytes: 0,
                 image_pushed_at: chrono::Utc::now() - chrono::Duration::days(30),
                 last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
             },
         );
         repo.image_tags
@@ -1121,6 +1146,11 @@ mod lifecycle_timestamp_tests {
                     image_size_in_bytes: 0,
                     image_pushed_at: chrono::Utc::now() - chrono::Duration::days(60),
                     last_recorded_pull_time: None,
+                    image_status: "ACTIVE".to_string(),
+                    last_archived_at: None,
+                    last_activated_at: None,
+                    last_in_use_at: None,
+                    in_use_count: 0,
                 },
             );
         }
@@ -1149,5 +1179,374 @@ mod lifecycle_timestamp_tests {
             !repo.images.contains_key("sha256:older"),
             "tick should have pruned the 60-day-old image"
         );
+    }
+}
+
+// ── P5: pull-time exclusions, storage class, referrers, in-use tracking ──
+#[cfg(test)]
+mod p5_polish_tests {
+    use super::super::EcrService;
+    use crate::state::{EcrState, Image, Repository, SharedEcrState};
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "111111111111";
+
+    fn make_request(action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: ACCOUNT.into(),
+            request_id: "req-1".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn fixture() -> (EcrService, SharedEcrState) {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
+        let state = mas.get_or_create(ACCOUNT);
+        let arn = state.repository_arn("app");
+        let repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
+        state.repositories.insert("app".to_string(), repo);
+        let shared: SharedEcrState = Arc::new(RwLock::new(mas));
+        let svc = EcrService::new(shared.clone());
+        (svc, shared)
+    }
+
+    fn seed_image(state: &SharedEcrState, digest: &str, manifest: &str) {
+        let mut accounts = state.write();
+        let s = accounts.get_mut(ACCOUNT).unwrap();
+        let repo = s.repositories.get_mut("app").unwrap();
+        repo.images.insert(
+            digest.to_string(),
+            Image {
+                image_digest: digest.to_string(),
+                image_manifest: manifest.to_string(),
+                image_manifest_media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+                artifact_media_type: None,
+                image_size_in_bytes: manifest.len() as u64,
+                image_pushed_at: chrono::Utc::now(),
+                last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
+            },
+        );
+    }
+
+    // ── PullTimeUpdateExclusion round-trip ────────────────────────
+    #[test]
+    fn pull_time_exclusion_register_list_deregister_round_trip() {
+        let (svc, _state) = fixture();
+        let arn = "arn:aws:iam::111111111111:role/ci-puller";
+
+        let req = make_request(
+            "RegisterPullTimeUpdateExclusion",
+            json!({ "principalArn": arn }),
+        );
+        let resp = svc.register_pull_time_update_exclusion(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["principalArn"], arn);
+
+        let req = make_request("ListPullTimeUpdateExclusions", json!({}));
+        let resp = svc.list_pull_time_update_exclusions(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let list = body["pullTimeUpdateExclusions"].as_array().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["principalArn"], arn);
+
+        let req = make_request(
+            "DeregisterPullTimeUpdateExclusion",
+            json!({ "principalArn": arn }),
+        );
+        svc.deregister_pull_time_update_exclusion(&req).unwrap();
+
+        let req = make_request("ListPullTimeUpdateExclusions", json!({}));
+        let resp = svc.list_pull_time_update_exclusions(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["pullTimeUpdateExclusions"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    // ── UpdateImageStorageClass: ARCHIVE then STANDARD round-trip ─
+    #[test]
+    fn update_image_storage_class_archive_then_restore_persists() {
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:abc", "{}");
+
+        let req = make_request(
+            "UpdateImageStorageClass",
+            json!({
+                "repositoryName": "app",
+                "imageId": { "imageDigest": "sha256:abc" },
+                "targetStorageClass": "ARCHIVE",
+            }),
+        );
+        let resp = svc.update_image_storage_class(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["imageStatus"], "ARCHIVED");
+
+        // DescribeImages reflects the archive.
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:abc" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["imageStatus"], "ARCHIVED");
+        assert!(detail["lastArchivedAt"].is_i64());
+        assert!(detail.get("lastActivatedAt").is_none());
+
+        // Restore.
+        let req = make_request(
+            "UpdateImageStorageClass",
+            json!({
+                "repositoryName": "app",
+                "imageId": { "imageDigest": "sha256:abc" },
+                "targetStorageClass": "STANDARD",
+            }),
+        );
+        let resp = svc.update_image_storage_class(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["imageStatus"], "ACTIVE");
+
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:abc" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["imageStatus"], "ACTIVE");
+        assert!(detail["lastActivatedAt"].is_i64());
+    }
+
+    #[test]
+    fn update_image_storage_class_rejects_unknown_class() {
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:abc", "{}");
+        let req = make_request(
+            "UpdateImageStorageClass",
+            json!({
+                "repositoryName": "app",
+                "imageId": { "imageDigest": "sha256:abc" },
+                "targetStorageClass": "GLACIER",
+            }),
+        );
+        let err = svc
+            .update_image_storage_class(&req)
+            .err()
+            .expect("GLACIER must be rejected");
+        match err {
+            fakecloud_core::service::AwsServiceError::AwsError { status, code, .. } => {
+                assert_eq!(code, "InvalidParameterException");
+                assert!(status.is_client_error());
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // ── ListImageReferrers walks the manifest subject graph ───────
+    #[test]
+    fn list_image_referrers_returns_images_with_matching_subject() {
+        let (svc, state) = fixture();
+        // Subject image.
+        seed_image(&state, "sha256:subject", "{}");
+        // Referrer with subject pointing at sha256:subject (signature artifact).
+        let referrer_manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "artifactType": "application/vnd.dev.cosign.artifact.sig.v1+json",
+            "config": { "mediaType": "application/vnd.oci.empty.v1+json" },
+            "subject": {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:subject",
+                "size": 2,
+            },
+            "annotations": { "org.opencontainers.image.created": "2026-05-03T00:00:00Z" },
+            "layers": [],
+        })
+        .to_string();
+        seed_image(&state, "sha256:sig", &referrer_manifest);
+        // Unrelated image (different subject) — must not appear.
+        let other_manifest = serde_json::json!({
+            "subject": { "digest": "sha256:other" },
+        })
+        .to_string();
+        seed_image(&state, "sha256:other-ref", &other_manifest);
+
+        let req = make_request(
+            "ListImageReferrers",
+            json!({
+                "repositoryName": "app",
+                "subjectId": { "imageDigest": "sha256:subject" },
+            }),
+        );
+        let resp = svc.list_image_referrers(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let referrers = body["referrers"].as_array().unwrap();
+        assert_eq!(referrers.len(), 1, "exactly one matching referrer");
+        assert_eq!(referrers[0]["digest"], "sha256:sig");
+        assert_eq!(
+            referrers[0]["artifactType"],
+            "application/vnd.dev.cosign.artifact.sig.v1+json"
+        );
+        assert_eq!(referrers[0]["artifactStatus"], "ACTIVE");
+        assert!(referrers[0]["annotations"]["org.opencontainers.image.created"].is_string());
+    }
+
+    #[test]
+    fn list_image_referrers_filters_by_artifact_type() {
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:subject", "{}");
+        let sig_manifest = serde_json::json!({
+            "artifactType": "cosign.sig",
+            "subject": { "digest": "sha256:subject" },
+        })
+        .to_string();
+        seed_image(&state, "sha256:sig", &sig_manifest);
+        let sbom_manifest = serde_json::json!({
+            "artifactType": "cyclonedx.sbom",
+            "subject": { "digest": "sha256:subject" },
+        })
+        .to_string();
+        seed_image(&state, "sha256:sbom", &sbom_manifest);
+
+        let req = make_request(
+            "ListImageReferrers",
+            json!({
+                "repositoryName": "app",
+                "subjectId": { "imageDigest": "sha256:subject" },
+                "filter": { "artifactTypes": ["cosign.sig"] },
+            }),
+        );
+        let resp = svc.list_image_referrers(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let referrers = body["referrers"].as_array().unwrap();
+        assert_eq!(referrers.len(), 1);
+        assert_eq!(referrers[0]["digest"], "sha256:sig");
+    }
+
+    #[test]
+    fn list_image_referrers_rejects_missing_subject_image() {
+        let (svc, _state) = fixture();
+        let req = make_request(
+            "ListImageReferrers",
+            json!({
+                "repositoryName": "app",
+                "subjectId": { "imageDigest": "sha256:nope" },
+            }),
+        );
+        let err = svc
+            .list_image_referrers(&req)
+            .err()
+            .expect("missing subject image must error");
+        match err {
+            fakecloud_core::service::AwsServiceError::AwsError { code, .. } => {
+                assert_eq!(code, "ImageNotFoundException");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // ── DescribeImages: lastInUseAt + inUseCount track BatchGetImage ─
+    #[test]
+    fn describe_images_reflects_in_use_after_batch_get_image() {
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:hot", "{}");
+
+        // Before any pull: counter is 0, lastInUseAt absent.
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["inUseCount"], 0);
+        assert!(detail.get("lastInUseAt").is_none());
+
+        // Two BatchGetImage calls bump the counter to 2.
+        for _ in 0..2 {
+            let req = make_request(
+                "BatchGetImage",
+                json!({
+                    "repositoryName": "app",
+                    "imageIds": [{ "imageDigest": "sha256:hot" }],
+                }),
+            );
+            svc.batch_get_image(&req).unwrap();
+        }
+
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["inUseCount"], 2);
+        assert!(detail["lastInUseAt"].is_i64());
+        // lastRecordedPullTime is touched in lockstep so existing
+        // SDK callers see consistent timestamps.
+        assert!(detail["lastRecordedPullTime"].is_i64());
+    }
+
+    // ── DescribeImages: subjectManifestDigest is surfaced for referrers ─
+    #[test]
+    fn describe_images_includes_subject_manifest_digest_for_referrers() {
+        let (svc, state) = fixture();
+        let manifest = serde_json::json!({
+            "subject": { "digest": "sha256:parent" },
+        })
+        .to_string();
+        seed_image(&state, "sha256:child", &manifest);
+
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:child" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["subjectManifestDigest"], "sha256:parent");
     }
 }

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -1549,4 +1549,103 @@ mod p5_polish_tests {
         let detail = &body["imageDetails"][0];
         assert_eq!(detail["subjectManifestDigest"], "sha256:parent");
     }
+
+    // ── Pull-time exclusion suppresses in-use bookkeeping ─────────
+    #[test]
+    fn batch_get_image_skips_pull_metadata_for_excluded_principal() {
+        use fakecloud_core::auth::{Principal, PrincipalType};
+
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:hot", "{}");
+
+        let role_arn = "arn:aws:iam::111111111111:role/ci-puller";
+        let req = make_request(
+            "RegisterPullTimeUpdateExclusion",
+            json!({ "principalArn": role_arn }),
+        );
+        svc.register_pull_time_update_exclusion(&req).unwrap();
+
+        let mut req = make_request(
+            "BatchGetImage",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        req.principal = Some(Principal {
+            arn: role_arn.to_string(),
+            user_id: "AROAEXCLUDED".to_string(),
+            account_id: ACCOUNT.to_string(),
+            principal_type: PrincipalType::AssumedRole,
+            source_identity: None,
+            tags: None,
+        });
+        svc.batch_get_image(&req).unwrap();
+
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(
+            detail["inUseCount"], 0,
+            "excluded principal must not bump inUseCount"
+        );
+        assert!(
+            detail.get("lastInUseAt").is_none(),
+            "excluded principal must not set lastInUseAt"
+        );
+    }
+
+    // ── Non-excluded principals still bump after a registration ───
+    #[test]
+    fn batch_get_image_still_tracks_other_principals_after_exclusion() {
+        use fakecloud_core::auth::{Principal, PrincipalType};
+
+        let (svc, state) = fixture();
+        seed_image(&state, "sha256:hot", "{}");
+
+        let excluded_arn = "arn:aws:iam::111111111111:role/excluded";
+        let active_arn = "arn:aws:iam::111111111111:role/active";
+        let req = make_request(
+            "RegisterPullTimeUpdateExclusion",
+            json!({ "principalArn": excluded_arn }),
+        );
+        svc.register_pull_time_update_exclusion(&req).unwrap();
+
+        let mut req = make_request(
+            "BatchGetImage",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        req.principal = Some(Principal {
+            arn: active_arn.to_string(),
+            user_id: "AROAACTIVE".to_string(),
+            account_id: ACCOUNT.to_string(),
+            principal_type: PrincipalType::AssumedRole,
+            source_identity: None,
+            tags: None,
+        });
+        svc.batch_get_image(&req).unwrap();
+
+        let req = make_request(
+            "DescribeImages",
+            json!({
+                "repositoryName": "app",
+                "imageIds": [{ "imageDigest": "sha256:hot" }],
+            }),
+        );
+        let resp = svc.describe_images(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let detail = &body["imageDetails"][0];
+        assert_eq!(detail["inUseCount"], 1);
+        assert!(detail["lastInUseAt"].is_i64());
+    }
 }

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -14,7 +14,7 @@ impl fakecloud_core::multi_account::AccountState for EcrState {
     }
 }
 
-pub const ECR_SNAPSHOT_SCHEMA_VERSION: u32 = 3;
+pub const ECR_SNAPSHOT_SCHEMA_VERSION: u32 = 4;
 
 /// Top-level persisted ECR snapshot. The shape mirrors the convention
 /// used by other multi-account services (Kinesis, ElastiCache) so the
@@ -263,6 +263,40 @@ pub struct Image {
     pub image_size_in_bytes: u64,
     pub image_pushed_at: DateTime<Utc>,
     pub last_recorded_pull_time: Option<DateTime<Utc>>,
+    /// Lifecycle/storage state surfaced through `ImageDetail.imageStatus`
+    /// in `DescribeImages`. One of `ACTIVE`, `ARCHIVED`, `ACTIVATING`.
+    /// Defaults to `ACTIVE` (the only value AWS exposes for newly pushed
+    /// images); transitions are driven by `UpdateImageStorageClass`.
+    #[serde(default = "default_image_status")]
+    pub image_status: String,
+    /// Last time `UpdateImageStorageClass` archived this image. `None`
+    /// while the image has never been archived. Surfaced as
+    /// `ImageDetail.lastArchivedAt`.
+    #[serde(default)]
+    pub last_archived_at: Option<DateTime<Utc>>,
+    /// Last time `UpdateImageStorageClass` restored this image from
+    /// archive. `None` while the image has never been activated from
+    /// archive. Surfaced as `ImageDetail.lastActivatedAt`.
+    #[serde(default)]
+    pub last_activated_at: Option<DateTime<Utc>>,
+    /// Last time the image was read by a pull-shaped op (`BatchGetImage`,
+    /// `GetDownloadUrlForLayer`, OCI manifest GET, OCI blob GET). Updated
+    /// alongside `last_recorded_pull_time` so callers that rely on the
+    /// fakecloud-extension `lastInUseAt`/`inUseCount` pair can introspect
+    /// pull frequency in tests.
+    #[serde(default)]
+    pub last_in_use_at: Option<DateTime<Utc>>,
+    /// Monotonic counter of pull-shaped accesses. Bumped by the same
+    /// touch points that update `last_in_use_at`. Defaults to 0; not
+    /// part of the AWS Smithy model — fakecloud surfaces it as
+    /// `inUseCount` in `DescribeImages` for parity with the user
+    /// expectation.
+    #[serde(default)]
+    pub in_use_count: u64,
+}
+
+fn default_image_status() -> String {
+    "ACTIVE".to_string()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Phase P5 of the ECR polish plan promotes three stub-shaped ops to real
behaviour and threads pull bookkeeping through every read path.

- **UpdateImageStorageClass** persists `image_status` (`ACTIVE` /
  `ARCHIVED`), stamps `last_archived_at` / `last_activated_at`, and
  surfaces them through `DescribeImages.imageStatus`. Previously the
  call was accepted and the result thrown away.
- **ListImageReferrers** walks each image's manifest for
  `subject.digest == requested_digest`, honours the `artifactTypes` /
  `artifactStatus` filter, and surfaces `artifactType`, `mediaType`,
  `size`, `annotations` per the OCI Distribution v1.1 referrer shape.
  Previously returned `[]`.
- **DescribeImages** now exposes `lastInUseAt` + `inUseCount` (fakecloud
  extension, not in Smithy) and `subjectManifestDigest` (Smithy). The
  in-use pair is bumped by every pull-shaped op: BatchGetImage,
  GetDownloadUrlForLayer, OCI manifest GET, OCI blob GET.

Pull-time exclusion ops were already implemented in earlier batches, so
this PR keeps the Smithy-correct principal-ARN keying (the original plan
referenced a `repository_arn + tag/digest` shape that does not match the
real Smithy model `RegisterPullTimeUpdateExclusionRequest`).

Snapshot schema bumped 3 -> 4. New fields all carry `#[serde(default)]`,
so a v3 snapshot still deserializes cleanly.

## Test plan

- [x] `cargo build -p fakecloud-ecr`
- [x] `cargo test -p fakecloud-ecr --lib` (55 tests, 8 new)
- [x] `cargo clippy -p fakecloud-ecr --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo build --workspace`

New tests:
- `pull_time_exclusion_register_list_deregister_round_trip`
- `update_image_storage_class_archive_then_restore_persists`
- `update_image_storage_class_rejects_unknown_class`
- `list_image_referrers_returns_images_with_matching_subject`
- `list_image_referrers_filters_by_artifact_type`
- `list_image_referrers_rejects_missing_subject_image`
- `describe_images_reflects_in_use_after_batch_get_image`
- `describe_images_includes_subject_manifest_digest_for_referrers`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds storage lifecycle controls, OCI referrers, and pull-time in-use tracking in ECR. Pull metrics and subject digests are surfaced in DescribeImages; GET pulls persist state and respect exclusions, while HEAD does not bump counters.

- **New Features**
  - UpdateImageStorageClass persists imageStatus and timestamps; DescribeImages returns imageStatus, lastArchivedAt, and lastActivatedAt. The API now returns imageStatus in the response.
  - ListImageReferrers returns referrers for images whose manifest subject matches the digest. Supports filter.artifactTypes and filter.artifactStatus. Includes artifactType, mediaType, size, annotations, and artifactStatus.
  - In-use tracking: BatchGetImage, GetDownloadUrlForLayer, and OCI manifest/blob GET bump lastInUseAt, inUseCount, and lastRecordedPullTime. GET is treated as mutating so snapshots persist; manifest HEAD never bumps. Pull-through cache misses also bump and honor exclusions. DescribeImages includes subjectManifestDigest. Pull-time exclusions are honored across all fields.

- **Migration**
  - Snapshot schema v4. Backward compatible with v3 via defaults; no action needed.

<sup>Written for commit 4f19f2eb9653f1be7fcf53508d227bb57b32a9fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

