### PR TITLE
feat(organizations): CreateAccount + CloseAccount + lifecycle ops (H1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,7 @@ dependencies = [
  "fakecloud-core",
  "http 1.4.0",
  "parking_lot",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -5305,7 +5305,12 @@ impl ResourceProvisioner {
         let org = org_lock
             .as_mut()
             .ok_or_else(|| "Organization not yet created".to_string())?;
-        let status = org.create_account(&email, &name, None);
+        // CFN provisioning is its own asynchronous flow; we don't need
+        // a second layer of poll-for-completion on top. Begin the
+        // request and immediately drive it to SUCCEEDED so the rest of
+        // this provisioner sees a fully enrolled account.
+        let pending = org.begin_create_account(&email, &name, None);
+        let status = org.complete_create_account(&pending.id).unwrap_or(pending);
         let account_id = status
             .account_id
             .clone()

--- a/crates/fakecloud-e2e/tests/organizations_lifecycle.rs
+++ b/crates/fakecloud-e2e/tests/organizations_lifecycle.rs
@@ -1,0 +1,375 @@
+//! End-to-end tests for the Organizations account lifecycle ops:
+//! `CreateAccount`, `CreateGovCloudAccount`, `DescribeCreateAccountStatus`,
+//! `ListCreateAccountStatus`, `CloseAccount`, and
+//! `RemoveAccountFromOrganization`.
+//!
+//! Drives real `aws-sdk-organizations` against a fakecloud server with
+//! `FAKECLOUD_IAM=strict` so the wire format and async lifecycle
+//! (IN_PROGRESS -> SUCCEEDED) match the real AWS shape.
+
+mod helpers;
+
+use std::time::{Duration, Instant};
+
+use aws_credential_types::Credentials;
+use aws_sdk_organizations::types::{
+    CreateAccountState, CreateAccountStatus as SdkCreateAccountStatus,
+};
+use aws_sdk_organizations::Client as OrgsClient;
+use helpers::TestServer;
+
+const MGMT_ACCOUNT: &str = "111111111111";
+
+async fn start() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+        // Organizations is pure control plane; no container runtime needed.
+        ("FAKECLOUD_CONTAINER_CLI", "false"),
+    ])
+    .await
+}
+
+async fn config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(akid, secret, None, None, "orgs-lifecycle"))
+        .load()
+        .await
+}
+
+/// Poll `DescribeCreateAccountStatus` until the request reaches a
+/// terminal state, with a generous timeout so CI machines under load
+/// still pass. Returns the terminal status.
+async fn poll_until_terminal(orgs: &OrgsClient, request_id: &str) -> SdkCreateAccountStatus {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let resp = orgs
+            .describe_create_account_status()
+            .create_account_request_id(request_id)
+            .send()
+            .await
+            .unwrap();
+        let status = resp.create_account_status().unwrap().clone();
+        match status.state() {
+            Some(CreateAccountState::Succeeded) | Some(CreateAccountState::Failed) => {
+                return status;
+            }
+            _ => {}
+        }
+        assert!(
+            Instant::now() < deadline,
+            "CreateAccount {request_id} did not terminate within 15s"
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+#[tokio::test]
+async fn create_account_in_progress_then_succeeds_then_lists() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(MGMT_ACCOUNT, "admin").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+    orgs.create_organization().send().await.unwrap();
+
+    let created = orgs
+        .create_account()
+        .email("new@example.com")
+        .account_name("New")
+        .send()
+        .await
+        .unwrap();
+    let initial = created.create_account_status().unwrap();
+    assert_eq!(
+        initial.state(),
+        Some(&CreateAccountState::InProgress),
+        "first response should be IN_PROGRESS"
+    );
+    let request_id = initial.id().unwrap().to_string();
+    assert!(
+        request_id.starts_with("car-"),
+        "request id should start with car-, got {request_id}"
+    );
+    let new_account_id = initial.account_id().unwrap().to_string();
+    assert_eq!(new_account_id.len(), 12);
+    assert!(
+        new_account_id.chars().all(|c| c.is_ascii_digit()),
+        "account id should be 12 digits, got {new_account_id}"
+    );
+
+    // While IN_PROGRESS, the new account is not yet in ListAccounts —
+    // mirrors AWS's "appears only after success" semantics.
+    let listed_pending = orgs.list_accounts().send().await.unwrap();
+    assert!(
+        !listed_pending
+            .accounts()
+            .iter()
+            .any(|a| a.id() == Some(&new_account_id)),
+        "new account should not appear in ListAccounts while IN_PROGRESS"
+    );
+
+    let final_status = poll_until_terminal(&orgs, &request_id).await;
+    assert_eq!(final_status.state(), Some(&CreateAccountState::Succeeded));
+    assert!(final_status.completed_timestamp().is_some());
+
+    // Now the account should be enrolled.
+    let listed_post = orgs.list_accounts().send().await.unwrap();
+    let found = listed_post
+        .accounts()
+        .iter()
+        .find(|a| a.id() == Some(&new_account_id))
+        .expect("new account must appear in ListAccounts after SUCCEEDED");
+    assert_eq!(found.email(), Some("new@example.com"));
+    assert_eq!(found.name(), Some("New"));
+    assert_eq!(
+        found.status(),
+        Some(&aws_sdk_organizations::types::AccountStatus::Active)
+    );
+}
+
+#[tokio::test]
+async fn list_create_account_status_filters_and_paginates() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(MGMT_ACCOUNT, "admin").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+    orgs.create_organization().send().await.unwrap();
+
+    // Three concurrent CreateAccount requests.
+    let mut request_ids = Vec::new();
+    for i in 0..3 {
+        let resp = orgs
+            .create_account()
+            .email(format!("p{i}@example.com"))
+            .account_name(format!("P{i}"))
+            .send()
+            .await
+            .unwrap();
+        request_ids.push(
+            resp.create_account_status()
+                .unwrap()
+                .id()
+                .unwrap()
+                .to_string(),
+        );
+    }
+
+    // Wait for all to reach SUCCEEDED.
+    for id in &request_ids {
+        poll_until_terminal(&orgs, id).await;
+    }
+
+    // SUCCEEDED filter returns all three.
+    let succeeded = orgs
+        .list_create_account_status()
+        .states(CreateAccountState::Succeeded)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(succeeded.create_account_statuses().len(), 3);
+
+    // IN_PROGRESS filter returns none.
+    let in_progress = orgs
+        .list_create_account_status()
+        .states(CreateAccountState::InProgress)
+        .send()
+        .await
+        .unwrap();
+    assert!(in_progress.create_account_statuses().is_empty());
+
+    // Pagination: MaxResults=2 yields 2 + NextToken; second page yields 1.
+    let page1 = orgs
+        .list_create_account_status()
+        .max_results(2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page1.create_account_statuses().len(), 2);
+    let token = page1
+        .next_token()
+        .expect("first page should return a NextToken")
+        .to_string();
+    let page2 = orgs
+        .list_create_account_status()
+        .max_results(2)
+        .next_token(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.create_account_statuses().len(), 1);
+    assert!(
+        page2.next_token().is_none(),
+        "last page should not return a NextToken"
+    );
+}
+
+#[tokio::test]
+async fn create_gov_cloud_account_returns_paired_id() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(MGMT_ACCOUNT, "admin").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+    orgs.create_organization().send().await.unwrap();
+
+    let created = orgs
+        .create_gov_cloud_account()
+        .email("gov@example.com")
+        .account_name("Gov")
+        .send()
+        .await
+        .unwrap();
+    let status = created.create_account_status().unwrap();
+    assert_eq!(status.state(), Some(&CreateAccountState::InProgress));
+    let request_id = status.id().unwrap().to_string();
+    let commercial_id = status.account_id().unwrap().to_string();
+    let gov_id = status.gov_cloud_account_id().unwrap().to_string();
+    assert_ne!(
+        commercial_id, gov_id,
+        "commercial and GovCloud ids must differ"
+    );
+
+    let final_status = poll_until_terminal(&orgs, &request_id).await;
+    assert_eq!(final_status.state(), Some(&CreateAccountState::Succeeded));
+    assert_eq!(final_status.account_id(), Some(commercial_id.as_str()));
+    assert_eq!(final_status.gov_cloud_account_id(), Some(gov_id.as_str()));
+
+    // Both the commercial and GovCloud paired accounts should now be
+    // enrolled in the org.
+    let accounts = orgs.list_accounts().send().await.unwrap();
+    let ids: Vec<&str> = accounts.accounts().iter().filter_map(|a| a.id()).collect();
+    assert!(ids.contains(&commercial_id.as_str()));
+    assert!(ids.contains(&gov_id.as_str()));
+}
+
+#[tokio::test]
+async fn close_account_marks_suspended() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(MGMT_ACCOUNT, "admin").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+    orgs.create_organization().send().await.unwrap();
+
+    let created = orgs
+        .create_account()
+        .email("close@example.com")
+        .account_name("Close")
+        .send()
+        .await
+        .unwrap();
+    let request_id = created
+        .create_account_status()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    let final_status = poll_until_terminal(&orgs, &request_id).await;
+    let account_id = final_status.account_id().unwrap().to_string();
+
+    orgs.close_account()
+        .account_id(&account_id)
+        .send()
+        .await
+        .unwrap();
+
+    let described = orgs
+        .describe_account()
+        .account_id(&account_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described.account().unwrap().status(),
+        Some(&aws_sdk_organizations::types::AccountStatus::Suspended),
+    );
+
+    // Closing the management account is rejected.
+    let err = orgs
+        .close_account()
+        .account_id(MGMT_ACCOUNT)
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("ConstraintViolationException"),
+        "expected ConstraintViolationException, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn remove_account_unlinks_member_from_organization() {
+    let server = start().await;
+    let (akid, secret) = server.create_admin(MGMT_ACCOUNT, "admin").await;
+    let cfg = config_with(&server, &akid, &secret).await;
+    let orgs = OrgsClient::new(&cfg);
+    orgs.create_organization().send().await.unwrap();
+
+    let created = orgs
+        .create_account()
+        .email("remove@example.com")
+        .account_name("Remove")
+        .send()
+        .await
+        .unwrap();
+    let request_id = created
+        .create_account_status()
+        .unwrap()
+        .id()
+        .unwrap()
+        .to_string();
+    let final_status = poll_until_terminal(&orgs, &request_id).await;
+    let account_id = final_status.account_id().unwrap().to_string();
+
+    // Move the account into a fresh OU so we can confirm removal also
+    // unlinks it from the OU subtree (DescribeAccount must fail across
+    // the board, not just under the root).
+    let root = orgs.list_roots().send().await.unwrap();
+    let root_id = root.roots().first().unwrap().id().unwrap().to_string();
+    let ou = orgs
+        .create_organizational_unit()
+        .parent_id(&root_id)
+        .name("UnlinkTest")
+        .send()
+        .await
+        .unwrap();
+    let ou_id = ou.organizational_unit().unwrap().id().unwrap().to_string();
+    orgs.move_account()
+        .account_id(&account_id)
+        .source_parent_id(&root_id)
+        .destination_parent_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+
+    orgs.remove_account_from_organization()
+        .account_id(&account_id)
+        .send()
+        .await
+        .unwrap();
+
+    let err = orgs
+        .describe_account()
+        .account_id(&account_id)
+        .send()
+        .await
+        .unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccountNotFoundException"),
+        "expected AccountNotFoundException after removal, got: {msg}"
+    );
+
+    // The OU should no longer list the account either.
+    let ou_accounts = orgs
+        .list_accounts_for_parent()
+        .parent_id(&ou_id)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        ou_accounts.accounts().is_empty(),
+        "OU should be empty after RemoveAccountFromOrganization"
+    );
+}

