### PR TITLE
fix(elasticache): use <member> tags for SecurityGroups list per AWS query protocol

### DIFF
--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -652,10 +652,10 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
                 .security_group_ids
                 .iter()
                 .map(|sg| format!(
-                    "<SecurityGroupMembership>\
+                    "<member>\
                      <SecurityGroupId>{}</SecurityGroupId>\
                      <Status>active</Status>\
-                     </SecurityGroupMembership>",
+                     </member>",
                     xml_escape(sg)
                 ))
                 .collect::<String>()


### PR DESCRIPTION
## Summary

DescribeCacheClusters response was emitting `<SecurityGroupMembership>` tags inside `<SecurityGroups>`, but the AWS SDK XML deserializer for `com.amazonaws.elasticache#SecurityGroupMembershipList` expects `<member>`. The mismatch silently dropped the security groups list on the client side, breaking the kitchen-sink E2E test added in N2 (#1169).

Verified the SDK source at aws-sdk-elasticache 1.104.0:
```
s if s.matches("member") /* member com.amazonaws.elasticache#SecurityGroupMembershipList$member */ => …
```

## Test plan
- [x] Existing 206 elasticache unit tests pass
- [ ] Pre-existing E2E `elasticache_create_cache_cluster_round_trips_extended_fields` (which has been failing on main) passes once Docker is available in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ElastiCache DescribeCacheClusters to emit `SecurityGroups` list items as `<member>` per AWS query protocol. This matches the AWS SDK deserializer so security groups are returned to clients and the N2 E2E stops failing.

- **Bug Fixes**
  - Replace `<SecurityGroupMembership>` with `<member>` inside `SecurityGroups` for compatibility with `com.amazonaws.elasticache#SecurityGroupMembershipList`.

<sup>Written for commit 31a588e96c1f5de4a91c736c3c15d5001d525b3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

