### PR TITLE
feat(ssm): parameter policies (I2)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1267,6 +1267,8 @@ impl ResourceProvisioner {
             data_type: "text".to_string(),
             tier: "Standard".to_string(),
             policies: None,
+            expiration_notified: false,
+            no_change_notified: false,
         };
 
         state.parameters.insert(name.to_string(), parameter);

--- a/crates/fakecloud-e2e/tests/ssm_parameter_policies.rs
+++ b/crates/fakecloud-e2e/tests/ssm_parameter_policies.rs
@@ -1,0 +1,274 @@
+//! E2E tests for SSM Parameter Store policies (I2): Expiration,
+//! ExpirationNotification, NoChangeNotification. Verifies lazy
+//! deletion + notification fan-out via the
+//! `/_fakecloud/ssm/parameter-policy-events` admin endpoint.
+
+mod helpers;
+
+use aws_sdk_ssm::types::{ParameterTier, ParameterType};
+use helpers::TestServer;
+use serde_json::json;
+
+fn policies_json(items: serde_json::Value) -> String {
+    serde_json::to_string(&items).unwrap()
+}
+
+async fn fetch_policy_events(server: &TestServer) -> serde_json::Value {
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!(
+            "{}/_fakecloud/ssm/parameter-policy-events",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "admin endpoint failed");
+    resp.json().await.unwrap()
+}
+
+#[tokio::test]
+async fn ssm_expiration_in_past_deletes_on_get() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let past = "1990-01-01T00:00:00.000Z";
+    let policies = policies_json(json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": past }
+    }]));
+
+    client
+        .put_parameter()
+        .name("/policies/expired-now")
+        .value("v1")
+        .r#type(ParameterType::String)
+        .tier(ParameterTier::Advanced)
+        .policies(policies)
+        .send()
+        .await
+        .unwrap();
+
+    // Lazy deletion fires on the next read.
+    let err = client
+        .get_parameter()
+        .name("/policies/expired-now")
+        .send()
+        .await
+        .expect_err("expected ParameterNotFound for expired param");
+    let svc_err = err.into_service_error();
+    assert!(
+        svc_err.is_parameter_not_found(),
+        "expected ParameterNotFound, got: {svc_err:?}"
+    );
+
+    // Admin endpoint records the deletion event.
+    let body = fetch_policy_events(&server).await;
+    let events = body["events"].as_array().unwrap();
+    let deletion = events
+        .iter()
+        .find(|e| e["eventType"] == "Expiration" && e["parameterName"] == "/policies/expired-now")
+        .expect("expected Expiration deletion event");
+    assert!(deletion["message"]
+        .as_str()
+        .unwrap()
+        .contains("was deleted"));
+}
+
+#[tokio::test]
+async fn ssm_expiration_in_future_still_readable() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let future = "9999-01-01T00:00:00.000Z";
+    let policies = policies_json(json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": future }
+    }]));
+
+    client
+        .put_parameter()
+        .name("/policies/future")
+        .value("still-here")
+        .r#type(ParameterType::String)
+        .tier(ParameterTier::Advanced)
+        .policies(policies)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_parameter()
+        .name("/policies/future")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.parameter().unwrap().value().unwrap(), "still-here");
+}
+
+#[tokio::test]
+async fn ssm_no_change_notification_fires_after_window() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // 1 second `After` window: real AWS only accepts Days/Hours, but
+    // fakecloud also recognises Minutes/Seconds so E2E tests can wait
+    // past the threshold without burning real time. Verifies the lazy
+    // tick fires when reads happen after `last_modified + window`.
+    let policies = policies_json(json!([{
+        "Type": "NoChangeNotification",
+        "Version": "1.0",
+        "Attributes": { "After": "1", "Unit": "Seconds" }
+    }]));
+
+    client
+        .put_parameter()
+        .name("/policies/inactive")
+        .value("v1")
+        .r#type(ParameterType::String)
+        .tier(ParameterTier::Advanced)
+        .policies(policies)
+        .send()
+        .await
+        .unwrap();
+
+    // Wait past the 1s window then read to drive a lazy tick.
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+    client
+        .get_parameter()
+        .name("/policies/inactive")
+        .send()
+        .await
+        .unwrap();
+
+    let body = fetch_policy_events(&server).await;
+    let events = body["events"].as_array().unwrap();
+
+    let registered = events.iter().any(|e| {
+        e["eventType"] == "NoChangeNotificationRegistered"
+            && e["parameterName"] == "/policies/inactive"
+    });
+    assert!(
+        registered,
+        "expected NoChangeNotificationRegistered event, got {events:?}"
+    );
+
+    let fired = events.iter().any(|e| {
+        e["eventType"] == "NoChangeNotification" && e["parameterName"] == "/policies/inactive"
+    });
+    assert!(
+        fired,
+        "expected NoChangeNotification to fire after window; events={events:?}"
+    );
+}
+
+#[tokio::test]
+async fn ssm_expiration_notification_fires_within_window() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Expire 10 seconds from now, with a Before=20 second window so
+    // the notification fires immediately on the first read.
+    let exp_at = chrono::Utc::now() + chrono::Duration::seconds(10);
+    let policies = policies_json(json!([
+        {
+            "Type": "Expiration",
+            "Version": "1.0",
+            "Attributes": { "Timestamp": exp_at.to_rfc3339() }
+        },
+        {
+            "Type": "ExpirationNotification",
+            "Version": "1.0",
+            "Attributes": { "Before": "20", "Unit": "Seconds" }
+        }
+    ]));
+
+    client
+        .put_parameter()
+        .name("/policies/expiring-soon")
+        .value("v1")
+        .r#type(ParameterType::String)
+        .tier(ParameterTier::Advanced)
+        .policies(policies)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .get_parameter()
+        .name("/policies/expiring-soon")
+        .send()
+        .await
+        .unwrap();
+
+    let body = fetch_policy_events(&server).await;
+    let events = body["events"].as_array().unwrap();
+    let fired = events.iter().any(|e| {
+        e["eventType"] == "ExpirationNotification"
+            && e["parameterName"] == "/policies/expiring-soon"
+    });
+    assert!(
+        fired,
+        "expected ExpirationNotification to fire within window; events={events:?}"
+    );
+}
+
+#[tokio::test]
+async fn ssm_policy_on_standard_tier_rejected() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let policies = policies_json(json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]));
+
+    let err = client
+        .put_parameter()
+        .name("/policies/standard-rejected")
+        .value("nope")
+        .r#type(ParameterType::String)
+        // No .tier() => Standard default
+        .policies(policies)
+        .send()
+        .await
+        .expect_err("expected Standard-tier policy rejection");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Advanced") || msg.contains("ValidationException"),
+        "expected Advanced-tier validation error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn ssm_malformed_policies_rejected() {
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Missing required Attributes.Timestamp -> InvalidPolicyAttributeException.
+    let policies = policies_json(json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": {}
+    }]));
+
+    let err = client
+        .put_parameter()
+        .name("/policies/malformed")
+        .value("nope")
+        .r#type(ParameterType::String)
+        .tier(ParameterTier::Advanced)
+        .policies(policies)
+        .send()
+        .await
+        .expect_err("expected InvalidPolicyAttributeException");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidPolicyAttribute") || msg.contains("Timestamp"),
+        "expected InvalidPolicyAttributeException, got: {msg}"
+    );
+}

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -303,6 +303,27 @@ pub struct FailSsmCommandResponse {
     pub updated_invocations: usize,
 }
 
