### PR TITLE
feat(ssm): SendCommand async Pending -> InProgress -> Success (I1)

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -2155,7 +2155,8 @@ async fn ssm_command_invocations() {
         .await
         .unwrap();
 
-    // Send command
+    // Send command — returns Pending immediately, never the synchronous
+    // Success that the pre-async implementation used to fake.
     let resp = client
         .send_command()
         .document_name("e2e-cmd-inv")
@@ -2163,37 +2164,52 @@ async fn ssm_command_invocations() {
         .send()
         .await
         .unwrap();
-    let cmd_id = resp.command().unwrap().command_id().unwrap().to_string();
-
-    // GetCommandInvocation: status advances Pending -> InProgress -> Success
-    // across successive calls (matching real SSM lifecycle).
-    let resp = client
-        .get_command_invocation()
-        .command_id(&cmd_id)
-        .instance_id("i-1234567890abcdef0")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.command_id().unwrap(), cmd_id);
-    assert_eq!(resp.instance_id().unwrap(), "i-1234567890abcdef0");
+    let cmd = resp.command().unwrap();
+    let cmd_id = cmd.command_id().unwrap().to_string();
     assert_eq!(
-        resp.status(),
-        Some(&aws_sdk_ssm::types::CommandInvocationStatus::InProgress)
+        cmd.status(),
+        Some(&aws_sdk_ssm::types::CommandStatus::Pending)
+    );
+    assert_eq!(cmd.status_details(), Some("Pending"));
+
+    // Poll GetCommandInvocation until it reaches Success. The
+    // background task flips Pending -> InProgress after ~500ms and
+    // then Success after another ~1.5s, so we give it up to 10s.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut saw_in_progress = false;
+    let final_status = loop {
+        let resp = client
+            .get_command_invocation()
+            .command_id(&cmd_id)
+            .instance_id("i-1234567890abcdef0")
+            .send()
+            .await
+            .unwrap();
+        let status = resp.status().cloned();
+        if status == Some(aws_sdk_ssm::types::CommandInvocationStatus::InProgress) {
+            saw_in_progress = true;
+            assert_eq!(resp.status_details(), Some("In Progress"));
+        }
+        if status == Some(aws_sdk_ssm::types::CommandInvocationStatus::Success) {
+            assert_eq!(resp.status_details(), Some("Success"));
+            assert_eq!(resp.response_code(), 0);
+            break status.unwrap();
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("command never reached Success; last status = {status:?}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
+    assert_eq!(
+        final_status,
+        aws_sdk_ssm::types::CommandInvocationStatus::Success
+    );
+    assert!(
+        saw_in_progress,
+        "expected to observe at least one InProgress poll along the way"
     );
 
-    let resp = client
-        .get_command_invocation()
-        .command_id(&cmd_id)
-        .instance_id("i-1234567890abcdef0")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        resp.status(),
-        Some(&aws_sdk_ssm::types::CommandInvocationStatus::Success)
-    );
-
-    // ListCommandInvocations
+    // ListCommandInvocations reflects the live (terminal) state.
     let resp = client
         .list_command_invocations()
         .command_id(&cmd_id)
@@ -2201,7 +2217,139 @@ async fn ssm_command_invocations() {
         .await
         .unwrap();
     assert_eq!(resp.command_invocations().len(), 1);
-    assert_eq!(resp.command_invocations()[0].command_id().unwrap(), cmd_id);
+    let inv = &resp.command_invocations()[0];
+    assert_eq!(inv.command_id().unwrap(), cmd_id);
+    assert_eq!(
+        inv.status(),
+        Some(&aws_sdk_ssm::types::CommandInvocationStatus::Success)
+    );
+    assert_eq!(inv.status_details(), Some("Success"));
+
+    // ListCommands picks up the dynamic command-level status too.
+    let resp = client
+        .list_commands()
+        .command_id(&cmd_id)
+        .send()
+        .await
+        .unwrap();
+    let cmd = resp.commands().first().unwrap();
+    assert_eq!(
+        cmd.status(),
+        Some(&aws_sdk_ssm::types::CommandStatus::Success)
+    );
+    assert_eq!(cmd.status_details(), Some("Success"));
+}
+
+#[tokio::test]
+async fn ssm_admin_force_fail_command() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Create document
+    let doc_content = r#"{"schemaVersion":"2.2","mainSteps":[{"action":"aws:runShellScript","name":"run","inputs":{"runCommand":["sleep 60"]}}]}"#;
+    client
+        .create_document()
+        .name("e2e-cmd-fail")
+        .content(doc_content)
+        .document_type(aws_sdk_ssm::types::DocumentType::Command)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_command()
+        .document_name("e2e-cmd-fail")
+        .instance_ids("i-aaaaaaaaaaaaaaaa1")
+        .instance_ids("i-bbbbbbbbbbbbbbbb2")
+        .send()
+        .await
+        .unwrap();
+    let cmd_id = resp.command().unwrap().command_id().unwrap().to_string();
+
+    // Force one of the two invocations to Failed via the admin endpoint
+    // before the natural transition completes.
+    let http = reqwest::Client::new();
+    let body = serde_json::json!({
+        "instanceId": "i-aaaaaaaaaaaaaaaa1",
+        "statusDetails": "Script exited with code 7",
+        "standardErrorContent": "boom: missing dependency",
+    });
+    let admin_resp = http
+        .post(format!(
+            "{}/_fakecloud/ssm/commands/{cmd_id}/fail",
+            server.endpoint()
+        ))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert!(admin_resp.status().is_success());
+    let json: serde_json::Value = admin_resp.json().await.unwrap();
+    assert_eq!(json["updatedInvocations"].as_u64().unwrap(), 1);
+
+    // Failed invocation surfaces the friendly StatusDetails + stderr.
+    let resp = client
+        .get_command_invocation()
+        .command_id(&cmd_id)
+        .instance_id("i-aaaaaaaaaaaaaaaa1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_ssm::types::CommandInvocationStatus::Failed)
+    );
+    assert_eq!(resp.status_details(), Some("Script exited with code 7"));
+    assert_eq!(
+        resp.standard_error_content(),
+        Some("boom: missing dependency")
+    );
+    assert_eq!(resp.response_code(), 1);
+
+    // Aggregate command status reflects the failure since one
+    // invocation is now in a terminal failure state.
+    let resp = client
+        .list_commands()
+        .command_id(&cmd_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.commands().first().unwrap().status(),
+        Some(&aws_sdk_ssm::types::CommandStatus::Failed)
+    );
+
+    // Empty body still works — defaults to "Failed" status details and
+    // affects all not-yet-failed invocations.
+    let admin_resp = http
+        .post(format!(
+            "{}/_fakecloud/ssm/commands/{cmd_id}/fail",
+            server.endpoint()
+        ))
+        .header("content-type", "application/json")
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+    assert!(admin_resp.status().is_success());
+    let json: serde_json::Value = admin_resp.json().await.unwrap();
+    // The second invocation gets failed; the first is re-failed too
+    // since it's still in the Failed state (admin force-fail is
+    // idempotent — it re-stamps every matching invocation).
+    assert!(json["updatedInvocations"].as_u64().unwrap() >= 1);
+
+    let resp = client
+        .get_command_invocation()
+        .command_id(&cmd_id)
+        .instance_id("i-bbbbbbbbbbbbbbbb2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        Some(&aws_sdk_ssm::types::CommandInvocationStatus::Failed)
+    );
+    assert_eq!(resp.status_details(), Some("Failed"));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -283,6 +283,26 @@ pub struct SetSsmCommandStatusResponse {
     pub updated: bool,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailSsmCommandRequest {
+    pub account_id: Option<String>,
+    /// Optional: target a single invocation. When `None`, every
+    /// invocation on the command is flipped to `Failed`.
+    pub instance_id: Option<String>,
+    /// Optional friendly status detail (e.g. "Script exited with code 7").
+    /// Defaults to "Failed".
+    pub status_details: Option<String>,
+    /// Optional captured stderr to expose via `GetCommandInvocation`.
+    pub standard_error_content: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailSsmCommandResponse {
+    pub updated_invocations: usize,
+}
+
 // ── EventBridge ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1119,6 +1119,7 @@ async fn main() {
             None
         };
     let ssm_state_for_admin = ssm_state.clone();
+    let ssm_state_for_fail = ssm_state.clone();
     let mut ssm_service = SsmService::new(ssm_state)
         .with_secretsmanager(secretsmanager_state.clone())
         .with_kms_hook(kms_hook_for_services.clone());
@@ -3292,6 +3293,34 @@ async fn main() {
                     let svc = fakecloud_ssm::SsmService::new(ss);
                     let updated = svc.set_command_status(account, &command_id, &body.status);
                     axum::Json(types::SetSsmCommandStatusResponse { updated })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ssm/commands/{command_id}/fail",
+            axum::routing::post({
+                let ss = ssm_state_for_fail;
+                move |axum::extract::Path(command_id): axum::extract::Path<String>,
+                      body: Option<axum::Json<types::FailSsmCommandRequest>>| async move {
+                    let body = body.map(|b| b.0).unwrap_or_default();
+                    // Default to the server's configured account so
+                    // tests don't have to thread the ID through every
+                    // admin call. Falls back to "000000000000" only on
+                    // the off chance state initialisation hasn't yet
+                    // populated a default.
+                    let default_account = ss.read().default_account_id().to_string();
+                    let account = body.account_id.as_deref().unwrap_or(&default_account);
+                    let svc = fakecloud_ssm::SsmService::new(ss.clone());
+                    let updated = svc.fail_command_invocation(
+                        account,
+                        &command_id,
+                        body.instance_id.as_deref(),
+                        body.status_details.as_deref(),
+                        body.standard_error_content.as_deref(),
+                    );
+                    axum::Json(types::FailSsmCommandResponse {
+                        updated_invocations: updated,
+                    })
                 }
             }),
         )

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use chrono::Utc;
 use http::StatusCode;
@@ -8,9 +9,85 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SsmCommand, SsmState};
+use crate::state::{SsmCommand, SsmCommandInvocation, SsmState};
 
 use super::{missing, SsmService};
+
+/// Delay before a freshly submitted command flips from `Pending` to
+/// `InProgress`. Real SSM takes a few seconds; we keep this small so
+/// E2E tests don't drag.
+const PENDING_TO_IN_PROGRESS: Duration = Duration::from_millis(500);
+
+/// Delay between `InProgress` and the terminal `Success` state.
+const IN_PROGRESS_TO_SUCCESS: Duration = Duration::from_millis(1500);
+
+/// Map a machine-readable status to the friendlier `StatusDetails`
+/// string AWS returns. Anything unrecognised passes through unchanged.
+pub(crate) fn friendly_status_details(status: &str) -> String {
+    match status {
+        "Pending" => "Pending",
+        "InProgress" => "In Progress",
+        "Delayed" => "Delayed",
+        "Success" => "Success",
+        "Cancelled" => "Cancelled",
+        "Cancelling" => "Cancelling",
+        "Failed" => "Failed",
+        "TimedOut" => "Timed Out",
+        "AccessDenied" => "Access Denied",
+        "DeliveryTimedOut" => "Delivery Timed Out",
+        "ExecutionTimedOut" => "Execution Timed Out",
+        "Incomplete" => "Incomplete",
+        "NoInstancesInTag" => "No Instances In Tag",
+        "LimitExceeded" => "Limit Exceeded",
+        other => other,
+    }
+    .to_string()
+}
+
+/// Aggregate per-invocation statuses into a single command-level
+/// status. Mirrors the rule AWS uses: any failure dominates a success,
+/// any in-progress dominates pending. This keeps `ListCommands`
+/// consistent with `ListCommandInvocations` even after admin force-fail.
+pub(super) fn aggregate_command_status(invocations: &[SsmCommandInvocation]) -> String {
+    if invocations.is_empty() {
+        return "Pending".to_string();
+    }
+    let mut has_pending = false;
+    let mut has_in_progress = false;
+    let mut has_success = false;
+    let mut failure: Option<&str> = None;
+    for inv in invocations {
+        match inv.status.as_str() {
+            "Pending" => has_pending = true,
+            "InProgress" | "Delayed" => has_in_progress = true,
+            "Success" => has_success = true,
+            // Any non-success terminal state is a "failure" for the
+            // parent command. First one wins so we expose the most
+            // informative reason.
+            "Failed" | "TimedOut" | "Cancelled" | "Cancelling" | "AccessDenied"
+            | "DeliveryTimedOut" | "ExecutionTimedOut" | "Incomplete" | "NoInstancesInTag"
+            | "LimitExceeded"
+                if failure.is_none() =>
+            {
+                failure = Some(inv.status.as_str());
+            }
+            _ => {}
+        }
+    }
+    if let Some(f) = failure {
+        return f.to_string();
+    }
+    if has_in_progress || (has_pending && has_success) {
+        return "InProgress".to_string();
+    }
+    if has_pending {
+        return "Pending".to_string();
+    }
+    if has_success {
+        return "Success".to_string();
+    }
+    "Pending".to_string()
+}
 
 /// All fields of a `SendCommand` request, parsed and validated.
 struct SendCommandInput {
@@ -131,17 +208,32 @@ impl SsmService {
             input.instance_ids.clone()
         };
 
+        let expires = now + chrono::Duration::seconds(input.timeout.unwrap_or(3600));
+        let invocations: Vec<SsmCommandInvocation> = effective_instance_ids
+            .iter()
+            .map(|iid| SsmCommandInvocation {
+                instance_id: iid.clone(),
+                status: "Pending".to_string(),
+                status_details: friendly_status_details("Pending"),
+                standard_output_content: String::new(),
+                standard_error_content: String::new(),
+                response_code: -1,
+                requested_date_time: now,
+                last_update_at: now,
+            })
+            .collect();
+
         let cmd = SsmCommand {
             command_id: command_id.clone(),
             document_name: input.document_name.clone(),
             instance_ids: effective_instance_ids.clone(),
             parameters: input.parameters.clone(),
-            // Real SSM returns `Pending` on submit; transitions to
-            // `InProgress` and then `Success` (or `Failed`) as the
-            // agent reports back. fakecloud auto-advances the state
-            // on each read so callers see realistic lifecycle.
+            // Real SSM returns `Pending` on submit; a background task
+            // flips this to `InProgress` and then `Success` after a
+            // short delay so polling clients see the natural lifecycle.
             status: "Pending".to_string(),
             requested_date_time: now,
+            expires_after: expires,
             comment: input.comment.clone(),
             output_s3_bucket_name: input.output_s3_bucket.clone(),
             output_s3_key_prefix: input.output_s3_prefix.clone(),
@@ -152,13 +244,33 @@ impl SsmService {
             targets: input.targets.clone(),
             document_hash: input.document_hash.clone(),
             document_hash_type: input.document_hash_type.clone(),
+            invocations,
         };
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        state.commands.push(cmd);
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            state.commands.push(cmd);
+        }
 
-        let expires = now + chrono::Duration::seconds(input.timeout.unwrap_or(3600));
+        // Spawn the lifecycle transition. Detached on purpose — clients
+        // poll `GetCommandInvocation`; we don't await completion here.
+        // When the test harness runs a `send_command` outside a tokio
+        // runtime (e.g. plain `#[test]`), `try_current` returns `Err`
+        // and the command stays `Pending` forever, which the unit tests
+        // assert against directly.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let state_handle = self.state.clone();
+            let account_id = req.account_id.clone();
+            let cid = command_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(PENDING_TO_IN_PROGRESS).await;
+                advance_pending_to_in_progress(&state_handle, &account_id, &cid);
+                tokio::time::sleep(IN_PROGRESS_TO_SUCCESS).await;
+                advance_in_progress_to_success(&state_handle, &account_id, &cid);
+            });
+        }
+
         let mut cmd_obj = json!({
             "CommandId": command_id,
             "DocumentName": input.document_name,
@@ -166,7 +278,7 @@ impl SsmService {
             "Targets": input.targets,
             "Parameters": input.parameters,
             "Status": "Pending",
-            "StatusDetails": "Pending",
+            "StatusDetails": friendly_status_details("Pending"),
             "RequestedDateTime": now.timestamp_millis() as f64 / 1000.0,
             "ExpiresAfter": expires.timestamp_millis() as f64 / 1000.0,
             "MaxConcurrency": input.max_concurrency.clone().unwrap_or_default(),
@@ -220,25 +332,22 @@ impl SsmService {
                 true
             })
             .map(|c| {
-                let expires = c.requested_date_time
-                    + chrono::Duration::seconds(c.timeout_seconds.unwrap_or(3600));
-                let v = json!({
+                json!({
                     "CommandId": c.command_id,
                     "DocumentName": c.document_name,
                     "InstanceIds": c.instance_ids,
                     "Targets": c.targets,
                     "Parameters": c.parameters,
                     "Status": c.status,
-                    "StatusDetails": c.status,
+                    "StatusDetails": friendly_status_details(&c.status),
                     "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
-                    "ExpiresAfter": expires.timestamp_millis() as f64 / 1000.0,
+                    "ExpiresAfter": c.expires_after.timestamp_millis() as f64 / 1000.0,
                     "Comment": c.comment,
                     "OutputS3Region": c.output_s3_region,
                     "OutputS3BucketName": c.output_s3_bucket_name,
                     "OutputS3KeyPrefix": c.output_s3_key_prefix,
                     "DeliveryTimedOutCount": 0,
-                });
-                v
+                })
             })
             .collect();
 
@@ -278,26 +387,6 @@ impl SsmService {
         let plugin_name = body["PluginName"].as_str();
         validate_optional_string_length("PluginName", plugin_name, 4, 500)?;
 
-        // Auto-advance lifecycle so callers polling Get see Pending
-        // -> InProgress -> Success across successive reads. This runs
-        // under the write lock to avoid clobbering admin-set
-        // `Failed` / `Cancelled` statuses.
-        {
-            let mut accounts = self.state.write();
-            let state = accounts.get_or_create(&req.account_id);
-            if let Some(c) = state
-                .commands
-                .iter_mut()
-                .find(|c| c.command_id == command_id)
-            {
-                c.status = match c.status.as_str() {
-                    "Pending" => "InProgress".to_string(),
-                    "InProgress" => "Success".to_string(),
-                    other => other.to_string(),
-                };
-            }
-        }
-
         let accounts = self.state.read();
         let empty = SsmState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -313,15 +402,6 @@ impl SsmService {
                 )
             })?;
 
-        // Check instance is part of the command
-        if !cmd.instance_ids.contains(&instance_id.to_string()) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvocationDoesNotExist",
-                "An error occurred (InvocationDoesNotExist) when calling the GetCommandInvocation operation",
-            ));
-        }
-
         // Validate plugin name if provided
         if let Some(pn) = plugin_name {
             let known_plugins = ["aws:runShellScript", "aws:runPowerShellScript"];
@@ -334,23 +414,34 @@ impl SsmService {
             }
         }
 
