### PR TITLE
feat(lambda): real PublishVersion snapshots + ListVersionsByFunction (D2)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -548,3 +548,280 @@ async fn lambda_update_function_code_with_image_uri_clears_size_and_sha() {
         &aws_sdk_lambda::types::PackageType::Image
     );
 }
+
+fn make_zip_with(payload: &[u8]) -> Vec<u8> {
+    // Each call returns different ZIP bytes when `payload` differs, which
+    // bumps `CodeSha256` so PublishVersion stops being a no-op idempotent
+    // re-publish on the second call. Real callers do this implicitly via
+    // CI bumping the artifact between deploys.
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.py", options).unwrap();
+    writer.write_all(payload).unwrap();
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+#[tokio::test]
+async fn lambda_publish_version_snapshots_and_lists() {
+    // End-to-end PublishVersion / ListVersionsByFunction / Get* with
+    // Qualifier / DeleteFunction(Qualifier) / idempotent re-publish /
+    // PreconditionFailedException on stale CodeSha256.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("ver-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_zip_with(b"v0\n")))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Newly-created function has $LATEST and no numbered versions.
+    let listed = client
+        .list_versions_by_function()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    let versions: Vec<String> = listed
+        .versions()
+        .iter()
+        .map(|v| v.version().unwrap_or("").to_string())
+        .collect();
+    assert_eq!(versions, vec!["$LATEST".to_string()]);
+
+    // PublishVersion returns Version="1" with FunctionArn ending in :1.
+    let v1 = client
+        .publish_version()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(v1.version().unwrap(), "1");
+    assert!(v1.function_arn().unwrap().ends_with(":1"));
+    let v1_sha = v1.code_sha256().unwrap().to_string();
+
+    // GetFunction(Qualifier="1") returns the v1 snapshot config.
+    let v1_get = client
+        .get_function()
+        .function_name("ver-fn")
+        .qualifier("1")
+        .send()
+        .await
+        .unwrap();
+    let v1_cfg = v1_get.configuration().unwrap();
+    assert_eq!(v1_cfg.version().unwrap(), "1");
+    assert!(v1_cfg.function_arn().unwrap().ends_with(":1"));
+    assert_eq!(v1_cfg.code_sha256().unwrap(), v1_sha);
+
+    // Mutate $LATEST: UpdateFunctionConfiguration on description must
+    // not mutate the v1 snapshot.
+    client
+        .update_function_configuration()
+        .function_name("ver-fn")
+        .description("after-v1")
+        .send()
+        .await
+        .unwrap();
+
+    let v1_recheck = client
+        .get_function_configuration()
+        .function_name("ver-fn")
+        .qualifier("1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(v1_recheck.description().unwrap_or(""), "");
+    assert_eq!(v1_recheck.code_sha256().unwrap(), v1_sha);
+
+    // PublishVersion with same code+description is idempotent: returns v1.
+    // We reset the description to keep parity with the v1 snapshot first.
+    client
+        .update_function_configuration()
+        .function_name("ver-fn")
+        .description("")
+        .send()
+        .await
+        .unwrap();
+    let again = client
+        .publish_version()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(again.version().unwrap(), "1");
+
+    // UpdateFunctionCode with new bytes -> bumps $LATEST sha.
+    let new_zip = make_zip_with(b"v2-payload\n");
+    client
+        .update_function_code()
+        .function_name("ver-fn")
+        .zip_file(Blob::new(new_zip))
+        .send()
+        .await
+        .unwrap();
+
+    // Stale CodeSha256 precondition -> 412 PreconditionFailedException.
+    let stale = client
+        .publish_version()
+        .function_name("ver-fn")
+        .code_sha256(v1_sha.clone())
+        .send()
+        .await;
+    assert!(stale.is_err(), "expected PreconditionFailedException");
+    let err_str = format!("{:?}", stale.err().unwrap());
+    assert!(
+        err_str.contains("PreconditionFailed"),
+        "expected PreconditionFailed, got {err_str}"
+    );
+
+    // PublishVersion without preconditions -> v2.
+    let v2 = client
+        .publish_version()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(v2.version().unwrap(), "2");
+    assert!(v2.function_arn().unwrap().ends_with(":2"));
+    assert_ne!(v2.code_sha256().unwrap(), v1_sha);
+
+    // ListVersionsByFunction returns 3 entries: $LATEST, 1, 2 with
+    // full FunctionConfiguration each (not just version strings).
+    let listed = client
+        .list_versions_by_function()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    let entries = listed.versions();
+    assert_eq!(entries.len(), 3);
+    let versions: Vec<&str> = entries.iter().map(|v| v.version().unwrap_or("")).collect();
+    assert_eq!(versions, vec!["$LATEST", "1", "2"]);
+    // Each entry carries a Runtime / Handler / Role — i.e. a full
+    // FunctionConfiguration, not just a version label.
+    for v in entries {
+        assert_eq!(v.runtime().unwrap().as_str(), "python3.12");
+        assert_eq!(v.handler().unwrap(), "index.handler");
+    }
+
+    // DeleteFunction(Qualifier="1") drops only that version.
+    client
+        .delete_function()
+        .function_name("ver-fn")
+        .qualifier("1")
+        .send()
+        .await
+        .unwrap();
+
+    let listed = client
+        .list_versions_by_function()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    let versions: Vec<&str> = listed
+        .versions()
+        .iter()
+        .map(|v| v.version().unwrap_or(""))
+        .collect();
+    assert_eq!(versions, vec!["$LATEST", "2"]);
+
+    // GetFunction(Qualifier="1") now 404s.
+    let missing_v1 = client
+        .get_function()
+        .function_name("ver-fn")
+        .qualifier("1")
+        .send()
+        .await;
+    assert!(missing_v1.is_err());
+
+    // DeleteFunction without Qualifier removes everything.
+    client
+        .delete_function()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .unwrap();
+    assert!(client
+        .get_function()
+        .function_name("ver-fn")
+        .send()
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn lambda_alias_targets_published_version_snapshot() {
+    // Aliases pointing at a numbered version must resolve to the
+    // immutable snapshot at GetFunction time even after $LATEST is
+    // rewritten — a key reason version snapshots exist at all.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("alias-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_zip_with(b"alias-v1\n")))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let v1 = client
+        .publish_version()
+        .function_name("alias-fn")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(v1.version().unwrap(), "1");
+    let v1_sha = v1.code_sha256().unwrap().to_string();
+
+    // Create alias prod -> 1.
+    client
+        .create_alias()
+        .function_name("alias-fn")
+        .name("prod")
+        .function_version("1")
+        .send()
+        .await
+        .unwrap();
+
+    // Mutate $LATEST.
+    client
+        .update_function_code()
+        .function_name("alias-fn")
+        .zip_file(Blob::new(make_zip_with(b"alias-v2\n")))
+        .send()
+        .await
+        .unwrap();
+
+    // GetFunction(Qualifier="prod") must hit the v1 snapshot, not $LATEST.
+    let via_alias = client
+        .get_function()
+        .function_name("alias-fn")
+        .qualifier("prod")
+        .send()
+        .await
+        .unwrap();
+    let cfg = via_alias.configuration().unwrap();
+    assert_eq!(cfg.code_sha256().unwrap(), v1_sha);
+    assert!(cfg.function_arn().unwrap().ends_with(":1"));
+}

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1140,21 +1140,84 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
         let region = state.region.clone();
-        let account_id = state.account_id.clone();
+        let account_id_owned = state.account_id.clone();
+
+        // Qualifier=N targets a single immutable version snapshot; the
+        // live $LATEST function and other versions stay put. AWS only
+        // accepts numeric qualifiers here — alias targets are deleted
+        // via DeleteAlias, and `$LATEST` is rejected as
+        // InvalidParameterValueException.
+        if let Some(q) = qualifier {
+            if q == "$LATEST" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    "$LATEST version cannot be deleted without deleting the function.",
+                ));
+            }
+            if !q.chars().all(|c| c.is_ascii_digit()) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!(
+                        "Value '{q}' at 'qualifier' failed to satisfy constraint: Member must satisfy regular expression pattern: (|[a-zA-Z0-9$_-]+)"
+                    ),
+                ));
+            }
+            // Live function must exist or AWS 404s before checking the version.
+            if !state.functions.contains_key(function_name) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{region}:{account_id_owned}:function:{function_name}:{q}"
+                    ),
+                ));
+            }
+            let snap_existed = state
+                .function_version_snapshots
+                .get_mut(function_name)
+                .map(|m| m.remove(q).is_some())
+                .unwrap_or(false);
+            if !snap_existed {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{region}:{account_id_owned}:function:{function_name}:{q}"
+                    ),
+                ));
+            }
+            // Drop the version from the ordered list too so
+            // ListVersionsByFunction reflects the deletion.
+            if let Some(list) = state.function_versions.get_mut(function_name) {
+                list.retain(|v| v != q);
+            }
+            return Ok(AwsResponse::json(StatusCode::NO_CONTENT, ""));
+        }
+
         if state.functions.remove(function_name).is_none() {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
                 format!(
-                    "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                    region, account_id, function_name
+                    "Function not found: arn:aws:lambda:{region}:{account_id_owned}:function:{function_name}"
                 ),
             ));
         }
