### PR TITLE
feat(scheduler): FlexibleTimeWindow + RetryPolicy + tz support (K11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,6 +3643,7 @@ dependencies = [
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/fakecloud-e2e/tests/scheduler.rs
+++ b/crates/fakecloud-e2e/tests/scheduler.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use aws_sdk_scheduler::types::{
     ActionAfterCompletion, DeadLetterConfig, FlexibleTimeWindow, FlexibleTimeWindowMode,
-    ScheduleState, Target,
+    RetryPolicy, ScheduleState, Target,
 };
 use aws_sdk_sqs::types::QueueAttributeName;
 use fakecloud_testkit::TestServer;
@@ -451,4 +451,212 @@ async fn cross_account_sqs_target_delivers_to_target_account_queue() {
         .await
         .expect("cross-account schedule should deliver to account B queue");
     assert_eq!(msg.body.unwrap(), "{\"crossAccount\":true}");
+}
+
+// ---------------------------------------------------------------------------
+// K11: FlexibleTimeWindow + RetryPolicy + ScheduleExpressionTimezone
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scheduler_flexible_time_window_off_fires_immediately() {
+    // Mode=OFF (default) must fire on the next tick after due, with no
+    // window-driven deferral. This locks the OFF semantics so the
+    // FLEXIBLE test below has a meaningful baseline.
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q_url = queue_url(&sqs, "flex-off-dest").await;
+    let q_arn = queue_arn(&sqs, &q_url).await;
+
+    let target = Target::builder()
+        .arn(q_arn)
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"k\":\"off\"}")
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("flex-off")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    let msg = wait_for_message(&sqs, &q_url, Duration::from_secs(10))
+        .await
+        .expect("OFF mode must fire promptly on next tick");
+    assert_eq!(msg.body.unwrap(), "{\"k\":\"off\"}");
+}
+
+#[tokio::test]
+async fn scheduler_flexible_time_window_flexible_fires_within_window() {
+    // Mode=FLEXIBLE with MaximumWindowInMinutes=1 must fire within
+    // [0, 60]s of due. We use a 1-minute window (the smallest AWS
+    // accepts) and a 90s deadline so the window can complete with
+    // headroom. The RNG is seeded per (schedule_arn, fire_minute) so
+    // the offset is bounded but non-deterministic across schedules.
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let q_url = queue_url(&sqs, "flex-on-dest").await;
+    let q_arn = queue_arn(&sqs, &q_url).await;
+
+    let target = Target::builder()
+        .arn(q_arn)
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"k\":\"flex\"}")
+        .build()
+        .unwrap();
+
+    let window = FlexibleTimeWindow::builder()
+        .mode(FlexibleTimeWindowMode::Flexible)
+        .maximum_window_in_minutes(1)
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("flex-on")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(window)
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    let msg = wait_for_message(&sqs, &q_url, Duration::from_secs(90))
+        .await
+        .expect("FLEXIBLE schedule must fire within MaximumWindowInMinutes");
+    assert_eq!(msg.body.unwrap(), "{\"k\":\"flex\"}");
+}
+
+#[tokio::test]
+async fn scheduler_retry_policy_routes_to_dlq_after_budget_exhausted() {
+    // Schedule with MaximumRetryAttempts=2 against a non-existent queue.
+    // Expected: initial attempt + 2 retries all fail -> DLQ receives
+    // exactly one message after the budget is exhausted.
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let dlq_url = queue_url(&sqs, "retry-dlq").await;
+    let dlq_arn = queue_arn(&sqs, &dlq_url).await;
+
+    let target = Target::builder()
+        .arn("arn:aws:sqs:us-east-1:000000000000:retry-missing")
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"v\":\"retry-fail\"}")
+        .dead_letter_config(DeadLetterConfig::builder().arn(dlq_arn.clone()).build())
+        .retry_policy(
+            RetryPolicy::builder()
+                .maximum_event_age_in_seconds(86400)
+                .maximum_retry_attempts(2)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("retry-fail")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    let msg = wait_for_message(&sqs, &dlq_url, Duration::from_secs(30))
+        .await
+        .expect("DLQ must receive failed delivery once retry budget is exhausted");
+    assert_eq!(msg.body.unwrap(), "{\"v\":\"retry-fail\"}");
+    let attrs = msg.message_attributes.unwrap();
+    assert!(attrs.contains_key("X-Amz-Scheduler-Error-Code"));
+}
+
+#[tokio::test]
+async fn scheduler_retry_policy_does_not_dlq_when_target_recovers() {
+    // Schedule against a queue that DOES exist. Initial attempt
+    // succeeds -> no DLQ traffic. This pins the success path so we
+    // know retries don't double-deliver to the DLQ when the target
+    // accepts the first attempt.
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+    let sqs = server.sqs_client().await;
+
+    let dest_url = queue_url(&sqs, "retry-ok-dest").await;
+    let dest_arn = queue_arn(&sqs, &dest_url).await;
+    let dlq_url = queue_url(&sqs, "retry-ok-dlq").await;
+    let dlq_arn = queue_arn(&sqs, &dlq_url).await;
+
+    let target = Target::builder()
+        .arn(dest_arn)
+        .role_arn("arn:aws:iam::000000000000:role/scheduler")
+        .input("{\"v\":\"recovers\"}")
+        .dead_letter_config(DeadLetterConfig::builder().arn(dlq_arn).build())
+        .retry_policy(
+            RetryPolicy::builder()
+                .maximum_event_age_in_seconds(86400)
+                .maximum_retry_attempts(3)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    sched
+        .create_schedule()
+        .name("retry-ok")
+        .schedule_expression("rate(1 minute)")
+        .flexible_time_window(off_window())
+        .target(target)
+        .send()
+        .await
+        .unwrap();
+
+    // Target receives the message normally.
+    let msg = wait_for_message(&sqs, &dest_url, Duration::from_secs(15))
+        .await
+        .expect("target must receive on first attempt when reachable");
+    assert_eq!(msg.body.unwrap(), "{\"v\":\"recovers\"}");
+
+    // DLQ stays empty (allow a brief window in case retries fired
+    // late, then poll once).
+    let dlq_msg = wait_for_message(&sqs, &dlq_url, Duration::from_secs(2)).await;
+    assert!(
+        dlq_msg.is_none(),
+        "DLQ must remain empty when target accepts delivery"
+    );
+}
+
+#[tokio::test]
+async fn scheduler_schedule_expression_timezone_round_trips() {
+    // Wall-clock testing of cron-in-tz is fragile; the firing logic
+    // for tz lives in unit tests on `expr::matches_cron_in_tz`. This
+    // e2e pins the contract that ScheduleExpressionTimezone is
+    // accepted, persisted, and returned via GetSchedule unchanged.
+    let server = TestServer::start().await;
+    let sched = server.scheduler_client().await;
+
+    sched
+        .create_schedule()
+        .name("tz-sched")
+        .schedule_expression("cron(0 12 * * ? *)")
+        .schedule_expression_timezone("America/New_York")
+        .flexible_time_window(off_window())
+        .target(sqs_target())
+        .send()
+        .await
+        .unwrap();
+
+    let got = sched.get_schedule().name("tz-sched").send().await.unwrap();
+    assert_eq!(
+        got.schedule_expression_timezone().unwrap(),
+        "America/New_York"
+    );
+    assert_eq!(got.schedule_expression().unwrap(), "cron(0 12 * * ? *)");
 }

--- a/crates/fakecloud-scheduler/Cargo.toml
+++ b/crates/fakecloud-scheduler/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/fakecloud-scheduler/src/ticker.rs
+++ b/crates/fakecloud-scheduler/src/ticker.rs
@@ -148,8 +148,7 @@ impl Ticker {
                         _ => 0,
                     };
                     if window_minutes > 0 {
-                        let offset_seconds =
-                            stable_offset_seconds(&pending_key, now, window_minutes);
+                        let offset_seconds = stable_offset_seconds(&sched.arn, now, window_minutes);
                         let fire_at = now + chrono::Duration::seconds(offset_seconds);
                         pending_fires.insert(pending_key, PendingFire { fire_at });
                         continue;
@@ -210,15 +209,17 @@ impl Ticker {
                         .map(|s| (now - entry.first_due).num_seconds() >= s)
                         .unwrap_or(false);
                     if entry.attempts <= max_attempts && !aged_out {
-                        // Retry: schedule a re-fire on a later tick by
-                        // pushing this schedule back onto the pending
-                        // map a few seconds out (no exponential backoff
-                        // — fakecloud does not promise wall-clock
-                        // accuracy, just retry budget exhaustion).
+                        // Exponential backoff capped at 60s: 1s, 2s, 4s,
+                        // 8s, ... AWS Scheduler does not document the
+                        // exact curve, but using a bounded geometric
+                        // schedule ensures retry budget exhaustion and
+                        // MaximumEventAgeInSeconds enforcement remain
+                        // observable in tests.
+                        let backoff = backoff_seconds(entry.attempts);
                         pending_fires.insert(
                             retry_key,
                             PendingFire {
-                                fire_at: now + chrono::Duration::seconds(1),
+                                fire_at: now + chrono::Duration::seconds(backoff),
                             },
                         );
                     } else {
@@ -248,22 +249,34 @@ impl Ticker {
     }
 }
 
-/// Pick a deterministic random offset within [0, window_minutes*60)
-/// seconds for a given schedule key + now. Stable per schedule + minute
-/// so the offset is honored across multiple ticks at the same boundary.
-fn stable_offset_seconds(
-    key: &(String, ScheduleKey),
-    now: DateTime<Utc>,
-    window_minutes: i64,
-) -> i64 {
+/// Geometric backoff schedule for failed target deliveries. Returns
+/// `1s, 2s, 4s, 8s, ..., 60s` then caps. Caller passes the current
+/// attempt count (1-indexed: first retry is `attempt=1`).
+fn backoff_seconds(attempt: i64) -> i64 {
+    const CAP_SECONDS: i64 = 60;
+    let shift = attempt.saturating_sub(1).clamp(0, 30) as u32;
+    (1_i64 << shift).min(CAP_SECONDS)
+}
+
+/// Pick a uniform-random offset within `[0, window_minutes*60]` seconds
+/// for a given schedule. Reproducible: the RNG is seeded from a hash of
+/// `(schedule_arn, fire_at_unix_minute)` so the same `(schedule, minute)`
+/// pair yields the same offset across ticks (the offset is honored on
+/// every tick until it lands), and tests can predict the value without
+/// freezing wall time.
+fn stable_offset_seconds(schedule_arn: &str, now: DateTime<Utc>, window_minutes: i64) -> i64 {
+    use rand::{Rng, SeedableRng};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
     let mut h = DefaultHasher::new();
-    key.0.hash(&mut h);
-    key.1.hash(&mut h);
+    schedule_arn.hash(&mut h);
     now.timestamp().div_euclid(60).hash(&mut h);
-    let bound = (window_minutes * 60).max(1) as u64;
-    (h.finish() % bound) as i64
+    let seed = h.finish();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let upper = (window_minutes * 60).max(0) as u64;
+    // Inclusive upper: AWS's FlexibleTimeWindow spec covers the whole
+    // [0, MaximumWindowInMinutes*60] window.
+    rng.gen_range(0..=upper) as i64
 }
 
 enum PostFire {
@@ -354,7 +367,7 @@ fn is_due_with_dedup(
 mod tests {
     use super::*;
     use crate::state::{FlexibleTimeWindow, Schedule, SharedSchedulerState, Target};
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use fakecloud_aws::arn::Arn;
     use fakecloud_core::delivery::{SqsDelivery, SqsDeliveryError, SqsMessageAttribute};
     use parking_lot::RwLock;
@@ -745,5 +758,122 @@ mod tests {
         let mut retries = HashMap::new();
         ticker.tick(&mut cron, &mut pending, &mut retries);
         assert!(rec.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn backoff_seconds_is_exponential_and_capped() {
+        // 1, 2, 4, 8, 16, 32, 60 (cap), 60, ...
+        assert_eq!(super::backoff_seconds(1), 1);
+        assert_eq!(super::backoff_seconds(2), 2);
+        assert_eq!(super::backoff_seconds(3), 4);
+        assert_eq!(super::backoff_seconds(4), 8);
+        assert_eq!(super::backoff_seconds(5), 16);
+        assert_eq!(super::backoff_seconds(6), 32);
+        assert_eq!(super::backoff_seconds(7), 60);
+        assert_eq!(super::backoff_seconds(20), 60);
+        // Defensive: 0 and negatives shouldn't panic.
+        assert_eq!(super::backoff_seconds(0), 1);
+        assert_eq!(super::backoff_seconds(-1), 1);
+    }
+
+    #[test]
+    fn stable_offset_seconds_is_reproducible_and_within_bounds() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 1, 12, 30, 15).unwrap();
+        let arn = "arn:aws:scheduler:us-east-1:1:schedule/default/foo";
+        // Same (arn, minute) -> same offset.
+        let a = super::stable_offset_seconds(arn, now, 5);
+        let b = super::stable_offset_seconds(arn, now, 5);
+        assert_eq!(a, b, "offset must be stable per (arn, minute)");
+        // Within [0, 5*60].
+        assert!((0..=300).contains(&a), "offset {a} not in [0, 300]");
+        // Different schedule ARN -> almost certainly different offset.
+        let c = super::stable_offset_seconds(
+            "arn:aws:scheduler:us-east-1:1:schedule/default/bar",
+            now,
+            5,
+        );
+        assert!((0..=300).contains(&c));
+    }
+
+    #[test]
+    fn retry_then_success_clears_retry_state_and_delivers_to_target() {
+        // Schedule with MaxRetryAttempts=3, target succeeds on the 3rd attempt.
+        let state = make_state();
+        seed_schedule(
+            &state,
+            "retry-then-ok",
+            "rate(1 minute)",
+            "arn:aws:sqs:us-east-1:111122223333:flaky",
+        );
+        {
+            let mut accounts = state.write();
+            let s = accounts.get_or_create(ACCOUNT);
+            let sched = s
+                .schedules
+                .get_mut(&("default".to_string(), "retry-then-ok".to_string()))
+                .unwrap();
+            sched.target.retry_policy = Some(crate::state::RetryPolicy {
+                maximum_event_age_in_seconds: Some(86400),
+                maximum_retry_attempts: Some(3),
+            });
+        }
+
+        struct FlakyN {
+            calls: Mutex<Vec<String>>,
+            fail_first_n: i64,
+        }
+        impl SqsDelivery for FlakyN {
+            fn deliver_to_queue(&self, _: &str, _: &str, _: &HashMap<String, String>) {}
+            fn try_deliver_to_queue_with_attrs(
+                &self,
+                queue_arn: &str,
+                _body: &str,
+                _attrs: &HashMap<String, SqsMessageAttribute>,
+                _g: Option<&str>,
+                _d: Option<&str>,
+            ) -> Result<(), SqsDeliveryError> {
+                let mut calls = self.calls.lock().unwrap();
+                calls.push(queue_arn.to_string());
+                if (calls.len() as i64) <= self.fail_first_n {
+                    Err(SqsDeliveryError::QueueNotFound(queue_arn.to_string()))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+        let rec = Arc::new(FlakyN {
+            calls: Mutex::new(Vec::new()),
+            fail_first_n: 2,
+        });
+        let bus = Arc::new(DeliveryBus::new().with_sqs(rec.clone()));
+        let ticker = Ticker::new(state.clone(), bus);
+        let mut cron = HashMap::new();
+        let mut pending = HashMap::new();
+        let mut retries = HashMap::new();
+
+        // Tick 1: initial fire fails (call #1), retry queued.
+        ticker.tick(&mut cron, &mut pending, &mut retries);
+        assert_eq!(retries.len(), 1, "retry state must be tracked");
+        for (_, p) in pending.iter_mut() {
+            p.fire_at = Utc::now() - chrono::Duration::seconds(1);
+        }
+        // Tick 2: first retry fails (call #2), retry queued.
+        ticker.tick(&mut cron, &mut pending, &mut retries);
+        for (_, p) in pending.iter_mut() {
+            p.fire_at = Utc::now() - chrono::Duration::seconds(1);
+        }
+        // Tick 3: second retry succeeds (call #3) -> retry state cleared.
+        ticker.tick(&mut cron, &mut pending, &mut retries);
+
+        let calls = rec.calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            3,
+            "expected 3 delivery attempts (2 fail + 1 ok)"
+        );
+        assert!(
+            retries.is_empty(),
+            "retry state must be cleared after success"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- FlexibleTimeWindow OFF/FLEXIBLE perturbs fire time within window
- RetryPolicy with exp backoff and DLQ fallback after retry budget exhausted
- Timezone-aware cron evaluation via chrono-tz

## Test plan
- [ ] Unit tests for ticker
- [ ] e2e test for FlexibleTimeWindow + RetryPolicy + DLQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements K11 scheduler features: FlexibleTimeWindow, RetryPolicy with exponential backoff and DLQ, and timezone-aware cron. Improves delivery timing, failure handling, and cron evaluation with named timezones.

- New Features
  - FlexibleTimeWindow: OFF fires on next tick; FLEXIBLE adds a stable random delay within [0, window].
  - RetryPolicy: exponential backoff (1s, 2s, 4s, ... capped at 60s), respects MaximumRetryAttempts and MaximumEventAgeInSeconds, then sends to DeadLetterConfig.
  - ScheduleExpressionTimezone: cron evaluated via `chrono-tz`; `rate()`/`at()` unchanged; unknown zones fall back to UTC.

- Dependencies
  - Added `rand` for stable window offset generation.

<sup>Written for commit 076097c72adcd455296adb6907bfaac0dd66d9b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

