### PR TITLE
feat(ses): verified-identity gate on send (v1 + v2) (X1)

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_verification_gate.rs
+++ b/crates/fakecloud-e2e/tests/ses_verification_gate.rs
@@ -1,0 +1,427 @@
+//! End-to-end coverage for the SES verified-identity gate.
+//!
+//! Real AWS SES rejects every send whose `From` is not a verified
+//! identity, and additionally rejects every recipient that is not
+//! verified while the account is still in the sandbox. fakecloud
+//! mirrors both behaviors across SES v1 and SES v2; this suite drives
+//! the gate end-to-end through the AWS SDKs so regressions in the
+//! Smithy-translated request paths get caught.
+
+mod helpers;
+
+use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
+use helpers::TestServer;
+
+/// Flip the running fakecloud server into sandbox mode for the default
+/// account. fakecloud defaults to production-access-on so that the
+/// majority of SES tests don't need to pre-verify recipients; this
+/// helper opts a single test back into sandbox semantics via the
+/// `/_fakecloud/ses/account/sandbox` admin endpoint.
+async fn set_sandbox(server: &TestServer, sandbox: bool) {
+    let url = format!("{}/_fakecloud/ses/account/sandbox", server.endpoint());
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({ "sandbox": sandbox }))
+        .send()
+        .await
+        .expect("sandbox toggle request");
+    assert!(
+        resp.status().is_success(),
+        "sandbox toggle failed: {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn sandbox_rejects_unverified_recipient() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    set_sandbox(&server, true).await;
+
+    // Sender is verified, recipient is not — sandbox rule says the send
+    // must fail with `MessageRejected` (real SES) which fakecloud surfaces
+    // unchanged through the SDK error.
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@unverified.test")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("not verified"),
+        "expected MessageRejected for unverified recipient, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn sandbox_accepts_verified_sender_and_recipient() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    set_sandbox(&server, true).await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("verified-from + verified-to send should succeed in sandbox");
+
+    assert!(!resp.message_id().unwrap_or_default().is_empty());
+}
+
+#[tokio::test]
+async fn production_skips_recipient_verification() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    // fakecloud defaults to production access on, but flip explicitly so
+    // the test documents the requirement rather than relying on the default.
+    set_sandbox(&server, false).await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("production accounts should not gate on recipient verification");
+
+    assert!(!resp.message_id().unwrap_or_default().is_empty());
+}
+
+#[tokio::test]
+async fn domain_verification_covers_all_addresses_on_that_domain() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    set_sandbox(&server, true).await;
+
+    // Verify only the domain — every address on `example.com` should be
+    // accepted as both sender and (sandbox-required) recipient.
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("anything@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("someone-else@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("domain identity should cover every address on the domain");
+
+    assert!(!resp.message_id().unwrap_or_default().is_empty());
+}
+
+#[tokio::test]
+async fn sandbox_rejects_unverified_sender() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    set_sandbox(&server, true).await;
+
+    // No identities at all — the From-address gate must trip with the
+    // dedicated `MailFromDomainNotVerifiedException` SES uses for v2.
+    let err = client
+        .send_email()
+        .from_email_address("noreply@unverified.test")
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@unverified.test")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MailFromDomainNotVerified"),
+        "expected MailFromDomainNotVerifiedException, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn simulator_addresses_bypass_the_gate() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    set_sandbox(&server, true).await;
+
+    // Sender stays verified — the interesting bit is that *recipients*
+    // on `simulator.amazonses.com` are accepted without verification, the
+    // way real SES treats them.
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    for recipient in [
+        "bounce@simulator.amazonses.com",
+        "complaint@simulator.amazonses.com",
+        "success@simulator.amazonses.com",
+        "suppressionlist@simulator.amazonses.com",
+    ] {
+        let resp = client
+            .send_email()
+            .from_email_address("sender@example.com")
+            .destination(Destination::builder().to_addresses(recipient).build())
+            .content(
+                EmailContent::builder()
+                    .simple(
+                        Message::builder()
+                            .subject(Content::builder().data("Hi").build().unwrap())
+                            .body(
+                                Body::builder()
+                                    .text(Content::builder().data("Hello").build().unwrap())
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .send()
+            .await
+            .unwrap_or_else(|e| {
+                panic!("simulator recipient {recipient} should be accepted: {e:?}")
+            });
+        assert!(!resp.message_id().unwrap_or_default().is_empty());
+    }
+
+    // Sending *from* the simulator domain should also work even with no
+    // verified identities matching it.
+    let resp = client
+        .send_email()
+        .from_email_address("ooto@simulator.amazonses.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("bounce@simulator.amazonses.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Hi").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("simulator sender should bypass the verified-identity gate");
+    assert!(!resp.message_id().unwrap_or_default().is_empty());
+}
+
+#[tokio::test]
+async fn v1_send_email_rejects_unverified_sender_with_message_rejected() {
+    let server = TestServer::start().await;
+    let v1 = server.ses_client().await;
+    set_sandbox(&server, true).await;
+
+    // SES v1 surfaces the same gate as `MessageRejected` (not the v2
+    // `MailFromDomainNotVerifiedException`).
+    let err = v1
+        .send_email()
+        .source("noreply@unverified.test")
+        .destination(
+            aws_sdk_ses::types::Destination::builder()
+                .to_addresses("any@unverified.test")
+                .build(),
+        )
+        .message(
+            aws_sdk_ses::types::Message::builder()
+                .subject(
+                    aws_sdk_ses::types::Content::builder()
+                        .data("Hi")
+                        .build()
+                        .unwrap(),
+                )
+                .body(
+                    aws_sdk_ses::types::Body::builder()
+                        .text(
+                            aws_sdk_ses::types::Content::builder()
+                                .data("Hello")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("not verified"),
+        "expected MessageRejected from SES v1, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn v1_send_email_succeeds_with_verified_sender_in_production() {
+    let server = TestServer::start().await;
+    let v1 = server.ses_client().await;
+    set_sandbox(&server, false).await;
+
+    v1.verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    v1.send_email()
+        .source("sender@example.com")
+        .destination(
+            aws_sdk_ses::types::Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .message(
+            aws_sdk_ses::types::Message::builder()
+                .subject(
+                    aws_sdk_ses::types::Content::builder()
+                        .data("Hi")
+                        .build()
+                        .unwrap(),
+                )
+                .body(
+                    aws_sdk_ses::types::Body::builder()
+                        .text(
+                            aws_sdk_ses::types::Content::builder()
+                                .data("Hello")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("verified v1 sender should succeed in production");
+}

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -21,9 +21,27 @@ fn extract_email_address(from: &str) -> &str {
     from.trim()
 }
 
+/// Real SES treats every address on the mailbox simulator domain as
+/// implicitly verified, both for senders and (in sandbox accounts) for
+/// recipients. The well-known mailboxes are
+/// `bounce@simulator.amazonses.com`, `complaint@simulator.amazonses.com`,
+/// `success@simulator.amazonses.com`, `suppressionlist@simulator.amazonses.com`,
+/// and `ooto@simulator.amazonses.com`, plus the auto-responder
+/// `*@simulator.amazonses.com` form (e.g. `auto-responder-N@`). We accept
+/// the whole domain instead of hard-coding a list — AWS docs explicitly
+/// say the domain itself bypasses the verification gate.
+pub(super) fn is_simulator_address(email: &str) -> bool {
+    matches!(email.split_once('@'), Some((_, "simulator.amazonses.com")))
+}
+
 /// Match an email against verified identities: exact email or matching
 /// verified-domain. Shared between sender + sandbox-recipient gates.
+/// Mailbox-simulator addresses bypass the gate (real SES treats them as
+/// always-verified).
 pub(super) fn identity_is_verified(state: &crate::state::SesState, email: &str) -> bool {
+    if is_simulator_address(email) {
+        return true;
+    }
     if state
         .identities
         .get(email)

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -791,6 +791,61 @@ async fn send_email_v2_accepts_verified_domain_when_from_uses_subdomain_or_addre
 }
 
 #[tokio::test]
+async fn send_email_v2_accepts_simulator_recipients_in_sandbox() {
+    // Real SES treats `*@simulator.amazonses.com` as always-verified so
+    // bounce/complaint/suppression flows can be exercised from sandbox
+    // accounts without registering the domain as a verified identity.
+    let state = make_state();
+    disable_production_access(&state);
+    seed_identity(&state, "sender@example.com");
+    let svc = SesV2Service::new(state);
+
+    for recipient in [
+        "bounce@simulator.amazonses.com",
+        "complaint@simulator.amazonses.com",
+        "success@simulator.amazonses.com",
+        "suppressionlist@simulator.amazonses.com",
+    ] {
+        let body = format!(
+            r#"{{
+                "FromEmailAddress": "sender@example.com",
+                "Destination": {{"ToAddresses": ["{recipient}"]}},
+                "Content": {{"Simple": {{"Subject": {{"Data": "S"}}, "Body": {{"Text": {{"Data": "B"}}}}}}}}
+            }}"#
+        );
+        let req = make_request(Method::POST, "/v2/email/outbound-emails", &body);
+        let resp = svc.handle(req).await.unwrap();
+        assert_eq!(
+            resp.status,
+            StatusCode::OK,
+            "simulator recipient {recipient} should bypass the gate"
+        );
+    }
+}
+
+#[tokio::test]
+async fn send_email_v2_accepts_simulator_sender_without_verified_identity() {
+    // Sending from the simulator domain itself should succeed even with no
+    // verified identities on the account — matches AWS docs that call out
+    // the domain as "always verified" for both sender and recipient.
+    let state = make_state();
+    disable_production_access(&state);
+    let svc = SesV2Service::new(state);
+
+    let req = make_request(
+        Method::POST,
+        "/v2/email/outbound-emails",
+        r#"{
+            "FromEmailAddress": "ooto@simulator.amazonses.com",
+            "Destination": {"ToAddresses": ["bounce@simulator.amazonses.com"]},
+            "Content": {"Simple": {"Subject": {"Data": "S"}, "Body": {"Text": {"Data": "B"}}}}
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_send_bulk_email_empty_entries() {
     let state = make_state();
     let svc = SesV2Service::new(state);

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -110,9 +110,21 @@ fn extract_email_address(from: &str) -> &str {
     from.trim()
 }
 
+/// True for mailbox-simulator addresses. Real SES treats every address
+/// on `simulator.amazonses.com` as implicitly verified; we match that
+/// behavior so callers can exercise bounce/complaint/suppression flows
+/// without having to register the simulator domain as a verified identity.
+fn is_simulator_address(email: &str) -> bool {
+    matches!(email.split_once('@'), Some((_, "simulator.amazonses.com")))
+}
+
 /// Match an email against verified identities (exact email or verified
-/// domain match).
+/// domain match). Mailbox-simulator addresses bypass the gate the same
+/// way real SES does.
 fn identity_is_verified(st: &SesState, email: &str) -> bool {
+    if is_simulator_address(email) {
+        return true;
+    }
     if st
         .identities
         .get(email)

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1150,6 +1150,54 @@ fn send_email_v1_skips_recipient_check_in_production() {
 }
 
 #[test]
+fn send_email_v1_accepts_simulator_recipients_in_sandbox() {
+    // Mailbox simulator addresses bypass the gate the same way real SES
+    // documents (`simulator.amazonses.com` is implicitly verified).
+    let state = make_state();
+    disable_production_access(&state);
+    seed_identity(&state, "sender@example.com");
+    for recipient in [
+        "bounce@simulator.amazonses.com",
+        "complaint@simulator.amazonses.com",
+        "success@simulator.amazonses.com",
+        "suppressionlist@simulator.amazonses.com",
+    ] {
+        let req = make_v1_request(
+            "SendEmail",
+            vec![
+                ("Source", "sender@example.com"),
+                ("Destination.ToAddresses.member.1", recipient),
+                ("Message.Subject.Data", "Hi"),
+                ("Message.Body.Text.Data", "Hello"),
+            ],
+        );
+        let resp = handle_v1_action(&state, &req)
+            .unwrap_or_else(|e| panic!("simulator recipient {recipient}: {}", e.message()));
+        assert_eq!(resp.status, StatusCode::OK);
+    }
+}
+
+#[test]
+fn send_email_v1_accepts_simulator_sender_without_verified_identity() {
+    let state = make_state();
+    disable_production_access(&state);
+    let req = make_v1_request(
+        "SendEmail",
+        vec![
+            ("Source", "ooto@simulator.amazonses.com"),
+            (
+                "Destination.ToAddresses.member.1",
+                "bounce@simulator.amazonses.com",
+            ),
+            ("Message.Subject.Data", "Hi"),
+            ("Message.Body.Text.Data", "Hello"),
+        ],
+    );
+    let resp = handle_v1_action(&state, &req).unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[test]
 fn test_send_raw_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");


### PR DESCRIPTION
## Summary
- Mailbox-simulator addresses (`*@simulator.amazonses.com`) now bypass the verified-identity gate the same way real SES treats them, so callers can exercise bounce/complaint/suppression flows from sandbox accounts without registering the simulator domain.
- Adds the missing simulator-bypass branch to both the v2 (`crates/fakecloud-ses/src/service/sending.rs`) and v1 (`crates/fakecloud-ses/src/v1_helpers.rs`) verification helpers.
- The verified-sender / sandbox-recipient gate itself was already in place: v2 returns `MailFromDomainNotVerifiedException`, v1 returns `MessageRejected`, exact-email > domain match, sandbox accounts (`production_access_enabled=false`) also reject unverified recipients.

## Test plan
- [x] `cargo test -p fakecloud-ses` (228 passing, includes 4 new simulator-bypass unit tests across v1 + v2)
- [x] `cargo test -p fakecloud-e2e --test ses_verification_gate` (8 new E2E tests covering sandbox-rejects-unverified-from, sandbox-rejects-unverified-to, sandbox-accepts-verified-pair, production-skips-recipient-check, domain-verification-covers-all-addresses, simulator-bypass, v1 MessageRejected wire format, v1 production happy path)
- [x] `cargo test -p fakecloud-e2e --test ses --test ses_v1` (no regressions, 73 tests passing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mailbox simulator addresses now bypass SES verified-identity checks in both v1 and v2, matching AWS. This lets sandbox accounts test bounce/complaint/suppression flows without verifying `simulator.amazonses.com`.

- **New Features**
  - Treat `*@simulator.amazonses.com` as verified for senders and recipients (v1 + v2).
  - Mirror AWS gating: v2 rejects unverified From with `MailFromDomainNotVerifiedException`; v1 uses `MessageRejected`.
  - Sandbox rejects unverified recipients; production skips recipient checks; domain verification covers all addresses on that domain.
  - Added e2e and unit tests in `fakecloud-e2e` and `fakecloud-ses` to cover sandbox/production, domain match, simulator paths.

<sup>Written for commit 091e549bc3b854371e784bc33849416a6daa1c01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

