### PR TITLE
feat(ecr): repository policy enforcement on cross-account image/layer ops (P2)

### DIFF
--- a/crates/fakecloud-e2e/tests/ecr_cross_account.rs
+++ b/crates/fakecloud-e2e/tests/ecr_cross_account.rs
@@ -1,0 +1,371 @@
+//! ECR cross-account repository policy enforcement (P2).
+//!
+//! Validates that the JSON control plane evaluates the repository
+//! resource policy via the IAM evaluator on cross-account image and
+//! layer ops, returning the canonical AWS error codes:
+//!
+//! * `RepositoryPolicyNotFoundException` when the repository has no
+//!   policy at all.
+//! * `AccessDeniedException` when a policy exists but doesn't grant
+//!   the requested action to the caller.
+//! * Allow when the policy explicitly grants the action to the caller.
+//!
+//! Same-account flows are covered by the wider ECR test suite — this
+//! file deliberately focuses on the cross-account gate that real AWS
+//! enforces and that real customers rely on for share-out scenarios.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use aws_sdk_ecr::Client as EcrClient;
+use helpers::TestServer;
+
+const ACCOUNT_A: &str = "123456789012"; // repository owner
+const ACCOUNT_B: &str = "222222222222"; // allowed cross-account caller
+const ACCOUNT_C: &str = "333333333333"; // unrelated caller
+
+async fn start() -> TestServer {
+    TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await
+}
+
+async fn ecr_client_for(server: &TestServer, akid: &str, secret: &str) -> EcrClient {
+    let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(akid, secret, None, None, "ecr-x-acct"))
+        .load()
+        .await;
+    EcrClient::new(&cfg)
+}
+
+#[tokio::test]
+async fn cross_account_batch_get_image_honours_repo_policy() {
+    let server = start().await;
+
+    // Bootstrap admins in all three accounts.
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+    let (c_akid, c_secret) = server.create_admin(ACCOUNT_C, "admin-c").await;
+
+    let ecr_a = ecr_client_for(&server, &a_akid, &a_secret).await;
+    let ecr_b = ecr_client_for(&server, &b_akid, &b_secret).await;
+    let ecr_c = ecr_client_for(&server, &c_akid, &c_secret).await;
+
+    // Account A creates a repo and pushes an image so we can request it
+    // by tag from accounts B and C.
+    ecr_a
+        .create_repository()
+        .repository_name("shared")
+        .send()
+        .await
+        .expect("create_repository in A");
+
+    let manifest = r#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":0,"mediaType":"application/vnd.docker.container.image.v1+json"},"layers":[]}"#;
+    ecr_a
+        .put_image()
+        .repository_name("shared")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .expect("put_image in A");
+
+    // Step 1: with NO policy, account B's BatchGetImage targeting A's
+    // registry must fail with RepositoryPolicyNotFoundException so the
+    // caller can tell that the owner hasn't shared the repo at all.
+    let err_no_policy = ecr_b
+        .batch_get_image()
+        .registry_id(ACCOUNT_A)
+        .repository_name("shared")
+        .image_ids(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("expected RepositoryPolicyNotFoundException without policy");
+    let msg = format!("{err_no_policy:?}");
+    assert!(
+        msg.contains("RepositoryPolicyNotFound"),
+        "expected RepositoryPolicyNotFoundException without policy, got: {msg}"
+    );
+
+    // Step 2: A sets a policy allowing only account B for BatchGetImage.
+    let policy = format!(
+        r#"{{
+            "Version": "2012-10-17",
+            "Statement": [{{
+                "Sid": "ShareToB",
+                "Effect": "Allow",
+                "Principal": {{"AWS": "arn:aws:iam::{ACCOUNT_B}:root"}},
+                "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"],
+                "Resource": "*"
+            }}]
+        }}"#
+    );
+    ecr_a
+        .set_repository_policy()
+        .repository_name("shared")
+        .policy_text(&policy)
+        .send()
+        .await
+        .expect("set_repository_policy");
+
+    // Step 3: account B's BatchGetImage now succeeds (policy explicitly allows).
+    let resp_b = ecr_b
+        .batch_get_image()
+        .registry_id(ACCOUNT_A)
+        .repository_name("shared")
+        .image_ids(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("BatchGetImage from B should succeed");
+    assert_eq!(
+        resp_b.images().len(),
+        1,
+        "expected one image returned to allowed caller"
+    );
+
+    // Step 4: account C is not in the policy — implicit deny path returns
+    // AccessDeniedException, NOT RepositoryPolicyNotFoundException, so the
+    // caller can tell a policy exists but they're not on the allow list.
+    let err_c = ecr_c
+        .batch_get_image()
+        .registry_id(ACCOUNT_A)
+        .repository_name("shared")
+        .image_ids(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("expected AccessDeniedException for unrelated caller");
+    let msg_c = format!("{err_c:?}");
+    assert!(
+        msg_c.contains("AccessDenied"),
+        "expected AccessDeniedException for C, got: {msg_c}"
+    );
+
+    // Step 5: same-account caller (A itself) bypasses the resource policy
+    // entirely. The IAM identity policies handle this path; the
+    // resource-policy gate must not block the owner.
+    let resp_a = ecr_a
+        .batch_get_image()
+        .repository_name("shared")
+        .image_ids(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("BatchGetImage from A should always succeed");
+    assert_eq!(resp_a.images().len(), 1);
+}
+
+#[tokio::test]
+async fn cross_account_get_download_url_honours_repo_policy() {
+    let server = start().await;
+
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+    let (c_akid, c_secret) = server.create_admin(ACCOUNT_C, "admin-c").await;
+
+    let ecr_a = ecr_client_for(&server, &a_akid, &a_secret).await;
+    let ecr_b = ecr_client_for(&server, &b_akid, &b_secret).await;
+    let ecr_c = ecr_client_for(&server, &c_akid, &c_secret).await;
+
+    ecr_a
+        .create_repository()
+        .repository_name("layer-share")
+        .send()
+        .await
+        .expect("create_repository");
+
+    // Push a layer so GetDownloadUrlForLayer has something to look up.
+    let init = ecr_a
+        .initiate_layer_upload()
+        .repository_name("layer-share")
+        .send()
+        .await
+        .expect("initiate_layer_upload");
+    let upload_id = init.upload_id().unwrap().to_string();
+
+    let blob = b"hello-fakecloud-layer-bytes";
+    ecr_a
+        .upload_layer_part()
+        .repository_name("layer-share")
+        .upload_id(&upload_id)
+        .part_first_byte(0)
+        .part_last_byte((blob.len() as i64) - 1)
+        .layer_part_blob(aws_smithy_types::Blob::new(blob.to_vec()))
+        .send()
+        .await
+        .expect("upload_layer_part");
+
+    // Compute sha256 of the blob so CompleteLayerUpload accepts the digest.
+    use sha2::Digest as _;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(blob);
+    let bytes = hasher.finalize();
+    let mut hex_digest = String::with_capacity(2 * bytes.len());
+    for b in bytes.iter() {
+        hex_digest.push_str(&format!("{b:02x}"));
+    }
+    let digest = format!("sha256:{hex_digest}");
+
+    ecr_a
+        .complete_layer_upload()
+        .repository_name("layer-share")
+        .upload_id(&upload_id)
+        .layer_digests(&digest)
+        .send()
+        .await
+        .expect("complete_layer_upload");
+
+    // No policy: B sees RepositoryPolicyNotFoundException.
+    let err_no_policy = ecr_b
+        .get_download_url_for_layer()
+        .registry_id(ACCOUNT_A)
+        .repository_name("layer-share")
+        .layer_digest(&digest)
+        .send()
+        .await
+        .expect_err("expected RepositoryPolicyNotFoundException without policy");
+    let msg = format!("{err_no_policy:?}");
+    assert!(
+        msg.contains("RepositoryPolicyNotFound"),
+        "expected RepositoryPolicyNotFoundException, got: {msg}"
+    );
+
+    // Owner allows only B for GetDownloadUrlForLayer.
+    let policy = format!(
+        r#"{{
+            "Version": "2012-10-17",
+            "Statement": [{{
+                "Effect": "Allow",
+                "Principal": {{"AWS": "arn:aws:iam::{ACCOUNT_B}:root"}},
+                "Action": "ecr:GetDownloadUrlForLayer",
+                "Resource": "*"
+            }}]
+        }}"#
+    );
+    ecr_a
+        .set_repository_policy()
+        .repository_name("layer-share")
+        .policy_text(&policy)
+        .send()
+        .await
+        .expect("set_repository_policy");
+
+    // B succeeds.
+    let resp_b = ecr_b
+        .get_download_url_for_layer()
+        .registry_id(ACCOUNT_A)
+        .repository_name("layer-share")
+        .layer_digest(&digest)
+        .send()
+        .await
+        .expect("GetDownloadUrlForLayer from B should succeed");
+    assert_eq!(resp_b.layer_digest(), Some(digest.as_str()));
+
+    // C is denied with AccessDeniedException.
+    let err_c = ecr_c
+        .get_download_url_for_layer()
+        .registry_id(ACCOUNT_A)
+        .repository_name("layer-share")
+        .layer_digest(&digest)
+        .send()
+        .await
+        .expect_err("expected AccessDeniedException for unrelated caller");
+    let msg_c = format!("{err_c:?}");
+    assert!(
+        msg_c.contains("AccessDenied"),
+        "expected AccessDeniedException, got: {msg_c}"
+    );
+}
+
+#[tokio::test]
+async fn cross_account_explicit_deny_overrides_allow() {
+    let server = start().await;
+
+    let (a_akid, a_secret) = server.create_admin(ACCOUNT_A, "admin-a").await;
+    let (b_akid, b_secret) = server.create_admin(ACCOUNT_B, "admin-b").await;
+
+    let ecr_a = ecr_client_for(&server, &a_akid, &a_secret).await;
+    let ecr_b = ecr_client_for(&server, &b_akid, &b_secret).await;
+
+    ecr_a
+        .create_repository()
+        .repository_name("deny-wins")
+        .send()
+        .await
+        .expect("create_repository");
+
+    let manifest = r#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":0,"mediaType":"application/vnd.docker.container.image.v1+json"},"layers":[]}"#;
+    ecr_a
+        .put_image()
+        .repository_name("deny-wins")
+        .image_manifest(manifest)
+        .image_tag("v1")
+        .send()
+        .await
+        .expect("put_image");
+
+    // Allow + explicit Deny on the same action — Deny wins (matches AWS
+    // semantics implemented in fakecloud-iam's evaluator).
+    let policy = format!(
+        r#"{{
+            "Version": "2012-10-17",
+            "Statement": [
+                {{
+                    "Effect": "Allow",
+                    "Principal": {{"AWS": "arn:aws:iam::{ACCOUNT_B}:root"}},
+                    "Action": "ecr:BatchGetImage",
+                    "Resource": "*"
+                }},
+                {{
+                    "Effect": "Deny",
+                    "Principal": {{"AWS": "arn:aws:iam::{ACCOUNT_B}:root"}},
+                    "Action": "ecr:BatchGetImage",
+                    "Resource": "*"
+                }}
+            ]
+        }}"#
+    );
+    ecr_a
+        .set_repository_policy()
+        .repository_name("deny-wins")
+        .policy_text(&policy)
+        .send()
+        .await
+        .expect("set_repository_policy");
+
+    let err = ecr_b
+        .batch_get_image()
+        .registry_id(ACCOUNT_A)
+        .repository_name("deny-wins")
+        .image_ids(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("expected AccessDeniedException due to explicit Deny");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AccessDenied"),
+        "expected AccessDeniedException with explicit Deny, got: {msg}"
+    );
+}