--- a/crates/fakecloud-organizations/Cargo.toml
+++ b/crates/fakecloud-organizations/Cargo.toml
@@ -13,8 +13,10 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -613,17 +613,55 @@ impl OrganizationsService {
             })
             .unwrap_or_default();
         // AWS caps MaxResults at 20 for ListCreateAccountStatus and
-        // defaults to 20 when unset. Match that so SDK pagination
-        // tests don't have to special-case fakecloud.
-        let max_results = body
-            .get("MaxResults")
-            .and_then(|v| v.as_u64())
-            .map(|n| n.clamp(1, 20) as usize)
-            .unwrap_or(20);
-        let next_token = body
-            .get("NextToken")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        // defaults to 20 when unset. Reject out-of-range values with
+        // InvalidInputException so callers see the same wire error
+        // they would from real AWS, instead of silently clamping.
+        let max_results = match body.get("MaxResults") {
+            None | Some(Value::Null) => 20,
+            Some(v) => {
+                let n = v.as_u64().ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidInputException",
+                        "MaxResults must be a positive integer between 1 and 20.",
+                    )
+                })?;
+                if !(1..=20).contains(&n) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidInputException",
+                        "MaxResults must be between 1 and 20.",
+                    ));
+                }
+                n as usize
+            }
+        };
+        // NextToken must round-trip a token we previously emitted.
+        // Reject anything we didn't mint (non-numeric, negative, etc.)
+        // up front so callers learn about a typo instead of silently
+        // re-reading page 1.
+        let next_token = match body.get("NextToken") {
+            None | Some(Value::Null) => None,
+            Some(v) => {
+                let s = v.as_str().ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidInputException",
+                        "NextToken must be a string.",
+                    )
+                })?;
+                // Tokens we mint are positive offset integers (see
+                // fakecloud_core::pagination::paginate).
+                if s.parse::<usize>().is_err() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidInputException",
+                        "NextToken is not a valid pagination token.",
+                    ));
+                }
+                Some(s.to_string())
+            }
+        };
 
         let guard = self.state.read();
         let org = self.require_member(&guard, &req.account_id)?;
