### PR TITLE
feat(apigateway): authorizer enforcement (TOKEN/REQUEST/COGNITO_USER_POOLS) (R1)

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -194,6 +194,9 @@ pub async fn handle(
             // Consult any configured gateway response template for the
             // failure category (UNAUTHORIZED for 401, ACCESS_DENIED for
             // 403) so customers can override the status code and body.
+            // If the specific category has no override, fall back to
+            // DEFAULT_4XX — AWS treats it as the catch-all for any 4xx
+            // response that isn't otherwise customized.
             let response_type = match err.status() {
                 StatusCode::UNAUTHORIZED => "UNAUTHORIZED",
                 StatusCode::FORBIDDEN => "ACCESS_DENIED",
@@ -205,7 +208,20 @@ pub async fn handle(
                 &api_id,
                 response_type,
                 &err,
-            );
+            )
+            .or_else(|| {
+                if response_type == "DEFAULT_4XX" {
+                    None
+                } else {
+                    apply_gateway_response_override(
+                        service,
+                        &req.account_id,
+                        &api_id,
+                        "DEFAULT_4XX",
+                        &err,
+                    )
+                }
+            });
             let recorded_status = overridden
                 .as_ref()
                 .map(|r| r.status)
@@ -723,13 +739,17 @@ fn apply_gateway_response_override(
     let accounts = service.state_handle().read();
     let state = accounts.get(account_id)?;
     let value = state.gateway_responses.get(api_id)?.get(response_type)?;
-    // `statusCode` may be a string or numeric per AWS docs; accept both.
+    // `statusCode` may be a string or numeric per AWS docs; accept both
+    // and reject anything that doesn't fit a u16 instead of silently
+    // truncating it.
     let status_code = value
         .get("statusCode")
         .and_then(|v| {
-            v.as_str()
-                .and_then(|s| s.parse::<u16>().ok())
-                .or_else(|| v.as_u64().map(|n| n as u16))
+            v.as_str().and_then(|s| s.parse::<u16>().ok()).or_else(|| {
+                v.as_u64()
+                    .filter(|n| *n <= u16::MAX as u64)
+                    .map(|n| n as u16)
+            })
         })
         .and_then(|n| StatusCode::from_u16(n).ok())
         .unwrap_or_else(|| err.status());
@@ -2013,6 +2033,44 @@ mod tests {
         // missing identity source check.
         assert_eq!(lambda.invocation_count(FN_ARN), 0);
         assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn default_4xx_gateway_response_template_falls_back_for_unauthorized() {
+        // No UNAUTHORIZED-specific override is registered, but
+        // DEFAULT_4XX is. AWS treats DEFAULT_4XX as the catch-all for
+        // any uncustomized 4xx, so the missing-token 401 must adopt the
+        // fallback's status and body.
+        let state = build_state("CUSTOM", Some(token_authorizer()));
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mut by_type = BTreeMap::new();
+            by_type.insert(
+                "DEFAULT_4XX".to_string(),
+                serde_json::json!({
+                    "responseType": "DEFAULT_4XX",
+                    "statusCode": 451,
+                    "responseTemplates": {
+                        "application/json": "{\"fallback\":$context.error.messageString}"
+                    }
+                }),
+            );
+            st.gateway_responses
+                .insert(TEST_API_ID.to_string(), by_type);
+        }
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let resp = handle(&service, &make_request(HeaderMap::new()))
+            .await
+            .expect("DEFAULT_4XX fallback must surface as a successful AwsResponse");
+        assert_eq!(resp.status, StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
+        let body_bytes = match &resp.body {
+            fakecloud_core::service::ResponseBody::Bytes(b) => b.clone(),
+            _ => panic!("override body should be inline bytes"),
+        };
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(body["fallback"].as_str().unwrap().contains("Authorization"));
     }
 
     #[tokio::test]

--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -191,8 +191,30 @@ pub async fn handle(
     {
         Ok(out) => out,
         Err(err) => {
-            service.record_request(&req.account_id, &api_id, &stage_name, req, err.status());
-            return Err(err);
+            // Consult any configured gateway response template for the
+            // failure category (UNAUTHORIZED for 401, ACCESS_DENIED for
+            // 403) so customers can override the status code and body.
+            let response_type = match err.status() {
+                StatusCode::UNAUTHORIZED => "UNAUTHORIZED",
+                StatusCode::FORBIDDEN => "ACCESS_DENIED",
+                _ => "DEFAULT_4XX",
+            };
+            let overridden = apply_gateway_response_override(
+                service,
+                &req.account_id,
+                &api_id,
+                response_type,
+                &err,
+            );
+            let recorded_status = overridden
+                .as_ref()
+                .map(|r| r.status)
+                .unwrap_or_else(|| err.status());
+            service.record_request(&req.account_id, &api_id, &stage_name, req, recorded_status);
+            return match overridden {
+                Some(resp) => Ok(resp),
+                None => Err(err),
+            };
         }
     };
 
@@ -681,6 +703,80 @@ fn interpret_cached(
         })),
         AuthEffect::Deny => Err(forbidden("User is not authorized to access this resource")),
     }
+}
+
+/// Apply the customer-configured gateway response template (if any) for
+/// `response_type`. Returns `None` when no override is registered, in
+/// which case the caller should propagate the original `AwsServiceError`
+/// unchanged. AWS allows overriding the HTTP status code and the
+/// response body via `responseTemplates` keyed by content type; we honor
+/// both and substitute `$context.error.messageString` /
+/// `$context.error.responseType` so the standard AWS-recommended template
+/// `{"message":$context.error.messageString}` renders correctly.
+fn apply_gateway_response_override(
+    service: &ApiGatewayService,
+    account_id: &str,
+    api_id: &str,
+    response_type: &str,
+    err: &AwsServiceError,
+) -> Option<AwsResponse> {
+    let accounts = service.state_handle().read();
+    let state = accounts.get(account_id)?;
+    let value = state.gateway_responses.get(api_id)?.get(response_type)?;
+    // `statusCode` may be a string or numeric per AWS docs; accept both.
+    let status_code = value
+        .get("statusCode")
+        .and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse::<u16>().ok())
+                .or_else(|| v.as_u64().map(|n| n as u16))
+        })
+        .and_then(|n| StatusCode::from_u16(n).ok())
+        .unwrap_or_else(|| err.status());
+    let templates = value.get("responseTemplates").and_then(|v| v.as_object());
+    let template = templates
+        .and_then(|t| t.get("application/json").and_then(|v| v.as_str()))
+        .map(|s| s.to_string());
+    let body = match template {
+        Some(t) => render_error_template(&t, response_type, &err.message()),
+        // Default body matches AWS's built-in shape for an UNAUTHORIZED /
+        // ACCESS_DENIED response.
+        None => format!("{{\"message\":\"{}\"}}", escape_json(&err.message())),
+    };
+    Some(AwsResponse {
+        status: status_code,
+        content_type: "application/json".to_string(),
+        body: bytes::Bytes::from(body.into_bytes()).into(),
+        headers: http::HeaderMap::new(),
+    })
+}
+
+/// Substitute the two `$context.error.*` variables AWS exposes in
+/// gateway response templates. Anything else is left verbatim — full VTL
+/// rendering belongs to integration request/response transforms, not
+/// here.
+fn render_error_template(template: &str, response_type: &str, message: &str) -> String {
+    let escaped = escape_json(message);
+    template
+        .replace("$context.error.messageString", &format!("\"{escaped}\""))
+        .replace("$context.error.message", &escaped)
+        .replace("$context.error.responseType", response_type)
+}
+
+fn escape_json(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 fn inject_authorizer_into_event(event: &mut serde_json::Value, outcome: &AuthorizerOutcome) {
@@ -1836,6 +1932,87 @@ mod tests {
             current_quota_window(april, QuotaPeriod::Month, 0),
             current_quota_window(may, QuotaPeriod::Month, 0)
         );
+    }
+
+    #[tokio::test]
+    async fn token_authorizer_cache_short_circuits_second_invocation() {
+        // Two requests with the same identity-source value must hit the
+        // authorizer Lambda once; the cached Allow result feeds the
+        // second call directly.
+        let state = build_state("CUSTOM", Some(token_authorizer()));
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            FN_ARN,
+            serde_json::json!({
+                "principalId": "u",
+                "policyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [{"Effect": "Allow", "Resource": "*"}]
+                }
+            }),
+        );
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "tok-cache".parse().unwrap());
+
+        for _ in 0..2 {
+            let resp = handle(&service, &make_request(headers.clone()))
+                .await
+                .expect("Allow must let request through");
+            assert_eq!(resp.status, StatusCode::OK);
+        }
+        // Authorizer Lambda invoked exactly once across both requests
+        // (cache TTL is 300s by default in this fixture).
+        assert_eq!(lambda.invocation_count(FN_ARN), 1);
+        // Backend Lambda invoked twice — caching only applies to the
+        // authorizer decision, not to the integration.
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 2);
+    }
+
+    #[tokio::test]
+    async fn unauthorized_gateway_response_template_overrides_status_and_body() {
+        // Customer registers a gateway response template that maps
+        // UNAUTHORIZED to HTTP 418 with a custom JSON body. A request
+        // missing the identity-source header must surface that override
+        // instead of the default 401.
+        let state = build_state("CUSTOM", Some(token_authorizer()));
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mut by_type = BTreeMap::new();
+            by_type.insert(
+                "UNAUTHORIZED".to_string(),
+                serde_json::json!({
+                    "responseType": "UNAUTHORIZED",
+                    "statusCode": "418",
+                    "responseTemplates": {
+                        "application/json": "{\"reason\":$context.error.messageString}"
+                    }
+                }),
+            );
+            st.gateway_responses
+                .insert(TEST_API_ID.to_string(), by_type);
+        }
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let resp = handle(&service, &make_request(HeaderMap::new()))
+            .await
+            .expect("override must surface as a successful AwsResponse");
+        assert_eq!(resp.status, StatusCode::IM_A_TEAPOT);
+        let body_bytes = match &resp.body {
+            fakecloud_core::service::ResponseBody::Bytes(b) => b.clone(),
+            _ => panic!("override body should be inline bytes"),
+        };
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(body["reason"].as_str().unwrap().contains("Authorization"));
+        // Authorizer Lambda never invoked — request shorted at the
+        // missing identity source check.
+        assert_eq!(lambda.invocation_count(FN_ARN), 0);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
     }
 
     #[tokio::test]

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -10,6 +10,10 @@ mod helpers;
 
 use helpers::TestServer;
 
