### PR TITLE
feat(ses): verified-identity gate on SendCustomVerificationEmail (X1)

### DIFF
--- a/crates/fakecloud-conformance/tests/ses.rs
+++ b/crates/fakecloud-conformance/tests/ses.rs
@@ -1108,6 +1108,16 @@ async fn ses_custom_verification_email_templates() {
     let server = TestServer::start().await;
     let client = server.sesv2_client().await;
 
+    // Verify the template's from-domain so SendCustomVerificationEmail
+    // passes the verified-identity gate (real SES otherwise rejects with
+    // `MailFromDomainNotVerifiedException`).
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+
     // Create
     client
         .create_custom_verification_email_template()

--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -1585,6 +1585,16 @@ async fn ses_send_custom_verification_email() {
     let server = TestServer::start().await;
     let client = server.sesv2_client().await;
 
+    // Verify the from-domain so the verified-identity gate lets the send
+    // through. Real SES rejects SendCustomVerificationEmail with
+    // `MailFromDomainNotVerifiedException` otherwise.
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+
     // Create template first
     client
         .create_custom_verification_email_template()
@@ -1607,6 +1617,38 @@ async fn ses_send_custom_verification_email() {
         .await
         .unwrap();
     assert!(resp.message_id().is_some());
+}
+
+#[tokio::test]
+async fn ses_send_custom_verification_email_unverified_sender() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    // Template's FromEmailAddress has no matching verified identity.
+    client
+        .create_custom_verification_email_template()
+        .template_name("send-verify-unverified")
+        .from_email_address("noone@unverified.test")
+        .template_subject("Verify")
+        .template_content("content")
+        .success_redirection_url("https://ok")
+        .failure_redirection_url("https://fail")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .send_custom_verification_email()
+        .email_address("user@example.com")
+        .template_name("send-verify-unverified")
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MailFromDomainNotVerifiedException"),
+        "expected MailFromDomainNotVerifiedException, got {dbg}"
+    );
 }
 
 // --- Group 4: TestRenderEmailTemplate ---

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -406,15 +406,19 @@ impl SesV2Service {
             }
         };
 
