### PR TITLE
feat(elasticache): ModifyReplicationGroup accepts all rotation/encryption/log/multi-AZ fields (N3)

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -1353,6 +1353,371 @@ async fn elasticache_modify_replication_group_description() {
 }
 
 #[tokio::test]
+async fn elasticache_modify_replication_group_kitchen_sink() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    // Seed two user groups so we can both add and remove memberships.
+    client
+        .create_user_group()
+        .user_group_id("ks-ug-add")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_user_group()
+        .user_group_id("ks-ug-remove")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+
+    // Bring up the replication group with the existing membership pre-attached
+    // so the modify call can prove RemoveUserGroupIds drops it. UserGroupIds
+    // is required at create time when AuthToken+TransitEncryption are set.
+    client
+        .create_replication_group()
+        .replication_group_id("ks-mod-rg")
+        .replication_group_description("kitchen sink modify base")
+        .engine("redis")
+        .engine_version("7.1")
+        .auth_token("initial-token")
+        .transit_encryption_enabled(true)
+        .at_rest_encryption_enabled(true)
+        .multi_az_enabled(false)
+        .automatic_failover_enabled(false)
+        .user_group_ids("ks-ug-remove")
+        .send()
+        .await
+        .unwrap();
+
+    let cw_details = aws_sdk_elasticache::types::CloudWatchLogsDestinationDetails::builder()
+        .log_group("/aws/elasticache/slow-modified")
+        .build();
+    let dest = aws_sdk_elasticache::types::DestinationDetails::builder()
+        .cloud_watch_logs_details(cw_details)
+        .build();
+    let log_cfg = aws_sdk_elasticache::types::LogDeliveryConfigurationRequest::builder()
+        .log_type(aws_sdk_elasticache::types::LogType::SlowLog)
+        .destination_type(aws_sdk_elasticache::types::DestinationType::CloudWatchLogs)
+        .destination_details(dest)
+        .log_format(aws_sdk_elasticache::types::LogFormat::Json)
+        .enabled(true)
+        .build();
+
+    let modify_resp = client
+        .modify_replication_group()
+        .replication_group_id("ks-mod-rg")
+        .replication_group_description("kitchen sink modified")
+        .apply_immediately(true)
+        .auth_token("rotated-token")
+        .auth_token_update_strategy(aws_sdk_elasticache::types::AuthTokenUpdateStrategyType::Rotate)
+        .transit_encryption_enabled(true)
+        .transit_encryption_mode(aws_sdk_elasticache::types::TransitEncryptionMode::Required)
+        .multi_az_enabled(true)
+        .automatic_failover_enabled(true)
+        .ip_discovery(aws_sdk_elasticache::types::IpDiscovery::Ipv6)
+        .cluster_mode(aws_sdk_elasticache::types::ClusterMode::Compatible)
+        .snapshot_retention_limit(14)
+        .snapshot_window("06:00-07:00")
+        .preferred_maintenance_window("mon:02:00-mon:03:00")
+        .notification_topic_arn("arn:aws:sns:us-east-1:123456789012:rg-events")
+        .notification_topic_status("active")
+        .cache_parameter_group_name("default.redis7")
+        .auto_minor_version_upgrade(false)
+        .engine_version("7.1")
+        .cache_node_type("cache.r6g.large")
+        .user_group_ids_to_add("ks-ug-add")
+        .user_group_ids_to_remove("ks-ug-remove")
+        .log_delivery_configurations(log_cfg)
+        .send()
+        .await
+        .unwrap();
+
+    // Modify response must echo all updates synchronously.
+    let modified = modify_resp.replication_group().expect("replication group");
+    assert_eq!(modified.description(), Some("kitchen sink modified"));
+    assert_eq!(modified.transit_encryption_enabled(), Some(true));
+    assert_eq!(
+        modified.transit_encryption_mode(),
+        Some(&aws_sdk_elasticache::types::TransitEncryptionMode::Required)
+    );
+    assert_eq!(
+        modified.multi_az(),
+        Some(&aws_sdk_elasticache::types::MultiAzStatus::Enabled)
+    );
+    assert_eq!(
+        modified.automatic_failover(),
+        Some(&aws_sdk_elasticache::types::AutomaticFailoverStatus::Enabled)
+    );
+    assert_eq!(
+        modified.ip_discovery(),
+        Some(&aws_sdk_elasticache::types::IpDiscovery::Ipv6)
+    );
+    assert_eq!(
+        modified.cluster_mode(),
+        Some(&aws_sdk_elasticache::types::ClusterMode::Compatible)
+    );
+
+    // Re-describe and assert each persisted field.
+    let describe = client
+        .describe_replication_groups()
+        .replication_group_id("ks-mod-rg")
+        .send()
+        .await
+        .unwrap();
+    let groups = describe.replication_groups();
+    assert_eq!(groups.len(), 1);
+    let g = &groups[0];
+
+    assert_eq!(g.description(), Some("kitchen sink modified"));
+    assert_eq!(g.snapshot_retention_limit(), Some(14));
+    assert_eq!(g.snapshot_window(), Some("06:00-07:00"));
+    assert_eq!(g.cache_node_type(), Some("cache.r6g.large"));
+    assert_eq!(g.auth_token_enabled(), Some(true));
+    assert_eq!(g.transit_encryption_enabled(), Some(true));
+    assert_eq!(
+        g.transit_encryption_mode(),
+        Some(&aws_sdk_elasticache::types::TransitEncryptionMode::Required)
+    );
+    assert_eq!(g.at_rest_encryption_enabled(), Some(true));
+    assert_eq!(g.auto_minor_version_upgrade(), Some(false));
+    assert_eq!(
+        g.multi_az(),
+        Some(&aws_sdk_elasticache::types::MultiAzStatus::Enabled)
+    );
+    assert_eq!(
+        g.automatic_failover(),
+        Some(&aws_sdk_elasticache::types::AutomaticFailoverStatus::Enabled)
+    );
+    assert_eq!(
+        g.ip_discovery(),
+        Some(&aws_sdk_elasticache::types::IpDiscovery::Ipv6)
+    );
+    assert_eq!(
+        g.cluster_mode(),
+        Some(&aws_sdk_elasticache::types::ClusterMode::Compatible)
+    );
+    assert_eq!(g.cluster_enabled(), Some(true));
+
+    // User-group membership: ks-ug-add added, ks-ug-remove removed.
+    let user_group_ids: Vec<&str> = g.user_group_ids().iter().map(String::as_str).collect();
+    assert!(
+        user_group_ids.contains(&"ks-ug-add"),
+        "ks-ug-add must be attached: {user_group_ids:?}"
+    );
+    assert!(
+        !user_group_ids.contains(&"ks-ug-remove"),
+        "ks-ug-remove must be detached: {user_group_ids:?}"
+    );
+
+    // CacheParameterGroup, NotificationConfiguration, and
+    // PreferredMaintenanceWindow are not modeled on the SDK ReplicationGroup
+    // type but they are emitted in the raw XML AWS returns. Verify those
+    // wire-level fields by querying the endpoint directly.
+    let raw = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=fake/20260101/us-east-1/elasticache/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .body("Action=DescribeReplicationGroups&Version=2015-02-02&ReplicationGroupId=ks-mod-rg")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        raw.contains("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"),
+        "missing CacheParameterGroup XML: {raw}"
+    );
+    assert!(
+        raw.contains("<TopicArn>arn:aws:sns:us-east-1:123456789012:rg-events</TopicArn>"),
+        "missing NotificationConfiguration TopicArn: {raw}"
+    );
+    assert!(
+        raw.contains("<TopicStatus>active</TopicStatus>"),
+        "missing NotificationConfiguration TopicStatus: {raw}"
+    );
+    assert!(
+        raw.contains(
+            "<PreferredMaintenanceWindow>mon:02:00-mon:03:00</PreferredMaintenanceWindow>"
+        ),
+        "missing PreferredMaintenanceWindow: {raw}"
+    );
+
+    // Log delivery: the modify call replaced the set with one CW Logs entry
+    // pointing at the new log group.
+    let log_configs = g.log_delivery_configurations();
+    assert_eq!(log_configs.len(), 1);
+    let cfg = &log_configs[0];
+    assert_eq!(
+        cfg.log_type(),
+        Some(&aws_sdk_elasticache::types::LogType::SlowLog)
+    );
+    assert_eq!(
+        cfg.destination_type(),
+        Some(&aws_sdk_elasticache::types::DestinationType::CloudWatchLogs)
+    );
+    let log_group = cfg
+        .destination_details()
+        .and_then(|d| d.cloud_watch_logs_details())
+        .and_then(|c| c.log_group());
+    assert_eq!(log_group, Some("/aws/elasticache/slow-modified"));
+
+    // Reverse-side: ks-ug-remove no longer references the rg, ks-ug-add does.
+    let ugs = client
+        .describe_user_groups()
+        .send()
+        .await
+        .unwrap()
+        .user_groups()
+        .to_vec();
+    let ug_add = ugs
+        .iter()
+        .find(|g| g.user_group_id() == Some("ks-ug-add"))
+        .expect("ks-ug-add user group");
+    let ug_remove = ugs
+        .iter()
+        .find(|g| g.user_group_id() == Some("ks-ug-remove"))
+        .expect("ks-ug-remove user group");
+    assert!(ug_add
+        .replication_groups()
+        .iter()
+        .any(|id| id == "ks-mod-rg"));
+    assert!(!ug_remove
+        .replication_groups()
+        .iter()
+        .any(|id| id == "ks-mod-rg"));
+}
+
+#[tokio::test]
+async fn elasticache_modify_replication_group_remove_user_groups_clears_all() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user_group()
+        .user_group_id("rm-ug-1")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_user_group()
+        .user_group_id("rm-ug-2")
+        .engine("redis")
+        .user_ids("default")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_replication_group()
+        .replication_group_id("rm-rg")
+        .replication_group_description("remove user groups")
+        .auth_token("token")
+        .transit_encryption_enabled(true)
+        .user_group_ids("rm-ug-1")
+        .user_group_ids("rm-ug-2")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_replication_group()
+        .replication_group_id("rm-rg")
+        .remove_user_groups(true)
+        .send()
+        .await
+        .unwrap();
+
+    let g = client
+        .describe_replication_groups()
+        .replication_group_id("rm-rg")
+        .send()
+        .await
+        .unwrap()
+        .replication_groups()
+        .first()
+        .cloned()
+        .expect("rg");
+    assert!(g.user_group_ids().is_empty());
+}
+
+#[tokio::test]
+async fn elasticache_modify_replication_group_auth_token_delete_clears() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("auth-del-rg")
+        .replication_group_description("delete auth token")
+        .auth_token("initial")
+        .transit_encryption_enabled(true)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .modify_replication_group()
+        .replication_group_id("auth-del-rg")
+        .auth_token_update_strategy(aws_sdk_elasticache::types::AuthTokenUpdateStrategyType::Delete)
+        .send()
+        .await
+        .unwrap();
+
+    let g = resp.replication_group().expect("rg");
+    assert_eq!(g.auth_token_enabled(), Some(false));
+}
+
+#[tokio::test]
+async fn elasticache_modify_replication_group_rejects_invalid_cluster_mode() {
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("bad-cm-rg")
+        .replication_group_description("invalid cluster mode")
+        .send()
+        .await
+        .unwrap();
+
+    // SDK accepts unknown enum strings via Unknown(_); send raw via the
+    // customizable ModifyReplicationGroup path is overkill, so instead use a
+    // raw HTTP request for the invalid path. The build-time enum on the SDK
+    // prevents passing arbitrary strings through the typed builder.
+    let raw = reqwest::Client::new()
+        .post(server.endpoint())
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=fake/20260101/us-east-1/elasticache/aws4_request, SignedHeaders=host, Signature=fake",
+        )
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(
+            "Action=ModifyReplicationGroup\
+             &Version=2015-02-02\
+             &ReplicationGroupId=bad-cm-rg\
+             &ClusterMode=wat",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(raw.status().as_u16(), 400);
+    let body = raw.text().await.unwrap();
+    assert!(body.contains("InvalidParameterValue"), "body: {body}");
+    assert!(body.contains("ClusterMode"), "body: {body}");
+}
+
+#[tokio::test]
 async fn elasticache_increase_replica_count() {
     let server = TestServer::start().await;
     let client = server.elasticache_client().await;

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -265,8 +265,17 @@ pub(crate) fn parse_log_delivery_configs(req: &AwsRequest) -> Vec<LogDeliveryCon
         let base = format!("LogDeliveryConfigurations.LogDeliveryConfigurationRequest.{i}");
         let log_type = optional_query_param(req, &format!("{base}.LogType"));
         let dest_type = optional_query_param(req, &format!("{base}.DestinationType"));
-        if log_type.is_none() && dest_type.is_none() {
+        let enabled = optional_query_param(req, &format!("{base}.Enabled"));
+        if log_type.is_none() && dest_type.is_none() && enabled.is_none() {
             break;
+        }
+        // AWS deletes a log delivery destination when Enabled=false. Skip it
+        // here so the modify handler ends up with only the active set.
+        if matches!(
+            enabled.as_deref(),
+            Some("false") | Some("False") | Some("FALSE")
+        ) {
+            continue;
         }
         let log_format = optional_query_param(req, &format!("{base}.LogFormat"))
             .unwrap_or_else(|| "json".into());
@@ -964,6 +973,26 @@ pub(crate) fn replication_group_xml(g: &ReplicationGroup, region: &str) -> Strin
         .as_ref()
         .map(|m| format!("<ClusterMode>{}</ClusterMode>", xml_escape(m)))
         .unwrap_or_default();
+    let cache_parameter_group_xml = g
+        .cache_parameter_group_name
+        .as_ref()
+        .map(|n| {
+            format!(
+                "<CacheParameterGroup><CacheParameterGroupName>{}</CacheParameterGroupName></CacheParameterGroup>",
+                xml_escape(n)
+            )
+        })
+        .unwrap_or_default();
+    let preferred_maintenance_window_xml = g
+        .preferred_maintenance_window
+        .as_ref()
+        .map(|w| {
+            format!(
+                "<PreferredMaintenanceWindow>{}</PreferredMaintenanceWindow>",
+                xml_escape(w)
+            )
+        })
+        .unwrap_or_default();
 
     let id = xml_escape(&g.replication_group_id);
     let description = xml_escape(&g.description);
@@ -1080,6 +1109,8 @@ pub(crate) fn replication_group_xml(g: &ReplicationGroup, region: &str) -> Strin
          {configuration_endpoint_xml}\
          {notification_topic_xml}\
          {cluster_mode_xml}\
+         {cache_parameter_group_xml}\
+         {preferred_maintenance_window_xml}\
          <PendingModifiedValues/>\
          <ARN>{arn}</ARN>",
     )
@@ -1633,5 +1664,132 @@ mod cluster_xml_tests {
         assert!(xml.contains("<AuthTokenEnabled>true</AuthTokenEnabled>"));
         assert!(xml.contains("<LogType>slow-log</LogType>"));
         assert!(xml.contains("<ConfigurationEndpoint>"));
+    }
+}
+
+#[cfg(test)]
+mod replication_group_xml_tests {
+    use super::*;
+    use crate::state::{LogDeliveryConfiguration, ReplicationGroup};
+
+    fn fixture() -> ReplicationGroup {
+        ReplicationGroup {
+            replication_group_id: "rg1".into(),
+            description: "fixture".into(),
+            global_replication_group_id: None,
+            global_replication_group_role: None,
+            status: "available".into(),
+            cache_node_type: "cache.t3.micro".into(),
+            engine: "redis".into(),
+            engine_version: "7.1".into(),
+            num_cache_clusters: 1,
+            automatic_failover_enabled: false,
+            endpoint_address: "127.0.0.1".into(),
+            endpoint_port: 6379,
+            arn: "arn:aws:elasticache:us-east-1:000000000000:replicationgroup:rg1".into(),
+            created_at: "2026-05-02T00:00:00Z".into(),
+            container_id: String::new(),
+            host_port: 6379,
+            member_clusters: vec!["rg1-001".into()],
+            snapshot_retention_limit: 0,
+            snapshot_window: "05:00-09:00".into(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            cluster_enabled: false,
+            kms_key_id: None,
+            auth_token_enabled: false,
+            user_group_ids: Vec::new(),
+            multi_az_enabled: false,
+            log_delivery_configurations: Vec::new(),
+            data_tiering: None,
+            ip_discovery: None,
+            network_type: None,
+            transit_encryption_mode: None,
+            num_node_groups: 1,
+            configuration_endpoint_address: None,
+            configuration_endpoint_port: None,
+            replicas_per_node_group: None,
+            auth_token: None,
+            port: 6379,
+            notification_topic_arn: None,
+            cluster_mode: None,
+            data_tiering_enabled: None,
+            notification_topic_status: None,
+            cache_parameter_group_name: None,
+            cache_subnet_group_name: None,
+            security_group_ids: Vec::new(),
+            preferred_maintenance_window: None,
+            snapshot_name: None,
+            snapshot_arns: Vec::new(),
+            auto_minor_version_upgrade: true,
+        }
+    }
+
+    #[test]
+    fn modify_kitchen_sink_fields_appear_in_xml() {
+        let mut g = fixture();
+        g.transit_encryption_enabled = true;
+        g.transit_encryption_mode = Some("required".into());
+        g.at_rest_encryption_enabled = true;
+        g.kms_key_id = Some("alias/k".into());
+        g.multi_az_enabled = true;
+        g.automatic_failover_enabled = true;
+        g.user_group_ids = vec!["ug-a".into(), "ug-b".into()];
+        g.log_delivery_configurations = vec![LogDeliveryConfiguration {
+            log_type: "slow-log".into(),
+            destination_type: "cloudwatch-logs".into(),
+            destination_details: Some("/aws/elasticache/x".into()),
+            log_format: "json".into(),
+            status: "active".into(),
+        }];
+        g.ip_discovery = Some("ipv6".into());
+        g.network_type = Some("dual_stack".into());
+        g.cluster_mode = Some("compatible".into());
+        g.cluster_enabled = true;
+        g.notification_topic_arn = Some("arn:aws:sns:us-east-1:000:t".into());
+        g.notification_topic_status = Some("active".into());
+        g.cache_parameter_group_name = Some("default.redis7".into());
+        g.preferred_maintenance_window = Some("mon:02:00-mon:03:00".into());
+        g.auto_minor_version_upgrade = false;
+
+        let xml = replication_group_xml(&g, "us-east-1");
+        assert!(xml.contains("<TransitEncryptionEnabled>true</TransitEncryptionEnabled>"));
+        assert!(xml.contains("<TransitEncryptionMode>required</TransitEncryptionMode>"));
+        assert!(xml.contains("<AtRestEncryptionEnabled>true</AtRestEncryptionEnabled>"));
+        assert!(xml.contains("<KmsKeyId>alias/k</KmsKeyId>"));
+        assert!(xml.contains("<MultiAZ>enabled</MultiAZ>"));
+        assert!(xml.contains("<AutomaticFailover>enabled</AutomaticFailover>"));
+        assert!(xml.contains("<member>ug-a</member>"));
+        assert!(xml.contains("<member>ug-b</member>"));
+        assert!(xml.contains("<LogType>slow-log</LogType>"));
+        assert!(xml.contains("<IpDiscovery>ipv6</IpDiscovery>"));
+        assert!(xml.contains("<NetworkType>dual_stack</NetworkType>"));
+        assert!(xml.contains("<ClusterMode>compatible</ClusterMode>"));
+        assert!(xml.contains("<ClusterEnabled>true</ClusterEnabled>"));
+        assert!(xml.contains("<TopicArn>arn:aws:sns:us-east-1:000:t</TopicArn>"));
+        assert!(xml.contains("<TopicStatus>active</TopicStatus>"));
+        assert!(xml.contains("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"));
+        assert!(xml.contains(
+            "<PreferredMaintenanceWindow>mon:02:00-mon:03:00</PreferredMaintenanceWindow>"
+        ));
+        assert!(xml.contains("<AutoMinorVersionUpgrade>false</AutoMinorVersionUpgrade>"));
+    }
+
+    #[test]
+    fn defaults_emit_canonical_state() {
+        let g = fixture();
+        let xml = replication_group_xml(&g, "us-east-1");
+        // Defaults: AMVU true, encryption flags false, no optional sections.
+        assert!(xml.contains("<AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>"));
+        assert!(xml.contains("<TransitEncryptionEnabled>false</TransitEncryptionEnabled>"));
+        assert!(xml.contains("<AtRestEncryptionEnabled>false</AtRestEncryptionEnabled>"));
+        assert!(xml.contains("<MultiAZ>disabled</MultiAZ>"));
+        assert!(xml.contains("<AutomaticFailover>disabled</AutomaticFailover>"));
+        assert!(xml.contains("<UserGroupIds/>"));
+        assert!(xml.contains("<LogDeliveryConfigurations/>"));
+        // No CacheParameterGroup / NotificationConfiguration when unset.
+        assert!(!xml.contains("<CacheParameterGroup>"));
+        assert!(!xml.contains("<NotificationConfiguration>"));
+        assert!(!xml.contains("<PreferredMaintenanceWindow>"));
     }
 }

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2476,6 +2476,22 @@ impl ElastiCacheService {
         let new_transit_encryption_enabled = parse_optional_bool(
             optional_query_param(request, "TransitEncryptionEnabled").as_deref(),
         )?;
+        let new_transit_encryption_mode = optional_query_param(request, "TransitEncryptionMode");
+        if let Some(ref mode) = new_transit_encryption_mode {
+            if mode != "preferred" && mode != "required" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Invalid value for TransitEncryptionMode: '{mode}'. Valid values: preferred, required."
+                    ),
+                ));
+            }
+        }
+        let new_at_rest_encryption_enabled = parse_optional_bool(
+            optional_query_param(request, "AtRestEncryptionEnabled").as_deref(),
+        )?;
+        let new_kms_key_id = optional_query_param(request, "KmsKeyId");
         let new_multi_az_enabled =
             parse_optional_bool(optional_query_param(request, "MultiAZEnabled").as_deref())?;
         let remove_user_groups =
