### PR TITLE
fix(elbv2): listener validation + WAF ARN + ipv6 SNAT bool (Q4)

### DIFF
--- a/crates/fakecloud-e2e/tests/elbv2.rs
+++ b/crates/fakecloud-e2e/tests/elbv2.rs
@@ -1,0 +1,382 @@
+//! ELBv2 control-plane validation E2E (Q4):
+//! - Listener Protocol/Port matrix per LB type.
+//! - `ipv6.enable_prefix_for_source_nat` round-trip as bool.
+//! - WAFv2 `AssociateWebACL` accepts both LoadBalancer and Listener
+//!   ARNs against an ALB.
+
+mod helpers;
+
+use aws_sdk_elasticloadbalancingv2::types::{
+    Action, ActionTypeEnum, FixedResponseActionConfig, LoadBalancerAttribute, LoadBalancerTypeEnum,
+    ProtocolEnum,
+};
+use aws_sdk_wafv2::types::{DefaultAction, Scope, VisibilityConfig};
+use helpers::TestServer;
+
+fn fixed_200() -> Action {
+    Action::builder()
+        .r#type(ActionTypeEnum::FixedResponse)
+        .fixed_response_config(
+            FixedResponseActionConfig::builder()
+                .status_code("200")
+                .build(),
+        )
+        .build()
+}
+
+#[tokio::test]
+async fn create_listener_alb_rejects_tcp_protocol() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb = elbv2
+        .create_load_balancer()
+        .name("alb-bad-proto")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap();
+    let lb_arn = lb
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    let err = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Tcp)
+        .port(80)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .expect_err("ALB should reject TCP listener");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("ValidationError"), "{msg}");
+    assert!(msg.contains("application"), "{msg}");
+}
+
+#[tokio::test]
+async fn create_listener_alb_accepts_http_and_https() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("alb-good-proto")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    for (proto, port) in [(ProtocolEnum::Http, 80), (ProtocolEnum::Https, 443)] {
+        elbv2
+            .create_listener()
+            .load_balancer_arn(&lb_arn)
+            .protocol(proto.clone())
+            .port(port)
+            .default_actions(fixed_200())
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("ALB should accept {proto:?}: {e:?}"));
+    }
+}
+
+#[tokio::test]
+async fn create_listener_nlb_rejects_http_protocol() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("nlb-bad-proto")
+        .r#type(LoadBalancerTypeEnum::Network)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    let err = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .expect_err("NLB should reject HTTP listener");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("ValidationError"), "{msg}");
+    assert!(msg.contains("network"), "{msg}");
+}
+
+#[tokio::test]
+async fn create_listener_nlb_accepts_tcp_udp_tls() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("nlb-good-proto")
+        .r#type(LoadBalancerTypeEnum::Network)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    for (proto, port) in [
+        (ProtocolEnum::Tcp, 1234),
+        (ProtocolEnum::Udp, 1235),
+        (ProtocolEnum::TcpUdp, 1236),
+        (ProtocolEnum::Tls, 1237),
+    ] {
+        elbv2
+            .create_listener()
+            .load_balancer_arn(&lb_arn)
+            .protocol(proto.clone())
+            .port(port)
+            .default_actions(fixed_200())
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("NLB should accept {proto:?}: {e:?}"));
+    }
+}
+
+#[tokio::test]
+async fn create_listener_gwlb_requires_geneve_on_6081() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("gwlb-strict")
+        .r#type(LoadBalancerTypeEnum::Gateway)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+    // Wrong protocol on GWLB.
+    let err = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Tcp)
+        .port(6081)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .expect_err("GWLB should reject TCP");
+    assert!(format!("{err:?}").contains("ValidationError"));
+    // GENEVE on the wrong port.
+    let err = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Geneve)
+        .port(443)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .expect_err("GWLB GENEVE on 443 should be rejected");
+    assert!(format!("{err:?}").contains("6081"));
+    // GENEVE on 6081 is accepted.
+    elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Geneve)
+        .port(6081)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .expect("GWLB GENEVE/6081 should be accepted");
+}
+
+#[tokio::test]
+async fn modify_load_balancer_attributes_round_trips_ipv6_source_nat() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("nlb-snat")
+        .r#type(LoadBalancerTypeEnum::Network)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+
+    // Reject a non-bool value.
+    let err = elbv2
+        .modify_load_balancer_attributes()
+        .load_balancer_arn(&lb_arn)
+        .attributes(
+            LoadBalancerAttribute::builder()
+                .key("ipv6.enable_prefix_for_source_nat")
+                .value("yes")
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("non-bool ipv6 SNAT value should be rejected");
+    assert!(format!("{err:?}").contains("ValidationError"));
+
+    // Accept all four valid values and verify round-trip via Describe.
+    for v in ["true", "false", "on", "off"] {
+        elbv2
+            .modify_load_balancer_attributes()
+            .load_balancer_arn(&lb_arn)
+            .attributes(
+                LoadBalancerAttribute::builder()
+                    .key("ipv6.enable_prefix_for_source_nat")
+                    .value(v)
+                    .build(),
+            )
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("ipv6 SNAT value {v} should be accepted: {e:?}"));
+
+        let described = elbv2
+            .describe_load_balancer_attributes()
+            .load_balancer_arn(&lb_arn)
+            .send()
+            .await
+            .unwrap();
+        let echoed = described
+            .attributes()
+            .iter()
+            .find(|a| a.key() == Some("ipv6.enable_prefix_for_source_nat"))
+            .and_then(|a| a.value())
+            .map(str::to_owned)
+            .unwrap_or_default();
+        assert_eq!(echoed, v, "ipv6 SNAT value should round-trip verbatim");
+    }
+}
+
+fn allow_default() -> DefaultAction {
+    DefaultAction::builder()
+        .allow(aws_sdk_wafv2::types::AllowAction::builder().build())
+        .build()
+}
+
+fn vis(name: &str) -> VisibilityConfig {
+    VisibilityConfig::builder()
+        .sampled_requests_enabled(false)
+        .cloud_watch_metrics_enabled(false)
+        .metric_name(name)
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn associate_web_acl_accepts_listener_arn_against_load_balancer() {
+    let server = TestServer::start().await;
+    let elbv2 = server.elbv2_client().await;
+    let waf = server.wafv2_client().await;
+
+    let lb_arn = elbv2
+        .create_load_balancer()
+        .name("waf-alb")
+        .r#type(LoadBalancerTypeEnum::Application)
+        .send()
+        .await
+        .unwrap()
+        .load_balancers()
+        .first()
+        .unwrap()
+        .load_balancer_arn()
+        .unwrap()
+        .to_string();
+
+    let listener_arn = elbv2
+        .create_listener()
+        .load_balancer_arn(&lb_arn)
+        .protocol(ProtocolEnum::Http)
+        .port(80)
+        .default_actions(fixed_200())
+        .send()
+        .await
+        .unwrap()
+        .listeners()
+        .first()
+        .unwrap()
+        .listener_arn()
+        .unwrap()
+        .to_string();
+
+    let acl_arn = waf
+        .create_web_acl()
+        .name("alb-acl")
+        .scope(Scope::Regional)
+        .default_action(allow_default())
+        .visibility_config(vis("alb-acl"))
+        .send()
+        .await
+        .unwrap()
+        .summary
+        .unwrap()
+        .arn()
+        .expect("arn")
+        .to_owned();
+
+    // Listener ARN should be normalized to the load-balancer ARN
+    // server-side, so a follow-up GetWebACLForResource on the LB
+    // ARN sees the association.
+    waf.associate_web_acl()
+        .web_acl_arn(&acl_arn)
+        .resource_arn(&listener_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let got_via_lb = waf
+        .get_web_acl_for_resource()
+        .resource_arn(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        got_via_lb.web_acl().is_some(),
+        "associating via Listener ARN should be visible via the LB ARN"
+    );
+    let got_via_listener = waf
+        .get_web_acl_for_resource()
+        .resource_arn(&listener_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        got_via_listener.web_acl().is_some(),
+        "Listener ARN lookups should also resolve once normalized"
+    );
+
+    // Disassociating via the LB ARN should clear the lookup whether
+    // we go through the listener or the LB.
+    waf.disassociate_web_acl()
+        .resource_arn(&lb_arn)
+        .send()
+        .await
+        .unwrap();
+    let after = waf
+        .get_web_acl_for_resource()
+        .resource_arn(&listener_arn)
+        .send()
+        .await
+        .unwrap();
+    assert!(after.web_acl().is_none());
+}

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1174,9 +1174,11 @@ impl Elbv2Service {
 
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
-        if !st.load_balancers.contains_key(&lb_arn) {
-            return Err(lb_not_found(&lb_arn));
-        }
+        let lb_type = match st.load_balancers.get(&lb_arn) {
+            Some(lb) => lb.lb_type.clone(),
+            None => return Err(lb_not_found(&lb_arn)),
+        };
+        validate_listener_protocol_port_for_lb_type(&lb_type, protocol.as_deref(), port)?;
         // Validate referenced target groups exist (forward action targets).
         for action in &actions {
             if let Some(tg_arn) = &action.target_group_arn {
@@ -1267,21 +1269,55 @@ impl Elbv2Service {
 
     fn modify_listener(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let arn = required_query_param(req, "ListenerArn")?;
+        // Pre-parse + validate the standalone shapes before grabbing
+        // the write lock so we don't have to juggle the borrow against
+        // the load-balancer lookup the per-LB-type matrix needs.
+        let new_port = match optional_query_param(req, "Port") {
+            Some(s) => {
+                let parsed: i32 = s
+                    .parse()
+                    .map_err(|_| invalid_param(format!("Port '{s}' must be a number")))?;
+                validate_listener_port(parsed)?;
+                Some(parsed)
+            }
+            None => None,
+        };
+        let new_protocol = match optional_query_param(req, "Protocol") {
+            Some(p) => {
+                validate_listener_protocol(&p)?;
+                Some(p)
+            }
+            None => None,
+        };
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
+        let lb_arn = st
+            .listeners
+            .get(&arn)
+            .map(|l| l.load_balancer_arn.clone())
+            .ok_or_else(|| listener_not_found(&arn))?;
+        let lb_type = st
+            .load_balancers
+            .get(&lb_arn)
+            .map(|lb| lb.lb_type.clone())
+            .unwrap_or_default();
+        // Run the per-LB-type matrix against the *resulting* shape:
+        // for ALB, e.g., changing only the port still has to satisfy
+        // the protocol matrix even if the protocol field is omitted.
+        let listener_for_check = st.listeners.get(&arn).expect("checked above");
+        let effective_protocol = new_protocol
+            .as_deref()
+            .or(listener_for_check.protocol.as_deref());
+        let effective_port = new_port.or(listener_for_check.port);
+        validate_listener_protocol_port_for_lb_type(&lb_type, effective_protocol, effective_port)?;
         let listener = st
             .listeners
             .get_mut(&arn)
             .ok_or_else(|| listener_not_found(&arn))?;
-        if let Some(s) = optional_query_param(req, "Port") {
-            let parsed: i32 = s
-                .parse()
-                .map_err(|_| invalid_param(format!("Port '{s}' must be a number")))?;
-            validate_listener_port(parsed)?;
-            listener.port = Some(parsed);
+        if let Some(p) = new_port {
+            listener.port = Some(p);
         }
-        if let Some(p) = optional_query_param(req, "Protocol") {
-            validate_listener_protocol(&p)?;
+        if let Some(p) = new_protocol {
             listener.protocol = Some(p);
         }
         if let Some(p) = optional_query_param(req, "SslPolicy") {
@@ -1613,6 +1649,14 @@ impl Elbv2Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let arn = required_query_param(req, "LoadBalancerArn")?;
         let new_attrs = parse_attributes(req);
+        // Validate the bool-ish attributes up front so the caller
+        // can't smuggle a bogus value past us - AWS returns a
+        // ValidationError before the attribute is persisted.
+        for (k, v) in &new_attrs {
+            if k == "ipv6.enable_prefix_for_source_nat" {
+                validate_ipv6_source_nat_value(v)?;
+            }
+        }
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let lb = st

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -137,6 +137,64 @@ pub(crate) fn validate_listener_port(port: i32) -> Result<(), AwsServiceError> {
     Ok(())
 }
 
+/// Each load balancer type accepts only a subset of listener
+/// protocols, and GWLB pins the port to GENEVE's standard `6081`.
+/// AWS rejects mismatches up front - e.g. an ALB cannot listen on
+/// raw TCP, an NLB cannot listen on HTTP, and a GWLB cannot listen
+/// on anything except GENEVE/6081.
+///
+/// `protocol` and `port` are optional: callers should still call
+/// [`validate_listener_protocol`] / [`validate_listener_port`] for
+/// the standalone shape checks; this helper only enforces the
+/// per-type matrix.
+pub(crate) fn validate_listener_protocol_port_for_lb_type(
+    lb_type: &str,
+    protocol: Option<&str>,
+    port: Option<i32>,
+) -> Result<(), AwsServiceError> {
+    let allowed: &[&str] = match lb_type {
+        "application" => &["HTTP", "HTTPS"],
+        "network" => &["TCP", "UDP", "TCP_UDP", "TLS"],
+        "gateway" => &["GENEVE"],
+        // Unknown LB type - fall back to permissive; the caller has
+        // already gated on the enum.
+        _ => return Ok(()),
+    };
+    if let Some(p) = protocol {
+        if !allowed.contains(&p) {
+            return Err(invalid_param(format!(
+                "Protocol '{p}' is not valid for {lb_type} load balancers. Valid values: {}",
+                allowed.join(", ")
+            )));
+        }
+    }
+    if lb_type == "gateway" {
+        if let Some(port) = port {
+            if port != 6081 {
+                return Err(invalid_param(format!(
+                    "Port '{port}' is not valid for gateway load balancers. GENEVE listeners must use port 6081"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `ipv6.enable_prefix_for_source_nat` is the only LB attribute
+/// whose value is restricted to a tight set of bool-ish strings.
+/// AWS accepts `true`/`false` and the `on`/`off` aliases used by
+/// the corresponding `EnablePrefixForIpv6SourceNat` create-time
+/// enum. Anything else returns a `ValidationError` rather than
+/// being silently round-tripped.
+pub(crate) fn validate_ipv6_source_nat_value(value: &str) -> Result<(), AwsServiceError> {
+    if !matches!(value, "true" | "false" | "on" | "off") {
+        return Err(invalid_param(format!(
+            "ipv6.enable_prefix_for_source_nat must be one of true|false|on|off, got '{value}'"
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn lb_not_found(arn: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -362,13 +362,10 @@ async fn create_listener_rejects_port_above_65535() {
 }
 
 #[tokio::test]
-async fn create_listener_accepts_valid_protocols() {
+async fn create_listener_accepts_alb_protocols() {
     let svc = svc();
     let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
-    for proto in ["HTTP", "HTTPS", "TCP", "UDP", "TCP_UDP", "TLS", "GENEVE"] {
-        // Only HTTP/HTTPS work with the default ALB; for the test we just
-        // need protocol validation to pass, even if downstream rejects.
-        // We assert no ValidationError on the protocol token itself.
+    for proto in ["HTTP", "HTTPS"] {
         let res = svc
             .handle(req(
                 "CreateListener",
@@ -382,11 +379,210 @@ async fn create_listener_accepts_valid_protocols() {
             ))
             .await;
         if let Err(e) = res {
-            assert!(
-                !format!("{e:?}").contains("not valid"),
-                "protocol {proto} should be accepted: {e:?}"
-            );
+            panic!("protocol {proto} should be accepted on an ALB: {e:?}");
         }
+    }
+}
+
+async fn create_typed_lb(svc: &Elbv2Service, name: &str, lb_type: &str) -> String {
+    svc.handle(req(
+        "CreateLoadBalancer",
+        &[
+            ("Name", name),
+            ("Type", lb_type),
+            ("Subnets.member.1", "subnet-1"),
+        ],
+    ))
+    .await
+    .unwrap();
+    let st = svc.state.read();
+    st.get("123456789012")
+        .unwrap()
+        .load_balancers
+        .values()
+        .find(|lb| lb.name == name)
+        .map(|lb| lb.arn.clone())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_listener_alb_rejects_tcp() {
+    let svc = svc();
+    let (lb_arn, tg_arn) = create_lb_and_tg_for_listener_test(&svc).await;
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "TCP"),
+                ("Port", "80"),
+                ("DefaultActions.member.1.Type", "forward"),
+                ("DefaultActions.member.1.TargetGroupArn", &tg_arn),
+            ],
+        ))
+        .await
+        .err()
+        .expect("TCP should be rejected on an ALB");
+    assert_eq!(err.code(), "ValidationError");
+    assert!(format!("{err:?}").contains("application"));
+}
+
+#[tokio::test]
+async fn create_listener_nlb_rejects_http() {
+    let svc = svc();
+    let lb_arn = create_typed_lb(&svc, "nlb", "network").await;
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "HTTP"),
+                ("Port", "80"),
+                ("DefaultActions.member.1.Type", "fixed-response"),
+                (
+                    "DefaultActions.member.1.FixedResponseConfig.StatusCode",
+                    "200",
+                ),
+            ],
+        ))
+        .await
+        .err()
+        .expect("HTTP should be rejected on an NLB");
+    assert_eq!(err.code(), "ValidationError");
+}
+
+#[tokio::test]
+async fn create_listener_nlb_accepts_tcp_and_udp() {
+    let svc = svc();
+    let lb_arn = create_typed_lb(&svc, "nlb-ok", "network").await;
+    for proto in ["TCP", "UDP", "TCP_UDP", "TLS"] {
+        let res = svc
+            .handle(req(
+                "CreateListener",
+                &[
+                    ("LoadBalancerArn", &lb_arn),
+                    ("Protocol", proto),
+                    ("Port", "443"),
+                    ("DefaultActions.member.1.Type", "fixed-response"),
+                    (
+                        "DefaultActions.member.1.FixedResponseConfig.StatusCode",
+                        "200",
+                    ),
+                ],
+            ))
+            .await;
+        if let Err(e) = res {
+            panic!("protocol {proto} should be accepted on an NLB: {e:?}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn create_listener_gwlb_requires_geneve_on_6081() {
+    let svc = svc();
+    let lb_arn = create_typed_lb(&svc, "gwlb", "gateway").await;
+    // Wrong protocol on GWLB.
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "TCP"),
+                ("Port", "6081"),
+                ("DefaultActions.member.1.Type", "fixed-response"),
+                (
+                    "DefaultActions.member.1.FixedResponseConfig.StatusCode",
+                    "200",
+                ),
+            ],
+        ))
+        .await
+        .err()
+        .expect("TCP should be rejected on a GWLB");
+    assert_eq!(err.code(), "ValidationError");
+    // GENEVE but wrong port.
+    let err = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "GENEVE"),
+                ("Port", "443"),
+                ("DefaultActions.member.1.Type", "fixed-response"),
+                (
+                    "DefaultActions.member.1.FixedResponseConfig.StatusCode",
+                    "200",
+                ),
+            ],
+        ))
+        .await
+        .err()
+        .expect("GENEVE on port 443 should be rejected on a GWLB");
+    assert_eq!(err.code(), "ValidationError");
+    // GENEVE on 6081 succeeds.
+    let res = svc
+        .handle(req(
+            "CreateListener",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                ("Protocol", "GENEVE"),
+                ("Port", "6081"),
+                ("DefaultActions.member.1.Type", "fixed-response"),
+                (
+                    "DefaultActions.member.1.FixedResponseConfig.StatusCode",
+                    "200",
+                ),
+            ],
+        ))
+        .await;
+    if let Err(e) = res {
+        panic!("GENEVE on 6081 should succeed: {e:?}");
+    }
+}
+
+#[tokio::test]
+async fn modify_load_balancer_attributes_validates_ipv6_source_nat_value() {
+    let svc = svc();
+    let lb_arn = create_typed_lb(&svc, "snat-lb", "network").await;
+    let err = svc
+        .handle(req(
+            "ModifyLoadBalancerAttributes",
+            &[
+                ("LoadBalancerArn", &lb_arn),
+                (
+                    "Attributes.member.1.Key",
+                    "ipv6.enable_prefix_for_source_nat",
+                ),
+                ("Attributes.member.1.Value", "yes"),
+            ],
+        ))
+        .await
+        .err()
+        .expect("non-bool ipv6 SNAT value should be rejected");
+    assert_eq!(err.code(), "ValidationError");
+    // All four supported values round-trip without error.
+    for v in ["true", "false", "on", "off"] {
+        let res = svc
+            .handle(req(
+                "ModifyLoadBalancerAttributes",
+                &[
+                    ("LoadBalancerArn", &lb_arn),
+                    (
+                        "Attributes.member.1.Key",
+                        "ipv6.enable_prefix_for_source_nat",
+                    ),
+                    ("Attributes.member.1.Value", v),
+                ],
+            ))
+            .await
+            .unwrap_or_else(|e| panic!("ipv6 SNAT value {v} should be accepted: {e:?}"));
+        let body = body_string(&res);
+        assert!(
+            body.contains(&format!(
+                "<Key>ipv6.enable_prefix_for_source_nat</Key><Value>{v}</Value>"
+            )),
+            "round-trip should echo {v} verbatim: {body}"
+        );
     }
 }
 

--- a/crates/fakecloud-wafv2/src/service.rs
+++ b/crates/fakecloud-wafv2/src/service.rs
@@ -1035,7 +1035,7 @@ impl Wafv2Service {
     fn associate_web_acl(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let acl_arn = require_str(&body, "WebACLArn")?;
-        let resource_arn = require_str(&body, "ResourceArn")?;
+        let resource_arn = normalize_resource_arn(&require_str(&body, "ResourceArn")?);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         if !account.web_acls.values().any(|a| a.arn == acl_arn) {
@@ -1047,7 +1047,7 @@ impl Wafv2Service {
 
     fn disassociate_web_acl(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resource_arn = require_str(&body, "ResourceArn")?;
+        let resource_arn = normalize_resource_arn(&require_str(&body, "ResourceArn")?);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         account.associations.remove(&resource_arn);
@@ -1056,7 +1056,7 @@ impl Wafv2Service {
 
     fn get_web_acl_for_resource(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let resource_arn = require_str(&body, "ResourceArn")?;
+        let resource_arn = normalize_resource_arn(&require_str(&body, "ResourceArn")?);
         let state = self.state.read();
         let account = state.accounts.get(&req.account_id);
         let acl_arn = account.and_then(|a| a.associations.get(&resource_arn).cloned());
@@ -1720,6 +1720,39 @@ fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "WAFInvalidParameterException", msg)
 }
 
+/// Normalize an ELBv2-style `ResourceArn` to the canonical
+/// load-balancer ARN. Real AWS associates web ACLs with the load
+/// balancer (not the listener), but callers regularly pass through
+/// listener ARNs - either by accident or because they only have
+/// the listener handy in their CloudFormation template. Trim the
+/// listener suffix so the persisted association matches the lb
+/// arn the data plane looks up.
+///
+/// Non-ELBv2 ARNs (API Gateway, AppSync, Cognito, Verified Access)
+/// are returned unchanged.
+fn normalize_resource_arn(arn: &str) -> String {
+    // Listener ARN:
+    //   arn:aws:elasticloadbalancing:<region>:<acct>:listener/<type>/<name>/<lb-suffix>/<listener-suffix>
+    // LoadBalancer ARN:
+    //   arn:aws:elasticloadbalancing:<region>:<acct>:loadbalancer/<type>/<name>/<lb-suffix>
+    if let Some(rest) = arn.strip_prefix("arn:aws:elasticloadbalancing:") {
+        if let Some((before, after)) = rest.split_once(":listener/") {
+            // Listener path has 4 segments (<type>/<name>/<lb-suffix>/<listener-suffix>);
+            // drop the trailing listener suffix to recover the lb ARN.
+            let mut parts = after.splitn(4, '/');
+            let ty = parts.next();
+            let name = parts.next();
+            let lb_suffix = parts.next();
+            if let (Some(ty), Some(name), Some(lb_suffix)) = (ty, name, lb_suffix) {
+                return format!(
+                    "arn:aws:elasticloadbalancing:{before}:loadbalancer/{ty}/{name}/{lb_suffix}"
+                );
+            }
+        }
+    }
+    arn.to_string()
+}
+
 fn not_found(resource: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -2092,4 +2125,43 @@ fn regex_set_detail_json(set: &RegexPatternSet) -> Value {
             .insert("Description".to_string(), Value::String(d.clone()));
     }
     obj
+}
+
+#[cfg(test)]
+mod arn_norm_tests {
+    use super::normalize_resource_arn;
+
+    #[test]
+    fn elb_listener_arn_collapses_to_load_balancer_arn() {
+        let listener =
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/web/abc/xyz";
+        assert_eq!(
+            normalize_resource_arn(listener),
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/abc"
+        );
+    }
+
+    #[test]
+    fn elb_load_balancer_arn_passes_through() {
+        let lb = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/web/abc";
+        assert_eq!(normalize_resource_arn(lb), lb);
+    }
+
+    #[test]
+    fn nlb_listener_arn_collapses_to_network_load_balancer_arn() {
+        let listener =
+            "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/net/wire/abc/xyz";
+        assert_eq!(
+            normalize_resource_arn(listener),
+            "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/net/wire/abc"
+        );
+    }
+
+    #[test]
+    fn non_elbv2_arn_passes_through() {
+        let apigw = "arn:aws:apigateway:us-east-1::/restapis/abc/stages/prod";
+        assert_eq!(normalize_resource_arn(apigw), apigw);
+        let cog = "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_xxx";
+        assert_eq!(normalize_resource_arn(cog), cog);
+    }
 }

--- a/website/content/docs/services/elbv2.md
+++ b/website/content/docs/services/elbv2.md
@@ -32,6 +32,9 @@ fakecloud implements ELBv2 with full control-plane coverage across all three loa
 - Target group name validation, target type enum (`instance`, `ip`, `lambda`, `alb`), health check threshold ranges all match AWS.
 - `DeleteTargetGroup` returns `ResourceInUse` when any listener default action or rule action — including those wrapped in `ForwardConfig.TargetGroups` — still references the target group.
 - `CreateRule`/`ModifyRule` reject priority values <= 0 with `ValidationError`, and rule actions referencing a non-existent target group return `TargetGroupNotFound`.
+- `CreateListener`/`ModifyListener` reject Protocol/Port mismatches per LB type with `ValidationError`. ALB (`application`) accepts only `HTTP`, `HTTPS` on ports 1-65535. NLB (`network`) accepts only `TCP`, `UDP`, `TCP_UDP`, `TLS` on ports 1-65535. GWLB (`gateway`) accepts only `GENEVE` and pins the port to `6081`.
+- `ModifyLoadBalancerAttributes` validates `ipv6.enable_prefix_for_source_nat` against the AWS-supported set `true`, `false`, `on`, `off` and rejects anything else with `ValidationError`. The value round-trips verbatim through `DescribeLoadBalancerAttributes`.
+- `wafv2:AssociateWebACL`/`DisassociateWebACL`/`GetWebACLForResource` accept either a load balancer ARN or a listener ARN as `ResourceArn` for ELBv2 targets — the listener ARN is normalized to its parent load-balancer ARN server-side so the data plane lookup matches.
 
 ### Idempotent creates
 


### PR DESCRIPTION
## Summary

- ELBv2 `CreateListener` / `ModifyListener` now reject Protocol/Port mismatches per LB type with `ValidationError`. ALB accepts only `HTTP`/`HTTPS`, NLB accepts `TCP`/`UDP`/`TCP_UDP`/`TLS`, and GWLB pins to `GENEVE` on port `6081`. `ModifyListener` re-evaluates the matrix against the resulting effective shape so partial edits can't smuggle a bad combo past it.
- WAFv2 `AssociateWebACL` / `DisassociateWebACL` / `GetWebACLForResource` now accept either the load-balancer ARN or a listener ARN as `ResourceArn` for ELBv2 targets - the listener ARN is normalized to its parent LB ARN so the data-plane WAF lookup hits.
- ELBv2 `ModifyLoadBalancerAttributes` validates `ipv6.enable_prefix_for_source_nat` against the AWS-supported set `true|false|on|off` and round-trips the value verbatim through `DescribeLoadBalancerAttributes`.

## Test plan

- [x] `cargo build -p fakecloud-elbv2 -p fakecloud-wafv2`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-elbv2 --lib` (45 unit tests)
- [x] `cargo test -p fakecloud-wafv2 --lib` (16 unit tests, includes new ARN-normalization tests)
- [x] `cargo test -p fakecloud-e2e --test elbv2` (7 new e2e tests)
- [x] `cargo test -p fakecloud-e2e --test elbv2_dataplane --test elbv2_health_probes --test elbv2_access_logs --test wafv2 --test cloudformation_elbv2` (no regressions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ELBv2 and WAFv2 behavior with AWS: strict listener Protocol/Port validation per LB type, listener-ARN normalization for WAF associations, and stricter IPv6 SNAT attribute validation. This prevents invalid configs and makes WAF lookups reliable.

- **Bug Fixes**
  - `CreateListener`/`ModifyListener` now enforce Protocol/Port per LB type: ALB only `HTTP`/`HTTPS`; NLB only `TCP`/`UDP`/`TCP_UDP`/`TLS`; GWLB only `GENEVE` on port `6081`.
  - `wafv2:AssociateWebACL`/`DisassociateWebACL`/`GetWebACLForResource` accept either a load balancer ARN or a listener ARN for ELBv2. Listener ARNs are normalized to the parent LB ARN.
  - `ModifyLoadBalancerAttributes` validates `ipv6.enable_prefix_for_source_nat` as one of `true`, `false`, `on`, `off` and echoes the value verbatim via `DescribeLoadBalancerAttributes`.

<sup>Written for commit 622c99308af6d4545cf8be4a24525adc04d06bc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