--- a/crates/fakecloud-ecr/src/service.rs
+++ b/crates/fakecloud-ecr/src/service.rs
@@ -1065,6 +1065,15 @@ impl EcrService {
             .get_mut(&name)
             .ok_or_else(|| repository_not_found(&name))?;
 
+        check_repo_policy(
+            &account,
+            &request.account_id,
+            &repo.repository_arn,
+            &name,
+            repo.policy.as_deref(),
+            "ecr:BatchDeleteImage",
+        )?;
+
         let mut deleted: Vec<Value> = Vec::new();
         let mut failures: Vec<Value> = Vec::new();
         for id in &ids {

--- a/crates/fakecloud-ecr/src/service_helpers.rs
+++ b/crates/fakecloud-ecr/src/service_helpers.rs
@@ -800,8 +800,17 @@ pub(crate) fn repository_filters_match(
 /// Enforce the cross-account repo-policy gate at a handler. Returns
 /// Ok(()) when the caller belongs to the same account as the repo
 /// (in which case ECR falls back to the caller's IAM perms — out of
-/// scope for this batch), or when an explicit Allow on `action` exists.
-/// Otherwise returns the canonical AccessDeniedException.
+/// scope for this batch), or when the repository policy explicitly
+/// Allows the requested action for the caller. Otherwise returns the
+/// canonical AWS error:
+///
+/// * `RepositoryPolicyNotFoundException` — the repository has no
+///   policy at all (real AWS distinguishes "no policy" from "policy
+///   denies" so callers can tell whether they need to ask the
+///   repository owner to create a policy or fix an existing one).
+/// * `AccessDeniedException` — a policy exists but doesn't grant the
+///   requested action to the caller (either implicit or explicit
+///   deny).
 pub(crate) fn check_repo_policy(
     repo_owner_account: &str,
     caller_account: &str,
@@ -813,28 +822,45 @@ pub(crate) fn check_repo_policy(
     if caller_account == repo_owner_account {
         return Ok(());
     }
-    if repository_policy_allows(policy_doc, caller_account, repo_arn, action) {
-        return Ok(());
+    match repository_policy_decision(policy_doc, caller_account, repo_arn, action) {
+        RepoPolicyDecision::Allow => Ok(()),
+        RepoPolicyDecision::NoPolicy => Err(repository_policy_not_found(repo_name)),
+        RepoPolicyDecision::Deny => Err(repository_policy_denied(repo_name, action)),
     }
-    Err(repository_policy_denied(repo_name, action))
 }
 
-/// Cross-account ECR repository policy gate. When the caller's account
-/// differs from the repository's owning account, the repo must have a
-/// resource policy that explicitly Allows the requested action — empty
-/// policies implicitly deny, mirroring real AWS.
-pub(crate) fn repository_policy_allows(
+/// Outcome of evaluating a cross-account ECR request against a
+/// repository's resource policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoPolicyDecision {
+    /// Policy exists and explicitly allows the requested action for
+    /// the caller. Maps to `Decision::Allow` from the IAM evaluator.
+    Allow,
+    /// No repository policy exists at all (or it's an empty string).
+    /// AWS surfaces this as `RepositoryPolicyNotFoundException` so
+    /// callers can distinguish "owner hasn't shared this repo" from
+    /// "owner shared it but not with you".
+    NoPolicy,
+    /// A policy exists but its evaluation produced `ImplicitDeny` or
+    /// `ExplicitDeny`. AWS surfaces this as `AccessDeniedException`.
+    Deny,
+}
+
+/// Cross-account ECR repository policy decision. When the caller's
+/// account differs from the repository's owning account, the repo
+/// must have a resource policy that explicitly Allows the requested
+/// action — empty / missing policies map to [`RepoPolicyDecision::NoPolicy`]
+/// so the handler can return the more specific AWS error code.
+pub(crate) fn repository_policy_decision(
     policy_doc: Option<&str>,
     caller_account: &str,
     repo_arn: &str,
     action: &str,
-) -> bool {
-    let Some(doc) = policy_doc else {
-        return false;
+) -> RepoPolicyDecision {
+    let doc = match policy_doc {
+        Some(d) if !d.is_empty() => d,
+        _ => return RepoPolicyDecision::NoPolicy,
     };
-    if doc.is_empty() {
-        return false;
-    }
     use fakecloud_core::auth::{Principal, PrincipalType};
     use fakecloud_iam::evaluator::{evaluate, Decision, EvalRequest, PolicyDocument};
     let parsed = PolicyDocument::parse(doc);
@@ -853,5 +879,24 @@ pub(crate) fn repository_policy_allows(
         resource: repo_arn.to_string(),
         context: Default::default(),
     };
-    matches!(evaluate(&[parsed], &req), Decision::Allow)
+    match evaluate(&[parsed], &req) {
+        Decision::Allow => RepoPolicyDecision::Allow,
+        Decision::ImplicitDeny | Decision::ExplicitDeny => RepoPolicyDecision::Deny,
+    }
+}
+
+/// Boolean shim retained for the existing unit tests (and any callers
+/// that only need a yes/no answer). Returns `true` only when the
+/// repository policy explicitly allows the action.
+#[cfg(test)]
+pub(crate) fn repository_policy_allows(
+    policy_doc: Option<&str>,
+    caller_account: &str,
+    repo_arn: &str,
+    action: &str,
+) -> bool {
+    matches!(
+        repository_policy_decision(policy_doc, caller_account, repo_arn, action),
+        RepoPolicyDecision::Allow
+    )
 }

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -413,6 +413,119 @@ fn repository_policy_allows_empty_policy_denies() {
     ));
 }
 
+#[test]
+fn check_repo_policy_same_account_passes_without_policy() {
+    use super::check_repo_policy;
+    // Same-account caller: policy is irrelevant (real ECR falls back to
+    // the caller's IAM identity policies for the same-account path).
+    let res = check_repo_policy(
+        "111111111111",
+        "111111111111",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "app",
+        None,
+        "ecr:BatchGetImage",
+    );
+    assert!(res.is_ok());
+}
+
+#[test]
+fn check_repo_policy_cross_account_no_policy_returns_not_found() {
+    use super::check_repo_policy;
+    let err = check_repo_policy(
+        "111111111111",
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "app",
+        None,
+        "ecr:BatchGetImage",
+    )
+    .expect_err("expected error");
+    assert_eq!(err.code(), "RepositoryPolicyNotFoundException");
+}
+
+#[test]
+fn check_repo_policy_cross_account_explicit_allow_passes() {
+    use super::check_repo_policy;
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+            "Action": "ecr:BatchGetImage",
+            "Resource": "*"
+        }]
+    }"#;
+    let res = check_repo_policy(
+        "111111111111",
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "app",
+        Some(policy),
+        "ecr:BatchGetImage",
+    );
+    assert!(res.is_ok());
+}
+
+#[test]
+fn check_repo_policy_cross_account_implicit_deny_returns_access_denied() {
+    use super::check_repo_policy;
+    // Policy exists but doesn't grant the requested action: ECR returns
+    // AccessDeniedException, not RepositoryPolicyNotFoundException.
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::333333333333:root"},
+            "Action": "ecr:BatchGetImage",
+            "Resource": "*"
+        }]
+    }"#;
+    let err = check_repo_policy(
+        "111111111111",
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "app",
+        Some(policy),
+        "ecr:BatchGetImage",
+    )
+    .expect_err("expected error");
+    assert_eq!(err.code(), "AccessDeniedException");
+}
+
+#[test]
+fn check_repo_policy_cross_account_explicit_deny_returns_access_denied() {
+    use super::check_repo_policy;
+    // Explicit Deny in the resource policy beats any matching Allow.
+    let policy = r#"{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+                "Action": "ecr:BatchGetImage",
+                "Resource": "*"
+            },
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+                "Action": "ecr:BatchGetImage",
+                "Resource": "*"
+            }
+        ]
+    }"#;
+    let err = check_repo_policy(
+        "111111111111",
+        "222222222222",
+        "arn:aws:ecr:us-east-1:111111111111:repository/app",
+        "app",
+        Some(policy),
+        "ecr:BatchGetImage",
+    )
+    .expect_err("expected error");
+    assert_eq!(err.code(), "AccessDeniedException");
+}
+
 // ── Replication: PutImage trigger + DescribeImageReplicationStatus ──
 
 #[cfg(test)]
