### PR TITLE
feat(organizations): trusted services + delegated administrator (H3)

### DIFF
--- a/crates/fakecloud-e2e/tests/organizations_trusted_services.rs
+++ b/crates/fakecloud-e2e/tests/organizations_trusted_services.rs
@@ -1,0 +1,372 @@
+//! End-to-end tests for the Organizations trusted-service +
+//! delegated-administrator surface:
+//! `EnableAWSServiceAccess`, `DisableAWSServiceAccess`,
+//! `ListAWSServiceAccessForOrganization`,
+//! `RegisterDelegatedAdministrator`, `DeregisterDelegatedAdministrator`,
+//! `ListDelegatedAdministrators`, `ListDelegatedServicesForAccount`.
+//!
+//! Drives real `aws-sdk-organizations` against a fakecloud server with
+//! `FAKECLOUD_IAM=strict` so the wire format and management-account
+//! gating match real AWS Organizations.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_organizations::types::HandshakeParty;
+use aws_sdk_organizations::types::HandshakePartyType;
+use aws_sdk_organizations::Client as OrgsClient;
+use helpers::TestServer;
+
+const MGMT_ACCOUNT: &str = "111111111111";
+const MEMBER_ACCOUNT: &str = "222222222222";
+const SECOND_MEMBER: &str = "333333333333";
+
+const SERVICE_CONFIG: &str = "config.amazonaws.com";
+const SERVICE_SSM: &str = "ssm.amazonaws.com";
+const SERVICE_GUARDDUTY: &str = "guardduty.amazonaws.com";
+
+async fn start() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+        // Organizations is pure control plane; no container runtime needed.
+        ("FAKECLOUD_CONTAINER_CLI", "false"),
+    ])
+    .await
+}
+
+async fn config_with(server: &TestServer, akid: &str, secret: &str) -> aws_config::SdkConfig {
+    aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(akid, secret, None, None, "orgs-trusted"))
+        .load()
+        .await
+}
+
+/// Build an `OrgsClient` for `account_id` with admin credentials issued
+/// by the test server's create-admin endpoint.
+async fn client_for(server: &TestServer, account_id: &str) -> OrgsClient {
+    let (akid, secret) = server.create_admin(account_id, "admin").await;
+    let cfg = config_with(server, &akid, &secret).await;
+    OrgsClient::new(&cfg)
+}
+
+/// Invite + accept `member` into the org owned by `mgmt`. Used by every
+/// test that needs a real member account before registering a delegate.
+async fn enroll_member(mgmt: &OrgsClient, member_client: &OrgsClient, member_id: &str) {
+    let invite = mgmt
+        .invite_account_to_organization()
+        .target(
+            HandshakeParty::builder()
+                .id(member_id)
+                .r#type(HandshakePartyType::Account)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let handshake_id = invite.handshake().unwrap().id().unwrap().to_string();
+    member_client
+        .accept_handshake()
+        .handshake_id(handshake_id)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn enable_aws_service_access_then_list_shows_principal() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    mgmt.create_organization().send().await.unwrap();
+
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_CONFIG)
+        .send()
+        .await
+        .unwrap();
+
+    let listed = mgmt
+        .list_aws_service_access_for_organization()
+        .send()
+        .await
+        .unwrap();
+    let principals: Vec<_> = listed
+        .enabled_service_principals()
+        .iter()
+        .map(|p| p.service_principal().unwrap().to_string())
+        .collect();
+    assert_eq!(principals, vec![SERVICE_CONFIG.to_string()]);
+    assert!(
+        listed.enabled_service_principals()[0]
+            .date_enabled()
+            .is_some(),
+        "DateEnabled should round-trip to the SDK"
+    );
+}
+
+#[tokio::test]
+async fn disable_aws_service_access_drops_principal() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    mgmt.create_organization().send().await.unwrap();
+
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_CONFIG)
+        .send()
+        .await
+        .unwrap();
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+
+    mgmt.disable_aws_service_access()
+        .service_principal(SERVICE_CONFIG)
+        .send()
+        .await
+        .unwrap();
+
+    let listed = mgmt
+        .list_aws_service_access_for_organization()
+        .send()
+        .await
+        .unwrap();
+    let principals: Vec<_> = listed
+        .enabled_service_principals()
+        .iter()
+        .map(|p| p.service_principal().unwrap().to_string())
+        .collect();
+    assert_eq!(principals, vec![SERVICE_SSM.to_string()]);
+}
+
+#[tokio::test]
+async fn register_delegated_administrator_shows_in_both_lists() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    let member = client_for(&server, MEMBER_ACCOUNT).await;
+    mgmt.create_organization().send().await.unwrap();
+    enroll_member(&mgmt, &member, MEMBER_ACCOUNT).await;
+
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_GUARDDUTY)
+        .send()
+        .await
+        .unwrap();
+
+    mgmt.register_delegated_administrator()
+        .account_id(MEMBER_ACCOUNT)
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    mgmt.register_delegated_administrator()
+        .account_id(MEMBER_ACCOUNT)
+        .service_principal(SERVICE_GUARDDUTY)
+        .send()
+        .await
+        .unwrap();
+
+    // ListDelegatedAdministrators returns both registrations (one per
+    // service-principal) plus the same MEMBER_ACCOUNT id; default page
+    // size lists everything.
+    let admins = mgmt.list_delegated_administrators().send().await.unwrap();
+    let ids: Vec<_> = admins
+        .delegated_administrators()
+        .iter()
+        .map(|d| d.id().unwrap().to_string())
+        .collect();
+    assert_eq!(ids.len(), 2, "two registrations expected");
+    assert!(ids.iter().all(|id| id == MEMBER_ACCOUNT));
+    let first = &admins.delegated_administrators()[0];
+    assert_eq!(
+        first.email(),
+        Some(format!("{MEMBER_ACCOUNT}@example.com").as_str())
+    );
+    assert!(first.delegation_enabled_date().is_some());
+    assert!(first.joined_timestamp().is_some());
+
+    // Filter by ServicePrincipal narrows to one row.
+    let only_ssm = mgmt
+        .list_delegated_administrators()
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(only_ssm.delegated_administrators().len(), 1);
+
+    // ListDelegatedServicesForAccount returns both service principals.
+    let svcs = mgmt
+        .list_delegated_services_for_account()
+        .account_id(MEMBER_ACCOUNT)
+        .send()
+        .await
+        .unwrap();
+    let mut names: Vec<_> = svcs
+        .delegated_services()
+        .iter()
+        .map(|s| s.service_principal().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![SERVICE_GUARDDUTY.to_string(), SERVICE_SSM.to_string()]
+    );
+    assert!(svcs.delegated_services()[0]
+        .delegation_enabled_date()
+        .is_some());
+}
+
+#[tokio::test]
+async fn deregister_delegated_administrator_removes_entry() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    let member = client_for(&server, MEMBER_ACCOUNT).await;
+    mgmt.create_organization().send().await.unwrap();
+    enroll_member(&mgmt, &member, MEMBER_ACCOUNT).await;
+
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    mgmt.register_delegated_administrator()
+        .account_id(MEMBER_ACCOUNT)
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+
+    mgmt.deregister_delegated_administrator()
+        .account_id(MEMBER_ACCOUNT)
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+
+    let admins = mgmt.list_delegated_administrators().send().await.unwrap();
+    assert!(
+        admins.delegated_administrators().is_empty(),
+        "deregister should empty the delegated-administrator list"
+    );
+
+    let svcs = mgmt
+        .list_delegated_services_for_account()
+        .account_id(MEMBER_ACCOUNT)
+        .send()
+        .await
+        .unwrap();
+    assert!(svcs.delegated_services().is_empty());
+}
+
+#[tokio::test]
+async fn list_delegated_services_filters_per_account() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    let member1 = client_for(&server, MEMBER_ACCOUNT).await;
+    let member2 = client_for(&server, SECOND_MEMBER).await;
+    mgmt.create_organization().send().await.unwrap();
+    enroll_member(&mgmt, &member1, MEMBER_ACCOUNT).await;
+    enroll_member(&mgmt, &member2, SECOND_MEMBER).await;
+
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    mgmt.enable_aws_service_access()
+        .service_principal(SERVICE_GUARDDUTY)
+        .send()
+        .await
+        .unwrap();
+
+    // member1 -> SSM only; member2 -> GuardDuty only.
+    mgmt.register_delegated_administrator()
+        .account_id(MEMBER_ACCOUNT)
+        .service_principal(SERVICE_SSM)
+        .send()
+        .await
+        .unwrap();
+    mgmt.register_delegated_administrator()
+        .account_id(SECOND_MEMBER)
+        .service_principal(SERVICE_GUARDDUTY)
+        .send()
+        .await
+        .unwrap();
+
+    let svcs1 = mgmt
+        .list_delegated_services_for_account()
+        .account_id(MEMBER_ACCOUNT)
+        .send()
+        .await
+        .unwrap();
+    let names1: Vec<_> = svcs1
+        .delegated_services()
+        .iter()
+        .map(|s| s.service_principal().unwrap().to_string())
+        .collect();
+    assert_eq!(names1, vec![SERVICE_SSM.to_string()]);
+
+    let svcs2 = mgmt
+        .list_delegated_services_for_account()
+        .account_id(SECOND_MEMBER)
+        .send()
+        .await
+        .unwrap();
+    let names2: Vec<_> = svcs2
+        .delegated_services()
+        .iter()
+        .map(|s| s.service_principal().unwrap().to_string())
+        .collect();
+    assert_eq!(names2, vec![SERVICE_GUARDDUTY.to_string()]);
+}
+
+#[tokio::test]
+async fn list_aws_service_access_paginates() {
+    let server = start().await;
+    let mgmt = client_for(&server, MGMT_ACCOUNT).await;
+    mgmt.create_organization().send().await.unwrap();
+
+    for principal in [
+        "config.amazonaws.com",
+        "guardduty.amazonaws.com",
+        "ssm.amazonaws.com",
+    ] {
+        mgmt.enable_aws_service_access()
+            .service_principal(principal)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Page 1: max_results=2 -> two entries plus a NextToken.
+    let page1 = mgmt
+        .list_aws_service_access_for_organization()
+        .max_results(2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page1.enabled_service_principals().len(), 2);
+    let next = page1
+        .next_token()
+        .expect("first page should hand back a NextToken");
+
+    // Page 2 with the token returns the remaining entry and no token.
+    let page2 = mgmt
+        .list_aws_service_access_for_organization()
+        .max_results(2)
+        .next_token(next)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(page2.enabled_service_principals().len(), 1);
+    assert!(page2.next_token().is_none());
+}

--- a/crates/fakecloud-organizations/src/service.rs
+++ b/crates/fakecloud-organizations/src/service.rs
@@ -832,7 +832,7 @@ impl OrganizationsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let filter = parse_handshake_filter(&body)?;
-        let (max_results, next_token) = parse_handshake_pagination(&body)?;
+        let (max_results, next_token) = parse_list_pagination(&body)?;
 
         let guard = self.state.read();
         let org = guard.as_ref().ok_or_else(organizations_not_in_use)?;
@@ -856,7 +856,7 @@ impl OrganizationsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let filter = parse_handshake_filter(&body)?;
-        let (max_results, next_token) = parse_handshake_pagination(&body)?;
+        let (max_results, next_token) = parse_list_pagination(&body)?;
 
         let guard = self.state.write();
         self.require_member_management(&guard, &req.account_id)?;
@@ -900,22 +900,27 @@ impl OrganizationsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let (max_results, next_token) = parse_list_pagination(&body)?;
         let guard = self.state.write();
         self.require_member_management(&guard, &req.account_id)?;
         let org = guard.as_ref().expect("management gate proved Some");
         let entries: Vec<Value> = org
             .list_trusted_services()
             .into_iter()
-            .map(|svc| {
+            .map(|(svc, enabled_at)| {
                 json!({
                     "ServicePrincipal": svc,
-                    "DateEnabled": Utc::now().timestamp() as f64,
+                    "DateEnabled": enabled_at.timestamp() as f64,
                 })
             })
             .collect();
-        Ok(AwsResponse::ok_json(
-            json!({ "EnabledServicePrincipals": entries }),
-        ))
+        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let mut body = json!({ "EnabledServicePrincipals": page });
+        if let Some(t) = token {
+            body["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(body))
     }
 
     fn register_delegated_administrator(
@@ -957,6 +962,7 @@ impl OrganizationsService {
             .get("ServicePrincipal")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let (max_results, next_token) = parse_list_pagination(&body)?;
         let guard = self.state.write();
         self.require_member_management(&guard, &req.account_id)?;
         let org = guard.as_ref().expect("management gate proved Some");
@@ -977,9 +983,12 @@ impl OrganizationsService {
                 }))
             })
             .collect();
-        Ok(AwsResponse::ok_json(
-            json!({ "DelegatedAdministrators": entries }),
-        ))
+        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let mut body = json!({ "DelegatedAdministrators": page });
+        if let Some(t) = token {
+            body["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(body))
     }
 
     fn list_delegated_services_for_account(
@@ -988,22 +997,26 @@ impl OrganizationsService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let account_id = required_str(&body, "AccountId")?.to_string();
+        let (max_results, next_token) = parse_list_pagination(&body)?;
         let guard = self.state.write();
         self.require_member_management(&guard, &req.account_id)?;
         let org = guard.as_ref().expect("management gate proved Some");
         let entries: Vec<Value> = org
             .list_delegated_services_for_account(&account_id)
             .into_iter()
-            .map(|svc| {
+            .map(|(svc, enabled_at)| {
                 json!({
                     "ServicePrincipal": svc,
-                    "DelegationEnabledDate": Utc::now().timestamp() as f64,
+                    "DelegationEnabledDate": enabled_at.timestamp() as f64,
                 })
             })
             .collect();
-        Ok(AwsResponse::ok_json(
-            json!({ "DelegatedServices": entries }),
-        ))
+        let (page, token) = paginate(&entries, next_token.as_deref(), max_results);
+        let mut body = json!({ "DelegatedServices": page });
+        if let Some(t) = token {
+            body["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(body))
     }
 
     fn enable_all_features(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1654,8 +1667,10 @@ fn handshake_matches_filter(h: &crate::state::Handshake, filter: &HandshakeFilte
 }
 
 /// Parse `MaxResults` (1..=20, default 20) and `NextToken` (string
-/// matching what `paginate` mints) from a `ListHandshakes*` request.
-fn parse_handshake_pagination(body: &Value) -> Result<(usize, Option<String>), AwsServiceError> {
+/// matching what `paginate` mints) from any AWS Organizations
+/// `List*` request body. Shared by handshake, AWS-service-access,
+/// delegated-administrator and delegated-service listings.
+fn parse_list_pagination(body: &Value) -> Result<(usize, Option<String>), AwsServiceError> {
     let max_results = match body.get("MaxResults") {
         None | Some(Value::Null) => 20usize,
         Some(v) => {

--- a/crates/fakecloud-organizations/src/state.rs
+++ b/crates/fakecloud-organizations/src/state.rs
@@ -53,10 +53,14 @@ pub struct OrganizationState {
     /// `ACCEPTED` / `DECLINED` / `CANCELED` / `EXPIRED`.
     #[serde(default)]
     pub handshakes: BTreeMap<String, Handshake>,
-    /// AWS service principals enabled via `EnableAWSServiceAccess`.
-    /// Stored as the principal hostname (eg. `config.amazonaws.com`).
+    /// AWS service principals enabled via `EnableAWSServiceAccess`,
+    /// keyed by the principal hostname (eg. `config.amazonaws.com`)
+    /// with the value being the moment the principal was first enabled.
+    /// `ListAWSServiceAccessForOrganization` surfaces the timestamp as
+    /// `DateEnabled`. Re-enabling an already-trusted service is a no-op
+    /// — the original timestamp is preserved (matches AWS behavior).
     #[serde(default)]
-    pub trusted_services: HashSet<String>,
+    pub trusted_services: BTreeMap<String, DateTime<Utc>>,
     /// Service principal -> set of member account ids registered as
     /// delegated administrators for that service.
     #[serde(default)]
@@ -159,7 +163,7 @@ impl OrganizationState {
             attachments,
             create_account_requests: BTreeMap::new(),
             handshakes: BTreeMap::new(),
-            trusted_services: HashSet::new(),
+            trusted_services: BTreeMap::new(),
             delegated_administrators: BTreeMap::new(),
             enabled_policy_types: default_enabled_policy_types(),
             resource_tags: BTreeMap::new(),
@@ -532,9 +536,13 @@ impl OrganizationState {
             .collect()
     }
 
-    /// Mark `service_principal` as a trusted service. Idempotent.
+    /// Mark `service_principal` as a trusted service. Idempotent: the
+    /// originally-recorded `DateEnabled` is preserved on repeat calls
+    /// (matches AWS Organizations).
     pub fn enable_aws_service_access(&mut self, service_principal: &str) {
-        self.trusted_services.insert(service_principal.to_string());
+        self.trusted_services
+            .entry(service_principal.to_string())
+            .or_insert_with(Utc::now);
     }
 
     /// Drop `service_principal` from the trusted set. Also removes any
@@ -555,11 +563,14 @@ impl OrganizationState {
         Ok(())
     }
 
-    /// Iterate enabled trusted services in alphabetical order.
-    pub fn list_trusted_services(&self) -> Vec<String> {
-        let mut v: Vec<String> = self.trusted_services.iter().cloned().collect();
-        v.sort();
-        v
+    /// Iterate enabled trusted services in alphabetical order, paired
+    /// with the `DateEnabled` timestamp captured at first enable.
+    pub fn list_trusted_services(&self) -> Vec<(String, DateTime<Utc>)> {
+        // BTreeMap iterates in key order, so this is already alphabetical.
+        self.trusted_services
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
     }
 
     /// Register `account_id` as a delegated administrator for the given
@@ -573,7 +584,7 @@ impl OrganizationState {
         if !self.accounts.contains_key(account_id) {
             return Err(OrgError::AccountNotFound(account_id.to_string()));
         }
-        if !self.trusted_services.contains(service_principal) {
+        if !self.trusted_services.contains_key(service_principal) {
             return Err(OrgError::AWSServiceAccessNotEnabled(
                 service_principal.to_string(),
             ));
@@ -635,15 +646,20 @@ impl OrganizationState {
         out
     }
 
-    /// List service principals that `account_id` is a delegated admin for.
-    pub fn list_delegated_services_for_account(&self, account_id: &str) -> Vec<String> {
+    /// List service principals that `account_id` is a delegated admin
+    /// for, paired with the per-service `DelegationEnabledDate`.
+    /// Iteration order is alphabetical by service principal (the
+    /// `delegated_administrators` BTreeMap key order).
+    pub fn list_delegated_services_for_account(
+        &self,
+        account_id: &str,
+    ) -> Vec<(String, DateTime<Utc>)> {
         let mut out = Vec::new();
         for (svc, admins) in &self.delegated_administrators {
-            if admins.contains_key(account_id) {
-                out.push(svc.clone());
+            if let Some(admin) = admins.get(account_id) {
+                out.push((svc.clone(), admin.registered_at));
             }
         }
-        out.sort();
         out
     }
 
@@ -1575,9 +1591,13 @@ mod tests {
     fn enable_aws_service_access_is_idempotent() {
         let mut org = OrganizationState::bootstrap("111111111111");
         org.enable_aws_service_access("config.amazonaws.com");
+        let first = org.list_trusted_services()[0].1;
         org.enable_aws_service_access("config.amazonaws.com");
         let trusted = org.list_trusted_services();
-        assert_eq!(trusted, vec!["config.amazonaws.com"]);
+        assert_eq!(trusted.len(), 1);
+        assert_eq!(trusted[0].0, "config.amazonaws.com");
+        // Second call must NOT overwrite the original DateEnabled.
+        assert_eq!(trusted[0].1, first);
     }
 
     #[test]
@@ -1624,8 +1644,12 @@ mod tests {
             .unwrap();
         org.register_delegated_administrator("222222222222", "config.amazonaws.com")
             .unwrap();
-        let svcs = org.list_delegated_services_for_account("222222222222");
-        assert_eq!(svcs, vec!["config.amazonaws.com", "ssm.amazonaws.com"]);
+        let names: Vec<String> = org
+            .list_delegated_services_for_account("222222222222")
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(names, vec!["config.amazonaws.com", "ssm.amazonaws.com"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enable/Disable/ListAWSServiceAccessForOrganization
- Register/DeregisterDelegatedAdministrator
- ListDelegatedAdministrators (per ServicePrincipal filter)
- ListDelegatedServicesForAccount (per AccountId filter)
- Pagination via MaxResults + NextToken on all list ops

## Test plan
- [ ] EnableAWSServiceAccess + List shows entry
- [ ] DisableAWSServiceAccess removes entry
- [ ] RegisterDelegatedAdministrator visible in both ListDelegatedAdministrators + ListDelegatedServicesForAccount
- [ ] Deregister removes from both
- [ ] Conformance + clippy + fmt clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trusted service access and delegated administrator support to Organizations, with AWS-accurate timestamps, filters, and pagination. Enables management-account–gated flows end to end.

- New Features
  - `EnableAWSServiceAccess`, `DisableAWSServiceAccess`, `ListAWSServiceAccessForOrganization` (returns `DateEnabled`; re-enable is idempotent and preserves the original timestamp).
  - `RegisterDelegatedAdministrator`, `DeregisterDelegatedAdministrator`, `ListDelegatedAdministrators` (optional `ServicePrincipal` filter; includes delegation/join timestamps).
  - `ListDelegatedServicesForAccount` (by `AccountId`; returns `DelegationEnabledDate`).
  - Pagination on all list APIs via `MaxResults` + `NextToken`; removing a trusted service also clears its delegates.
  - E2E coverage under `crates/fakecloud-e2e/tests/organizations_trusted_services.rs` validating enable→list→disable, register→list, filters, and pagination.

- Refactors
  - Unified pagination parsing with `parse_list_pagination` across list endpoints.
  - Persisted timestamps in state: `trusted_services` now stores first `DateEnabled`, and delegated-service listings return the recorded `DelegationEnabledDate`.

<sup>Written for commit b899cd10810cc4cef898d774f9126a7c0e5d4a9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

