### PR TITLE
feat(rds): real DescribeEvents from emit_event buffer (M3)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_events.rs
+++ b/crates/fakecloud-e2e/tests/rds_events.rs
@@ -1,0 +1,244 @@
+//! End-to-end coverage for `DescribeEvents` reading from the buffer
+//! that lifecycle ops populate via `emit_event` (M3 batch).
+//!
+//! Exercises:
+//!
+//! * Cluster + parameter-group lifecycle ops (Create/Modify/Delete)
+//!   land in the events buffer with the expected RDS messages.
+//! * `SourceIdentifier` filter narrows to a single resource.
+//! * `SourceType` filter respects the kebab-case AWS spec values
+//!   (`db-cluster`, `db-parameter-group`, ...).
+//! * `MaxRecords` + `Marker` paginate the result set deterministically.
+//!
+//! The cluster + parameter-group paths take the no-runtime branch, so
+//! these tests run on every shard without Docker.
+
+mod helpers;
+
+use aws_sdk_rds::types::{ApplyMethod, Parameter};
+use helpers::TestServer;
+
+#[tokio::test]
+async fn describe_events_returns_create_db_cluster_event() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_cluster()
+        .db_cluster_identifier("orders-cluster")
+        .engine("aurora-postgresql")
+        .send()
+        .await
+        .unwrap();
+
+    let response = client.describe_events().send().await.unwrap();
+    let events = response.events();
+    assert!(
+        events
+            .iter()
+            .any(|e| e.source_identifier() == Some("orders-cluster")
+                && e.source_type().is_some_and(|t| t.as_str() == "db-cluster")
+                && e.message() == Some("DB cluster created")),
+        "expected DB cluster created event, got {events:#?}"
+    );
+}
+
+#[tokio::test]
+async fn describe_events_filter_by_source_identifier_narrows_to_single_resource() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    for id in ["cluster-a", "cluster-b", "cluster-c"] {
+        client
+            .create_db_cluster()
+            .db_cluster_identifier(id)
+            .engine("aurora-postgresql")
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let response = client
+        .describe_events()
+        .source_identifier("cluster-b")
+        .send()
+        .await
+        .unwrap();
+
+    let events = response.events();
+    assert!(!events.is_empty(), "expected at least one event");
+    for e in events {
+        assert_eq!(e.source_identifier(), Some("cluster-b"));
+    }
+}
+
+#[tokio::test]
+async fn describe_events_filter_by_source_type_only_returns_matching_resources() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_cluster()
+        .db_cluster_identifier("the-cluster")
+        .engine("aurora-postgresql")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("the-pg")
+        .db_parameter_group_family("postgres16")
+        .description("source type filter check")
+        .send()
+        .await
+        .unwrap();
+
+    // db-cluster only
+    let cluster_response = client
+        .describe_events()
+        .source_type(aws_sdk_rds::types::SourceType::DbCluster)
+        .send()
+        .await
+        .unwrap();
+    let cluster_events = cluster_response.events();
+    assert!(!cluster_events.is_empty());
+    for e in cluster_events {
+        assert_eq!(e.source_type().map(|t| t.as_str()), Some("db-cluster"));
+    }
+
+    // db-parameter-group only
+    let pg_response = client
+        .describe_events()
+        .source_type(aws_sdk_rds::types::SourceType::DbParameterGroup)
+        .send()
+        .await
+        .unwrap();
+    let pg_events = pg_response.events();
+    assert!(pg_events
+        .iter()
+        .any(|e| e.source_identifier() == Some("the-pg")));
+    for e in pg_events {
+        assert_eq!(
+            e.source_type().map(|t| t.as_str()),
+            Some("db-parameter-group")
+        );
+    }
+}
+
+#[tokio::test]
+async fn describe_events_modify_db_parameter_group_records_event() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let group = "pg-modify-event";
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name(group)
+        .db_parameter_group_family("postgres16")
+        .description("modify event check")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_db_parameter_group()
+        .db_parameter_group_name(group)
+        .parameters(
+            Parameter::builder()
+                .parameter_name("max_connections")
+                .parameter_value("400")
+                .apply_method(ApplyMethod::Immediate)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let response = client
+        .describe_events()
+        .source_identifier(group)
+        .send()
+        .await
+        .unwrap();
+    let events = response.events();
+    assert!(events
+        .iter()
+        .any(|e| e.message() == Some("DB parameter group created")));
+    assert!(events
+        .iter()
+        .any(|e| e.message() == Some("DB parameter group modified")));
+}
+
+#[tokio::test]
+async fn describe_events_paginates_with_max_records_and_marker() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Create several clusters so we have at least 5 events to paginate.
+    for id in ["pg-c1", "pg-c2", "pg-c3", "pg-c4", "pg-c5"] {
+        client
+            .create_db_cluster()
+            .db_cluster_identifier(id)
+            .engine("aurora-postgresql")
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let first = client
+        .describe_events()
+        .source_type(aws_sdk_rds::types::SourceType::DbCluster)
+        .max_records(2)
+        .send()
+        .await
+        .unwrap();
+    let first_events = first.events();
+    assert_eq!(first_events.len(), 2);
+    let marker = first
+        .marker()
+        .expect("first page should yield a marker when more events remain")
+        .to_string();
+
+    let second = client
+        .describe_events()
+        .source_type(aws_sdk_rds::types::SourceType::DbCluster)
+        .max_records(2)
+        .marker(marker)
+        .send()
+        .await
+        .unwrap();
+    let second_events = second.events();
+    assert_eq!(second_events.len(), 2);
+
+    // The second page must not duplicate the first page's events.
+    let first_ids: Vec<_> = first_events
+        .iter()
+        .map(|e| e.source_identifier().unwrap_or_default())
+        .collect();
+    for e in second_events {
+        let id = e.source_identifier().unwrap_or_default();
+        assert!(!first_ids.contains(&id), "second page repeated id {id}");
+    }
+}
+
+#[tokio::test]
+async fn describe_events_rejects_invalid_source_type() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // The Smithy enum on the SDK side filters obvious typos, so push an
+    // unknown variant by hand to confirm the server validates strict
+    // AWS-spec membership.
+    let err = client
+        .describe_events()
+        .source_type(aws_sdk_rds::types::SourceType::from("not-a-real-type"))
+        .send()
+        .await
+        .expect_err("server should reject unknown SourceType");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidParameterValue") || msg.contains("not a valid value"),
+        "unexpected error: {msg}"
+    );
+}

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -129,17 +129,37 @@ impl RdsService {
                     "ReaderEndpoint": format!("{id}.cluster-ro-xxx.{region}.rds.amazonaws.com"),
                     "Port": 5432, "MasterUsername": get_param(req, "MasterUsername").unwrap_or_else(|| "postgres".to_string()),
                 });