@@ -2486,7 +2502,50 @@ impl ElastiCacheService {
                 k.starts_with("LogDeliveryConfigurations.LogDeliveryConfigurationRequest.")
             });
         let new_ip_discovery = optional_query_param(request, "IpDiscovery");
+        if let Some(ref ip) = new_ip_discovery {
+            if ip != "ipv4" && ip != "ipv6" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("Invalid value for IpDiscovery: '{ip}'. Valid values: ipv4, ipv6."),
+                ));
+            }
+        }
         let new_network_type = optional_query_param(request, "NetworkType");
+        if let Some(ref nt) = new_network_type {
+            if nt != "ipv4" && nt != "ipv6" && nt != "dual_stack" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Invalid value for NetworkType: '{nt}'. Valid values: ipv4, ipv6, dual_stack."
+                    ),
+                ));
+            }
+        }
+        let new_cluster_mode = optional_query_param(request, "ClusterMode");
+        if let Some(ref cm) = new_cluster_mode {
+            if cm != "compatible" && cm != "enabled" && cm != "disabled" {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Invalid value for ClusterMode: '{cm}'. Valid values: compatible, enabled, disabled."
+                    ),
+                ));
+            }
+        }
+        let new_preferred_maintenance_window =
+            optional_query_param(request, "PreferredMaintenanceWindow");
+        let new_cache_parameter_group_name =
+            optional_query_param(request, "CacheParameterGroupName");
+        let new_auto_minor_version_upgrade = parse_optional_bool(
+            optional_query_param(request, "AutoMinorVersionUpgrade").as_deref(),
+        )?;
+        // ApplyImmediately is parsed for wire compatibility but fakecloud always
+        // applies modifications synchronously since there's no reboot window.
+        let _apply_immediately =
+            parse_optional_bool(optional_query_param(request, "ApplyImmediately").as_deref())?;
         let new_notification_topic_arn = optional_query_param(request, "NotificationTopicArn");
         let new_notification_topic_status =
             optional_query_param(request, "NotificationTopicStatus");