@@ -2873,6 +2911,46 @@ mod tests {
             .clone();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["Id"].as_str().unwrap(), request_id);
+    }
+
+    #[tokio::test]
+    async fn list_create_account_status_rejects_out_of_range_max_results() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        for bad in [json!(0), json!(21), json!(-1), json!("five")] {
+            let err = expect_err(
+                svc.handle(req_with(
+                    "111111111111",
+                    "ListCreateAccountStatus",
+                    json!({"MaxResults": bad}),
+                ))
+                .await,
+            );
+            assert_eq!(err.code(), "InvalidInputException");
+        }
+    }
+
+    #[tokio::test]
+    async fn list_create_account_status_rejects_invalid_next_token() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        let err = expect_err(
+            svc.handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"NextToken": "not-a-number"}),
+            ))
+            .await,
+        );
+        assert_eq!(err.code(), "InvalidInputException");
+        // Numeric NextToken is accepted (round-trips a token we minted).
+        svc.handle(req_with(
+            "111111111111",
+            "ListCreateAccountStatus",
+            json!({"NextToken": "0"}),
+        ))
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use fakecloud_core::pagination::paginate;
 use http::StatusCode;
+use rand::Rng;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
@@ -11,6 +14,13 @@ use crate::state::{
     MemberAccount, OrgError, OrganizationState, OrganizationalUnit, Policy,
     SharedOrganizationsState, FEATURE_SET_ALL, POLICY_TYPE_SCP,
 };
