### PR TITLE
feat(dynamodb): atomic ExecuteTransaction with snapshot/revert + stream emission (L3)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -836,20 +836,93 @@ impl DynamoDbService {
             )
         })?;
 
-        // Snapshot every account state on the default account up-front
-        // so we can revert in one shot if any statement fails. Cheap
-        // because PartiQL targets the default account only (PartiQL has
-        // no per-account scoping), and atomicity is required by the
-        // spec.
+        // Acquire the write lock once for the whole batch — DDB
+        // ExecuteTransaction is all-or-nothing so we cannot release
+        // the lock between phases or another writer could observe
+        // partial state.
         let mut accounts = self.state.write();
         let state = accounts.default_mut();
-        let snapshot_tables = state.tables.clone();
 
         let region = req.region.clone();
-        let mut responses: Vec<Value> = Vec::with_capacity(transact_statements.len());
+
+        // Phase 1: validate every statement against a cloned state.
+        // Cloning the tables map (Vec<HashMap<...>> per table) is
+        // cheap for typical transaction sizes (<=25 items per AWS
+        // limits) and lets us collect a CancellationReason per
+        // statement without mutating real state. Each clone-write
+        // within this phase is discarded — we only keep the
+        // per-statement reason so phase 2 can replay against the
+        // real state.
+        let mut clone_state = state.clone();
+
+        let mut cancellation_reasons: Vec<Value> = Vec::with_capacity(transact_statements.len());
+        let mut any_failed = false;
+
+        for stmt_obj in transact_statements.iter() {
+            let statement = stmt_obj["Statement"].as_str().unwrap_or_default();
+            let parameters = stmt_obj["Parameters"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+
+            match execute_partiql_in_state(&mut clone_state, statement, &parameters) {
+                Ok(_) => {
+                    cancellation_reasons.push(json!({ "Code": "None" }));
+                }
+                Err(e) => {
+                    any_failed = true;
+                    let dbg = format!("{e:?}");
+                    let code = if dbg.contains("ConditionalCheckFailed") {
+                        "ConditionalCheckFailed"
+                    } else if dbg.contains("DuplicateItemException") {
+                        "DuplicateItem"
+                    } else if dbg.contains("ResourceNotFoundException") {
+                        "ResourceNotFound"
+                    } else {
+                        "ValidationError"
+                    };
+                    cancellation_reasons.push(json!({
+                        "Code": code,
+                        "Message": e.to_string(),
+                    }));
+                }
+            }
+        }
+
+        if any_failed {
+            // Build the dedup'd code list real DDB embeds in the
+            // top-level message so SDKs that match on `[Code, ...]`
+            // still work.
+            let mut seen: Vec<String> = Vec::new();
+            for r in &cancellation_reasons {
+                if let Some(code) = r.get("Code").and_then(|c| c.as_str()) {
+                    if code != "None" && !seen.iter().any(|s| s == code) {
+                        seen.push(code.to_string());
+                    }
+                }
+            }
+            let codes_str = seen.join(", ");
+            let error_body = json!({
+                "__type": "TransactionCanceledException",
+                "message": format!("Transaction cancelled, please refer cancellation reasons for specific reasons [{codes_str}]"),
+                "CancellationReasons": cancellation_reasons,
+            });
+            return Ok(AwsResponse::json(
+                StatusCode::BAD_REQUEST,
+                serde_json::to_vec(&error_body).unwrap(),
+            ));
+        }
+
+        // Phase 2: apply for real. We replay every statement against
+        // the live tables map. By construction the validation pass
+        // succeeded against the cloned state so this should not fail,
+        // but if a statement does fail (defensive), we still revert
+        // by snapshotting before we begin and restoring on error.
+        let snapshot_tables = state.tables.clone();
         let mut pending_stream: Vec<(String, crate::state::StreamRecord)> = Vec::new();
         let mut pending_kinesis: Vec<PendingKinesis> = Vec::new();
-        let mut failure: Option<(usize, String)> = None;
+        let mut apply_failure: Option<(usize, String)> = None;
+        let mut applied_responses: Vec<Value> = Vec::with_capacity(transact_statements.len());
 
         for (i, stmt_obj) in transact_statements.iter().enumerate() {
             let statement = stmt_obj["Statement"].as_str().unwrap_or_default();
@@ -860,7 +933,7 @@ impl DynamoDbService {
 
             match execute_partiql_in_state(state, statement, &parameters) {
                 Ok(outcome) => {
-                    responses.push(outcome.response);
+                    applied_responses.push(outcome.response);
                     let table_name = match outcome.table_name {
                         Some(n) => n,
                         None => continue,
@@ -893,22 +966,21 @@ impl DynamoDbService {
                     }
                 }
                 Err(e) => {
-                    failure = Some((i, e.to_string()));
+                    apply_failure = Some((i, e.to_string()));
                     break;
                 }
             }
         }
 
-        if let Some((failed_idx, msg)) = failure {
-            // Revert: replace the tables map with the pre-transaction
-            // snapshot so all earlier statements in this transaction
-            // are undone.
+        if let Some((failed_idx, msg)) = apply_failure {
+            // Revert to pre-apply snapshot — drops every partial
+            // write from earlier statements in this transaction.
             state.tables = snapshot_tables;
             let reasons: Vec<Value> = (0..transact_statements.len())
                 .map(|i| {
                     if i == failed_idx {
                         json!({
-                            "Code": "ValidationException",
+                            "Code": "ValidationError",
                             "Message": msg.clone(),
                         })
                     } else {
@@ -918,8 +990,8 @@ impl DynamoDbService {
                 .collect();
             let error_body = json!({
                 "__type": "TransactionCanceledException",
-                "message": "Transaction cancelled due to validation errors",
-                "CancellationReasons": reasons
+                "message": "Transaction cancelled, please refer cancellation reasons for specific reasons [ValidationError]",
+                "CancellationReasons": reasons,
             });
             return Ok(AwsResponse::json(
                 StatusCode::BAD_REQUEST,
@@ -927,13 +999,18 @@ impl DynamoDbService {
             ));
         }
 
-        // Append pending stream records under each table's lock.
+        // Append pending stream records under each table's lock so
+        // observers (DescribeStream/GetRecords) only see them once
+        // the transaction has fully committed.
         for (table_name, record) in pending_stream {
             if let Some(table) = state.tables.get_mut(&table_name) {
                 crate::streams::add_stream_record(table, record);
             }
         }
 
+        // Drop the write lock before firing kinesis deliveries so
+        // the delivery bus (which may take a read lock to look up
+        // the target stream) doesn't deadlock against us.
         drop(accounts);
         for (target, event_name, keys, old_image, new_image) in pending_kinesis {
             self.deliver_to_kinesis_destinations(
@@ -945,7 +1022,7 @@ impl DynamoDbService {
             );
         }
 
-        Self::ok_json(json!({ "Responses": responses }))
+        Self::ok_json(json!({ "Responses": applied_responses }))
     }
 }
 
@@ -1413,5 +1490,103 @@ mod tests {
             0,
             "first INSERT must be reverted when the second statement fails"
         );
+    }
+
+    #[tokio::test]
+    async fn execute_transaction_three_writes_middle_fails_reverts_all() {
+        // L3 spec: 3 writes where #2 fails (duplicate-key on a seeded
+        // item) — all 3 must be reverted, no stream records emitted,
+        // CancellationReasons array length 3 with #2 marked.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        // Pre-seed pk=b so the 2nd INSERT in the transaction collides.
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'b'}"}),
+        ))
+        .unwrap();
+        // Reset stream records so we only count what the txn emits.
+        {
+            let accts = state.read();
+            let s = accts.get("123456789012").unwrap();
+            let table = s.tables.get("Widgets").unwrap();
+            table.stream_records.write().clear();
+        }
+
+        let req = req_for(
+            "ExecuteTransaction",
+            json!({
+                "TransactStatements": [
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'b'}"}, // dup
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'c'}"},
+                ]
+            }),
+        );
+        let resp = svc.execute_transaction(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::BAD_REQUEST);
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            body["__type"].as_str().unwrap(),
+            "TransactionCanceledException"
+        );
+        let reasons = body["CancellationReasons"].as_array().unwrap();
+        assert_eq!(reasons.len(), 3, "one CancellationReason per statement");
+        assert_eq!(reasons[0]["Code"].as_str().unwrap(), "None");
+        assert_eq!(reasons[1]["Code"].as_str().unwrap(), "DuplicateItem");
+        assert_eq!(reasons[2]["Code"].as_str().unwrap(), "None");
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        // Only the pre-seed should remain — neither 'a' nor 'c' from
+        // the rolled-back txn must persist.
+        let pks: Vec<String> = table
+            .items
+            .iter()
+            .map(|i| i["pk"]["S"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(pks, vec!["b".to_string()], "all 3 statements reverted");
+        // No stream records should have been emitted from the failed
+        // txn — the apply phase never ran.
+        assert_eq!(
+            table.stream_records.read().len(),
+            0,
+            "no stream records on failed txn"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_transaction_happy_path_commits_and_emits_per_write() {
+        // L3 spec: happy-path commits all + each write emits a stream
+        // record. Mirrors items.rs::put_item per-write hook semantics.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        let req = req_for(
+            "ExecuteTransaction",
+            json!({
+                "TransactStatements": [
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'b'}"},
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'c'}"},
+                ]
+            }),
+        );
+        let resp = svc.execute_transaction(&req).unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["Responses"].as_array().unwrap().len(), 3);
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        assert_eq!(table.items.len(), 3);
+        let records = table.stream_records.read();
+        assert_eq!(records.len(), 3, "one stream record per write");
+        assert!(records.iter().all(|r| r.event_name == "INSERT"));
     }
 }

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4241,3 +4241,268 @@ async fn dynamodb_put_item_omits_item_collection_metrics_without_lsi() {
         "Tables without LSI must omit ItemCollectionMetrics"
     );
 }
