### PR TITLE
feat(apigateway): API key requirement + usage plan throttle/quota (R2)

### DIFF
--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -265,7 +265,12 @@ pub async fn handle(
     // this `(api_id, stage_name)` in `apiStages`, throttle + quota are
     // enforced. Plans without throttle/quota fall through unchanged.
     if api_key_required {
-        if let Err(err) = enforce_usage_plan(service, req, &api_id, &stage_name) {
+        // Effective method on the request — for ANY-method matches, the
+        // caller's verb still drives method-level throttle lookups. The
+        // method path AWS uses in `apiStages[].throttle` keys is
+        // `<resource_path>/<HTTP_METHOD>` (e.g. `/items/GET`).
+        let method_path = format!("{}/{}", resource_path, req.method.as_str().to_uppercase());
+        if let Err(err) = enforce_usage_plan(service, req, &api_id, &stage_name, &method_path) {
             service.record_request(&req.account_id, &api_id, &stage_name, req, err.status());
             return Err(err);
         }
@@ -975,13 +980,16 @@ async fn http_proxy(
 
 // ── Usage plan throttle + quota ──
 
-/// In-memory throttle + quota state. Keyed by
-/// `(account_id, plan_id, key_id)` for buckets and additionally by the
-/// quota's period window string for counters. Lives in
-/// `ApiGatewayService::meters`; not persisted across restarts.
+/// In-memory throttle + quota state. Buckets are keyed by
+/// `(account_id, plan_id, key_id, method_override_path)` — the trailing
+/// segment is empty when the plan-level throttle is in effect, or the
+/// `apiStages[].throttle` map key (e.g. `/items/GET`) when a method
+/// override applies. Counters add a period-window string to the same
+/// `(account, plan, key)` tuple so each window meters independently.
+/// Lives in `ApiGatewayService::meters`; not persisted across restarts.
 #[derive(Default)]
 pub struct UsageMeters {
-    pub buckets: HashMap<(String, String, String), TokenBucket>,
+    pub buckets: HashMap<(String, String, String, String), TokenBucket>,
     pub counters: HashMap<(String, String, String, String), u64>,
 }
 
@@ -1037,6 +1045,7 @@ fn enforce_usage_plan(
     req: &AwsRequest,
     api_id: &str,
     stage_name: &str,
+    method_path: &str,
 ) -> Result<(), AwsServiceError> {
     let presented = req
         .headers
@@ -1065,7 +1074,7 @@ fn enforce_usage_plan(
             Some(k) if k.enabled => k,
             _ => return Err(api_key_forbidden()),
         };
-        let plan = first_matching_plan(state, &key.id, api_id, stage_name);
+        let plan = first_matching_plan(state, &key.id, api_id, stage_name, method_path);
         (key.id, plan)
     };
     let Some(plan) = plan else {
@@ -1074,9 +1083,19 @@ fn enforce_usage_plan(
 
     let mut meters = service.meters.lock();
 
-    // Throttle.
-    if let Some((rate, burst)) = plan.throttle {
-        let bucket_key = (req.account_id.clone(), plan.id.clone(), key_id.clone());
+    // Throttle. A method-level override (`apiStages[].throttle[<path>]`)
+    // takes precedence over the plan-level throttle. The bucket key
+    // includes the method override path so each `(plan, key, method)`
+    // triple meters independently — matching AWS's documented behavior
+    // that method-level limits are evaluated separately from the plan
+    // overall throttle.
+    if let Some((rate, burst, method_override)) = plan.throttle {
+        let bucket_key = (
+            req.account_id.clone(),
+            plan.id.clone(),
+            key_id.clone(),
+            method_override.unwrap_or_default(),
+        );
         let bucket = meters
             .buckets
             .entry(bucket_key)
@@ -1111,8 +1130,14 @@ fn enforce_usage_plan(
 #[derive(Debug, Clone)]
 struct UsagePlanSnapshot {
     id: String,
-    /// `(rateLimit_per_sec, burstLimit)` when configured.
-    throttle: Option<(f64, f64)>,
+    /// Effective throttle for the request:
+    /// `(rateLimit_per_sec, burstLimit, method_override_path)`. The
+    /// third value is `Some(path)` when an `apiStages[].throttle[path]`
+    /// entry overrode the plan-level limits, and `None` when the
+    /// plan-level throttle (or no throttle) is in effect. Carrying the
+    /// path through to the meter key keeps method-level buckets
+    /// segregated from plan-level ones, matching AWS's docs.
+    throttle: Option<(f64, f64, Option<String>)>,
     /// `(limit, period, offset_days)` when configured.
     quota: Option<(u64, QuotaPeriod, i64)>,
 }
@@ -1135,12 +1160,15 @@ fn parse_quota_period(s: &str) -> Option<QuotaPeriod> {
 
 /// AWS picks any matching plan when multiple plans associate the same
 /// key; we pick the first per `BTreeMap` iteration order, which is
-/// deterministic by `usagePlanId`.
+/// deterministic by `usagePlanId`. `method_path` (e.g. `/items/GET`)
+/// drives selection of the per-method throttle override under the
+/// matched `apiStages[]` entry.
 fn first_matching_plan(
     state: &crate::state::ApiGatewayState,
     key_id: &str,
     api_id: &str,
     stage_name: &str,
+    method_path: &str,
 ) -> Option<UsagePlanSnapshot> {
     for (plan_id, keys) in &state.usage_plan_keys {
         if !keys.contains_key(key_id) {
@@ -1149,30 +1177,41 @@ fn first_matching_plan(
         let Some(plan) = state.usage_plans.get(plan_id) else {
             continue;
         };
-        let stage_match = plan.api_stages.iter().any(|stage_entry| {
+        let matched_stage = plan.api_stages.iter().find(|stage_entry| {
             let api = stage_entry.get("apiId").and_then(|v| v.as_str());
             let stage = stage_entry.get("stage").and_then(|v| v.as_str());
             matches!((api, stage), (Some(a), Some(s)) if a == api_id && s == stage_name)
         });
-        if !stage_match {
+        let Some(matched_stage) = matched_stage else {
             continue;
-        }
-        return Some(snapshot_plan(plan));
+        };
+        return Some(snapshot_plan(plan, matched_stage, method_path));
     }
     None
 }
 
-fn snapshot_plan(plan: &crate::state::UsagePlan) -> UsagePlanSnapshot {
-    let throttle = plan.throttle.as_ref().and_then(|t| {
-        let rate = t.get("rateLimit").and_then(|v| v.as_f64())?;
-        let burst = t
-            .get("burstLimit")
-            .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|n| n as f64)))?;
-        if rate <= 0.0 || burst <= 0.0 {
-            return None;
-        }
-        Some((rate, burst))
-    });
+fn snapshot_plan(
+    plan: &crate::state::UsagePlan,
+    matched_stage: &serde_json::Value,
+    method_path: &str,
+) -> UsagePlanSnapshot {
+    let plan_throttle = plan.throttle.as_ref().and_then(parse_throttle);
+    // Method-level override under the matched apiStage entry. AWS keys
+    // these by `<resource_path>/<HTTP_METHOD>`. We try the exact path
+    // first, then the AWS catch-all `/*/*` if no exact match.
+    let method_throttle = matched_stage
+        .get("throttle")
+        .and_then(|t| t.as_object())
+        .and_then(|map| {
+            let exact = map.get(method_path);
+            let wildcard = map.get("/*/*");
+            exact
+                .or(wildcard)
+                .and_then(parse_throttle)
+                .map(|(rate, burst)| (rate, burst, Some(method_path.to_string())))
+        });
+    let throttle =
+        method_throttle.or_else(|| plan_throttle.map(|(rate, burst)| (rate, burst, None)));
     let quota = plan.quota.as_ref().and_then(|q| {
         let limit = q.get("limit").and_then(|v| v.as_u64())?;
         let period_str = q.get("period").and_then(|v| v.as_str())?;
@@ -1185,6 +1224,20 @@ fn snapshot_plan(plan: &crate::state::UsagePlan) -> UsagePlanSnapshot {
         throttle,
         quota,
     }
+}
+
+/// Parse a `{rateLimit, burstLimit}` JSON object into a `(rate, burst)`
+/// pair. Returns `None` for missing fields, non-numeric values, or
+/// non-positive limits — AWS treats those as "no throttle configured".
+fn parse_throttle(t: &serde_json::Value) -> Option<(f64, f64)> {
+    let rate = t.get("rateLimit").and_then(|v| v.as_f64())?;
+    let burst = t
+        .get("burstLimit")
+        .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|n| n as f64)))?;
+    if rate <= 0.0 || burst <= 0.0 {
+        return None;
+    }
+    Some((rate, burst))
 }
 
 /// Compute the canonical window key for a quota period. AWS resets
@@ -2016,6 +2069,168 @@ mod tests {
         let err = match handle(&service, &make_request(headers)).await {
             Err(e) => e,
             Ok(_) => panic!("second request must trip quota"),
+        };
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// Plan throttle is generous (100/100) but the apiStages entry
+    /// pins `/items/GET` to 1/1. The second request must trip the
+    /// method-level bucket even though the plan-level rate would have
+    /// allowed it — mirroring AWS's documented per-method overrides.
+    #[tokio::test]
+    async fn method_level_throttle_override_takes_precedence_over_plan() {
+        use crate::state::{ApiKey, UsagePlan};
+        let state = build_state("NONE", None);
+        let key_value = "method-key".to_string();
+        let plan_id = "plan-method-override".to_string();
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.api_key_required = true;
+            }
+            st.api_keys.insert(
+                "k1".to_string(),
+                ApiKey {
+                    id: "k1".to_string(),
+                    value: key_value.clone(),
+                    name: "k".to_string(),
+                    description: None,
+                    enabled: true,
+                    created_date: Utc::now(),
+                    last_updated_date: Utc::now(),
+                    stage_keys: vec![],
+                    tags: BTreeMap::new(),
+                    customer_id: None,
+                },
+            );
+            st.usage_plans.insert(
+                plan_id.clone(),
+                UsagePlan {
+                    id: plan_id.clone(),
+                    name: "p".to_string(),
+                    description: None,
+                    api_stages: vec![serde_json::json!({
+                        "apiId": TEST_API_ID,
+                        "stage": "prod",
+                        "throttle": {
+                            "/items/GET": {"rateLimit": 1.0, "burstLimit": 1}
+                        }
+                    })],
+                    // Plan-level limits intentionally generous so a
+                    // failure here proves the method-level bucket was
+                    // consulted.
+                    throttle: Some(serde_json::json!({"rateLimit": 100.0, "burstLimit": 100})),
+                    quota: None,
+                    product_code: None,
+                    tags: BTreeMap::new(),
+                },
+            );
+            let mut plan_keys = BTreeMap::new();
+            plan_keys.insert(
+                "k1".to_string(),
+                serde_json::json!({"id": "k1", "type": "API_KEY", "value": key_value}),
+            );
+            st.usage_plan_keys.insert(plan_id.clone(), plan_keys);
+        }
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", key_value.parse().unwrap());
+
+        let first = handle(&service, &make_request(headers.clone()))
+            .await
+            .expect("first request consumes the only method-level token");
+        assert_eq!(first.status, StatusCode::OK);
+
+        let err = match handle(&service, &make_request(headers)).await {
+            Err(e) => e,
+            Ok(_) => panic!("second request must trip method-level throttle"),
+        };
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
+    }
+
+    /// `/*/*` wildcard under apiStages.throttle applies to any method
+    /// path that lacks a more specific entry. Same shape as the exact
+    /// override test, but keyed under the catch-all instead of
+    /// `/items/GET`.
+    #[tokio::test]
+    async fn method_level_throttle_wildcard_catchall_applies() {
+        use crate::state::{ApiKey, UsagePlan};
+        let state = build_state("NONE", None);
+        let key_value = "wildcard-key".to_string();
+        let plan_id = "plan-wildcard".to_string();
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.api_key_required = true;
+            }
+            st.api_keys.insert(
+                "k2".to_string(),
+                ApiKey {
+                    id: "k2".to_string(),
+                    value: key_value.clone(),
+                    name: "k".to_string(),
+                    description: None,
+                    enabled: true,
+                    created_date: Utc::now(),
+                    last_updated_date: Utc::now(),
+                    stage_keys: vec![],
+                    tags: BTreeMap::new(),
+                    customer_id: None,
+                },
+            );
+            st.usage_plans.insert(
+                plan_id.clone(),
+                UsagePlan {
+                    id: plan_id.clone(),
+                    name: "p".to_string(),
+                    description: None,
+                    api_stages: vec![serde_json::json!({
+                        "apiId": TEST_API_ID,
+                        "stage": "prod",
+                        "throttle": {
+                            "/*/*": {"rateLimit": 1.0, "burstLimit": 1}
+                        }
+                    })],
+                    throttle: None,
+                    quota: None,
+                    product_code: None,
+                    tags: BTreeMap::new(),
+                },
+            );
+            let mut plan_keys = BTreeMap::new();
+            plan_keys.insert(
+                "k2".to_string(),
+                serde_json::json!({"id": "k2", "type": "API_KEY", "value": key_value}),
+            );
+            st.usage_plan_keys.insert(plan_id.clone(), plan_keys);
+        }
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", key_value.parse().unwrap());
+
+        let first = handle(&service, &make_request(headers.clone()))
+            .await
+            .expect("first request consumes the only wildcard token");
+        assert_eq!(first.status, StatusCode::OK);
+
+        let err = match handle(&service, &make_request(headers)).await {
+            Err(e) => e,
+            Ok(_) => panic!("second request must trip wildcard throttle"),
         };
         assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
     }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -575,3 +575,158 @@ async fn data_plane_cognito_authorizer_accepts_real_jwt_and_rejects_garbage() {
         .expect("send");
     assert_eq!(good.status(), 200);
 }
+
+// ── Usage plan throttle + quota (Phase R2) ──
+//
+// Drives the api-key + usage-plan enforcement path end-to-end through
+// real HTTP requests so we exercise the facade routing, the api-key
+// header check, and the in-memory token bucket. The unit tests cover
+// the meter math and method-level overrides; this case proves the wiring
+// is connected through the public API surface.
+
+/// Provision an API with `apiKeyRequired = true` on a MOCK GET method and
+/// associate a fresh API key + usage plan with the given throttle. Returns
+/// `(api_id, api_key_value)`.
+async fn provision_metered_api(
+    client: &aws_sdk_apigateway::Client,
+    plan_throttle: aws_sdk_apigateway::types::ThrottleSettings,
+) -> (String, String) {
+    use aws_sdk_apigateway::types::{ApiStage, IntegrationType};
+
+    let api = client
+        .create_rest_api()
+        .name("metered")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+    let resource = client
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("items")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+    client
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .authorization_type("NONE")
+        .api_key_required(true)
+        .send()
+        .await
+        .expect("put_method");
+    client
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .r#type(IntegrationType::Mock)
+        .send()
+        .await
+        .expect("put_integration");
+    client
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+
+    let key = client
+        .create_api_key()
+        .name("metered-key")
+        .enabled(true)
+        .send()
+        .await
+        .expect("create_api_key");
+    let key_id = key.id().unwrap().to_string();
+    let key_value = key.value().unwrap().to_string();
+
+    let plan = client
+        .create_usage_plan()
+        .name("metered-plan")
+        .api_stages(ApiStage::builder().api_id(&api_id).stage("prod").build())
+        .throttle(plan_throttle)
+        .send()
+        .await
+        .expect("create_usage_plan");
+    let plan_id = plan.id().unwrap().to_string();
+    client
+        .create_usage_plan_key()
+        .usage_plan_id(&plan_id)
+        .key_id(&key_id)
+        .key_type("API_KEY")
+        .send()
+        .await
+        .expect("create_usage_plan_key");
+
+    (api_id, key_value)
+}
+
+#[tokio::test]
+async fn data_plane_missing_api_key_returns_403() {
+    use aws_sdk_apigateway::types::ThrottleSettings;
+
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+    let (api_id, _key) = provision_metered_api(
+        &client,
+        ThrottleSettings::builder()
+            .rate_limit(100.0)
+            .burst_limit(100)
+            .build(),
+    )
+    .await;
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 403);
+}
+
+#[tokio::test]
+async fn data_plane_throttle_returns_429_when_burst_exhausted() {
+    use aws_sdk_apigateway::types::ThrottleSettings;
+
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+    // 1 RPS / burst=1: the bucket has exactly one token at start, the
+    // second request must trip 429 before the rate refills a fresh
+    // token.
+    let (api_id, key_value) = provision_metered_api(
+        &client,
+        ThrottleSettings::builder()
+            .rate_limit(1.0)
+            .burst_limit(1)
+            .build(),
+    )
+    .await;
+
+    let http = reqwest::Client::new();
+    let first = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("x-api-key", &key_value)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(first.status(), 200);
+
+    let second = http
+        .get(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("x-api-key", &key_value)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(second.status(), 429);
+}

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -646,16 +646,22 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
     let security_groups_xml = if cluster.security_group_ids.is_empty() {
         "<SecurityGroups/>".to_string()
     } else {
+        // SecurityGroupMembershipList's member has no xmlName trait, so
+        // awsQuery serializes each entry under the default `<member>`
+        // tag — not `<SecurityGroupMembership>`. Real AWS responses use
+        // `<member>`, and the AWS SDK Rust deserializer treats anything
+        // else as an unknown element and drops the entry, leaving
+        // `cluster.security_groups()` empty on the client side.
         format!(
             "<SecurityGroups>{}</SecurityGroups>",
             cluster
                 .security_group_ids
                 .iter()
                 .map(|sg| format!(
-                    "<SecurityGroupMembership>\
+                    "<member>\
                      <SecurityGroupId>{}</SecurityGroupId>\
                      <Status>active</Status>\
-                     </SecurityGroupMembership>",
+                     </member>",
                     xml_escape(sg)
                 ))
                 .collect::<String>()

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -4039,6 +4039,19 @@ fn create_cache_cluster_persists_security_and_subnet_groups() {
     assert!(body.contains("<CacheSecurityGroupName>ec2c-1</CacheSecurityGroupName>"));
     assert!(body.contains("<CacheSecurityGroupName>ec2c-2</CacheSecurityGroupName>"));
     assert!(body.contains("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"));
+    // SecurityGroupMembershipList's member has no xmlName so awsQuery
+    // serializes each entry under `<member>`. Anything else (e.g.
+    // `<SecurityGroupMembership>`) makes the AWS SDK Rust deserializer
+    // drop the entry. Lock the wire shape in so the regression in
+    // PR #1169 doesn't come back.
+    let normalized = body.replace([' ', '\n'], "");
+    assert!(normalized.contains(
+        "<member><SecurityGroupId>sg-aaa</SecurityGroupId><Status>active</Status></member>"
+    ));
+    assert!(normalized.contains(
+        "<member><SecurityGroupId>sg-bbb</SecurityGroupId><Status>active</Status></member>"
+    ));
+    assert!(!body.contains("<SecurityGroupMembership>"));
 }
 
 #[test]

--- a/website/content/docs/services/apigateway.md
+++ b/website/content/docs/services/apigateway.md
@@ -16,7 +16,7 @@ REST APIs (v1) and HTTP APIs (v2) are independent AWS services. The v2 (HTTP API
 - **Deployments & stages** — CreateDeployment auto-creates a stage when `stageName` is set; cache flush operations
 - **Models & request validators** — schema management; validator CRUD
 - **Authorizers** — TOKEN, REQUEST, COGNITO_USER_POOLS shapes
-- **API keys & usage plans** — CRUD + association via `usage_plan_keys`; data plane enforces `apiKeyRequired`, plan-level `throttle` (token-bucket per key+plan), and `quota` (DAY/WEEK/MONTH counters)
+- **API keys & usage plans** — CRUD + association via `usage_plan_keys`; data plane enforces `apiKeyRequired`, plan-level `throttle` (token-bucket per key+plan), method-level overrides under `apiStages[].throttle["{path}/{HTTP_METHOD}"]` (including the `/*/*` wildcard), and `quota` (DAY/WEEK/MONTH counters)
 - **VPC links, domain names, base path mappings, client certificates** — full CRUD
 - **Documentation parts/versions** — full CRUD
 - **Gateway responses** — full CRUD
@@ -32,7 +32,7 @@ When a request arrives at a deployed stage URL (`/restapis/{api_id}/{stage}/{pat
 - `HTTP` / `HTTP_PROXY` — forwards via `reqwest` to the configured URI.
 - `MOCK` — returns an empty JSON body unless an integration response template overrides it.
 
-Before the integration runs, methods with `apiKeyRequired = true` go through the API key + usage plan gate: an `x-api-key` header is required, the value is matched against `state.api_keys` (must be enabled), and the first usage plan whose `apiStages[]` contains `(api_id, stage)` is selected. The plan's `throttle` (token-bucket on `rateLimit`/`burstLimit`) and `quota` (DAY/WEEK/MONTH counter against `limit`, with `offset` shifting the period boundary) are enforced; failures return `403 ForbiddenException` and `429 LimitExceededException` respectively, matching the AWS wire shape.
+Before the integration runs, methods with `apiKeyRequired = true` go through the API key + usage plan gate: an `x-api-key` header is required, the value is matched against `state.api_keys` (must be enabled), and the first usage plan whose `apiStages[]` contains `(api_id, stage)` is selected. Throttle resolution prefers the matched apiStage's `throttle["{resource_path}/{HTTP_METHOD}"]` override (with `/*/*` honored as the catch-all) over the plan-level `throttle`; the chosen `(rateLimit, burstLimit)` drives a token-bucket whose meter key includes the override path so per-method buckets stay segregated. The plan's `quota` (DAY/WEEK/MONTH counter against `limit`, with `offset` shifting the period boundary) is enforced after throttle. Failures return `403 ForbiddenException` and `429 LimitExceededException` respectively, matching the AWS wire shape.
 
 ## Protocol
 


### PR DESCRIPTION
## Summary

- Adds method-level throttle override resolution under `apiStages[].throttle["{path}/{HTTP_METHOD}"]` (with `/*/*` honored as the catch-all) on top of the plan-level throttle shipped in #1117.
- Method-level limits short-circuit the plan-level throttle and meter into their own bucket keyed by `(account, plan, key, method_path)` so per-method buckets stay segregated.
- Updates `apigateway.md` doc to describe the override resolution order.
- Drive-by fix for an unrelated CI red on `main` introduced by #1169: ElastiCache `DescribeCacheClusters` was emitting `<SecurityGroupMembership>` instead of the awsQuery default `<member>` tag, so the AWS SDK Rust deserializer dropped every entry. Fix is a single-line tag rename plus a regression-locking unit test assertion.

## Test plan

- [x] Unit: `method_level_throttle_override_takes_precedence_over_plan` — plan-level 100/100, method-level `/items/GET` 1/1; second request 429s.
- [x] Unit: `method_level_throttle_wildcard_catchall_applies` — only `/*/*` set to 1/1; second request 429s.
- [x] E2E: `data_plane_missing_api_key_returns_403` — full `create_rest_api -> put_method(api_key_required) -> create_usage_plan -> create_usage_plan_key` chain via the AWS SDK; HTTP without `x-api-key` returns 403.
- [x] E2E: `data_plane_throttle_returns_429_when_burst_exhausted` — same chain with throttle 1/1; first request 200, second 429.
- [x] Unit: `create_cache_cluster_persists_security_and_subnet_groups` — locks `<member><SecurityGroupId>...</SecurityGroupId></member>` wire shape and explicitly rejects the regressed `<SecurityGroupMembership>` tag.
- [x] `cargo test -p fakecloud-apigateway` — 29 passed (incl. 2 new).
- [x] `cargo test -p fakecloud-e2e --test apigateway` — 8 passed (incl. 2 new).
- [x] `cargo test -p fakecloud-elasticache` — 206 passed (incl. extended assertion).
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt --check` clean.