### PR TITLE
feat(iam): real SimulateCustomPolicy + SimulatePrincipalPolicy (F2)

### DIFF
--- a/crates/fakecloud-e2e/tests/iam_simulate.rs
+++ b/crates/fakecloud-e2e/tests/iam_simulate.rs
@@ -1,0 +1,219 @@
+//! End-to-end coverage for SimulateCustomPolicy + SimulatePrincipalPolicy.
+//!
+//! These tests drive the AWS Rust SDK against fakecloud's IAM simulator
+//! and assert on the structured `EvaluationResult` decisions we return —
+//! exercising the full evaluator pipeline (action match, explicit deny,
+//! conditions, principal-policy resolution including group union).
+
+mod helpers;
+
+use aws_sdk_iam::types::{ContextEntry, ContextKeyTypeEnum};
+use helpers::TestServer;
+
+const ALLOW_S3_GET: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+
+const ALLOW_S3_DENY_DELETE: &str = r#"{"Version":"2012-10-17","Statement":[
+    {"Effect":"Allow","Action":"s3:*","Resource":"*"},
+    {"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}
+]}"#;
+
+const ALLOW_TAG_CONDITION: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*","Condition":{"StringEquals":{"aws:RequestTag/team":"red"}}}]}"#;
+
+#[tokio::test]
+async fn simulate_custom_policy_allows_matching_action() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    let resp = iam
+        .simulate_custom_policy()
+        .policy_input_list(ALLOW_S3_GET)
+        .action_names("s3:GetObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+
+    let results = resp.evaluation_results();
+    assert_eq!(results.len(), 1);
+    let r = &results[0];
+    assert_eq!(r.eval_action_name(), "s3:GetObject");
+    assert_eq!(r.eval_resource_name(), Some("arn:aws:s3:::bucket/key"));
+    assert_eq!(
+        r.eval_decision().as_str(),
+        "allowed",
+        "expected allowed, got {:?}",
+        r.eval_decision()
+    );
+}
+
+#[tokio::test]
+async fn simulate_custom_policy_explicit_deny_wins_over_allow() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    let resp = iam
+        .simulate_custom_policy()
+        .policy_input_list(ALLOW_S3_DENY_DELETE)
+        .action_names("s3:DeleteObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(
+        r.eval_decision().as_str(),
+        "explicitDeny",
+        "explicit Deny must trump matching Allow"
+    );
+}
+
+#[tokio::test]
+async fn simulate_custom_policy_implicit_deny_when_condition_mismatches() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    // Caller supplies aws:RequestTag/team=blue but the policy only
+    // allows team=red. No Deny statement, no matching Allow -> implicit
+    // deny. The supplied context key must NOT show up under
+    // MissingContextValues.
+    let resp = iam
+        .simulate_custom_policy()
+        .policy_input_list(ALLOW_TAG_CONDITION)
+        .action_names("s3:PutObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .context_entries(
+            ContextEntry::builder()
+                .context_key_name("aws:RequestTag/team")
+                .context_key_values("blue")
+                .context_key_type(ContextKeyTypeEnum::String)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(r.eval_decision().as_str(), "implicitDeny");
+    assert!(
+        r.missing_context_values().is_empty(),
+        "supplied key must not be missing: {:?}",
+        r.missing_context_values()
+    );
+}
+
+#[tokio::test]
+async fn simulate_custom_policy_lists_missing_context_values() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    // Caller didn't supply aws:RequestTag/team — simulator should
+    // surface it under MissingContextValues so the AWS console UX
+    // works the same against fakecloud.
+    let resp = iam
+        .simulate_custom_policy()
+        .policy_input_list(ALLOW_TAG_CONDITION)
+        .action_names("s3:PutObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(r.eval_decision().as_str(), "implicitDeny");
+    assert!(
+        r.missing_context_values()
+            .iter()
+            .any(|k| k == "aws:RequestTag/team"),
+        "expected missing key surfaced, got {:?}",
+        r.missing_context_values()
+    );
+}
+
+#[tokio::test]
+async fn simulate_principal_policy_via_attached_managed_policy() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    iam.create_user().user_name("simuser").send().await.unwrap();
+    iam.create_policy()
+        .policy_name("AllowS3Get")
+        .policy_document(ALLOW_S3_GET)
+        .send()
+        .await
+        .unwrap();
+    let policy_arn = "arn:aws:iam::123456789012:policy/AllowS3Get";
+    iam.attach_user_policy()
+        .user_name("simuser")
+        .policy_arn(policy_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = iam
+        .simulate_principal_policy()
+        .policy_source_arn("arn:aws:iam::123456789012:user/simuser")
+        .action_names("s3:GetObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(r.eval_decision().as_str(), "allowed");
+}
+
+#[tokio::test]
+async fn simulate_principal_policy_unions_group_attached_policies() {
+    let server = TestServer::start().await;
+    let iam = server.iam_client().await;
+
+    // The user has zero identity-side policies; the only allow comes
+    // from the group's attached managed policy. AWS unions group
+    // policies into the user's effective policy set during simulation.
+    iam.create_user()
+        .user_name("groupuser")
+        .send()
+        .await
+        .unwrap();
+    iam.create_group()
+        .group_name("readers")
+        .send()
+        .await
+        .unwrap();
+    iam.add_user_to_group()
+        .group_name("readers")
+        .user_name("groupuser")
+        .send()
+        .await
+        .unwrap();
+
+    iam.create_policy()
+        .policy_name("GroupAllowGet")
+        .policy_document(ALLOW_S3_GET)
+        .send()
+        .await
+        .unwrap();
+    iam.attach_group_policy()
+        .group_name("readers")
+        .policy_arn("arn:aws:iam::123456789012:policy/GroupAllowGet")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = iam
+        .simulate_principal_policy()
+        .policy_source_arn("arn:aws:iam::123456789012:user/groupuser")
+        .action_names("s3:GetObject")
+        .resource_arns("arn:aws:s3:::bucket/key")
+        .send()
+        .await
+        .unwrap();
+
+    let r = &resp.evaluation_results()[0];
+    assert_eq!(
+        r.eval_decision().as_str(),
+        "allowed",
+        "user must inherit group's attached policy"
+    );
+}

--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -52,7 +52,9 @@ fn collect_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
 
 /// Resolve an IAM principal ARN (user or role) to its full identity
 /// policy set: managed policies (default version) plus inline
-/// policies. Returns an empty vec if the ARN doesn't resolve.
+/// policies. For users this also unions every policy attached to the
+/// groups they belong to, matching AWS's `SimulatePrincipalPolicy`
+/// semantics. Returns an empty vec if the ARN doesn't resolve.
 fn collect_principal_policies(
     state: &IamState,
     source_arn: &str,
@@ -90,6 +92,26 @@ fn collect_principal_policies(
     }
     for doc in inline.values() {
         out.push(PolicyDocument::parse(doc));
+    }
+    // Users inherit every policy attached to a group they belong to —
+    // both managed and inline. Roles can't be group members so this
+    // step is user-only.
+    if matches!(kind, PrincipalKind::User) {
+        for group in state.groups.values() {
+            if !group.members.iter().any(|m| m == name) {
+                continue;
+            }
+            for arn in &group.attached_policies {
+                if let Some(policy) = state.policies.get(arn) {
+                    if let Some(v) = policy.versions.iter().find(|v| v.is_default) {
+                        out.push(PolicyDocument::parse(&v.document));
+                    }
+                }
+            }
+            for doc in group.inline_policies.values() {
+                out.push(PolicyDocument::parse(doc));
+            }
+        }
     }
     out
 }
@@ -846,6 +868,12 @@ impl IamService {
         // to for any key it doesn't recognize.
         apply_context_entries(req, &mut ctx);
 
+        // Pre-compute the set of condition keys referenced by the
+        // identity policies (plus the optional boundary). Any key the
+        // caller didn't supply is reported under MissingContextValues
+        // so simulators can warn about gaps before the real call.
+        let missing_keys = collect_missing_context_values(req, &ctx);
+
         let mut members = String::new();
         for action_name in &actions {
             for resource in &resources {
@@ -862,11 +890,16 @@ impl IamService {
                     Decision::ImplicitDeny => "implicitDeny",
                     Decision::ExplicitDeny => "explicitDeny",
                 };
+                let missing_xml: String = missing_keys
+                    .iter()
+                    .map(|k| format!("<member>{}</member>", xml_escape(k)))
+                    .collect();
                 members.push_str(&format!(
-                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision><MatchedStatements/><MissingContextValues/></member>",
+                    "<member><EvalActionName>{}</EvalActionName><EvalResourceName>{}</EvalResourceName><EvalDecision>{}</EvalDecision><MatchedStatements/><MissingContextValues>{}</MissingContextValues></member>",
                     xml_escape(action_name),
                     xml_escape(resource),
-                    decision_str
+                    decision_str,
+                    missing_xml,
                 ));
             }
         }
@@ -1102,6 +1135,36 @@ impl IamService {
             empty_response("UpdateServerCertificate", &req.request_id),
         ))
     }