@@ -2526,6 +2585,15 @@ impl ElastiCacheService {
         if let Some(transit) = new_transit_encryption_enabled {
             group.transit_encryption_enabled = transit;
         }
+        if let Some(mode) = new_transit_encryption_mode {
+            group.transit_encryption_mode = Some(mode);
+        }
+        if let Some(at_rest) = new_at_rest_encryption_enabled {
+            group.at_rest_encryption_enabled = at_rest;
+        }
+        if let Some(kms) = new_kms_key_id {
+            group.kms_key_id = Some(kms);
+        }
         if let Some(multi_az) = new_multi_az_enabled {
             group.multi_az_enabled = multi_az;
         }
@@ -2535,6 +2603,22 @@ impl ElastiCacheService {
         if let Some(network_type) = new_network_type {
             group.network_type = Some(network_type);
         }
+        if let Some(cluster_mode) = new_cluster_mode {
+            // ClusterMode "enabled"/"compatible" both flip cluster_enabled true;
+            // "disabled" turns it off. Mirrors create_replication_group semantics.
+            let enabled = cluster_mode == "enabled" || cluster_mode == "compatible";
+            group.cluster_enabled = enabled;
+            group.cluster_mode = Some(cluster_mode);
+        }
+        if let Some(window) = new_preferred_maintenance_window {
+            group.preferred_maintenance_window = Some(window);
+        }
+        if let Some(name) = new_cache_parameter_group_name {
+            group.cache_parameter_group_name = Some(name);
+        }
+        if let Some(amvu) = new_auto_minor_version_upgrade {
+            group.auto_minor_version_upgrade = amvu;
+        }
         if let Some(arn) = new_notification_topic_arn {
             group.notification_topic_arn = Some(arn);
         }
@@ -2542,10 +2626,24 @@ impl ElastiCacheService {
             group.notification_topic_status = Some(status);
         }
         if has_log_delivery_input {
+            // AWS replaces the full log-delivery configuration set per call;
+            // disabled entries (Enabled=false) are dropped from state.
             group.log_delivery_configurations = new_log_delivery_configurations;
         }
         if remove_user_groups == Some(true) {
             group.user_group_ids.clear();
+        }
+        // Add / remove user-group ids on the replication group itself.
+        // Skipped when RemoveUserGroups already cleared the list above only
+        // for removes; adds still apply because AWS lets a single call clear
+        // and then re-attach. Dedup on add to match AWS idempotency.
+        for ug_id in &user_group_ids_to_add {
+            if !group.user_group_ids.contains(ug_id) {
+                group.user_group_ids.push(ug_id.clone());
+            }
+        }
+        for ug_id in &user_group_ids_to_remove {
+            group.user_group_ids.retain(|id| id != ug_id);
         }
         // AuthToken rotation: SET / ROTATE store the new token, DELETE clears
         // it. Default strategy is SET when AuthToken is supplied without one.
@@ -2577,7 +2675,8 @@ impl ElastiCacheService {
             }
         }
 
-        // Associate/disassociate user groups
+        // Mirror the membership change onto the user-group side so
+        // DescribeUserGroups reflects which RGs each group covers.
         for ug_id in &user_group_ids_to_add {
             if let Some(ug) = state.user_groups.get_mut(ug_id) {
                 if !ug.replication_groups.contains(&replication_group_id) {


### PR DESCRIPTION
## Summary

- Extends `ModifyReplicationGroup` to accept and persist the full parameter surface AWS exposes: AuthToken (SET/ROTATE/DELETE), TransitEncryption (Enabled+Mode), AtRestEncryption, KmsKeyId, MultiAZ, AutomaticFailover, user-group add/remove + RemoveUserGroups, LogDeliveryConfigurations (with Enabled=false drop), IpDiscovery, NetworkType, ClusterMode (also flips `cluster_enabled`), Snapshot retention/window, PreferredMaintenanceWindow, NotificationTopic Arn/Status, CacheParameterGroupName, AutoMinorVersionUpgrade, EngineVersion, CacheNodeType, ApplyImmediately.
- Adds wire-boundary enum validation for IpDiscovery, NetworkType, ClusterMode, TransitEncryptionMode.
- Wires UserGroupIdsToAdd/Remove into the replication group's own `user_group_ids` list (previously the reverse user-group link was updated but the RG-side list was untouched, leaving DescribeReplicationGroups stale).
- `replication_group_xml` now emits CacheParameterGroup + PreferredMaintenanceWindow so DescribeReplicationGroups round-trips fields used by terraform plan diff.

## Test plan

- [x] `cargo test -p fakecloud-elasticache` (208 unit tests pass, including 2 new helpers tests for the kitchen-sink XML emission and default-state output)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] E2E: `elasticache_modify_replication_group_kitchen_sink` (drives full surface, asserts via SDK + raw XML), `elasticache_modify_replication_group_remove_user_groups_clears_all`, `elasticache_modify_replication_group_auth_token_delete_clears`, `elasticache_modify_replication_group_rejects_invalid_cluster_mode` (verified via CI; local docker unavailable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands ElastiCache ModifyReplicationGroup to support the full AWS parameter surface, adds strict enum validation, and fixes user-group persistence. Improves DescribeReplicationGroups parity (including XML) to reduce config drift in tooling like Terraform.

- New Features
  - ModifyReplicationGroup now supports the full AWS surface: AuthToken (SET/ROTATE/DELETE), transit/at-rest encryption (mode, `KmsKeyId`), Multi-AZ/failover, `ClusterMode` (toggles `cluster_enabled`), networking (`IpDiscovery`, `NetworkType`), and log delivery (replaces the set; `Enabled=false` removes entries).
  - Persists snapshot retention/window, maintenance window, notifications, cache parameter group, engine version, node type, `AutoMinorVersionUpgrade`, and `ApplyImmediately`.
  - Adds wire-level enum validation for `IpDiscovery`, `NetworkType`, `ClusterMode`, and `TransitEncryptionMode` with clear 400 errors.
  - ReplicationGroup XML now includes CacheParameterGroup and PreferredMaintenanceWindow for Describe parity.

- Bug Fixes
  - Replication group `user_group_ids` now updates on add/remove (and `RemoveUserGroups` clears all), with membership mirrored on user-group objects.

<sup>Written for commit bd2bfbd1723f4f62bcf355c242345ef1cbdea9a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

