### PR TITLE
feat(cloudformation): Mappings + Fn::FindInMap (BB4)

### DIFF
--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -121,7 +121,7 @@ pub fn parse_template_with_resolution(
 
         // Pre-resolve Fn::FindInMap before the main intrinsics pass so the
         // existing resolver doesn't need to thread mappings through.
-        let properties = apply_mappings(&properties, parameters, &mappings);
+        let properties = apply_mappings(&properties, parameters, &mappings)?;
 
         // Resolve Ref and parameter substitutions in properties
         let resolved = resolve_refs_full(
@@ -463,59 +463,119 @@ fn stringify_value(value: &Value, parameters: &BTreeMap<String, String>) -> Stri
 }
 
 /// Walk `value`, replacing every `Fn::FindInMap` map ref with its
-/// resolved leaf value. Args resolve `Ref` against `parameters`. Unknown
-/// map / key returns the original node so downstream resolvers can flag
-/// the gap.
+/// resolved leaf value. Args resolve `Ref` / nested `Fn::FindInMap`
+/// against `parameters` + `mappings` first. Unresolvable lookups return
+/// the optional `DefaultValue` from the 4-arg form, otherwise surface a
+/// `ValidationError`-shaped string matching CloudFormation's error.
 fn apply_mappings(
     value: &Value,
     parameters: &BTreeMap<String, String>,
     mappings: &Mappings,
-) -> Value {
+) -> Result<Value, String> {
     match value {
         Value::Object(map) => {
             if let Some(arr) = map.get("Fn::FindInMap").and_then(|v| v.as_array()) {
-                if arr.len() == 3 {
-                    let map_name = stringify_findinmap_arg(&arr[0], parameters);
-                    let top_key = stringify_findinmap_arg(&arr[1], parameters);
-                    let second_key = stringify_findinmap_arg(&arr[2], parameters);
-                    if let Some(top) = mappings.get(&map_name) {
-                        if let Some(second) = top.get(&top_key) {
-                            if let Some(leaf) = second.get(&second_key) {
-                                return leaf.clone();
-                            }
-                        }
-                    }
-                    return value.clone();
-                }
+                return resolve_find_in_map(arr, parameters, mappings);
             }
             let mut new_map = serde_json::Map::new();
             for (k, v) in map {
-                new_map.insert(k.clone(), apply_mappings(v, parameters, mappings));
+                new_map.insert(k.clone(), apply_mappings(v, parameters, mappings)?);
             }
-            Value::Object(new_map)
+            Ok(Value::Object(new_map))
         }
-        Value::Array(arr) => Value::Array(
-            arr.iter()
-                .map(|v| apply_mappings(v, parameters, mappings))
-                .collect(),
-        ),
-        other => other.clone(),
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for v in arr {
+                out.push(apply_mappings(v, parameters, mappings)?);
+            }
+            Ok(Value::Array(out))
+        }
+        other => Ok(other.clone()),
     }
 }
 