-                let mut accounts = write_state!();
-                let state = accounts.get_or_create(&aid);
-                store(&mut state.extras, "clusters").insert(id.clone(), entry);
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    store(&mut state.extras, "clusters").insert(id.clone(), entry);
+                }
+                self.emit_event(
+                    RdsSourceType::DbCluster,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0170",
+                    &["creation"],
+                    "DB cluster created",
+                );
                 Ok(xml_response("CreateDBCluster", db_cluster_xml(&id, &arn), &rid))
             }
             "DeleteDBCluster" => {
                 let id = get_param(req, "DBClusterIdentifier").ok_or_else(|| missing("DBClusterIdentifier"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
-                let mut accounts = write_state!();
-                let state = accounts.get_or_create(&aid);
-                if let Some(m) = state.extras.get_mut("clusters") { m.remove(&id); }
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(m) = state.extras.get_mut("clusters") { m.remove(&id); }
+                }
+                self.emit_event(
+                    RdsSourceType::DbCluster,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0171",
+                    &["deletion"],
+                    "DB cluster deleted",
+                );
                 Ok(xml_response("DeleteDBCluster", db_cluster_xml(&id, &arn), &rid))
             }
             "ModifyDBCluster" => {
@@ -159,19 +179,29 @@ impl RdsService {
                     ("EnableIAMDatabaseAuthentication", "IAMDatabaseAuthenticationEnabled"),
                     ("CopyTagsToSnapshot", "CopyTagsToSnapshot"),
                 ];
-                let mut accounts = write_state!();
-                let state = accounts.get_or_create(&aid);
-                if let Some(map) = state.extras.get_mut("clusters") {
-                    if let Some(entry) = map.get_mut(&id) {
-                        if let Some(obj) = entry.as_object_mut() {
-                            for (param_name, json_key) in updates {
-                                if let Some(v) = get_param(req, param_name) {
-                                    obj.insert((*json_key).to_string(), json!(v));
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(map) = state.extras.get_mut("clusters") {
+                        if let Some(entry) = map.get_mut(&id) {
+                            if let Some(obj) = entry.as_object_mut() {
+                                for (param_name, json_key) in updates {
+                                    if let Some(v) = get_param(req, param_name) {
+                                        obj.insert((*json_key).to_string(), json!(v));
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                self.emit_event(
+                    RdsSourceType::DbCluster,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0016",
+                    &["configuration change"],
+                    "DB cluster was modified",
+                );
                 Ok(xml_response("ModifyDBCluster", db_cluster_xml(&id, &arn), &rid))
             }
             "StartDBCluster" => {
@@ -320,22 +350,32 @@ impl RdsService {
                     .ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster-snapshot:{id}")).to_string();
                 let cluster = get_param(req, "DBClusterIdentifier").unwrap_or_else(|| "default".to_string());
-                let mut accounts = write_state!();
-                let state = accounts.get_or_create(&aid);
-                let mut entry = state
-                    .extras
-                    .get("clusters")
-                    .and_then(|m| m.get(&cluster))
-                    .cloned()
-                    .unwrap_or_else(|| json!({}));
-                if let Some(obj) = entry.as_object_mut() {
-                    obj.insert("DBClusterSnapshotIdentifier".to_string(), json!(id));
-                    obj.insert("DBClusterSnapshotArn".to_string(), json!(arn));
-                    obj.insert("DBClusterIdentifier".to_string(), json!(cluster));
-                    obj.insert("Status".to_string(), json!("available"));
-                    obj.insert("SnapshotType".to_string(), json!("manual"));
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let mut entry = state
+                        .extras
+                        .get("clusters")
+                        .and_then(|m| m.get(&cluster))
+                        .cloned()
+                        .unwrap_or_else(|| json!({}));
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert("DBClusterSnapshotIdentifier".to_string(), json!(id));
+                        obj.insert("DBClusterSnapshotArn".to_string(), json!(arn));
+                        obj.insert("DBClusterIdentifier".to_string(), json!(cluster));
+                        obj.insert("Status".to_string(), json!("available"));
+                        obj.insert("SnapshotType".to_string(), json!("manual"));
+                    }
+                    store(&mut state.extras, "cluster_snapshots").insert(id.clone(), entry);
                 }
-                store(&mut state.extras, "cluster_snapshots").insert(id.clone(), entry);
+                self.emit_event(
+                    RdsSourceType::DbClusterSnapshot,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0074",
+                    &["backup"],
+                    "DB cluster snapshot created",
+                );
                 Ok(xml_response(action.as_str(), cluster_snapshot_xml(&id, &arn, &cluster), &rid))
             }
             "CopyDBClusterSnapshot" => {
@@ -377,9 +417,19 @@ impl RdsService {
             "DeleteDBClusterSnapshot" => {
                 let id = get_param(req, "DBClusterSnapshotIdentifier").ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
                 let arn = Arn::new("rds", region, &aid, &format!("cluster-snapshot:{id}")).to_string();
-                let mut accounts = write_state!();
-                let state = accounts.get_or_create(&aid);
-                if let Some(m) = state.extras.get_mut("cluster_snapshots") { m.remove(&id); }
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if let Some(m) = state.extras.get_mut("cluster_snapshots") { m.remove(&id); }
+                }
+                self.emit_event(
+                    RdsSourceType::DbClusterSnapshot,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0075",
+                    &["deletion"],
+                    "DB cluster snapshot deleted",
+                );
                 Ok(xml_response("DeleteDBClusterSnapshot", cluster_snapshot_xml(&id, &arn, "default"), &rid))
             }
             "DescribeDBClusterSnapshots" => list_extras_xml(self, &aid, "cluster_snapshots", "DBClusterSnapshots", "DescribeDBClusterSnapshots", cluster_snapshot_member_xml, &rid),
@@ -1681,17 +1731,41 @@ fn event_sub_xml(v: &Value) -> String {
     )
 }
 
+/// AWS-spec `SourceType` enum values for the `DescribeEvents` filter.
+/// Anything else triggers `InvalidParameterValue`.
+const VALID_DESCRIBE_EVENTS_SOURCE_TYPES: &[&str] = &[
+    "db-instance",
+    "db-cluster",
+    "db-parameter-group",
+    "db-security-group",
+    "db-snapshot",
+    "db-cluster-snapshot",
+    "db-proxy",
+    "blue-green-deployment",
+    "custom-engine-version",
+];
+
 impl RdsService {
     /// Real DescribeEvents implementation: read the per-account events
     /// ring written to by `emit_event`. Honour SourceType /
     /// SourceIdentifier / Duration / StartTime / EndTime / EventCategories
-    /// filters and emit them as the DescribeEventsResult shape.
+    /// filters plus MaxRecords / Marker pagination, and emit them as the
+    /// DescribeEventsResult shape.
     pub(crate) fn describe_events(
         &self,
         req: &AwsRequest,
         rid: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         let source_type = get_param(req, "SourceType");
+        if let Some(ref t) = source_type {
+            if !VALID_DESCRIBE_EVENTS_SOURCE_TYPES.contains(&t.as_str()) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("SourceType '{t}' is not a valid value."),
+                ));
+            }
+        }
         let source_identifier = get_param(req, "SourceIdentifier");
         let event_categories: Vec<String> = (1..=20)
             .filter_map(|i| get_param(req, &format!("EventCategories.member.{i}")))
@@ -1710,25 +1784,79 @@ impl RdsService {
             .unwrap_or(now);
 
         let state = self.state_handle().read();
-        let events = state
+        let mut events = state
             .get(&req.account_id)
             .map(|s| s.events.clone())
             .unwrap_or_default();
         drop(state);
 
-        let mut body = String::from("    <Events>\n");
-        for e in events.iter().filter(|e| {
-            source_type.as_deref().is_none_or(|t| e.source_type == t)
-                && source_identifier
-                    .as_deref()
-                    .is_none_or(|i| e.source_identifier == i)
-                && (event_categories.is_empty()
-                    || event_categories
-                        .iter()
-                        .any(|c| e.event_categories.iter().any(|ec| ec == c)))
-                && e.date >= start_time
-                && e.date <= end_time
-        }) {
+        // AWS returns events ordered by `Date` ascending (oldest first).
+        events.sort_by_key(|e| e.date);
+
+        let filtered: Vec<crate::state::RdsEventRecord> = events
+            .into_iter()
+            .filter(|e| {
+                source_type.as_deref().is_none_or(|t| e.source_type == t)
+                    && source_identifier
+                        .as_deref()
+                        .is_none_or(|i| e.source_identifier == i)
+                    && (event_categories.is_empty()
+                        || event_categories
+                            .iter()
+                            .any(|c| e.event_categories.iter().any(|ec| ec == c)))
+                    && e.date >= start_time
+                    && e.date <= end_time
+            })
+            .collect();
+
+        // MaxRecords (1..=100, default 100) and Marker pagination. We key
+        // the marker by the event's RFC3339 timestamp + identifier so
+        // duplicate dates still paginate deterministically.
+        let max_records: usize = match get_param(req, "MaxRecords") {
+            Some(raw) => {
+                let parsed: i32 = raw.parse().map_err(|_| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValue",
+                        "MaxRecords must be a valid integer.",
+                    )
+                })?;
+                if !(1..=100).contains(&parsed) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterValue",
+                        "MaxRecords must be between 1 and 100.",
+                    ));
+                }
+                parsed as usize
+            }
+            None => 100,
+        };
+
+        let start_index = match get_param(req, "Marker") {
+            Some(marker) => marker.parse::<usize>().map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    "Marker is invalid.",
+                )
+            })?,
+            None => 0,
+        };
+        let end_index = std::cmp::min(start_index.saturating_add(max_records), filtered.len());
+        let next_marker = if end_index < filtered.len() {
+            Some(end_index.to_string())
+        } else {
+            None
+        };
+        let page = filtered.get(start_index..end_index).unwrap_or(&[]);
+
+        let mut body = String::new();
+        if let Some(m) = next_marker {
+            body.push_str(&format!("    <Marker>{}</Marker>\n", xml_escape(&m)));
+        }
+        body.push_str("    <Events>\n");
+        for e in page {
             body.push_str("      <Event>\n");
             body.push_str(&format!(
                 "        <SourceIdentifier>{}</SourceIdentifier>\n",

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -204,15 +204,33 @@ pub(crate) enum RdsSourceType {
     DbSnapshot,
     DbParameterGroup,
     DbCluster,
+    DbClusterSnapshot,
 }
 
 impl RdsSourceType {
+    /// EventBridge `SourceType` enum string. Matches the SCREAMING_SNAKE
+    /// form AWS publishes in the `aws.rds` event detail.
     fn as_str(self) -> &'static str {
         match self {
             Self::DbInstance => "DB_INSTANCE",
             Self::DbSnapshot => "DB_SNAPSHOT",
             Self::DbParameterGroup => "DB_PARAMETER_GROUP",
             Self::DbCluster => "DB_CLUSTER",
+            Self::DbClusterSnapshot => "DB_CLUSTER_SNAPSHOT",
+        }
+    }
+
+    /// `DescribeEvents` `SourceType` filter / response value. Per AWS
+    /// API spec this is the kebab-case form (`db-instance`,
+    /// `db-cluster`, `db-snapshot`, `db-parameter-group`, ...) — distinct
+    /// from the EventBridge `SourceType` returned by [`Self::as_str`].
+    pub(crate) fn describe_events_str(self) -> &'static str {
+        match self {
+            Self::DbInstance => "db-instance",
+            Self::DbSnapshot => "db-snapshot",
+            Self::DbParameterGroup => "db-parameter-group",
+            Self::DbCluster => "db-cluster",
+            Self::DbClusterSnapshot => "db-cluster-snapshot",
         }
     }
 
@@ -222,6 +240,7 @@ impl RdsSourceType {
             Self::DbSnapshot => "RDS DB Snapshot Event",
             Self::DbParameterGroup => "RDS DB Parameter Group Event",
             Self::DbCluster => "RDS DB Cluster Event",
+            Self::DbClusterSnapshot => "RDS DB Cluster Snapshot Event",
         }
     }
 }
@@ -2998,7 +3017,18 @@ impl RdsService {
 
         state
             .parameter_groups
-            .insert(db_parameter_group_name, parameter_group.clone());
+            .insert(db_parameter_group_name.clone(), parameter_group.clone());
+        let arn = parameter_group.db_parameter_group_arn.clone();
+        drop(accounts);
+
+        self.emit_event(
+            RdsSourceType::DbParameterGroup,
+            &db_parameter_group_name,
+            &arn,
+            "RDS-EVENT-0179",
+            &["creation"],
+            "DB parameter group created",
+        );
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -3097,28 +3127,39 @@ impl RdsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let db_parameter_group_name = required_query_param(request, "DBParameterGroupName")?;
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
+        let arn = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
 
-        if db_parameter_group_name.starts_with("default.") {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                "Cannot delete default parameter groups.",
-            ));
-        }
+            if db_parameter_group_name.starts_with("default.") {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    "Cannot delete default parameter groups.",
+                ));
+            }
 
-        if state
-            .parameter_groups
-            .remove(&db_parameter_group_name)
-            .is_none()
-        {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "DBParameterGroupNotFound",
-                format!("DBParameterGroup {db_parameter_group_name} not found."),
-            ));
-        }
+            let removed = state
+                .parameter_groups
+                .remove(&db_parameter_group_name)
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "DBParameterGroupNotFound",
+                        format!("DBParameterGroup {db_parameter_group_name} not found."),
+                    )
+                })?;
+            removed.db_parameter_group_arn
+        };
+
+        self.emit_event(
+            RdsSourceType::DbParameterGroup,
+            &db_parameter_group_name,
+            &arn,
+            "RDS-EVENT-0064",
+            &["deletion"],
+            "DB parameter group deleted",
+        );
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -3161,6 +3202,17 @@ impl RdsService {
         }
 
         let parameter_group_clone = parameter_group.clone();