+        // Drop all numbered versions + their snapshots so the function
+        // is gone end-to-end (AWS deletes everything when no Qualifier
+        // is supplied).
+        state.function_versions.remove(function_name);
+        state.function_version_snapshots.remove(function_name);
+        // Aliases on this function disappear too.
+        let prefix = format!("{function_name}:");
+        state.aliases.retain(|k, _| !k.starts_with(&prefix));
 
         // Clean up any running container for this function
         if let Some(ref runtime) = self.runtime {
@@ -1493,12 +1556,39 @@ impl LambdaService {
             .get(function_name)
             .cloned()
             .unwrap_or_default();
-        let next: u64 = existing
-            .iter()
-            .filter_map(|v| v.parse::<u64>().ok())
-            .max()
-            .unwrap_or(0)
-            + 1;
+        let latest_version = existing.iter().filter_map(|v| v.parse::<u64>().ok()).max();
+
+        // PublishVersion is idempotent on AWS: if `$LATEST` hasn't
+        // changed since the most recent published version (same
+        // CodeSha256 and same Description, when none is overridden),
+        // return that existing snapshot instead of bumping the
+        // counter. This keeps deploy pipelines that re-publish on
+        // every CI run from leaking a fresh numbered version per
+        // build when the underlying artifact is identical.
+        if let Some(latest_num) = latest_version {
+            let latest_str = latest_num.to_string();
+            if let Some(prev_snap) = state
+                .function_version_snapshots
+                .get(function_name)
+                .and_then(|m| m.get(&latest_str))
+                .cloned()
+            {
+                let same_sha = prev_snap.code_sha256 == func.code_sha256;
+                let effective_desc = description_override
+                    .clone()
+                    .unwrap_or_else(|| func.description.clone());
+                let same_desc = prev_snap.description == effective_desc;
+                if same_sha && same_desc {
+                    let mut config = self.function_config_json(&prev_snap);
+                    config["Version"] = json!(latest_str);
+                    config["FunctionArn"] = json!(format!("{}:{latest_str}", func.function_arn));
+                    config["MasterArn"] = json!(func.function_arn);
+                    return Ok(AwsResponse::json(StatusCode::CREATED, config.to_string()));
+                }
+            }
+        }
+
+        let next: u64 = latest_version.unwrap_or(0) + 1;
         let next_str = next.to_string();
 
         // Snapshot the function config + code for the new immutable version.
@@ -1716,7 +1806,11 @@ impl AwsService for LambdaService {
                 req.region.as_str(),
                 req.query_params.get("Qualifier").map(String::as_str),
             ),
-            "DeleteFunction" => self.delete_function(resource_name.as_deref().unwrap_or(""), aid),
+            "DeleteFunction" => self.delete_function(
+                resource_name.as_deref().unwrap_or(""),
+                aid,
+                req.query_params.get("Qualifier").map(String::as_str),
+            ),
             "Invoke" => {
                 let invocation_type = InvocationType::from_header(
                     req.headers
@@ -1747,11 +1841,20 @@ impl AwsService for LambdaService {
                 self.publish_version(resource_name.as_deref().unwrap_or(""), aid, &req)
             }
             "AddPermission" => self.add_permission(resource_name.as_deref().unwrap_or(""), &req),
-            "GetPolicy" => self.get_policy(resource_name.as_deref().unwrap_or(""), aid),
+            "GetPolicy" => self.get_policy(
+                resource_name.as_deref().unwrap_or(""),
+                aid,
+                req.query_params.get("Qualifier").map(String::as_str),
+            ),
             "RemovePermission" => {
                 // Path: /2015-03-31/functions/{name}/policy/{sid}
                 let sid = req.path_segments.get(4).cloned().unwrap_or_default();
-                self.remove_permission(resource_name.as_deref().unwrap_or(""), &sid, aid)
+                self.remove_permission(
+                    resource_name.as_deref().unwrap_or(""),
+                    &sid,
+                    aid,
+                    req.query_params.get("Qualifier").map(String::as_str),
+                )
             }
             "CreateEventSourceMapping" => self.create_event_source_mapping(&req),
             "ListEventSourceMappings" => self.list_event_source_mappings(aid),

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -447,6 +447,52 @@ impl Drop for ConcurrencyGuard {
 /// `$LATEST`) to a concrete numeric version string. Aliases with a
 /// `RoutingConfig.AdditionalVersionWeights` table do a weighted pick
 /// across the alias's primary `function_version` plus the additional
+/// True when `prev` is byte-equivalent to `live` for every field
+/// that `PublishVersion` would otherwise capture into a new snapshot.
+/// Used to short-circuit a no-op publish (AWS-style idempotency:
+/// re-publishing without any change returns the previous version
+/// unchanged). The comparison spans code identity (sha + size),
+/// configuration (runtime/handler/role/timeout/memory/env/layers/...)
+/// and every advanced field round-tripped through
+/// `function_config_json`. The caller is responsible for resolving
+/// the `effective_description` (caller-supplied override wins over
+/// the live `$LATEST` description, matching real PublishVersion
+/// semantics).
+fn function_config_unchanged_for_publish(
+    prev: &LambdaFunction,
+    live: &LambdaFunction,
+    effective_description: &str,
+) -> bool {
+    prev.code_sha256 == live.code_sha256
+        && prev.code_size == live.code_size
+        && prev.image_uri == live.image_uri
+        && prev.package_type == live.package_type
+        && prev.runtime == live.runtime
+        && prev.role == live.role
+        && prev.handler == live.handler
+        && prev.description == effective_description
+        && prev.timeout == live.timeout
+        && prev.memory_size == live.memory_size
+        && prev.environment == live.environment
+        && prev.architectures == live.architectures
+        && prev.layers.len() == live.layers.len()
+        && prev
+            .layers
+            .iter()
+            .zip(live.layers.iter())
+            .all(|(a, b)| a.arn == b.arn && a.code_size == b.code_size)
+        && prev.tracing_mode == live.tracing_mode
+        && prev.kms_key_arn == live.kms_key_arn
+        && prev.ephemeral_storage_size == live.ephemeral_storage_size
+        && prev.vpc_config == live.vpc_config
+        && prev.dead_letter_config_arn == live.dead_letter_config_arn
+        && prev.file_system_configs == live.file_system_configs
+        && prev.logging_config == live.logging_config
+        && prev.image_config == live.image_config
+        && prev.signing_profile_version_arn == live.signing_profile_version_arn
+        && prev.signing_job_arn == live.signing_job_arn
+}
+
 /// versions in the weight map. Returns `None` for `$LATEST` /
 /// unqualified invokes (caller uses the live `$LATEST` config).
 pub(crate) fn resolve_qualifier_to_version(
@@ -1559,12 +1605,17 @@ impl LambdaService {
         let latest_version = existing.iter().filter_map(|v| v.parse::<u64>().ok()).max();
 
         // PublishVersion is idempotent on AWS: if `$LATEST` hasn't
-        // changed since the most recent published version (same
-        // CodeSha256 and same Description, when none is overridden),
-        // return that existing snapshot instead of bumping the
-        // counter. This keeps deploy pipelines that re-publish on
-        // every CI run from leaking a fresh numbered version per
-        // build when the underlying artifact is identical.
+        // changed since the most recent published version, return that
+        // existing snapshot instead of bumping the counter. We compare
+        // every field that PublishVersion would otherwise carry into
+        // the new snapshot — code identity, description, runtime,
+        // handler, role, env, memory/timeout, layers, image config,
+        // VPC, EFS, logging, tracing, kms, ephemeral storage — so a
+        // config-only change (e.g. UpdateFunctionConfiguration bumping
+        // memory) still produces a fresh version. This keeps deploy
+        // pipelines that re-publish on every CI run from leaking a
+        // fresh numbered version per build when the underlying
+        // artifact + config are identical.
         if let Some(latest_num) = latest_version {
             let latest_str = latest_num.to_string();
             if let Some(prev_snap) = state
@@ -1573,12 +1624,10 @@ impl LambdaService {
                 .and_then(|m| m.get(&latest_str))
                 .cloned()
             {
-                let same_sha = prev_snap.code_sha256 == func.code_sha256;
                 let effective_desc = description_override
                     .clone()
                     .unwrap_or_else(|| func.description.clone());
-                let same_desc = prev_snap.description == effective_desc;
-                if same_sha && same_desc {
+                if function_config_unchanged_for_publish(&prev_snap, func, &effective_desc) {
                     let mut config = self.function_config_json(&prev_snap);
                     config["Version"] = json!(latest_str);
                     config["FunctionArn"] = json!(format!("{}:{latest_str}", func.function_arn));

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -492,7 +492,27 @@ fn function_config_unchanged_for_publish(
         && prev.signing_profile_version_arn == live.signing_profile_version_arn
         && prev.signing_job_arn == live.signing_job_arn
         && prev.runtime_version_config == live.runtime_version_config
-        && prev.snap_start == live.snap_start
+        && snap_start_apply_on_eq(prev.snap_start.as_ref(), live.snap_start.as_ref())
+}
+
+/// Compare two `SnapStart` configs by `ApplyOn` only — that's the
+/// caller-supplied knob. `OptimizationStatus` is server-side state
+/// that PublishVersion mutates on snapshots (flipping to "On" when
+/// ApplyOn=PublishedVersions) while $LATEST stays "Off", so a deep
+/// equality check here would never match on a SnapStart-enabled
+/// function and PublishVersion would never be idempotent. Treating
+/// `None` and `{ApplyOn:"None"}` as equivalent matches AWS, which
+/// emits the latter when the field is unset.
+fn snap_start_apply_on_eq(prev: Option<&Value>, live: Option<&Value>) -> bool {
+    let prev_apply = prev
+        .and_then(|v| v.get("ApplyOn"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("None");
+    let live_apply = live
+        .and_then(|v| v.get("ApplyOn"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("None");
+    prev_apply == live_apply
 }
 
 /// versions in the weight map. Returns `None` for `$LATEST` /

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -491,6 +491,8 @@ fn function_config_unchanged_for_publish(
         && prev.image_config == live.image_config
         && prev.signing_profile_version_arn == live.signing_profile_version_arn
         && prev.signing_job_arn == live.signing_job_arn
+        && prev.runtime_version_config == live.runtime_version_config
+        && prev.snap_start == live.snap_start
 }
 
 /// versions in the weight map. Returns `None` for `$LATEST` /

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -153,13 +153,13 @@ impl LambdaService {
         // unqualified, alias-name for an alias qualifier. AWS clients
         // that read back the policy via GetPolicy expect this exact
         // shape so IAM-level evaluators can match the principal's
-        // request resource.
+        // request resource. `func.function_arn` is always the bare ARN
+        // (snapshots clone the live arn without a suffix), so a plain
+        // concat is correct — `trim_end_matches` would over-strip on
+        // pathological function names like "v1" plus qualifier "1".
         let resource_arn = match qualifier.as_deref() {
             None | Some("$LATEST") => func.function_arn.clone(),
-            Some(q) => format!(
-                "{}:{q}",
-                func.function_arn.trim_end_matches(&format!(":{q}"))
-            ),
+            Some(q) => format!("{}:{q}", func.function_arn),
         };
 
         let mut new_statement = serde_json::Map::new();

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -70,15 +70,15 @@ impl LambdaService {
             .and_then(|v| v.as_str())
             .map(str::to_string);
 
+        // `Qualifier` scopes the policy to a specific numbered version
+        // snapshot. AWS keeps a separate resource policy per qualifier
+        // (so a v1 policy doesn't leak to $LATEST or to v2). Aliases
+        // and `$LATEST` map back to the live function record's policy.
+        let qualifier = req.query_params.get("Qualifier").cloned();
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let func = state.functions.get_mut(function_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFoundException",
-                format!("Function not found: {function_name}"),
-            )
-        })?;
+        let func = resolve_policy_target_mut(state, function_name, qualifier.as_deref())?;
 
         // Load current policy or seed a fresh canonical doc. Any
         // stored blob that doesn't parse as a JSON object is treated
@@ -148,12 +148,26 @@ impl LambdaService {
         // `lambda:s3:PutObject` double-prefix). Cross-service evaluator
         // paths that want a `service:verb` form should already pass
         // the qualified name; we don't second-guess them here.
+        // Resource ARN matches the qualifier the policy is scoped to:
+        // `:1` for a numbered version, plain ARN for `$LATEST` or
+        // unqualified, alias-name for an alias qualifier. AWS clients
+        // that read back the policy via GetPolicy expect this exact
+        // shape so IAM-level evaluators can match the principal's
+        // request resource.
+        let resource_arn = match qualifier.as_deref() {
+            None | Some("$LATEST") => func.function_arn.clone(),
+            Some(q) => format!(
+                "{}:{q}",
+                func.function_arn.trim_end_matches(&format!(":{q}"))
+            ),
+        };
+
         let mut new_statement = serde_json::Map::new();
         new_statement.insert("Sid".to_string(), json!(statement_id));
         new_statement.insert("Effect".to_string(), json!("Allow"));
         new_statement.insert("Principal".to_string(), principal_value);
         new_statement.insert("Action".to_string(), json!(action));
-        new_statement.insert("Resource".to_string(), json!(func.function_arn));
+        new_statement.insert("Resource".to_string(), json!(resource_arn));
         if !condition.is_empty() {
             new_statement.insert("Condition".to_string(), Value::Object(condition));
         }
@@ -173,16 +187,11 @@ impl LambdaService {
         function_name: &str,
         statement_id: &str,
         account_id: &str,
+        qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
-        let func = state.functions.get_mut(function_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFoundException",
-                format!("Function not found: {function_name}"),
-            )
-        })?;
+        let func = resolve_policy_target_mut(state, function_name, qualifier)?;
         let policy_str = func.policy.as_deref().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -227,17 +236,12 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let accounts = self.state.read();
         let empty = LambdaState::new(account_id, "");
         let state = accounts.get(account_id).unwrap_or(&empty);
-        let func = state.functions.get(function_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFoundException",
-                format!("Function not found: {function_name}"),
-            )
-        })?;
+        let func = resolve_policy_target_ref(state, function_name, qualifier)?;
         let policy = func.policy.as_deref().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -249,9 +253,86 @@ impl LambdaService {
             StatusCode::OK,
             json!({
                 "Policy": policy,
-                "RevisionId": uuid::Uuid::new_v4().to_string(),
+                "RevisionId": func.revision_id.clone(),
             })
             .to_string(),
         ))
+    }
+}
+
+/// Mutable lookup for the LambdaFunction record that owns the
+/// resource policy for `(function_name, qualifier)`. When the
+/// qualifier is a numeric version, the policy lives on the
+/// immutable snapshot in `function_version_snapshots`. Aliases
+/// resolve to the version they point at; missing aliases / versions
+/// 404 with `ResourceNotFoundException`. `$LATEST` and unqualified
+/// requests target the live `functions` map.
+fn resolve_policy_target_mut<'a>(
+    state: &'a mut crate::state::LambdaState,
+    function_name: &str,
+    qualifier: Option<&str>,
+) -> Result<&'a mut crate::state::LambdaFunction, AwsServiceError> {
+    let resolved_version =
+        crate::service::resolve_qualifier_to_version(state, function_name, qualifier);
+    let region = state.region.clone();
+    let account_id = state.account_id.clone();
+    match resolved_version {
+        None => state.functions.get_mut(function_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!(
+                    "Function not found: arn:aws:lambda:{region}:{account_id}:function:{function_name}"
+                ),
+            )
+        }),
+        Some(v) => state
+            .function_version_snapshots
+            .get_mut(function_name)
+            .and_then(|m| m.get_mut(&v))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{region}:{account_id}:function:{function_name}:{v}"
+                    ),
+                )
+            }),
+    }
+}
+
+fn resolve_policy_target_ref<'a>(
+    state: &'a crate::state::LambdaState,
+    function_name: &str,
+    qualifier: Option<&str>,
+) -> Result<&'a crate::state::LambdaFunction, AwsServiceError> {
+    let resolved_version =
+        crate::service::resolve_qualifier_to_version(state, function_name, qualifier);
+    match resolved_version {
+        None => state.functions.get(function_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFoundException",
+                format!(
+                    "Function not found: arn:aws:lambda:{}:{}:function:{}",
+                    state.region, state.account_id, function_name
+                ),
+            )
+        }),
+        Some(v) => state
+            .function_version_snapshots
+            .get(function_name)
+            .and_then(|m| m.get(&v))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{}:{}:function:{}:{v}",
+                        state.region, state.account_id, function_name
+                    ),
+                )
+            }),
     }
 }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1732,6 +1732,36 @@ async fn publish_version_idempotent_when_latest_unchanged() {
 }
 
 #[tokio::test]