+use aws_sdk_cognitoidentityprovider::types::{
+    ExplicitAuthFlowsType, PasswordPolicyType, UserPoolPolicyType,
+};
+
 #[tokio::test]
 async fn create_rest_api_round_trip() {
     let server = TestServer::start().await;
@@ -247,4 +251,327 @@ async fn get_export_returns_openapi_with_real_paths() {
     assert!(params
         .iter()
         .any(|p| p["name"] == "limit" && p["in"] == "query"));
+}
+
+// ── Authorizer enforcement (Phase R1) ──
+//
+// Drives the data plane through real HTTP requests so we exercise the
+// facade routing (host header `{api-id}.execute-api...`), the authorizer
+// machinery, and the integration handoff end-to-end. Lambda authorizers
+// would require a Docker runtime; the unit tests in
+// `fakecloud_apigateway::data_plane::tests` cover Allow/Deny against a
+// stub LambdaDelivery, so the e2e cases focus on the wiring fakecloud
+// owns: status codes, header plumbing, and the Cognito JWT path that
+// runs entirely in-process via the StateBackedJwtVerifier.
+
+/// Build a synthetic execute-api Host header so the
+/// `ApiGatewayFacade` routes the unsigned request to v1.
+fn execute_api_host(api_id: &str) -> String {
+    format!("{api_id}.execute-api.us-east-1.amazonaws.com")
+}
+
+/// Stand up an API with a single `/items` resource, the requested
+/// authorization config on its GET method, and a MOCK integration so
+/// allowed requests succeed without needing a backend Lambda.
+async fn provision_protected_api(
+    client: &aws_sdk_apigateway::Client,
+    auth_type: &str,
+    authorizer_id: Option<&str>,
+) -> String {
+    let api = client
+        .create_rest_api()
+        .name("auth-test")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+    let resource = client
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("items")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+    let mut put_method = client
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .authorization_type(auth_type);
+    if let Some(aid) = authorizer_id {
+        put_method = put_method.authorizer_id(aid);
+    }
+    put_method.send().await.expect("put_method");
+    client
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .r#type(aws_sdk_apigateway::types::IntegrationType::Mock)
+        .send()
+        .await
+        .expect("put_integration");
+    client
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+    api_id
+}
+
+#[tokio::test]
+async fn data_plane_allows_method_without_authorizer() {
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+    let api_id = provision_protected_api(&client, "NONE", None).await;
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn data_plane_token_authorizer_missing_header_returns_401() {
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    // Create a TOKEN authorizer pointing at a non-existent Lambda;
+    // identity-source enforcement runs before the Lambda invocation, so
+    // the missing token must short-circuit to 401 without needing a
+    // real backend.
+    let api = client
+        .create_rest_api()
+        .name("auth-token-401")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+
+    let authorizer = client
+        .create_authorizer()
+        .rest_api_id(&api_id)
+        .name("tok-auth")
+        .r#type(aws_sdk_apigateway::types::AuthorizerType::Token)
+        .authorizer_uri("arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:nope/invocations")
+        .identity_source("method.request.header.Authorization")
+        .send()
+        .await
+        .expect("create_authorizer");
+    let auth_id = authorizer.id().unwrap().to_string();
+
+    let resource = client
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("items")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+
+    client
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .authorization_type("CUSTOM")
+        .authorizer_id(&auth_id)
+        .send()
+        .await
+        .expect("put_method");
+    client
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .r#type(aws_sdk_apigateway::types::IntegrationType::Mock)
+        .send()
+        .await
+        .expect("put_integration");
+    client
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn data_plane_cognito_authorizer_accepts_real_jwt_and_rejects_garbage() {
+    use aws_sdk_cognitoidentityprovider::types::AuthFlowType;
+
+    let server = TestServer::start().await;
+    let cog = server.cognito_client().await;
+    let apigw = server.apigateway_client().await;
+
+    // Stand up a Cognito user pool with a usable password policy and a
+    // user we can sign in as.
+    let pool = cog
+        .create_user_pool()
+        .pool_name("apigw-cognito")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_user_pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let pool_arn = format!("arn:aws:cognito-idp:us-east-1:000000000000:userpool/{pool_id}");
+    let app = cog
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("c")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowAdminUserPasswordAuth)
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowRefreshTokenAuth)
+        .send()
+        .await
+        .expect("create_user_pool_client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+    cog.admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .send()
+        .await
+        .expect("admin_create_user");
+    cog.admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .password("secret1")
+        .permanent(true)
+        .send()
+        .await
+        .expect("admin_set_user_password");
+    let auth = cog
+        .admin_initiate_auth()
+        .user_pool_id(&pool_id)
+        .client_id(&client_id)
+        .auth_flow(AuthFlowType::AdminUserPasswordAuth)
+        .auth_parameters("USERNAME", "alice")
+        .auth_parameters("PASSWORD", "secret1")
+        .send()
+        .await
+        .expect("admin_initiate_auth");
+    let id_token = auth
+        .authentication_result()
+        .and_then(|r| r.id_token())
+        .expect("id_token must be present after admin_initiate_auth")
+        .to_string();
+
+    // Stand up a REST API protected by a COGNITO_USER_POOLS authorizer
+    // pointing at the pool we just provisioned.
+    let api = apigw
+        .create_rest_api()
+        .name("auth-cognito")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+
+    let authorizer = apigw
+        .create_authorizer()
+        .rest_api_id(&api_id)
+        .name("cog-auth")
+        .r#type(aws_sdk_apigateway::types::AuthorizerType::CognitoUserPools)
+        .provider_arns(&pool_arn)
+        .identity_source("method.request.header.Authorization")
+        .send()
+        .await
+        .expect("create_authorizer");
+    let auth_id = authorizer.id().unwrap().to_string();
+
+    let resource = apigw
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("items")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+    apigw
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .authorization_type("COGNITO_USER_POOLS")
+        .authorizer_id(&auth_id)
+        .send()
+        .await
+        .expect("put_method");
+    apigw
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .r#type(aws_sdk_apigateway::types::IntegrationType::Mock)
+        .send()
+        .await
+        .expect("put_integration");
+    apigw
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+
+    let http = reqwest::Client::new();
+
+    // Tampered JWT must short-circuit at signature verification.
+    let bad = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("authorization", "Bearer not-a-real-jwt")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(bad.status(), 401);
+
+    // Real pool-issued JWT must verify against the in-process JWKS and
+    // let the request through to the MOCK integration.
+    let good = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("authorization", format!("Bearer {id_token}"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(good.status(), 200);
 }


### PR DESCRIPTION
## Summary
- Honor customer-configured gateway response templates for `UNAUTHORIZED` and `ACCESS_DENIED`. A failed authorizer decision now consults `state.gateway_responses[api_id][response_type]`, applies the configured `statusCode` and `responseTemplates['application/json']`, and substitutes `\$context.error.messageString` / `\$context.error.responseType` so the AWS-recommended `{\"message\":\$context.error.messageString}` template renders correctly.
- Existing TOKEN/REQUEST/COGNITO_USER_POOLS enforcement, identity-source extraction, and `authorizerResultTtlInSeconds` caching are unchanged; this PR adds tests proving the cache short-circuits the authorizer Lambda on a repeat call and that the gateway response override surfaces a custom status (e.g. 418) instead of the default 401.
- e2e coverage now drives the data plane through real HTTP requests against the `{api-id}.execute-api...` host: `NONE` -> 200, TOKEN with missing identity-source header -> 401, and `COGNITO_USER_POOLS` with a pool-issued JWT (200) vs a tampered token (401), exercising the in-process Cognito JWKS verifier end-to-end.

## Test plan
- [x] `cargo build -p fakecloud-apigateway`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-apigateway --lib` (26 passed, including new `token_authorizer_cache_short_circuits_second_invocation` and `unauthorized_gateway_response_template_overrides_status_and_body`)
- [x] `cargo test -p fakecloud-e2e --test apigateway` (6 passed, including the 3 new authorizer e2e cases)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds gateway response template enforcement for authorizer failures in `fakecloud-apigateway`, with `DEFAULT_4XX` fallback and strict `statusCode` parsing. Expands e2e coverage for TOKEN/REQUEST/COGNITO_USER_POOLS flows.

- **New Features**
  - Apply `UNAUTHORIZED`/`ACCESS_DENIED` gateway responses: honor `statusCode` and `responseTemplates['application/json']`, substituting `$context.error.messageString` and `$context.error.responseType`.
  - E2E HTTP tests: `NONE` -> 200; TOKEN missing header -> 401; `COGNITO_USER_POOLS` with pool-issued JWT -> 200, tampered token -> 401. Unit test confirms authorizer cache short-circuits repeat calls.

- **Bug Fixes**
  - Reject `statusCode` values that don’t fit a u16 (no truncation).
  - Fall back to `DEFAULT_4XX` when a specific override is missing; add unit test to cover this path.

<sup>Written for commit 6bc7c29f87ebf1f8b9142c42cd38f346f4866047. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