+        let arn = parameter_group_clone.db_parameter_group_arn.clone();
+        drop(accounts);
+
+        self.emit_event(
+            RdsSourceType::DbParameterGroup,
+            &db_parameter_group_name,
+            &arn,
+            "RDS-EVENT-0037",
+            &["configuration change"],
+            "DB parameter group modified",
+        );
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -876,9 +876,12 @@ pub(crate) fn emit_event_static_with_state(
     if let (Some(state), Some(account_id)) = (state, account_id) {
         let mut accounts = state.write();
         let s = accounts.get_or_create(account_id);
+        // The events ring is the read-side for `DescribeEvents`, so we
+        // store the kebab-case form AWS uses there. EventBridge keeps the
+        // SCREAMING_SNAKE form below to match the published RDS schema.
         s.push_event(crate::state::RdsEventRecord {
             source_identifier: source_identifier.to_string(),
-            source_type: source_type.as_str().to_string(),
+            source_type: source_type.describe_events_str().to_string(),
             source_arn: source_arn.to_string(),
             event_id: event_id.to_string(),
             event_categories: event_categories.iter().map(|s| s.to_string()).collect(),


### PR DESCRIPTION
## Summary

- `DescribeEvents` reads from the per-account events ring populated by
  `emit_event` and applies the full AWS filter set (`SourceIdentifier`,
  `SourceType`, `StartTime`/`EndTime`, `Duration`, `EventCategories`)
  plus `MaxRecords` + `Marker` pagination. Unknown `SourceType` values
  return `InvalidParameterValue`.
- Events buffer now stores the kebab-case `SourceType` form
  (`db-instance`, `db-cluster`, `db-snapshot`, `db-parameter-group`,
  `db-cluster-snapshot`) used by the `DescribeEvents` API. EventBridge
  details keep the `SCREAMING_SNAKE` `aws.rds` schema form, so the
  existing `rds_eventbridge` E2E suite remains green.
- Existing emit_event sites already covered DBInstance create / modify /
  delete / reboot, DBSnapshot create / delete, restore-from-snapshot /
  PITR / S3, and read replicas. This batch adds emit_event for
  DBCluster create / modify / delete, DBClusterSnapshot create / delete,
  and DBParameterGroup create / modify / delete so cluster + parameter
  group lifecycle ops show up in `DescribeEvents`.

## Test plan

- [x] `cargo test -p fakecloud-rds` (189 unit tests, 0 failures)
- [x] `cargo test -p fakecloud-e2e --test rds_events` covers
  Create -> Describe round trip, SourceIdentifier filter, SourceType
  filter, modify-event capture, MaxRecords + Marker pagination, invalid
  SourceType rejection (6 / 6 pass)
- [x] `cargo test -p fakecloud-e2e --test rds_eventbridge` (3 / 3 pass)
- [x] `cargo test -p fakecloud-e2e --test rds_parameter_group` (4 / 4 pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real RDS `DescribeEvents` backed by the per-account event ring with full AWS filters and pagination. Adds event emission for clusters, cluster snapshots, and parameter groups so lifecycle ops appear in `DescribeEvents` without changing EventBridge behavior.

- New Features
  - Implemented `DescribeEvents` with `SourceIdentifier`, `SourceType` (kebab-case), `StartTime`/`EndTime`, `Duration`, `EventCategories`, and `MaxRecords`/`Marker` pagination; rejects unknown `SourceType` with `InvalidParameterValue`.
  - Events buffer now stores kebab-case `SourceType`; EventBridge detail remains `SCREAMING_SNAKE`.
  - Added `emit_event` for DBCluster, DBClusterSnapshot, and DBParameterGroup create/modify/delete; added E2E tests for round-trip, filters, pagination, and invalid `SourceType` handling.

<sup>Written for commit e2a8043f845590f398e5e3b7e2f11686a8427e58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