-        // Verify template exists
-        {
+        // Verify template exists, then gate on the template's
+        // FromEmailAddress matching a verified identity. Real SES v2
+        // raises `MailFromDomainNotVerifiedException` from the
+        // SendCustomVerificationEmail action when the from-address has
+        // no matching verified email/domain identity.
+        let from_email = {
             let accounts = self.state.read();
             let empty = SesState::new(&req.account_id, &req.region);
             let state = accounts.get(&req.account_id).unwrap_or(&empty);
-            if !state
+            let Some(tmpl) = state
                 .custom_verification_email_templates
-                .contains_key(&template_name)
-            {
+                .get(&template_name)
+            else {
                 return Ok(Self::json_error(
                     StatusCode::NOT_FOUND,
                     "NotFoundException",
@@ -423,7 +427,12 @@ impl SesV2Service {
                         template_name
                     ),
                 ));
-            }
+            };
+            tmpl.from_email_address.clone()
+        };
+
+        if let Some(err) = self.reject_unverified_sender(&req.account_id, &from_email) {
+            return Ok(err);
         }
 
         let message_id = uuid::Uuid::new_v4().to_string();
@@ -431,7 +440,7 @@ impl SesV2Service {
         // Store as a sent email for introspection
         let sent = SentEmail {
             message_id: message_id.clone(),
-            from: String::new(),
+            from: from_email,
             to: vec![email_address],
             cc: Vec::new(),
             bcc: Vec::new(),

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -2559,6 +2559,8 @@ async fn test_duplicate_custom_verification_template() {
 #[tokio::test]
 async fn test_send_custom_verification_email() {
     let state = make_state();
+    // Seed verified sender so the verified-identity gate lets the send through.
+    seed_identity(&state, "a@b.com");
     let svc = SesV2Service::new(state.clone());
 
     // Create template first
@@ -2587,11 +2589,80 @@ async fn test_send_custom_verification_email() {
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert!(body["MessageId"].as_str().is_some());
 
-    // Verify stored in sent_emails
+    // Verify stored in sent_emails with the resolved sender on the record.
     let _mas_r = state.read();
     let s = _mas_r.default_ref();
     assert_eq!(s.sent_emails.len(), 1);
     assert_eq!(s.sent_emails[0].to, vec!["user@example.com"]);
+    assert_eq!(s.sent_emails[0].from, "a@b.com");
+}
+
+#[tokio::test]
+async fn test_send_custom_verification_email_unverified_sender() {
+    let state = make_state();
+    let svc = SesV2Service::new(state);
+
+    // Template's FromEmailAddress has no matching verified identity.
+    let req = make_request(
+        Method::POST,
+        "/v2/email/custom-verification-email-templates",
+        r#"{
+            "TemplateName": "verify",
+            "FromEmailAddress": "unverified@nowhere.com",
+            "TemplateSubject": "Verify",
+            "TemplateContent": "content",
+            "SuccessRedirectionURL": "https://ok",
+            "FailureRedirectionURL": "https://fail"
+        }"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-custom-verification-emails",
+        r#"{"EmailAddress": "user@example.com", "TemplateName": "verify"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["__type"].as_str(),
+        Some("MailFromDomainNotVerifiedException")
+    );
+}
+
+#[tokio::test]
+async fn test_send_custom_verification_email_domain_verified_sender() {
+    let state = make_state();
+    // Verifying the domain implicitly verifies all addresses on it.
+    seed_identity(&state, "example.com");
+    let svc = SesV2Service::new(state.clone());
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/custom-verification-email-templates",
+        r#"{
+            "TemplateName": "verify",
+            "FromEmailAddress": "noreply@example.com",
+            "TemplateSubject": "Verify",
+            "TemplateContent": "content",
+            "SuccessRedirectionURL": "https://ok",
+            "FailureRedirectionURL": "https://fail"
+        }"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-custom-verification-emails",
+        r#"{"EmailAddress": "user@example.com", "TemplateName": "verify"}"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let _mas_r = state.read();
+    let s = _mas_r.default_ref();
+    assert_eq!(s.sent_emails.len(), 1);
+    assert_eq!(s.sent_emails[0].from, "noreply@example.com");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Wires the verified-sender gate into `SendCustomVerificationEmail` (v2). The template's `FromEmailAddress` is resolved at send time and the request is rejected with `MailFromDomainNotVerifiedException` (HTTP 400) when no verified email/domain identity matches. Mirrors real SES, whose Smithy model lists `MailFromDomainNotVerifiedException` as an error for this op.
- Records the resolved sender on the introspection `SentEmail` entry instead of an empty string.
- Updates lib + e2e + conformance tests so the existing `noreply@example.com` paths first verify the `example.com` domain identity, plus adds unverified-sender + domain-verified-sender coverage.

PR #1091 shipped the X1 gate for `SendEmail`/`SendBulkEmail` v1+v2; `SendCustomVerificationEmail` was the remaining v2 send op without it.

## Test plan

- [x] `cargo build -p fakecloud-ses`
- [x] `cargo test -p fakecloud-ses --lib` (224 passed)
- [x] `cargo test -p fakecloud-e2e --test ses ses_send_custom_verification` (2 passed)
- [x] `cargo test -p fakecloud-conformance --test ses ses_custom_verification_email_templates` (1 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verified-identity gate to SES v2 `SendCustomVerificationEmail`. The template’s `FromEmailAddress` is resolved at send time; unverified senders return `MailFromDomainNotVerifiedException` (400), and the resolved sender is stored in `SentEmail` for introspection.

- **Migration**
  - Verify the template sender before calling `SendCustomVerificationEmail` (create an identity for the email or its domain, e.g., `example.com`).

<sup>Written for commit 1ff76eced7a3cbf058a733a5ee0f201c9bcd945d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