+/// One emitted parameter-policy event, as recorded by the
+/// `/_fakecloud/ssm/parameter-policy-events` admin endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SsmParameterPolicyEvent {
+    pub parameter_name: String,
+    pub parameter_arn: String,
+    /// One of `ExpirationRegistered`, `ExpirationNotificationRegistered`,
+    /// `NoChangeNotificationRegistered`, `Expiration`,
+    /// `ExpirationNotification`, `NoChangeNotification`.
+    pub event_type: String,
+    pub message: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SsmParameterPolicyEventsResponse {
+    pub events: Vec<SsmParameterPolicyEvent>,
+}
+
 // ── EventBridge ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1120,6 +1120,7 @@ async fn main() {
         };
     let ssm_state_for_admin = ssm_state.clone();
     let ssm_state_for_fail = ssm_state.clone();
+    let ssm_state_for_policy_events = ssm_state.clone();
     let mut ssm_service = SsmService::new(ssm_state)
         .with_secretsmanager(secretsmanager_state.clone())
         .with_kms_hook(kms_hook_for_services.clone());
@@ -3321,6 +3322,52 @@ async fn main() {
                     axum::Json(types::FailSsmCommandResponse {
                         updated_invocations: updated,
                     })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ssm/parameter-policy-events",
+            axum::routing::get({
+                let ss = ssm_state_for_policy_events.clone();
+                move |query: axum::extract::Query<
+                    std::collections::HashMap<String, String>,
+                >| async move {
+                    let default_account = ss.read().default_account_id().to_string();
+                    let account = query
+                        .get("accountId")
+                        .cloned()
+                        .unwrap_or(default_account);
+                    let svc = fakecloud_ssm::SsmService::new(ss.clone());
+                    let events = svc
+                        .parameter_policy_events(&account)
+                        .into_iter()
+                        .map(|e| types::SsmParameterPolicyEvent {
+                            parameter_name: e.parameter_name,
+                            parameter_arn: e.parameter_arn,
+                            event_type: e.event_type,
+                            message: e.message,
+                            created_at: e.created_at.to_rfc3339(),
+                        })
+                        .collect();
+                    axum::Json(types::SsmParameterPolicyEventsResponse { events })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ssm/parameter-policy-events",
+            axum::routing::delete({
+                let ss = ssm_state_for_policy_events;
+                move |query: axum::extract::Query<
+                    std::collections::HashMap<String, String>,
+                >| async move {
+                    let default_account = ss.read().default_account_id().to_string();
+                    let account = query
+                        .get("accountId")
+                        .cloned()
+                        .unwrap_or(default_account);
+                    let svc = fakecloud_ssm::SsmService::new(ss.clone());
+                    svc.clear_parameter_policy_events(&account);
+                    axum::http::StatusCode::NO_CONTENT
                 }
             }),
         )

--- a/crates/fakecloud-ssm/src/lib.rs
+++ b/crates/fakecloud-ssm/src/lib.rs
@@ -2,4 +2,7 @@ pub(crate) mod service;
 pub(crate) mod state;
 
 pub use service::SsmService;
-pub use state::{SharedSsmState, SsmParameter, SsmSnapshot, SsmState, SSM_SNAPSHOT_SCHEMA_VERSION};
+pub use state::{
+    ParameterPolicyEvent, SharedSsmState, SsmParameter, SsmSnapshot, SsmState,
+    SSM_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/fakecloud-ssm/src/service/mod.rs
+++ b/crates/fakecloud-ssm/src/service/mod.rs
@@ -142,6 +142,30 @@ impl SsmService {
         updated
     }
 
+    /// Admin: read out the parameter-policy event log for the given
+    /// account. Used by tests to verify that Expiration deletions and
+    /// notification windows actually fired without standing up an
+    /// EventBridge target. Reads also tick the lazy policy evaluator so
+    /// callers don't have to issue a Get* call first.
+    pub fn parameter_policy_events(
+        &self,
+        account_id: &str,
+    ) -> Vec<crate::state::ParameterPolicyEvent> {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        parameters::purge_expired_params(state);
+        parameters::tick_policy_notifications(state);
+        state.parameter_policy_events.clone()
+    }
+
+    /// Admin: drop the recorded parameter-policy event log for the
+    /// given account. Tests use this to reset between assertions.
+    pub fn clear_parameter_policy_events(&self, account_id: &str) {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        state.parameter_policy_events.clear();
+    }
+
     /// Persist current state as a snapshot. Held across the
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -9,27 +9,176 @@ use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::{SsmParameter, SsmParameterVersion, SsmState};
+use crate::state::{ParameterPolicyEvent, SsmParameter, SsmParameterVersion, SsmState};
 
 use super::{missing, SsmService, PARAMETER_VERSION_LIMIT};
 
-/// Parse the `Expiration` policy timestamp from the parameter's `Policies`
-/// JSON. The wire format is an array of `{Type, Version, Attributes:{...}}`
-/// objects; for `Type=Expiration` the `Attributes.Timestamp` field is an
-/// ISO 8601 string. Returns `None` for any malformed/missing data — we
-/// fail open rather than rejecting parameters with unparseable policies.
-fn extract_expiration(policies_str: &str) -> Option<chrono::DateTime<Utc>> {
-    let value: Value = serde_json::from_str(policies_str).ok()?;
-    for policy in value.as_array()? {
-        if policy["Type"].as_str() == Some("Expiration") {
-            if let Some(ts) = policy["Attributes"]["Timestamp"].as_str() {
-                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
-                    return Some(dt.with_timezone(&Utc));
-                }
+/// One parsed entry from the `Policies` JSON array on `PutParameter`.
+/// AWS supports three policy types — Expiration deletes the parameter
+/// at a specific instant; ExpirationNotification fires an EventBridge
+/// event in the run-up to expiry; NoChangeNotification fires when a
+/// parameter goes too long without being updated.
+#[derive(Debug, Clone)]
+pub(crate) enum ParsedPolicy {
+    Expiration(chrono::DateTime<Utc>),
+    ExpirationNotification { before: i64, unit: PolicyUnit },
+    NoChangeNotification { after: i64, unit: PolicyUnit },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PolicyUnit {
+    Days,
+    Hours,
+    /// fakecloud-only extension: lets E2E tests trigger notification
+    /// thresholds in seconds rather than waiting hours.
+    Minutes,
+    /// fakecloud-only extension; same rationale as `Minutes`.
+    Seconds,
+}
+
+impl PolicyUnit {
+    fn to_duration(self, n: i64) -> chrono::Duration {
+        match self {
+            PolicyUnit::Days => chrono::Duration::days(n),
+            PolicyUnit::Hours => chrono::Duration::hours(n),
+            PolicyUnit::Minutes => chrono::Duration::minutes(n),
+            PolicyUnit::Seconds => chrono::Duration::seconds(n),
+        }
+    }
+}
+
+/// Error helper: build the AWS-shaped `InvalidPolicyAttributeException`
+/// reply. Used both for malformed JSON and for individual
+/// missing/unparseable attributes within a well-formed array.
+fn invalid_policy_error(detail: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidPolicyAttributeException",
+        detail.into(),
+    )
+}
+
+/// Parse and validate the `Policies` JSON string on `PutParameter`.
+/// Returns the parsed policy list. Empty/`None` input is OK and yields
+/// an empty list. Malformed JSON or unrecognized policy shapes raise
+/// `InvalidPolicyAttributeException` to match the real API.
+pub(crate) fn parse_policies(policies_str: &str) -> Result<Vec<ParsedPolicy>, AwsServiceError> {
+    let value: Value = serde_json::from_str(policies_str)
+        .map_err(|e| invalid_policy_error(format!("Policies must be valid JSON: {e}")))?;
+    let arr = value
+        .as_array()
+        .ok_or_else(|| invalid_policy_error("Policies must be a JSON array."))?;
+
+    let mut parsed = Vec::with_capacity(arr.len());
+    for (i, policy) in arr.iter().enumerate() {
+        let kind = policy["Type"].as_str().ok_or_else(|| {
+            invalid_policy_error(format!(
+                "Policy at index {i} is missing required field 'Type'."
+            ))
+        })?;
+        let attrs = &policy["Attributes"];
+        if !attrs.is_object() {
+            return Err(invalid_policy_error(format!(
+                "Policy at index {i} is missing required field 'Attributes'."
+            )));
+        }
+        match kind {
+            "Expiration" => {
+                let ts = attrs["Timestamp"].as_str().ok_or_else(|| {
+                    invalid_policy_error(format!(
+                        "Expiration policy at index {i} requires Attributes.Timestamp."
+                    ))
+                })?;
+                let dt = chrono::DateTime::parse_from_rfc3339(ts).map_err(|e| {
+                    invalid_policy_error(format!(
+                        "Expiration policy at index {i} has invalid Timestamp: {e}"
+                    ))
+                })?;
+                parsed.push(ParsedPolicy::Expiration(dt.with_timezone(&Utc)));
+            }
+            "ExpirationNotification" => {
+                let (n, unit) = parse_window_attrs(attrs, "Before", i, kind)?;
+                parsed.push(ParsedPolicy::ExpirationNotification { before: n, unit });
+            }
+            "NoChangeNotification" => {
+                let (n, unit) = parse_window_attrs(attrs, "After", i, kind)?;
+                parsed.push(ParsedPolicy::NoChangeNotification { after: n, unit });
+            }
+            other => {
+                return Err(invalid_policy_error(format!(
+                    "Policy at index {i} has unsupported Type: {other}. \
+                     Valid types: Expiration, ExpirationNotification, NoChangeNotification."
+                )));
             }
         }
     }
-    None
+    Ok(parsed)
+}
+
+/// Pull a `{<key>: number, "Unit": "Days"|"Hours"}` pair out of a
+/// notification policy's `Attributes` block. Used by both
+/// ExpirationNotification (`Before`) and NoChangeNotification (`After`).
+fn parse_window_attrs(
+    attrs: &Value,
+    key: &str,
+    idx: usize,
+    kind: &str,
+) -> Result<(i64, PolicyUnit), AwsServiceError> {
+    // AWS accepts the numeric attribute as either a JSON number or a
+    // stringified integer (the SSM PutParameter docs describe the
+    // attribute values as strings, but real callers send both).
+    let n = if let Some(n) = attrs[key].as_i64() {
+        n
+    } else if let Some(s) = attrs[key].as_str() {
+        s.parse::<i64>().map_err(|_| {
+            invalid_policy_error(format!(
+                "{kind} policy at index {idx} has non-numeric {key}: {s}"
+            ))
+        })?
+    } else {
+        return Err(invalid_policy_error(format!(
+            "{kind} policy at index {idx} requires Attributes.{key}."
+        )));
+    };
+    if n <= 0 {
+        return Err(invalid_policy_error(format!(
+            "{kind} policy at index {idx} requires {key} > 0."
+        )));
+    }
+    let unit_str = attrs["Unit"].as_str().ok_or_else(|| {
+        invalid_policy_error(format!(
+            "{kind} policy at index {idx} requires Attributes.Unit."
+        ))
+    })?;
+    let unit = match unit_str {
+        "Days" => PolicyUnit::Days,
+        "Hours" => PolicyUnit::Hours,
+        // fakecloud-only extensions: AWS proper accepts only Days/Hours,
+        // but Minutes/Seconds let E2E tests verify notification firing
+        // without sitting on the runner for an hour.
+        "Minutes" => PolicyUnit::Minutes,
+        "Seconds" => PolicyUnit::Seconds,
+        other => {
+            return Err(invalid_policy_error(format!(
+                "{kind} policy at index {idx} has unsupported Unit: {other}. \
+                 Valid units: Days, Hours (fakecloud extensions: Minutes, Seconds)."
+            )));
+        }
+    };
+    Ok((n, unit))
+}
+
+/// Convenience wrapper used by read paths: parse `policies` (if any)
+/// and return the Expiration timestamp if one is set. Silently ignores
+/// malformed JSON — at this point the param was already accepted, so
+/// we don't want to re-fail the read.
+fn extract_expiration(policies_str: &str) -> Option<chrono::DateTime<Utc>> {
+    parse_policies(policies_str).ok().and_then(|policies| {
+        policies.into_iter().find_map(|p| match p {
+            ParsedPolicy::Expiration(ts) => Some(ts),
+            _ => None,
+        })
+    })
 }
 
 /// Returns true if the parameter has an `Expiration` policy whose timestamp
@@ -41,6 +190,167 @@ pub(crate) fn is_param_expired(p: &SsmParameter) -> bool {
         .as_deref()
         .and_then(extract_expiration)
         .is_some_and(|exp| exp < Utc::now())
+}
+
+/// On `PutParameter`, record a "Policy registered" event for each
+/// supplied policy so callers can verify (via the admin endpoint) that
+/// the server saw and accepted them. Notification policies still
+/// require a separate threshold-crossing event; this is the
+/// at-creation receipt.
+pub(crate) fn record_policy_events(
+    state: &mut SsmState,
+    name: &str,
+    arn: &str,
+    policies: &[ParsedPolicy],
+) {
+    let now = Utc::now();
+    for policy in policies {
+        let (event_type, message) = match policy {
+            ParsedPolicy::Expiration(ts) => (
+                "ExpirationRegistered",
+                format!(
+                    "Parameter {name} registered with Expiration at {}.",
+                    ts.to_rfc3339()
+                ),
+            ),
+            ParsedPolicy::ExpirationNotification { before, unit } => (
+                "ExpirationNotificationRegistered",
+                format!(
+                    "Parameter {name} registered ExpirationNotification window of {before} {}.",
+                    unit_str(*unit)
+                ),
+            ),
+            ParsedPolicy::NoChangeNotification { after, unit } => (
+                "NoChangeNotificationRegistered",
+                format!(
+                    "Parameter {name} registered NoChangeNotification window of {after} {}.",
+                    unit_str(*unit)
+                ),
+            ),
+        };
+        state.parameter_policy_events.push(ParameterPolicyEvent {
+            parameter_name: name.to_string(),
+            parameter_arn: arn.to_string(),
+            event_type: event_type.to_string(),
+            message,
+            created_at: now,
+        });
+    }
+}
+
+fn unit_str(u: PolicyUnit) -> &'static str {
+    match u {
+        PolicyUnit::Days => "Days",
+        PolicyUnit::Hours => "Hours",
+        PolicyUnit::Minutes => "Minutes",
+        PolicyUnit::Seconds => "Seconds",
+    }
+}
+
+/// Lazy-fire notification policy events for every parameter in
+/// `state`. Called from every read path; cheap when no parameters
+/// have policies.
+///
+/// `ExpirationNotification` fires when `now >= expiration - window`.
+/// `NoChangeNotification` fires when `now >= last_modified + window`.
+/// Both are guarded by per-parameter "already-fired" flags that get
+/// reset on overwrite.
+pub(crate) fn tick_policy_notifications(state: &mut SsmState) {
+    let now = Utc::now();
+    for param in state.parameters.values_mut() {
+        let Some(policies_str) = param.policies.as_deref() else {
+            continue;
+        };
+        let Ok(policies) = parse_policies(policies_str) else {
+            continue;
+        };
+
+        // Find an Expiration timestamp to anchor ExpirationNotification.
+        let expiration_at = policies.iter().find_map(|p| match p {
+            ParsedPolicy::Expiration(ts) => Some(*ts),
+            _ => None,
+        });
+
+        for policy in &policies {
+            match policy {
+                ParsedPolicy::ExpirationNotification { before, unit } => {
+                    if param.expiration_notified {
+                        continue;
+                    }
+                    let Some(exp) = expiration_at else { continue };
+                    let window = unit.to_duration(*before);
+                    if now >= exp - window {
+                        state.parameter_policy_events.push(ParameterPolicyEvent {
+                            parameter_name: param.name.clone(),
+                            parameter_arn: param.arn.clone(),
+                            event_type: "ExpirationNotification".to_string(),
+                            message: format!(
+                                "Parameter {} is within {} {} of its Expiration ({}).",
+                                param.name,
+                                before,
+                                unit_str(*unit),
+                                exp.to_rfc3339()
+                            ),
+                            created_at: now,
+                        });
+                        param.expiration_notified = true;
+                    }
+                }
+                ParsedPolicy::NoChangeNotification { after, unit } => {
+                    if param.no_change_notified {
+                        continue;
+                    }
+                    let window = unit.to_duration(*after);
+                    if now >= param.last_modified + window {
+                        state.parameter_policy_events.push(ParameterPolicyEvent {
+                            parameter_name: param.name.clone(),
+                            parameter_arn: param.arn.clone(),
+                            event_type: "NoChangeNotification".to_string(),
+                            message: format!(
+                                "Parameter {} has gone {} {} without an update.",
+                                param.name,
+                                after,
+                                unit_str(*unit)
+                            ),
+                            created_at: now,
+                        });
+                        param.no_change_notified = true;
+                    }
+                }
+                ParsedPolicy::Expiration(_) => {}
+            }
+        }
+    }
+}
+
+/// Sweep expired parameters out of `state` and record one
+/// `Expiration` policy event per deletion. Real AWS deletes expired
+/// advanced-tier parameters at the scheduled time, so reads must
+/// observe the deletion. Returns the names that were removed for
+/// callers that want to log them.
+pub(crate) fn purge_expired_params(state: &mut SsmState) -> Vec<String> {
+    let now = Utc::now();
+    let expired: Vec<String> = state
+        .parameters
+        .iter()
+        .filter(|(_, p)| is_param_expired(p))
+        .map(|(name, _)| name.clone())
+        .collect();
+    for name in &expired {
+        if let Some(removed) = state.parameters.remove(name) {
+            state.parameter_policy_events.push(ParameterPolicyEvent {
+                parameter_name: removed.name.clone(),
+                parameter_arn: removed.arn.clone(),
+                event_type: "Expiration".to_string(),
+                message: format!(
+                    "Parameter {} reached its Expiration policy and was deleted.",
+                    removed.name
+                ),
+                created_at: now,
+            });
+        }
+    }
+    expired
 }
 
 /// Build the JSON `Parameter` body for a historical version of `param`.
@@ -86,6 +396,11 @@ struct PutParameterInput {
     data_type_explicit: bool,
     tier: String,
     policies: Option<String>,
+    /// Pre-parsed `policies` view, populated by ``from_body`` when the
+    /// caller supplied a non-empty Policies array. Notification policies
+    /// fan out to ``state.parameter_policy_events`` after the parameter
+    /// is committed; Expiration policies drive lazy deletion on read.
+    parsed_policies: Vec<ParsedPolicy>,
     tags: Option<Vec<(String, String)>>,
 }
 
@@ -153,6 +468,29 @@ impl PutParameterInput {
                 .collect()
         });
 
+        let tier = body["Tier"].as_str().unwrap_or("Standard").to_string();
+
+        // Parse + validate the Policies JSON up front so PutParameter
+        // can return InvalidPolicyAttributeException without touching
+        // state. Empty/absent Policies -> empty list -> no-op.
+        let policies = body["Policies"].as_str().map(|s| s.to_string());
+        let parsed_policies = match policies.as_deref() {
+            Some(s) if !s.trim().is_empty() => parse_policies(s)?,
+            _ => Vec::new(),
+        };
+
+        // AWS only allows policies on Advanced-tier parameters. The
+        // real API rejects this with ValidationException; we mirror
+        // that.
+        if !parsed_policies.is_empty() && tier != "Advanced" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Policies are only supported on Advanced-tier parameters. \
+                 Set Tier=Advanced when including Policies.",
+            ));
+        }
+
         Ok(Self {
             name,
             value,
@@ -163,8 +501,9 @@ impl PutParameterInput {
             allowed_pattern: body["AllowedPattern"].as_str().map(|s| s.to_string()),
             data_type,
             data_type_explicit,
-            tier: body["Tier"].as_str().unwrap_or("Standard").to_string(),
-            policies: body["Policies"].as_str().map(|s| s.to_string()),
+            tier,
+            policies,
+            parsed_policies,
             tags,
         })
     }
@@ -257,6 +596,14 @@ fn apply_overwrite(
     if input.data_type_explicit {
         existing.data_type = input.data_type;
     }
+    // Always replace the policy list on overwrite. AWS treats Policies
+    // as a wholesale property of the current value: passing a fresh
+    // array swaps them out, omitting it clears them. Reset the
+    // emitted-event flags so updated policies and the new value each
+    // get a fresh notification window.
+    existing.policies = input.policies;
+    existing.expiration_notified = false;
+    existing.no_change_notified = false;
 
     Ok(AwsResponse::ok_json(json!({
         "Version": existing.version,
@@ -300,6 +647,8 @@ fn create_new_parameter(
         data_type: input.data_type,
         tier: input.tier,
         policies: input.policies,
+        expiration_notified: false,
+        no_change_notified: false,
     })
 }
 
@@ -332,18 +681,34 @@ impl SsmService {
             );
         }
 
-        if let Some(existing) = lookup_param_mut(&mut state.parameters, &input.name) {
-            return apply_overwrite(existing, input);
-        }
+        // Hold on to the parsed policies + identifying metadata before
+        // the input is consumed by overwrite/create. We use them after
+        // the parameter is stored to fan out notification events.
+        let parsed_policies = input.parsed_policies.clone();
+        let param_name_for_events = input.name.clone();
+        let param_arn_for_events = param_arn(&req.region, &state.account_id, &input.name);
 
-        let tier_for_response = input.tier.clone();
-        let name = input.name.clone();
-        let param = create_new_parameter(&req.region, &state.account_id, input)?;
-        state.parameters.insert(name, param);
-        Ok(AwsResponse::ok_json(json!({
-            "Version": 1,
-            "Tier": tier_for_response,
-        })))
+        let resp = if let Some(existing) = lookup_param_mut(&mut state.parameters, &input.name) {
+            apply_overwrite(existing, input)?
+        } else {
+            let tier_for_response = input.tier.clone();
+            let name = input.name.clone();
+            let param = create_new_parameter(&req.region, &state.account_id, input)?;
+            state.parameters.insert(name, param);
+            AwsResponse::ok_json(json!({
+                "Version": 1,
+                "Tier": tier_for_response,
+            }))
+        };
+
+        record_policy_events(
+            state,
+            &param_name_for_events,
+            &param_arn_for_events,
+            &parsed_policies,
+        );
+
+        Ok(resp)
     }
 
     /// Encrypt a SecureString value via the configured KMS hook. Returns
@@ -557,16 +922,16 @@ impl SsmService {
             );
         }
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        // Take the write lock so the lazy-policy sweep (delete expired,
+        // emit notifications) can mutate state in line with this read.
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        purge_expired_params(state);
+        tick_policy_notifications(state);
 
         // Handle ARN-style names directly (they contain many colons)
         if raw_name.starts_with("arn:aws:ssm:") {
             let param = resolve_param_by_name_or_arn(state, raw_name)?;
-            if is_param_expired(param) {
-                return Err(param_not_found(raw_name));
-            }
             return Ok(AwsResponse::ok_json(json!({
                 "Parameter": self.render_param_to_json(param, true, with_decryption, &req.region, &req.account_id),
             })));
@@ -582,9 +947,6 @@ impl SsmService {
         // Try looking up by name or by ARN - use raw_name in error for full context
         let param = resolve_param_by_name_or_arn(state, base_name)
             .map_err(|_| param_not_found(raw_name))?;
-        if is_param_expired(param) {
-            return Err(param_not_found(raw_name));
-        }
 
         match selector {
             ParamSelector::None => Ok(AwsResponse::ok_json(json!({
@@ -670,9 +1032,10 @@ impl SsmService {
             ));
         }
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        purge_expired_params(state);
+        tick_policy_notifications(state);
         let mut parameters = Vec::new();
         let mut invalid = Vec::new();
         let mut seen_names = std::collections::HashSet::new();
@@ -692,26 +1055,20 @@ impl SsmService {
                     }
                     ParamSelector::None => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            if is_param_expired(param) {
-                                invalid.push(raw_name.to_string());
-                            } else {
-                                parameters.push(self.render_param_to_json(
-                                    param,
-                                    true,
-                                    with_decryption,
-                                    &req.region,
-                                    &req.account_id,
-                                ));
-                            }
+                            parameters.push(self.render_param_to_json(
+                                param,
+                                true,
+                                with_decryption,
+                                &req.region,
+                                &req.account_id,
+                            ));
                         } else {
                             invalid.push(raw_name.to_string());
                         }
                     }
                     ParamSelector::Version(ver) => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            if is_param_expired(param) {
-                                invalid.push(raw_name.to_string());
-                            } else if param.version == ver {
+                            if param.version == ver {
                                 parameters.push(self.render_param_to_json(
                                     param,
                                     true,
@@ -738,10 +1095,6 @@ impl SsmService {
                     }
                     ParamSelector::Label(ref label) => {
                         if let Some(param) = lookup_param(&state.parameters, base_name) {
-                            if is_param_expired(param) {
-                                invalid.push(raw_name.to_string());
-                                continue;
-                            }
                             let mut found = false;
                             for (ver, labels) in &param.labels {
                                 if labels.contains(label) {
@@ -820,13 +1173,13 @@ impl SsmService {
             validate_parameter_filters_by_path(f)?;
         }
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        purge_expired_params(state);
+        tick_policy_notifications(state);
         let all_params: Vec<&SsmParameter> = state
             .parameters
             .values()
-            .filter(|p| !is_param_expired(p))
             .filter(|p| param_matches_path(p, path, recursive))
             .filter(|p| apply_parameter_filters(p, filters.as_ref()))
             .collect();
@@ -916,9 +1269,10 @@ impl SsmService {
             validate_parameter_filters(filters)?;
         }
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        purge_expired_params(state);
+        tick_policy_notifications(state);
 
         // Check if any filter explicitly targets /aws/ prefix paths
         let targets_aws_prefix = param_filters.as_ref().is_some_and(|filters| {
@@ -997,9 +1351,10 @@ impl SsmService {
         }
         let max_results = max_results.unwrap_or(50) as usize;
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        purge_expired_params(state);
+        tick_policy_notifications(state);
         let param = state
             .parameters
             .get(name)

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -1708,17 +1708,20 @@ pub(super) fn param_to_describe_json(p: &SsmParameter, region: &str) -> Value {
     if let Some(key_id) = &p.key_id {
         v["KeyId"] = json!(key_id);
     }
-    // Add policies if present and valid JSON
+    // Add policies if present and valid JSON. AWS describes each
+    // attached policy as `{PolicyText, PolicyType, PolicyStatus}`,
+    // where PolicyText is the original JSON the caller passed in and
+    // PolicyType is the `Type` field of that object.
     if let Some(policies_str) = &p.policies {
         if let Ok(parsed) = serde_json::from_str::<Value>(policies_str) {
             if let Some(arr) = parsed.as_array() {
                 let policy_objects: Vec<Value> = arr
                     .iter()
-                    .filter_map(|p| p.as_str())
-                    .map(|p| {
+                    .map(|policy| {
+                        let policy_type = policy["Type"].as_str().unwrap_or("Unknown").to_string();
                         json!({
-                            "PolicyText": p,
-                            "PolicyType": p,
+                            "PolicyText": policy.to_string(),
+                            "PolicyType": policy_type,
                             "PolicyStatus": "Finished",
                         })
                     })

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -596,12 +596,15 @@ fn apply_overwrite(
     if input.data_type_explicit {
         existing.data_type = input.data_type;
     }
-    // Always replace the policy list on overwrite. AWS treats Policies
-    // as a wholesale property of the current value: passing a fresh
-    // array swaps them out, omitting it clears them. Reset the
-    // emitted-event flags so updated policies and the new value each
-    // get a fresh notification window.
-    existing.policies = input.policies;
+    // Replace the policy list whenever the caller explicitly passed
+    // Policies. Omitting Policies on overwrite preserves whatever was
+    // already attached (matches the SDK behavior of treating policies
+    // as an independent property). Reset the emitted-event flags so
+    // updated policies and the new value each get a fresh notification
+    // window.
+    if input.policies.is_some() {
+        existing.policies = input.policies;
+    }
     existing.expiration_notified = false;
     existing.no_change_notified = false;
 

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -4313,3 +4313,194 @@ fn get_parameters_by_path_skips_expired_entries() {
         .collect();
     assert_eq!(names, vec!["/app/live"]);
 }
+
+#[test]
+fn put_parameter_rejects_policy_on_standard_tier() {
+    let svc = make_service();
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/standard-policy",
+            "Value": "v1",
+            "Type": "String",
+            "Policies": policies
+        }),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("standard tier with policies should fail"),
+    };
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        err.message().contains("Advanced"),
+        "expected Advanced-tier message, got: {}",
+        err.message()
+    );
+}
+
+#[test]
+fn put_parameter_rejects_malformed_policies() {
+    let svc = make_service();
+    // Missing Attributes.Timestamp on an Expiration policy.
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": {}
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/malformed",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("malformed policy should fail"),
+    };
+    assert_eq!(err.code(), "InvalidPolicyAttributeException");
+}
+
+#[test]
+fn put_parameter_rejects_unknown_policy_type() {
+    let svc = make_service();
+    let policies = serde_json::to_string(&json!([{
+        "Type": "NotARealPolicy",
+        "Version": "1.0",
+        "Attributes": { "X": "Y" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/unknown-type",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("unknown type should fail"),
+    };
+    assert_eq!(err.code(), "InvalidPolicyAttributeException");
+}
+
+#[test]
+fn put_parameter_rejects_invalid_policies_json() {
+    let svc = make_service();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/garbage",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": "{not-json"
+        }),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("non-JSON Policies should fail"),
+    };
+    assert_eq!(err.code(), "InvalidPolicyAttributeException");
+}
+
+#[test]
+fn put_parameter_records_policy_registration_event() {
+    let svc = make_service();
+    let policies = serde_json::to_string(&json!([
+        {
+            "Type": "Expiration",
+            "Version": "1.0",
+            "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+        },
+        {
+            "Type": "ExpirationNotification",
+            "Version": "1.0",
+            "Attributes": { "Before": "30", "Unit": "Days" }
+        }
+    ]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/with-policies",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    let events = svc.parameter_policy_events("123456789012");
+    assert!(events
+        .iter()
+        .any(|e| e.event_type == "ExpirationRegistered" && e.parameter_name == "/with-policies"));
+    assert!(events
+        .iter()
+        .any(|e| e.event_type == "ExpirationNotificationRegistered"
+            && e.parameter_name == "/with-policies"));
+}
+
+#[test]
+fn overwrite_keeps_existing_policies_when_omitted() {
+    let svc = make_service();
+    let policies = serde_json::to_string(&json!([{
+        "Type": "Expiration",
+        "Version": "1.0",
+        "Attributes": { "Timestamp": "9999-01-01T00:00:00.000Z" }
+    }]))
+    .unwrap();
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/keep-policies",
+            "Value": "v1",
+            "Type": "String",
+            "Tier": "Advanced",
+            "Policies": policies
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    // Overwrite without Policies.
+    let req = make_request(
+        "PutParameter",
+        json!({
+            "Name": "/keep-policies",
+            "Value": "v2",
+            "Type": "String",
+            "Overwrite": true
+        }),
+    );
+    svc.put_parameter(&req).unwrap();
+
+    // Read back via DescribeParameters and confirm Policies survived.
+    let req = make_request(
+        "DescribeParameters",
+        json!({
+            "ParameterFilters": [{
+                "Key": "Name",
+                "Values": ["/keep-policies"]
+            }]
+        }),
+    );
+    let resp = svc.describe_parameters(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let params = body["Parameters"].as_array().unwrap();
+    assert_eq!(params.len(), 1);
+    assert!(params[0]["Policies"].is_array());
+}

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -20,6 +20,18 @@ pub struct SsmParameter {
     pub data_type: String, // "text" or "aws:ec2:image"
     pub tier: String,      // "Standard", "Advanced", "Intelligent-Tiering"
     pub policies: Option<String>,
+    /// Whether the `ExpirationNotification` event has already been
+    /// emitted for the current Policies list. Reset whenever the
+    /// parameter is overwritten so updated policies fire fresh
+    /// notifications. Snapshots from before this field existed
+    /// deserialize as `false`.
+    #[serde(default)]
+    pub expiration_notified: bool,
+    /// Whether the `NoChangeNotification` event has already been
+    /// emitted for the current value. Reset whenever the parameter is
+    /// overwritten so the inactivity window restarts on each update.
+    #[serde(default)]
+    pub no_change_notified: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -444,6 +456,25 @@ pub struct SsmState {
     pub managed_instances: BTreeMap<String, ManagedInstance>,
     pub execution_previews: BTreeMap<String, ExecutionPreview>,
     pub execution_preview_counter: u64,
+    /// Local log of parameter-policy notification events. Real AWS sends
+    /// these to EventBridge; we record them in-memory so tests can
+    /// inspect notification fan-out via the admin endpoint. Defaults to
+    /// empty when deserializing snapshots from before this field
+    /// existed.
+    #[serde(default)]
+    pub parameter_policy_events: Vec<ParameterPolicyEvent>,
+}
+
+/// One emission of a parameter-policy notification (Expiration/
+/// ExpirationNotification/NoChangeNotification). Captured at PutParameter
+/// time and at read time when an Expiration ages out a parameter.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ParameterPolicyEvent {
+    pub parameter_name: String,
+    pub parameter_arn: String,
+    pub event_type: String,
+    pub message: String,
+    pub created_at: DateTime<Utc>,
 }
 
 impl SsmState {
@@ -483,6 +514,7 @@ impl SsmState {
             managed_instances: BTreeMap::new(),
             execution_previews: BTreeMap::new(),
             execution_preview_counter: 0,
+            parameter_policy_events: Vec::new(),
         };
         state.seed_defaults();
         state
@@ -521,6 +553,7 @@ impl SsmState {
         self.managed_instances.clear();
         self.execution_previews.clear();
         self.execution_preview_counter = 0;
+        self.parameter_policy_events.clear();
         self.seed_defaults();
     }
 
@@ -687,6 +720,8 @@ impl SsmState {
                 data_type: "text".to_string(),
                 tier: "Standard".to_string(),
                 policies: None,
+                expiration_notified: false,
+                no_change_notified: false,
             },
         );
     }


### PR DESCRIPTION
## Summary

Batch I2 of Phase I (SSM behavior). Implements real Parameter Store policy enforcement on `PutParameter`:

- **Expiration**: lazy delete on `Get*` once `Attributes.Timestamp` passes; matches AWS behavior (parameter is removed, not just hidden).
- **ExpirationNotification**: lazy event when reads happen within `Before` window of Expiration.
- **NoChangeNotification**: lazy event when reads happen `After` window past `last_modified`.

Validation: malformed Policies JSON raises `InvalidPolicyAttributeException`; policies on Standard-tier parameters raise `ValidationException` (AWS only allows policies on Advanced tier).

Notification events are buffered into `state.parameter_policy_events` and exposed via the new admin endpoint for test introspection. fakecloud-only `Minutes` / `Seconds` units (alongside AWS `Days`/`Hours`) let E2E tests verify the lazy tick without sitting on the runner for an hour.

## Test plan

- [x] `cargo test -p fakecloud-ssm` (209 tests pass)
- [x] `cargo test -p fakecloud-e2e --test ssm_parameter_policies` (6 new tests pass: expire-now, future-expire, expiration-notification window, no-change-notification window, Standard-tier rejection, malformed-policies rejection)
- [x] `cargo test -p fakecloud-e2e --test ssm` (53 existing SSM e2e tests still pass)
- [x] `cargo test -p fakecloud-e2e --test ssm_persistence --test ssm_kms --test ssm_patch_tracking` (all green)
- [x] `cargo test -p fakecloud-cloudformation` (CFN provisioner uses SsmParameter; new fields default to `false`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real SSM Parameter Store policy support: Expiration, ExpirationNotification, and NoChangeNotification. Expired parameters are lazily deleted on reads, and policy notifications are buffered and exposed via an admin endpoint for tests.

- New Features
  - Parse and validate `Policies` on `PutParameter`; malformed JSON -> `InvalidPolicyAttributeException`; policies require Advanced tier -> `ValidationException`; overwrites keep existing policies when `Policies` is omitted.
  - Lazy enforcement on reads: `GetParameter`, `GetParameters`, `GetParametersByPath`, `DescribeParameters`, and `GetParameterHistory` sweep expired params and fire notification events.
  - Admin endpoint `/_fakecloud/ssm/parameter-policy-events` (GET/DELETE) to inspect and clear buffered events; events include both registration and firing; SDK adds `SsmParameterPolicyEvent` and `SsmParameterPolicyEventsResponse`.
  - Accept `Minutes` and `Seconds` units (in addition to AWS `Days`/`Hours`) to enable fast E2E testing.

- Bug Fixes
  - `DescribeParameters` now returns `Policies` as objects with `PolicyText`, `PolicyType`, and `PolicyStatus`, with `PolicyType` derived from each policy’s `Type`.

<sup>Written for commit 70dec18853f14dd71799696daea6a636ad0d88f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

