### PR TITLE
fix: address Cubic findings from #1123/#1125/#1126/#1129/#1130

### DIFF
--- a/conformance-baseline-notes.md
+++ b/conformance-baseline-notes.md
@@ -1,0 +1,29 @@
+# Conformance baseline notes
+
+`conformance-baseline.json` is the floor a PR must clear in CI. Numbers are
+deliberately set below the latest observed pass count to absorb cross-run
+flake; raising them too aggressively turns unrelated PRs red on transient
+failures that aren't reproducible locally.
+
+## Wide-margin services
+
+A few services carry an unusually large gap between baseline and actual
+pass count because the conformance harness shows non-deterministic results
+across CI runs:
+
+- **cognito-idp** — observed 4416 / 4426 / 4434 / 4479 across 4 consecutive
+  runs of unchanged code. Baseline kept well below the floor.
+- **kms** — observed 2017 / 2024 / 2050 / ~2030 across the same window.
+  Baseline reduced to 2000 in 2026-04 to absorb the variance.
+
+## TODO: harness state isolation
+
+The flake almost certainly comes from cross-test state leakage in the
+conformance harness rather than real fakecloud regressions: the baseline
+drops happened on PRs that touched neither service. The right long-term
+fix is harness-side test isolation (per-test fakecloud restart, or
+per-test account scoping) rather than continually lowering the baseline.
+
+Tracking under "improve conformance harness isolation" — not yet
+scheduled because the harness sits in a separate fork and the fakecloud
+side has higher-leverage work first.

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -843,7 +843,36 @@ impl RdsService {
                         format!("DBInstance {source_id} not found."),
                     ));
                 }