+}
+
+/// Walk every policy doc supplied in the request (PolicyInputList +
+/// PermissionsBoundaryPolicyInputList) and return the condition keys
+/// that the request's [`ConditionContext`] can't resolve. The order is
+/// stable + deduped so callers get a deterministic XML response.
+///
+/// AWS uses this list to surface "you're missing aws:RequestedRegion"
+/// style hints in the simulator UI even when the decision is `allowed`.
+fn collect_missing_context_values(
+    req: &AwsRequest,
+    ctx: &fakecloud_core::auth::ConditionContext,
+) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    let policy_lists = [
+        "PolicyInputList.member.",
+        "PermissionsBoundaryPolicyInputList.member.",
+    ];
+    for prefix in policy_lists {
+        for body in collect_member_list(req, prefix) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
+                extract_condition_keys(&parsed, &mut keys);
+            }
+        }
+    }
+    keys.sort();
+    keys.dedup();
+    keys.into_iter()
+        .filter(|k| ctx.lookup(k).is_none())
+        .collect()
 }
 
 fn extract_condition_keys(v: &serde_json::Value, out: &mut Vec<String>) {

--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -51,16 +51,18 @@ fn collect_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
 }
 
 /// Resolve an IAM principal ARN (user or role) to its full identity
-/// policy set: managed policies (default version) plus inline
-/// policies. For users this also unions every policy attached to the
-/// groups they belong to, matching AWS's `SimulatePrincipalPolicy`
-/// semantics. Returns an empty vec if the ARN doesn't resolve.
-fn collect_principal_policies(
-    state: &IamState,
-    source_arn: &str,
-) -> Vec<crate::evaluator::PolicyDocument> {
-    use crate::evaluator::PolicyDocument;
-    let mut out: Vec<PolicyDocument> = Vec::new();
+/// policy set as raw JSON strings: managed policies (default version)
+/// plus inline policies. For users this also unions every policy
+/// attached to the groups they belong to, matching AWS's
+/// `SimulatePrincipalPolicy` semantics. Returns an empty vec if the
+/// ARN doesn't resolve.
+///
+/// Returning raw JSON (instead of `PolicyDocument`) lets callers feed
+/// the same docs into both the evaluator (via `PolicyDocument::parse`)
+/// and the condition-key scanner used to populate
+/// `MissingContextValues`.
+fn collect_principal_policy_jsons(state: &IamState, source_arn: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
     let (kind, name) = match parse_principal_arn(source_arn) {
         Some(p) => p,
         None => return out,
@@ -86,12 +88,12 @@ fn collect_principal_policies(
     for arn in &managed {
         if let Some(policy) = state.policies.get(arn) {
             if let Some(v) = policy.versions.iter().find(|v| v.is_default) {
-                out.push(PolicyDocument::parse(&v.document));
+                out.push(v.document.clone());
             }
         }
     }
     for doc in inline.values() {
-        out.push(PolicyDocument::parse(doc));
+        out.push(doc.clone());
     }
     // Users inherit every policy attached to a group they belong to —
     // both managed and inline. Roles can't be group members so this
@@ -104,12 +106,12 @@ fn collect_principal_policies(
             for arn in &group.attached_policies {
                 if let Some(policy) = state.policies.get(arn) {
                     if let Some(v) = policy.versions.iter().find(|v| v.is_default) {
-                        out.push(PolicyDocument::parse(&v.document));
+                        out.push(v.document.clone());
                     }
                 }
             }
             for doc in group.inline_policies.values() {
-                out.push(PolicyDocument::parse(doc));
+                out.push(doc.clone());
             }
         }
     }
@@ -789,7 +791,11 @@ impl IamService {
         // Identity-side policies. SimulateCustomPolicy reads
         // PolicyInputList; SimulatePrincipalPolicy resolves the
         // PolicySourceArn principal's attached + inline policies.
+        // We collect the raw JSON alongside the parsed `PolicyDocument`
+        // so MissingContextValues can scan the *resolved* doc set
+        // (principal + group + boundary), not just the request inputs.
         let mut identity_docs: Vec<PolicyDocument> = Vec::new();
+        let mut raw_policy_jsons: Vec<String> = Vec::new();
         let mut caller_arn: Option<String> = req.query_params.get("CallerArn").cloned();
         let mut boundary_docs: Option<Vec<PolicyDocument>> = None;
 
@@ -797,6 +803,7 @@ impl IamService {
             "SimulateCustomPolicy" => {
                 for body in collect_member_list(req, "PolicyInputList.member.") {
                     identity_docs.push(PolicyDocument::parse(&body));
+                    raw_policy_jsons.push(body);
                 }
                 if identity_docs.is_empty() {
                     return Err(AwsServiceError::aws_error(
@@ -810,10 +817,11 @@ impl IamService {
                 if !boundaries.is_empty() {
                     boundary_docs = Some(
                         boundaries
-                            .into_iter()
-                            .map(|s| PolicyDocument::parse(&s))
+                            .iter()
+                            .map(|s| PolicyDocument::parse(s))
                             .collect(),
                     );
+                    raw_policy_jsons.extend(boundaries);
                 }
             }
             "SimulatePrincipalPolicy" => {
@@ -828,17 +836,23 @@ impl IamService {
                 let accounts = self.state.read();
                 let empty = IamState::new(&req.account_id);
                 let state = accounts.get(&req.account_id).unwrap_or(&empty);
-                identity_docs = collect_principal_policies(state, source_arn);
+                let resolved = collect_principal_policy_jsons(state, source_arn);
+                for body in &resolved {
+                    identity_docs.push(PolicyDocument::parse(body));
+                }
+                raw_policy_jsons.extend(resolved);
                 if let Some(boundary_arn) = principal_boundary(state, source_arn) {
                     if let Some(p) = state.policies.get(&boundary_arn) {
                         if let Some(v) = p.versions.iter().find(|v| v.is_default) {
                             boundary_docs = Some(vec![PolicyDocument::parse(&v.document)]);
+                            raw_policy_jsons.push(v.document.clone());
                         }
                     }
                 }
                 // Add policies attached via PolicyInputList overlay.
                 for body in collect_member_list(req, "PolicyInputList.member.") {
                     identity_docs.push(PolicyDocument::parse(&body));
+                    raw_policy_jsons.push(body);
                 }
             }
             _ => {}
@@ -868,11 +882,13 @@ impl IamService {
         // to for any key it doesn't recognize.
         apply_context_entries(req, &mut ctx);
 
-        // Pre-compute the set of condition keys referenced by the
-        // identity policies (plus the optional boundary). Any key the
+        // Pre-compute the set of condition keys referenced by every
+        // resolved policy doc (PolicyInputList + boundary inputs for
+        // SimulateCustomPolicy; principal/group/boundary policies +
+        // optional overlay for SimulatePrincipalPolicy). Any key the
         // caller didn't supply is reported under MissingContextValues
         // so simulators can warn about gaps before the real call.
-        let missing_keys = collect_missing_context_values(req, &ctx);
+        let missing_keys = collect_missing_context_values(&raw_policy_jsons, &ctx);
 
         let mut members = String::new();
         for action_name in &actions {
@@ -1137,27 +1153,22 @@ impl IamService {
     }
 }
 
-/// Walk every policy doc supplied in the request (PolicyInputList +
-/// PermissionsBoundaryPolicyInputList) and return the condition keys
-/// that the request's [`ConditionContext`] can't resolve. The order is
-/// stable + deduped so callers get a deterministic XML response.
+/// Walk every resolved policy doc (request inputs + principal/group/
+/// boundary policies for SimulatePrincipalPolicy) and return the
+/// condition keys that the request's [`ConditionContext`] can't
+/// resolve. Order is stable + deduped so callers get a deterministic
+/// XML response.
 ///
 /// AWS uses this list to surface "you're missing aws:RequestedRegion"
 /// style hints in the simulator UI even when the decision is `allowed`.
 fn collect_missing_context_values(
-    req: &AwsRequest,
+    policy_jsons: &[String],
     ctx: &fakecloud_core::auth::ConditionContext,
 ) -> Vec<String> {
     let mut keys: Vec<String> = Vec::new();
-    let policy_lists = [
-        "PolicyInputList.member.",
-        "PermissionsBoundaryPolicyInputList.member.",
-    ];
-    for prefix in policy_lists {
-        for body in collect_member_list(req, prefix) {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
-                extract_condition_keys(&parsed, &mut keys);
-            }
+    for body in policy_jsons {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+            extract_condition_keys(&parsed, &mut keys);
         }
     }
     keys.sort();

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -3807,6 +3807,49 @@ fn simulate_principal_policy_unions_attached_group_managed_policy() {
 }
 
 #[test]
+fn simulate_principal_policy_reports_missing_context_from_resolved_policies() {
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "ed")]))
+        .unwrap();
+    // Attach a managed policy whose Condition references a key the
+    // request never supplies. The simulator must walk the *resolved*
+    // policy set, not just PolicyInputList, when reporting missing
+    // context values.
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*","Condition":{"StringEquals":{"aws:RequestedRegion":"us-east-1"}}}]}"#;
+    svc.create_policy(&make_request(
+        "CreatePolicy",
+        vec![("PolicyName", "RegionGate"), ("PolicyDocument", policy_doc)],
+    ))
+    .unwrap();
+    svc.attach_user_policy(&make_request(
+        "AttachUserPolicy",
+        vec![
+            ("UserName", "ed"),
+            ("PolicyArn", "arn:aws:iam::123456789012:policy/RegionGate"),
+        ],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .simulate_principal_policy(&make_request(
+            "SimulatePrincipalPolicy",
+            vec![
+                ("PolicySourceArn", "arn:aws:iam::123456789012:user/ed"),
+                ("ActionNames.member.1", "s3:PutObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains(
+            "<MissingContextValues><member>aws:RequestedRegion</member></MissingContextValues>"
+        ),
+        "expected resolved-policy condition key reported, body: {body}"
+    );
+}
+
+#[test]
 fn simulate_custom_policy_reports_missing_context_values() {
     let svc = make_service();
     let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*","Condition":{"StringEquals":{"aws:RequestTag/team":"red"}}}]}"#;

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -3721,6 +3721,118 @@ fn simulate_principal_policy_blocked_by_permission_boundary() {
 }
 
 #[test]
+fn simulate_principal_policy_unions_group_policies() {
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "carol")]))
+        .unwrap();
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "ops")]))
+        .unwrap();
+    svc.add_user_to_group(&make_request(
+        "AddUserToGroup",
+        vec![("UserName", "carol"), ("GroupName", "ops")],
+    ))
+    .unwrap();
+    // Group inline policy grants s3:GetObject — the user has no
+    // identity-side policies of their own.
+    let inline_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}"#;
+    svc.put_group_policy(&make_request(
+        "PutGroupPolicy",
+        vec![
+            ("GroupName", "ops"),
+            ("PolicyName", "InlineRead"),
+            ("PolicyDocument", inline_doc),
+        ],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .simulate_principal_policy(&make_request(
+            "SimulatePrincipalPolicy",
+            vec![
+                ("PolicySourceArn", "arn:aws:iam::123456789012:user/carol"),
+                ("ActionNames.member.1", "s3:GetObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<EvalDecision>allowed</EvalDecision>"),
+        "expected allowed via group inline policy, body: {body}"
+    );
+}
+
+#[test]
+fn simulate_principal_policy_unions_attached_group_managed_policy() {
+    let svc = make_service();
+    svc.create_user(&make_request("CreateUser", vec![("UserName", "dave")]))
+        .unwrap();
+    svc.create_group(&make_request("CreateGroup", vec![("GroupName", "admins")]))
+        .unwrap();
+    svc.add_user_to_group(&make_request(
+        "AddUserToGroup",
+        vec![("UserName", "dave"), ("GroupName", "admins")],
+    ))
+    .unwrap();
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*"}]}"#;
+    svc.create_policy(&make_request(
+        "CreatePolicy",
+        vec![("PolicyName", "GroupPut"), ("PolicyDocument", policy_doc)],
+    ))
+    .unwrap();
+    svc.attach_group_policy(&make_request(
+        "AttachGroupPolicy",
+        vec![
+            ("GroupName", "admins"),
+            ("PolicyArn", "arn:aws:iam::123456789012:policy/GroupPut"),
+        ],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .simulate_principal_policy(&make_request(
+            "SimulatePrincipalPolicy",
+            vec![
+                ("PolicySourceArn", "arn:aws:iam::123456789012:user/dave"),
+                ("ActionNames.member.1", "s3:PutObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(
+        body.contains("<EvalDecision>allowed</EvalDecision>"),
+        "expected allowed via attached group managed policy, body: {body}"
+    );
+}
+
+#[test]
+fn simulate_custom_policy_reports_missing_context_values() {
+    let svc = make_service();
+    let policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*","Condition":{"StringEquals":{"aws:RequestTag/team":"red"}}}]}"#;
+    let resp = svc
+        .simulate_custom_policy(&make_request(
+            "SimulateCustomPolicy",
+            vec![
+                ("PolicyInputList.member.1", policy),
+                ("ActionNames.member.1", "s3:GetObject"),
+                ("ResourceArns.member.1", "arn:aws:s3:::b/k"),
+            ],
+        ))
+        .unwrap();
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    // Caller didn't pass aws:RequestTag/team — should appear under
+    // MissingContextValues, and the eval should implicitly deny.
+    assert!(
+        body.contains(
+            "<MissingContextValues><member>aws:RequestTag/team</member></MissingContextValues>"
+        ),
+        "expected missing context key reported, body: {body}"
+    );
+    assert!(body.contains("<EvalDecision>implicitDeny</EvalDecision>"));
+}
+
+#[test]
 fn misc_extras_smoke() {
     let svc = make_service();
     svc.create_user(&make_request("CreateUser", vec![("UserName", "u1")]))


### PR DESCRIPTION
## Summary
- SimulateCustomPolicy now parses PolicyInputList, PermissionsBoundaryPolicyInputList, and ContextEntries.member.N, then runs the policies through the same evaluate_with_gates() pipeline used by S3/SQS/etc.
- SimulatePrincipalPolicy resolves PolicySourceArn to its attached + inline policies, unions every group's attached + inline policies for user principals, and applies the user/role's permission boundary as a gate. Optional PolicyInputList overlay still extends the doc set.
- EvalDecision returned as `allowed | implicitDeny | explicitDeny`. MissingContextValues now lists condition keys referenced by the supplied policies but absent from the request.
- Unit + E2E coverage for: allow on action match, explicit deny wins, condition mismatch with supplied tag, missing-context surfacing, principal-policy via attached managed policy, group-policy union.

## Test plan
- [x] `cargo build -p fakecloud-iam`
- [x] `cargo test -p fakecloud-iam` (430 passed)
- [x] `cargo test -p fakecloud-e2e --test iam_simulate` (6 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real IAM policy simulation for SimulateCustomPolicy and SimulatePrincipalPolicy using the shared evaluator. Honors permission boundaries, unions group policies for users, and returns accurate decisions while reporting missing context keys from all resolved policies.

- New Features
  - Parse `PolicyInputList`, `PermissionsBoundaryPolicyInputList`, and `ContextEntries.member.N` into the condition context.
  - SimulatePrincipalPolicy: resolve `PolicySourceArn` to attached + inline policies; for users, union group attached + inline policies; apply the principal’s permission boundary.
  - Optional `PolicyInputList` overlay extends the resolved policy set.
  - Return `EvalDecision` as `allowed`, `implicitDeny`, or `explicitDeny`.
  - Tests in `fakecloud-iam` and `fakecloud-e2e` cover allow, explicit deny, condition mismatch, group union, and missing-context surfacing (including from resolved policies).

- Bug Fixes
  - MissingContextValues now scans the full resolved policy set (principal, group, boundary, and overlay), not just `PolicyInputList`, so keys referenced by attached/inline/boundary policies are correctly reported.

<sup>Written for commit 5258dbee01d8b3b368a1f53df276ef3b923ca8b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