+
+/// `ExecuteTransaction` is the PartiQL counterpart to
+/// `TransactWriteItems`. It must be all-or-nothing: a happy-path
+/// commits every statement and emits one Streams record per write,
+/// while a mid-batch failure rolls back every earlier statement and
+/// emits no records — matching real DDB's atomic semantics.
+#[tokio::test]
+async fn dynamodb_execute_transaction_happy_path_commits_and_emits_streams() {
+    use aws_sdk_dynamodb::types::ParameterizedStatement;
+
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+
+    let table_name = "PartiqlTxnHappy";
+    ddb.create_table()
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name(table_name)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+
+    // Three INSERTs in one transaction.
+    ddb.execute_transaction()
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'a'}}"))
+                .build()
+                .unwrap(),
+        )
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'b'}}"))
+                .build()
+                .unwrap(),
+        )
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'c'}}"))
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // All three rows committed.
+    let scan = ddb.scan().table_name(table_name).send().await.unwrap();
+    assert_eq!(scan.items().len(), 3, "all 3 INSERTs must commit");
+
+    // One stream record per write.
+    let desc = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap();
+    let shard_id = desc
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+    let it = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let r = streams
+        .get_records()
+        .shard_iterator(it.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    let records = r.records();
+    assert_eq!(
+        records.len(),
+        3,
+        "ExecuteTransaction must emit one stream record per write"
+    );
+    assert!(records
+        .iter()
+        .all(|rec| rec.event_name().unwrap().as_str() == "INSERT"));
+}
+
+/// Mid-batch failure inside `ExecuteTransaction` rolls back every
+/// earlier statement. The DuplicateItemException on statement #2 must
+/// abort the transaction so neither #1 nor #3 commit, and no Streams
+/// records leak out.
+#[tokio::test]
+async fn dynamodb_execute_transaction_three_writes_middle_fails_reverts_all() {
+    use aws_sdk_dynamodb::types::ParameterizedStatement;
+
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+
+    let table_name = "PartiqlTxnRollback";
+    ddb.create_table()
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name(table_name)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+
+    // Pre-seed pk=b so the second INSERT collides.
+    ddb.put_item()
+        .table_name(table_name)
+        .item("pk", AttributeValue::S("b".into()))
+        .send()
+        .await
+        .unwrap();
+
+    let err = ddb
+        .execute_transaction()
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'a'}}"))
+                .build()
+                .unwrap(),
+        )
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'b'}}"))
+                .build()
+                .unwrap(),
+        )
+        .transact_statements(
+            ParameterizedStatement::builder()
+                .statement(format!("INSERT INTO \"{table_name}\" VALUE {{'pk': 'c'}}"))
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect_err("transaction must fail");
+
+    let cancelled = match err.into_service_error() {
+        aws_sdk_dynamodb::operation::execute_transaction::ExecuteTransactionError::TransactionCanceledException(e) => e,
+        other => panic!("expected TransactionCanceledException, got {other:?}"),
+    };
+    let reasons = cancelled.cancellation_reasons();
+    assert_eq!(reasons.len(), 3, "one CancellationReason per statement");
+    assert_eq!(reasons[0].code(), Some("None"));
+    assert_eq!(reasons[1].code(), Some("DuplicateItem"));
+    assert_eq!(reasons[2].code(), Some("None"));
+
+    // Only the pre-seed must remain.
+    let scan = ddb.scan().table_name(table_name).send().await.unwrap();
+    let pks: Vec<String> = scan
+        .items()
+        .iter()
+        .map(|i| i.get("pk").unwrap().as_s().unwrap().to_string())
+        .collect();
+    assert_eq!(pks, vec!["b".to_string()], "all 3 statements reverted");
+
+    // Only the seed put's INSERT — no stream records from the failed
+    // transaction.
+    let desc = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap();
+    let shard_id = desc
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+    let it = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let r = streams
+        .get_records()
+        .shard_iterator(it.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.records().len(),
+        1,
+        "only the pre-seed INSERT should be on the stream — failed txn emits nothing"
+    );
+}

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -643,6 +643,11 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
         ),
         None => String::new(),
     };