-fn stringify_findinmap_arg(value: &Value, parameters: &BTreeMap<String, String>) -> String {
+/// Resolve a single `Fn::FindInMap` array. Supports the 3-arg form
+/// `[MapName, TopKey, SecondKey]` and the 4-arg form
+/// `[MapName, TopKey, SecondKey, { DefaultValue: <value> }]`. Args may
+/// themselves be intrinsics (e.g. `{ "Ref": "AWS::Region" }` or a
+/// nested `Fn::FindInMap`); those resolve before lookup.
+fn resolve_find_in_map(
+    arr: &[Value],
+    parameters: &BTreeMap<String, String>,
+    mappings: &Mappings,
+) -> Result<Value, String> {
+    if arr.len() != 3 && arr.len() != 4 {
+        return Err(format!(
+            "Fn::FindInMap requires 3 or 4 arguments, got {}",
+            arr.len()
+        ));
+    }
+    let default_value: Option<Value> = if arr.len() == 4 {
+        let opts = arr[3].as_object().ok_or_else(|| {
+            "Fn::FindInMap fourth argument must be an object with a DefaultValue key".to_string()
+        })?;
+        let dv = opts.get("DefaultValue").ok_or_else(|| {
+            "Fn::FindInMap fourth argument must contain a DefaultValue key".to_string()
+        })?;
+        Some(apply_mappings(dv, parameters, mappings)?)
+    } else {
+        None
+    };
+
+    let map_name = stringify_findinmap_arg(&arr[0], parameters, mappings)?;
+    let top_key = stringify_findinmap_arg(&arr[1], parameters, mappings)?;
+    let second_key = stringify_findinmap_arg(&arr[2], parameters, mappings)?;
+
+    if let Some(top) = mappings.get(&map_name) {
+        if let Some(second) = top.get(&top_key) {
+            if let Some(leaf) = second.get(&second_key) {
+                return Ok(leaf.clone());
+            }
+        }
+    }
+
+    if let Some(dv) = default_value {
+        return Ok(dv);
+    }
+
+    Err(format!(
+        "Template error: Unable to get mapping for {map_name}::{top_key}::{second_key}"
+    ))
+}
+
+fn stringify_findinmap_arg(
+    value: &Value,
+    parameters: &BTreeMap<String, String>,
+    mappings: &Mappings,
+) -> Result<String, String> {
     match value {
-        Value::String(s) => s.clone(),
+        Value::String(s) => Ok(s.clone()),
         Value::Object(m) => {
             if let Some(name) = m.get("Ref").and_then(|v| v.as_str()) {
                 if let Some(p) = parameters.get(name) {
-                    return p.clone();
+                    return Ok(p.clone());
                 }
-                return name.to_string();
+                // Pseudo refs that have a canonical default value
+                // resolve so FindInMap keyed off `AWS::Region` etc.
+                // works without the caller priming `parameters`.
+                if let Some(Value::String(s)) = pseudo_value(name, parameters) {
+                    return Ok(s);
+                }
+                return Ok(name.to_string());
             }
-            value.to_string()
+            // Nested Fn::FindInMap as a key — resolve it and stringify
+            // the leaf, so e.g. `Fn::FindInMap: [Outer, !FindInMap [...], K]`
+            // works.
+            if let Some(arr) = m.get("Fn::FindInMap").and_then(|v| v.as_array()) {
+                let resolved = resolve_find_in_map(arr, parameters, mappings)?;
+                return Ok(match resolved {
+                    Value::String(s) => s,
+                    other => other.to_string(),
+                });
+            }
+            Ok(value.to_string())
         }
-        _ => value.to_string(),
+        _ => Ok(value.to_string()),
     }
 }
 
@@ -567,7 +627,7 @@ pub fn resolve_resource_properties_with_attrs(
     // provisioned property map.
     let conditions = evaluate_conditions(&value, parameters)?;
     let mappings = parse_mappings(&value);
-    let raw_props = apply_mappings(&raw_props, parameters, &mappings);
+    let raw_props = apply_mappings(&raw_props, parameters, &mappings)?;
 
     let resolved = resolve_refs_full(
         &raw_props,
@@ -1775,7 +1835,7 @@ Resources:
     }
 
     #[test]
-    fn fn_find_in_map_unknown_keys_passes_through() {
+    fn fn_find_in_map_unknown_keys_returns_error() {
         let template = r#"{
             "Mappings": {
                 "RegionMap": {
@@ -1791,10 +1851,208 @@ Resources:
                 }
             }
         }"#;
+        let err = parse_template(template, &BTreeMap::new()).unwrap_err();
+        assert!(
+            err.contains("Unable to get mapping for RegionMap::ap-south-1::AMI"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_four_arg_returns_default_when_missing() {
+        let template = r#"{
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::FindInMap": [
+                            "RegionMap",
+                            "ap-south-1",
+                            "AMI",
+                            {"DefaultValue": "ami-fallback"}
+                        ]}
+                    }
+                }
+            }
+        }"#;
         let parsed = parse_template(template, &BTreeMap::new()).unwrap();