+
+/// Bounds for the synthetic delay before a `CreateAccount` request
+/// flips from `IN_PROGRESS` to `SUCCEEDED`. Real AWS takes minutes; a
+/// 1-2s window is enough for SDK callers to observe the IN_PROGRESS
+/// phase via at least one poll without making tests slow.
+const CREATE_ACCOUNT_MIN_DELAY: Duration = Duration::from_millis(1000);
+const CREATE_ACCOUNT_MAX_DELAY: Duration = Duration::from_millis(2000);
 
 /// Single source of truth for supported Organizations actions.
 /// Enforcement of attached SCPs ships in Batch 4.
@@ -509,7 +519,12 @@ impl OrganizationsService {
         let mut guard = self.state.write();
         self.require_member_management(&guard, &req.account_id)?;
         let org = guard.as_mut().expect("management gate proved Some");
-        let status = org.create_account(&email, &name, None);
+        let status = org.begin_create_account(&email, &name, None);
+        let request_id = status.id.clone();
+        drop(guard);
+
+        self.spawn_create_account_completion(request_id);
+
         Ok(AwsResponse::ok_json(json!({
             "CreateAccountStatus": create_account_status_payload(&status),
         })))
@@ -527,10 +542,41 @@ impl OrganizationsService {
         // GovCloud partition; we mint one alongside the commercial id
         // so callers see both, matching the real AWS response.
         let gov_id = org.next_account_id();
-        let status = org.create_account(&email, &name, Some(gov_id));
+        let status = org.begin_create_account(&email, &name, Some(gov_id));
+        let request_id = status.id.clone();
+        drop(guard);
+
+        self.spawn_create_account_completion(request_id);
+
         Ok(AwsResponse::ok_json(json!({
             "CreateAccountStatus": create_account_status_payload(&status),
         })))
+    }
+
+    /// Spawn a background tokio task that flips `request_id` from
+    /// `IN_PROGRESS` to `SUCCEEDED` after a synthetic 1-2s delay,
+    /// enrolling the reserved account id (and GovCloud paired id, if
+    /// any) into `state.accounts`. Mirrors the async shape of real
+    /// AWS `CreateAccount` so SDK callers can observe both phases.
+    fn spawn_create_account_completion(&self, request_id: String) {
+        let state = self.state.clone();
+        let delay = {
+            let mut rng = rand::thread_rng();
+            let span = CREATE_ACCOUNT_MAX_DELAY.saturating_sub(CREATE_ACCOUNT_MIN_DELAY);
+            let jitter_millis = if span.is_zero() {
+                0
+            } else {
+                rng.gen_range(0..=span.as_millis() as u64)
+            };
+            CREATE_ACCOUNT_MIN_DELAY + Duration::from_millis(jitter_millis)
+        };
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let mut guard = state.write();
+            if let Some(org) = guard.as_mut() {
+                org.complete_create_account(&request_id);
+            }
+        });
     }
 
     fn describe_create_account_status(
@@ -540,20 +586,15 @@ impl OrganizationsService {
         let body = req.json_body();
         let request_id = required_str(&body, "CreateAccountRequestId")?.to_string();
 
-        let mut guard = self.state.write();
-        let org = guard.as_mut().ok_or_else(organizations_not_in_use)?;
-        if !org.accounts.contains_key(&req.account_id) {
-            return Err(organizations_not_in_use());
-        }
-        let status = org
-            .complete_or_describe_create_account(&request_id)
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "CreateAccountStatusNotFoundException",
-                    format!("Create account status with id {request_id} was not found."),
-                )
-            })?;
+        let guard = self.state.read();
+        let org = self.require_member(&guard, &req.account_id)?;
+        let status = org.describe_create_account(&request_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "CreateAccountStatusNotFoundException",
+                format!("Create account status with id {request_id} was not found."),
+            )
+        })?;
         Ok(AwsResponse::ok_json(json!({
             "CreateAccountStatus": create_account_status_payload(&status),
         })))