+    // SecurityGroups is a list of SecurityGroupMembership keyed on the
+    // generic `member` wrapper element — not `<SecurityGroupMembership>`
+    // — per the Smithy `SecurityGroupMembershipList$member` shape. The
+    // SDK XML deserializer drops anything else, so each entry must be
+    // wrapped in `<member>`.
     let security_groups_xml = if cluster.security_group_ids.is_empty() {
         "<SecurityGroups/>".to_string()
     } else {
@@ -652,10 +657,10 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
                 .security_group_ids
                 .iter()
                 .map(|sg| format!(
-                    "<SecurityGroupMembership>\
+                    "<member>\
                      <SecurityGroupId>{}</SecurityGroupId>\
                      <Status>active</Status>\
-                     </SecurityGroupMembership>",
+                     </member>",
                     xml_escape(sg)
                 ))
                 .collect::<String>()


### PR DESCRIPTION
## Summary

- Replace the single-pass apply-with-snapshot-revert in `ExecuteTransaction` with a two-phase validate-then-apply: phase 1 runs every PartiQL statement against a cloned state to populate a per-statement `CancellationReasons[]` (mapping `DuplicateItem`/`ResourceNotFound`/`ConditionalCheckFailed`/`ValidationError` back through the wire); only when all statements validate does phase 2 commit them against the real state, with snapshot-revert as a defensive backstop.
- Per-write DDB Streams + Kinesis emission lands only after the apply phase fully succeeds, mirroring `items.rs::put_item` semantics so consumers see the same event stream regardless of write origin.
- Single write lock spans the whole batch — no other writer can observe partial state mid-transaction.

## Test plan
- [x] Unit: `execute_transaction_three_writes_middle_fails_reverts_all` — 3 INSERTs where #2 collides; all reverted, 3 reasons reported, no stream records emitted.
- [x] Unit: `execute_transaction_happy_path_commits_and_emits_per_write` — 3 INSERTs all commit, 3 stream records emitted.
- [x] E2E: `dynamodb_execute_transaction_happy_path_commits_and_emits_streams` via real `aws-sdk-dynamodb` ExecuteTransaction + DynamoDB Streams.
- [x] E2E: `dynamodb_execute_transaction_three_writes_middle_fails_reverts_all` — verifies CancellationReasons + no stream-record leak from a failed txn.
- [x] `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings` clean.
- [x] `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ExecuteTransaction` fully atomic with a two-phase validate-then-apply flow, returning per-statement cancellation reasons and emitting Streams/Kinesis events only after a successful commit. Also fixes `ElastiCache` XML so security groups are returned correctly.

- **New Features**
  - Validate all PartiQL statements against a cloned state; build `CancellationReasons[]` with codes: DuplicateItem, ResourceNotFound, ConditionalCheckFailed, ValidationError.
  - Apply phase snapshots and reverts on any unexpected failure; responses preserved in order.
  - Emit one DynamoDB Streams record per write and deliver Kinesis events only after commit, matching put_item behavior.
  - Hold a single write lock for the entire transaction; release before Kinesis delivery to avoid deadlocks.

- **Bug Fixes**
  - `ElastiCache`: wrap `SecurityGroupMembership` entries in `<member>` in `DescribeCacheClusters` XML so SDKs populate `CacheCluster.security_groups`.

<sup>Written for commit ba2c0a037a6061ec896727112f0b1574c6856fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

