### PR TITLE
fix(lambda): UpdateFunctionCode replaces code + recomputes hash/size (D1)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -359,3 +359,192 @@ async fn lambda_add_get_remove_permission_roundtrip() {
         .await;
     assert!(err.is_err());
 }
+
+fn make_python_zip_returning(payload: &str) -> Vec<u8> {
+    // A second-flavor zip whose handler returns a payload-derived value,
+    // so callers can confirm UpdateFunctionCode actually swapped the code
+    // bundle (rather than just the metadata).
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.py", options).unwrap();
+    writer
+        .write_all(
+            format!("def handler(event, context):\n    return {{\"payload\": \"{payload}\"}}\n")
+                .as_bytes(),
+        )
+        .unwrap();
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+#[tokio::test]
+async fn lambda_update_function_code_replaces_zip_and_recomputes_hash() {
+    // Fresh zip -> CodeSha256 + CodeSize must move; same zip again ->
+    // RevisionId stays put. GetFunctionConfiguration round-trips the new
+    // hash, proving the update persisted in state and not just the
+    // immediate response.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let initial_zip = make_python_zip();
+    client
+        .create_function()
+        .function_name("upd-code")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(initial_zip.clone()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let pre = client
+        .get_function_configuration()
+        .function_name("upd-code")
+        .send()
+        .await
+        .unwrap();
+    let pre_sha = pre.code_sha256().unwrap().to_string();
+    let pre_rev = pre.revision_id().unwrap().to_string();
+    let pre_size = pre.code_size();
+    assert_eq!(pre_size, initial_zip.len() as i64);
+
+    // Replace with a different zip -- CodeSha256 + CodeSize must change,
+    // RevisionId must rotate.
+    let new_zip = make_python_zip_returning("v2");
+    let updated = client
+        .update_function_code()
+        .function_name("upd-code")
+        .zip_file(Blob::new(new_zip.clone()))
+        .send()
+        .await
+        .unwrap();
+    let post_sha = updated.code_sha256().unwrap().to_string();
+    let post_rev = updated.revision_id().unwrap().to_string();
+    assert_ne!(post_sha, pre_sha, "CodeSha256 should change");
+    assert_ne!(post_rev, pre_rev, "RevisionId should rotate on real change");
+    assert_eq!(updated.code_size(), new_zip.len() as i64);
+
+    // Persisted in state.
+    let cfg = client
+        .get_function_configuration()
+        .function_name("upd-code")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cfg.code_sha256().unwrap(), post_sha);
+    assert_eq!(cfg.code_size(), new_zip.len() as i64);
+
+    // Same bytes again -> RevisionId must stay put.
+    let same = client
+        .update_function_code()
+        .function_name("upd-code")
+        .zip_file(Blob::new(new_zip.clone()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(same.revision_id().unwrap(), post_rev);
+    assert_eq!(same.code_sha256().unwrap(), post_sha);
+}
+
+#[tokio::test]
+async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
+    // S3Bucket+S3Key swap fingerprints the descriptor; a different
+    // descriptor must rotate CodeSha256 / RevisionId, identical
+    // descriptor must not.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("upd-s3")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let pre_sha = client
+        .get_function_configuration()
+        .function_name("upd-s3")
+        .send()
+        .await
+        .unwrap()
+        .code_sha256()
+        .unwrap()
+        .to_string();
+
+    let updated = client
+        .update_function_code()
+        .function_name("upd-s3")
+        .s3_bucket("deploy-bucket")
+        .s3_key("lambdas/v2.zip")
+        .send()
+        .await
+        .unwrap();
+    let post_sha = updated.code_sha256().unwrap().to_string();
+    assert_ne!(post_sha, pre_sha);
+
+    // Adding S3ObjectVersion changes the descriptor, so the hash rotates.
+    let versioned = client
+        .update_function_code()
+        .function_name("upd-s3")
+        .s3_bucket("deploy-bucket")
+        .s3_key("lambdas/v2.zip")
+        .s3_object_version("ver-abc123")
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(versioned.code_sha256().unwrap(), post_sha);
+}
+
+#[tokio::test]
+async fn lambda_update_function_code_with_image_uri_clears_size_and_sha() {
+    // Real AWS reports CodeSize=0 and an empty CodeSha256 for image
+    // functions; verify UpdateFunctionCode lines those fields up when
+    // swapping to a new image URI.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("upd-img")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/r")
+        .handler("index.handler")
+        .package_type(aws_sdk_lambda::types::PackageType::Image)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .image_uri("old.example.com/image:1")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let updated = client
+        .update_function_code()
+        .function_name("upd-img")
+        .image_uri("new.example.com/image:2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(updated.code_size(), 0);
+    assert_eq!(updated.code_sha256().unwrap_or(""), "");
+    assert_eq!(
+        updated.package_type().unwrap(),
+        &aws_sdk_lambda::types::PackageType::Image
+    );
+}

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -430,10 +430,9 @@ impl LambdaService {
         let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap_or_default();
 
         // ZipFile / ImageUri / S3Bucket+S3Key are mutually exclusive; AWS
-        // rejects the request when more than one is present, but we just
-        // pick the first available with a defined precedence: ZipFile,
-        // ImageUri, S3 (which we resolve only enough to swap the bytes —
-        // S3 fetches happen out of band on real Lambda).
+        // rejects the request when more than one is present. The handler
+        // picks one with a defined precedence: ZipFile, S3 descriptor,
+        // ImageUri.
         let new_zip: Option<Vec<u8>> = match body["ZipFile"].as_str() {
             Some(b64) => Some(
                 base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).map_err(
@@ -449,6 +448,30 @@ impl LambdaService {
             None => None,
         };
         let new_image_uri = body["ImageUri"].as_str().map(String::from);
+        // S3 source descriptor: when the caller didn't supply ZipFile or
+        // ImageUri, AWS expects S3Bucket+S3Key (S3ObjectVersion is
+        // optional). fakecloud doesn't fetch the object — CreateFunction
+        // takes the same shortcut — so we synthesize a fingerprint from
+        // the descriptor and use that as the new code identity. The hash
+        // and size still rotate when the descriptor differs, so
+        // optimistic-concurrency callers see RevisionId bump on real
+        // changes.
+        let new_s3_descriptor: Option<Vec<u8>> =
+            match (body["S3Bucket"].as_str(), body["S3Key"].as_str()) {
+                (Some(bucket), Some(key)) if new_zip.is_none() && new_image_uri.is_none() => {
+                    let mut descriptor = serde_json::Map::new();
+                    descriptor.insert("S3Bucket".to_string(), Value::String(bucket.to_string()));
+                    descriptor.insert("S3Key".to_string(), Value::String(key.to_string()));
+                    if let Some(ver) = body["S3ObjectVersion"].as_str() {
+                        descriptor.insert(
+                            "S3ObjectVersion".to_string(),
+                            Value::String(ver.to_string()),
+                        );
+                    }
+                    Some(serde_json::to_vec(&Value::Object(descriptor)).unwrap_or_default())
+                }
+                _ => None,
+            };
         let supplied_signing_profile = body["SigningProfileVersionArn"].as_str().map(String::from);
         let supplied_revision_id = body["RevisionId"].as_str().map(String::from);
         let new_architectures: Option<Vec<String>> = body["Architectures"].as_array().map(|arr| {
@@ -538,6 +561,29 @@ impl LambdaService {
             func.code_sha256 = code_sha256;
             func.image_uri = None;
             func.package_type = "Zip".to_string();
+        } else if let Some(descriptor_bytes) = new_s3_descriptor {
+            // Hash the S3 descriptor JSON (S3Bucket+S3Key+optional
+            // S3ObjectVersion) so the same descriptor produces a stable
+            // sha and a different descriptor rotates RevisionId. This
+            // mirrors CreateFunction's behavior for S3-sourced code,
+            // which also fingerprints the descriptor rather than fetching
+            // S3 (real Lambda fetches asynchronously).
+            let mut hasher = Sha256::new();
+            hasher.update(&descriptor_bytes);
+            let hash = hasher.finalize();
+            let code_sha256 =
+                base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
+            if code_sha256 != func.code_sha256 {
+                changed = true;
+            }
+            func.code_size = descriptor_bytes.len() as i64;
+            // We don't have the object bytes — clear the cached zip so
+            // the runtime falls back to whatever it had previously cached
+            // rather than serving stale bytes for the new descriptor.
+            func.code_zip = None;
+            func.code_sha256 = code_sha256;
+            func.image_uri = None;
+            func.package_type = "Zip".to_string();
         } else if let Some(uri) = new_image_uri {
             if func.image_uri.as_deref() != Some(uri.as_str()) {
                 changed = true;
@@ -545,6 +591,11 @@ impl LambdaService {
             func.image_uri = Some(uri);
             func.code_zip = None;
             func.package_type = "Image".to_string();
+            // AWS reports CodeSize=0 and an empty CodeSha256 for
+            // image-package functions — the actual digest lives on the
+            // ECR side, not in the Lambda response.
+            func.code_size = 0;
+            func.code_sha256 = String::new();
         }
 
         if let Some(arns) = new_architectures {
@@ -569,6 +620,11 @@ impl LambdaService {
         if changed {
             func.revision_id = uuid::Uuid::new_v4().to_string();
         }
+        // A successful UpdateFunctionCode clears any prior failure
+        // reason — function_config_json elides the field when None,
+        // matching AWS's "no LastUpdateStatusReason on success" shape.
+        func.last_update_status_reason = None;
+        func.last_update_status_reason_code = None;
 
         // Publish=true mints a new immutable version snapshot off the
         // freshly updated $LATEST and returns that version's config.

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1569,6 +1569,101 @@ async fn update_function_code_dry_run_does_not_mutate() {
     assert_eq!(cfg["RevisionId"].as_str().unwrap(), pre_rev);
 }
 
+#[tokio::test]
+async fn update_function_code_with_s3_descriptor_rotates_hash() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "s3src").await;
+
+    let req = make_request(Method::GET, "/2015-03-31/functions/s3src/configuration", "");
+    let pre: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    let pre_sha = pre["CodeSha256"].as_str().unwrap().to_string();
+    let pre_rev = pre["RevisionId"].as_str().unwrap().to_string();
+
+    // S3Bucket+S3Key swap -- fakecloud fingerprints the descriptor, so a
+    // different bucket/key must produce a different CodeSha256 and rotate
+    // RevisionId.
+    let body = json!({"S3Bucket": "deploy-bucket", "S3Key": "lambdas/v2.zip"});
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/s3src/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let post: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let post_sha = post["CodeSha256"].as_str().unwrap().to_string();
+    assert_ne!(post_sha, pre_sha, "S3 swap should rotate CodeSha256");
+    assert_ne!(
+        post["RevisionId"].as_str().unwrap(),
+        pre_rev,
+        "S3 swap should rotate RevisionId"
+    );
+    assert!(post["CodeSize"].as_i64().unwrap() > 0);
+    assert_eq!(post["PackageType"].as_str().unwrap(), "Zip");
+
+    // Same descriptor again -> RevisionId stable (no spurious bump).
+    let body = json!({"S3Bucket": "deploy-bucket", "S3Key": "lambdas/v2.zip"});
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/s3src/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let again: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(again["CodeSha256"].as_str().unwrap(), post_sha);
+    assert_eq!(
+        again["RevisionId"].as_str().unwrap(),
+        post["RevisionId"].as_str().unwrap()
+    );
+
+    // Different S3ObjectVersion on the same bucket+key counts as a new
+    // descriptor and must rotate the hash.
+    let body = json!({
+        "S3Bucket": "deploy-bucket",
+        "S3Key": "lambdas/v2.zip",
+        "S3ObjectVersion": "v-abc123",
+    });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/s3src/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let versioned: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_ne!(versioned["CodeSha256"].as_str().unwrap(), post_sha);
+}
+
+#[tokio::test]
+async fn update_function_code_image_uri_clears_size_and_sha() {
+    // AWS reports CodeSize=0 and an empty CodeSha256 for image-package
+    // functions; the digest lives on the ECR side, not in the Lambda
+    // response. Verify UpdateFunctionCode brings those fields in line
+    // when swapping to a new image.
+    let svc = LambdaService::new(make_state());
+    let body = json!({
+        "FunctionName": "img-clear",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/r",
+        "Handler": "index.handler",
+        "PackageType": "Image",
+        "Code": {"ImageUri": "old.example.com/image:1"},
+    });
+    let req = make_request(Method::POST, "/2015-03-31/functions", &body.to_string());
+    svc.handle(req).await.unwrap();
+
+    let body = json!({"ImageUri": "new.example.com/image:2"});
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/img-clear/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let post: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(post["CodeSize"].as_i64().unwrap(), 0);
+    assert_eq!(post["CodeSha256"].as_str().unwrap(), "");
+    assert_eq!(post["PackageType"].as_str().unwrap(), "Image");
+}
+
 // ── PublishVersion behavior tests (D2) ──
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- UpdateFunctionCode now actually replaces the function's code instead of leaving `code_zip` / `image_uri` / `code_sha256` / `code_size` stale.
- ZipFile path: decode base64, store bytes in `code_zip`, recompute `code_sha256` (SHA256 base64) + `code_size`, switch to `PackageType=Zip`, drop any prior ImageUri.
- S3 source path: when the caller sends `S3Bucket`+`S3Key` (and optional `S3ObjectVersion`), fingerprint the descriptor JSON the same way `CreateFunction` does — same descriptor produces a stable SHA, swapping bucket/key/version rotates `RevisionId`. fakecloud doesn't fetch from S3 (real Lambda fetches asynchronously); descriptor fingerprinting keeps Update at parity with Create.
- ImageUri path: store the new URI, switch to `PackageType=Image`, set `CodeSize=0` and clear `CodeSha256` to match what real AWS reports for image-package functions (digest lives on the ECR side).
- `RevisionId` rotates only on real change — same bytes / same descriptor / same image keeps the prior UUID, so optimistic-concurrency callers don't see spurious bumps.
- Successful update clears any prior `LastUpdateStatusReason` / `LastUpdateStatusReasonCode` so `LastUpdateStatus=Successful` doesn't ride alongside a stale reason from a failed earlier attempt.
- CodeSigningConfig allowed-publisher gating was already in place (Enforce policy rejects with `CodeVerificationFailedException` when a `SigningProfileVersionArn` isn't on the allow-list); kept untouched.

## Test plan

- [x] `cargo test -p fakecloud-lambda --lib` -> 126 passed (12 UpdateFunctionCode unit tests including the 2 new D1 ones for S3 descriptor + ImageUri size/sha clearing)
- [x] `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all`
- [ ] e2e: `lambda_update_function_code_replaces_zip_and_recomputes_hash`, `lambda_update_function_code_with_s3_descriptor_rotates_hash`, `lambda_update_function_code_with_image_uri_clears_size_and_sha` (CI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UpdateFunctionCode now actually replaces Lambda code for zip, S3, and image sources and updates hash/size and package type to match AWS behavior. This fixes stale metadata and avoids unnecessary RevisionId bumps.

- **Bug Fixes**
  - ZipFile: decode base64, store bytes, recompute CodeSha256 (SHA256 base64) and CodeSize; set PackageType=Zip; clear ImageUri.
  - S3: fingerprint S3Bucket+S3Key(+S3ObjectVersion) to compute a stable hash; rotate RevisionId only when the descriptor changes; no S3 fetch.
  - ImageUri: switch to PackageType=Image; set CodeSize=0; clear CodeSha256 to match AWS image responses.
  - RevisionId changes only on real updates; no-ops keep the prior ID; GetFunctionConfiguration reflects the new values.
  - Clear LastUpdateStatusReason/Code after a successful update.
  - CodeSigningConfig allowed-publishers enforcement remains unchanged.

<sup>Written for commit f2e8466ea6e833be0447f2fdd53a37127c5739f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

