### PR TITLE
feat(rds): tagging multiplexed across all resource types (M4)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_tagging.rs
+++ b/crates/fakecloud-e2e/tests/rds_tagging.rs
@@ -1,0 +1,316 @@
+//! End-to-end coverage for RDS tagging multiplexed across every
+//! supported resource type (M4 batch).
+//!
+//! `AddTagsToResource`, `ListTagsForResource`, and
+//! `RemoveTagsFromResource` accept any RDS resource ARN and dispatch
+//! on the resource-type segment (`db`, `snapshot`, `cluster`,
+//! `cluster-snapshot`, `pg`, `cluster-pg`, `og`, `subgrp`, `secgrp`,
+//! `db-proxy`, `es`). These tests exercise the dispatch over the
+//! types that are easy to spin up via the SDK without booting a real
+//! engine container, plus the unknown-resource-type error path.
+
+mod helpers;
+
+use aws_sdk_rds::types::{Tag, UserAuthConfig};
+use helpers::TestServer;
+
+async fn add_tag(client: &aws_sdk_rds::Client, arn: &str, key: &str, value: &str) {
+    client
+        .add_tags_to_resource()
+        .resource_name(arn)
+        .tags(Tag::builder().key(key).value(value).build())
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("AddTagsToResource failed for {arn}: {e}"));
+}
+
+async fn list_tag_keys(client: &aws_sdk_rds::Client, arn: &str) -> Vec<String> {
+    let resp = client
+        .list_tags_for_resource()
+        .resource_name(arn)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("ListTagsForResource failed for {arn}: {e}"));
+    resp.tag_list()
+        .iter()
+        .filter_map(|t| t.key().map(str::to_string))
+        .collect()
+}
+
+async fn remove_tag(client: &aws_sdk_rds::Client, arn: &str, key: &str) {
+    client
+        .remove_tags_from_resource()
+        .resource_name(arn)
+        .tag_keys(key)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("RemoveTagsFromResource failed for {arn}: {e}"));
+}
+
+async fn assert_tag_round_trip(client: &aws_sdk_rds::Client, arn: &str, label: &str) {
+    add_tag(client, arn, "env", "prod").await;
+    add_tag(client, arn, "team", "platform").await;
+
+    let keys = list_tag_keys(client, arn).await;
+    assert!(
+        keys.contains(&"env".to_string()) && keys.contains(&"team".to_string()),
+        "[{label}] expected env+team after AddTags, got {keys:?}"
+    );
+
+    remove_tag(client, arn, "env").await;
+
+    let keys = list_tag_keys(client, arn).await;
+    assert!(
+        !keys.contains(&"env".to_string()) && keys.contains(&"team".to_string()),
+        "[{label}] expected env removed and team present after RemoveTags, got {keys:?}"
+    );
+}
+
+#[tokio::test]
+async fn rds_tagging_db_parameter_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let arn = client
+        .create_db_parameter_group()
+        .db_parameter_group_name("tag-pg")
+        .db_parameter_group_family("postgres16")
+        .description("tag dispatch test")
+        .send()
+        .await
+        .unwrap()
+        .db_parameter_group()
+        .and_then(|g| g.db_parameter_group_arn())
+        .map(str::to_string)
+        .expect("parameter group arn");
+    assert!(arn.contains(":pg:"), "expected pg ARN segment, got {arn}");
+
+    assert_tag_round_trip(&client, &arn, "pg").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_db_subnet_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let arn = client
+        .create_db_subnet_group()
+        .db_subnet_group_name("tag-subnet")
+        .db_subnet_group_description("tag dispatch test")
+        .subnet_ids("subnet-aaa")
+        .subnet_ids("subnet-bbb")
+        .send()
+        .await
+        .unwrap()
+        .db_subnet_group()
+        .and_then(|g| g.db_subnet_group_arn())
+        .map(str::to_string)
+        .expect("subnet group arn");
+    assert!(
+        arn.contains(":subgrp:"),
+        "expected subgrp ARN segment, got {arn}"
+    );
+
+    assert_tag_round_trip(&client, &arn, "subgrp").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_db_cluster() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let arn = client
+        .create_db_cluster()
+        .db_cluster_identifier("tag-cluster")
+        .engine("aurora-postgresql")
+        .send()
+        .await
+        .unwrap()
+        .db_cluster()
+        .and_then(|c| c.db_cluster_arn())
+        .map(str::to_string)
+        .expect("cluster arn");
+    assert!(
+        arn.contains(":cluster:"),
+        "expected cluster ARN segment, got {arn}"
+    );
+
+    assert_tag_round_trip(&client, &arn, "cluster").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_db_cluster_snapshot() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_cluster()
+        .db_cluster_identifier("tag-cluster-for-snap")
+        .engine("aurora-postgresql")
+        .send()
+        .await
+        .unwrap();
+
+    let arn = client
+        .create_db_cluster_snapshot()
+        .db_cluster_identifier("tag-cluster-for-snap")
+        .db_cluster_snapshot_identifier("tag-csnap")
+        .send()
+        .await
+        .unwrap()
+        .db_cluster_snapshot()
+        .and_then(|s| s.db_cluster_snapshot_arn())
+        .map(str::to_string)
+        .expect("cluster snapshot arn");
+    assert!(
+        arn.contains(":cluster-snapshot:"),
+        "expected cluster-snapshot ARN segment, got {arn}"
+    );
+
+    assert_tag_round_trip(&client, &arn, "cluster-snapshot").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_db_cluster_parameter_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    let arn = client
+        .create_db_cluster_parameter_group()
+        .db_cluster_parameter_group_name("tag-cpg")
+        .db_parameter_group_family("aurora-postgresql15")
+        .description("tag dispatch test")
+        .send()
+        .await
+        .unwrap()
+        .db_cluster_parameter_group()
+        .and_then(|g| g.db_cluster_parameter_group_arn())
+        .map(str::to_string)
+        .expect("cluster parameter group arn");
+    assert!(
+        arn.contains(":cluster-pg:"),
+        "expected cluster-pg ARN segment, got {arn}"
+    );
+
+    assert_tag_round_trip(&client, &arn, "cluster-pg").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_option_group() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // CreateOptionGroup currently emits a flat XML body without an
+    // <OptionGroup> wrapper, so the SDK can't extract the arn from the
+    // response; we construct it deterministically from the testkit's
+    // hardcoded account/region. The dispatcher itself is what we're
+    // testing, not the response shape.
+    client
+        .create_option_group()
+        .option_group_name("tag-og")
+        .engine_name("mysql")
+        .major_engine_version("8.0")
+        .option_group_description("tag dispatch test")
+        .send()
+        .await
+        .unwrap();
+
+    let arn = "arn:aws:rds:us-east-1:123456789012:og:tag-og";
+    assert_tag_round_trip(&client, arn, "og").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_db_proxy() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // CreateDBProxy emits a flat XML body without a <DBProxy> wrapper,
+    // so we construct the ARN deterministically rather than parsing it
+    // out of the SDK response. The dispatcher under test resolves the
+    // ARN to the `proxies` extras bucket regardless.
+    client
+        .create_db_proxy()
+        .db_proxy_name("tag-proxy")
+        .engine_family(aws_sdk_rds::types::EngineFamily::Postgresql)
+        .auth(
+            UserAuthConfig::builder()
+                .auth_scheme(aws_sdk_rds::types::AuthScheme::Secrets)
+                .secret_arn("arn:aws:secretsmanager:us-east-1:123:secret:dummy")
+                .build(),
+        )
+        .role_arn("arn:aws:iam::123:role/dummy")
+        .vpc_subnet_ids("subnet-aaa")
+        .vpc_subnet_ids("subnet-bbb")
+        .send()
+        .await
+        .unwrap();
+
+    let arn = "arn:aws:rds:us-east-1:123456789012:db-proxy:tag-proxy";
+    assert_tag_round_trip(&client, arn, "db-proxy").await;
+}
+
+#[tokio::test]
+async fn rds_tagging_event_subscription() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Same shape gap as option_group / db-proxy — construct the ARN
+    // ourselves so the test exercises the `es` dispatch arm.
+    client
+        .create_event_subscription()
+        .subscription_name("tag-es")
+        .sns_topic_arn("arn:aws:sns:us-east-1:123456789012:dummy")
+        .source_type("db-instance")
+        .send()
+        .await
+        .unwrap();
+
+    let arn = "arn:aws:rds:us-east-1:123456789012:es:tag-es";
+    assert_tag_round_trip(&client, arn, "es").await;
+}
+
+// `db` ARN coverage already lives in `rds.rs::rds_tag_roundtrip`,
+// which exercises the same dispatcher arm against a real DBInstance.
+// Replicating it here would just double the Docker engine startup
+// cost without adding signal.
+
+#[tokio::test]
+async fn rds_tagging_unknown_arn_segment_errors() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Unknown resource-type segment must reject as InvalidParameterValue
+    // (per AWS), not surface as a per-type NotFound, so callers can
+    // distinguish "you typed the ARN wrong" from "the resource is gone".
+    let err = client
+        .list_tags_for_resource()
+        .resource_name("arn:aws:rds:us-east-1:000000000000:bogus:nope")
+        .send()
+        .await
+        .expect_err("unknown segment should error");
+    assert_eq!(
+        err.into_service_error().meta().code(),
+        Some("InvalidParameterValue"),
+        "unknown ARN segment should map to InvalidParameterValue"
+    );
+}
+
+#[tokio::test]
+async fn rds_tagging_missing_resource_returns_typed_not_found() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // Well-formed ARN, recognised segment, missing instance: the typed
+    // NotFound is what AWS clients (and most IaC tooling) expect.
+    let err = client
+        .list_tags_for_resource()
+        .resource_name("arn:aws:rds:us-east-1:000000000000:db:does-not-exist")
+        .send()
+        .await
+        .expect_err("missing db should error");
+    assert_eq!(
+        err.into_service_error().meta().code(),
+        Some("DBInstanceNotFound"),
+        "missing DB should map to DBInstanceNotFound"
+    );
+}

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -1601,8 +1601,7 @@ impl RdsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let mut target = resolve_tag_target_mut(state, &resource_name)
-            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        let mut target = resolve_tag_target_mut(state, &resource_name)?;
         target.merge(&tags);
 
         Ok(AwsResponse::xml(
@@ -1624,8 +1623,7 @@ impl RdsService {
         let accounts = self.state.read();
         let empty = RdsState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let target = resolve_tag_target(state, &resource_name)
-            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        let target = resolve_tag_target(state, &resource_name)?;
         let tag_xml = target.to_xml();
 
         Ok(AwsResponse::xml(
@@ -1656,8 +1654,7 @@ impl RdsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let mut target = resolve_tag_target_mut(state, &resource_name)
-            .ok_or_else(|| tag_resource_not_found(&resource_name))?;
+        let mut target = resolve_tag_target_mut(state, &resource_name)?;
         target.remove_keys(&tag_keys);
 
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -1720,72 +1720,157 @@ fn extras_bucket_for_resource_type(kind: &str) -> Option<&'static str> {
         "og" => "option_groups",
         "secgrp" => "security_groups",
         "es" => "event_subscriptions",
-        "proxy" => "db_proxies",
+        "db-proxy" => "proxies",
         _ => return None,
     })
 }
 
+/// Returns `true` if `kind` is a recognised RDS resource-type segment
+/// for tagging operations. Anything not in this list is treated as an
+/// invalid ARN by AddTags/ListTags/RemoveTags.
+fn is_known_tag_resource_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "db" | "snapshot" | "subgrp" | "pg" | "secgrp" | "og" | "es"
+    ) || extras_bucket_for_resource_type(kind).is_some()
+}
+
+/// Build the per-resource-type NotFound error AWS returns when an ARN
+/// is well-formed and the segment is recognised but the named resource
+/// doesn't exist in this account/region.
+fn resource_not_found_for_kind(kind: &str, name: &str) -> AwsServiceError {
+    let (code, msg) = match kind {
+        "db" => (
+            "DBInstanceNotFound",
+            format!("DBInstance {name} not found."),
+        ),
+        "snapshot" => (
+            "DBSnapshotNotFound",
+            format!("DBSnapshot {name} not found."),
+        ),
+        "cluster" => (
+            "DBClusterNotFoundFault",
+            format!("DBCluster {name} not found."),
+        ),
+        "cluster-snapshot" => (
+            "DBClusterSnapshotNotFoundFault",
+            format!("DBClusterSnapshot {name} not found."),
+        ),
+        "pg" => (
+            "DBParameterGroupNotFound",
+            format!("DBParameterGroup {name} not found."),
+        ),
+        "cluster-pg" => (
+            "DBParameterGroupNotFound",
+            format!("DBClusterParameterGroup {name} not found."),
+        ),
+        "og" => (
+            "OptionGroupNotFoundFault",
+            format!("OptionGroup {name} not found."),
+        ),
+        "subgrp" => (
+            "DBSubnetGroupNotFoundFault",
+            format!("DBSubnetGroup {name} not found."),
+        ),
+        "secgrp" => (
+            "DBSecurityGroupNotFound",
+            format!("DBSecurityGroup {name} not found."),
+        ),
+        "db-proxy" => ("DBProxyNotFoundFault", format!("DBProxy {name} not found.")),
+        "es" => (
+            "SubscriptionNotFound",
+            format!("EventSubscription {name} not found."),
+        ),
+        _ => unreachable!("kind already validated by is_known_tag_resource_kind"),
+    };
+    AwsServiceError::aws_error(StatusCode::NOT_FOUND, code, msg)
+}
+
 /// Locate tag storage on whichever RDS resource the ARN points at.
