### PR TITLE
fix(ses): default to production_access_enabled (unblock Java e2e)

### DIFF
--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -24,6 +24,15 @@ fn enable_production_access(state: &SharedSesState) {
     st.account_settings.production_access_enabled = true;
 }
 
+/// Flip into sandbox mode for tests that explicitly verify the sandbox
+/// recipient gate. Default is production access (set in
+/// `MultiAccountState::new`).
+fn disable_production_access(state: &SharedSesState) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    st.account_settings.production_access_enabled = false;
+}
+
 /// Seed a verified identity for the default test account so send tests
 /// don't trip the verified-sender gate.
 fn seed_identity(state: &SharedSesState, name: &str) {
@@ -719,6 +728,7 @@ async fn send_email_v2_accepts_verified_from_when_recipient_also_verified_in_san
 #[tokio::test]
 async fn send_email_v2_rejects_unverified_recipient_in_sandbox() {
     let state = make_state();
+    disable_production_access(&state);
     seed_identity(&state, "sender@example.com");
     let svc = SesV2Service::new(state);
 

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -463,7 +463,7 @@ impl SesState {
                 suppressed_reasons: Vec::new(),
                 vdm_attributes: None,
                 details: None,
-                production_access_enabled: false,
+                production_access_enabled: true,
             },
             import_jobs: BTreeMap::new(),
             export_jobs: BTreeMap::new(),

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -54,6 +54,14 @@ fn enable_production_access(state: &SharedSesState) {
     st.account_settings.production_access_enabled = true;
 }
 
+/// Flip into sandbox mode for tests that explicitly verify the sandbox
+/// recipient gate. Default is production access.
+fn disable_production_access(state: &SharedSesState) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create("123456789012");
+    st.account_settings.production_access_enabled = false;
+}
+
 fn make_v1_request(action: &str, params: Vec<(&str, &str)>) -> AwsRequest {
     let mut query_params: HashMap<String, String> = HashMap::new();
     query_params.insert("Action".to_string(), action.to_string());
@@ -1097,6 +1105,7 @@ fn send_email_v1_same_path() {
 #[test]
 fn send_email_v1_rejects_unverified_recipient_in_sandbox() {
     let state = make_state();
+    disable_production_access(&state);
     seed_identity(&state, "sender@example.com");
     let req = make_v1_request(
         "SendEmail",


### PR DESCRIPTION
## Summary
Default SES account state to `production_access_enabled=true`. Sandbox default (added in X2) blocked unverified recipients, breaking Java SDK e2e (`sesGetEmailsReturnsSentEmails`) and any user sending to a recipient they didn't pre-verify. fakecloud is a testing tool — sandbox restrictions as default add friction without value. Tests that explicitly verify the sandbox gate now call a new `disable_production_access(&state)` helper.

## Test plan
- [x] `cargo test -p fakecloud-ses --lib` — 222 passed
- [x] `cargo clippy -p fakecloud-ses --all-targets -- -D warnings` — clean
- [x] Java SDK `sesGetEmailsReturnsSentEmails` will now pass (the test sends to an unverified recipient)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default SES accounts to production access (`production_access_enabled=true`) so unverified recipients are allowed by default. This removes sandbox friction and fixes the Java SDK e2e test that sends to an unverified recipient.

- **Bug Fixes**
  - Set production access as the default in `SesState` for `fakecloud-ses`.
  - Added `disable_production_access(&state)` for tests that verify the sandbox gate and updated v1/v2 tests to use it.

<sup>Written for commit 7915670f7f60f24e8fe576eb686b4b873b3c34ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

