### PR TITLE
test(kms): prove RSA Sign verifies outside fakecloud (G1)

### DIFF
--- a/crates/fakecloud-e2e/tests/kms.rs
+++ b/crates/fakecloud-e2e/tests/kms.rs
@@ -679,6 +679,190 @@ async fn kms_sign_verify_roundtrip() {
     assert!(verify_resp.signature_valid());
 }
 
+/// Proves G1 is real, not canned: ask KMS to Sign, fetch the published
+/// SubjectPublicKeyInfo via GetPublicKey, and verify the signature
+/// OUTSIDE fakecloud using the rsa crate directly. Covers all three
+/// PKCS1v15 hash sizes plus all three PSS hash sizes for an RSA_2048
+/// key, then repeats one combo on an RSA_3072 and RSA_4096 key to
+/// confirm keypair generation works at the larger sizes too.
+#[tokio::test]
+async fn kms_rsa_sign_verifies_outside_fakecloud() {
+    use rsa::pkcs1v15::{Signature as Pkcs1Signature, VerifyingKey as Pkcs1VerifyingKey};
+    use rsa::pkcs8::DecodePublicKey;
+    use rsa::pss::{Signature as PssSignature, VerifyingKey as PssVerifyingKey};
+    use rsa::sha2::{Sha256, Sha384, Sha512};
+    use rsa::signature::Verifier;
+    use rsa::RsaPublicKey;
+
+    let server = TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let pkcs1_algs = [
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha256,
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha384,
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha512,
+    ];
+    let pss_algs = [
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha256,
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha384,
+        aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha512,
+    ];
+
+    for spec in [
+        aws_sdk_kms::types::KeySpec::Rsa2048,
+        aws_sdk_kms::types::KeySpec::Rsa3072,
+        aws_sdk_kms::types::KeySpec::Rsa4096,
+    ] {
+        let resp = client
+            .create_key()
+            .key_usage(aws_sdk_kms::types::KeyUsageType::SignVerify)
+            .key_spec(spec.clone())
+            .send()
+            .await
+            .unwrap();
+        let key_id = resp.key_metadata().unwrap().key_id().to_string();
+
+        // GetPublicKey must return parseable SubjectPublicKeyInfo DER.
+        let pk_resp = client
+            .get_public_key()
+            .key_id(&key_id)
+            .send()
+            .await
+            .unwrap();
+        let spki_der = pk_resp.public_key().unwrap().clone();
+        let public = RsaPublicKey::from_public_key_der(spki_der.as_ref())
+            .expect("GetPublicKey must return parseable SPKI DER");
+
+        let message = b"prove this signature is real RSA crypto";
+
+        // RSA_3072 / RSA_4096 only need one combo to prove keygen works
+        // at that size; we exhaustively cover all six algorithms on
+        // RSA_2048 below.
+        let pkcs1_subset: &[_] = if matches!(spec, aws_sdk_kms::types::KeySpec::Rsa2048) {
+            &pkcs1_algs[..]
+        } else {
+            &pkcs1_algs[..1]
+        };
+        let pss_subset: &[_] = if matches!(spec, aws_sdk_kms::types::KeySpec::Rsa2048) {
+            &pss_algs[..]
+        } else {
+            &pss_algs[..1]
+        };
+
+        for alg in pkcs1_subset {
+            let sig = client
+                .sign()
+                .key_id(&key_id)
+                .message(Blob::new(message.to_vec()))
+                .signing_algorithm(alg.clone())
+                .send()
+                .await
+                .unwrap()
+                .signature()
+                .unwrap()
+                .clone();
+            let sig_bytes = sig.as_ref();
+            let parsed = Pkcs1Signature::try_from(sig_bytes).unwrap();
+            let verified = match alg {
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha256 => {
+                    let vk: Pkcs1VerifyingKey<Sha256> = Pkcs1VerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha384 => {
+                    let vk: Pkcs1VerifyingKey<Sha384> = Pkcs1VerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha512 => {
+                    let vk: Pkcs1VerifyingKey<Sha512> = Pkcs1VerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                _ => unreachable!(),
+            };
+            assert!(
+                verified,
+                "external rsa crate must verify {alg:?} signature on {spec:?}"
+            );
+        }
+
+        for alg in pss_subset {
+            let sig = client
+                .sign()
+                .key_id(&key_id)
+                .message(Blob::new(message.to_vec()))
+                .signing_algorithm(alg.clone())
+                .send()
+                .await
+                .unwrap()
+                .signature()
+                .unwrap()
+                .clone();
+            let sig_bytes = sig.as_ref();
+            let parsed = PssSignature::try_from(sig_bytes).unwrap();
+            let verified = match alg {
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha256 => {
+                    let vk: PssVerifyingKey<Sha256> = PssVerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha384 => {
+                    let vk: PssVerifyingKey<Sha384> = PssVerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha512 => {
+                    let vk: PssVerifyingKey<Sha512> = PssVerifyingKey::new(public.clone());
+                    vk.verify(message, &parsed).is_ok()
+                }
+                _ => unreachable!(),
+            };
+            assert!(
+                verified,
+                "external rsa crate must verify {alg:?} signature on {spec:?}"
+            );
+        }
+
+        // Tampered message must NOT verify under the published key.
+        let sig = client
+            .sign()
+            .key_id(&key_id)
+            .message(Blob::new(message.to_vec()))
+            .signing_algorithm(aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPkcs1V15Sha256)
+            .send()
+            .await
+            .unwrap()
+            .signature()
+            .unwrap()
+            .clone();
+        let parsed = Pkcs1Signature::try_from(sig.as_ref()).unwrap();
+        let vk: Pkcs1VerifyingKey<Sha256> = Pkcs1VerifyingKey::new(public.clone());
+        assert!(
+            vk.verify(b"different bytes", &parsed).is_err(),
+            "tampered message must fail external verify"
+        );
+
+        // Fakecloud's own Verify must agree on a fresh signature.
+        let sig = client
+            .sign()
+            .key_id(&key_id)
+            .message(Blob::new(message.to_vec()))
+            .signing_algorithm(aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha256)
+            .send()
+            .await
+            .unwrap()
+            .signature()
+            .unwrap()
+            .clone();
+        let verify_resp = client
+            .verify()
+            .key_id(&key_id)
+            .message(Blob::new(message.to_vec()))
+            .signature(sig)
+            .signing_algorithm(aws_sdk_kms::types::SigningAlgorithmSpec::RsassaPssSha256)
+            .send()
+            .await
+            .unwrap();
+        assert!(verify_resp.signature_valid());
+    }
+}
+
 #[tokio::test]
 async fn kms_generate_random() {
     let server = TestServer::start().await;


### PR DESCRIPTION
## Summary

The G1 batch of the parity-gap loop (real RSA keypair generation + Sign/Verify/GetPublicKey for `RSA_2048`/`3072`/`4096`) shipped earlier in commit 1bdf8085. The existing E2E test, however, only round-tripped fakecloud's own Verify against its own Sign, so it could not catch a regression where Sign returned canned bytes.

Adds `kms_rsa_sign_verifies_outside_fakecloud` which:

- Covers all six RSA signing algorithms on `RSA_2048`: `RSASSA_PKCS1_V1_5_SHA_{256,384,512}` plus `RSASSA_PSS_SHA_{256,384,512}`.
- Exercises one PKCS1v15 combo plus one PSS combo on each of `RSA_3072` and `RSA_4096` to confirm keypair generation works at the larger sizes.
- Calls `GetPublicKey`, parses the result with `rsa::RsaPublicKey::from_public_key_der`, and verifies the signature locally via the `rsa` crate (i.e. outside fakecloud).
- Confirms a tampered message fails external verify.
- Confirms fakecloud's own `Verify` still agrees on a fresh PSS signature.

This is a test-only change — no service code was modified.

## Test plan

- [x] `cargo test -p fakecloud-e2e --test kms -- kms_rsa_sign_verifies_outside_fakecloud kms_sign_verify_roundtrip` passes locally
- [x] `cargo test -p fakecloud-kms` — 174 passed
- [x] `cargo clippy -p fakecloud-kms --all-features --all-targets -- -D warnings` clean
- [x] `cargo clippy -p fakecloud-e2e --tests --all-features` clean
- [x] CI green
- [x] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an end-to-end test that verifies KMS RSA signatures using the `rsa` crate against the SPKI returned by `GetPublicKey`, proving signatures are real (not canned). Covers all six RSA algorithms on `RSA_2048` and spot-checks `RSA_3072`/`RSA_4096`; also ensures tampered messages fail and KMS `Verify` still succeeds on a fresh PSS signature.

<sup>Written for commit 0e2c4a9d2dae9f4aafcaafa1d8f416e65f67c431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

