### PR TITLE
feat(rds): ModifyDBParameterGroup + DescribeDB(Cluster)Parameters real (M2)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_parameter_group.rs
+++ b/crates/fakecloud-e2e/tests/rds_parameter_group.rs
@@ -1,0 +1,278 @@
+//! End-to-end coverage for RDS parameter group editing/inspection
+//! shipped in the M2 batch:
+//!
+//! * `ModifyDBParameterGroup` parses `Parameters.member.N.*` and persists
+//!   the values onto the parameter group.
+//! * `DescribeDBParameters` reports stored values as `Source=user` and
+//!   the engine-default seed for the family as `Source=engine-default`.
+//! * `ModifyDBClusterParameterGroup` /
+//!   `DescribeDBClusterParameters` are symmetric for cluster parameter
+//!   groups.
+
+mod helpers;
+
+use aws_sdk_rds::types::Parameter;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn modify_db_parameter_group_persists_user_values_visible_via_describe() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let group = "pg-m2-user";
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name(group)
+        .db_parameter_group_family("postgres16")
+        .description("user param round-trip")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_db_parameter_group()
+        .db_parameter_group_name(group)
+        .parameters(
+            Parameter::builder()
+                .parameter_name("max_connections")
+                .parameter_value("250")
+                .apply_method(aws_sdk_rds::types::ApplyMethod::Immediate)
+                .build(),
+        )
+        .parameters(
+            Parameter::builder()
+                .parameter_name("work_mem")
+                .parameter_value("8192")
+                .apply_method(aws_sdk_rds::types::ApplyMethod::PendingReboot)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let user_only = client
+        .describe_db_parameters()
+        .db_parameter_group_name(group)
+        .source("user")
+        .send()
+        .await
+        .unwrap();
+
+    let params = user_only.parameters();
+    let max_connections = params
+        .iter()
+        .find(|p| p.parameter_name() == Some("max_connections"))
+        .expect("max_connections present in user source");
+    assert_eq!(max_connections.parameter_value(), Some("250"));
+    assert_eq!(max_connections.source(), Some("user"));
+
+    let work_mem = params
+        .iter()
+        .find(|p| p.parameter_name() == Some("work_mem"))
+        .expect("work_mem present in user source");
+    assert_eq!(work_mem.parameter_value(), Some("8192"));
+    assert_eq!(work_mem.source(), Some("user"));
+
+    // The engine-default source should not contain user-only knobs we did
+    // not seed in the engine defaults table, but should still surface
+    // baseline parameters (e.g. `shared_buffers` for postgres16).
+    let engine_defaults = client
+        .describe_db_parameters()
+        .db_parameter_group_name(group)
+        .source("engine-default")
+        .send()
+        .await
+        .unwrap();
+
+    let engine_params = engine_defaults.parameters();
+    assert!(engine_params
+        .iter()
+        .all(|p| p.source() == Some("engine-default")));
+    assert!(engine_params
+        .iter()
+        .any(|p| p.parameter_name() == Some("shared_buffers")));
+    // `max_connections` is shadowed by the user override, so it must not
+    // surface under the `engine-default` source.
+    assert!(engine_params
+        .iter()
+        .all(|p| p.parameter_name() != Some("max_connections")));
+}
+
+#[tokio::test]
+async fn describe_db_parameters_engine_default_for_fresh_group_lists_seeded_params() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let group = "pg-m2-defaults";
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name(group)
+        .db_parameter_group_family("postgres16")
+        .description("engine defaults only")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_db_parameters()
+        .db_parameter_group_name(group)
+        .source("engine-default")
+        .send()
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = response
+        .parameters()
+        .iter()
+        .filter_map(|p| p.parameter_name())
+        .collect();
+    assert!(names.contains(&"max_connections"));
+    assert!(names.contains(&"shared_buffers"));
+    assert!(names.contains(&"work_mem"));
+}
+
+#[tokio::test]
+async fn describe_db_parameters_no_filter_returns_user_and_engine_defaults() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let group = "pg-m2-merged";
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name(group)
+        .db_parameter_group_family("mysql8.0")
+        .description("merge user + defaults")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_db_parameter_group()
+        .db_parameter_group_name(group)
+        .parameters(
+            Parameter::builder()
+                .parameter_name("max_connections")
+                .parameter_value("500")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_db_parameters()
+        .db_parameter_group_name(group)
+        .send()
+        .await
+        .unwrap();
+
+    let max_connections_entries: Vec<&Parameter> = response
+        .parameters()
+        .iter()
+        .filter(|p| p.parameter_name() == Some("max_connections"))
+        .collect();
+    assert_eq!(
+        max_connections_entries.len(),
+        1,
+        "max_connections must appear exactly once when user shadows default"
+    );
+    assert_eq!(max_connections_entries[0].source(), Some("user"));
+    assert_eq!(max_connections_entries[0].parameter_value(), Some("500"));
+
+    // Other engine defaults remain.
+    let names: Vec<&str> = response
+        .parameters()
+        .iter()
+        .filter_map(|p| p.parameter_name())
+        .collect();
+    assert!(names.contains(&"innodb_buffer_pool_size"));
+}
+
+#[tokio::test]
+async fn modify_db_cluster_parameter_group_round_trips_through_describe() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let group = "cpg-m2";
+    client
+        .create_db_cluster_parameter_group()
+        .db_cluster_parameter_group_name(group)
+        .db_parameter_group_family("aurora-postgresql15")
+        .description("cluster param round-trip")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_db_cluster_parameter_group()
+        .db_cluster_parameter_group_name(group)
+        .parameters(
+            Parameter::builder()
+                .parameter_name("max_connections")
+                .parameter_value("750")
+                .apply_method(aws_sdk_rds::types::ApplyMethod::Immediate)
+                .build(),
+        )
+        .parameters(
+            Parameter::builder()
+                .parameter_name("custom_cluster_knob")
+                .parameter_value("on")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let user_only = client
+        .describe_db_cluster_parameters()
+        .db_cluster_parameter_group_name(group)
+        .source("user")
+        .send()
+        .await
+        .unwrap();
+
+    let user_params = user_only.parameters();
+    assert!(user_params.iter().all(|p| p.source() == Some("user")));
+    let max_connections = user_params
+        .iter()
+        .find(|p| p.parameter_name() == Some("max_connections"))
+        .expect("max_connections persisted");
+    assert_eq!(max_connections.parameter_value(), Some("750"));
+    assert!(user_params
+        .iter()
+        .any(|p| p.parameter_name() == Some("custom_cluster_knob")));
+
+    let defaults = client
+        .describe_db_cluster_parameters()
+        .db_cluster_parameter_group_name(group)
+        .source("engine-default")
+        .send()
+        .await
+        .unwrap();
+    let default_names: Vec<&str> = defaults
+        .parameters()
+        .iter()
+        .filter_map(|p| p.parameter_name())
+        .collect();
+    // aurora-postgresql15 inherits the postgres engine defaults seed.
+    assert!(default_names.contains(&"shared_buffers"));
+    // User-only knob never surfaces under engine-default.
+    assert!(!default_names.contains(&"custom_cluster_knob"));
+    // Shadowed default suppressed from engine-default view.
+    assert!(!default_names.contains(&"max_connections"));
+
+    let merged = client
+        .describe_db_cluster_parameters()
+        .db_cluster_parameter_group_name(group)
+        .send()
+        .await
+        .unwrap();
+    let merged_names: Vec<&str> = merged
+        .parameters()
+        .iter()
+        .filter_map(|p| p.parameter_name())
+        .collect();
+    assert!(merged_names.contains(&"max_connections"));
+    assert!(merged_names.contains(&"custom_cluster_knob"));
+    assert!(merged_names.contains(&"shared_buffers"));
+}

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -439,31 +439,57 @@ impl RdsService {
             "DescribeDBClusterParameters" => {
                 let name = get_param(req, "DBClusterParameterGroupName").ok_or_else(|| missing("DBClusterParameterGroupName"))?;
                 let source_filter = get_param(req, "Source");
-                let want_user_source = source_filter.as_deref().is_none_or(|s| s == "user");
+                let source = source_filter.as_deref();
+                let include_user = source.is_none_or(|s| s == "user");
+                let include_engine_default = source.is_none_or(|s| s == "engine-default");
                 let accounts = self.state_handle().read();
                 let state = accounts.get(&aid);
+                let entry = state
+                    .and_then(|s| s.extras.get("cluster_param_groups"))
+                    .and_then(|m| m.get(&name));
+                let family = entry
+                    .and_then(|e| e.get("DBParameterGroupFamily"))
+                    .and_then(|f| f.as_str())
+                    .unwrap_or("aurora-postgresql15")
+                    .to_string();
+                let user_params: BTreeMap<String, String> = entry
+                    .and_then(|e| e.get("Parameters"))
+                    .and_then(|p| p.as_object())
+                    .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string())).collect())
+                    .unwrap_or_default();
                 let mut members = String::new();
