### PR TITLE
feat(cognito): real RSA-2048 RS256 JWT signing per user pool (Y1)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -6228,7 +6228,12 @@ impl ResourceProvisioner {
         let account_recovery_setting =
             parse_cognito_account_recovery(props.get("AccountRecoverySetting"));
 
-        let signing_kid = format!("{pool_id}-key-1");
+        // Generate the RSA-2048 keypair eagerly. The kid is derived
+        // from a SHA-256 of the public SPKI DER so it stays stable
+        // across snapshots and matches the JWKS document.
+        let signing = fakecloud_cognito::jwt::generate_pool_signing_key();
+        let signing_key_pem = signing.private_key_pem;
+        let signing_kid = signing.kid;
         let pool = UserPool {
             id: pool_id.clone(),
             name: pool_name,
@@ -6259,10 +6264,7 @@ impl ResourceProvisioner {
             sms_mfa_configuration: None,
             user_pool_tier,
             verification_message_template: None,
-            // Generate the RSA-2048 keypair eagerly so CloudFormation-
-            // created pools sign RS256 JWTs out of the box, matching the
-            // runtime CreateUserPool handler.
-            signing_key_pem: Some(fakecloud_cognito::jwt::generate_pool_signing_key()),
+            signing_key_pem: Some(signing_key_pem),
             signing_kid: Some(signing_kid),
         };
 

--- a/crates/fakecloud-cognito/src/jwt.rs
+++ b/crates/fakecloud-cognito/src/jwt.rs
@@ -9,48 +9,89 @@ use base64::Engine as _;
 use rsa::pkcs1v15::SigningKey;
 use rsa::pkcs8::EncodePrivateKey;
 use rsa::pkcs8::EncodePublicKey;
-use rsa::sha2::Sha256;
+use rsa::sha2::{Digest, Sha256};
 use rsa::signature::{RandomizedSigner, SignatureEncoding};
 use rsa::traits::PublicKeyParts;
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use serde_json::Value;
 
+/// A freshly-minted pool signing key plus the deterministic `kid`
+/// derived from its SubjectPublicKeyInfo DER. Both halves travel
+/// together so callers don't have to re-derive the kid on every issue.
+pub struct PoolSigningKey {
+    /// PKCS#8-encoded private key PEM (embeds the public half).
+    pub private_key_pem: String,
+    /// Stable JWKS key id: first 16 hex chars of `SHA-256(SPKI DER)`.
+    pub kid: String,
+}
+
 /// Generate a fresh RSA-2048 keypair, returning the PKCS#8 PEM-encoded
-/// private key (which embeds the public half).
-pub fn generate_pool_signing_key() -> String {
+/// private key alongside its deterministic kid. AWS Cognito generates
+/// the keypair at pool-create time and serves the public half at
+/// `/<pool>/.well-known/jwks.json`.
+pub fn generate_pool_signing_key() -> PoolSigningKey {
     let mut rng = rand::thread_rng();
     // 2048 bits matches what Cognito issues today; the PKCS#8 encoding
     // round-trips through `RsaPrivateKey::from_pkcs8_pem` for sign-time
     // recovery.
     let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("RSA-2048 keygen should not fail");
-    private_key
+    let private_key_pem = private_key
         .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
         .expect("PKCS#8 PEM encode")
-        .to_string()
+        .to_string();
+    let public_key = RsaPublicKey::from(&private_key);
+    let kid = compute_kid(&public_key);
+    PoolSigningKey {
+        private_key_pem,
+        kid,
+    }
 }
 
-/// Sign `header`+`payload` with `private_key_pem` using PKCS#1 v1.5 RS256
-/// and return the compact-serialized JWT (`<header>.<payload>.<sig>`).
-/// Falls back to an unsigned token only if the PEM fails to decode, so
-/// callers always get a structurally valid three-part token.
-pub(crate) fn sign_rs256(header: &Value, payload: &Value, private_key_pem: &str) -> String {
+/// Derive the JWKS `kid` deterministically from the public key.
+///
+/// `kid = first 16 hex chars of SHA-256(SubjectPublicKeyInfo DER)`.
+/// 16 hex chars (8 bytes / 64 bits) is enough to make collisions
+/// astronomically unlikely while keeping the JWT header compact.
+pub fn compute_kid(public_key: &RsaPublicKey) -> String {
+    let spki_der = public_key
+        .to_public_key_der()
+        .expect("SPKI DER encode")
+        .to_vec();
+    let mut hasher = Sha256::new();
+    hasher.update(&spki_der);
+    let digest = hasher.finalize();
+    // 8 bytes -> 16 hex chars. Long enough that two keys never collide
+    // in practice, short enough to fit comfortably in a JWT header.
+    let mut hex = String::with_capacity(16);
+    for byte in &digest[..8] {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+/// Sign `header` + `payload` with `private_key_pem` using PKCS#1 v1.5
+/// RS256 and return the compact-serialized JWT
+/// (`<header>.<payload>.<sig>`). Caller is expected to set `alg=RS256`
+/// and a real `kid` on the header; this function trusts those values.
+///
+/// Returns `None` if the PEM fails to decode. Pools created through
+/// `CreateUserPool` always carry a valid PEM, and
+/// `ensure_pool_signing_key` lazily fills in pre-existing snapshots, so
+/// `None` only happens when a caller passes garbage in.
+pub(crate) fn sign_rs256(header: &Value, payload: &Value, private_key_pem: &str) -> Option<String> {
+    use rsa::pkcs8::DecodePrivateKey;
+
     let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let header_b64 = b64.encode(header.to_string().as_bytes());
     let payload_b64 = b64.encode(payload.to_string().as_bytes());
     let signing_input = format!("{header_b64}.{payload_b64}");
 
-    use rsa::pkcs8::DecodePrivateKey;
-    let Ok(private_key) = RsaPrivateKey::from_pkcs8_pem(private_key_pem) else {
-        // Fallback: emit a placeholder signature so the token still
-        // parses; legitimately-created pools always have a valid PEM.
-        let sig_b64 = b64.encode(signing_input.as_bytes());
-        return format!("{header_b64}.{payload_b64}.{sig_b64}");
-    };
+    let private_key = RsaPrivateKey::from_pkcs8_pem(private_key_pem).ok()?;
     let signing_key = SigningKey::<Sha256>::new(private_key);
     let mut rng = rand::thread_rng();
     let signature = signing_key.sign_with_rng(&mut rng, signing_input.as_bytes());
     let sig_b64 = b64.encode(signature.to_bytes());
-    format!("{header_b64}.{payload_b64}.{sig_b64}")
+    Some(format!("{header_b64}.{payload_b64}.{sig_b64}"))
 }
 
 /// Render the pool's RSA public key as a single-key JWKS document
@@ -147,15 +188,16 @@ mod tests {
 
     #[test]
     fn signed_jwt_verifies_with_pool_public_key() {
-        let pem = generate_pool_signing_key();
-        let header = serde_json::json!({"alg": "RS256", "kid": "pool-1", "typ": "JWT"});
+        let key = generate_pool_signing_key();
+        let header = serde_json::json!({"alg": "RS256", "kid": &key.kid, "typ": "JWT"});
         let payload = serde_json::json!({"sub": "user-1"});
-        let token = sign_rs256(&header, &payload, &pem);
+        let token = sign_rs256(&header, &payload, &key.private_key_pem)
+            .expect("freshly-generated PEM must sign");
 
         let parts: Vec<&str> = token.split('.').collect();
         assert_eq!(parts.len(), 3);
 
-        let private_key = RsaPrivateKey::from_pkcs8_pem(&pem).unwrap();
+        let private_key = RsaPrivateKey::from_pkcs8_pem(&key.private_key_pem).unwrap();
         let public_key = RsaPublicKey::from(&private_key);
         let verifying_key = VerifyingKey::<Sha256>::new(public_key);
 
@@ -171,13 +213,36 @@ mod tests {
 
     #[test]
     fn jwks_document_emits_n_and_e() {
-        let pem = generate_pool_signing_key();
-        let jwks = jwks_document(&pem, "pool-1");
-        let key = &jwks["keys"][0];
-        assert_eq!(key["kid"], "pool-1");
-        assert_eq!(key["alg"], "RS256");
-        assert_eq!(key["kty"], "RSA");
-        assert!(key["n"].as_str().unwrap().len() > 100);
-        assert!(!key["e"].as_str().unwrap().is_empty());
+        let key = generate_pool_signing_key();
+        let jwks = jwks_document(&key.private_key_pem, &key.kid);
+        let jwk = &jwks["keys"][0];
+        assert_eq!(jwk["kid"], key.kid);
+        assert_eq!(jwk["alg"], "RS256");
+        assert_eq!(jwk["kty"], "RSA");
+        assert!(jwk["n"].as_str().unwrap().len() > 100);
+        assert!(!jwk["e"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn kid_is_deterministic_16_hex_chars_per_key() {
+        let key = generate_pool_signing_key();
+        assert_eq!(key.kid.len(), 16, "kid must be 16 hex chars");
+        assert!(
+            key.kid.chars().all(|c| c.is_ascii_hexdigit()),
+            "kid must be lowercase hex: {}",
+            key.kid
+        );
+        // Re-deriving the kid from the same public half must reproduce
+        // the same value — that's what JWKS clients depend on.
+        let private_key = RsaPrivateKey::from_pkcs8_pem(&key.private_key_pem).unwrap();
+        let public_key = RsaPublicKey::from(&private_key);
+        assert_eq!(compute_kid(&public_key), key.kid);
+    }
+
+    #[test]
+    fn distinct_keys_produce_distinct_kids() {
+        let a = generate_pool_signing_key();
+        let b = generate_pool_signing_key();
+        assert_ne!(a.kid, b.kid);
     }
 }

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -18,7 +18,6 @@ use base64::Engine;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
@@ -1523,11 +1522,13 @@ struct TokenSet {
     refresh_token: String,
 }
 
-/// Generate Cognito ID/Access/Refresh tokens. When `signing` is supplied
-/// (the pool's PKCS#8 PEM + stable kid), the JWTs are signed with real
-/// RS256 so SDK-side JWKS verification round-trips. Pre-existing pools
-/// without a stored key fall back to a placeholder signature so test
-/// fixtures keep parsing.
+/// Generate Cognito ID/Access/Refresh tokens. `signing` is the pool's
+/// PKCS#8 PEM + JWKS kid; production callers always pass `Some` because
+/// `CreateUserPool` allocates a keypair eagerly and
+/// `ensure_pool_signing_key` backfills any legacy snapshot. When `None`
+/// (only reachable from in-process unit tests that intentionally skip
+/// keygen for speed), we synthesize a one-shot keypair so the resulting
+/// JWT still has a real RS256 signature — never a placeholder.
 fn generate_tokens(
     pool_id: &str,
     client_id: &str,
@@ -1540,9 +1541,15 @@ fn generate_tokens(
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
     let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
-    let kid = signing
-        .map(|(_, k)| k.to_string())
-        .unwrap_or_else(|| "fakecloud-key-1".to_string());
+
+    let owned_signing = signing
+        .map(|(p, k)| (p.to_string(), k.to_string()))
+        .unwrap_or_else(|| {
+            let key = crate::jwt::generate_pool_signing_key();
+            (key.private_key_pem, key.kid)
+        });
+    let pem = owned_signing.0.as_str();
+    let kid = owned_signing.1.as_str();
 
     let id_header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
     let id_payload = json!({
@@ -1556,7 +1563,7 @@ fn generate_tokens(
         "iat": now,
         "jti": jti,
     });
-    let id_token = sign_jwt(&id_header, &id_payload, &b64url, signing.map(|(p, _)| p));
+    let id_token = sign_jwt(&id_header, &id_payload, pem);
 
     let access_jti = Uuid::new_v4().to_string();
     let access_header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
@@ -1570,12 +1577,7 @@ fn generate_tokens(
         "exp": now + 3600,
         "iat": now,
     });
-    let access_token = sign_jwt(
-        &access_header,
-        &access_payload,
-        &b64url,
-        signing.map(|(p, _)| p),
-    );
+    let access_token = sign_jwt(&access_header, &access_payload, pem);
 
     let mut refresh_bytes = Vec::with_capacity(72);
     for _ in 0..5 {
@@ -1590,29 +1592,22 @@ fn generate_tokens(
     }
 }
 
-fn sign_jwt(
-    header: &Value,
-    payload: &Value,
-    engine: &base64::engine::general_purpose::GeneralPurpose,
-    private_key_pem: Option<&str>,
-) -> String {
-    if let Some(pem) = private_key_pem {
-        return crate::jwt::sign_rs256(header, payload, pem);
-    }
-    let header_b64 = engine.encode(header.to_string().as_bytes());
-    let payload_b64 = engine.encode(payload.to_string().as_bytes());
-    let signing_input = format!("{header_b64}.{payload_b64}");
-    let mut hasher = Sha256::new();
-    hasher.update(signing_input.as_bytes());
-    let signature = hasher.finalize();
-    let sig_b64 = engine.encode(signature);
-    format!("{header_b64}.{payload_b64}.{sig_b64}")
+/// Sign a Cognito-shaped JWT with the pool's PKCS#8 private key.
+/// Always RS256 — there is no placeholder fallback, callers must pass
+/// a valid pool PEM.
+fn sign_jwt(header: &Value, payload: &Value, private_key_pem: &str) -> String {
+    crate::jwt::sign_rs256(header, payload, private_key_pem)
+        .expect("pool PEM must be a valid PKCS#8 RSA private key")
 }
 
 /// Look up a pool's signing key, generating one off the runtime thread if
 /// missing. Returns `(pkcs8_pem, kid)` for callers that need to sign a
 /// JWT or render a JWKS document. The expensive RSA-2048 keygen only
 /// runs once per pool — subsequent calls hit the cache.
+///
+/// Pre-Y1 snapshots may have a stored PEM with no `kid`, or neither;
+/// we fill in whatever's missing so the JWKS document and the JWT
+/// header always agree on a stable kid derived from the public key.
 pub async fn ensure_pool_signing_key(
     state: &SharedCognitoState,
     pool_id: &str,
@@ -1636,7 +1631,15 @@ pub async fn ensure_pool_signing_key(
     for (_, account) in mas.iter_mut() {
         if let Some(pool) = account.user_pools.get_mut(pool_id) {
             if pool.signing_key_pem.is_none() {
-                pool.signing_key_pem = Some(generated.clone());
+                pool.signing_key_pem = Some(generated.private_key_pem.clone());
+                pool.signing_kid = Some(generated.kid.clone());
+            } else if pool.signing_kid.is_none() {
+                // PEM was carried forward from an older snapshot but
+                // the kid wasn't — re-derive it from the public half
+                // so JWKS and JWT header stay consistent.
+                if let Some(pem) = pool.signing_key_pem.as_deref() {
+                    pool.signing_kid = derive_kid_from_pem(pem);
+                }
             }
             if let (Some(p), Some(k)) = (&pool.signing_key_pem, &pool.signing_kid) {
                 result = Some((p.clone(), k.clone()));
@@ -1645,6 +1648,16 @@ pub async fn ensure_pool_signing_key(
         }
     }
     result
+}
+
+/// Re-derive a pool's `kid` from a stored PEM. Used to backfill
+/// older snapshots that predate the deterministic kid scheme.
+fn derive_kid_from_pem(pem: &str) -> Option<String> {
+    use rsa::pkcs8::DecodePrivateKey;
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+    let private_key = RsaPrivateKey::from_pkcs8_pem(pem).ok()?;
+    let public_key = RsaPublicKey::from(&private_key);
+    Some(crate::jwt::compute_kid(&public_key))
 }
 
 /// JWKS document for a pool (`{"keys": [<jwk>]}`). Triggers lazy keypair
@@ -1917,13 +1930,23 @@ fn build_client_credentials_access_token(
     region: &str,
     signing: Option<(&str, &str)>,
 ) -> String {
-    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
     let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
-    let kid = signing
-        .map(|(_, k)| k.to_string())
-        .unwrap_or_else(|| "fakecloud-key-1".to_string());
+
+    // Synthesize a keypair on the fly when callers haven't loaded one
+    // (only happens on legacy snapshots that lack a stored PEM and
+    // pre-date `ensure_pool_signing_key`). Production paths always
+    // pass `Some`.
+    let owned_signing = signing
+        .map(|(p, k)| (p.to_string(), k.to_string()))
+        .unwrap_or_else(|| {
+            let key = crate::jwt::generate_pool_signing_key();
+            (key.private_key_pem, key.kid)
+        });
+    let pem = owned_signing.0.as_str();
+    let kid = owned_signing.1.as_str();
+
     let header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
     let payload = json!({
         "sub": client_id,
@@ -1935,7 +1958,7 @@ fn build_client_credentials_access_token(
         "exp": now + 3600,
         "iat": now,
     });
-    sign_jwt(&header, &payload, &b64url, signing.map(|(p, _)| p))
+    sign_jwt(&header, &payload, pem)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -661,7 +661,15 @@ fn jwt_id_token_payload_contains_required_fields() {
     let payload: Value = serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
 
     assert_eq!(header["alg"], "RS256");
-    assert_eq!(header["kid"], "fakecloud-key-1");
+    // No `signing` was passed, so generate_tokens synthesized a fresh
+    // keypair on the fly. The kid is the deterministic 16-hex-char
+    // SHA-256 prefix of the public key's SPKI DER.
+    let kid = header["kid"].as_str().unwrap();
+    assert_eq!(kid.len(), 16, "kid must be 16 hex chars: {kid}");
+    assert!(
+        kid.chars().all(|c| c.is_ascii_hexdigit()),
+        "kid must be lowercase hex: {kid}"
+    );
     assert_eq!(payload["sub"], "sub-uuid");
     assert_eq!(payload["aud"], "client123");
     assert_eq!(payload["cognito:username"], "user1");
@@ -6716,7 +6724,14 @@ fn jwks_endpoint_returns_pool_public_key() {
     assert_eq!(key["alg"], "RS256");
     assert_eq!(key["use"], "sig");
     assert_eq!(key["e"], "AQAB");
-    assert_eq!(key["kid"], format!("{pool_id}-key-1"));
+    // kid is the deterministic SHA-256 prefix of the pool's public
+    // SubjectPublicKeyInfo DER, not derived from `pool_id`.
+    let kid = key["kid"].as_str().expect("kid must be a string");
+    assert_eq!(kid.len(), 16, "kid must be 16 hex chars: {kid}");
+    assert!(
+        kid.chars().all(|c| c.is_ascii_hexdigit()),
+        "kid must be lowercase hex: {kid}"
+    );
 }
 
 #[test]

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -145,9 +145,12 @@ impl CognitoService {
         // token-issuing path (InitiateAuth, RespondToAuthChallenge,
         // AdminInitiateAuth, GetTokensFromRefreshToken, OAuth2 token
         // grant) signs with a real RS256 signature out of the box.
-        // Real AWS Cognito assigns the keypair at pool creation time too.
-        let signing_key_pem = crate::jwt::generate_pool_signing_key();
-        let signing_kid = format!("{pool_id}-key-1");
+        // Real AWS Cognito assigns the keypair at pool creation time
+        // and derives the JWKS `kid` from a hash of the public half so
+        // it stays stable across snapshots.
+        let signing = crate::jwt::generate_pool_signing_key();
+        let signing_key_pem = signing.private_key_pem;
+        let signing_kid = signing.kid;
         let pool = UserPool {
             id: pool_id.clone(),
             name: pool_name.to_string(),

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4724,7 +4724,9 @@ async fn cognito_well_known_jwks_returns_public_key() {
     assert_eq!(key["alg"], "RS256");
     assert_eq!(key["kty"], "RSA");
     assert_eq!(key["use"], "sig");
-    assert!(key["kid"].as_str().unwrap().contains(&pool_id));
+    let kid = key["kid"].as_str().expect("kid string");
+    assert_eq!(kid.len(), 16, "kid is the 16-hex-char SHA-256 prefix");
+    assert!(kid.chars().all(|c| c.is_ascii_hexdigit()));
     assert!(key["n"].as_str().unwrap().len() > 100);
     assert!(!key["e"].as_str().unwrap().is_empty());
 }
@@ -4760,6 +4762,156 @@ async fn cognito_well_known_openid_configuration_uses_pool_region() {
         .as_array()
         .unwrap();
     assert_eq!(algs[0], "RS256");
+}
+
+/// Y1: every JWT issued by the pool is real RS256-signed against the
+/// per-pool RSA-2048 keypair. End-to-end shape:
+///   1. CreateUserPool -> pool gets a freshly-generated keypair.
+///   2. AdminInitiateAuth issues real ID + access tokens.
+///   3. The pool's JWKS endpoint serves the matching public key.
+///   4. Tokens verify cryptographically with that public key.
+#[tokio::test]
+async fn cognito_jwt_is_real_rs256_signed() {
+    use base64::Engine as _;
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::sha2::Sha256;
+    use rsa::signature::Verifier;
+    use rsa::traits::PublicKeyParts;
+    use rsa::{BigUint, RsaPublicKey};
+
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("rs256-pool")
+        .send()
+        .await
+        .expect("create user pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let upc = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("rs256-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = upc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("rs256user")
+        .temporary_password("TempP@ss1!")
+        .send()
+        .await
+        .expect("create user");
+    client
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("rs256user")
+        .password("Permanent1!")
+        .permanent(true)
+        .send()
+        .await
+        .expect("set password");
+
+    let auth = client
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "rs256user")
+        .auth_parameters("PASSWORD", "Permanent1!")
+        .send()
+        .await
+        .expect("auth");
+    let result = auth.authentication_result().expect("authentication result");
+    let id_token = result.id_token().expect("id token").to_string();
+    let access_token = result.access_token().expect("access token").to_string();
+
+    // Header is base64url JSON; assert AWS-shaped fields.
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header_segment = id_token.split('.').next().expect("header segment");
+    let header_bytes = b64.decode(header_segment).expect("header decodes");
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("header JSON");
+    assert_eq!(header["alg"], "RS256", "header.alg must be RS256");
+    assert_eq!(header["typ"], "JWT", "header.typ must be JWT");
+    let kid = header["kid"].as_str().expect("kid present");
+    assert_eq!(kid.len(), 16, "kid is 16-hex-char SHA-256 prefix: {kid}");
+    assert!(
+        kid.chars().all(|c| c.is_ascii_hexdigit()),
+        "kid must be lowercase hex: {kid}"
+    );
+
+    // Pull the matching public key from the pool's JWKS endpoint —
+    // the same path AWS-side SDKs (aws-jwt-verify, jose, etc.) hit.
+    let http = reqwest::Client::new();
+    let jwks: serde_json::Value = http
+        .get(format!(
+            "{}/{}/.well-known/jwks.json",
+            server.endpoint(),
+            pool_id
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let jwk = jwks["keys"]
+        .as_array()
+        .and_then(|keys| keys.iter().find(|k| k["kid"] == kid))
+        .expect("JWKS exposes the kid we signed with");
+
+    let n_bytes = b64.decode(jwk["n"].as_str().unwrap()).expect("n decodes");
+    let e_bytes = b64.decode(jwk["e"].as_str().unwrap()).expect("e decodes");
+    let n = BigUint::from_bytes_be(&n_bytes);
+    let e = BigUint::from_bytes_be(&e_bytes);
+    let public_key = RsaPublicKey::new(n, e).expect("valid RSA public key");
+    assert_eq!(
+        public_key.n().bits(),
+        2048,
+        "Cognito mints 2048-bit keys; got {}",
+        public_key.n().bits()
+    );
+    let verifying_key = VerifyingKey::<Sha256>::new(public_key);
+
+    // Verify both ID and access token against the JWKS-published public key.
+    for (label, token) in [("id_token", &id_token), ("access_token", &access_token)] {
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "{label} must be a three-segment JWT");
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = b64.decode(parts[2]).expect("sig decodes");
+        let signature = Signature::try_from(sig_bytes.as_slice()).expect("sig parses");
+        verifying_key
+            .verify(signing_input.as_bytes(), &signature)
+            .unwrap_or_else(|err| {
+                panic!("{label} signature must verify against pool's JWKS public key: {err}")
+            });
+    }
+
+    // Finally, prove the verification is non-trivial: tampering the
+    // payload breaks the signature against the same public key.
+    let id_parts: Vec<&str> = id_token.split('.').collect();
+    let mut payload: serde_json::Value =
+        serde_json::from_slice(&b64.decode(id_parts[1]).unwrap()).unwrap();
+    payload["sub"] = serde_json::json!("attacker");
+    let tampered_payload = b64.encode(payload.to_string().as_bytes());
+    let tampered_input = format!("{}.{}", id_parts[0], tampered_payload);
+    let sig_bytes = b64.decode(id_parts[2]).unwrap();
+    let signature = Signature::try_from(sig_bytes.as_slice()).unwrap();
+    verifying_key
+        .verify(tampered_input.as_bytes(), &signature)
+        .expect_err("tampered payload must NOT verify");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Every Cognito user pool now mints a fresh RSA-2048 keypair at `CreateUserPool` time and signs every issued JWT (ID token, access token, OAuth2 client-credentials access token, refresh-grant tokens) with real RS256 via `rsa::pkcs1v15::SigningKey<Sha256>`.
- The JWT header carries `alg: RS256`, `typ: JWT`, and a deterministic `kid` derived from the first 16 hex chars of `SHA-256(SubjectPublicKeyInfo DER)`. The same kid lands on the pool's `/.well-known/jwks.json` document so SDK-side verifiers (`aws-jwt-verify`, `jose`, `pyjwt`, etc.) round-trip cleanly.
- Drops the placeholder SHA-256 fallback that the old `sign_jwt` used when no key was loaded; pre-Y1 snapshots without a stored kid get one backfilled from the public key on first use.
- CloudFormation-provisioned pools now generate the keypair via the same path so JWKS+JWTs match runtime behavior.

## Test plan

- [x] `cargo test -p fakecloud-cognito` (305 unit tests including pre-existing RS256 round-trip + tamper checks)
- [x] `cargo test -p fakecloud-e2e --test cognito` (79 tests, including new `cognito_jwt_is_real_rs256_signed` which fetches JWKS, parses `n`/`e`, builds `RsaPublicKey` from scratch, verifies both ID and access tokens, and confirms a tampered payload fails verification)
- [x] `cargo test -p fakecloud-e2e --test cognito_persistence` (snapshot round-trip)
- [x] `cargo test -p fakecloud-cloudformation` (CFN-provisioned pools still serialize cleanly)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every Cognito user pool now issues real RS256-signed JWTs using a per-pool RSA-2048 keypair and exposes a matching JWKS for standard verification. This replaces placeholder signatures and makes tokens verifiable by common SDKs.

- New Features
  - Generate an RSA-2048 keypair at `CreateUserPool` and CloudFormation; store PKCS#8 PEM and a deterministic `kid` (first 16 hex of `SHA-256(SPKI DER)`).
  - Sign ID, access, OAuth2 client-credentials, and refresh-grant tokens with `rsa::pkcs1v15::SigningKey<Sha256)`; JWT headers include `alg: RS256`, `typ: JWT`, and the `kid`.
  - Serve JWKS with matching `n`/`e` and `kid` so verifiers like `aws-jwt-verify`, `jose`, and `pyjwt` work out of the box.

- Migration
  - No action needed. Legacy pools get a `kid` backfilled from the stored PEM; if a PEM is missing, a new keypair is generated lazily.

<sup>Written for commit 17e16fcf5a4ffac0f0c06bd9542017b417f2f6ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

