### PR TITLE
feat(iam): trust policy enforcement on AssumeRole/SAML/WebIdentity (F1)

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -3086,6 +3086,58 @@ async fn sts_assume_role_with_web_identity_rejects_unknown_audience() {
 }
 
 #[tokio::test]
+async fn sts_assume_role_with_web_identity_accepts_array_audience() {
+    // RFC 7519 §4.1.3: JWT `aud` may be a JSON array. Real Google /
+    // Auth0 / Cognito tokens use the array form. The audience check
+    // must accept any entry that's in the provider's client_id_list.
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    iam.create_open_id_connect_provider()
+        .url("https://accounts.google.com")
+        .client_id_list("primary-client-id")
+        .thumbprint_list("0".repeat(40))
+        .send()
+        .await
+        .unwrap();
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{
+        "Effect":"Allow",
+        "Principal":{"Federated":"arn:aws:iam::123456789012:oidc-provider/accounts.google.com"},
+        "Action":"sts:AssumeRoleWithWebIdentity"
+    }]}"#;
+    iam.create_role()
+        .role_name("oidc-array-aud-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+
+    use base64::Engine;
+    let header =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        br#"{"iss":"https://accounts.google.com","aud":["other-client","primary-client-id"],"sub":"u1"}"#,
+    );
+    let token = format!("{header}.{payload}.");
+
+    let resp = sts
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/oidc-array-aud-role")
+        .role_session_name("array-aud")
+        .web_identity_token(&token)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .credentials()
+        .unwrap()
+        .access_key_id()
+        .starts_with("FSIA"));
+}
+
+#[tokio::test]
 async fn sts_assume_role_with_web_identity_succeeds_when_iss_aud_match() {
     // F1: with a registered OIDC provider whose client_id_list contains
     // the JWT `aud`, AssumeRoleWithWebIdentity must succeed and the

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -2830,3 +2830,310 @@ async fn iam_get_access_key_last_used() {
     let json = output.stdout_json();
     assert_eq!(json["UserName"], "lastused-user");
 }
+
+// ─── F1: STS trust-policy enforcement ──────────────────────────────────
+//
+// AWS gates AssumeRole / AssumeRoleWithSAML / AssumeRoleWithWebIdentity
+// behind the role's trust policy. These tests pin the new behavior end
+// to end against a running fakecloud server: a Deny in the trust policy
+// must turn into AccessDenied, ExternalId / MFA conditions must be
+// enforced, service-linked roles refuse non-service callers, and the
+// federated entry points reject mis-issued tokens.
+
+#[tokio::test]
+async fn sts_assume_role_trust_policy_explicit_deny_returns_access_denied() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    // Trust policy denies everyone explicitly — Deny must beat the
+    // earlier Allow regardless of who calls.
+    let trust = r#"{"Version":"2012-10-17","Statement":[
+        {"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"},
+        {"Effect":"Deny","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}
+    ]}"#;
+    let role = iam
+        .create_role()
+        .role_name("trust-deny-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+    let role_arn = role.role().unwrap().arn().to_string();
+
+    let err = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("denied")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDenied"),
+        "expected AccessDenied for explicit-deny trust policy, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sts_assume_role_trust_policy_external_id_required() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{
+        "Effect":"Allow",
+        "Principal":{"AWS":"*"},
+        "Action":"sts:AssumeRole",
+        "Condition":{"StringEquals":{"sts:ExternalId":"shared-secret"}}
+    }]}"#;
+    let role = iam
+        .create_role()
+        .role_name("ext-id-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+    let role_arn = role.role().unwrap().arn().to_string();
+
+    // Missing ExternalId -> denied.
+    let err = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("missing-eid")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDenied"));
+
+    // Wrong ExternalId -> denied.
+    let err = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("wrong-eid")
+        .external_id("nope")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDenied"));
+
+    // Correct ExternalId -> allowed.
+    let resp = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("ok-eid")
+        .external_id("shared-secret")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .credentials()
+        .unwrap()
+        .access_key_id()
+        .starts_with("FSIA"));
+}
+
+#[tokio::test]
+async fn sts_assume_role_trust_policy_mfa_required() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{
+        "Effect":"Allow",
+        "Principal":{"AWS":"*"},
+        "Action":"sts:AssumeRole",
+        "Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}
+    }]}"#;
+    let role = iam
+        .create_role()
+        .role_name("mfa-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+    let role_arn = role.role().unwrap().arn().to_string();
+
+    // No MFA -> denied.
+    let err = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("no-mfa")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("AccessDenied"));
+
+    // MFA supplied -> allowed.
+    let resp = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("with-mfa")
+        .serial_number("arn:aws:iam::123456789012:mfa/admin")
+        .token_code("123456")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .credentials()
+        .unwrap()
+        .access_key_id()
+        .starts_with("FSIA"));
+}
+
+#[tokio::test]
+async fn sts_assume_role_service_linked_role_blocks_non_service_caller() {
+    // Service-linked roles (path /aws-service-role/<service>/...) are
+    // only assumable by the matching service; a generic caller must
+    // get AccessDenied even with a permissive trust policy.
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{
+        "Effect":"Allow","Principal":{"Service":"ecs.amazonaws.com"},
+        "Action":"sts:AssumeRole"
+    }]}"#;
+    let role = iam
+        .create_role()
+        .role_name("AWSServiceRoleForECS")
+        .path("/aws-service-role/ecs.amazonaws.com/")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+    let role_arn = role.role().unwrap().arn().to_string();
+
+    let err = sts
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("not-ecs")
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDenied"),
+        "service-linked role must reject non-service caller, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sts_assume_role_with_web_identity_rejects_unregistered_issuer() {
+    // F1: a JWT whose `iss` doesn't map to any registered
+    // OpenIDConnectProvider must be rejected with InvalidIdentityToken.
+    let server = TestServer::start().await;
+    let sts = server.sts_client().await;
+
+    use base64::Engine;
+    let header =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(br#"{"iss":"https://unknown-issuer.example.com","aud":"my-app","sub":"user-1"}"#);
+    let token = format!("{header}.{payload}.");
+
+    let err = sts
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/oidc-role")
+        .role_session_name("oidc")
+        .web_identity_token(&token)
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidIdentityToken"),
+        "unregistered issuer must error InvalidIdentityToken, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sts_assume_role_with_web_identity_rejects_unknown_audience() {
+    // F1: even with a registered OIDC provider, the JWT's `aud` claim
+    // must be in the provider's client_id_list, otherwise reject.
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    iam.create_open_id_connect_provider()
+        .url("https://accounts.google.com")
+        .client_id_list("known-client-id")
+        .thumbprint_list("0".repeat(40))
+        .send()
+        .await
+        .unwrap();
+
+    use base64::Engine;
+    let header =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(br#"{"iss":"https://accounts.google.com","aud":"wrong-aud","sub":"u1"}"#);
+    let token = format!("{header}.{payload}.");
+
+    let err = sts
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/oidc-role")
+        .role_session_name("oidc")
+        .web_identity_token(&token)
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidIdentityToken"),
+        "audience mismatch must error InvalidIdentityToken, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn sts_assume_role_with_web_identity_succeeds_when_iss_aud_match() {
+    // F1: with a registered OIDC provider whose client_id_list contains
+    // the JWT `aud`, AssumeRoleWithWebIdentity must succeed and the
+    // returned creds must trace back to a federated session.
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+    let sts = server.sts_client().await;
+
+    iam.create_open_id_connect_provider()
+        .url("https://accounts.google.com")
+        .client_id_list("my-app-id")
+        .thumbprint_list("0".repeat(40))
+        .send()
+        .await
+        .unwrap();
+
+    let trust = r#"{"Version":"2012-10-17","Statement":[{
+        "Effect":"Allow",
+        "Principal":{"Federated":"arn:aws:iam::123456789012:oidc-provider/accounts.google.com"},
+        "Action":"sts:AssumeRoleWithWebIdentity",
+        "Condition":{"StringEquals":{"accounts.google.com:aud":"my-app-id"}}
+    }]}"#;
+    iam.create_role()
+        .role_name("oidc-role")
+        .assume_role_policy_document(trust)
+        .send()
+        .await
+        .unwrap();
+
+    use base64::Engine;
+    let header =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        br#"{"iss":"https://accounts.google.com","aud":"my-app-id","sub":"google-user-7"}"#,
+    );
+    let token = format!("{header}.{payload}.");
+
+    let resp = sts
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/oidc-role")
+        .role_session_name("oidc-sess")
+        .web_identity_token(&token)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .credentials()
+        .unwrap()
+        .access_key_id()
+        .starts_with("FSIA"));
+}

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -157,6 +157,14 @@ pub(crate) enum PrincipalRef {
     /// including the service host, matching how AWS builds
     /// service-linked role ARNs).
     Service(String),
+    /// `"Principal": {"Federated": "arn:aws:iam::ACCOUNT:saml-provider/Idp"}`
+    /// or `{"Federated": "accounts.google.com"}` /
+    /// `{"Federated": "cognito-identity.amazonaws.com"}`. Matches a
+    /// federated principal whose ARN equals the named SAML/OIDC
+    /// provider — STS sets the principal ARN to the provider when
+    /// minting the trust-policy evaluation request for
+    /// AssumeRoleWithSAML / AssumeRoleWithWebIdentity.
+    Federated(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -309,6 +317,11 @@ fn parse_principal(value: &Value) -> Vec<PrincipalRef> {
                     "Service" => {
                         for s in coerce_string_list(v) {
                             out.push(PrincipalRef::Service(s));
+                        }
+                    }
+                    "Federated" => {
+                        for s in coerce_string_list(v) {
+                            out.push(PrincipalRef::Federated(s));
                         }
                     }
                     other => {
@@ -741,7 +754,18 @@ fn principal_matches(refs: &[PrincipalRef], principal: &Principal) -> bool {
         PrincipalRef::AwsAccountRoot(account) => &principal.account_id == account,
         PrincipalRef::AwsArn(arn) => &principal.arn == arn,
         PrincipalRef::Service(service) => principal_is_service(principal, service),
+        PrincipalRef::Federated(provider) => principal_is_federated(principal, provider),
     })
+}
+
+/// Match a `"Federated"` principal. STS injects the federated provider
+/// (SAML provider ARN, OIDC issuer URL, or `cognito-identity.amazonaws.com`)
+/// as the principal ARN when evaluating trust policies for
+/// `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity`. We require the
+/// principal to be of type `FederatedUser` and its ARN to equal the
+/// provider — never silently grant.
+fn principal_is_federated(principal: &Principal, provider: &str) -> bool {
+    matches!(principal.principal_type, PrincipalType::FederatedUser) && principal.arn == provider
 }
 
 /// Approximate match for a `"Service"` principal. AWS represents a

--- a/crates/fakecloud-iam/src/evaluator_tests.rs
+++ b/crates/fakecloud-iam/src/evaluator_tests.rs
@@ -1229,8 +1229,30 @@ fn not_principal_with_account_root() {
 
 #[test]
 fn not_principal_with_unrecognized_type_safe_skips() {
-    // NotPrincipal with only Federated type (unrecognized) ->
-    // empty refs list -> statement skipped safely.
+    // NotPrincipal with only CanonicalUser (still unrecognized) ->
+    // empty refs list -> statement skipped safely. Federated is now
+    // recognized (F1) so we use CanonicalUser to keep covering the
+    // safe-skip path.
+    let alice = principal_in(ACCT_A, "alice");
+    let resource = json!({
+        "Statement": [{
+            "Effect": "Allow",
+            "NotPrincipal": {"CanonicalUser": "abc123"},
+            "Action": "s3:GetObject",
+            "Resource": "*"
+        }]
+    });
+    assert_eq!(
+        eval_cross(None, Some(resource), &alice, ACCT_A),
+        Decision::ImplicitDeny
+    );
+}
+
+#[test]
+fn not_principal_federated_excludes_federated_callers() {
+    // F1: NotPrincipal with Federated now actually filters federated
+    // callers. A non-federated caller (alice) doesn't match the
+    // federated entry, so the statement applies and the Allow fires.
     let alice = principal_in(ACCT_A, "alice");
     let resource = json!({
         "Statement": [{
@@ -1242,7 +1264,7 @@ fn not_principal_with_unrecognized_type_safe_skips() {
     });
     assert_eq!(
         eval_cross(None, Some(resource), &alice, ACCT_A),
-        Decision::ImplicitDeny
+        Decision::Allow
     );
 }
 

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -671,24 +671,28 @@ impl StsService {
                         format!("No OpenIDConnect provider found in your account for issuer {iss}"),
                     ));
                 }
-                // Audience must be in the provider's client_id_list when
-                // the provider has any client IDs configured. Empty
-                // list means "accept any aud" (matches AWS for
-                // legacy/uninitialized providers).
+                // Audience must overlap with the provider's
+                // client_id_list when the provider has any client IDs
+                // configured. Empty list means "accept any aud"
+                // (matches AWS for legacy/uninitialized providers).
+                // Tokens carry every audience claim the IdP issued the
+                // assertion to (RFC 7519 array form), so any one
+                // matching client_id_list entry is enough.
                 if let Some((ref _iss, ref provider)) = oidc_match {
                     if !provider.client_id_list.is_empty() {
-                        match claims.aud.as_deref() {
-                            Some(aud) if provider.client_id_list.iter().any(|c| c == aud) => {}
-                            _ => {
-                                return Err(AwsServiceError::aws_error(
-                                    StatusCode::BAD_REQUEST,
-                                    "InvalidIdentityToken",
-                                    format!(
-                                        "Incorrect token audience: not in client_id_list for provider {}",
-                                        provider.arn
-                                    ),
-                                ));
-                            }
+                        let any_match = claims
+                            .aud
+                            .iter()
+                            .any(|aud| provider.client_id_list.iter().any(|c| c == aud));
+                        if !any_match {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "InvalidIdentityToken",
+                                format!(
+                                    "Incorrect token audience: not in client_id_list for provider {}",
+                                    provider.arn
+                                ),
+                            ));
                         }
                     }
                 }
@@ -733,10 +737,14 @@ impl StsService {
                 .or_else(|| provider_id_param.as_deref().map(normalize_issuer));
             if let Some(prefix) = key_prefix {
                 if let Some(ref claims) = jwt {
-                    if let Some(ref aud) = claims.aud {
+                    if !claims.aud.is_empty() {
+                        // `aud` is multi-valued (RFC 7519); surface
+                        // every audience so a `StringEquals` /
+                        // `ForAnyValue:StringEquals` condition matches
+                        // whichever entry the policy names.
                         context
                             .service_keys
-                            .insert(format!("{prefix}:aud"), vec![aud.clone()]);
+                            .insert(format!("{prefix}:aud"), claims.aud.clone());
                     }
                     if let Some(ref sub) = claims.sub {
                         context
@@ -1464,7 +1472,11 @@ fn extract_xml_text_after(xml: &str, local_name: &str) -> Option<String> {
 #[derive(Debug, Clone, Default)]
 struct JwtClaims {
     iss: Option<String>,
-    aud: Option<String>,
+    /// `aud` per RFC 7519 §4.1.3 may be either a single string or a JSON
+    /// array of strings. Real-world IdPs (Google, Auth0, Cognito) all
+    /// emit the array form regularly, so we carry every entry and
+    /// match against any of them when validating.
+    aud: Vec<String>,
     sub: Option<String>,
     raw: serde_json::Map<String, serde_json::Value>,
 }
@@ -1486,9 +1498,20 @@ fn decode_jwt(token: &str) -> Option<JwtClaims> {
     let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     let map = json.as_object()?.clone();
     let str_field = |k: &str| map.get(k).and_then(|v| v.as_str()).map(|s| s.to_string());
+    // RFC 7519 §4.1.3: `aud` is either a string or a JSON array of
+    // strings. Accept both shapes — Google, Auth0, and Cognito all
+    // emit the array form.
+    let aud = match map.get("aud") {
+        Some(serde_json::Value::String(s)) => vec![s.clone()],
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        _ => Vec::new(),
+    };
     Some(JwtClaims {
         iss: str_field("iss"),
-        aud: str_field("aud"),
+        aud,
         sub: str_field("sub"),
         raw: map,
     })

--- a/crates/fakecloud-iam/src/sts_service.rs
+++ b/crates/fakecloud-iam/src/sts_service.rs
@@ -466,6 +466,15 @@ impl StsService {
                     .service_keys
                     .insert("sts:sourceidentity".to_string(), vec![src.clone()]);
             }
+            // `aws:SourceAccount` — the calling account (cross-account
+            // confused-deputy guard). Trust policies on third-party-
+            // hosted roles commonly gate on this so a service running
+            // in a tenant account can't impersonate the integration
+            // owner.
+            context.service_keys.insert(
+                "aws:sourceaccount".to_string(),
+                vec![caller_principal.account_id.clone()],
+            );
 
             let eval_req = EvalRequest {
                 principal: &caller_principal,
@@ -576,7 +585,7 @@ impl StsService {
             )
         })?;
         validate_string_length("webIdentityToken", web_identity_token, 4, 20000)?;
-        let _web_identity_token = web_identity_token.clone();
+        let web_identity_token_owned = web_identity_token.clone();
 
         // Validate optional Policy
         validate_optional_string_length(
@@ -631,6 +640,137 @@ impl StsService {
         );
         let assumed_role_id_str = format!("{}:{}", role_id, role_session_name);
 
+        // Decode the JWT for trust-policy enforcement and to figure out
+        // which OIDC provider vouched for the assertion. We never verify
+        // signatures — fakecloud is not a security boundary — but we
+        // require enough structure to extract `iss` and `aud` so the
+        // trust policy gate can fire on real AWS-shaped policies.
+        let jwt = decode_jwt(&web_identity_token_owned);
+
+        // Pick the federated provider ARN. Preference order:
+        //   1. JWT iss matched against a registered OpenIDConnectProvider —
+        //      we use the provider's stored ARN.
+        //   2. Caller-supplied ProviderId param (legacy IdP host name).
+        //   3. Synthetic placeholder so policies that just check for "any
+        //      federated session" still bind. This branch only fires for
+        //      tokens that aren't real JWTs — real OIDC clients hit (1).
+        let provider_id_param = req.query_params.get("ProviderId").cloned();
+        let oidc_match = jwt.as_ref().and_then(|c| c.iss.as_deref()).and_then(|iss| {
+            find_oidc_provider(&accounts, iss).map(|(_, p)| (iss.to_string(), p.clone()))
+        });
+
+        // If we have a JWT with an `iss` claim, the issuer MUST resolve
+        // to a registered OIDC provider — anything else is a federation
+        // misconfiguration and AWS rejects with InvalidIdentityToken.
+        if let Some(ref claims) = jwt {
+            if let Some(ref iss) = claims.iss {
+                if oidc_match.is_none() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidIdentityToken",
+                        format!("No OpenIDConnect provider found in your account for issuer {iss}"),
+                    ));
+                }
+                // Audience must be in the provider's client_id_list when
+                // the provider has any client IDs configured. Empty
+                // list means "accept any aud" (matches AWS for
+                // legacy/uninitialized providers).
+                if let Some((ref _iss, ref provider)) = oidc_match {
+                    if !provider.client_id_list.is_empty() {
+                        match claims.aud.as_deref() {
+                            Some(aud) if provider.client_id_list.iter().any(|c| c == aud) => {}
+                            _ => {
+                                return Err(AwsServiceError::aws_error(
+                                    StatusCode::BAD_REQUEST,
+                                    "InvalidIdentityToken",
+                                    format!(
+                                        "Incorrect token audience: not in client_id_list for provider {}",
+                                        provider.arn
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let federated_provider = oidc_match
+            .as_ref()
+            .map(|(_iss, p)| p.arn.clone())
+            .or(provider_id_param.clone())
+            .unwrap_or_else(|| format!("arn:aws:iam::{}:oidc-provider/web-identity", account_id));
+
+        // Trust-policy gate: same shape as AssumeRole, but the caller
+        // principal is the federated provider and the action is
+        // `sts:AssumeRoleWithWebIdentity`. Service-linked roles are
+        // never assumable via web identity, so we don't replicate the
+        // SLR shortcut from `assume_role`.
+        let target_state = accounts.get_or_create(&account_id);
+        if let Some(role) = target_state.roles.get(role_name).cloned() {
+            let trust_doc = PolicyDocument::parse(&role.assume_role_policy_document);
+            let caller_principal = federated_principal(&federated_provider, &account_id);
+            let mut context = RequestContext {
+                aws_principal_arn: Some(caller_principal.arn.clone()),
+                aws_principal_account: Some(caller_principal.account_id.clone()),
+                aws_principal_type: Some(caller_principal.principal_type.as_str().to_string()),
+                aws_federated_provider: Some(federated_provider.clone()),
+                ..Default::default()
+            };
+            context.service_keys.insert(
+                "sts:rolesessionname".to_string(),
+                vec![role_session_name.clone()],
+            );
+            // Per-provider `<provider>:aud`/`<provider>:sub` keys —
+            // AWS exposes these scoped to the issuer host so policies
+            // can write `accounts.google.com:aud`, `cognito-identity.amazonaws.com:sub`,
+            // etc. We key off the registered provider URL (no scheme)
+            // when we matched one, otherwise the caller-supplied
+            // ProviderId.
+            let key_prefix = oidc_match
+                .as_ref()
+                .map(|(_iss, p)| normalize_issuer(&p.url))
+                .or_else(|| provider_id_param.as_deref().map(normalize_issuer));
+            if let Some(prefix) = key_prefix {
+                if let Some(ref claims) = jwt {
+                    if let Some(ref aud) = claims.aud {
+                        context
+                            .service_keys
+                            .insert(format!("{prefix}:aud"), vec![aud.clone()]);
+                    }
+                    if let Some(ref sub) = claims.sub {
+                        context
+                            .service_keys
+                            .insert(format!("{prefix}:sub"), vec![sub.clone()]);
+                        context.aws_userid = Some(sub.clone());
+                    }
+                    if let Some(amr) = claims.raw.get("amr").and_then(|v| v.as_array()).map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect::<Vec<_>>()
+                    }) {
+                        context.service_keys.insert(format!("{prefix}:amr"), amr);
+                    }
+                }
+            }
+            let eval_req = EvalRequest {
+                principal: &caller_principal,
+                action: "sts:AssumeRoleWithWebIdentity".to_string(),
+                resource: role_arn.clone(),
+                context,
+            };
+            if !matches!(
+                evaluate_resource_policy_only(&trust_doc, &eval_req),
+                Decision::Allow
+            ) {
+                return Err(trust_policy_denied(
+                    "sts:AssumeRoleWithWebIdentity",
+                    &caller_principal.arn,
+                    role_arn,
+                ));
+            }
+        }
+
         let target_state = accounts.get_or_create(&account_id);
         target_state.credential_identities.insert(
             creds.access_key_id.clone(),
@@ -640,20 +780,11 @@ impl StsService {
                 account_id: account_id.clone(),
             },
         );
-        // `aws:FederatedProvider` is the OIDC provider ARN (or the
-        // friendly host name when supplied via `ProviderId`). Real AWS
-        // populates it from the registered OIDC provider used during
-        // token validation; this emulator carries the caller-supplied
-        // ProviderId verbatim, falling back to a synthetic OIDC
-        // provider ARN keyed off the role's account when absent so a
-        // policy condition that just checks for "any federated session"
-        // still has a value to bind to.
-        let federated_provider = req.query_params.get("ProviderId").cloned().or_else(|| {
-            Some(format!(
-                "arn:aws:iam::{}:oidc-provider/web-identity",
-                account_id
-            ))
-        });
+        // `aws:FederatedProvider` is the OIDC provider ARN (preferred)
+        // or the caller-supplied ProviderId (legacy idp host name).
+        // Falls back to a synthetic ARN so policies that simply check
+        // for "any federated session" still have a value to bind to.
+        let federated_provider = Some(federated_provider);
         target_state.sts_temp_credentials.insert(
             creds.access_key_id.clone(),
             StsTempCredential {
@@ -747,9 +878,11 @@ impl StsService {
         let expiration_at = compute_expiration_at(req, DEFAULT_ASSUME_ROLE_DURATION)?;
         let expiration = format_expiration(expiration_at);
 
-        // Decode the SAML assertion to extract the RoleSessionName
+        // Decode the SAML assertion to extract the RoleSessionName plus
+        // the issuer/audience claims used for trust-policy enforcement.
         let role_session_name =
             extract_saml_session_name(saml_assertion).unwrap_or_else(|| "saml-session".to_string());
+        let saml_claims = extract_saml_claims(saml_assertion);
 
         let partition = partition_for_region(&req.region);
         let creds = StsCredentials::generate();
@@ -767,6 +900,75 @@ impl StsService {
             partition, account_id, role_name, &role_session_name
         );
         let assumed_role_id_str = format!("{}:{}", role_id, role_session_name);
+
+        // If the named SAML provider IS registered, enforce its
+        // metadata-derived audience against the assertion's
+        // `<Audience>` claim. Unregistered providers fall through —
+        // tests still in the pre-F1 era (and AWS itself, when the
+        // provider was nuked between assertion issue and use) get a
+        // soft pass; the trust policy below still gates the call.
+        if let Some(provider) = find_saml_provider(&accounts, &saml_provider_arn) {
+            if let Some(expected_aud) = expected_saml_audience(&provider.saml_metadata_document) {
+                if let Some(ref got) = saml_claims.audience {
+                    if got != &expected_aud {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidIdentityToken",
+                            format!(
+                                "SAML assertion audience '{got}' does not match SAML provider '{}'",
+                                provider.arn
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Trust-policy gate: caller principal is the SAML provider,
+        // action is `sts:AssumeRoleWithSAML`. Trust policies typically
+        // gate on `saml:aud` / `saml:iss` plus `aws:FederatedProvider`.
+        let target_state = accounts.get_or_create(&account_id);
+        if let Some(role) = target_state.roles.get(role_name).cloned() {
+            let trust_doc = PolicyDocument::parse(&role.assume_role_policy_document);
+            let caller_principal = federated_principal(&saml_provider_arn, &account_id);
+            let mut context = RequestContext {
+                aws_principal_arn: Some(caller_principal.arn.clone()),
+                aws_principal_account: Some(caller_principal.account_id.clone()),
+                aws_principal_type: Some(caller_principal.principal_type.as_str().to_string()),
+                aws_federated_provider: Some(saml_provider_arn.clone()),
+                ..Default::default()
+            };
+            if let Some(ref aud) = saml_claims.audience {
+                context
+                    .service_keys
+                    .insert("saml:aud".to_string(), vec![aud.clone()]);
+            }
+            if let Some(ref iss) = saml_claims.issuer {
+                context
+                    .service_keys
+                    .insert("saml:iss".to_string(), vec![iss.clone()]);
+            }
+            context.service_keys.insert(
+                "sts:rolesessionname".to_string(),
+                vec![role_session_name.clone()],
+            );
+            let eval_req = EvalRequest {
+                principal: &caller_principal,
+                action: "sts:AssumeRoleWithSAML".to_string(),
+                resource: role_arn.clone(),
+                context,
+            };
+            if !matches!(
+                evaluate_resource_policy_only(&trust_doc, &eval_req),
+                Decision::Allow
+            ) {
+                return Err(trust_policy_denied(
+                    "sts:AssumeRoleWithSAML",
+                    &caller_principal.arn,
+                    role_arn,
+                ));
+            }
+        }
 
         let target_state = accounts.get_or_create(&account_id);
         target_state.credential_identities.insert(
@@ -1187,6 +1389,211 @@ fn extract_account_from_arn(arn: &str) -> Option<String> {
     }
 }
 
+/// Decoded view of the trusted bits of a SAML assertion. We only pull the
+/// `Issuer` and `Audience` so the trust policy and OIDC-style lookups can
+/// gate on them — full assertion verification (signature, NotBefore /
+/// NotOnOrAfter, etc.) is out of scope for the emulator.
+#[derive(Debug, Clone, Default)]
+struct SamlClaims {
+    issuer: Option<String>,
+    audience: Option<String>,
+}
+
+/// Pull `Issuer` and `Audience` out of a base64-encoded SAML assertion.
+/// Returns whatever fields could be extracted (both fields are optional);
+/// callers decide what to do when one is missing.
+fn extract_saml_claims(saml_b64: &str) -> SamlClaims {
+    use base64::Engine;
+    let mut claims = SamlClaims::default();
+    let decoded = match base64::engine::general_purpose::STANDARD.decode(saml_b64) {
+        Ok(b) => b,
+        Err(_) => return claims,
+    };
+    let xml_str = match String::from_utf8(decoded) {
+        Ok(s) => s,
+        Err(_) => return claims,
+    };
+    claims.issuer = extract_xml_text_after(&xml_str, "Issuer");
+    claims.audience = extract_xml_text_after(&xml_str, "Audience");
+    claims
+}
+
+/// Find the first occurrence of an opening tag with `local_name` (with or
+/// without an XML namespace prefix) and return its text content. Used by
+/// the SAML claim extractor — matches the same pragmatic, prefix-tolerant
+/// approach as `extract_saml_session_name`.
+fn extract_xml_text_after(xml: &str, local_name: &str) -> Option<String> {
+    // Try `<local_name`, `<saml:local_name`, `<saml2:local_name`, etc by
+    // scanning for `<` followed by the local name preceded by either `:`
+    // or just `<`.
+    let mut search_from = 0;
+    while let Some(idx) = xml[search_from..].find('<') {
+        let abs = search_from + idx;
+        let after_lt = &xml[abs + 1..];
+        // Strip optional namespace prefix.
+        let tag_start = after_lt
+            .split_once(':')
+            .map(|(_pfx, rest)| rest)
+            .unwrap_or(after_lt);
+        if let Some(after_name) = tag_start.strip_prefix(local_name) {
+            // Verify the next char ends the local name (whitespace, '>', '/').
+            let valid_terminator = after_name
+                .chars()
+                .next()
+                .map(|c| c == '>' || c == ' ' || c == '/' || c == '\t' || c == '\n')
+                .unwrap_or(false);
+            if valid_terminator {
+                let gt_pos = after_lt.find('>')?;
+                let content_start = abs + 1 + gt_pos + 1;
+                let next_lt = xml[content_start..].find('<')?;
+                let value = xml[content_start..content_start + next_lt].trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+        search_from = abs + 1;
+    }
+    None
+}
+
+/// Decoded JWT claims we care about for `AssumeRoleWithWebIdentity`.
+/// We never verify the signature — fakecloud is not a security boundary —
+/// but we DO require the token to be a syntactically valid JWT with an
+/// `iss` claim so trust-policy enforcement has something to bind to.
+#[derive(Debug, Clone, Default)]
+struct JwtClaims {
+    iss: Option<String>,
+    aud: Option<String>,
+    sub: Option<String>,
+    raw: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Parse a base64url-encoded JWT into its `iss`/`aud`/`sub` claims.
+/// Returns `None` when the token is not a 3-segment JWT or the payload
+/// is not JSON. We accept both unpadded base64url (canonical) and the
+/// padded variant some libraries emit.
+fn decode_jwt(token: &str) -> Option<JwtClaims> {
+    use base64::Engine;
+    let segments: Vec<&str> = token.split('.').collect();
+    if segments.len() != 3 {
+        return None;
+    }
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(segments[1])
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(segments[1]))
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    let map = json.as_object()?.clone();
+    let str_field = |k: &str| map.get(k).and_then(|v| v.as_str()).map(|s| s.to_string());
+    Some(JwtClaims {
+        iss: str_field("iss"),
+        aud: str_field("aud"),
+        sub: str_field("sub"),
+        raw: map,
+    })
+}
+
+/// Normalize an OIDC issuer URL for comparison with a registered
+/// `OpenIDConnectProvider` URL. AWS stores the URL without scheme and
+/// without trailing slash, while JWT `iss` claims usually carry
+/// `https://`. We strip both ends so callers can do an equality check.
+fn normalize_issuer(value: &str) -> String {
+    let no_scheme = value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"))
+        .unwrap_or(value);
+    no_scheme.trim_end_matches('/').to_string()
+}
+
+/// Find a registered OIDC provider whose URL matches the given JWT
+/// `iss` claim. Searches across every account's IAM state — federation
+/// is a global concern, and the calling account doesn't necessarily own
+/// the provider record.
+fn find_oidc_provider<'a>(
+    accounts: &'a fakecloud_core::multi_account::MultiAccountState<IamState>,
+    issuer: &str,
+) -> Option<(&'a str, &'a crate::state::OidcProvider)> {
+    let normalized = normalize_issuer(issuer);
+    for (acct_id, state) in accounts.iter() {
+        for provider in state.oidc_providers.values() {
+            if normalize_issuer(&provider.url) == normalized {
+                return Some((acct_id, provider));
+            }
+        }
+    }
+    None
+}
+
+/// Find a registered SAML provider by ARN. Same cross-account scan as
+/// the OIDC variant — SAML provider ARNs name the provider's owning
+/// account in the ARN itself.
+fn find_saml_provider<'a>(
+    accounts: &'a fakecloud_core::multi_account::MultiAccountState<IamState>,
+    arn: &str,
+) -> Option<&'a crate::state::SamlProvider> {
+    for (_acct_id, state) in accounts.iter() {
+        if let Some(provider) = state.saml_providers.get(arn) {
+            return Some(provider);
+        }
+    }
+    None
+}
+
+/// Pull the expected audience out of a SAML provider's metadata
+/// document. Real metadata uses `entityID="..."` on the `<EntityDescriptor>`
+/// root element to name the IdP — AWS treats it as the audience the
+/// assertion must be addressed to. We use a best-effort string scan
+/// rather than full XML parsing; the metadata format is stable and
+/// callers that want the strict path can supply a SAML provider with
+/// no metadata, in which case we skip the audience check.
+fn expected_saml_audience(metadata: &str) -> Option<String> {
+    let needle = "entityID=";
+    let pos = metadata.find(needle)?;
+    let after = &metadata[pos + needle.len()..];
+    let quote = after.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let rest = &after[1..];
+    let end = rest.find(quote)?;
+    let value = rest[..end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+/// Build the synthetic federated `Principal` we hand to the trust-policy
+/// evaluator for `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity`. The
+/// ARN is the federated provider (SAML provider ARN or OIDC issuer);
+/// `principal_type` is `FederatedUser`, which is what
+/// [`PrincipalRef::Federated`] matches against.
+fn federated_principal(provider_arn: &str, account_id: &str) -> Principal {
+    Principal {
+        arn: provider_arn.to_string(),
+        user_id: provider_arn.to_string(),
+        account_id: account_id.to_string(),
+        principal_type: PrincipalType::FederatedUser,
+        source_identity: None,
+        tags: None,
+    }
+}
+
+/// Produce the AWS-style AccessDenied error returned when the role's
+/// trust policy refuses an STS AssumeRole* call.
+fn trust_policy_denied(action: &str, caller_arn: &str, role_arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::FORBIDDEN,
+        "AccessDenied",
+        format!(
+            "User: {} is not authorized to perform: {} on resource: {}",
+            caller_arn, action, role_arn
+        ),
+    )
+}
+
 /// Extract the RoleSessionName from a base64-encoded SAML assertion.
 fn extract_saml_session_name(saml_b64: &str) -> Option<String> {
     use base64::Engine;
@@ -1572,7 +1979,8 @@ mod tests {
     #[tokio::test]
     async fn assume_role_with_web_identity() {
         let (svc, state) = make_sts_service();
-        let role_arn = create_role_in_state(&state, "web-role");
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "web-role", trust);
 
         let req = sts_request(
             "AssumeRoleWithWebIdentity",
@@ -2024,7 +2432,8 @@ mod tests {
         use base64::Engine;
         use fakecloud_core::auth::CredentialResolver;
         let (svc, state) = make_sts_service();
-        let role_arn = create_role_in_state(&state, "saml-role");
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithSAML"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "saml-role", trust);
         let saml_xml = r#"<?xml version="1.0"?><samlp:Response><Assertion><AttributeStatement><Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName"><AttributeValue>jane</AttributeValue></Attribute></AttributeStatement></Assertion></samlp:Response>"#;
         let saml_b64 = base64::engine::general_purpose::STANDARD.encode(saml_xml);
         let provider_arn = "arn:aws:iam::123456789012:saml-provider/idp";
@@ -2063,7 +2472,8 @@ mod tests {
         use crate::credential_resolver::IamCredentialResolver;
         use fakecloud_core::auth::CredentialResolver;
         let (svc, state) = make_sts_service();
-        let role_arn = create_role_in_state(&state, "oidc-role");
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "oidc-role", trust);
         let req = sts_request(
             "AssumeRoleWithWebIdentity",
             vec![

--- a/website/content/docs/reference/security.md
+++ b/website/content/docs/reference/security.md
@@ -151,6 +151,7 @@ The resource's owning account is parsed from the ARN; S3 ARNs have an empty acco
 - **S3 bucket policies** are stored by `PutBucketPolicy` and updated by `DeleteBucketPolicy`. `GetBucketPolicy` returns the raw JSON.
 - **SNS topic policies** are stored in the topic's `Policy` attribute by `SetTopicAttributes` (full document) or by `AddPermission` / `RemovePermission` (incremental statements). `GetTopicAttributes` returns them.
 - **Lambda function policies** are built incrementally by `AddPermission`: fakecloud composes a canonical `{"Version":"2012-10-17","Statement":[...]}` document from `(StatementId, Action, Principal, SourceArn?, SourceAccount?)` so the existing evaluator reads it without a Lambda-specific fork. `SourceArn` becomes an `ArnLike` `Condition` on `aws:SourceArn`, and `SourceAccount` becomes a `StringEquals` `Condition` on `aws:SourceAccount` — both are already in the operator set. `GetPolicy` returns the composed document; `RemovePermission` strips the matching `Sid` and leaves an empty `Statement` array behind, matching AWS.
+- **IAM role trust policies** (`assume_role_policy_document`) are evaluated on every `AssumeRole`, `AssumeRoleWithSAML`, and `AssumeRoleWithWebIdentity` call before STS issues credentials. The trust policy is the *only* authorization source for role assumption — identity policies do not factor in. Caller principal, action (`sts:AssumeRole*`), `Condition` keys (`sts:ExternalId`, `sts:RoleSessionName`, `sts:SourceIdentity`, `aws:MultiFactorAuthPresent`, `aws:SourceAccount`), and federation-specific keys (`saml:aud`, `saml:iss`, `<provider>:aud`, `<provider>:sub`) are all populated. `AssumeRoleWithWebIdentity` additionally requires the JWT's `iss` to match a registered `OpenIDConnectProvider` and `aud` to be in its `client_id_list`; service-linked roles (path `/aws-service-role/<service>/...`) refuse non-service callers regardless of trust-policy contents.
 
 **Principal matching.** Resource policies use `Principal` / `NotPrincipal` keys that identity policies don't. The evaluator supports the shapes resource policies actually use in practice:
 
@@ -163,10 +164,11 @@ The resource's owning account is parsed from the ARN; S3 ARNs have an empty acco
 | `"Principal": {"AWS": "arn:aws:iam::ACCOUNT:user/alice"}` | Exact principal ARN match |
 | `"Principal": {"AWS": [...]}` | List form — any entry matches |
 | `"Principal": {"Service": "events.amazonaws.com"}` | Matches an assumed-role principal whose ARN contains the service host (covers EventBridge -> SNS and similar service-linked role scenarios) |
+| `"Principal": {"Federated": "<provider>"}` | Matches a federated session minted by `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity` whose provider ARN equals `<provider>`. Used by IAM role trust policies. |
 
-`NotPrincipal` is fully evaluated — a statement with `NotPrincipal` applies to all callers **except** those matching any entry in the list (the exact inverse of `Principal`). The classic AWS pattern `Deny` + `NotPrincipal` ("deny everyone except this user") works correctly. `NotPrincipal` entries with unrecognized principal types (`Federated`, `CanonicalUser`) are dropped from the match list; if all entries are unrecognized the statement is skipped with a `fakecloud::iam::audit` debug log and never silently grants.
+`NotPrincipal` is fully evaluated — a statement with `NotPrincipal` applies to all callers **except** those matching any entry in the list (the exact inverse of `Principal`). The classic AWS pattern `Deny` + `NotPrincipal` ("deny everyone except this user") works correctly. `NotPrincipal` entries with unrecognized principal types (`CanonicalUser`) are dropped from the match list; if all entries are unrecognized the statement is skipped with a `fakecloud::iam::audit` debug log and never silently grants.
 
-`Principal` types other than `AWS` / `Service` (`Federated`, `CanonicalUser`) fall through to "doesn't match" for the same reason.
+`Principal` types other than `AWS` / `Service` / `Federated` (`CanonicalUser`) fall through to "doesn't match" for the same reason.
 
 `Condition` blocks on resource-policy statements are evaluated with the same operator set and global condition keys as identity policies — the condition entry points are shared.
 

--- a/website/content/docs/services/sts.md
+++ b/website/content/docs/services/sts.md
@@ -8,9 +8,9 @@ fakecloud implements **11 of 11** STS operations at 100% Smithy conformance.
 
 ## Supported features
 
-- **AssumeRole** — with session name, duration, policies, external ID
-- **AssumeRoleWithWebIdentity** — OIDC federation
-- **AssumeRoleWithSAML** — SAML federation
+- **AssumeRole** — with session name, duration, policies, external ID; the role's trust policy is evaluated before credentials are issued (Principal, Condition, ExternalId, MFA, service-linked roles)
+- **AssumeRoleWithWebIdentity** — OIDC federation; JWT `iss` is matched against a registered `OpenIDConnectProvider` and `aud` against its `client_id_list`; trust policy is enforced with `<provider>:aud` / `<provider>:sub` context keys
+- **AssumeRoleWithSAML** — SAML federation; the named provider must exist, audience is matched against the provider metadata's `entityID`, and the trust policy is enforced with `saml:aud` / `saml:iss` context keys
 - **GetSessionToken** — temporary credentials
 - **GetFederationToken** — federated user credentials
 - **GetCallerIdentity** — account ID, user ARN, user ID


### PR DESCRIPTION
## Summary

- Phase F1 of the parity plan: AssumeRole, AssumeRoleWithSAML, and AssumeRoleWithWebIdentity now run the role's trust policy through the IAM evaluator before STS mints credentials. Previously the trust policy was stored but never consulted, so any caller could assume any role.
- Adds the Federated principal shape (`Principal: { "Federated": "<provider>" }`) to the evaluator and wires SAML/OIDC token claims (`saml:aud`, `saml:iss`, `<provider>:aud`, `<provider>:sub`, `aws:FederatedProvider`) into the request context for trust policies to gate on.
- AssumeRoleWithWebIdentity now decodes the JWT, matches `iss` against registered `OpenIDConnectProvider` records, and rejects audiences not in `client_id_list` with `InvalidIdentityToken`. AssumeRoleWithSAML validates the assertion's `<Audience>` against the SAML provider metadata's `entityID`.

## Test plan

- [x] `cargo test -p fakecloud-iam` — 427 passed
- [x] `cargo test -p fakecloud-e2e --test iam` — 67 passed (including 7 new F1 trust-policy tests)
- [x] `cargo test -p fakecloud-e2e --test iam_enforcement` — 45 passed (no regressions)
- [x] `cargo test -p fakecloud-e2e --test iam_pass_role` — 4 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI green
- [ ] Cubic review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces IAM role trust policies on all STS role assumption paths and tightens OIDC/SAML checks (including array-form JWT audiences) to drive those policies. This blocks unauthorized role use and delivers F1 parity.

- New Features
  - Evaluate trust policies before issuing creds for AssumeRole, AssumeRoleWithSAML, and AssumeRoleWithWebIdentity; populate `sts:ExternalId`, `sts:RoleSessionName`, `sts:SourceIdentity`, `aws:MultiFactorAuthPresent`, and `aws:SourceAccount`; service-linked roles deny non-service callers.
  - Web identity: decode JWT, require `iss` to match a registered OIDC provider and `aud` to be in its `client_id_list` (string or array); expose `<provider>:aud`, `<provider>:sub`, `<provider>:amr`, and `aws:FederatedProvider`.
  - SAML: validate assertion audience against the provider metadata `entityID`; expose `saml:aud`, `saml:iss`, and `aws:FederatedProvider`.
  - IAM evaluator supports `Principal: {"Federated": "<provider>"}` for trust policies; added end-to-end tests and updated STS/security docs.

- Migration
  - Ensure roles meant to be assumed have a trust policy that allows it; otherwise these calls return AccessDenied.
  - Register OIDC providers and client IDs so JWT `iss` and `aud` match your config (array `aud` supported).
  - For SAML, ensure the provider metadata `entityID` matches the assertion audience.
  - Non-service callers can no longer assume service-linked roles.

<sup>Written for commit 6066e41f411332e2b18532e8e9ac33d506d033cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

