### PR TITLE
feat(cognito): JWKS + OIDC discovery endpoints (Y2)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -6,8 +6,8 @@ pub mod user_status;
 
 pub use service::{
     ensure_pool_signing_key, handle_oauth2_revoke, handle_oauth2_token, handle_oauth2_userinfo,
-    oidc_discovery_document, pool_jwks_document, CognitoService, OAuthRevokeError, OAuthTokenError,
-    OAuthTokenResponse, OAuthUserInfoError,
+    oidc_discovery_document, pool_existence_and_domain, pool_jwks_document, CognitoService,
+    OAuthRevokeError, OAuthTokenError, OAuthTokenResponse, OAuthUserInfoError,
 };
 pub use state::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CognitoSnapshot,

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1667,20 +1667,54 @@ pub async fn pool_jwks_document(state: &SharedCognitoState, pool_id: &str) -> Op
     Some(crate::jwt::jwks_document(&pem, &kid))
 }
 
+/// Whether a pool with `pool_id` exists in any account, plus the first
+/// `UserPoolDomain` (if any) attached to it. Used by the OIDC discovery
+/// route so it can emit OAuth endpoints only when a domain is configured
+/// — matching real Cognito, which omits those endpoints from discovery
+/// until the pool has a hosted-UI domain.
+pub fn pool_existence_and_domain(
+    state: &SharedCognitoState,
+    pool_id: &str,
+) -> (bool, Option<String>) {
+    let mas = state.read();
+    let mut exists = false;
+    let mut domain = None;
+    for (_, account) in mas.iter() {
+        if account.user_pools.contains_key(pool_id) {
+            exists = true;
+            // First domain wins; pools rarely have more than one.
+            for (name, d) in account.domains.iter() {
+                if d.user_pool_id == pool_id {
+                    domain = Some(name.clone());
+                    break;
+                }
+            }
+            break;
+        }
+    }
+    (exists, domain)
+}
+
 /// Cognito-shaped OpenID-Connect discovery document for a pool. Mirrors
 /// the document AWS publishes at
 /// `https://cognito-idp.<region>.amazonaws.com/<pool>/.well-known/openid-configuration`.
 /// `base_url` is the externally-reachable origin (scheme+host+port) that
 /// clients use to reach fakecloud, so the URLs we hand back resolve.
