### PR TITLE
feat(ses): account + config-set sending pause + suppression enforcement (X2)

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_pause_suppression.rs
+++ b/crates/fakecloud-e2e/tests/ses_pause_suppression.rs
@@ -1,0 +1,557 @@
+//! End-to-end coverage for the SES sending-pause + suppression gates.
+//!
+//! Real SES rejects every send while account-level sending is paused
+//! (`AccountSendingPausedException`), every send into a paused
+//! configuration set (`ConfigurationSetSendingPausedException`), and
+//! every send to an address on the suppression list when the relevant
+//! reason is enforced. fakecloud mirrors all three across SES v1 + v2;
+//! this suite drives them through the AWS SDKs so regressions in the
+//! Smithy-translated request paths get caught.
+
+mod helpers;
+
+use aws_sdk_sesv2::types::{
+    Body, Content, Destination, EmailContent, Message, SuppressionListReason,
+};
+use helpers::TestServer;
+
+async fn pause_account_v2(client: &aws_sdk_sesv2::Client, paused: bool) {
+    client
+        .put_account_sending_attributes()
+        .sending_enabled(!paused)
+        .send()
+        .await
+        .expect("PutAccountSendingAttributes");
+}
+
+fn simple_content(subject: &str, body: &str) -> EmailContent {
+    EmailContent::builder()
+        .simple(
+            Message::builder()
+                .subject(Content::builder().data(subject).build().unwrap())
+                .body(
+                    Body::builder()
+                        .text(Content::builder().data(body).build().unwrap())
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+async fn metrics_drops_total(server: &TestServer) -> u64 {
+    let url = format!("{}/_fakecloud/ses/metrics", server.endpoint());
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("metrics request");
+    let body: serde_json::Value = resp.json().await.expect("metrics body");
+    body["suppressedDropsTotal"].as_u64().unwrap_or(0)
+}
+
+#[tokio::test]
+async fn v2_send_email_rejected_when_account_sending_paused() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    pause_account_v2(&client, true).await;
+
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("AccountSendingPausedException")
+            || dbg.contains("Email sending for the account is paused"),
+        "expected AccountSendingPausedException, got: {dbg}"
+    );
+
+    // Flip back on and confirm sends resume.
+    pause_account_v2(&client, false).await;
+    client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .expect("send should resume after un-pausing");
+}
+
+#[tokio::test]
+async fn v2_send_email_rejected_when_config_set_sending_paused() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let cs_name = "paused-cs";
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_configuration_set()
+        .configuration_set_name(cs_name)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_configuration_set_sending_options()
+        .configuration_set_name(cs_name)
+        .sending_enabled(false)
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .configuration_set_name(cs_name)
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("ConfigurationSetSendingPausedException")
+            || dbg.contains(&format!(
+                "Email sending for the configuration set {cs_name} is paused"
+            )),
+        "expected ConfigurationSetSendingPausedException, got: {dbg}"
+    );
+
+    // Sends without that config set should still go through.
+    client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .expect("send without paused config-set should succeed");
+}
+
+#[tokio::test]
+async fn v2_send_email_rejected_when_recipient_on_suppression_list() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_suppressed_destination()
+        .email_address("blocked@example.com")
+        .reason(SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+
+    let before = metrics_drops_total(&server).await;
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("blocked@example.com")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("suppression list"),
+        "expected MessageRejected for suppressed recipient, got: {dbg}"
+    );
+    let after = metrics_drops_total(&server).await;
+    assert_eq!(
+        after,
+        before + 1,
+        "suppression-drop counter should increment exactly once"
+    );
+}
+
+#[tokio::test]
+async fn v2_send_email_suppression_lookup_is_case_insensitive() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_suppressed_destination()
+        .email_address("Blocked@Example.com")
+        .reason(SuppressionListReason::Complaint)
+        .send()
+        .await
+        .unwrap();
+
+    // Different casing on the recipient must still hit the suppression list.
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("BLOCKED@example.COM")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("suppression list"),
+        "expected case-insensitive suppression match, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn v2_send_email_suppression_reason_filter_excludes_complaint() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    // Account-level filter only enforces BOUNCE; recipient is on the list
+    // for COMPLAINT, so the send should proceed.
+    client
+        .put_account_suppression_attributes()
+        .suppressed_reasons(SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_suppressed_destination()
+        .email_address("complainer@example.com")
+        .reason(SuppressionListReason::Complaint)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("complainer@example.com")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .expect("BOUNCE-only filter should let COMPLAINT-suppressed addresses through");
+
+    // Now with a BOUNCE-suppressed address, the same send must be rejected.
+    client
+        .put_suppressed_destination()
+        .email_address("hardbounce@example.com")
+        .reason(SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("hardbounce@example.com")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("suppression list"),
+        "expected BOUNCE filter to reject BOUNCE-suppressed address, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn v2_send_email_config_set_filter_overrides_account_filter() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+    let cs_name = "complaint-only-cs";
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_configuration_set()
+        .configuration_set_name(cs_name)
+        .send()
+        .await
+        .unwrap();
+    // Account enforces both reasons (default), config set narrows to COMPLAINT.
+    client
+        .put_configuration_set_suppression_options()
+        .configuration_set_name(cs_name)
+        .suppressed_reasons(SuppressionListReason::Complaint)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_suppressed_destination()
+        .email_address("hardbounce@example.com")
+        .reason(SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+
+    // The config-set scope narrows the filter, so a BOUNCE-suppressed
+    // address must NOT be rejected when sending into that config set.
+    client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .configuration_set_name(cs_name)
+        .destination(
+            Destination::builder()
+                .to_addresses("hardbounce@example.com")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .expect("config-set COMPLAINT-only filter should let BOUNCE-suppressed addresses through");
+
+    // Without the config-set override the default filter (both reasons)
+    // applies and the same send is rejected.
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("hardbounce@example.com")
+                .build(),
+        )
+        .content(simple_content("Hi", "Hello"))
+        .send()
+        .await
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("MessageRejected"));
+}
+
+#[tokio::test]
+async fn v1_send_email_rejected_when_account_sending_paused() {
+    let server = TestServer::start().await;
+    let v1 = server.ses_client().await;
+    let v2 = server.sesv2_client().await;
+
+    v1.verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    pause_account_v2(&v2, true).await;
+
+    let err = v1
+        .send_email()
+        .source("sender@example.com")
+        .destination(
+            aws_sdk_ses::types::Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .message(
+            aws_sdk_ses::types::Message::builder()
+                .subject(
+                    aws_sdk_ses::types::Content::builder()
+                        .data("Hi")
+                        .build()
+                        .unwrap(),
+                )
+                .body(
+                    aws_sdk_ses::types::Body::builder()
+                        .text(
+                            aws_sdk_ses::types::Content::builder()
+                                .data("Hello")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("Email sending for the account is paused"),
+        "expected MessageRejected (account paused) from SES v1, got: {dbg}"
+    );
+}
+
+#[tokio::test]
+async fn v1_send_email_rejected_when_recipient_on_suppression_list() {
+    let server = TestServer::start().await;
+    let v1 = server.ses_client().await;
+    let v2 = server.sesv2_client().await;
+
+    v1.verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    v2.put_suppressed_destination()
+        .email_address("blocked-v1@example.com")
+        .reason(SuppressionListReason::Bounce)
+        .send()
+        .await
+        .unwrap();
+
+    let before = metrics_drops_total(&server).await;
+    let err = v1
+        .send_email()
+        .source("sender@example.com")
+        .destination(
+            aws_sdk_ses::types::Destination::builder()
+                .to_addresses("blocked-v1@example.com")
+                .build(),
+        )
+        .message(
+            aws_sdk_ses::types::Message::builder()
+                .subject(
+                    aws_sdk_ses::types::Content::builder()
+                        .data("Hi")
+                        .build()
+                        .unwrap(),
+                )
+                .body(
+                    aws_sdk_ses::types::Body::builder()
+                        .text(
+                            aws_sdk_ses::types::Content::builder()
+                                .data("Hello")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("suppression list"),
+        "expected MessageRejected for suppressed recipient on v1, got: {dbg}"
+    );
+    let after = metrics_drops_total(&server).await;
+    assert_eq!(
+        after,
+        before + 1,
+        "v1 suppression-drop should bump the same counter v2 uses"
+    );
+}
+
+#[tokio::test]
+async fn v1_send_email_rejected_when_config_set_sending_paused() {
+    let server = TestServer::start().await;
+    let v1 = server.ses_client().await;
+    let v2 = server.sesv2_client().await;
+    let cs_name = "paused-cs-v1";
+
+    v1.verify_email_identity()
+        .email_address("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    v2.create_configuration_set()
+        .configuration_set_name(cs_name)
+        .send()
+        .await
+        .unwrap();
+    v2.put_configuration_set_sending_options()
+        .configuration_set_name(cs_name)
+        .sending_enabled(false)
+        .send()
+        .await
+        .unwrap();
+
+    let err = v1
+        .send_email()
+        .source("sender@example.com")
+        .configuration_set_name(cs_name)
+        .destination(
+            aws_sdk_ses::types::Destination::builder()
+                .to_addresses("anyone@elsewhere.test")
+                .build(),
+        )
+        .message(
+            aws_sdk_ses::types::Message::builder()
+                .subject(
+                    aws_sdk_ses::types::Content::builder()
+                        .data("Hi")
+                        .build()
+                        .unwrap(),
+                )
+                .body(
+                    aws_sdk_ses::types::Body::builder()
+                        .text(
+                            aws_sdk_ses::types::Content::builder()
+                                .data("Hello")
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap_err();
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("MessageRejected") || dbg.contains("paused"),
+        "expected MessageRejected (config set paused) from SES v1, got: {dbg}"
+    );
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2753,6 +2753,19 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/ses/metrics",
+            axum::routing::get({
+                let ss = ses_emails_state.clone();
+                move || async move {
+                    let mas = ss.read();
+                    let state = mas.default_ref();
+                    axum::Json(serde_json::json!({
+                        "suppressedDropsTotal": state.suppressed_drops_total,
+                    }))
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/ses/identities/{name}/mail-from-status",
             axum::routing::post({
                 let ss = ses_emails_state.clone();

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -146,13 +146,19 @@ pub fn classify_recipients(recipients: &[String]) -> (Vec<SesEventType>, bool) {
     (events, suppress)
 }
 
-/// Check if any recipient is on the suppression list.
-/// Returns the suppressed address if found.
-pub fn check_suppression_list(ses_state: &SharedSesState, recipients: &[String]) -> Option<String> {
+/// Check if any recipient is on the suppression list AND the stored
+/// reason is enforced under the effective `SuppressedReasons` filter
+/// (configuration-set scope first, then account-level fallback). Lookup
+/// is case-insensitive. Returns the suppressed address if found.
+pub fn check_suppression_list(
+    ses_state: &SharedSesState,
+    recipients: &[String],
+    config_set_name: Option<&str>,
+) -> Option<String> {
     let mas = ses_state.read();
     let state = mas.default_ref();
     for addr in recipients {
-        if state.suppressed_destinations.contains_key(addr) {
+        if state.suppressed_match(addr, config_set_name).is_some() {
             return Some(addr.clone());
         }
     }
@@ -273,12 +279,22 @@ pub fn process_send_events(
         None => return false, // No config set, no event destinations to fan out to
     };
 
-    // Check suppression list
-    if let Some(suppressed_addr) = check_suppression_list(&ctx.ses_state, &email.to) {
+    // Check suppression list with the effective reasons filter
+    if let Some(suppressed_addr) =
+        check_suppression_list(&ctx.ses_state, &email.to, Some(config_set.as_str()))
+    {
         tracing::info!(
             address = %suppressed_addr,
+            config_set = %config_set,
             "SES: recipient is on suppression list, generating bounce"
         );
+        // Increment the suppression-drop counter so introspection /
+        // /_fakecloud/ses/metrics callers can observe the gate firing.
+        {
+            let mut mas = ctx.ses_state.write();
+            let state = mas.default_mut();
+            state.suppressed_drops_total = state.suppressed_drops_total.saturating_add(1);
+        }
         let bounce_event = build_ses_event(SesEventType::Bounce, email);
         deliver_event(ctx, &bounce_event, SesEventType::Bounce, &config_set);
         return true;
@@ -502,6 +518,7 @@ mod tests {
                 "ok@example.com".to_string(),
                 "blocked@example.com".to_string(),
             ],
+            None,
         );
         assert_eq!(hit.as_deref(), Some("blocked@example.com"));
     }
@@ -509,8 +526,104 @@ mod tests {
     #[test]
     fn check_suppression_list_none_when_clean() {
         let state = shared_state();
-        let hit = check_suppression_list(&state, &["ok@example.com".to_string()]);
+        let hit = check_suppression_list(&state, &["ok@example.com".to_string()], None);
         assert!(hit.is_none());
+    }
+
+    #[test]
+    fn check_suppression_list_skips_when_reason_filter_excludes() {
+        // Address suppressed for COMPLAINT, but the resolved config set
+        // only enforces BOUNCE — fanout must not bounce that recipient.
+        let state = shared_state();
+        {
+            let mut mas = state.write();
+            let st = mas.default_mut();
+            st.suppressed_destinations.insert(
+                "blocked@example.com".to_string(),
+                SuppressedDestination {
+                    email_address: "blocked@example.com".to_string(),
+                    reason: "COMPLAINT".to_string(),
+                    last_update_time: Utc::now(),
+                },
+            );
+            st.configuration_sets.insert(
+                "bounce-only".to_string(),
+                crate::state::ConfigurationSet {
+                    name: "bounce-only".to_string(),
+                    sending_enabled: true,
+                    tls_policy: "OPTIONAL".to_string(),
+                    sending_pool_name: None,
+                    custom_redirect_domain: None,
+                    https_policy: None,
+                    suppressed_reasons: vec!["BOUNCE".to_string()],
+                    reputation_metrics_enabled: false,
+                    vdm_options: None,
+                    archive_arn: None,
+                },
+            );
+        }
+        let hit = check_suppression_list(
+            &state,
+            &["blocked@example.com".to_string()],
+            Some("bounce-only"),
+        );
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn check_suppression_list_account_fallback_when_config_set_empty() {
+        // Config set has no suppressed_reasons; fall back to account
+        // scope which only enforces COMPLAINT.
+        let state = shared_state();
+        {
+            let mut mas = state.write();
+            let st = mas.default_mut();
+            st.suppressed_destinations.insert(
+                "blocked@example.com".to_string(),
+                SuppressedDestination {
+                    email_address: "blocked@example.com".to_string(),
+                    reason: "BOUNCE".to_string(),
+                    last_update_time: Utc::now(),
+                },
+            );
+            st.account_settings.suppressed_reasons = vec!["COMPLAINT".to_string()];
+            st.configuration_sets.insert(
+                "passthrough".to_string(),
+                crate::state::ConfigurationSet {
+                    name: "passthrough".to_string(),
+                    sending_enabled: true,
+                    tls_policy: "OPTIONAL".to_string(),
+                    sending_pool_name: None,
+                    custom_redirect_domain: None,
+                    https_policy: None,
+                    suppressed_reasons: Vec::new(),
+                    reputation_metrics_enabled: false,
+                    vdm_options: None,
+                    archive_arn: None,
+                },
+            );
+        }
+        let hit = check_suppression_list(
+            &state,
+            &["blocked@example.com".to_string()],
+            Some("passthrough"),
+        );
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn check_suppression_list_case_insensitive() {
+        let state = shared_state();
+        state.write().default_mut().suppressed_destinations.insert(
+            "Blocked@Example.com".to_string(),
+            SuppressedDestination {
+                email_address: "Blocked@Example.com".to_string(),
+                reason: "BOUNCE".to_string(),
+                last_update_time: Utc::now(),
+            },
+        );
+        let hit = check_suppression_list(&state, &["BLOCKED@example.COM".to_string()], None);
+        assert_eq!(hit.as_deref(), Some("BLOCKED@example.COM"));
     }
 
     fn make_identity(name: &str, config_set: Option<&str>) -> crate::state::EmailIdentity {

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -128,18 +128,31 @@ impl SesV2Service {
         None
     }
 
-    /// Returns `true` if `address` (or its domain) is on the account's
-    /// suppression list. Mirrors SES behavior where suppression is keyed
-    /// by exact address; we don't currently honor per-config-set
-    /// suppression overrides because the underlying state only tracks
-    /// account-level suppression.
-    pub(super) fn address_is_suppressed(&self, account_id: &str, address: &str) -> bool {
+    /// Returns `true` if `address` is on the account suppression list
+    /// AND its stored reason matches the effective `SuppressedReasons`
+    /// filter (configuration-set scope first, then account-level
+    /// fallback). Address lookup is case-insensitive.
+    pub(super) fn address_is_suppressed(
+        &self,
+        account_id: &str,
+        address: &str,
+        config_set_name: Option<&str>,
+    ) -> bool {
         let accounts = self.state.read();
         let Some(state) = accounts.get(account_id) else {
             return false;
         };
-        let trimmed = address.trim();
-        state.suppressed_destinations.contains_key(trimmed)
+        let bare = extract_email_address(address);
+        state.suppressed_match(bare, config_set_name).is_some()
+    }
+
+    /// Increment the suppression-drop counter on the account state.
+    /// Surfaced via the introspection endpoint so tests can assert the
+    /// gate fired without scraping logs.
+    pub(super) fn bump_suppression_drop(&self, account_id: &str) {
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        state.suppressed_drops_total = state.suppressed_drops_total.saturating_add(1);
     }
 
     /// Reject sends where the sender is not a verified identity. Mirrors
@@ -254,10 +267,14 @@ impl SesV2Service {
         }
 
         // Single-recipient path: any suppressed recipient kills the send.
-        // Real SES surfaces this as `MessageRejected`.
+        // Real SES surfaces this as `MessageRejected`. Suppression is
+        // gated by the effective `SuppressedReasons` filter — if the
+        // address was suppressed for `COMPLAINT` but the config set only
+        // enforces `BOUNCE`, the send proceeds.
         for r in &recipients {
             let addr = extract_email_address(r);
-            if self.address_is_suppressed(&req.account_id, addr) {
+            if self.address_is_suppressed(&req.account_id, addr, config_set_name.as_deref()) {
+                self.bump_suppression_drop(&req.account_id);
                 return Ok(Self::json_error(
                     StatusCode::BAD_REQUEST,
                     "MessageRejected",
@@ -398,11 +415,14 @@ impl SesV2Service {
 
             // Drop entries with any suppressed recipient. Mirrors SES,
             // which fails the bulk entry rather than the whole batch.
+            // Honors the effective `SuppressedReasons` filter so callers
+            // can scope suppression to BOUNCE-only or COMPLAINT-only.
             let any_suppressed = recipients.iter().any(|r| {
                 let addr = extract_email_address(r);
-                self.address_is_suppressed(&req.account_id, addr)
+                self.address_is_suppressed(&req.account_id, addr, config_set_name.as_deref())
             });
             if any_suppressed {
+                self.bump_suppression_drop(&req.account_id);
                 results.push(json!({
                     "Status": "MESSAGE_REJECTED",
                     "Error": "Address is on the suppression list",

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -388,6 +388,12 @@ pub struct SesState {
     /// VDM recommendations (read-only, lazily seeded once on first read).
     #[serde(default)]
     pub vdm_recommendations: Vec<VdmRecommendation>,
+    /// Running count of recipients dropped because they were on the
+    /// suppression list (gated by the effective `SuppressedReasons`
+    /// filter). Surfaced through the introspection endpoint so tests can
+    /// assert the gate fired.
+    #[serde(default)]
+    pub suppressed_drops_total: u64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -483,6 +489,7 @@ impl SesState {
             deliverability_dashboard: DeliverabilityDashboard::default(),
             deliverability_test_reports: BTreeMap::new(),
             vdm_recommendations: Vec::new(),
+            suppressed_drops_total: 0,
         }
     }
 
@@ -491,6 +498,52 @@ impl SesState {
         let account_id = std::mem::take(&mut self.account_id);
         let region = std::mem::take(&mut self.region);
         *self = Self::new(&account_id, &region);
+    }
+
+    /// Effective `SuppressedReasons` for a send. Configuration-set scope
+    /// wins when populated; otherwise we fall back to the account-level
+    /// list. An empty list at both scopes is treated as "enforce both
+    /// reasons" (BOUNCE + COMPLAINT) — that matches the historical
+    /// fakecloud contract, and AWS callers who never call
+    /// PutAccountSuppressionAttributes still expect the suppression list
+    /// they explicitly populated to take effect.
+    pub fn effective_suppressed_reasons(&self, config_set_name: Option<&str>) -> Vec<String> {
+        if let Some(name) = config_set_name {
+            if let Some(cs) = self.configuration_sets.get(name) {
+                if !cs.suppressed_reasons.is_empty() {
+                    return cs.suppressed_reasons.clone();
+                }
+            }
+        }
+        if !self.account_settings.suppressed_reasons.is_empty() {
+            return self.account_settings.suppressed_reasons.clone();
+        }
+        vec!["BOUNCE".to_string(), "COMPLAINT".to_string()]
+    }
+
+    /// Look up `address` against the suppression list (case-insensitive,
+    /// trimmed). Returns the matching `SuppressedDestination` only when
+    /// the stored reason is enforced under the effective filter for the
+    /// supplied configuration-set scope.
+    pub fn suppressed_match(
+        &self,
+        address: &str,
+        config_set_name: Option<&str>,
+    ) -> Option<&SuppressedDestination> {
+        let key = address.trim().to_ascii_lowercase();
+        let entry = self.suppressed_destinations.iter().find_map(|(k, v)| {
+            if k.trim().eq_ignore_ascii_case(&key) {
+                Some(v)
+            } else {
+                None
+            }
+        })?;
+        let reasons = self.effective_suppressed_reasons(config_set_name);
+        if reasons.iter().any(|r| r == &entry.reason) {
+            Some(entry)
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -255,41 +255,68 @@ pub(crate) fn check_v1_sending_enabled(
 }
 
 /// Reject sends targeting a recipient on the account suppression list.
-/// Real SES v1 surfaces this as `MessageRejected`.
+/// Real SES v1 surfaces this as `MessageRejected`. Suppression is gated
+/// by the effective `SuppressedReasons` filter (configuration-set scope
+/// first, then account-level fallback).
 pub(crate) fn check_v1_recipients_not_suppressed(
     state: &SharedSesState,
     account_id: &str,
     recipients: &[String],
+    config_set_name: Option<&str>,
 ) -> Result<(), AwsServiceError> {
-    let accounts = state.read();
-    let Some(st) = accounts.get(account_id) else {
-        return Ok(());
-    };
-    for r in recipients {
-        let addr = extract_email_address(r);
-        if addr.is_empty() {
-            continue;
+    let mut hit = false;
+    {
+        let accounts = state.read();
+        let Some(st) = accounts.get(account_id) else {
+            return Ok(());
+        };
+        for r in recipients {
+            let addr = extract_email_address(r);
+            if addr.is_empty() {
+                continue;
+            }
+            if st.suppressed_match(addr, config_set_name).is_some() {
+                hit = true;
+                break;
+            }
         }
-        if st.suppressed_destinations.contains_key(addr) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MessageRejected",
-                "Address is on the suppression list".to_string(),
-            ));
-        }
+    }
+    if hit {
+        bump_suppression_drop(state, account_id);
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MessageRejected",
+            "Address is on the suppression list".to_string(),
+        ));
     }
     Ok(())
 }
 
-/// True when `addr` is on the account suppression list. Used by bulk
-/// paths that filter per-destination instead of failing the whole batch.
-pub(crate) fn is_address_suppressed(state: &SharedSesState, account_id: &str, addr: &str) -> bool {
+/// Increment the suppression-drop counter; mirrors the v2 helper so
+/// both paths feed the same introspection counter.
+pub(crate) fn bump_suppression_drop(state: &SharedSesState, account_id: &str) {
+    let mut accounts = state.write();
+    let st = accounts.get_or_create(account_id);
+    st.suppressed_drops_total = st.suppressed_drops_total.saturating_add(1);
+}
+
+/// True when `addr` is on the account suppression list AND its stored
+/// reason is enforced under the effective `SuppressedReasons` filter
+/// (configuration-set scope first, then account-level fallback). Used by
+/// bulk paths that filter per-destination instead of failing the whole
+/// batch.
+pub(crate) fn is_address_suppressed(
+    state: &SharedSesState,
+    account_id: &str,
+    addr: &str,
+    config_set_name: Option<&str>,
+) -> bool {
     let accounts = state.read();
     let Some(st) = accounts.get(account_id) else {
         return false;
     };
-    st.suppressed_destinations
-        .contains_key(extract_email_address(addr))
+    st.suppressed_match(extract_email_address(addr), config_set_name)
+        .is_some()
 }
 
 /// Parse a receipt rule from form parameters (for Create/Update).
@@ -1166,7 +1193,12 @@ pub(crate) fn send_email(
         .cloned()
         .collect();
     check_v1_verified_recipients(state, &req.account_id, &recipients)?;
-    check_v1_recipients_not_suppressed(state, &req.account_id, &recipients)?;
+    check_v1_recipients_not_suppressed(
+        state,
+        &req.account_id,
+        &recipients,
+        config_set_name.as_deref(),
+    )?;
 
     let subject = req.query_params.get("Message.Subject.Data").cloned();
     let html_body = req.query_params.get("Message.Body.Html.Data").cloned();
@@ -1243,7 +1275,7 @@ pub(crate) fn send_raw_email(
     }
     let to = parse_member_list(&req.query_params, "Destinations");
     check_v1_verified_recipients(state, &req.account_id, &to)?;
-    check_v1_recipients_not_suppressed(state, &req.account_id, &to)?;
+    check_v1_recipients_not_suppressed(state, &req.account_id, &to, config_set_name.as_deref())?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1318,7 +1350,12 @@ pub(crate) fn send_templated_email(
         .cloned()
         .collect();
     check_v1_verified_recipients(state, &req.account_id, &recipients)?;
-    check_v1_recipients_not_suppressed(state, &req.account_id, &recipients)?;
+    check_v1_recipients_not_suppressed(
+        state,
+        &req.account_id,
+        &recipients,
+        config_set_name.as_deref(),
+    )?;
 
     let message_id = format!(
         "{:016x}{:016x}-{:08x}-{:04x}",
@@ -1425,8 +1462,9 @@ pub(crate) fn send_bulk_templated_email(
         }
         let any_suppressed = recipients
             .iter()
-            .any(|r| is_address_suppressed(state, &req.account_id, r));
+            .any(|r| is_address_suppressed(state, &req.account_id, r, config_set_name.as_deref()));
         if any_suppressed {
+            bump_suppression_drop(state, &req.account_id);
             inner.push_str(
                 "<member><Status>MessageRejected</Status><Error>Address is on the suppression list</Error></member>",
             );


### PR DESCRIPTION
## Summary
- Account-level `SendingEnabled=false` rejects all sends with `AccountSendingPausedException` (v2) / `MessageRejected` (v1).
- ConfigurationSet-level `SendingOptions.SendingEnabled=false` rejects with `ConfigurationSetSendingPausedException` (v2) / `MessageRejected` (v1).
- Suppression list now enforces the effective `SuppressedReasons` filter (config-set scope wins, account-level fallback). Lookup is case-insensitive.
- New `/_fakecloud/ses/metrics` introspection endpoint surfaces the running suppression-drop counter so tests can assert the gate fired.

## Test plan
- [x] `cargo test -p fakecloud-ses` (231 unit tests green)
- [x] `cargo test -p fakecloud-e2e --test ses_pause_suppression` (9 E2E tests green)
- [x] `cargo test -p fakecloud-e2e --test ses --test ses_v1 --test ses_verification_gate` (existing SES suites still green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces SES sending pause and suppression rules across v1 and v2. Adds a metrics endpoint to observe suppression drops in tests.

- **New Features**
  - Account-level `SendingEnabled=false` rejects all sends with `AccountSendingPausedException` (v2) and `MessageRejected` (v1).
  - Configuration set `SendingOptions.SendingEnabled=false` rejects sends into that set with `ConfigurationSetSendingPausedException` (v2) and `MessageRejected` (v1).
  - Suppression list enforced on v1 + v2 send paths with case-insensitive lookup; honors effective `SuppressedReasons` (`BOUNCE`/`COMPLAINT`) where config-set scope overrides account scope.
  - Bulk paths drop entries with any suppressed recipient and bump a counter.
  - New introspection endpoint `/_fakecloud/ses/metrics` returns `{ "suppressedDropsTotal": <u64> }` for assertions in `fakecloud-e2e`.

<sup>Written for commit fc2de2e17db478c2f1149c63d114a1e380f9cfef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