-                if want_user_source {
-                    if let Some(s) = state {
-                        if let Some(map) = s.extras.get("cluster_param_groups") {
-                            if let Some(entry) = map.get(&name) {
-                                if let Some(params) = entry.get("Parameters").and_then(|p| p.as_object()) {
-                                    for (n, v) in params {
-                                        let value = v.as_str().unwrap_or("").to_string();
-                                        members.push_str(&format!(
-                                            "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
-                                            xml_escape(n),
-                                            xml_escape(&value),
-                                        ));
-                                    }
-                                }
-                            }
+                if include_user {
+                    for (n, v) in &user_params {
+                        members.push_str(&crate::service::render_user_parameter_xml(n, v));
+                    }
+                }
+                if include_engine_default {
+                    // A user override flips a parameter's effective
+                    // source from `engine-default` to `user`, so we
+                    // always hide modified parameters from engine-default
+                    // views — even if the caller filtered to that source.
+                    for default in crate::state::engine_default_parameters(&family) {
+                        if user_params.contains_key(default.name) {
+                            continue;
                         }
+                        members.push_str(&crate::service::render_engine_default_parameter_xml(default));
                     }
                 }
                 Ok(xml_response("DescribeDBClusterParameters", format!("    <Parameters>\n{members}    </Parameters>"), &rid))
             }
-            "DescribeEngineDefaultClusterParameters" => Ok(xml_response("DescribeEngineDefaultClusterParameters", "    <EngineDefaults>\n      <Parameters/>\n    </EngineDefaults>".to_string(), &rid)),
+            "DescribeEngineDefaultClusterParameters" => {
+                let family = get_param(req, "DBParameterGroupFamily").unwrap_or_else(|| "aurora-postgresql15".to_string());
+                let mut members = String::new();
+                for default in crate::state::engine_default_parameters(&family) {
+                    members.push_str(&crate::service::render_engine_default_parameter_xml(default));
+                }
+                let body = format!(
+                    "    <EngineDefaults>\n      <DBParameterGroupFamily>{}</DBParameterGroupFamily>\n      <Parameters>\n{}      </Parameters>\n    </EngineDefaults>",
+                    xml_escape(&family),
+                    members,
+                );
+                Ok(xml_response("DescribeEngineDefaultClusterParameters", body, &rid))
+            }
 
             // ── DB Cluster endpoints ──
             "CreateDBClusterEndpoint" => {
@@ -1186,7 +1212,19 @@ impl RdsService {
                 let name = get_param(req, "DBParameterGroupName").ok_or_else(|| missing("DBParameterGroupName"))?;
                 Ok(xml_response("ResetDBParameterGroup", format!("    <DBParameterGroupName>{}</DBParameterGroupName>", xml_escape(&name)), &rid))
             }
-            "DescribeEngineDefaultParameters" => Ok(xml_response("DescribeEngineDefaultParameters", "    <EngineDefaults>\n      <Parameters/>\n    </EngineDefaults>".to_string(), &rid)),
+            "DescribeEngineDefaultParameters" => {
+                let family = get_param(req, "DBParameterGroupFamily").unwrap_or_else(|| "postgres16".to_string());
+                let mut members = String::new();
+                for default in crate::state::engine_default_parameters(&family) {
+                    members.push_str(&crate::service::render_engine_default_parameter_xml(default));
+                }
+                let body = format!(
+                    "    <EngineDefaults>\n      <DBParameterGroupFamily>{}</DBParameterGroupFamily>\n      <Parameters>\n{}      </Parameters>\n    </EngineDefaults>",
+                    xml_escape(&family),
+                    members,
+                );
+                Ok(xml_response("DescribeEngineDefaultParameters", body, &rid))
+            }
             "DescribeDBSnapshotAttributes" => Ok(xml_response("DescribeDBSnapshotAttributes", "    <DBSnapshotAttributesResult>\n      <DBSnapshotAttributes/>\n    </DBSnapshotAttributesResult>".to_string(), &rid)),
             "ModifyDBSnapshot" | "ModifyDBSnapshotAttribute" => Ok(xml_response(action.as_str(), "    <DBSnapshot/>".to_string(), &rid)),
             "RestoreDBClusterFromSnapshot" => {

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -3205,19 +3205,34 @@ impl RdsService {
                 )
             })?;
 
-        // Modified params surface as Source=user; engine defaults
-        // surface as Source=engine-default. We only persist user-set
-        // values, so we always report `user` and skip when the caller
-        // requested only `engine-default`.
-        let want_user_source = source_filter.as_deref().is_none_or(|s| s == "user");
+        // Real RDS surfaces two parameter sources for a group:
+        //   * `user` — values set via `ModifyDBParameterGroup`.
+        //   * `engine-default` — baseline values inherited from the
+        //     parameter group family (e.g. `postgres16`).
+        // With no `Source` filter we return both, mirroring AWS. When a
+        // user value shadows an engine default we skip the default so
+        // each parameter appears exactly once.
+        let source = source_filter.as_deref();
+        let include_user = source.is_none_or(|s| s == "user");
+        let include_engine_default = source.is_none_or(|s| s == "engine-default");
         let mut members_xml = String::new();
-        if want_user_source {
+        if include_user {
             for (name, value) in &parameter_group.parameters {
-                members_xml.push_str(&format!(
-                    "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
-                    xml_escape(name),
-                    xml_escape(value),
-                ));
+                members_xml.push_str(&render_user_parameter_xml(name, value));
+            }
+        }
+        if include_engine_default {
+            // A user override flips a parameter's effective source from
+            // `engine-default` to `user`, so engine-default views always
+            // skip parameters the user has modified — even when the
+            // caller asks only for `engine-default`.
+            for default in
+                crate::state::engine_default_parameters(&parameter_group.db_parameter_group_family)
+            {
+                if parameter_group.parameters.contains_key(default.name) {
+                    continue;
+                }
+                members_xml.push_str(&render_engine_default_parameter_xml(default));
             }
         }
         let body = format!("    <Parameters>\n{members_xml}    </Parameters>");
@@ -3228,23 +3243,59 @@ impl RdsService {
     }
 }
 
-/// Parse `Parameters.member.N.{ParameterName,ParameterValue,ApplyMethod}`
-/// from a Query-protocol request. Skips members missing a name or value;
-/// ApplyMethod is accepted but ignored (single-state model).
+/// Render a single user-set parameter as the XML shape AWS emits inside
+/// `DescribeDB(Cluster)Parameters` responses. We don't store metadata
+/// alongside user values so we report `dynamic`/`string` defaults.
+pub(crate) fn render_user_parameter_xml(name: &str, value: &str) -> String {
+    format!(
+        "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>user</Source>\n        <ApplyType>dynamic</ApplyType>\n        <DataType>string</DataType>\n        <IsModifiable>true</IsModifiable>\n      </Parameter>\n",
+        xml_escape(name),
+        xml_escape(value),
+    )
+}
+
+/// Render a single engine-default parameter as the XML shape AWS emits
+/// inside `DescribeDB(Cluster)Parameters` and
+/// `DescribeEngineDefault(Cluster)Parameters` responses.
+pub(crate) fn render_engine_default_parameter_xml(
+    default: &crate::state::EngineDefaultParameter,
+) -> String {
+    format!(
+        "      <Parameter>\n        <ParameterName>{}</ParameterName>\n        <ParameterValue>{}</ParameterValue>\n        <Source>engine-default</Source>\n        <ApplyType>{}</ApplyType>\n        <DataType>{}</DataType>\n        <AllowedValues>{}</AllowedValues>\n        <IsModifiable>{}</IsModifiable>\n      </Parameter>\n",
+        xml_escape(default.name),
+        xml_escape(default.value),
+        xml_escape(default.apply_type),
+        xml_escape(default.data_type),
+        xml_escape(default.allowed_values),
+        default.is_modifiable,
+    )
+}
+
+/// Parse `Parameters.{Parameter|member}.N.{ParameterName,ParameterValue,ApplyMethod}`
+/// from a Query-protocol request. AWS RDS uses `Parameters.Parameter.N`
+/// (the `Parameter` list location name from the Smithy model); we also
+/// accept the generic `Parameters.member.N` form so hand-built clients
+/// using the default Query list shape keep working. Skips members
+/// missing a name or value; ApplyMethod is accepted but ignored
+/// (single-state model).
 pub(crate) fn parse_db_parameter_members(request: &AwsRequest) -> Vec<(String, String)> {
     let mut out = Vec::new();
-    for index in 1.. {
-        let name_key = format!("Parameters.member.{index}.ParameterName");
-        let value_key = format!("Parameters.member.{index}.ParameterValue");
-        match (
-            optional_query_param(request, &name_key),
-            optional_query_param(request, &value_key),
-        ) {
-            (Some(name), Some(value)) if !name.is_empty() => {
-                out.push((name, value));
+    for prefix in ["Parameters.Parameter", "Parameters.member"] {
+        let mut index = 1;
+        loop {
+            let name_key = format!("{prefix}.{index}.ParameterName");
+            let value_key = format!("{prefix}.{index}.ParameterValue");
+            let name = optional_query_param(request, &name_key);
+            let value = optional_query_param(request, &value_key);
+            if name.is_none() && value.is_none() {
+                break;
             }
-            (None, None) => break,
-            _ => continue,
+            if let (Some(n), Some(v)) = (name, value) {
+                if !n.is_empty() {
+                    out.push((n, v));
+                }
+            }
+            index += 1;
         }
     }
     out

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1291,12 +1291,15 @@ fn describe_db_parameters_returns_user_set_values() {
 fn describe_db_parameters_with_engine_default_source_omits_user_params() {
     let svc = make_service();
     create_param_group(&svc, "pg1");
+    // Modify a parameter that is NOT seeded as an engine default so the
+    // `engine-default` source filter has a clean way to demonstrate it
+    // skips user-only parameters.
     let req = request(
         "ModifyDBParameterGroup",
         &[
             ("DBParameterGroupName", "pg1"),
-            ("Parameters.member.1.ParameterName", "max_connections"),
-            ("Parameters.member.1.ParameterValue", "200"),
+            ("Parameters.member.1.ParameterName", "user_only_knob"),
+            ("Parameters.member.1.ParameterValue", "42"),
         ],
     );
     svc.modify_db_parameter_group(&req).unwrap();
@@ -1310,7 +1313,42 @@ fn describe_db_parameters_with_engine_default_source_omits_user_params() {
     );
     let resp = svc.describe_db_parameters_real(&req).unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
-    assert!(!body.contains("max_connections"));
+    // User-only parameter is hidden when filtering on engine defaults.
+    assert!(!body.contains("user_only_knob"));
+    // Engine defaults still surface (postgres16 seeds `max_connections`).
+    assert!(body.contains("max_connections"));
+    assert!(body.contains("<Source>engine-default</Source>"));
+    assert!(!body.contains("<Source>user</Source>"));
+}
+
+#[test]
+fn describe_db_parameters_with_no_source_returns_user_and_engine_defaults() {
+    let svc = make_service();
+    create_param_group(&svc, "pg1");
+    let req = request(
+        "ModifyDBParameterGroup",
+        &[
+            ("DBParameterGroupName", "pg1"),
+            ("Parameters.member.1.ParameterName", "max_connections"),
+            ("Parameters.member.1.ParameterValue", "200"),
+        ],
+    );
+    svc.modify_db_parameter_group(&req).unwrap();
+
+    let req = request("DescribeDBParameters", &[("DBParameterGroupName", "pg1")]);
+    let resp = svc.describe_db_parameters_real(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    // User override of `max_connections` shadows the engine default so
+    // the parameter appears exactly once with `Source=user`.
+    assert_eq!(
+        body.matches("<ParameterName>max_connections</ParameterName>")
+            .count(),
+        1
+    );
+    assert!(body.contains("<ParameterValue>200</ParameterValue>"));
+    // Other engine defaults (e.g. work_mem) still come through.
+    assert!(body.contains("<ParameterName>work_mem</ParameterName>"));
+    assert!(body.contains("<Source>engine-default</Source>"));
 }
 
 #[test]

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -411,6 +411,147 @@ pub struct DbParameterGroup {
     pub tags: Vec<RdsTag>,
 }
 
+/// Static metadata for an engine-default parameter, used by
+/// `DescribeDBParameters`/`DescribeDBClusterParameters`/`DescribeEngineDefaultParameters`
+/// to surface a baseline set of parameters when no user override exists.
+///
+/// The seed below is intentionally small (a handful of common knobs per
+/// engine family). Real RDS exposes hundreds of parameters per family;
+/// callers needing comprehensive coverage should add entries to
+/// [`engine_default_parameters`] as needs arise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineDefaultParameter {
+    pub name: &'static str,
+    pub value: &'static str,
+    pub apply_type: &'static str,
+    pub data_type: &'static str,
+    pub allowed_values: &'static str,
+    pub is_modifiable: bool,
+}
+
+/// Return a small, representative set of engine-default parameters for the
+/// given parameter group family (e.g. `postgres16`, `mysql8.0`,
+/// `aurora-postgresql15`). The list is not comprehensive — real RDS
+/// exposes hundreds of parameters; we ship just enough to make callers
+/// that round-trip `DescribeDBParameters` with `Source=engine-default`
+/// see meaningful entries. Unknown families fall through to an empty list.
+pub fn engine_default_parameters(family: &str) -> &'static [EngineDefaultParameter] {
+    if family.starts_with("postgres") || family.starts_with("aurora-postgresql") {
+        POSTGRES_DEFAULT_PARAMETERS
+    } else if family.starts_with("mysql") || family.starts_with("aurora-mysql") {
+        MYSQL_DEFAULT_PARAMETERS
+    } else if family.starts_with("mariadb") {
+        MARIADB_DEFAULT_PARAMETERS
+    } else {
+        &[]
+    }
+}
+
+const POSTGRES_DEFAULT_PARAMETERS: &[EngineDefaultParameter] = &[
+    EngineDefaultParameter {
+        name: "max_connections",
+        value: "LEAST({DBInstanceClassMemory/9531392},5000)",
+        apply_type: "static",
+        data_type: "integer",
+        allowed_values: "6-8388607",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "shared_buffers",
+        value: "{DBInstanceClassMemory/32768}",
+        apply_type: "static",
+        data_type: "integer",
+        allowed_values: "16-1073741823",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "work_mem",
+        value: "4096",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "64-2147483647",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "maintenance_work_mem",
+        value: "GREATEST({DBInstanceClassMemory/63963136*1024},65536)",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1024-2147483647",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "effective_cache_size",
+        value: "{DBInstanceClassMemory/16384}",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1-2147483647",
+        is_modifiable: true,
+    },
+];
+
+const MYSQL_DEFAULT_PARAMETERS: &[EngineDefaultParameter] = &[
+    EngineDefaultParameter {
+        name: "max_connections",
+        value: "{DBInstanceClassMemory/12582880}",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1-100000",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "innodb_buffer_pool_size",
+        value: "{DBInstanceClassMemory*3/4}",
+        apply_type: "static",
+        data_type: "integer",
+        allowed_values: "5242880-2147483648",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "max_allowed_packet",
+        value: "67108864",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1024-1073741824",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "character_set_server",
+        value: "utf8mb4",
+        apply_type: "dynamic",
+        data_type: "string",
+        allowed_values: "utf8,utf8mb4,latin1",
+        is_modifiable: true,
+    },
+];
+
+const MARIADB_DEFAULT_PARAMETERS: &[EngineDefaultParameter] = &[
+    EngineDefaultParameter {
+        name: "max_connections",
+        value: "{DBInstanceClassMemory/12582880}",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1-100000",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "innodb_buffer_pool_size",
+        value: "{DBInstanceClassMemory*3/4}",
+        apply_type: "static",
+        data_type: "integer",
+        allowed_values: "5242880-2147483648",
+        is_modifiable: true,
+    },
+    EngineDefaultParameter {
+        name: "max_allowed_packet",
+        value: "67108864",
+        apply_type: "dynamic",
+        data_type: "integer",
+        allowed_values: "1024-1073741824",
+        is_modifiable: true,
+    },
+];
+
 impl RdsState {
     pub fn new(account_id: &str, region: &str) -> Self {
         Self {


### PR DESCRIPTION
## Summary
- Parse `Parameters.Parameter.N.{ParameterName,ParameterValue,ApplyMethod}` (the AWS SDK serialization shape) and `Parameters.member.N.*` from `ModifyDBParameterGroup` / `ModifyDBClusterParameterGroup` and persist values onto the parameter group state.
- `DescribeDBParameters` and `DescribeDBClusterParameters` now emit stored user values (`Source=user`) and a per-family engine default seed (`Source=engine-default`); a user override hides the matching default so each parameter appears once with its effective source.
- `DescribeEngineDefaultParameters` and `DescribeEngineDefaultClusterParameters` return the same seeded list keyed by `DBParameterGroupFamily`.
- Engine defaults seed is small and family-aware (`postgres*`/`aurora-postgresql*`, `mysql*`/`aurora-mysql*`, `mariadb*`); documented as non-comprehensive so callers can extend it.

## Test plan
- [x] `cargo test -p fakecloud-rds --lib` (189 passed, including new unit coverage for the engine-default + merged source paths)
- [x] `cargo test -p fakecloud-e2e --test rds_parameter_group` (4/4 covers user + engine-default + no-filter + cluster round-trip via the AWS SDK)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real RDS parameter group handling: parse and persist params in modify calls, and return merged/user vs engine-default sources in describe calls with family-aware defaults.

- New Features
  - Parse `Parameters.Parameter.N.*` and `Parameters.member.N.*` in `ModifyDBParameterGroup` and `ModifyDBClusterParameterGroup`; persist to group state.
  - `DescribeDBParameters` and `DescribeDBClusterParameters` now return `Source=user` for stored values and `Source=engine-default` for seeded defaults; user values shadow matching defaults so each parameter appears once.
  - Added small, family-aware engine default seed for `postgres*`/`aurora-postgresql*`, `mysql*`/`aurora-mysql*`, and `mariadb*`.
  - `DescribeEngineDefaultParameters` and `DescribeEngineDefaultClusterParameters` return the seeded list keyed by `DBParameterGroupFamily`.
  - New coverage in `@fakecloud-rds` and `@fakecloud-e2e` validates round-trips, source filtering, and merged views via `aws_sdk_rds`.

<sup>Written for commit 89ff09a2223a4eefcc948053315aca540f90ef8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