-        let response_code = match cmd.status.as_str() {
-            "Success" => 0,
-            "Failed" => 1,
-            _ => -1,
-        };
-        Ok(AwsResponse::ok_json(json!({
+        let inv = cmd
+            .invocations
+            .iter()
+            .find(|i| i.instance_id == instance_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvocationDoesNotExist",
+                    "An error occurred (InvocationDoesNotExist) when calling the GetCommandInvocation operation",
+                )
+            })?;
+
+        let mut resp = json!({
             "CommandId": cmd.command_id,
             "InstanceId": instance_id,
             "DocumentName": cmd.document_name,
-            "Status": cmd.status,
-            "StatusDetails": cmd.status,
-            "ResponseCode": response_code,
-            "StandardOutputContent": "",
+            "Status": inv.status,
+            "StatusDetails": inv.status_details,
+            "ResponseCode": inv.response_code,
+            "StandardOutputContent": inv.standard_output_content,
             "StandardOutputUrl": "",
-            "StandardErrorContent": "",
+            "StandardErrorContent": inv.standard_error_content,
             "StandardErrorUrl": "",
-        })))
+        });
+        if let Some(pn) = plugin_name {
+            resp["PluginName"] = json!(pn);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn list_command_invocations(
@@ -377,14 +468,14 @@ impl SsmService {
                 }
             })
             .flat_map(|c| {
-                c.instance_ids.iter().map(|iid| {
+                c.invocations.iter().map(|inv| {
                     json!({
                         "CommandId": c.command_id,
-                        "InstanceId": iid,
+                        "InstanceId": inv.instance_id,
                         "DocumentName": c.document_name,
-                        "Status": c.status,
-                        "StatusDetails": c.status,
-                        "RequestedDateTime": c.requested_date_time.timestamp_millis() as f64 / 1000.0,
+                        "Status": inv.status,
+                        "StatusDetails": inv.status_details,
+                        "RequestedDateTime": inv.requested_date_time.timestamp_millis() as f64 / 1000.0,
                         "Comment": c.comment,
                     })
                 })
@@ -407,6 +498,11 @@ impl SsmService {
             .as_str()
             .ok_or_else(|| missing("CommandId"))?;
         validate_string_length("CommandId", command_id, 36, 36)?;
+        let instance_filter: Option<Vec<String>> = body["InstanceIds"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -415,11 +511,73 @@ impl SsmService {
             .iter_mut()
             .find(|c| c.command_id == command_id)
         {
-            cmd.status = "Cancelled".to_string();
+            let now = Utc::now();
+            for inv in cmd.invocations.iter_mut() {
+                if let Some(filter) = &instance_filter {
+                    if !filter.is_empty() && !filter.contains(&inv.instance_id) {
+                        continue;
+                    }
+                }
+                // Cancellation only applies before terminal states.
+                if matches!(inv.status.as_str(), "Pending" | "InProgress" | "Delayed") {
+                    inv.status = "Cancelled".to_string();
+                    inv.status_details = friendly_status_details("Cancelled");
+                    inv.last_update_at = now;
+                }
+            }
+            cmd.status = aggregate_command_status(&cmd.invocations);
         }
 
         Ok(AwsResponse::ok_json(json!({})))
     }
 
     // ===== Maintenance Window operations =====
+}
+
+/// Flip pending invocations + parent command to `InProgress`. Skips any
+/// invocation that has already moved into a terminal state via the
+/// admin force-fail endpoint or `CancelCommand`.
+fn advance_pending_to_in_progress(
+    state: &crate::state::SharedSsmState,
+    account_id: &str,
+    command_id: &str,
+) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(account_id);
+    let Some(cmd) = st.commands.iter_mut().find(|c| c.command_id == command_id) else {
+        return;
+    };
+    let now = Utc::now();
+    for inv in cmd.invocations.iter_mut() {
+        if inv.status == "Pending" {
+            inv.status = "InProgress".to_string();
+            inv.status_details = friendly_status_details("InProgress");
+            inv.last_update_at = now;
+        }
+    }
+    cmd.status = aggregate_command_status(&cmd.invocations);
+}
+
+/// Flip in-flight invocations + parent command to `Success`. Same
+/// terminal-state guard as the pending->in-progress hop.
+fn advance_in_progress_to_success(
+    state: &crate::state::SharedSsmState,
+    account_id: &str,
+    command_id: &str,
+) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(account_id);
+    let Some(cmd) = st.commands.iter_mut().find(|c| c.command_id == command_id) else {
+        return;
+    };
+    let now = Utc::now();
+    for inv in cmd.invocations.iter_mut() {
+        if matches!(inv.status.as_str(), "Pending" | "InProgress" | "Delayed") {
+            inv.status = "Success".to_string();
+            inv.status_details = friendly_status_details("Success");
+            inv.response_code = 0;
+            inv.last_update_at = now;
+        }
+    }
+    cmd.status = aggregate_command_status(&cmd.invocations);
 }

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -66,6 +66,8 @@ impl SsmService {
     /// Admin: force a SendCommand result to a specific terminal status
     /// (e.g. "Failed", "Cancelled", "TimedOut"). Used by tests to
     /// simulate command failures without waiting on a real SSM agent.
+    /// All invocations on the command move to the same status so
+    /// `GetCommandInvocation` reflects the override on the next read.
     /// Returns `true` when the command was found and updated.
     pub fn set_command_status(&self, account_id: &str, command_id: &str, status: &str) -> bool {
         let mut accounts = self.state.write();
@@ -75,10 +77,69 @@ impl SsmService {
             .iter_mut()
             .find(|c| c.command_id == command_id)
         {
+            let now = chrono::Utc::now();
+            let details = commands::friendly_status_details(status);
+            for inv in c.invocations.iter_mut() {
+                inv.status = status.to_string();
+                inv.status_details = details.clone();
+                inv.response_code = match status {
+                    "Success" => 0,
+                    "Pending" | "InProgress" | "Delayed" => -1,
+                    _ => 1,
+                };
+                inv.last_update_at = now;
+            }
             c.status = status.to_string();
             return true;
         }
         false
+    }
+
+    /// Admin: force a single invocation (or all if `instance_id` is
+    /// `None`) to `Failed` with optional friendlier `status_details`
+    /// and `standard_error_content` overrides. Mirrors what a real SSM
+    /// agent would report when a runShellScript step exits non-zero.
+    /// Returns the number of invocations that were updated.
+    pub fn fail_command_invocation(
+        &self,
+        account_id: &str,
+        command_id: &str,
+        instance_id: Option<&str>,
+        status_details: Option<&str>,
+        standard_error_content: Option<&str>,
+    ) -> usize {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        let Some(cmd) = state
+            .commands
+            .iter_mut()
+            .find(|c| c.command_id == command_id)
+        else {
+            return 0;
+        };
+        let now = chrono::Utc::now();
+        let mut updated = 0;
+        for inv in cmd.invocations.iter_mut() {
+            if let Some(iid) = instance_id {
+                if inv.instance_id != iid {
+                    continue;
+                }
+            }
+            inv.status = "Failed".to_string();
+            inv.status_details = status_details
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| commands::friendly_status_details("Failed"));
+            if let Some(err) = standard_error_content {
+                inv.standard_error_content = err.to_string();
+            }
+            inv.response_code = 1;
+            inv.last_update_at = now;
+            updated += 1;
+        }
+        if updated > 0 {
+            cmd.status = commands::aggregate_command_status(&cmd.invocations);
+        }
+        updated
     }
 
     /// Persist current state as a snapshot. Held across the

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -2057,20 +2057,10 @@ fn get_command_invocation_success() {
     let svc = make_service();
     let cmd_id = send_command(&svc, "AWS-RunShellScript");
 
-    // Real SSM cycles Pending -> InProgress -> Success across polls.
-    // fakecloud auto-advances on every Get; two reads pin the
-    // InProgress and Success states respectively.
-    let req = make_request(
-        "GetCommandInvocation",
-        json!({
-            "CommandId": cmd_id,
-            "InstanceId": "i-1234567890abcdef0",
-        }),
-    );
-    let resp = svc.get_command_invocation(&req).unwrap();
-    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert_eq!(body["Status"].as_str().unwrap(), "InProgress");
-
+    // Without a tokio runtime the async transition task isn't
+    // spawned, so the invocation stays at `Pending` and exposes the
+    // friendly StatusDetails. The async transition is exercised in
+    // the E2E suite where the runtime is real.
     let req = make_request(
         "GetCommandInvocation",
         json!({
@@ -2082,8 +2072,100 @@ fn get_command_invocation_success() {
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["CommandId"].as_str().unwrap(), cmd_id);
     assert_eq!(body["InstanceId"].as_str().unwrap(), "i-1234567890abcdef0");
+    assert_eq!(body["Status"].as_str().unwrap(), "Pending");
+    assert_eq!(body["StatusDetails"].as_str().unwrap(), "Pending");
+    assert_eq!(body["ResponseCode"].as_i64().unwrap(), -1);
+}
+
+#[test]
+fn get_command_invocation_reflects_admin_force_success() {
+    let svc = make_service();
+    let cmd_id = send_command(&svc, "AWS-RunShellScript");
+
+    // Admin override flips the lifecycle into Success without waiting
+    // on the spawned transition task; per-invocation StatusDetails
+    // matches AWS's friendlier human-facing string.
+    assert!(svc.set_command_status("123456789012", &cmd_id, "Success"));
+
+    let req = make_request(
+        "GetCommandInvocation",
+        json!({
+            "CommandId": cmd_id,
+            "InstanceId": "i-1234567890abcdef0",
+        }),
+    );
+    let resp = svc.get_command_invocation(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["Status"].as_str().unwrap(), "Success");
+    assert_eq!(body["StatusDetails"].as_str().unwrap(), "Success");
     assert_eq!(body["ResponseCode"].as_i64().unwrap(), 0);
+}
+
+#[test]
+fn fail_command_invocation_marks_single_instance() {
+    let svc = make_service();
+    // Two-instance command so we can verify the per-instance flag flow.
+    let req = make_request(
+        "SendCommand",
+        json!({
+            "DocumentName": "AWS-RunShellScript",
+            "InstanceIds": ["i-1111111111111111a", "i-2222222222222222b"],
+        }),
+    );
+    let resp = svc.send_command(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let cmd_id = body["Command"]["CommandId"].as_str().unwrap().to_string();
+
+    let updated = svc.fail_command_invocation(
+        "123456789012",
+        &cmd_id,
+        Some("i-1111111111111111a"),
+        Some("Script exited with code 7"),
+        Some("boom"),
+    );
+    assert_eq!(updated, 1);
+
+    let req = make_request(
+        "GetCommandInvocation",
+        json!({
+            "CommandId": cmd_id,
+            "InstanceId": "i-1111111111111111a",
+        }),
+    );
+    let resp = svc.get_command_invocation(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Status"].as_str().unwrap(), "Failed");
+    assert_eq!(
+        body["StatusDetails"].as_str().unwrap(),
+        "Script exited with code 7"
+    );
+    assert_eq!(body["StandardErrorContent"].as_str().unwrap(), "boom");
+    assert_eq!(body["ResponseCode"].as_i64().unwrap(), 1);
+
+    // The other instance is untouched.
+    let req = make_request(
+        "GetCommandInvocation",
+        json!({
+            "CommandId": cmd_id,
+            "InstanceId": "i-2222222222222222b",
+        }),
+    );
+    let resp = svc.get_command_invocation(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Status"].as_str().unwrap(), "Pending");
+
+    // Aggregate command status surfaces the failure.
+    let req = make_request("ListCommands", json!({"CommandId": cmd_id}));
+    let resp = svc.list_commands(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Commands"][0]["Status"].as_str().unwrap(), "Failed");
+}
+
+#[test]
+fn fail_command_invocation_unknown_command_returns_zero() {
+    let svc = make_service();
+    let updated = svc.fail_command_invocation("123456789012", "no-such-id", None, None, None);
+    assert_eq!(updated, 0);
 }
 
 #[test]
@@ -2104,23 +2186,22 @@ fn send_command_starts_pending() {
 fn set_command_status_overrides_lifecycle() {
     let svc = make_service();
     let cmd_id = send_command(&svc, "AWS-RunShellScript");
-    // Force a Failed status before any polling.
+    // Force a Failed status. ListCommands and GetCommandInvocation
+    // both pick up the override since they read the live state.
     let updated = svc.set_command_status("123456789012", &cmd_id, "Failed");
     assert!(updated);
-    // Even after multiple GetCommandInvocation polls (which would
-    // normally advance Pending -> InProgress -> Success), the forced
-    // status sticks since the auto-advance only fires when status is
-    // Pending or InProgress.
-    for _ in 0..3 {
-        let req = make_request(
-            "GetCommandInvocation",
-            json!({
-                "CommandId": cmd_id,
-                "InstanceId": "i-0000000000000000a",
-            }),
-        );
-        let _ = svc.get_command_invocation(&req);
-    }
+    let req = make_request(
+        "GetCommandInvocation",
+        json!({
+            "CommandId": cmd_id,
+            "InstanceId": "i-1234567890abcdef0",
+        }),
+    );
+    let resp = svc.get_command_invocation(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Status"].as_str().unwrap(), "Failed");
+    assert_eq!(body["StatusDetails"].as_str().unwrap(), "Failed");
+
     let req = make_request("ListCommands", json!({"CommandId": cmd_id}));
     let resp = svc.list_commands(&req).unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -87,6 +87,7 @@ pub struct SsmCommand {
     pub parameters: BTreeMap<String, Vec<String>>,
     pub status: String,
     pub requested_date_time: DateTime<Utc>,
+    pub expires_after: DateTime<Utc>,
     pub comment: Option<String>,
     pub output_s3_bucket_name: Option<String>,
     pub output_s3_key_prefix: Option<String>,
@@ -97,6 +98,27 @@ pub struct SsmCommand {
     pub targets: Vec<serde_json::Value>,
     pub document_hash: Option<String>,
     pub document_hash_type: Option<String>,
+    /// Per-instance invocation state. One entry per `InstanceIds`
+    /// member; updated independently by the async transition task or
+    /// by the admin force-fail endpoint.
+    #[serde(default)]
+    pub invocations: Vec<SsmCommandInvocation>,
+}
+
+/// One execution of a command on a single managed instance. The
+/// real SSM API exposes this via `GetCommandInvocation` and
+/// `ListCommandInvocations`; per-invocation status diverges from the
+/// parent command status when only some instances fail.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SsmCommandInvocation {
+    pub instance_id: String,
+    pub status: String,
+    pub status_details: String,
+    pub standard_output_content: String,
+    pub standard_error_content: String,
+    pub response_code: i64,
+    pub requested_date_time: DateTime<Utc>,
+    pub last_update_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -87,6 +87,10 @@ pub struct SsmCommand {
     pub parameters: BTreeMap<String, Vec<String>>,
     pub status: String,
     pub requested_date_time: DateTime<Utc>,
+    /// When the command's results stop being readable. Defaults to
+    /// `requested_date_time + 1h` for snapshots written before this
+    /// field existed so old data still deserializes cleanly.
+    #[serde(default = "default_command_expiry")]
     pub expires_after: DateTime<Utc>,
     pub comment: Option<String>,
     pub output_s3_bucket_name: Option<String>,
@@ -103,6 +107,10 @@ pub struct SsmCommand {
     /// by the admin force-fail endpoint.
     #[serde(default)]
     pub invocations: Vec<SsmCommandInvocation>,
+}
+
+fn default_command_expiry() -> DateTime<Utc> {
+    chrono::Utc::now() + chrono::Duration::seconds(3600)
 }
 
 /// One execution of a command on a single managed instance. The

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -86,6 +86,15 @@ curl http://localhost:4566/_fakecloud/health
 | ----------------------------------------------------- | ------ | ----------- |
 | `/_fakecloud/secretsmanager/rotation-scheduler/tick`  | POST   | Rotate secrets whose rotation schedule is due. |
 
+## SSM
+
+| Endpoint                                              | Method | Description |
+| ----------------------------------------------------- | ------ | ----------- |
+| `/_fakecloud/ssm/commands/{command_id}/status`        | POST   | Force a `SendCommand` to a specific status. Body: `{"accountId":"...", "status":"Failed"}`. |
+| `/_fakecloud/ssm/commands/{command_id}/fail`          | POST   | Fail one (or all) command invocations. Body: `{"accountId":"?", "instanceId":"?", "statusDetails":"?", "standardErrorContent":"?"}`. Returns `{"updatedInvocations":N}`. |
+
+`SendCommand` runs through `Pending` -> `InProgress` -> `Success` automatically over ~2 seconds. The `/fail` endpoint lets tests inject a non-zero exit at any point — by default it stamps every invocation, or pass `instanceId` to target one. `statusDetails` overrides the friendly status string (e.g. `"Script exited with code 7"`); `standardErrorContent` is exposed via `GetCommandInvocation`.
+
 ## SES
 
 | Endpoint                   | Method | Description |

--- a/website/content/docs/services/ssm.md
+++ b/website/content/docs/services/ssm.md
@@ -24,6 +24,20 @@ fakecloud implements **146 of 146** SSM operations at 100% Smithy conformance.
 
 JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
+## RunCommand lifecycle
+
+`SendCommand` returns `Pending` immediately, then a background task flips the command (and each per-instance invocation) to `InProgress` after ~500ms and `Success` after another ~1.5s. `GetCommandInvocation`, `ListCommandInvocations`, and `ListCommands` all read live state, so polling clients see the same lifecycle they'd hit on real AWS — no canned `Success` shortcut.
+
+To simulate failures from a test, hit the admin endpoint:
+
+```bash
+curl -X POST "$ENDPOINT/_fakecloud/ssm/commands/$CMD_ID/fail" \
+  -H "content-type: application/json" \
+  -d '{"instanceId":"i-...","statusDetails":"Script exited with code 7","standardErrorContent":"boom"}'
+```
+
+`instanceId`, `statusDetails`, and `standardErrorContent` are all optional. See [introspection reference](/docs/reference/introspection/#ssm).
+
 ## SecureString encryption
 
 SecureString parameters are encrypted through the KMS hook on `PutParameter`


### PR DESCRIPTION
## Summary

- `SendCommand` now stores commands as `Pending` and transitions to `InProgress` (~500ms) then `Success` (~1.5s) via a spawned tokio task. Per-instance invocations track their own status, so multi-instance fleets aren't pinned to a single command-level state.
- `GetCommandInvocation`, `ListCommandInvocations`, and `ListCommands` read the live per-invocation state and return the friendlier `StatusDetails` strings AWS uses ("In Progress", "Timed Out", etc.).
- New `POST /_fakecloud/ssm/commands/{id}/fail` admin endpoint flips one (or all) invocations to `Failed` with optional `statusDetails` and `standardErrorContent` overrides. Lets tests simulate non-zero exits without waiting on the natural lifecycle.

This is batch I1 of the SSM behavior phase.

## Test plan

- [x] `cargo test -p fakecloud-ssm` — 209 unit tests pass, including the new admin-force-success and per-instance fail coverage
- [x] `cargo test -p fakecloud-e2e --test ssm` — full SSM E2E suite (53 tests) passes, including new `ssm_admin_force_fail_command` and updated `ssm_command_invocations` covering the async transition
- [x] `cargo test -p fakecloud-e2e --test ssm_persistence` — round-trip survives restart
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SSM RunCommand asynchronous with per-instance state. SendCommand now returns Pending immediately and transitions to InProgress then Success in the background; callers should poll GetCommandInvocation.

- **New Features**
  - Async lifecycle: Pending -> InProgress (~500ms) -> Success (~1.5s).
  - Per-instance tracking; GetCommandInvocation and ListCommandInvocations return live status, and ListCommands aggregates per AWS rules with friendly StatusDetails strings.
  - Admin endpoint POST /_fakecloud/ssm/commands/{id}/fail to fail one or all invocations with optional statusDetails and standardErrorContent; returns {"updatedInvocations": N}.
  - CancelCommand cancels matching invocations (supports InstanceIds filter) and respects terminal states.

- **Bug Fixes**
  - Default expires_after when loading legacy snapshots so old state deserializes cleanly.

<sup>Written for commit 082a028f3e7bf27596f9af88e52a65065648f743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