-/// Supports the four state-backed types (db, snapshot, subgrp, pg)
-/// and extras-backed cluster types (cluster, cluster-snapshot,
-/// cluster-pg, og, secgrp, es, proxy) — for those we mutate a `Tags`
-/// array on the stored JSON entry so it survives serde round-trips.
-/// Returns `None` if the ARN doesn't match any known resource.
+///
+/// Returns:
+/// - `Ok(target)` when the ARN parses, the kind is one of the 11
+///   tagged RDS resource types, and the named resource exists.
+/// - `Err(InvalidParameterValue)` when the ARN can't be parsed or its
+///   resource-type segment is not recognised.
+/// - `Err(<Type>NotFound)` when the kind is recognised but the named
+///   resource doesn't exist in this account/region.
+///
+/// State-backed types (db, snapshot, subgrp, pg) own a typed
+/// `Vec<RdsTag>`. Extras-backed types (cluster, cluster-snapshot,
+/// cluster-pg, og, secgrp, es, db-proxy) tag a `Tags` array on the
+/// stored JSON entry so changes survive serde round-trips.
 pub(crate) fn resolve_tag_target_mut<'a>(
     state: &'a mut crate::state::RdsState,
     arn: &str,
-) -> Option<TagTargetMut<'a>> {
-    let (kind, name) = parse_rds_arn(arn)?;
+) -> Result<TagTargetMut<'a>, AwsServiceError> {
+    let (kind, name) = parse_rds_arn(arn).ok_or_else(|| tag_resource_not_found(arn))?;
+    if !is_known_tag_resource_kind(&kind) {
+        return Err(tag_resource_not_found(arn));
+    }
     match kind.as_str() {
         "db" => state
             .instances
             .get_mut(&name)
-            .map(|i| TagTargetMut::Vec(&mut i.tags)),
+            .map(|i| TagTargetMut::Vec(&mut i.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "snapshot" => state
             .snapshots
             .get_mut(&name)
-            .map(|s| TagTargetMut::Vec(&mut s.tags)),
+            .map(|s| TagTargetMut::Vec(&mut s.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "subgrp" => state
             .subnet_groups
             .get_mut(&name)
-            .map(|g| TagTargetMut::Vec(&mut g.tags)),
+            .map(|g| TagTargetMut::Vec(&mut g.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "pg" => state
             .parameter_groups
             .get_mut(&name)
-            .map(|g| TagTargetMut::Vec(&mut g.tags)),
+            .map(|g| TagTargetMut::Vec(&mut g.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         other => extras_bucket_for_resource_type(other)
             .and_then(|bucket| state.extras.get_mut(bucket))
             .and_then(|map| map.get_mut(&name))
-            .map(TagTargetMut::Json),
+            .map(TagTargetMut::Json)
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
     }
 }
 
 pub(crate) fn resolve_tag_target<'a>(
     state: &'a crate::state::RdsState,
     arn: &str,
-) -> Option<TagTargetRef<'a>> {
-    let (kind, name) = parse_rds_arn(arn)?;
+) -> Result<TagTargetRef<'a>, AwsServiceError> {
+    let (kind, name) = parse_rds_arn(arn).ok_or_else(|| tag_resource_not_found(arn))?;
+    if !is_known_tag_resource_kind(&kind) {
+        return Err(tag_resource_not_found(arn));
+    }
     match kind.as_str() {
         "db" => state
             .instances
             .get(&name)
-            .map(|i| TagTargetRef::Vec(&i.tags)),
+            .map(|i| TagTargetRef::Vec(&i.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "snapshot" => state
             .snapshots
             .get(&name)
-            .map(|s| TagTargetRef::Vec(&s.tags)),
+            .map(|s| TagTargetRef::Vec(&s.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "subgrp" => state
             .subnet_groups
             .get(&name)
-            .map(|g| TagTargetRef::Vec(&g.tags)),
+            .map(|g| TagTargetRef::Vec(&g.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         "pg" => state
             .parameter_groups
             .get(&name)
-            .map(|g| TagTargetRef::Vec(&g.tags)),
+            .map(|g| TagTargetRef::Vec(&g.tags))
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
         other => extras_bucket_for_resource_type(other)
             .and_then(|bucket| state.extras.get(bucket))
             .and_then(|map| map.get(&name))
-            .map(TagTargetRef::Json),
+            .map(TagTargetRef::Json)
+            .ok_or_else(|| resource_not_found_for_kind(&kind, &name)),
     }
 }
 

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -732,11 +732,34 @@ fn list_tags_rejects_filters_param() {
 }
 
 #[test]
-fn list_tags_unknown_arn_errors() {
+fn list_tags_missing_db_instance_returns_typed_not_found() {
     let svc = make_service();
     let req = request(
         "ListTagsForResource",
         &[("ResourceName", "arn:aws:rds:us-east-1:123456789012:db:nope")],
+    );
+    assert_code(svc.list_tags_for_resource(&req), "DBInstanceNotFound");
+}
+
+#[test]
+fn list_tags_unknown_arn_resource_type_errors() {
+    let svc = make_service();
+    let req = request(
+        "ListTagsForResource",
+        &[(
+            "ResourceName",
+            "arn:aws:rds:us-east-1:123456789012:bogus:nope",
+        )],
+    );
+    assert_code(svc.list_tags_for_resource(&req), "InvalidParameterValue");
+}
+
+#[test]
+fn list_tags_malformed_arn_errors() {
+    let svc = make_service();
+    let req = request(
+        "ListTagsForResource",
+        &[("ResourceName", "not-even-an-arn")],
     );
     assert_code(svc.list_tags_for_resource(&req), "InvalidParameterValue");
 }
@@ -913,6 +936,128 @@ fn add_tags_to_extras_resource_arn_stores_on_json() {
     let tags = entry.get("Tags").and_then(|t| t.as_array()).unwrap();
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].get("Key").and_then(|k| k.as_str()), Some("team"));
+}
+
+/// Seed an extras-backed RDS resource with a minimal JSON entry so the
+/// tagging dispatcher can locate it. The kind/bucket pairs mirror the
+/// ones used by the create-time handlers in `extras.rs`; keeping this
+/// helper local to the test module avoids leaking test-only surface
+/// into the prod crate API.
+fn seed_extras_entry(svc: &RdsService, bucket: &str, name: &str) {
+    let mut accounts = svc.state.write();
+    let state = accounts.default_mut();
+    state
+        .extras
+        .entry(bucket.to_string())
+        .or_default()
+        .insert(name.to_string(), serde_json::json!({"Name": name}));
+}
+
+#[test]
+fn tags_dispatch_covers_every_supported_resource_type() {
+    // One tag round-trip (add -> list -> remove) per ARN segment, so the
+    // dispatcher and tag_resource_not_found mapping stay in lockstep
+    // with the resource buckets the rest of the crate writes to.
+    let svc = make_service();
+    let region = "us-east-1";
+    let acct = "123456789012";
+
+    // State-backed: db / snapshot / pg / subgrp.
+    let _db_arn = seed_instance(&svc, "db1");
+    seed_snapshot(&svc, "snap-1", "db1");
+    create_param_group(&svc, "pg1");
+    create_subnet_group(&svc, "sub1");
+
+    // Extras-backed: cluster / cluster-snapshot / cluster-pg / og /
+    // secgrp / es / db-proxy.
+    seed_extras_entry(&svc, "clusters", "cluster-1");
+    seed_extras_entry(&svc, "cluster_snapshots", "csnap-1");
+    seed_extras_entry(&svc, "cluster_param_groups", "cpg-1");
+    seed_extras_entry(&svc, "option_groups", "og-1");
+    seed_extras_entry(&svc, "security_groups", "secgrp-1");
+    seed_extras_entry(&svc, "event_subscriptions", "es-1");
+    seed_extras_entry(&svc, "proxies", "proxy-1");
+
+    let cases: &[(&str, &str)] = &[
+        ("db", "db1"),
+        ("snapshot", "snap-1"),
+        ("pg", "pg1"),
+        ("subgrp", "sub1"),
+        ("cluster", "cluster-1"),
+        ("cluster-snapshot", "csnap-1"),
+        ("cluster-pg", "cpg-1"),
+        ("og", "og-1"),
+        ("secgrp", "secgrp-1"),
+        ("es", "es-1"),
+        ("db-proxy", "proxy-1"),
+    ];
+
+    for (kind, name) in cases {
+        let arn = format!("arn:aws:rds:{region}:{acct}:{kind}:{name}");
+
+        let add = request(
+            "AddTagsToResource",
+            &[
+                ("ResourceName", arn.as_str()),
+                ("Tags.Tag.1.Key", "env"),
+                ("Tags.Tag.1.Value", "prod"),
+            ],
+        );
+        svc.add_tags_to_resource(&add)
+            .unwrap_or_else(|e| panic!("AddTags failed for kind={kind}: {e:?}"));
+
+        let list = request("ListTagsForResource", &[("ResourceName", arn.as_str())]);
+        let body = body_of(
+            svc.list_tags_for_resource(&list)
+                .unwrap_or_else(|e| panic!("ListTags failed for kind={kind}: {e:?}")),
+        );
+        assert!(
+            body.contains("<Key>env</Key>") && body.contains("<Value>prod</Value>"),
+            "ListTags for kind={kind} should echo the tag, body was: {body}"
+        );
+
+        let rm = request(
+            "RemoveTagsFromResource",
+            &[("ResourceName", arn.as_str()), ("TagKeys.member.1", "env")],
+        );
+        svc.remove_tags_from_resource(&rm)
+            .unwrap_or_else(|e| panic!("RemoveTags failed for kind={kind}: {e:?}"));
+
+        let body = body_of(svc.list_tags_for_resource(&list).unwrap());
+        assert!(
+            !body.contains("<Key>env</Key>"),
+            "RemoveTags for kind={kind} should strip the tag, body was: {body}"
+        );
+    }
+}
+
+#[test]
+fn tags_dispatch_typed_not_found_per_resource_type() {
+    // Each known resource-type must surface its own NotFound code rather
+    // than the generic InvalidParameterValue we use for malformed ARNs.
+    let svc = make_service();
+    let region = "us-east-1";
+    let acct = "123456789012";
+
+    let cases: &[(&str, &str)] = &[
+        ("db", "DBInstanceNotFound"),
+        ("snapshot", "DBSnapshotNotFound"),
+        ("cluster", "DBClusterNotFoundFault"),
+        ("cluster-snapshot", "DBClusterSnapshotNotFoundFault"),
+        ("pg", "DBParameterGroupNotFound"),
+        ("cluster-pg", "DBParameterGroupNotFound"),
+        ("og", "OptionGroupNotFoundFault"),
+        ("subgrp", "DBSubnetGroupNotFoundFault"),
+        ("secgrp", "DBSecurityGroupNotFound"),
+        ("db-proxy", "DBProxyNotFoundFault"),
+        ("es", "SubscriptionNotFound"),
+    ];
+
+    for (kind, expected_code) in cases {
+        let arn = format!("arn:aws:rds:{region}:{acct}:{kind}:ghost");
+        let req = request("ListTagsForResource", &[("ResourceName", arn.as_str())]);
+        assert_code(svc.list_tags_for_resource(&req), expected_code);
+    }
 }
 
 #[test]
@@ -1886,7 +2031,7 @@ fn list_tags_resource_not_found() {
         "ListTagsForResource",
         &[("ResourceName", "arn:aws:rds:us-east-1:123:db:ghost")],
     );
-    assert_code(svc.list_tags_for_resource(&req), "InvalidParameterValue");
+    assert_code(svc.list_tags_for_resource(&req), "DBInstanceNotFound");
 }
 
 // ── snapshot operations ──


### PR DESCRIPTION
## Summary

- `AddTagsToResource` / `ListTagsForResource` / `RemoveTagsFromResource` now dispatch on the ARN resource-type segment via `parse_rds_arn` -> `resolve_tag_target`. Eleven RDS resource types are tagged: db, snapshot, cluster, cluster-snapshot, pg, cluster-pg, og, subgrp, secgrp, db-proxy, es.
- Fixed a latent bug where `db-proxy` ARNs were silently failing: the dispatcher mapped a `proxy` segment (never emitted by AWS) to a non-existent `db_proxies` extras bucket. The real ARN segment AWS uses is `db-proxy` and entries live in the `proxies` bucket.
- Unknown/malformed ARN segments return `InvalidParameterValue`; missing-but-well-formed resources return per-type `<Type>NotFound` (e.g. `DBClusterNotFoundFault`, `DBProxyNotFoundFault`, `OptionGroupNotFoundFault`) instead of collapsing into `InvalidParameterValue`. Two existing unit tests that asserted the old generic code were tightened to expect the typed code AWS clients actually depend on.

## Test plan

- [x] `cargo test -p fakecloud-rds` -- 193 passing, includes new `tags_dispatch_covers_every_supported_resource_type` (round-trip add/list/remove for all 11 kinds) and `tags_dispatch_typed_not_found_per_resource_type` (correct `<Type>NotFound` per kind).
- [x] `cargo test -p fakecloud-e2e --test rds_tagging` -- 10 e2e tests passing, exercise SDK -> server tag dispatch over db-parameter-group, db-subnet-group, db-cluster, db-cluster-snapshot, db-cluster-parameter-group, option-group, db-proxy, event-subscription, plus unknown-segment and missing-resource error paths.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] DBInstance ARN coverage continues to live in `rds.rs::rds_tag_roundtrip`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands RDS tagging to all supported resource types via ARN-based dispatch and returns AWS-accurate errors. Also fixes `db-proxy` ARN handling and adds full unit and e2e coverage in `fakecloud-rds` and `fakecloud-e2e`.

- New Features
  - Tagging now works for 11 RDS resource types via ARN segment dispatch: `db`, `snapshot`, `cluster`, `cluster-snapshot`, `pg`, `cluster-pg`, `og`, `subgrp`, `secgrp`, `db-proxy`, `es`.
  - Error handling matches AWS: `InvalidParameterValue` for malformed/unknown segments; typed NotFound per resource (e.g., `DBInstanceNotFound`, `DBClusterNotFoundFault`, `DBProxyNotFoundFault`).
  - Added end-to-end tests covering add/list/remove for all types and error paths.

- Bug Fixes
  - Fixed `db-proxy` ARNs: dispatch now uses the `db-proxy` segment and stores tags in the `proxies` bucket (was `proxy` -> `db_proxies`, causing silent failures).

<sup>Written for commit 3506535db1c315dfa2537bb9071721f3f8065612. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

