### PR TITLE
feat(cloudformation): pseudo-parameters AWS::Region/Partition/URLSuffix/NoValue/NotificationARNs (BB6)

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -617,10 +617,17 @@ impl CloudFormationService {
             .or_insert_with(|| stack_name.clone());
         parameters
             .entry("AWS::Partition".to_string())
-            .or_insert_with(|| "aws".to_string());
+            .or_insert_with(|| template::partition_for_region(&req.region).to_string());
         parameters
             .entry("AWS::URLSuffix".to_string())
-            .or_insert_with(|| "amazonaws.com".to_string());
+            .or_insert_with(|| template::url_suffix_for_region(&req.region).to_string());
+        // NotificationARNs is array-typed; pseudo_value parses it back
+        // out of JSON. Always set so a `Ref: AWS::NotificationARNs`
+        // returns the request's actual list (or an empty array).
+        parameters.insert(
+            "AWS::NotificationARNs".to_string(),
+            serde_json::to_string(&notification_arns).unwrap_or_else(|_| "[]".to_string()),
+        );
 
         // First pass: parse to get resource definitions (without physical ID resolution)
         let parsed = template::parse_template(template_body, &parameters).map_err(|e| {
@@ -944,11 +951,41 @@ impl CloudFormationService {
         input
             .parameters
             .entry("AWS::Partition".to_string())
-            .or_insert_with(|| "aws".to_string());
+            .or_insert_with(|| template::partition_for_region(&req.region).to_string());
         input
             .parameters
             .entry("AWS::URLSuffix".to_string())
-            .or_insert_with(|| "amazonaws.com".to_string());
+            .or_insert_with(|| template::url_suffix_for_region(&req.region).to_string());
+        // Seed AWS::NotificationARNs from the update payload, falling
+        // back to whatever the existing stack carries when the request
+        // omits the param. Encoded as JSON so pseudo_value can split it
+        // back into the array shape Ref returns.
+        if !input.notification_arns.is_empty() {
+            input.parameters.insert(
+                "AWS::NotificationARNs".to_string(),
+                serde_json::to_string(&input.notification_arns)
+                    .unwrap_or_else(|_| "[]".to_string()),
+            );
+        } else {
+            // Carry the existing stack's notification ARNs forward so the
+            // pseudo-param keeps its previous value across updates.
+            let existing: Vec<String> = {
+                let accounts = self.state.read();
+                accounts
+                    .get(&req.account_id)
+                    .and_then(|s| {
+                        s.stacks
+                            .values()
+                            .find(|st| st.stack_id == found_stack_id)
+                            .map(|st| st.notification_arns.clone())
+                    })
+                    .unwrap_or_default()
+            };
+            input.parameters.insert(
+                "AWS::NotificationARNs".to_string(),
+                serde_json::to_string(&existing).unwrap_or_else(|_| "[]".to_string()),
+            );
+        }
 
         let parsed =
             template::parse_template(&input.template_body, &input.parameters).map_err(|e| {

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -868,21 +868,65 @@ pub fn resolve_resource_properties_with_attrs(
 /// caller hasn't supplied a value, fall back to the canonical default
 /// for that parameter (commercial partition / us-east-1 / empty list).
 fn pseudo_value(name: &str, parameters: &BTreeMap<String, String>) -> Option<Value> {
+    // AWS::NotificationARNs is array-typed; the seed encodes it as a
+    // JSON array string so it round-trips through the string-keyed
+    // parameters map cleanly. Falls back to the default empty list when
+    // the seed is missing or malformed.
+    if name == "AWS::NotificationARNs" {
+        if let Some(raw) = parameters.get(name) {
+            if let Ok(parsed) = serde_json::from_str::<Vec<String>>(raw) {
+                return Some(Value::Array(
+                    parsed.into_iter().map(Value::String).collect(),
+                ));
+            }
+        }
+        return Some(Value::Array(Vec::new()));
+    }
     if let Some(v) = parameters.get(name) {
         return Some(Value::String(v.clone()));
     }
+    let region = parameters
+        .get("AWS::Region")
+        .map(String::as_str)
+        .unwrap_or("us-east-1");
     match name {
-        "AWS::Partition" => Some(Value::String("aws".to_string())),
-        "AWS::URLSuffix" => Some(Value::String("amazonaws.com".to_string())),
-        "AWS::Region" => Some(Value::String("us-east-1".to_string())),
-        // NotificationARNs is an array; default to empty.
-        "AWS::NotificationARNs" => Some(Value::Array(Vec::new())),
+        // Partition + URLSuffix mirror real CFN: derive from the request
+        // region so a stack in `cn-north-1` lands `aws-cn` /
+        // `amazonaws.com.cn`, and `us-gov-west-1` lands `aws-us-gov`.
+        "AWS::Partition" => Some(Value::String(partition_for_region(region).to_string())),
+        "AWS::URLSuffix" => Some(Value::String(url_suffix_for_region(region).to_string())),
+        "AWS::Region" => Some(Value::String(region.to_string())),
         // NoValue is a sentinel: emit a private marker object so the
         // post-resolution `strip_no_value` walk can drop the parent
         // property entirely. CloudFormation removes the key from the
         // resolved object rather than leaving a JSON null behind.
         "AWS::NoValue" => Some(no_value_sentinel()),
         _ => None,
+    }
+}
+
+/// Map an AWS region to its IAM/ARN partition. China regions land on
+/// `aws-cn`, GovCloud on `aws-us-gov`, everything else on `aws`. Used
+/// by both `AWS::Partition` resolution and the URL-suffix derivation
+/// below so partition decisions stay consistent.
+pub(crate) fn partition_for_region(region: &str) -> &'static str {
+    if region.starts_with("cn-") {
+        "aws-cn"
+    } else if region.starts_with("us-gov-") {
+        "aws-us-gov"
+    } else {
+        "aws"
+    }
+}
+
+/// Map an AWS region to its DNS URL suffix. China regions use
+/// `amazonaws.com.cn`; every other partition (commercial + GovCloud)
+/// uses `amazonaws.com`, matching the real CFN `AWS::URLSuffix`.
+pub(crate) fn url_suffix_for_region(region: &str) -> &'static str {
+    if region.starts_with("cn-") {
+        "amazonaws.com.cn"
+    } else {
+        "amazonaws.com"
     }
 }
 
@@ -994,25 +1038,28 @@ fn resolve_refs_full(
         Value::Object(map) => {
             if let Some(ref_val) = map.get("Ref") {
                 if let Some(ref_name) = ref_val.as_str() {
-                    // 1. Check explicit parameters first
-                    if let Some(param_val) = parameters.get(ref_name) {
-                        return Value::String(param_val.clone());
-                    }
-                    // 2. Check already-provisioned resource physical IDs
-                    if let Some(physical_id) = resource_physical_ids.get(ref_name) {
-                        return Value::String(physical_id.clone());
-                    }
-                    // 3. Substitute pseudo-references with their stack-context
-                    //    value (or a sane default for shape-only parity).
+                    // 1. Pseudo-references go through `pseudo_value`
+                    //    first — `AWS::NotificationARNs` is array-typed
+                    //    and would otherwise fall through to the
+                    //    string-only parameter path and leak its JSON
+                    //    encoding into the resolved value.
                     if PSEUDO_REFS.contains(&ref_name) {
                         if let Some(v) = pseudo_value(ref_name, parameters) {
                             return v;
                         }
                         return Value::String(ref_name.to_string());
                     }
-                    // 4. If it's a known logical resource in the template but not yet
-                    //    provisioned, return the logical ID (will be resolved later
-                    //    during incremental provisioning)
+                    // 2. Explicit template parameters.
+                    if let Some(param_val) = parameters.get(ref_name) {
+                        return Value::String(param_val.clone());
+                    }
+                    // 3. Already-provisioned resource physical IDs.
+                    if let Some(physical_id) = resource_physical_ids.get(ref_name) {
+                        return Value::String(physical_id.clone());
+                    }
+                    // 4. Known logical resource in the template but
+                    //    not yet provisioned: return the logical ID and
+                    //    let incremental provisioning rewrite it.
                     if _resources.contains_key(ref_name) {
                         return Value::String(ref_name.to_string());
                     }
@@ -1260,16 +1307,89 @@ fn resolve_refs_full(
                 }
             }
             if let Some(sub_val) = map.get("Fn::Sub") {
-                if let Some(s) = sub_val.as_str() {
+                // Two CFN-supported shapes:
+                //   "Fn::Sub": "literal-${Var}"
+                //   "Fn::Sub": ["literal-${Var}", { "Var": <intrinsic> }]
+                // The array form lets the template author bind extra
+                // variables that aren't template parameters or resource
+                // logical IDs. We resolve each binding through
+                // `resolve_refs_full` so nested `Ref` / `Fn::GetAtt`
+                // works inside the map.
+                let (template_str, extra_vars): (Option<&str>, BTreeMap<String, String>) =
+                    if let Some(s) = sub_val.as_str() {
+                        (Some(s), BTreeMap::new())
+                    } else if let Some(arr) = sub_val.as_array() {
+                        let str_part = arr.first().and_then(|v| v.as_str());
+                        let mut bindings: BTreeMap<String, String> = BTreeMap::new();
+                        if let Some(obj) = arr.get(1).and_then(|v| v.as_object()) {
+                            for (k, v) in obj {
+                                let resolved = resolve_refs_full(
+                                    v,
+                                    parameters,
+                                    _resources,
+                                    resource_physical_ids,
+                                    resource_attributes,
+                                    imports,
+                                    conditions,
+                                );
+                                let s = match resolved {
+                                    Value::String(s) => s,
+                                    other => other.to_string(),
+                                };
+                                bindings.insert(k.clone(), s);
+                            }
+                        }
+                        (str_part, bindings)
+                    } else {
+                        (None, BTreeMap::new())
+                    };
+                if let Some(s) = template_str {
                     let mut result = s.to_string();
+                    // 1. Bindings from the array form take precedence —
+                    //    AWS docs spell this out: explicit map wins over
+                    //    template parameters with the same name.
+                    for (k, v) in &extra_vars {
+                        result = result.replace(&format!("${{{k}}}"), v);
+                    }
+                    // 2. Pseudo-parameters: handle AWS::NoValue by
+                    //    swapping in the sentinel string so the surrounding
+                    //    string literal still resolves cleanly. The walker
+                    //    `strip_no_value` only acts on object/array
+                    //    children, so a Fn::Sub that hard-references
+                    //    `${AWS::NoValue}` is best-effort: we drop the
+                    //    token from the rendered string. Other AWS::*
+                    //    pseudo-params resolve via `pseudo_value` with
+                    //    region-aware partition/URLSuffix derivation.
+                    for pseudo in PSEUDO_REFS {
+                        let token = format!("${{{pseudo}}}");
+                        if !result.contains(&token) {
+                            continue;
+                        }
+                        if *pseudo == "AWS::NoValue" {
+                            // Inside a string, NoValue collapses to empty
+                            // — there's no JSON-level key to drop.
+                            result = result.replace(&token, "");
+                            continue;
+                        }
+                        if let Some(v) = pseudo_value(pseudo, parameters) {
+                            let s = match v {
+                                Value::String(s) => s,
+                                other => other.to_string(),
+                            };
+                            result = result.replace(&token, &s);
+                        }
+                    }
+                    // 3. Template parameters (including AWS::Region etc.
+                    //    if the caller seeded them).
                     for (k, v) in parameters {
                         result = result.replace(&format!("${{{k}}}"), v);
                     }
-                    // Also substitute resource physical IDs in Fn::Sub
+                    // 4. Resource physical IDs from already-provisioned
+                    //    siblings.
                     for (k, v) in resource_physical_ids {
                         result = result.replace(&format!("${{{k}}}"), v);
                     }
-                    // GetAtt-style substitutions: ${LogicalId.AttrName}
+                    // 5. GetAtt-style substitutions: ${LogicalId.AttrName}
                     for (logical, attrs) in resource_attributes {
                         for (attr, value) in attrs {
                             result = result.replace(&format!("${{{logical}.{attr}}}"), value);
@@ -1572,6 +1692,236 @@ Resources:
             parsed.resources[0].properties["QueueName"],
             Value::String("AWS::StackName".to_string())
         );
+    }
+
+    // ── BB6: pseudo-parameter coverage ────────────────────────────
+
+    #[test]
+    fn bb6_ref_aws_region_returns_seeded_region() {
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"Region": {"Ref": "AWS::Region"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "us-east-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Region"],
+            Value::String("us-east-1".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_fn_sub_substitutes_aws_account_id() {
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "Owner": {"Fn::Sub": "owner-${AWS::AccountId}"}
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::AccountId".to_string(), "123456789012".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Owner"],
+            Value::String("owner-123456789012".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_partition_for_china_region_is_aws_cn() {
+        // Caller seeds region but no explicit partition; pseudo_value
+        // should derive `aws-cn` for cn-* regions.
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"P": {"Ref": "AWS::Partition"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "cn-north-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["P"],
+            Value::String("aws-cn".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_partition_for_govcloud_region_is_aws_us_gov() {
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"P": {"Ref": "AWS::Partition"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "us-gov-west-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["P"],
+            Value::String("aws-us-gov".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_url_suffix_for_china_is_amazonaws_com_cn() {
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"S": {"Ref": "AWS::URLSuffix"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "cn-north-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["S"],
+            Value::String("amazonaws.com.cn".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_url_suffix_for_govcloud_stays_amazonaws_com() {
+        // GovCloud keeps the standard suffix — only China switches.
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"S": {"Ref": "AWS::URLSuffix"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "us-gov-east-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["S"],
+            Value::String("amazonaws.com".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_no_value_omits_property_from_resource_input() {
+        // Direct Ref to AWS::NoValue (no Fn::If wrapper) must still
+        // drop the property from the resolved resource map.
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "QueueName": "q",
+                        "OptionalProp": {"Ref": "AWS::NoValue"}
+                    }
+                }
+            }
+        }"#;
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        let props = parsed.resources[0].properties.as_object().unwrap();
+        assert!(
+            !props.contains_key("OptionalProp"),
+            "OptionalProp should be omitted, got: {props:?}"
+        );
+        assert_eq!(
+            props.get("QueueName"),
+            Some(&Value::String("q".to_string()))
+        );
+    }
+
+    #[test]
+    fn bb6_notification_arns_returns_seeded_array() {
+        // Pseudo-parameter `AWS::NotificationARNs` resolves to an array
+        // sourced from the JSON-encoded seed (matching the wiring in
+        // service::create_stack).
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"Targets": {"Ref": "AWS::NotificationARNs"}}
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert(
+            "AWS::NotificationARNs".to_string(),
+            r#"["arn:aws:sns:us-east-1:111122223333:topic"]"#.to_string(),
+        );
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Targets"],
+            serde_json::json!(["arn:aws:sns:us-east-1:111122223333:topic"])
+        );
+    }
+
+    #[test]
+    fn bb6_notification_arns_defaults_to_empty_array() {
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {"Targets": {"Ref": "AWS::NotificationARNs"}}
+                }
+            }
+        }"#;
+        let parsed = parse_template(template, &BTreeMap::new()).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Targets"],
+            serde_json::json!([])
+        );
+    }
+
+    #[test]
+    fn bb6_fn_sub_array_form_substitutes_extra_vars() {
+        // The array form `Fn::Sub: ["literal", {Var: ...}]` lets the
+        // template pass extra bindings; pseudo-params still resolve.
+        let template = r#"{
+            "Resources": {
+                "Q": {
+                    "Type": "AWS::SQS::Queue",
+                    "Properties": {
+                        "Path": {"Fn::Sub": ["${AWS::Region}/${Suffix}", {"Suffix": "tail"}]}
+                    }
+                }
+            }
+        }"#;
+        let mut params = BTreeMap::new();
+        params.insert("AWS::Region".to_string(), "eu-west-1".to_string());
+        let parsed = parse_template(template, &params).unwrap();
+        assert_eq!(
+            parsed.resources[0].properties["Path"],
+            Value::String("eu-west-1/tail".to_string())
+        );
+    }
+
+    #[test]
+    fn bb6_partition_helper_classifies_regions() {
+        assert_eq!(partition_for_region("us-east-1"), "aws");
+        assert_eq!(partition_for_region("eu-central-1"), "aws");
+        assert_eq!(partition_for_region("cn-north-1"), "aws-cn");
+        assert_eq!(partition_for_region("cn-northwest-1"), "aws-cn");
+        assert_eq!(partition_for_region("us-gov-west-1"), "aws-us-gov");
+        assert_eq!(partition_for_region("us-gov-east-1"), "aws-us-gov");
+    }
+
+    #[test]
+    fn bb6_url_suffix_helper_classifies_regions() {
+        assert_eq!(url_suffix_for_region("us-east-1"), "amazonaws.com");
+        assert_eq!(url_suffix_for_region("us-gov-west-1"), "amazonaws.com");
+        assert_eq!(url_suffix_for_region("cn-north-1"), "amazonaws.com.cn");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

BB6 of Phase BB (CloudFormation expansion).

- Substitutes the 7 AWS pseudo-parameters in `Ref` and `Fn::Sub`: `AWS::Region`, `AWS::AccountId`, `AWS::StackName`, `AWS::StackId`, `AWS::Partition`, `AWS::URLSuffix`, `AWS::NotificationARNs`, `AWS::NoValue`.
- `AWS::Partition` and `AWS::URLSuffix` are region-aware: `cn-*` -> `aws-cn` / `amazonaws.com.cn`, `us-gov-*` -> `aws-us-gov` / `amazonaws.com`, everything else -> `aws` / `amazonaws.com`. Helpers `partition_for_region` / `url_suffix_for_region` keep the mapping in one place.
- `AWS::NotificationARNs` is now sourced from the request's `NotificationARNs.member.N` parameters and resolves as an actual JSON array (not a string). Update payloads either supply a fresh list or carry the existing stack's list forward.
- `AWS::NoValue` continues to elide the parent property via the existing sentinel walker; in `Fn::Sub` strings it collapses to empty (no JSON-level key to drop).
- `Fn::Sub` now also accepts the array form `["literal-${Var}", { "Var": <intrinsic> }]` so template authors can bind extra variables alongside pseudo-params.

## Test plan

- [x] `cargo test -p fakecloud-cloudformation` (171 tests, including 11 new BB6 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation pseudo-parameter support and the `Fn::Sub` array form to better match AWS behavior. Improves region-aware values, correct array typing for notifications, and `NoValue` handling.

- New Features
  - Substitute pseudo-parameters in `Ref` and `Fn::Sub`: `AWS::Region`, `AWS::AccountId`, `AWS::StackName`, `AWS::StackId`, `AWS::Partition`, `AWS::URLSuffix`, `AWS::NotificationARNs`, `AWS::NoValue`.
  - Region-aware mapping: `AWS::Partition`/`AWS::URLSuffix` derive from `AWS::Region` (`cn-*` → `aws-cn`/`amazonaws.com.cn`, `us-gov-*` → `aws-us-gov`/`amazonaws.com`, others → `aws`/`amazonaws.com`).
  - `AWS::NotificationARNs` now resolves to a JSON array. Seeded from create/update requests and carried forward on updates when omitted.
  - `AWS::NoValue` removes the parent property; in `Fn::Sub` it collapses to an empty string.
  - Support `Fn::Sub` array form `["literal-${Var}", { "Var": <intrinsic> }]`, with extra vars resolving intrinsics and taking precedence over template params.

<sup>Written for commit c74778119369d0ac6ebf49b54fcb07c60abf977f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