@@ -693,6 +806,11 @@ mod repo_policy_enforcement_tests {
 
     #[test]
     fn batch_get_image_cross_account_blocked_when_no_policy() {
+        // Real ECR distinguishes "no resource policy at all" from "policy
+        // exists but denies": the former returns
+        // RepositoryPolicyNotFoundException so the cross-account caller can
+        // tell the owner hasn't shared the repo, while the latter returns
+        // AccessDeniedException.
         let (svc, _state) = fixture(None);
         let req = make_request(
             "BatchGetImage",
@@ -707,8 +825,8 @@ mod repo_policy_enforcement_tests {
             Err(e) => e,
             Ok(_) => panic!("expected denial"),
         };
-        assert_eq!(err.status(), StatusCode::FORBIDDEN);
-        assert_eq!(err.code(), "AccessDeniedException");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.code(), "RepositoryPolicyNotFoundException");
     }
 
     #[test]
@@ -785,8 +903,73 @@ mod repo_policy_enforcement_tests {
             Err(e) => e,
             Ok(_) => panic!("expected denial"),
         };
-        assert_eq!(err.status(), StatusCode::FORBIDDEN);
-        assert_eq!(err.code(), "AccessDeniedException");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.code(), "RepositoryPolicyNotFoundException");
+    }
+
+    #[test]
+    fn put_image_cross_account_blocked_when_no_policy_returns_policy_not_found() {
+        // PutImage with no repository policy at all on the cross-account
+        // path: same RepositoryPolicyNotFoundException semantics as the
+        // pull-side ops, since AWS ECR uses the same gate code path.
+        let (svc, _state) = fixture(None);
+        let manifest = "{\"mediaType\":\"x\"}";
+        let req = make_request(
+            "PutImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageManifest": manifest,
+                "imageTag": "v2",
+            }),
+        );
+        let err = match svc.put_image(&req) {
+            Err(e) => e,
+            Ok(_) => panic!("expected denial"),
+        };
+        assert_eq!(err.code(), "RepositoryPolicyNotFoundException");
+    }
+
+    #[test]
+    fn batch_delete_image_cross_account_gated_by_policy() {
+        // BatchDeleteImage is the most destructive cross-account op and
+        // gets the same policy gate as the pull/push ops. With no policy:
+        // RepositoryPolicyNotFoundException; with explicit Allow on the
+        // matching action: success.
+        let (svc, _state) = fixture(None);
+        let req_no_policy = make_request(
+            "BatchDeleteImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageIds": [{"imageTag": "v1"}],
+            }),
+        );
+        let err = match svc.batch_delete_image(&req_no_policy) {
+            Err(e) => e,
+            Ok(_) => panic!("expected RepositoryPolicyNotFoundException"),
+        };
+        assert_eq!(err.code(), "RepositoryPolicyNotFoundException");
+
+        let policy = cross_account_allow_policy("ecr:BatchDeleteImage");
+        let (svc, _state) = fixture(Some(&policy));
+        let req_allowed = make_request(
+            "BatchDeleteImage",
+            OTHER,
+            json!({
+                "registryId": OWNER,
+                "repositoryName": "app",
+                "imageIds": [{"imageTag": "v1"}],
+            }),
+        );
+        if let Err(e) = svc.batch_delete_image(&req_allowed) {
+            panic!(
+                "BatchDeleteImage with allow policy should succeed, got: {}",
+                e.code()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Cross-account ECR image/layer ops now distinguish "no resource policy at all" from "policy denies the request" so callers can tell whether the repository owner hasn't shared the repo or has shared it with a different account. Maps to canonical AWS error codes:

- No policy -> `RepositoryPolicyNotFoundException`
- Policy exists, denies (implicit or explicit) -> `AccessDeniedException`
- Policy explicitly allows -> request proceeds
- Same-account caller -> bypasses the resource policy gate (IAM identity policies handle that path)

The decision is computed by the existing IAM evaluator (`crates/fakecloud-iam/src/evaluator.rs`), so resource-policy semantics here exactly match what the same evaluator does for S3 bucket policies, KMS key policies, etc.

## Changes

- `BatchDeleteImage` joins the policy-gated set (was previously bypassing the gate).
- New `RepoPolicyDecision` enum replaces the boolean `repository_policy_allows()` shim so `check_repo_policy()` can route to the correct AWS error.
- 5 new unit tests covering same-account / no-policy / allow / implicit-deny / explicit-deny + `BatchDeleteImage`.
- New e2e suite `crates/fakecloud-e2e/tests/ecr_cross_account.rs` runs 3 accounts (owner / allowed / unrelated) against `BatchGetImage`, `GetDownloadUrlForLayer`, plus an Allow+Deny statement to verify Deny precedence.

## Test plan

- [x] `cargo test -p fakecloud-ecr --lib` (64 tests pass, includes the new policy-decision unit tests)
- [x] `cargo test -p fakecloud-e2e --test ecr_cross_account` (3 cross-account scenarios pass)
- [x] `cargo test -p fakecloud-e2e --test ecr` (existing ECR e2e suite still green)
- [x] `cargo clippy -p fakecloud-ecr --all-targets -- -D warnings`
- [x] `cargo clippy -p fakecloud-e2e --tests -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces ECR cross-account repository policies with AWS-accurate errors. Calls now return RepositoryPolicyNotFoundException when no policy exists and AccessDeniedException when a policy exists but denies; same-account behavior is unchanged and BatchDeleteImage is now gated.

- **New Features**
  - Enforced repo-policy gate on cross-account: BatchGetImage, GetDownloadUrlForLayer, BatchCheckLayerAvailability, InitiateLayerUpload, UploadLayerPart, CompleteLayerUpload, PutImage, and BatchDeleteImage (newly gated).
  - Decisions evaluated by `fakecloud-iam` to match AWS semantics; explicit Deny overrides Allow.
  - Added cross-account tests in `fakecloud-e2e` and unit tests in `fakecloud-ecr` covering no-policy, allow, implicit deny, explicit deny, and BatchDeleteImage.

<sup>Written for commit d064c10650fe01c4c14c7c6c3b6071f5b71e9d0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