@@ -571,21 +612,33 @@ impl OrganizationsService {
                     .collect()
             })
             .unwrap_or_default();
+        // AWS caps MaxResults at 20 for ListCreateAccountStatus and
+        // defaults to 20 when unset. Match that so SDK pagination
+        // tests don't have to special-case fakecloud.
+        let max_results = body
+            .get("MaxResults")
+            .and_then(|v| v.as_u64())
+            .map(|n| n.clamp(1, 20) as usize)
+            .unwrap_or(20);
+        let next_token = body
+            .get("NextToken")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         let guard = self.state.read();
-        let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
-        if !org.accounts.contains_key(&req.account_id) {
-            return Err(organizations_not_in_use());
-        }
-        let statuses: Vec<Value> = org
+        let org = self.require_member(&guard, &req.account_id)?;
+        let filtered: Vec<Value> = org
             .create_account_requests
             .values()
             .filter(|s| states.is_empty() || states.iter().any(|st| st == &s.state))
             .map(create_account_status_payload)
             .collect();
-        Ok(AwsResponse::ok_json(
-            json!({ "CreateAccountStatuses": statuses }),
-        ))
+        let (page, token) = paginate(&filtered, next_token.as_deref(), max_results);
+        let mut body = json!({ "CreateAccountStatuses": page });
+        if let Some(t) = token {
+            body["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(body))
     }
 
     fn close_account(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -2666,6 +2719,35 @@ mod tests {
         serde_json::from_slice(resp.body.expect_bytes()).unwrap()
     }
 
+    /// Poll `DescribeCreateAccountStatus` until the request reaches a
+    /// terminal state, with a timeout. Mirrors how SDK callers observe
+    /// the async `CreateAccount` lifecycle in fakecloud.
+    async fn poll_until_terminal(svc: &Arc<OrganizationsService>, request_id: &str) -> Value {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let resp = svc
+                .handle(req_with(
+                    "111111111111",
+                    "DescribeCreateAccountStatus",
+                    json!({"CreateAccountRequestId": request_id}),
+                ))
+                .await
+                .unwrap();
+            let body = body_value(resp);
+            let state = body["CreateAccountStatus"]["State"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            if state == "SUCCEEDED" || state == "FAILED" {
+                return body;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("CreateAccount {request_id} did not terminate before deadline");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
     #[tokio::test]
     async fn create_account_starts_in_progress_then_describes_succeeded() {
         let (svc, _state) = OrganizationsService::shared();
@@ -2686,47 +2768,37 @@ mod tests {
         let new_account_id = status["AccountId"].as_str().unwrap().to_string();
         assert_eq!(new_account_id.len(), 12);
 
-        // First Describe should flip the status to SUCCEEDED.
-        let resp = svc
-            .handle(req_with(
-                "111111111111",
-                "DescribeCreateAccountStatus",
-                json!({"CreateAccountRequestId": request_id}),
-            ))
-            .await
-            .unwrap();
-        let body = body_value(resp);
+        let body = poll_until_terminal(&svc, &request_id).await;
         assert_eq!(
             body["CreateAccountStatus"]["State"].as_str().unwrap(),
             "SUCCEEDED"
         );
         assert!(body["CreateAccountStatus"]["CompletedTimestamp"].is_number());
+        assert_eq!(
+            body["CreateAccountStatus"]["AccountId"].as_str().unwrap(),
+            new_account_id
+        );
     }
 
     #[tokio::test]
     async fn create_account_only_management_account_can_call() {
         let (svc, _state) = OrganizationsService::shared();
         create_org_with_root(&svc).await;
-        // Enroll a non-management account first.
-        svc.handle(req_with(
-            "111111111111",
-            "CreateAccount",
-            json!({"Email": "non-mgmt@example.com", "AccountName": "NonMgmt"}),
-        ))
-        .await
-        .unwrap();
-        // Find the new id via list.
+        // Enroll a non-management account first and wait for it to succeed.
         let resp = svc
-            .handle(req_with("111111111111", "ListAccounts", json!({})))
+            .handle(req_with(
+                "111111111111",
+                "CreateAccount",
+                json!({"Email": "non-mgmt@example.com", "AccountName": "NonMgmt"}),
+            ))
             .await
             .unwrap();
-        let listed = body_value(resp);
-        let new_id = listed["Accounts"]
-            .as_array()
+        let request_id = body_value(resp)["CreateAccountStatus"]["Id"]
+            .as_str()
             .unwrap()
-            .iter()
-            .find(|a| a["Name"].as_str() == Some("NonMgmt"))
-            .unwrap()["Id"]
+            .to_string();
+        let body = poll_until_terminal(&svc, &request_id).await;
+        let new_id = body["CreateAccountStatus"]["AccountId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -2771,14 +2843,9 @@ mod tests {
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["Id"].as_str().unwrap(), request_id);
 
-        // Flip to SUCCEEDED via Describe, then refilter.
-        svc.handle(req_with(
-            "111111111111",
-            "DescribeCreateAccountStatus",
-            json!({"CreateAccountRequestId": request_id}),
-        ))
-        .await
-        .unwrap();
+        // Wait for the spawned completion task to flip the status, then
+        // re-filter for IN_PROGRESS — the new request should drop out.
+        poll_until_terminal(&svc, &request_id).await;
         let resp = svc
             .handle(req_with(
                 "111111111111",
@@ -2791,6 +2858,71 @@ mod tests {
             .as_array()
             .unwrap()
             .is_empty());
+        // SUCCEEDED filter should now contain it.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"States": ["SUCCEEDED"]}),
+            ))
+            .await
+            .unwrap();
+        let arr = body_value(resp)["CreateAccountStatuses"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["Id"].as_str().unwrap(), request_id);
+    }
+
+    #[tokio::test]
+    async fn list_create_account_status_paginates_with_max_results() {
+        let (svc, _state) = OrganizationsService::shared();
+        create_org_with_root(&svc).await;
+        // Fire three CreateAccount requests so we have something to page over.
+        let mut request_ids = Vec::new();
+        for i in 0..3 {
+            let resp = svc
+                .handle(req_with(
+                    "111111111111",
+                    "CreateAccount",
+                    json!({"Email": format!("p{i}@example.com"), "AccountName": format!("P{i}")}),
+                ))
+                .await
+                .unwrap();
+            request_ids.push(
+                body_value(resp)["CreateAccountStatus"]["Id"]
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
+            );
+        }
+        // First page: MaxResults=2 -> 2 entries + NextToken.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"MaxResults": 2}),
+            ))
+            .await
+            .unwrap();
+        let body = body_value(resp);
+        assert_eq!(body["CreateAccountStatuses"].as_array().unwrap().len(), 2);
+        let next = body["NextToken"].as_str().unwrap().to_string();
+
+        // Second page: same MaxResults + the token returns the remaining one
+        // and no further token.
+        let resp = svc
+            .handle(req_with(
+                "111111111111",
+                "ListCreateAccountStatus",
+                json!({"MaxResults": 2, "NextToken": next}),
+            ))
+            .await
+            .unwrap();
+        let body = body_value(resp);
+        assert_eq!(body["CreateAccountStatuses"].as_array().unwrap().len(), 1);
+        assert!(body.get("NextToken").is_none());
     }
 
     #[tokio::test]
@@ -2805,7 +2937,12 @@ mod tests {
             ))
             .await
             .unwrap();
-        let new_id = body_value(new_resp)["CreateAccountStatus"]["AccountId"]
+        let request_id = body_value(new_resp)["CreateAccountStatus"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let body = poll_until_terminal(&svc, &request_id).await;
+        let new_id = body["CreateAccountStatus"]["AccountId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -2854,7 +2991,12 @@ mod tests {
             ))
             .await
             .unwrap();
-        let new_id = body_value(new_resp)["CreateAccountStatus"]["AccountId"]
+        let request_id = body_value(new_resp)["CreateAccountStatus"]["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let body = poll_until_terminal(&svc, &request_id).await;
+        let new_id = body["CreateAccountStatus"]["AccountId"]
             .as_str()
             .unwrap()
             .to_string();

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -297,12 +297,18 @@ impl OrganizationState {
         }
     }
 
-    /// Synchronously create a new member account under the root and
-    /// record an `IN_PROGRESS` `CreateAccountStatus`. The status is
-    /// flipped to `SUCCEEDED` on the next `DescribeCreateAccountStatus`
-    /// (matching the typical poll-then-observe AWS shape) so callers
-    /// see both phases.
-    pub fn create_account(
+    /// Begin a `CreateAccount` (or `CreateGovCloudAccount`) request.
+    /// Reserves the new 12-digit account id and records an
+    /// `IN_PROGRESS` `CreateAccountStatus` keyed by request id, but does
+    /// NOT enroll the account into `self.accounts` yet — that happens
+    /// when `complete_create_account` runs (mirroring AWS's async
+    /// CreateAccount where the account only appears in `ListAccounts`
+    /// after the status flips to `SUCCEEDED`).
+    ///
+    /// The caller is expected to spawn a background task that calls
+    /// `complete_create_account(request_id)` after a synthetic delay so
+    /// pollers can observe the IN_PROGRESS -> SUCCEEDED transition.
+    pub fn begin_create_account(
         &mut self,
         email: &str,
         name: &str,
@@ -311,22 +317,6 @@ impl OrganizationState {
         let now = Utc::now();
         let request_id = format!("car-{}", random_id(20));
         let new_account_id = self.next_account_id();
-        let arn = format!(
-            "arn:aws:organizations::{}:account/{}/{}",
-            self.management_account_id, self.org_id, new_account_id
-        );
-        let account = MemberAccount {
-            id: new_account_id.clone(),
-            arn,
-            email: email.to_string(),
-            name: name.to_string(),
-            status: "ACTIVE".to_string(),
-            joined_method: "CREATED".to_string(),
-            joined_timestamp: now,
-            parent_id: self.root_id.clone(),
-        };
-        self.accounts.insert(new_account_id.clone(), account);
-
         let status = CreateAccountStatus {
             id: request_id.clone(),
             account_id: Some(new_account_id),
@@ -336,10 +326,99 @@ impl OrganizationState {
             completed_timestamp: None,
             failure_reason: None,
             gov_cloud_account_id: gov_cloud_paired_id,
+            pending_email: Some(email.to_string()),
         };
         self.create_account_requests
             .insert(request_id, status.clone());
         status
+    }
+
+    /// Flip an `IN_PROGRESS` request to `SUCCEEDED` and enroll the
+    /// reserved account id into `self.accounts` (plus the GovCloud
+    /// paired id, if any). Idempotent: if the request is already
+    /// terminal this is a no-op. Returns the updated status, or `None`
+    /// if `request_id` is unknown.
+    pub fn complete_create_account(&mut self, request_id: &str) -> Option<CreateAccountStatus> {
+        let now = Utc::now();
+        let (account_id, account_name, email, gov_cloud_id) = {
+            let status = self.create_account_requests.get(request_id)?;
+            if status.state != "IN_PROGRESS" {
+                return Some(status.clone());
+            }
+            (
+                status.account_id.clone()?,
+                status.account_name.clone(),
+                status.pending_email.clone().unwrap_or_default(),
+                status.gov_cloud_account_id.clone(),
+            )
+        };
+
+        // Enroll the commercial account.
+        let arn = format!(
+            "arn:aws:organizations::{}:account/{}/{}",
+            self.management_account_id, self.org_id, account_id
+        );
+        self.accounts.insert(
+            account_id.clone(),
+            MemberAccount {
+                id: account_id.clone(),
+                arn,
+                email: email.clone(),
+                name: account_name.clone(),
+                status: "ACTIVE".to_string(),
+                joined_method: "CREATED".to_string(),
+                joined_timestamp: now,
+                parent_id: self.root_id.clone(),
+            },
+        );
+
+        // Enroll the GovCloud paired account too. Real AWS creates a
+        // mirror in the GovCloud partition; we keep the paired id
+        // visible in `ListAccounts` so callers can see both.
+        if let Some(gov_id) = &gov_cloud_id {
+            let gov_arn = format!(
+                "arn:aws-us-gov:organizations::{}:account/{}/{}",
+                self.management_account_id, self.org_id, gov_id
+            );
+            self.accounts.insert(
+                gov_id.clone(),
+                MemberAccount {
+                    id: gov_id.clone(),
+                    arn: gov_arn,
+                    email,
+                    name: account_name,
+                    status: "ACTIVE".to_string(),
+                    joined_method: "CREATED".to_string(),
+                    joined_timestamp: now,
+                    parent_id: self.root_id.clone(),
+                },
+            );
+        }
+
+        let status = self.create_account_requests.get_mut(request_id)?;
+        status.state = "SUCCEEDED".to_string();
+        status.completed_timestamp = Some(now);
+        status.pending_email = None;
+        Some(status.clone())
+    }
+
+    /// Mark an `IN_PROGRESS` request as `FAILED` with the given reason.
+    /// Used for synthetic failure injection in tests; real AWS sets a
+    /// reason like `EMAIL_ALREADY_EXISTS`. No accounts are enrolled.
+    pub fn fail_create_account(
+        &mut self,
+        request_id: &str,
+        reason: &str,
+    ) -> Option<CreateAccountStatus> {
+        let status = self.create_account_requests.get_mut(request_id)?;
+        if status.state != "IN_PROGRESS" {
+            return Some(status.clone());
+        }
+        status.state = "FAILED".to_string();
+        status.completed_timestamp = Some(Utc::now());
+        status.failure_reason = Some(reason.to_string());
+        status.pending_email = None;
+        Some(status.clone())
     }
 
     /// Issue a new pending invitation handshake to `target_account_id`.
@@ -569,19 +648,12 @@ impl OrganizationState {
         out
     }
 
-    /// Look up a `CreateAccountStatus` by its `car-...` id. If still
-    /// `IN_PROGRESS`, flip it to `SUCCEEDED` and stamp the completion
-    /// timestamp before returning. Returns `None` if no such request.
-    pub fn complete_or_describe_create_account(
-        &mut self,
-        request_id: &str,
-    ) -> Option<CreateAccountStatus> {
-        let status = self.create_account_requests.get_mut(request_id)?;
-        if status.state == "IN_PROGRESS" {
-            status.state = "SUCCEEDED".to_string();
-            status.completed_timestamp = Some(Utc::now());
-        }
-        Some(status.clone())
+    /// Look up a `CreateAccountStatus` by its `car-...` id without
+    /// mutating it. The deferred completion is driven by a background
+    /// tokio task in `OrganizationsService::create_account`, not by
+    /// `DescribeCreateAccountStatus`, so this is a pure read.
+    pub fn describe_create_account(&self, request_id: &str) -> Option<CreateAccountStatus> {
+        self.create_account_requests.get(request_id).cloned()
     }
 
     /// Mark `account_id` as `SUSPENDED` (mirrors `CloseAccount`). The
@@ -1034,6 +1106,13 @@ pub struct CreateAccountStatus {
     pub failure_reason: Option<String>,
     #[serde(default)]
     pub gov_cloud_account_id: Option<String>,
+    /// Email captured by `BeginCreateAccount`. Held here only while the
+    /// request is `IN_PROGRESS` so the deferred completion task can
+    /// stamp the right email on the resulting `MemberAccount`. Cleared
+    /// when the status flips to a terminal state. Not part of the
+    /// public API surface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_email: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Implements Phase H1 of the Organizations expansion: the async account lifecycle.

- CreateAccount / CreateGovCloudAccount: returns CreateAccountStatus with State=IN_PROGRESS, then a tokio background task flips to SUCCEEDED after a synthetic 1-2s delay. New account is only enrolled in state.accounts on SUCCEEDED, matching AWS's "appears in ListAccounts only after success" semantics.
- DescribeCreateAccountStatus: pure read by CreateAccountRequestId.
- ListCreateAccountStatus: pagination via MaxResults/NextToken (caps at 20) plus the existing States filter.
- CloseAccount: marks member SUSPENDED; management account is protected by ConstraintViolationException.
- RemoveAccountFromOrganization: unlinks member account from org and any direct policy attachments.
- CloudFormation provisioner for AWS::Organizations::Account: switched to begin + complete synchronously so stack rollouts still observe a fully enrolled account inline.

## Test plan

- [x] `cargo test -p fakecloud-organizations` (120 passed)
- [x] `cargo test -p fakecloud-e2e --test organizations_lifecycle` (5 passed)
- [x] `cargo test -p fakecloud-e2e --test organizations --test organizations_scp_enforcement --test cloudformation_organizations` (regression check, all passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the async Organizations account lifecycle with realistic polling behavior and synchronous CloudFormation enrollment. Adds close/remove ops and tightens pagination validation to match AWS errors.

- New Features
  - CreateAccount/CreateGovCloudAccount are async; a background task flips to SUCCEEDED in ~1–2s, and new accounts appear in ListAccounts only after success.
  - DescribeCreateAccountStatus is read-only; ListCreateAccountStatus supports MaxResults/NextToken pagination (cap/default 20), keeps the States filter, and returns InvalidInputException for out-of-range MaxResults or invalid NextToken.
  - CloseAccount marks the member SUSPENDED; the management account is protected.
  - RemoveAccountFromOrganization unlinks the member and any direct policy attachments.
  - `fakecloud-cloudformation` now begins and completes `AWS::Organizations::Account` synchronously so stacks see a fully enrolled account.

- Dependencies
  - Added `rand` and `tokio` to `fakecloud-organizations`.

<sup>Written for commit 78a62a957423a3e627b17652bb90a2fd435f2825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

