### PR TITLE
fix(lambda): AddPermission action prefix + tag store unification + UntagResource (D3)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -360,6 +360,122 @@ async fn lambda_add_get_remove_permission_roundtrip() {
     assert!(err.is_err());
 }
 
+#[tokio::test]
+async fn lambda_add_permission_with_qualified_action_no_double_prefix() {
+    // Caller passes `lambda:InvokeFunction` (already fully qualified).
+    // The stored policy should round-trip exactly that string back, with
+    // no `lambda:lambda:InvokeFunction` double-prefix on read.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("qprefix-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .add_permission()
+        .function_name("qprefix-fn")
+        .statement_id("with-prefix")
+        .action("lambda:InvokeFunction")
+        .principal("events.amazonaws.com")
+        .send()
+        .await
+        .unwrap();
+
+    let got = client
+        .get_policy()
+        .function_name("qprefix-fn")
+        .send()
+        .await
+        .unwrap();
+    let doc: serde_json::Value = serde_json::from_str(got.policy().unwrap()).unwrap();
+    let stmts = doc["Statement"].as_array().unwrap();
+    assert_eq!(stmts.len(), 1);
+    // Round-trip preserves the qualified verb verbatim — no lambda:lambda: prefix.
+    assert_eq!(stmts[0]["Action"], "lambda:InvokeFunction");
+}
+
+#[tokio::test]
+async fn lambda_tag_list_untag_roundtrip() {
+    // TagResource -> ListTagsForResource -> UntagResource end-to-end
+    // against the real fakecloud binary via aws-sdk-lambda. Pins the
+    // unified storage path: tags live on the function record, the
+    // SDK's UntagResource (which sends `tagKeys` as a query parameter)
+    // hits the right key, and DeleteFunction wipes them clean.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    client
+        .create_function()
+        .function_name("tag-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+
+    // TagResource adds env=prod, team=core.
+    client
+        .tag_resource()
+        .resource(arn)
+        .tags("env", "prod")
+        .tags("team", "core")
+        .send()
+        .await
+        .unwrap();
+
+    let listed = client.list_tags().resource(arn).send().await.unwrap();
+    let tags = listed.tags().unwrap();
+    assert_eq!(tags.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(tags.get("team").map(String::as_str), Some("core"));
+
+    // UntagResource removes env, leaves team.
+    client
+        .untag_resource()
+        .resource(arn)
+        .tag_keys("env")
+        .send()
+        .await
+        .unwrap();
+
+    let listed = client.list_tags().resource(arn).send().await.unwrap();
+    let tags = listed.tags().unwrap();
+    assert!(!tags.contains_key("env"));
+    assert_eq!(tags.get("team").map(String::as_str), Some("core"));
+
+    // DeleteFunction wipes the function and (transitively) its tags.
+    client
+        .delete_function()
+        .function_name("tag-fn")
+        .send()
+        .await
+        .unwrap();
+
+    // ListTagsForResource on the deleted function -> 404, confirming no
+    // stale state.tags entry hangs around.
+    let err = client.list_tags().resource(arn).send().await;
+    assert!(err.is_err(), "ListTags after DeleteFunction must 404");
+}
+
 fn make_python_zip_returning(payload: &str) -> Vec<u8> {
     // A second-flavor zip whose handler returns a payload-derived value,
     // so callers can confirm UpdateFunctionCode actually swapped the code

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -1832,14 +1832,36 @@ impl LambdaService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         // AWS sends keys as repeated `tagKeys=K1&tagKeys=K2` query
-        // params. The dispatcher's deduplicated `query_params` HashMap
-        // collapses repeats, so parse the raw query string for every
-        // occurrence. Also accept `tagKeys.1=K1` / `tagKeys.member.1=K1`
-        // for SDKs that serialize list params indexed-style.
+        // params per the Smithy model (`httpQuery: "tagKeys"`). The
+        // dispatcher's deduplicated `query_params` HashMap collapses
+        // repeats, so parse the raw query string for every occurrence.
+        // Also accept `tagKeys.1=K1` / `tagKeys.member.1=K1` for SDKs
+        // that serialize list params indexed-style.
+        //
+        // As a defensive fallback we also accept a JSON body of the
+        // form `{"TagKeys": [...]}` / `{"tagKeys": [...]}` for clients
+        // that mistakenly send the tag keys in the body. Query
+        // parameters win when both are present, since query is the
+        // AWS-canonical wire format.
         let mut keys: Vec<String> = Vec::new();
         for (k, v) in parse_query_pairs(&req.raw_query) {
             if k == "tagKeys" || k.starts_with("tagKeys.") {
                 keys.push(v);
+            }
+        }
+        if keys.is_empty() {
+            let parsed = body(req);
+            for field in ["TagKeys", "tagKeys"] {
+                if let Some(arr) = parsed.get(field).and_then(|v| v.as_array()) {
+                    for v in arr {
+                        if let Some(s) = v.as_str() {
+                            keys.push(s.to_string());
+                        }
+                    }
+                    if !keys.is_empty() {
+                        break;
+                    }
+                }
             }
         }
         let resource_arn_decoded = decode_query_segment(resource_arn);

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -2106,6 +2106,77 @@ async fn tag_state_unified_no_duplicate_state_tags() {
     // `func.tags` confirms tags actually landed in the unified slot.
 }
 
+#[tokio::test]
+async fn untag_resource_accepts_json_body_fallback() {
+    // Defensive: some clients put `TagKeys` in the JSON body even
+    // though the AWS Smithy model says `httpQuery: "tagKeys"`. When no
+    // query param is present we fall back to parsing the body so those
+    // clients still work end-to-end.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+
+    let body = json!({"Tags": {"A": "1", "B": "2", "C": "3"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // No query string, body carries `TagKeys`.
+    let body = json!({"TagKeys": ["A", "B"]});
+    let req = make_request(
+        Method::DELETE,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let accounts = svc.state.read();
+    let state = accounts.get("123456789012").unwrap();
+    let func = state.functions.get("tag-fn").unwrap();
+    assert!(!func.tags.contains_key("A"));
+    assert!(!func.tags.contains_key("B"));
+    assert_eq!(func.tags.get("C").map(String::as_str), Some("3"));
+}
+
+#[tokio::test]
+async fn untag_resource_query_wins_over_json_body() {
+    // When both query params and JSON body are present, query wins —
+    // it's the AWS-canonical wire format. The body is a defensive
+    // fallback only.
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "tag-fn").await;
+    let arn = "arn:aws:lambda:us-east-1:123456789012:function:tag-fn";
+
+    let body = json!({"Tags": {"A": "1", "B": "2", "C": "3"}});
+    let req = make_request(
+        Method::POST,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Query says delete A; body says delete C. Query wins, so only A
+    // is removed.
+    let body = json!({"TagKeys": ["C"]});
+    let mut req = make_request(
+        Method::DELETE,
+        &format!("/2017-03-31/tags/{arn}"),
+        &body.to_string(),
+    );
+    req.raw_query = "tagKeys=A".to_string();
+    svc.handle(req).await.unwrap();
+
+    let accounts = svc.state.read();
+    let state = accounts.get("123456789012").unwrap();
+    let func = state.functions.get("tag-fn").unwrap();
+    assert!(!func.tags.contains_key("A"));
+    assert_eq!(func.tags.get("B").map(String::as_str), Some("2"));
+    assert_eq!(func.tags.get("C").map(String::as_str), Some("3"));
+}
+
 // ── D4: reserved-concurrency enforcement at invoke ──
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Three Lambda fixes from the parity-gap D3 batch. Items 1 and 2 were already in tree from earlier D3 PRs (#904, #1112) — this PR adds the missing UntagResource JSON-body fallback plus end-to-end tests pinning the AddPermission action and tag-store contracts so they don't regress.

- **AddPermission action prefix**: stored verbatim (already correct). Added an e2e test that calls AddPermission with the qualified `lambda:InvokeFunction` form and asserts GetPolicy returns the exact same string — no `lambda:lambda:InvokeFunction` double-prefix.
- **Tag store unification**: tags live only on `LambdaFunction::tags` (already correct, no parallel `state.tags` map). Added an end-to-end test: TagResource -> ListTagsForResource -> UntagResource -> DeleteFunction round-trip via aws-sdk-lambda, confirming no stale tag entries survive the function delete.
- **UntagResource JSON body fallback**: AWS canonical wire format is `?tagKeys=K1&tagKeys=K2` (`httpQuery: \"tagKeys\"` per the Smithy model). For defensive interop with clients that mistakenly send `{\"TagKeys\":[...]}` in the JSON body we now also accept that shape as a fallback. Query parameters win when both are present.

## Test plan

- [x] `cargo build -p fakecloud-lambda`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-lambda --lib` (131 passed)
- [x] `cargo test -p fakecloud-e2e --test lambda -- lambda_tag_list_untag_roundtrip lambda_add_permission_with_qualified_action_no_double_prefix lambda_add_get_remove_permission_roundtrip` (3 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Lambda permission and tagging to match AWS behavior. Stores AddPermission actions verbatim, unifies tag storage on the function record, and accepts a JSON-body fallback for UntagResource. Adds e2e tests to pin these contracts and prevent regressions.

- **Bug Fixes**
  - AddPermission: GetPolicy returns the exact action passed by the caller; no double prefix when using lambda:InvokeFunction.
  - Tagging: Tags reside only on `LambdaFunction::tags`; DeleteFunction cleans them up. Verified via TagResource → ListTagsForResource → UntagResource → DeleteFunction roundtrip using `aws-sdk-lambda`.
  - UntagResource: Reads tagKeys from the query string (canonical). Also accepts {"TagKeys":[...]} or {"tagKeys":[...]} in the JSON body as a fallback; query takes precedence when both are present.

<sup>Written for commit 89fc1652d13d6ec29172d9b16844b1bca01c871c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