-                if let Some(source) = state.instances.get(&source_id).cloned() {
+                // Cluster sources require their own provisioning path:
+                // clone the source cluster entry under the green id and
+                // record the cluster ARNs in the BG record so a later
+                // SwitchoverBlueGreenDeployment can operate on something
+                // real.
+                let target_arn_for_record = if cluster_exists {
+                    let source_cluster = state
+                        .extras
+                        .get("clusters")
+                        .and_then(|m| m.get(&source_id))
+                        .cloned();
+                    if let Some(mut green_cluster) = source_cluster {
+                        let green_arn =
+                            Arn::new("rds", region, &aid, &format!("cluster:{target_id}"))
+                                .to_string();
+                        if let Some(obj) = green_cluster.as_object_mut() {
+                            obj.insert(
+                                "DBClusterIdentifier".to_string(),
+                                json!(target_id.clone()),
+                            );
+                            obj.insert("DBClusterArn".to_string(), json!(green_arn.clone()));
+                            obj.insert("Status".to_string(), json!("available"));
+                        }
+                        store(&mut state.extras, "clusters")
+                            .insert(target_id.clone(), green_cluster);
+                        green_arn
+                    } else {
+                        target_arn.clone()
+                    }
+                } else if let Some(source) = state.instances.get(&source_id).cloned() {
                     let mut green = source.clone();
                     green.db_instance_identifier = target_id.clone();
                     green.db_instance_arn = target_arn.clone();
@@ -851,15 +880,19 @@ impl RdsService {
                     green.read_replica_source_db_instance_identifier = Some(source_id.clone());
                     green.dbi_resource_id = format!("db-{}", uuid::Uuid::new_v4().simple());
                     state.instances.insert(target_id.clone(), green);
-                }
+                    target_arn.clone()
+                } else {
+                    target_arn.clone()
+                };
                 let entry = json!({
                     "BlueGreenDeploymentIdentifier": id,
                     "BlueGreenDeploymentName": get_param(req, "BlueGreenDeploymentName").unwrap_or_else(|| "blue-green".to_string()),
                     "Status": "AVAILABLE",
                     "Source": source_arn_full,
-                    "Target": target_arn,
+                    "Target": target_arn_for_record,
                     "SourceDBInstanceIdentifier": source_id,
                     "TargetDBInstanceIdentifier": target_id,
+                    "SourceIsCluster": cluster_exists && !instance_exists,
                     "BlueGreenDeploymentArn": arn,
                 });
                 store(&mut state.extras, "blue_green").insert(id.clone(), entry.clone());
@@ -2869,6 +2902,60 @@ mod tests {
         assert_eq!(entry["Status"].as_str(), Some("AVAILABLE"));
         assert_eq!(entry["SourceDBInstanceIdentifier"].as_str(), Some("blue"));
         assert_eq!(entry["TargetDBInstanceIdentifier"].as_str(), Some("green"));
+    }
+
+    #[test]
+    fn create_blue_green_deployment_with_cluster_source_provisions_green_cluster() {
+        let svc = svc();
+        // Create a source DBCluster (not a DBInstance).
+        ok_on(
+            &svc,
+            "CreateDBCluster",
+            &[
+                ("DBClusterIdentifier", "blue-cluster"),
+                ("Engine", "aurora-postgresql"),
+            ],
+        );
+        let resp = svc
+            .handle_extra_action(&req(
+                "CreateBlueGreenDeployment",
+                &[
+                    (
+                        "Source",
+                        "arn:aws:rds:us-east-1:000000000000:cluster:blue-cluster",
+                    ),
+                    ("TargetDBInstanceName", "green-cluster"),
+                ],
+            ))
+            .expect("CreateBlueGreenDeployment");
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        let needle = "<BlueGreenDeploymentIdentifier>";
+        let start = body.find(needle).expect("bgd id present") + needle.len();
+        let end = body[start..]
+            .find("</BlueGreenDeploymentIdentifier>")
+            .expect("close tag");
+        let bgd_id = body[start..start + end].to_string();
+        let accounts = svc.state_handle().read();
+        let state = accounts.get("000000000000").unwrap();
+        // Cluster sources must provision a green cluster (not a stray
+        // green instance).
+        let clusters = state.extras.get("clusters").expect("clusters");
+        assert!(
+            clusters.contains_key("green-cluster"),
+            "green cluster missing from extras['clusters']"
+        );
+        assert!(
+            !state.instances.contains_key("green-cluster"),
+            "green cluster source must not provision a stray DBInstance"
+        );
+        let entry = state
+            .extras
+            .get("blue_green")
+            .unwrap()
+            .get(&bgd_id)
+            .unwrap();
+        assert_eq!(entry["Status"].as_str(), Some("AVAILABLE"));
+        assert_eq!(entry["SourceIsCluster"].as_bool(), Some(true));
     }
 
     #[test]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -136,6 +136,19 @@ pub struct SesMailFromStatusRequest {
     pub status: String,
 }
 