-pub fn oidc_discovery_document(pool_id: &str, region: &str, base_url: &str) -> Value {
+///
+/// `pool_domain` is the hosted-UI domain prefix attached to the pool (if
+/// any). Real Cognito omits the OAuth2 endpoints from this document until
+/// a domain has been attached — those URLs literally don't resolve before
+/// then — so we mirror the same behaviour.
+pub fn oidc_discovery_document(
+    pool_id: &str,
+    region: &str,
+    base_url: &str,
+    pool_domain: Option<&str>,
+) -> Value {
     let issuer = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
     let trimmed = base_url.trim_end_matches('/');
-    serde_json::json!({
+    let mut doc = serde_json::json!({
         "issuer": issuer,
-        "authorization_endpoint": format!("{trimmed}/oauth2/authorize"),
-        "token_endpoint": format!("{trimmed}/oauth2/token"),
-        "userinfo_endpoint": format!("{trimmed}/oauth2/userInfo"),
-        "revocation_endpoint": format!("{trimmed}/oauth2/revoke"),
         "jwks_uri": format!("{trimmed}/{pool_id}/.well-known/jwks.json"),
         "response_types_supported": ["code", "token"],
         "subject_types_supported": ["public"],
@@ -1710,7 +1744,34 @@ pub fn oidc_discovery_document(pool_id: &str, region: &str, base_url: &str) -> V
         ],
         "code_challenge_methods_supported": ["S256", "plain"],
         "grant_types_supported": ["authorization_code", "implicit", "refresh_token", "client_credentials"],
-    })
+    });
+    if pool_domain.is_some() {
+        // OAuth2 endpoints are served by fakecloud at the same base URL
+        // as everything else. AWS Cognito routes them through
+        // `https://<domain>.auth.<region>.amazoncognito.com/...`, but
+        // those hosts don't resolve in a fakecloud test environment, so
+        // pointing clients at our local `<base_url>/oauth2/...` keeps
+        // discovery -> redeem -> userinfo flows actually working.
+        if let Some(map) = doc.as_object_mut() {
+            map.insert(
+                "authorization_endpoint".into(),
+                serde_json::Value::String(format!("{trimmed}/oauth2/authorize")),
+            );
+            map.insert(
+                "token_endpoint".into(),
+                serde_json::Value::String(format!("{trimmed}/oauth2/token")),
+            );
+            map.insert(
+                "userinfo_endpoint".into(),
+                serde_json::Value::String(format!("{trimmed}/oauth2/userInfo")),
+            );
+            map.insert(
+                "revocation_endpoint".into(),
+                serde_json::Value::String(format!("{trimmed}/oauth2/revoke")),
+            );
+        }
+    }
+    doc
 }
 
 /// Result of `/oauth2/token` handling. The HTTP wrapper translates

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -6788,7 +6788,12 @@ fn jwks_endpoint_unknown_pool_returns_404() {
 fn openid_configuration_returns_standard_doc() {
     let (svc, _state) = make_svc();
     let pool_id = create_pool(&svc);
-    let doc = oidc_discovery_document(&pool_id, "us-east-1", "http://localhost:4569");
+    let doc = oidc_discovery_document(
+        &pool_id,
+        "us-east-1",
+        "http://localhost:4569",
+        Some("myapp"),
+    );
 
     assert_eq!(
         doc["issuer"],
@@ -6829,12 +6834,40 @@ fn openid_configuration_returns_standard_doc() {
 fn openid_configuration_jwks_uri_matches_jwks_endpoint() {
     let (svc, _state) = make_svc();
     let pool_id = create_pool(&svc);
-    let doc = oidc_discovery_document(&pool_id, "us-east-1", "http://localhost:4569");
+    let doc = oidc_discovery_document(&pool_id, "us-east-1", "http://localhost:4569", None);
     assert_eq!(
         doc["jwks_uri"],
         format!("http://localhost:4569/{pool_id}/.well-known/jwks.json"),
         "discovery doc's jwks_uri must point at the same pool's JWKS endpoint"
     );
+}
+
+#[test]
+fn openid_configuration_omits_oauth_endpoints_without_domain() {
+    let (svc, _state) = make_svc();
+    let pool_id = create_pool(&svc);
+    // Real Cognito only advertises OAuth endpoints once the pool has a
+    // hosted-UI domain — until then the URLs literally don't resolve.
+    let doc = oidc_discovery_document(&pool_id, "us-east-1", "http://localhost:4569", None);
+    assert!(
+        doc.get("authorization_endpoint").is_none(),
+        "authorization_endpoint must be omitted without a domain: {doc}"
+    );
+    assert!(
+        doc.get("token_endpoint").is_none(),
+        "token_endpoint must be omitted without a domain"
+    );
+    assert!(
+        doc.get("userinfo_endpoint").is_none(),
+        "userinfo_endpoint must be omitted without a domain"
+    );
+    assert!(
+        doc.get("revocation_endpoint").is_none(),
+        "revocation_endpoint must be omitted without a domain"
+    );
+    // jwks_uri and issuer are still required and unconditional.
+    assert!(doc["jwks_uri"].is_string());
+    assert!(doc["issuer"].is_string());
 }
 
 #[test]

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -4762,6 +4762,80 @@ async fn cognito_well_known_openid_configuration_uses_pool_region() {
         .as_array()
         .unwrap();
     assert_eq!(algs[0], "RS256");
+    let response_types = body["response_types_supported"].as_array().unwrap();
+    assert!(response_types.iter().any(|v| v == "code"));
+    assert!(response_types.iter().any(|v| v == "token"));
+    assert_eq!(body["subject_types_supported"][0], "public");
+    let scopes = body["scopes_supported"].as_array().unwrap();
+    for required in ["openid", "email", "profile", "phone"] {
+        assert!(
+            scopes.iter().any(|v| v == required),
+            "scopes_supported must include {required}: {scopes:?}"
+        );
+    }
+    let auth_methods = body["token_endpoint_auth_methods_supported"]
+        .as_array()
+        .unwrap();
+    assert!(auth_methods.iter().any(|v| v == "client_secret_basic"));
+    assert!(auth_methods.iter().any(|v| v == "client_secret_post"));
+}
+
+/// OIDC discovery omits OAuth2 endpoints until the pool has a hosted-UI
+/// domain — matching real Cognito, which does the same. After
+/// `CreateUserPoolDomain` the endpoints must appear and resolve to
+/// fakecloud's local OAuth2 routes.
+#[tokio::test]
+async fn cognito_oidc_oauth_endpoints_track_pool_domain() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oidc-domain-pool")
+        .send()
+        .await
+        .expect("create user pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!(
+        "{}/{}/.well-known/openid-configuration",
+        server.endpoint(),
+        pool_id
+    );
+
+    // Domain not configured yet -> OAuth endpoints must be absent.
+    let body: serde_json::Value = http.get(&url).send().await.unwrap().json().await.unwrap();
+    assert!(
+        body.get("authorization_endpoint").is_none(),
+        "authorization_endpoint must be omitted before CreateUserPoolDomain: {body}"
+    );
+    assert!(body.get("token_endpoint").is_none());
+    assert!(body.get("userinfo_endpoint").is_none());
+    assert!(body.get("revocation_endpoint").is_none());
+    assert!(body["jwks_uri"].is_string(), "jwks_uri is unconditional");
+
+    // Attach a hosted-UI domain.
+    client
+        .create_user_pool_domain()
+        .user_pool_id(&pool_id)
+        .domain("oidc-domain-test")
+        .send()
+        .await
+        .expect("create user pool domain");
+
+    let body: serde_json::Value = http.get(&url).send().await.unwrap().json().await.unwrap();
+    let auth_ep = body["authorization_endpoint"].as_str().unwrap();
+    assert!(
+        auth_ep.ends_with("/oauth2/authorize"),
+        "authorization_endpoint must point at /oauth2/authorize: {auth_ep}"
+    );
+    let token_ep = body["token_endpoint"].as_str().unwrap();
+    assert!(token_ep.ends_with("/oauth2/token"));
+    let userinfo_ep = body["userinfo_endpoint"].as_str().unwrap();
+    assert!(userinfo_ep.ends_with("/oauth2/userInfo"));
+    let revoke_ep = body["revocation_endpoint"].as_str().unwrap();
+    assert!(revoke_ep.ends_with("/oauth2/revoke"));
 }
 
 /// Y1: every JWT issued by the pool is real RS256-signed against the

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3650,14 +3650,8 @@ async fn main() {
                       axum::extract::Path(pool_id): axum::extract::Path<String>| {
                     let cs = cs.clone();
                     async move {
-                        let exists = {
-                            let mas = cs.read();
-                            let found = mas
-                                .iter()
-                                .any(|(_, account)| account.user_pools.contains_key(&pool_id));
-                            drop(mas);
-                            found
-                        };
+                        let (exists, pool_domain) =
+                            fakecloud_cognito::pool_existence_and_domain(&cs, &pool_id);
                         if !exists {
                             return (
                                 axum::http::StatusCode::NOT_FOUND,
@@ -3680,7 +3674,10 @@ async fn main() {
                         (
                             axum::http::StatusCode::OK,
                             axum::Json(fakecloud_cognito::oidc_discovery_document(
-                                &pool_id, &region, &base_url,
+                                &pool_id,
+                                &region,
+                                &base_url,
+                                pool_domain.as_deref(),
                             )),
                         )
                     }

--- a/website/content/cognito-emulator.md
+++ b/website/content/cognito-emulator.md
@@ -71,6 +71,15 @@ auth = cog.initiate_auth(
 
 The tokens are real signed JWTs — your application's JWT verification (with jwks_uri pointing at the fakecloud public key endpoint) works unchanged.
 
+## JWKS + OIDC discovery
+
+Each user pool serves the same two well-known endpoints AWS Cognito does, so libraries like `aws-jwt-verify`, `jose`, or `jsonwebtoken` work against fakecloud out of the box:
+
+- `GET <fakecloud>/<pool_id>/.well-known/jwks.json` — the pool's RSA-2048 public key in JWK form (`kty=RSA`, `alg=RS256`, `use=sig`, deterministic `kid`).
+- `GET <fakecloud>/<pool_id>/.well-known/openid-configuration` — OIDC discovery document with `issuer`, `jwks_uri`, supported algs/scopes/response types. OAuth2 endpoints (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `revocation_endpoint`) appear after `CreateUserPoolDomain`, matching real Cognito.
+
+Point your verifier at `<fakecloud>/<pool_id>` and tokens issued by `InitiateAuth` / `AdminInitiateAuth` verify cryptographically — no test-only signing keys, no stubs.
+
 ## SRP authentication
 
 ```python


### PR DESCRIPTION
## Summary

- Wires the OIDC discovery endpoint (`/<pool_id>/.well-known/openid-configuration`) to look up the pool's hosted-UI domain and only advertise OAuth2 endpoints (`authorization_endpoint`/`token_endpoint`/`userinfo_endpoint`/`revocation_endpoint`) once one is configured. Real Cognito does the same — those URLs literally don't resolve before `CreateUserPoolDomain` runs.
- Adds a `pool_existence_and_domain` helper so the route avoids ad-hoc state walks.
- Y1 already shipped JWKS + the discovery doc skeleton; this batch closes the conditional-OAuth gap, beefs up the discovery shape coverage, and adds an end-to-end test that flips a pool from no-domain -> domain and asserts the endpoints appear.
- Docs: `cognito-emulator.md` gains a JWKS + OIDC discovery section pointing users at the well-known URLs `aws-jwt-verify` / `jose` / `jsonwebtoken` consume.

## Test plan

- [x] `cargo build -p fakecloud-cognito -p fakecloud`
- [x] `cargo test -p fakecloud-cognito --lib` (306 unit tests pass, includes new `openid_configuration_omits_oauth_endpoints_without_domain`)
- [x] `cargo test -p fakecloud-e2e --test cognito cognito_well_known cognito_oidc cognito_jwt` (5 tests pass, includes new `cognito_oidc_oauth_endpoints_track_pool_domain`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cognito-compatible OIDC discovery that only shows OAuth2 endpoints after a user pool domain is configured, matching AWS. Expands the discovery document and adds e2e/unit tests and docs so `aws-jwt-verify`, `jose`, and `jsonwebtoken` work out of the box.

- **New Features**
  - OIDC discovery (`/<pool_id>/.well-known/openid-configuration`) conditionally includes `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, and `revocation_endpoint` only after `CreateUserPoolDomain`; endpoints resolve to local `/oauth2/...` routes.
  - Added `pool_existence_and_domain` helper; the server route uses it to verify the pool and find its domain.
  - `oidc_discovery_document` takes an optional pool domain and conditionally emits OAuth endpoints; discovery covers issuer, `jwks_uri`, response types, scopes, grant types, and auth methods.

<sup>Written for commit 5a09632390d243ad820821ae4629f40677e23992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