-        assert!(parsed.resources[0].properties["ImageId"]
-            .as_object()
-            .is_some());
+        assert_eq!(
+            parsed.resources[0].properties["ImageId"],
+            Value::String("ami-fallback".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_four_arg_prefers_match_over_default() {
+        let template = r#"{
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::FindInMap": [
+                            "RegionMap",
+                            "us-east-1",
+                            "AMI",
+                            {"DefaultValue": "ami-fallback"}
+                        ]}
+                    }
+                }
+            }
+        }"#;
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["ImageId"],
+            Value::String("ami-east".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_default_value_is_resolved_intrinsic() {
+        let template = r#"{
+            "Parameters": {"Fallback": {"Type": "String"}},
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::FindInMap": [
+                            "RegionMap",
+                            "ap-south-1",
+                            "AMI",
+                            {"DefaultValue": {"Ref": "Fallback"}}
+                        ]}
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("Fallback".to_string(), "ami-default".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["ImageId"],
+            Value::String("ami-default".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_unknown_map_name_errors() {
+        let template = r#"{
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::FindInMap": ["DoesNotExist", "us-east-1", "AMI"]}
+                    }
+                }
+            }
+        }"#;
+        let err = parse_template(template, &BTreeMap::new()).unwrap_err();
+        assert!(
+            err.contains("Unable to get mapping for DoesNotExist::us-east-1::AMI"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_wrong_arg_count_errors() {
+        let template = r#"{
+            "Mappings": {"M": {"a": {"b": "c"}}},
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": {"Fn::FindInMap": ["M", "a"]}
+                    }
+                }
+            }
+        }"#;
+        let err = parse_template(template, &BTreeMap::new()).unwrap_err();
+        assert!(
+            err.contains("Fn::FindInMap requires 3 or 4 arguments"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_resolves_via_pseudo_region() {
+        let template = r#"{
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"},
+                    "us-west-2": {"AMI": "ami-west"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::FindInMap": [
+                            "RegionMap",
+                            {"Ref": "AWS::Region"},
+                            "AMI"
+                        ]}
+                    }
+                }
+            }
+        }"#;
+        // No AWS::Region in parameters — the pseudo-default ("us-east-1")
+        // should kick in so FindInMap still resolves.
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["ImageId"],
+            Value::String("ami-east".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_alongside_ref_and_sub_still_resolve() {
+        let template = r#"{
+            "Parameters": {"Env": {"Type": "String"}},
+            "Mappings": {
+                "EnvMap": {
+                    "prod": {"Suffix": "live"},
+                    "dev": {"Suffix": "test"}
+                }
+            },
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": {"Fn::FindInMap": ["EnvMap", {"Ref": "Env"}, "Suffix"]},
+                        "Tags": [
+                            {"Key": "EnvRef", "Value": {"Ref": "Env"}},
+                            {"Key": "Subbed", "Value": {"Fn::Sub": "env-${Env}"}}
+                        ]
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("Env".to_string(), "prod".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        let p = &parsed.resources[0].properties;
+        assert_eq!(p["QueueName"], Value::String("live".to_string()));
+        assert_eq!(p["Tags"][0]["Value"], Value::String("prod".to_string()));
+        assert_eq!(p["Tags"][1]["Value"], Value::String("env-prod".to_string()));
     }
 
     // ── Conditions: cycle detection + AWS::NoValue removal ──

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -120,8 +120,10 @@ pub fn parse_template_with_resolution(
             .unwrap_or(Value::Object(serde_json::Map::new()));
 
         // Pre-resolve Fn::FindInMap before the main intrinsics pass so the
-        // existing resolver doesn't need to thread mappings through.
-        let properties = apply_mappings(&properties, parameters, &mappings)?;
+        // existing resolver doesn't need to thread mappings through. We
+        // pass `conditions` so a FindInMap sitting in an unused Fn::If
+        // branch is skipped (CFN never executes the dropped branch).
+        let properties = apply_mappings(&properties, parameters, &mappings, &conditions)?;
 
         // Resolve Ref and parameter substitutions in properties
         let resolved = resolve_refs_full(
@@ -467,26 +469,61 @@ fn stringify_value(value: &Value, parameters: &BTreeMap<String, String>) -> Stri
 /// against `parameters` + `mappings` first. Unresolvable lookups return
 /// the optional `DefaultValue` from the 4-arg form, otherwise surface a
 /// `ValidationError`-shaped string matching CloudFormation's error.
+///
+/// `Fn::If` short-circuits: only the branch picked by `conditions`
+/// recurses, so a `Fn::FindInMap` sitting in an unused branch never
+/// trips the strict miss-handling. Conditions that aren't yet known
+/// (caller passed an empty map) recurse into both branches as before
+/// to preserve behaviour.
 fn apply_mappings(
     value: &Value,
     parameters: &BTreeMap<String, String>,
     mappings: &Mappings,
+    conditions: &BTreeMap<String, bool>,
 ) -> Result<Value, String> {
     match value {
         Value::Object(map) => {
+            if let Some(arr) = map.get("Fn::If").and_then(|v| v.as_array()) {
+                if arr.len() == 3 {
+                    let cond_name = arr[0].as_str().unwrap_or("");
+                    if let Some(picked_idx) =
+                        conditions
+                            .get(cond_name)
+                            .copied()
+                            .map(|b| if b { 1 } else { 2 })
+                    {
+                        // Resolve the picked branch eagerly; leave the
+                        // unused branch verbatim so the downstream
+                        // resolver (`resolve_refs_full`) still sees the
+                        // same Fn::If shape and re-applies its own
+                        // branch picking. Crucially, we never recurse
+                        // into the unused branch, so a FindInMap that
+                        // would fail there never executes.
+                        let mut new_arr = arr.clone();
+                        new_arr[picked_idx] =
+                            apply_mappings(&arr[picked_idx], parameters, mappings, conditions)?;
+                        let mut rewritten = serde_json::Map::new();
+                        rewritten.insert("Fn::If".to_string(), Value::Array(new_arr));
+                        return Ok(Value::Object(rewritten));
+                    }
+                }
+            }
             if let Some(arr) = map.get("Fn::FindInMap").and_then(|v| v.as_array()) {
-                return resolve_find_in_map(arr, parameters, mappings);
+                return resolve_find_in_map(arr, parameters, mappings, conditions);
             }
             let mut new_map = serde_json::Map::new();
             for (k, v) in map {
-                new_map.insert(k.clone(), apply_mappings(v, parameters, mappings)?);
+                new_map.insert(
+                    k.clone(),
+                    apply_mappings(v, parameters, mappings, conditions)?,
+                );
             }
             Ok(Value::Object(new_map))
         }
         Value::Array(arr) => {
             let mut out = Vec::with_capacity(arr.len());
             for v in arr {
-                out.push(apply_mappings(v, parameters, mappings)?);
+                out.push(apply_mappings(v, parameters, mappings, conditions)?);
             }
             Ok(Value::Array(out))
         }
@@ -503,6 +540,7 @@ fn resolve_find_in_map(
     arr: &[Value],
     parameters: &BTreeMap<String, String>,
     mappings: &Mappings,
+    conditions: &BTreeMap<String, bool>,
 ) -> Result<Value, String> {
     if arr.len() != 3 && arr.len() != 4 {
         return Err(format!(
@@ -517,14 +555,14 @@ fn resolve_find_in_map(
         let dv = opts.get("DefaultValue").ok_or_else(|| {
             "Fn::FindInMap fourth argument must contain a DefaultValue key".to_string()
         })?;
-        Some(apply_mappings(dv, parameters, mappings)?)
+        Some(apply_mappings(dv, parameters, mappings, conditions)?)
     } else {
         None
     };
 
-    let map_name = stringify_findinmap_arg(&arr[0], parameters, mappings)?;
-    let top_key = stringify_findinmap_arg(&arr[1], parameters, mappings)?;
-    let second_key = stringify_findinmap_arg(&arr[2], parameters, mappings)?;
+    let map_name = stringify_findinmap_arg(&arr[0], parameters, mappings, conditions)?;
+    let top_key = stringify_findinmap_arg(&arr[1], parameters, mappings, conditions)?;
+    let second_key = stringify_findinmap_arg(&arr[2], parameters, mappings, conditions)?;
 
     if let Some(top) = mappings.get(&map_name) {
         if let Some(second) = top.get(&top_key) {
@@ -547,6 +585,7 @@ fn stringify_findinmap_arg(
     value: &Value,
     parameters: &BTreeMap<String, String>,
     mappings: &Mappings,
+    conditions: &BTreeMap<String, bool>,
 ) -> Result<String, String> {
     match value {
         Value::String(s) => Ok(s.clone()),
@@ -567,7 +606,7 @@ fn stringify_findinmap_arg(
             // the leaf, so e.g. `Fn::FindInMap: [Outer, !FindInMap [...], K]`
             // works.
             if let Some(arr) = m.get("Fn::FindInMap").and_then(|v| v.as_array()) {
-                let resolved = resolve_find_in_map(arr, parameters, mappings)?;
+                let resolved = resolve_find_in_map(arr, parameters, mappings, conditions)?;
                 return Ok(match resolved {
                     Value::String(s) => s,
                     other => other.to_string(),
@@ -627,7 +666,7 @@ pub fn resolve_resource_properties_with_attrs(
     // provisioned property map.
     let conditions = evaluate_conditions(&value, parameters)?;
     let mappings = parse_mappings(&value);
-    let raw_props = apply_mappings(&raw_props, parameters, &mappings)?;
+    let raw_props = apply_mappings(&raw_props, parameters, &mappings, &conditions)?;
 
     let resolved = resolve_refs_full(
         &raw_props,
@@ -2020,6 +2059,81 @@ Resources:
         assert_eq!(
             parsed.resources[0].properties["ImageId"],
             Value::String("ami-east".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_in_unused_if_branch_does_not_error() {
+        // FindInMap sits in the FALSE branch of Fn::If; the path
+        // `RegionMap::ap-south-1::AMI` doesn't exist. Because
+        // `WantAlt` resolves to "no" the alt branch is unused and
+        // CFN never executes that FindInMap — parse_template must
+        // succeed instead of erroring.
+        let template = r#"{
+            "Parameters": {"WantAlt": {"Type": "String"}},
+            "Conditions": {
+                "UseAlt": {"Fn::Equals": [{"Ref": "WantAlt"}, "yes"]}
+            },
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::If": [
+                            "UseAlt",
+                            {"Fn::FindInMap": ["RegionMap", "ap-south-1", "AMI"]},
+                            {"Fn::FindInMap": ["RegionMap", "us-east-1", "AMI"]}
+                        ]}
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("WantAlt".to_string(), "no".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["ImageId"],
+            Value::String("ami-east".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_find_in_map_in_active_if_branch_still_errors_on_miss() {
+        // Same shape as above but the active branch is the broken
+        // one; the strict miss handling must still surface.
+        let template = r#"{
+            "Parameters": {"WantAlt": {"Type": "String"}},
+            "Conditions": {
+                "UseAlt": {"Fn::Equals": [{"Ref": "WantAlt"}, "yes"]}
+            },
+            "Mappings": {
+                "RegionMap": {
+                    "us-east-1": {"AMI": "ami-east"}
+                }
+            },
+            "Resources": {
+                "Inst": {
+                    "Type": "AWS::EC2::Instance",
+                    "Properties": {
+                        "ImageId": {"Fn::If": [
+                            "UseAlt",
+                            {"Fn::FindInMap": ["RegionMap", "ap-south-1", "AMI"]},
+                            {"Fn::FindInMap": ["RegionMap", "us-east-1", "AMI"]}
+                        ]}
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("WantAlt".to_string(), "yes".to_string());
+        let err = parse_template(template, &params).unwrap_err();
+        assert!(
+            err.contains("Unable to get mapping for RegionMap::ap-south-1::AMI"),
+            "got: {err}"
         );
     }
 

--- a/crates/fakecloud-e2e/tests/cloudformation.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation.rs
@@ -664,3 +664,134 @@ async fn cloudformation_stack_sends_sns_notification() {
         "notification should contain stack name"
     );
 }
+
+#[tokio::test]
+async fn cloudformation_mappings_find_in_map_resolves_resource_property() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template = r#"{
+        "Parameters": {
+            "Env": {"Type": "String"}
+        },
+        "Mappings": {
+            "EnvMap": {
+                "prod": {"QueueName": "cf-mapped-prod"},
+                "dev": {"QueueName": "cf-mapped-dev"}
+            }
+        },
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": {"Fn::FindInMap": ["EnvMap", {"Ref": "Env"}, "QueueName"]}
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("mappings-stack")
+        .template_body(template)
+        .parameters(
+            aws_sdk_cloudformation::types::Parameter::builder()
+                .parameter_key("Env")
+                .parameter_value("prod")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    let urls = queues.queue_urls();
+    assert!(
+        urls.iter().any(|u| u.contains("cf-mapped-prod")),
+        "Queue cf-mapped-prod should exist (resolved via Fn::FindInMap), got: {urls:?}"
+    );
+    assert!(
+        !urls.iter().any(|u| u.contains("cf-mapped-dev")),
+        "dev branch should not have been picked, got: {urls:?}"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_mappings_find_in_map_default_value_used_on_miss() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+    let sqs_client = server.sqs_client().await;
+
+    let template = r#"{
+        "Mappings": {
+            "EnvMap": {
+                "prod": {"QueueName": "cf-default-prod"}
+            }
+        },
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": {"Fn::FindInMap": [
+                        "EnvMap",
+                        "staging",
+                        "QueueName",
+                        {"DefaultValue": "cf-default-fallback"}
+                    ]}
+                }
+            }
+        }
+    }"#;
+
+    cf_client
+        .create_stack()
+        .stack_name("mappings-default-stack")
+        .template_body(template)
+        .send()
+        .await
+        .unwrap();
+
+    let queues = sqs_client.list_queues().send().await.unwrap();
+    let urls = queues.queue_urls();
+    assert!(
+        urls.iter().any(|u| u.contains("cf-default-fallback")),
+        "Queue cf-default-fallback should exist (DefaultValue used on miss), got: {urls:?}"
+    );
+}
+
+#[tokio::test]
+async fn cloudformation_mappings_find_in_map_missing_no_default_validation_error() {
+    let server = TestServer::start().await;
+    let cf_client = server.cloudformation_client().await;
+
+    let template = r#"{
+        "Mappings": {
+            "EnvMap": {
+                "prod": {"QueueName": "cf-only-prod"}
+            }
+        },
+        "Resources": {
+            "MyQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {
+                    "QueueName": {"Fn::FindInMap": ["EnvMap", "staging", "QueueName"]}
+                }
+            }
+        }
+    }"#;
+
+    let err = cf_client
+        .create_stack()
+        .stack_name("mappings-missing-stack")
+        .template_body(template)
+        .send()
+        .await
+        .expect_err("expected ValidationError when FindInMap path doesn't resolve and no DefaultValue is provided");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Unable to get mapping") || msg.contains("ValidationError"),
+        "expected ValidationError mentioning the missing mapping, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Promotes the existing best-effort `Fn::FindInMap` resolver into a strict, AWS-conformant intrinsic. Top-level `Mappings` block parsing already worked; this PR adds:

- 4-arg form `Fn::FindInMap: [MapName, TopLevelKey, SecondLevelKey, { DefaultValue: <value> }]`. `DefaultValue` is recursively resolved so it can be a `Ref`, nested `FindInMap`, etc.
- Strict miss handling: when the path doesn't resolve and no `DefaultValue` is given, return `ValidationError` with CFN's message format `Template error: Unable to get mapping for <Map>::<Top>::<Second>` (previously silently passed through).
- Pseudo-default resolution inside FindInMap keys so `{"Ref": "AWS::Region"}` works without the caller priming parameters.
- Nested `Fn::FindInMap` as a key argument.
- Arity validation (3 or 4 args; otherwise `ValidationError`).

3-arg form, refs-in-keys, and existing intrinsic resolution (`Ref`, `Sub`, `Join`, `If`, etc.) are unchanged and continue to work alongside FindInMap.

## Test plan

- [x] 10 unit tests in `template::tests` (3-arg, 4-arg w/ default, default vs match precedence, default as intrinsic, refs-in-keys, pseudo-region default, missing-map error, missing-key error, arity error, FindInMap + Sub/Ref together).
- [x] 3 e2e tests in `crates/fakecloud-e2e/tests/cloudformation.rs` against a live fakecloud server: SQS queue name resolved via FindInMap, DefaultValue used on miss, and ValidationError surfaced when the path doesn't resolve and no DefaultValue is supplied.
- [x] `cargo build -p fakecloud-cloudformation` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all`.
- [x] Full `fakecloud-cloudformation` test suite: 134 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Fn::FindInMap` AWS‑conformant: adds the 4‑arg form with `DefaultValue`, resolves key args (including pseudo‑refs and nested lookups), returns a ValidationError on misses, and skips evaluation in unused `Fn::If` branches to avoid false errors.

- **New Features**
  - Support 4‑arg `Fn::FindInMap: [Map, Top, Second, { DefaultValue: <value> }]` (default is recursively resolved).
  - Strict miss handling with AWS message: “Template error: Unable to get mapping for <Map>::<Top>::<Second>”.
  - Resolve key args from `Ref` (including `AWS::Region`) and nested `Fn::FindInMap`; arity must be 3 or 4.
  - Short‑circuit `Fn::If`: only the picked branch is evaluated; unused branch is left untouched.

- **Migration**
  - Templates that relied on pass‑through now fail when a mapping path is missing.
  - Add `{ DefaultValue: ... }` or fix map/keys to avoid the ValidationError.

<sup>Written for commit 6ce558276b0e15283e4aba50d980e646b51dceef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