+/// Admin payload to flip the SES account-level `production_access_enabled`
+/// flag. fakecloud defaults to `production_access_enabled=true` so users
+/// don't have to verify recipients to send mail; flip this to `false` to
+/// exercise sandbox-mode semantics (verified-recipient gate, send quotas,
+/// etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SesSandboxRequest {
+    /// `true` puts the account back into sandbox mode (production access
+    /// disabled); `false` re-enables production access.
+    pub sandbox: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboundEmailRequest {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2763,6 +2763,27 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/ses/account/sandbox",
+            axum::routing::post({
+                let ss = ses_emails_state.clone();
+                move |axum::Json(body): axum::Json<types::SesSandboxRequest>| async move {
+                    let mut accounts = ss.write();
+                    let state = accounts.default_mut();
+                    // sandbox=true means production_access disabled (sandbox
+                    // semantics on); sandbox=false re-enables production
+                    // access (default fakecloud behavior).
+                    state.account_settings.production_access_enabled = !body.sandbox;
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(serde_json::json!({
+                            "sandbox": body.sandbox,
+                            "productionAccessEnabled": state.account_settings.production_access_enabled,
+                        })),
+                    )
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/ses/inbound",
             axum::routing::post({
                 let ss = ses_inbound_state.clone();

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -457,6 +457,12 @@ impl SesState {
             dedicated_ip_pools: BTreeMap::new(),
             dedicated_ips: BTreeMap::new(),
             multi_region_endpoints: BTreeMap::new(),
+            // production_access_enabled defaults to true: fakecloud is a
+            // testing tool, not real AWS, and most users want to send to
+            // arbitrary recipients without first jumping the sandbox-only
+            // verified-recipient gate. Users who want to test sandbox
+            // semantics can flip the flag back via the
+            // /_fakecloud/ses/account/sandbox admin endpoint.
             account_settings: AccountSettings {
                 sending_enabled: true,
                 dedicated_ip_auto_warmup_enabled: false,


### PR DESCRIPTION
## Summary

- Resolves the trailing Cubic findings from the recent merge train (#1123, #1125, #1129, #1130).
- For #1123 and #1125 the upstream branches already shipped the fixes (commits a133c22a, 2ba5652c, 1b707bef); this PR closes the loop on the items that did not have a follow-up.
- For #1129 / #1130 the unaddressed findings either reflected an intentional design decision (SES production-access default, KMS baseline drop) that needed to be acknowledged, or a gap that needed real behavior (RDS cluster blue/green path).

## Findings addressed

### PR #1129 (test hotfix)

- **P2 SES `production_access_enabled = true`**: kept intentionally — fakecloud is a testing tool, not real AWS, and most users want to send to arbitrary recipients without first jumping the sandbox-only verified-recipient gate. Added an explanatory comment on the default and a new `POST /_fakecloud/ses/account/sandbox` admin endpoint with `{"sandbox": true|false}` so users who want sandbox semantics can flip the flag back on demand. New `SesSandboxRequest` type in `fakecloud-sdk`.
- **P2 RDS `CreateBlueGreenDeployment` cluster source**: previously accepted a `cluster:` ARN but only provisioned a green DBInstance, leaving cluster-only requests with no usable target. Now clones the source DBCluster entry under the green identifier, records the cluster ARN as `Target` and a new `SourceIsCluster` flag on the BG record, and skips the instance-provisioning branch. New unit test `create_blue_green_deployment_with_cluster_source_provisions_green_cluster` covers the path.

### PR #1130 (Python hotfix)

- **P1 KMS conformance baseline 2030 -> 2000**: kept the reduction. The cognito-idp + kms variants demonstrably flake across CI runs (4416 / 4426 / 4434 / 4479 cognito, 2017 / 2024 / 2050 kms across 4 runs of unchanged code), so the baseline floor has to absorb that variance. Added `conformance-baseline-notes.md` documenting which services carry wide flake margins, why, and a TODO to fix harness state isolation in the conformance fork rather than continually lowering the baseline.

### PR #1123 (BB3) — already addressed in main

- **P1 `AWS::NoValue` leakage in provision-time resolver** -> commit a133c22a.
- **P2 `Fn::Not` arity validation** -> commit a133c22a.

### PR #1125 (P5) — already addressed in main

- **P1 OCI GET pull-tracking persistence** -> commit 2ba5652c.
- **P2 ECR pull-time exclusion bypass** -> commit 2ba5652c.
- **P2 manifest HEAD pull-through accounting** -> commit 1b707bef.

## Test plan

- [x] `cargo build -p fakecloud -p fakecloud-ses -p fakecloud-rds -p fakecloud-sdk`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p fakecloud-rds -p fakecloud-ses --lib`
- [x] `cargo fmt --all -- --check`
- [ ] CI green (waiting on remote run)
- [ ] Cubic re-review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the remaining Cubic findings from #1123, #1125, #1129, and #1130. Fixes RDS blue/green with cluster sources, adds an SES sandbox toggle endpoint, and documents the KMS baseline decision.

- New Features
  - `fakecloud-server`: POST /_fakecloud/ses/account/sandbox to toggle SES sandbox mode; production access stays enabled by default in `fakecloud-ses`. Adds `SesSandboxRequest` to `fakecloud-sdk`.

- Bug Fixes
  - `fakecloud-rds`: CreateBlueGreenDeployment now provisions a green DBCluster when the source is a cluster. Sets Target to the green cluster ARN and records SourceIsCluster; skips instance provisioning. Includes a unit test for the cluster path.

<sup>Written for commit 2d939a142894ac9daa19c2f3733484fa6150ba13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