+async fn publish_version_creates_new_version_on_config_only_change() {
+    // PublishVersion idempotency must not collapse a config-only
+    // change (memory, env, etc.) to the previous snapshot — AWS
+    // produces a new numbered version when any field that the
+    // snapshot captures has moved, even if CodeSha256 is unchanged.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "cfg-fn").await;
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/cfg-fn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v1["Version"], "1");
+
+    // Bump MemorySize via UpdateFunctionConfiguration (no code change).
+    let body = json!({ "MemorySize": 256 });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/cfg-fn/configuration",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/cfg-fn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v2["Version"], "2");
+    assert_eq!(v2["MemorySize"].as_i64().unwrap(), 256);
+}
+
+#[tokio::test]
 async fn publish_version_snapshots_code_immutable() {
     let svc = LambdaService::new(make_state());
     seed_function(&svc, "pv3").await;

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1125,7 +1125,7 @@ async fn get_function_unknown_errors() {
 #[tokio::test]
 async fn delete_function_unknown_errors() {
     let svc = LambdaService::new(make_state());
-    assert!(svc.delete_function("ghost", "123456789012").is_err());
+    assert!(svc.delete_function("ghost", "123456789012", None).is_err());
 }
 
 #[tokio::test]
@@ -1692,10 +1692,43 @@ async fn publish_version_increments_per_function_counter() {
     let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(v1["Version"], "1");
 
+    // Mutate $LATEST so the next PublishVersion isn't a no-op idempotent
+    // re-publish — AWS returns the previous version when nothing changed.
+    let new_zip_b64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"diff-bytes");
+    let body = json!({ "ZipFile": new_zip_b64 });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/pv2/code",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
     let req = make_request(Method::POST, "/2015-03-31/functions/pv2/versions", "{}");
     let resp = svc.handle(req).await.unwrap();
     let v2: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(v2["Version"], "2");
+}
+
+#[tokio::test]
+async fn publish_version_idempotent_when_latest_unchanged() {
+    // AWS PublishVersion returns the existing latest version when
+    // $LATEST hasn't changed since the previous publish.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "idem").await;
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/idem/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v1["Version"], "1");
+    let v1_revision = v1["RevisionId"].as_str().unwrap().to_string();
+
+    // No mutation in between; second publish is a no-op that returns v1.
+    let req = make_request(Method::POST, "/2015-03-31/functions/idem/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let again: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(again["Version"], "1");
+    assert_eq!(again["RevisionId"].as_str().unwrap(), v1_revision);
 }
 
 #[tokio::test]
@@ -1742,10 +1775,21 @@ async fn list_versions_by_function_returns_all_plus_latest() {
     let svc = LambdaService::new(make_state());
     seed_function(&svc, "pv4").await;
 
-    for _ in 0..2 {
-        let req = make_request(Method::POST, "/2015-03-31/functions/pv4/versions", "{}");
-        svc.handle(req).await.unwrap();
-    }
+    // Two distinct publishes need a $LATEST mutation in between; AWS
+    // PublishVersion is idempotent when nothing has changed.
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv4/versions", "{}");
+    svc.handle(req).await.unwrap();
+    let new_zip_b64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"v2-bytes");
+    let body = json!({ "ZipFile": new_zip_b64 });
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/pv4/code",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+    let req = make_request(Method::POST, "/2015-03-31/functions/pv4/versions", "{}");
+    svc.handle(req).await.unwrap();
 
     let req = make_request(Method::GET, "/2015-03-31/functions/pv4/versions", "");
     let resp = svc.handle(req).await.unwrap();

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1732,6 +1732,39 @@ async fn publish_version_idempotent_when_latest_unchanged() {
 }
 
 #[tokio::test]
+async fn publish_version_idempotent_with_snap_start_published_versions() {
+    // PublishVersion mutates OptimizationStatus="On" on the snapshot
+    // when SnapStart.ApplyOn=PublishedVersions, while $LATEST keeps
+    // "Off". A naive deep-equality on snap_start would treat that
+    // post-publish $LATEST -> snapshot delta as a real change, minting
+    // a fresh version on every redundant call. The fix is to compare
+    // ApplyOn only, since that's the caller-controlled field.
+    let svc = LambdaService::new(make_state());
+    let body = json!({
+        "FunctionName": "snap-fn",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/r",
+        "Handler": "index.handler",
+        "Code": {},
+        "SnapStart": { "ApplyOn": "PublishedVersions" }
+    });
+    let req = make_request(Method::POST, "/2015-03-31/functions", &body.to_string());
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::POST, "/2015-03-31/functions/snap-fn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let v1: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v1["Version"], "1");
+
+    // Re-publish with no changes -> still v1 (idempotent), even
+    // though the snapshot had OptimizationStatus flipped to "On".
+    let req = make_request(Method::POST, "/2015-03-31/functions/snap-fn/versions", "{}");
+    let resp = svc.handle(req).await.unwrap();
+    let again: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(again["Version"], "1");
+}
+
+#[tokio::test]
 async fn publish_version_creates_new_version_on_config_only_change() {
     // PublishVersion idempotency must not collapse a config-only
     // change (memory, env, etc.) to the previous snapshot — AWS


### PR DESCRIPTION
## Summary

- PublishVersion is idempotent when \$LATEST hasn't changed since the previous publish (same CodeSha256 + Description); returns the existing numbered snapshot instead of bumping the counter, matching AWS.
- DeleteFunction honors Qualifier=N: drops only that version snapshot and leaves \$LATEST + other versions intact. Without Qualifier the whole function (and its versions/aliases) goes away. Rejects Qualifier=\$LATEST and non-numeric values with InvalidParameterValueException.
- AddPermission / RemovePermission / GetPolicy honor Qualifier, so each version snapshot has its own resource policy. Statement Resource ARN ends in :N when scoped to a numbered version. GetPolicy now returns the function's real RevisionId.
- ListVersionsByFunction already returned full FunctionConfiguration per version; now exercised end-to-end through aws-sdk-lambda.

## Test plan

- [x] cargo build -p fakecloud-lambda
- [x] cargo test -p fakecloud-lambda (127 unit tests, all green)
- [x] cargo test -p fakecloud-e2e --test lambda --test lambda_persistence (12 + 2, all green)
- [x] cargo clippy -p fakecloud-lambda -p fakecloud-e2e --all-targets -- -D warnings (clean)
- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
- [x] cargo fmt --all
- [x] New e2e: lambda_publish_version_snapshots_and_lists exercises Create -> Publish -> snapshot immutability -> idempotent re-publish -> stale CodeSha256 -> v2 -> ListVersionsByFunction (full configs) -> DeleteFunction(Qualifier) -> DeleteFunction (whole).
- [x] New e2e: lambda_alias_targets_published_version_snapshot verifies alias -> version snapshot resolution survives \$LATEST rewrites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real Lambda version snapshots with AWS-accurate behavior. PublishVersion idempotency compares the full snapshot and is SnapStart-aware; per-version policies, scoped deletes, and ListVersionsByFunction behave like AWS.

- **New Features**
  - PublishVersion is idempotent when $LATEST matches the last published snapshot across code and config; config-only changes mint a new version.
  - DeleteFunction honors Qualifier=N to delete only that version; rejects Qualifier=$LATEST and non-numeric; no Qualifier deletes the function, its versions, and aliases.
  - AddPermission, RemovePermission, and GetPolicy respect Qualifier; each version snapshot has its own policy. Statement Resource ARN includes :N for numbered versions. GetPolicy returns the function’s real RevisionId.
  - ListVersionsByFunction returns $LATEST and numbered versions as full FunctionConfiguration, exercised end-to-end via `aws_sdk_lambda`.

- **Bug Fixes**
  - PublishVersion idempotency now compares all snapshot fields (including runtime version config) and handles SnapStart correctly by comparing ApplyOn only and treating None/"None" as equivalent, preventing redundant version bumps when ApplyOn=PublishedVersions.
  - Fixed policy Resource ARN concatenation to avoid over-stripping while preserving the :N suffix for version-scoped policies.

<sup>Written for commit 89275fd2eaebbe3e0379a6357d5dd183e1ac1c7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

