### PR TITLE
feat(cloudformation): AWS::ApiGateway::* provisioners (BB9)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1002,6 +1002,30 @@ impl ResourceProvisioner {
             "AWS::Lambda::Url" => Some(self.update_lambda_url(existing, new_def)?),
             "AWS::Lambda::Alias" => Some(self.update_lambda_alias(existing, new_def)?),
             "AWS::Lambda::Version" => Some(self.update_lambda_version(existing, new_def)?),
+            "AWS::ApiGateway::RestApi" => Some(self.update_apigw_rest_api(existing, new_def)?),
+            "AWS::ApiGateway::Resource" => Some(self.update_apigw_resource(existing, new_def)?),
+            "AWS::ApiGateway::Method" => Some(self.update_apigw_method(existing, new_def)?),
+            "AWS::ApiGateway::Deployment" => Some(self.update_apigw_deployment(existing, new_def)?),
+            "AWS::ApiGateway::Stage" => Some(self.update_apigw_stage(existing, new_def)?),
+            "AWS::ApiGateway::Authorizer" => Some(self.update_apigw_authorizer(existing, new_def)?),
+            "AWS::ApiGateway::RequestValidator" => {
+                Some(self.update_apigw_request_validator(existing, new_def)?)
+            }
+            "AWS::ApiGateway::Model" => Some(self.update_apigw_model(existing, new_def)?),
+            "AWS::ApiGateway::GatewayResponse" => {
+                Some(self.update_apigw_gateway_response(existing, new_def)?)
+            }
+            "AWS::ApiGateway::UsagePlan" => Some(self.update_apigw_usage_plan(existing, new_def)?),
+            "AWS::ApiGateway::ApiKey" => Some(self.update_apigw_api_key(existing, new_def)?),
+            "AWS::ApiGateway::UsagePlanKey" => {
+                Some(self.update_apigw_usage_plan_key(existing, new_def)?)
+            }
+            "AWS::ApiGateway::DomainName" => {
+                Some(self.update_apigw_domain_name(existing, new_def)?)
+            }
+            "AWS::ApiGateway::BasePathMapping" => {
+                Some(self.update_apigw_base_path_mapping(existing, new_def)?)
+            }
             _ => None,
         };
 
@@ -11198,6 +11222,19 @@ impl ResourceProvisioner {
             .get("DisableExecuteApiEndpoint")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // CFN exposes optional `Body`/`BodyS3Location`/`CloneFrom` for OpenAPI
+        // import. We don't run a full Swagger import — we record the source
+        // in the api's `import_source` field so callers can reason about it.
+        let import_source = if props.get("Body").is_some() {
+            Some("Body".to_string())
+        } else if props.get("BodyS3Location").is_some() {
+            Some("BodyS3Location".to_string())
+        } else if props.get("CloneFrom").is_some() {
+            Some("CloneFrom".to_string())
+        } else {
+            None
+        };
+        let tags = parse_acm_tags(props.get("Tags"));
 
         let id = apigw_make_id();
         let root_resource_id = apigw_make_id();
@@ -11219,8 +11256,8 @@ impl ResourceProvisioner {
             minimum_compression_size,
             disable_execute_api_endpoint,
             root_resource_id: root_resource_id.clone(),
-            tags: BTreeMap::new(),
-            import_source: None,
+            tags,
+            import_source,
         };
 
         let mut accounts = self.apigateway_state.write();
@@ -11241,6 +11278,55 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone())
             .with("RestApiId", id.clone())
             .with("RootResourceId", root_resource_id))
+    }
+
+    fn update_apigw_rest_api(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let api = state
+            .apis
+            .get_mut(&id)
+            .ok_or_else(|| format!("RestApi {id} not found for update"))?;
+        if let Some(name) = props.get("Name").and_then(|v| v.as_str()) {
+            api.name = name.to_string();
+        }
+        if let Some(desc) = props.get("Description").and_then(|v| v.as_str()) {
+            api.description = Some(desc.to_string());
+        }
+        if let Some(source) = props.get("ApiKeySourceType").and_then(|v| v.as_str()) {
+            api.api_key_source = source.to_string();
+        }
+        if let Some(ep) = props.get("EndpointConfiguration").cloned() {
+            api.endpoint_configuration = ep;
+        }
+        if let Some(arr) = props.get("BinaryMediaTypes").and_then(|v| v.as_array()) {
+            api.binary_media_types = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(size) = props.get("MinimumCompressionSize").and_then(|v| v.as_i64()) {
+            api.minimum_compression_size = Some(size);
+        }
+        if let Some(b) = props
+            .get("DisableExecuteApiEndpoint")
+            .and_then(|v| v.as_bool())
+        {
+            api.disable_execute_api_endpoint = b;
+        }
+        if props.get("Tags").is_some() {
+            api.tags = parse_acm_tags(props.get("Tags"));
+        }
+        let root = api.root_resource_id.clone();
+        Ok(ProvisionResult::new(id.clone())
+            .with("RestApiId", id)
+            .with("RootResourceId", root))
     }
 
     fn delete_apigw_rest_api(&self, physical_id: &str) -> Result<(), String> {
@@ -11681,6 +11767,24 @@ impl ResourceProvisioner {
             .get("CacheClusterSize")
             .and_then(|v| v.as_str())
             .map(String::from);
+        // CFN models MethodSettings as a list of `{ResourcePath,HttpMethod,...}`
+        // entries; the live API stores them as a `path/method -> settings`
+        // map. Translate by joining ResourcePath + HttpMethod into the key.
+        let method_settings: BTreeMap<String, serde_json::Value> = props
+            .get("MethodSettings")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| {
+                        let path = s.get("ResourcePath").and_then(|v| v.as_str())?;
+                        let http = s.get("HttpMethod").and_then(|v| v.as_str())?;
+                        let key = format!("{}/{http}", path.strip_prefix('/').unwrap_or(path));
+                        Some((key, s.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags = parse_acm_tags(props.get("Tags"));
 
         let stage = ApiGwStage {
             stage_name: stage_name.clone(),
@@ -11692,14 +11796,14 @@ impl ResourceProvisioner {
             cache_cluster_enabled,
             cache_cluster_size,
             variables,
-            method_settings: BTreeMap::new(),
+            method_settings,
             created_date: Utc::now(),
             last_updated_date: Utc::now(),
             tracing_enabled,
             web_acl_arn: None,
             canary_settings: props.get("CanarySetting").cloned(),
             access_log_settings: props.get("AccessLogSetting").cloned(),
-            tags: BTreeMap::new(),
+            tags,
         };
 
         let mut accounts = self.apigateway_state.write();
@@ -12034,7 +12138,7 @@ impl ResourceProvisioner {
             throttle: props.get("Throttle").cloned().map(lowercase_first_keys),
             quota: props.get("Quota").cloned().map(lowercase_first_keys),
             product_code: None,
-            tags: BTreeMap::new(),
+            tags: parse_acm_tags(props.get("Tags")),
         };
         let mut accounts = self.apigateway_state.write();
         let state = accounts.get_or_create(&self.account_id);
@@ -12055,11 +12159,21 @@ impl ResourceProvisioner {
         resource: &ResourceDefinition,
     ) -> Result<ProvisionResult, String> {
         let props = &resource.properties;
+        let generate_distinct_id = props
+            .get("GenerateDistinctId")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let name = props
             .get("Name")
             .and_then(|v| v.as_str())
             .map(String::from)
-            .unwrap_or_else(|| format!("cfn-key-{}", resource.logical_id));
+            .unwrap_or_else(|| {
+                if generate_distinct_id {
+                    format!("cfn-key-{}-{}", resource.logical_id, apigw_make_id())
+                } else {
+                    format!("cfn-key-{}", resource.logical_id)
+                }
+            });
         let value = props
             .get("Value")
             .and_then(|v| v.as_str())
@@ -12069,6 +12183,21 @@ impl ResourceProvisioner {
             .get("Enabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+        // CFN's StageKeys are `[{RestApiId, StageName}, ...]` — we store each
+        // as `restApiId/stageName` per the live API key shape.
+        let stage_keys: Vec<String> = props
+            .get("StageKeys")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| {
+                        let rest = s.get("RestApiId").and_then(|v| v.as_str())?;
+                        let stage = s.get("StageName").and_then(|v| v.as_str())?;
+                        Some(format!("{rest}/{stage}"))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         let id = apigw_make_id();
         let now = Utc::now();
         let key = ApiGwApiKey {
@@ -12082,8 +12211,8 @@ impl ResourceProvisioner {
             enabled,
             created_date: now,
             last_updated_date: now,
-            stage_keys: Vec::new(),
-            tags: BTreeMap::new(),
+            stage_keys,
+            tags: parse_acm_tags(props.get("Tags")),
             customer_id: props
                 .get("CustomerId")
                 .and_then(|v| v.as_str())
@@ -12175,6 +12304,16 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .ok_or("DomainName is required")?
             .to_string();
+        let mtls = props
+            .get("MutualTlsAuthentication")
+            .cloned()
+            .map(lowercase_first_keys);
+        let regional_domain = format!(
+            "d-{}.execute-api.{}.amazonaws.com",
+            apigw_make_id(),
+            self.region
+        );
+        let distribution_domain = format!("d{}.cloudfront.net", apigw_make_id());
         let body = serde_json::json!({
             "domainName": domain_name,
             "certificateArn": props.get("CertificateArn").and_then(|v| v.as_str()),
@@ -12182,10 +12321,17 @@ impl ResourceProvisioner {
             "endpointConfiguration": props.get("EndpointConfiguration").cloned().unwrap_or(serde_json::json!({"types": ["EDGE"]})),
             "securityPolicy": props.get("SecurityPolicy").and_then(|v| v.as_str()),
             "ownershipVerificationCertificateArn": props.get("OwnershipVerificationCertificateArn").and_then(|v| v.as_str()),
-            "regionalDomainName": format!("d-{}.execute-api.{}.amazonaws.com", apigw_make_id(), self.region),
+            "regionalDomainName": regional_domain,
             "regionalHostedZoneId": "Z2FDTNDATAQYW2",
-            "distributionDomainName": format!("d{}.cloudfront.net", apigw_make_id()),
+            "distributionDomainName": distribution_domain,
             "distributionHostedZoneId": "Z2FDTNDATAQYW2",
+            "mutualTlsAuthentication": mtls,
+            "tags": serde_json::Value::Object(
+                parse_acm_tags(props.get("Tags"))
+                    .into_iter()
+                    .map(|(k, v)| (k, serde_json::Value::String(v)))
+                    .collect(),
+            ),
         });
         let mut accounts = self.apigateway_state.write();
         let state = accounts.get_or_create(&self.account_id);
@@ -12264,6 +12410,573 @@ impl ResourceProvisioner {
             map.remove(base_path);
         }
         Ok(())
+    }
+
+    // --- API Gateway v1 update paths ---
+    //
+    // These mirror the create_* helpers above but mutate an existing
+    // resource instead of inserting a new one. The physical id is
+    // preserved across updates so other stack resources keep referencing
+    // the same logical entity.
+
+    fn update_apigw_resource(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let api_resources = state
+            .resources
+            .get_mut(&rest_api_id)
+            .ok_or_else(|| format!("RestApi {rest_api_id} not found"))?;
+        if !api_resources.contains_key(&physical) {
+            return Err(format!("Resource {physical} not found"));
+        }
+        if let Some(part) = props.get("PathPart").and_then(|v| v.as_str()) {
+            // Read parent's path first (immutable borrow), then mutate.
+            let parent_id = api_resources
+                .get(&physical)
+                .and_then(|r| r.parent_id.clone());
+            let parent_path = parent_id
+                .as_ref()
+                .and_then(|pid| api_resources.get(pid).map(|p| p.path.clone()))
+                .unwrap_or_else(|| "/".to_string());
+            let new_path = if parent_path == "/" {
+                format!("/{part}")
+            } else {
+                format!("{parent_path}/{part}")
+            };
+            let res = api_resources
+                .get_mut(&physical)
+                .expect("contains_key checked above");
+            res.path_part = Some(part.to_string());
+            res.path = new_path;
+        }
+        Ok(ProvisionResult::new(physical.clone())
+            .with("ResourceId", physical)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_method(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // Method's physical id is the composite "rest/resource/method"
+        // key. Identity props can't change without replacement, so we
+        // simply rewrite the stored Method/Integration with current
+        // properties. We delegate to create_apigw_method which already
+        // handles the insert-or-replace semantics.
+        self.create_apigw_method(resource).map(|r| {
+            // Make sure the physical id stays stable.
+            ProvisionResult {
+                physical_id: existing.physical_id.clone(),
+                attributes: r.attributes,
+            }
+        })
+    }
+
+    fn update_apigw_deployment(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let dep = state
+            .deployments
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&physical))
+            .ok_or_else(|| format!("Deployment {physical} not found"))?;
+        if let Some(desc) = props.get("Description").and_then(|v| v.as_str()) {
+            dep.description = Some(desc.to_string());
+        }
+        Ok(ProvisionResult::new(physical.clone())
+            .with("DeploymentId", physical)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_stage(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let stage_name = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let stage = state
+            .stages
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&stage_name))
+            .ok_or_else(|| format!("Stage {stage_name} not found"))?;
+        if let Some(desc) = props.get("Description").and_then(|v| v.as_str()) {
+            stage.description = Some(desc.to_string());
+        }
+        if let Some(b) = props.get("TracingEnabled").and_then(|v| v.as_bool()) {
+            stage.tracing_enabled = b;
+        }
+        if let Some(b) = props.get("CacheClusterEnabled").and_then(|v| v.as_bool()) {
+            stage.cache_cluster_enabled = b;
+        }
+        if let Some(s) = props.get("CacheClusterSize").and_then(|v| v.as_str()) {
+            stage.cache_cluster_size = Some(s.to_string());
+        }
+        if let Some(obj) = props.get("Variables").and_then(|v| v.as_object()) {
+            stage.variables = obj
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect();
+        }
+        if let Some(dep) = props.get("DeploymentId").and_then(|v| v.as_str()) {
+            stage.deployment_id = dep.to_string();
+        }
+        if props.get("Tags").is_some() {
+            stage.tags = parse_acm_tags(props.get("Tags"));
+        }
+        if let Some(arr) = props.get("MethodSettings").and_then(|v| v.as_array()) {
+            stage.method_settings = arr
+                .iter()
+                .filter_map(|s| {
+                    let path = s.get("ResourcePath").and_then(|v| v.as_str())?;
+                    let http = s.get("HttpMethod").and_then(|v| v.as_str())?;
+                    let key = format!("{}/{http}", path.strip_prefix('/').unwrap_or(path));
+                    Some((key, s.clone()))
+                })
+                .collect();
+        }
+        if let Some(canary) = props.get("CanarySetting").cloned() {
+            stage.canary_settings = Some(canary);
+        }
+        if let Some(access) = props.get("AccessLogSetting").cloned() {
+            stage.access_log_settings = Some(access);
+        }
+        stage.last_updated_date = Utc::now();
+        Ok(ProvisionResult::new(stage_name.clone())
+            .with("StageName", stage_name)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_authorizer(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let auth = state
+            .authorizers
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&physical))
+            .ok_or_else(|| format!("Authorizer {physical} not found"))?;
+        if let Some(name) = props.get("Name").and_then(|v| v.as_str()) {
+            auth.name = name.to_string();
+        }
+        if let Some(t) = props.get("Type").and_then(|v| v.as_str()) {
+            auth.authorizer_type = t.to_string();
+        }
+        if let Some(uri) = props.get("AuthorizerUri").and_then(|v| v.as_str()) {
+            auth.authorizer_uri = Some(uri.to_string());
+        }
+        if let Some(arr) = props.get("ProviderARNs").and_then(|v| v.as_array()) {
+            auth.provider_arns = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(s) = props.get("IdentitySource").and_then(|v| v.as_str()) {
+            auth.identity_source = Some(s.to_string());
+        }
+        if let Some(s) = props
+            .get("IdentityValidationExpression")
+            .and_then(|v| v.as_str())
+        {
+            auth.identity_validation_expression = Some(s.to_string());
+        }
+        if let Some(n) = props
+            .get("AuthorizerResultTtlInSeconds")
+            .and_then(|v| v.as_i64())
+        {
+            auth.authorizer_result_ttl_in_seconds = Some(n as i32);
+        }
+        if let Some(s) = props.get("AuthType").and_then(|v| v.as_str()) {
+            auth.auth_type = Some(s.to_string());
+        }
+        if let Some(s) = props.get("AuthorizerCredentials").and_then(|v| v.as_str()) {
+            auth.authorizer_credentials = Some(s.to_string());
+        }
+        Ok(ProvisionResult::new(physical.clone())
+            .with("AuthorizerId", physical)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_request_validator(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let body = state
+            .request_validators
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&physical))
+            .ok_or_else(|| format!("RequestValidator {physical} not found"))?;
+        let obj = body.as_object_mut().ok_or("validator body not object")?;
+        if let Some(name) = props.get("Name").and_then(|v| v.as_str()) {
+            obj.insert("name".into(), serde_json::Value::String(name.into()));
+        }
+        if let Some(b) = props.get("ValidateRequestBody").and_then(|v| v.as_bool()) {
+            obj.insert("validateRequestBody".into(), serde_json::Value::Bool(b));
+        }
+        if let Some(b) = props
+            .get("ValidateRequestParameters")
+            .and_then(|v| v.as_bool())
+        {
+            obj.insert(
+                "validateRequestParameters".into(),
+                serde_json::Value::Bool(b),
+            );
+        }
+        Ok(ProvisionResult::new(physical.clone())
+            .with("RequestValidatorId", physical)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_model(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let model_name = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let model = state
+            .models
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&model_name))
+            .ok_or_else(|| format!("Model {model_name} not found"))?;
+        if let Some(desc) = props.get("Description").and_then(|v| v.as_str()) {
+            model.description = Some(desc.to_string());
+        }
+        if let Some(s) = props.get("ContentType").and_then(|v| v.as_str()) {
+            model.content_type = s.to_string();
+        }
+        if let Some(schema) = props.get("Schema") {
+            model.schema = Some(if let Some(s) = schema.as_str() {
+                s.to_string()
+            } else {
+                schema.to_string()
+            });
+        }
+        Ok(ProvisionResult::new(model_name.clone())
+            .with("ModelName", model_name)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_gateway_response(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let rest_api_id = existing
+            .attributes
+            .get("RestApiId")
+            .cloned()
+            .or_else(|| {
+                props
+                    .get("RestApiId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .ok_or("RestApiId is required")?;
+        let response_type = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let body = state
+            .gateway_responses
+            .get_mut(&rest_api_id)
+            .and_then(|m| m.get_mut(&response_type))
+            .ok_or_else(|| format!("GatewayResponse {response_type} not found"))?;
+        let obj = body.as_object_mut().ok_or("response body not object")?;
+        if let Some(s) = props.get("StatusCode").and_then(|v| v.as_str()) {
+            obj.insert("statusCode".into(), serde_json::Value::String(s.into()));
+        }
+        if let Some(v) = props.get("ResponseParameters").cloned() {
+            obj.insert("responseParameters".into(), v);
+        }
+        if let Some(v) = props.get("ResponseTemplates").cloned() {
+            obj.insert("responseTemplates".into(), v);
+        }
+        Ok(ProvisionResult::new(response_type.clone())
+            .with("ResponseType", response_type)
+            .with("RestApiId", rest_api_id))
+    }
+
+    fn update_apigw_usage_plan(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let plan = state
+            .usage_plans
+            .get_mut(&physical)
+            .ok_or_else(|| format!("UsagePlan {physical} not found"))?;
+        if let Some(name) = props.get("UsagePlanName").and_then(|v| v.as_str()) {
+            plan.name = name.to_string();
+        }
+        if let Some(s) = props.get("Description").and_then(|v| v.as_str()) {
+            plan.description = Some(s.to_string());
+        }
+        if let Some(arr) = props.get("ApiStages").and_then(|v| v.as_array()) {
+            plan.api_stages = arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(t) = props.get("Throttle").cloned() {
+            plan.throttle = Some(lowercase_first_keys(t));
+        }
+        if let Some(q) = props.get("Quota").cloned() {
+            plan.quota = Some(lowercase_first_keys(q));
+        }
+        if props.get("Tags").is_some() {
+            plan.tags = parse_acm_tags(props.get("Tags"));
+        }
+        Ok(ProvisionResult::new(physical.clone()).with("UsagePlanId", physical))
+    }
+
+    fn update_apigw_api_key(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let key = state
+            .api_keys
+            .get_mut(&physical)
+            .ok_or_else(|| format!("ApiKey {physical} not found"))?;
+        if let Some(name) = props.get("Name").and_then(|v| v.as_str()) {
+            key.name = name.to_string();
+        }
+        if let Some(s) = props.get("Description").and_then(|v| v.as_str()) {
+            key.description = Some(s.to_string());
+        }
+        if let Some(b) = props.get("Enabled").and_then(|v| v.as_bool()) {
+            key.enabled = b;
+        }
+        if let Some(s) = props.get("CustomerId").and_then(|v| v.as_str()) {
+            key.customer_id = Some(s.to_string());
+        }
+        if props.get("Tags").is_some() {
+            key.tags = parse_acm_tags(props.get("Tags"));
+        }
+        if let Some(arr) = props.get("StageKeys").and_then(|v| v.as_array()) {
+            key.stage_keys = arr
+                .iter()
+                .filter_map(|s| {
+                    let rest = s.get("RestApiId").and_then(|v| v.as_str())?;
+                    let stage = s.get("StageName").and_then(|v| v.as_str())?;
+                    Some(format!("{rest}/{stage}"))
+                })
+                .collect();
+        }
+        key.last_updated_date = Utc::now();
+        Ok(ProvisionResult::new(physical.clone()).with("ApiKeyId", physical))
+    }
+
+    fn update_apigw_usage_plan_key(
+        &self,
+        existing: &StackResource,
+        _resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // UsagePlanKey is a pure association (UsagePlan + ApiKey + Type) —
+        // CFN treats every property as `requires-replacement`, so a real
+        // UpdateStack would Delete+Create. Here we just preserve the
+        // existing physical id so resolution stays stable.
+        let physical = existing.physical_id.clone();
+        let mut parts = physical.splitn(2, '/');
+        let plan = parts.next().unwrap_or("").to_string();
+        let key = parts.next().unwrap_or("").to_string();
+        Ok(ProvisionResult::new(physical)
+            .with("UsagePlanId", plan)
+            .with("KeyId", key))
+    }
+
+    fn update_apigw_domain_name(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let domain = existing.physical_id.clone();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let body = state
+            .domain_names
+            .get_mut(&domain)
+            .ok_or_else(|| format!("DomainName {domain} not found"))?;
+        let obj = body.as_object_mut().ok_or("domain body not object")?;
+        if let Some(s) = props.get("CertificateArn").and_then(|v| v.as_str()) {
+            obj.insert("certificateArn".into(), serde_json::Value::String(s.into()));
+        }
+        if let Some(s) = props.get("RegionalCertificateArn").and_then(|v| v.as_str()) {
+            obj.insert(
+                "regionalCertificateArn".into(),
+                serde_json::Value::String(s.into()),
+            );
+        }
+        if let Some(v) = props.get("EndpointConfiguration").cloned() {
+            obj.insert("endpointConfiguration".into(), v);
+        }
+        if let Some(s) = props.get("SecurityPolicy").and_then(|v| v.as_str()) {
+            obj.insert("securityPolicy".into(), serde_json::Value::String(s.into()));
+        }
+        if let Some(v) = props.get("MutualTlsAuthentication").cloned() {
+            obj.insert("mutualTlsAuthentication".into(), lowercase_first_keys(v));
+        }
+        if let Some(s) = props
+            .get("OwnershipVerificationCertificateArn")
+            .and_then(|v| v.as_str())
+        {
+            obj.insert(
+                "ownershipVerificationCertificateArn".into(),
+                serde_json::Value::String(s.into()),
+            );
+        }
+        if props.get("Tags").is_some() {
+            obj.insert(
+                "tags".into(),
+                serde_json::Value::Object(
+                    parse_acm_tags(props.get("Tags"))
+                        .into_iter()
+                        .map(|(k, v)| (k, serde_json::Value::String(v)))
+                        .collect(),
+                ),
+            );
+        }
+        Ok(ProvisionResult::new(domain.clone())
+            .with("DomainName", domain)
+            .with("RegionalHostedZoneId", "Z2FDTNDATAQYW2".to_string())
+            .with("DistributionHostedZoneId", "Z2FDTNDATAQYW2".to_string()))
+    }
+
+    fn update_apigw_base_path_mapping(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical = existing.physical_id.clone();
+        let mut parts = physical.splitn(2, '/');
+        let domain = parts
+            .next()
+            .ok_or("malformed base path mapping id")?
+            .to_string();
+        let base_path = parts
+            .next()
+            .ok_or("malformed base path mapping id")?
+            .to_string();
+        let mut accounts = self.apigateway_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let map = state
+            .base_path_mappings
+            .get_mut(&domain)
+            .ok_or_else(|| format!("DomainName {domain} not found"))?;
+        let body = map
+            .get_mut(&base_path)
+            .ok_or_else(|| format!("BasePath {base_path} not found"))?;
+        let obj = body.as_object_mut().ok_or("mapping body not object")?;
+        if let Some(s) = props.get("RestApiId").and_then(|v| v.as_str()) {
+            obj.insert("restApiId".into(), serde_json::Value::String(s.into()));
+        }
+        if let Some(s) = props.get("Stage").and_then(|v| v.as_str()) {
+            obj.insert("stage".into(), serde_json::Value::String(s.into()));
+        }
+        Ok(ProvisionResult::new(physical)
+            .with("DomainName", domain)
+            .with("BasePath", base_path))
     }
 
     // --- API Gateway v2 (HTTP/WebSocket APIs) ---

--- a/crates/fakecloud-e2e/tests/cloudformation_apigateway.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_apigateway.rs
@@ -1,15 +1,27 @@
-//! CloudFormation provisioner for AWS::ApiGateway::* (BB9). Exercises
-//! a RestApi with a child Resource, a Method+Integration, a Deployment
-//! that inlines a Stage, plus a UsagePlan/ApiKey. Asserts via the real
-//! API Gateway v1 SDK so the test only passes when both the CFN side
-//! and the runtime API GW side agree on stored shape.
+//! CloudFormation provisioner for AWS::ApiGateway::* (BB9).
+//!
+//! The first test covers the full surface in one stack: RestApi,
+//! Resource, Method (with Integration), Deployment, Stage, Authorizer,
+//! RequestValidator, Model, GatewayResponse, UsagePlan, ApiKey,
+//! UsagePlanKey, DomainName, BasePathMapping. After CreateStack we
+//! assert each resource is visible via the matching API Gateway v1
+//! SDK call so we know the CFN side and the runtime side agree on the
+//! stored shape.
+//!
+//! The second test exercises UpdateStack on every resource type that
+//! supports an in-place update (everything except `UsagePlanKey`,
+//! whose properties are all "requires-replacement" in CFN). We mutate
+//! one or two well-known properties per resource and re-read via SDK.
+//!
+//! Finally DeleteStack should remove every resource — we verify the
+//! RestApi GET 404s after teardown.
 
 mod helpers;
 
 use aws_sdk_cloudformation::types::{Capability, OnFailure};
 use helpers::TestServer;
 
-const TEMPLATE: &str = r#"{
+const TEMPLATE_V1: &str = r#"{
   "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
     "Api": {
@@ -17,10 +29,15 @@ const TEMPLATE: &str = r#"{
       "Properties": {
         "Name": "cfn-api",
         "Description": "from cfn",
-        "EndpointConfiguration": {"Types": ["REGIONAL"]}
+        "EndpointConfiguration": {"Types": ["REGIONAL"]},
+        "BinaryMediaTypes": ["image/png"],
+        "MinimumCompressionSize": 1024,
+        "ApiKeySourceType": "HEADER",
+        "DisableExecuteApiEndpoint": false,
+        "Tags": [{"Key": "env", "Value": "test"}]
       }
     },
-    "Pets": {
+    "PetsResource": {
       "Type": "AWS::ApiGateway::Resource",
       "Properties": {
         "RestApiId": {"Ref": "Api"},
@@ -28,11 +45,41 @@ const TEMPLATE: &str = r#"{
         "PathPart": "pets"
       }
     },
+    "PetModel": {
+      "Type": "AWS::ApiGateway::Model",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "Pet",
+        "Description": "Pet model",
+        "ContentType": "application/json",
+        "Schema": {"type": "object", "properties": {"id": {"type": "string"}}}
+      }
+    },
+    "BodyValidator": {
+      "Type": "AWS::ApiGateway::RequestValidator",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "body-only",
+        "ValidateRequestBody": true,
+        "ValidateRequestParameters": false
+      }
+    },
+    "TokenAuth": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "token-auth",
+        "Type": "TOKEN",
+        "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:auth/invocations",
+        "IdentitySource": "method.request.header.Authorization",
+        "AuthorizerResultTtlInSeconds": 300
+      }
+    },
     "GetPets": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
         "RestApiId": {"Ref": "Api"},
-        "ResourceId": {"Ref": "Pets"},
+        "ResourceId": {"Ref": "PetsResource"},
         "HttpMethod": "GET",
         "AuthorizationType": "NONE",
         "Integration": {
@@ -42,12 +89,39 @@ const TEMPLATE: &str = r#"{
         }
       }
     },
+    "Default4xx": {
+      "Type": "AWS::ApiGateway::GatewayResponse",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ResponseType": "DEFAULT_4XX",
+        "StatusCode": "400",
+        "ResponseTemplates": {"application/json": "{\"message\": \"oops\"}"}
+      }
+    },
     "Deploy": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "GetPets",
       "Properties": {
         "RestApiId": {"Ref": "Api"},
-        "StageName": "prod"
+        "Description": "initial deployment"
+      }
+    },
+    "ProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "DeploymentId": {"Ref": "Deploy"},
+        "StageName": "prod",
+        "Description": "production",
+        "TracingEnabled": false,
+        "Variables": {"foo": "bar"},
+        "MethodSettings": [{
+          "ResourcePath": "/pets",
+          "HttpMethod": "GET",
+          "ThrottlingBurstLimit": 100,
+          "ThrottlingRateLimit": 50
+        }],
+        "Tags": [{"Key": "stage", "Value": "prod"}]
       }
     },
     "Plan": {
@@ -55,35 +129,224 @@ const TEMPLATE: &str = r#"{
       "Properties": {
         "UsagePlanName": "cfn-plan",
         "Description": "test plan",
-        "Throttle": {"BurstLimit": 100, "RateLimit": 50}
+        "Throttle": {"BurstLimit": 100, "RateLimit": 50},
+        "Quota": {"Limit": 1000, "Period": "DAY"},
+        "Tags": [{"Key": "tier", "Value": "free"}]
       }
     },
     "Key": {
       "Type": "AWS::ApiGateway::ApiKey",
       "Properties": {
         "Name": "cfn-key",
-        "Enabled": true
+        "Description": "test key",
+        "Enabled": true,
+        "Tags": [{"Key": "owner", "Value": "fakecloud"}]
+      }
+    },
+    "PlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "Properties": {
+        "UsagePlanId": {"Ref": "Plan"},
+        "KeyId": {"Ref": "Key"},
+        "KeyType": "API_KEY"
+      }
+    },
+    "Domain": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "DomainName": "api.example.test",
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/abcd",
+        "EndpointConfiguration": {"Types": ["REGIONAL"]},
+        "SecurityPolicy": "TLS_1_2"
+      }
+    },
+    "Mapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "DependsOn": "ProdStage",
+      "Properties": {
+        "DomainName": {"Ref": "Domain"},
+        "RestApiId": {"Ref": "Api"},
+        "Stage": "prod",
+        "BasePath": "v1"
       }
     }
   },
   "Outputs": {
     "ApiId": {"Value": {"Ref": "Api"}},
     "RootId": {"Value": {"Fn::GetAtt": ["Api", "RootResourceId"]}},
-    "PetsId": {"Value": {"Ref": "Pets"}},
+    "PetsId": {"Value": {"Ref": "PetsResource"}},
+    "ModelName": {"Value": {"Ref": "PetModel"}},
+    "ValidatorId": {"Value": {"Ref": "BodyValidator"}},
+    "AuthId": {"Value": {"Ref": "TokenAuth"}},
+    "DeployId": {"Value": {"Ref": "Deploy"}},
+    "StageName": {"Value": {"Ref": "ProdStage"}},
+    "PlanId": {"Value": {"Ref": "Plan"}},
+    "KeyId": {"Value": {"Ref": "Key"}},
+    "DomainName": {"Value": {"Ref": "Domain"}}
+  }
+}"#;
+
+const TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Api": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "cfn-api-renamed",
+        "Description": "updated description",
+        "EndpointConfiguration": {"Types": ["REGIONAL"]},
+        "BinaryMediaTypes": ["image/png", "application/octet-stream"],
+        "MinimumCompressionSize": 4096,
+        "Tags": [{"Key": "env", "Value": "prod"}]
+      }
+    },
+    "PetsResource": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ParentId": {"Fn::GetAtt": ["Api", "RootResourceId"]},
+        "PathPart": "pets"
+      }
+    },
+    "PetModel": {
+      "Type": "AWS::ApiGateway::Model",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "Pet",
+        "Description": "Pet model v2",
+        "ContentType": "application/json",
+        "Schema": {"type": "object"}
+      }
+    },
+    "BodyValidator": {
+      "Type": "AWS::ApiGateway::RequestValidator",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "full-validator",
+        "ValidateRequestBody": true,
+        "ValidateRequestParameters": true
+      }
+    },
+    "TokenAuth": {
+      "Type": "AWS::ApiGateway::Authorizer",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Name": "token-auth-renamed",
+        "Type": "TOKEN",
+        "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:auth/invocations",
+        "IdentitySource": "method.request.header.Authorization",
+        "AuthorizerResultTtlInSeconds": 600
+      }
+    },
+    "GetPets": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ResourceId": {"Ref": "PetsResource"},
+        "HttpMethod": "GET",
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "Type": "MOCK",
+          "PassthroughBehavior": "WHEN_NO_MATCH",
+          "RequestTemplates": {"application/json": "{\"statusCode\":200}"}
+        }
+      }
+    },
+    "Default4xx": {
+      "Type": "AWS::ApiGateway::GatewayResponse",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "ResponseType": "DEFAULT_4XX",
+        "StatusCode": "418",
+        "ResponseTemplates": {"application/json": "{\"message\": \"updated\"}"}
+      }
+    },
+    "Deploy": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "DependsOn": "GetPets",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "Description": "updated deployment"
+      }
+    },
+    "ProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": {"Ref": "Api"},
+        "DeploymentId": {"Ref": "Deploy"},
+        "StageName": "prod",
+        "Description": "production-renamed",
+        "TracingEnabled": true,
+        "Variables": {"foo": "baz", "extra": "yes"},
+        "Tags": [{"Key": "stage", "Value": "prod-v2"}]
+      }
+    },
+    "Plan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "Properties": {
+        "UsagePlanName": "cfn-plan-renamed",
+        "Description": "updated plan",
+        "Throttle": {"BurstLimit": 200, "RateLimit": 100},
+        "Quota": {"Limit": 5000, "Period": "WEEK"},
+        "Tags": [{"Key": "tier", "Value": "pro"}]
+      }
+    },
+    "Key": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Name": "cfn-key-renamed",
+        "Description": "updated key",
+        "Enabled": false,
+        "Tags": [{"Key": "owner", "Value": "fakecloud-v2"}]
+      }
+    },
+    "PlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "Properties": {
+        "UsagePlanId": {"Ref": "Plan"},
+        "KeyId": {"Ref": "Key"},
+        "KeyType": "API_KEY"
+      }
+    },
+    "Domain": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "DomainName": "api.example.test",
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/wxyz",
+        "EndpointConfiguration": {"Types": ["REGIONAL"]},
+        "SecurityPolicy": "TLS_1_2"
+      }
+    },
+    "Mapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "DependsOn": "ProdStage",
+      "Properties": {
+        "DomainName": {"Ref": "Domain"},
+        "RestApiId": {"Ref": "Api"},
+        "Stage": "prod",
+        "BasePath": "v1"
+      }
+    }
+  },
+  "Outputs": {
+    "ApiId": {"Value": {"Ref": "Api"}},
+    "ModelName": {"Value": {"Ref": "PetModel"}},
+    "ValidatorId": {"Value": {"Ref": "BodyValidator"}},
+    "AuthId": {"Value": {"Ref": "TokenAuth"}},
     "PlanId": {"Value": {"Ref": "Plan"}},
     "KeyId": {"Value": {"Ref": "Key"}}
   }
 }"#;
 
 #[tokio::test]
-async fn cfn_provisions_apigateway_v1() {
+async fn cfn_provisions_all_apigateway_v1_types() {
     let server = TestServer::start().await;
     let cfn = server.cloudformation_client().await;
     let agw = server.apigateway_client().await;
 
     cfn.create_stack()
         .stack_name("apigw-stack")
-        .template_body(TEMPLATE)
+        .template_body(TEMPLATE_V1)
         .capabilities(Capability::CapabilityIam)
         .on_failure(OnFailure::Rollback)
         .send()
@@ -107,10 +370,20 @@ async fn cfn_provisions_apigateway_v1() {
     let api_id = outputs.get("ApiId").copied().expect("ApiId output");
     let root_id = outputs.get("RootId").copied().expect("RootId output");
     let pets_id = outputs.get("PetsId").copied().expect("PetsId output");
+    let model_name = outputs.get("ModelName").copied().expect("ModelName output");
+    let validator_id = outputs
+        .get("ValidatorId")
+        .copied()
+        .expect("ValidatorId output");
+    let auth_id = outputs.get("AuthId").copied().expect("AuthId output");
     let plan_id = outputs.get("PlanId").copied().expect("PlanId output");
     let key_id = outputs.get("KeyId").copied().expect("KeyId output");
+    let domain = outputs
+        .get("DomainName")
+        .copied()
+        .expect("DomainName output");
 
-    // Verify RestApi via SDK GetRestApi.
+    // RestApi
     let api = agw
         .get_rest_api()
         .rest_api_id(api_id)
@@ -120,8 +393,14 @@ async fn cfn_provisions_apigateway_v1() {
     assert_eq!(api.name(), Some("cfn-api"));
     assert_eq!(api.description(), Some("from cfn"));
     assert_eq!(api.root_resource_id(), Some(root_id));
+    assert_eq!(api.minimum_compression_size(), Some(1024));
+    assert!(api.binary_media_types().iter().any(|s| s == "image/png"));
+    assert_eq!(
+        api.tags().expect("tags").get("env").map(String::as_str),
+        Some("test")
+    );
 
-    // Verify Resource via GetResources.
+    // Resource
     let resources = agw
         .get_resources()
         .rest_api_id(api_id)
@@ -136,7 +415,43 @@ async fn cfn_provisions_apigateway_v1() {
     assert_eq!(pets.path_part(), Some("pets"));
     assert_eq!(pets.path(), Some("/pets"));
 
-    // Verify Method + Integration.
+    // Model
+    let model = agw
+        .get_model()
+        .rest_api_id(api_id)
+        .model_name(model_name)
+        .send()
+        .await
+        .expect("get_model");
+    assert_eq!(model.name(), Some("Pet"));
+    assert_eq!(model.content_type(), Some("application/json"));
+    assert_eq!(model.description(), Some("Pet model"));
+
+    // RequestValidator
+    let validator = agw
+        .get_request_validator()
+        .rest_api_id(api_id)
+        .request_validator_id(validator_id)
+        .send()
+        .await
+        .expect("get_request_validator");
+    assert_eq!(validator.name(), Some("body-only"));
+    assert!(validator.validate_request_body());
+    assert!(!validator.validate_request_parameters());
+
+    // Authorizer
+    let auth = agw
+        .get_authorizer()
+        .rest_api_id(api_id)
+        .authorizer_id(auth_id)
+        .send()
+        .await
+        .expect("get_authorizer");
+    assert_eq!(auth.name(), Some("token-auth"));
+    assert_eq!(auth.r#type().map(|t| t.as_str()), Some("TOKEN"));
+    assert_eq!(auth.authorizer_result_ttl_in_seconds(), Some(300));
+
+    // Method + Integration
     let method = agw
         .get_method()
         .rest_api_id(api_id)
@@ -158,7 +473,17 @@ async fn cfn_provisions_apigateway_v1() {
         .expect("get_integration");
     assert_eq!(integration.r#type().map(|t| t.as_str()), Some("MOCK"));
 
-    // Verify Stage from inline Deployment.StageName.
+    // GatewayResponse
+    let gr = agw
+        .get_gateway_response()
+        .rest_api_id(api_id)
+        .response_type("DEFAULT_4XX".into())
+        .send()
+        .await
+        .expect("get_gateway_response");
+    assert_eq!(gr.status_code(), Some("400"));
+
+    // Stage (verifies MethodSettings applied + Tags + Variables)
     let stage = agw
         .get_stage()
         .rest_api_id(api_id)
@@ -168,8 +493,23 @@ async fn cfn_provisions_apigateway_v1() {
         .expect("get_stage");
     assert_eq!(stage.stage_name(), Some("prod"));
     assert!(!stage.deployment_id().unwrap_or_default().is_empty());
+    assert_eq!(stage.description(), Some("production"));
+    assert_eq!(
+        stage
+            .variables()
+            .expect("variables")
+            .get("foo")
+            .map(String::as_str),
+        Some("bar")
+    );
+    assert_eq!(
+        stage.tags().expect("tags").get("stage").map(String::as_str),
+        Some("prod")
+    );
+    let ms = stage.method_settings().expect("method_settings");
+    assert!(ms.contains_key("pets/GET"), "MethodSettings entry missing");
 
-    // Verify UsagePlan.
+    // UsagePlan
     let plan = agw
         .get_usage_plan()
         .usage_plan_id(plan_id)
@@ -180,8 +520,14 @@ async fn cfn_provisions_apigateway_v1() {
     let throttle = plan.throttle().expect("throttle present");
     assert_eq!(throttle.burst_limit(), 100);
     assert!((throttle.rate_limit() - 50.0).abs() < f64::EPSILON);
+    let quota = plan.quota().expect("quota present");
+    assert_eq!(quota.limit(), 1000);
+    assert_eq!(
+        plan.tags().expect("tags").get("tier").map(String::as_str),
+        Some("free")
+    );
 
-    // Verify ApiKey.
+    // ApiKey
     let key = agw
         .get_api_key()
         .api_key(key_id)
@@ -190,8 +536,177 @@ async fn cfn_provisions_apigateway_v1() {
         .expect("get_api_key");
     assert_eq!(key.name(), Some("cfn-key"));
     assert!(key.enabled());
+    assert_eq!(
+        key.tags().expect("tags").get("owner").map(String::as_str),
+        Some("fakecloud")
+    );
 
-    // Tear down.
+    // UsagePlanKey
+    let upk = agw
+        .get_usage_plan_keys()
+        .usage_plan_id(plan_id)
+        .send()
+        .await
+        .expect("get_usage_plan_keys");
+    assert!(
+        upk.items().iter().any(|k| k.id() == Some(key_id)),
+        "usage plan key missing"
+    );
+
+    // DomainName
+    let dom = agw
+        .get_domain_name()
+        .domain_name(domain)
+        .send()
+        .await
+        .expect("get_domain_name");
+    assert_eq!(dom.domain_name(), Some(domain));
+    assert_eq!(dom.security_policy().map(|p| p.as_str()), Some("TLS_1_2"));
+
+    // BasePathMapping
+    let mapping = agw
+        .get_base_path_mapping()
+        .domain_name(domain)
+        .base_path("v1")
+        .send()
+        .await
+        .expect("get_base_path_mapping");
+    assert_eq!(mapping.base_path(), Some("v1"));
+    assert_eq!(mapping.stage(), Some("prod"));
+    assert_eq!(mapping.rest_api_id(), Some(api_id));
+
+    // ---- UpdateStack: mutate one property on each updatable type. ----
+    cfn.update_stack()
+        .stack_name("apigw-stack")
+        .template_body(TEMPLATE_V2)
+        .capabilities(Capability::CapabilityIam)
+        .send()
+        .await
+        .expect("update_stack");
+
+    let after_described = cfn
+        .describe_stacks()
+        .stack_name("apigw-stack")
+        .send()
+        .await
+        .expect("describe_stacks v2");
+    let after_stack = after_described.stacks().first().expect("stack v2");
+    assert_eq!(
+        after_stack.stack_status().unwrap().as_str(),
+        "UPDATE_COMPLETE"
+    );
+
+    // RestApi rename + binary media types extended
+    let api2 = agw
+        .get_rest_api()
+        .rest_api_id(api_id)
+        .send()
+        .await
+        .expect("get_rest_api v2");
+    assert_eq!(api2.name(), Some("cfn-api-renamed"));
+    assert_eq!(api2.description(), Some("updated description"));
+    assert_eq!(api2.minimum_compression_size(), Some(4096));
+    assert!(api2
+        .binary_media_types()
+        .iter()
+        .any(|s| s == "application/octet-stream"));
+    assert_eq!(
+        api2.tags().expect("tags").get("env").map(String::as_str),
+        Some("prod")
+    );
+
+    // Model description updated
+    let model2 = agw
+        .get_model()
+        .rest_api_id(api_id)
+        .model_name("Pet")
+        .send()
+        .await
+        .expect("get_model v2");
+    assert_eq!(model2.description(), Some("Pet model v2"));
+
+    // Validator rename + both flags true
+    let validator2 = agw
+        .get_request_validator()
+        .rest_api_id(api_id)
+        .request_validator_id(validator_id)
+        .send()
+        .await
+        .expect("get_request_validator v2");
+    assert_eq!(validator2.name(), Some("full-validator"));
+    assert!(validator2.validate_request_body());
+    assert!(validator2.validate_request_parameters());
+
+    // Authorizer rename + ttl bumped
+    let auth2 = agw
+        .get_authorizer()
+        .rest_api_id(api_id)
+        .authorizer_id(auth_id)
+        .send()
+        .await
+        .expect("get_authorizer v2");
+    assert_eq!(auth2.name(), Some("token-auth-renamed"));
+    assert_eq!(auth2.authorizer_result_ttl_in_seconds(), Some(600));
+
+    // GatewayResponse status code rotated
+    let gr2 = agw
+        .get_gateway_response()
+        .rest_api_id(api_id)
+        .response_type("DEFAULT_4XX".into())
+        .send()
+        .await
+        .expect("get_gateway_response v2");
+    assert_eq!(gr2.status_code(), Some("418"));
+
+    // Stage description + tracing flipped + new variable
+    let stage2 = agw
+        .get_stage()
+        .rest_api_id(api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("get_stage v2");
+    assert_eq!(stage2.description(), Some("production-renamed"));
+    assert!(stage2.tracing_enabled());
+    assert_eq!(
+        stage2
+            .variables()
+            .expect("variables")
+            .get("extra")
+            .map(String::as_str),
+        Some("yes")
+    );
+
+    // UsagePlan rename + throttle bumped + quota updated
+    let plan2 = agw
+        .get_usage_plan()
+        .usage_plan_id(plan_id)
+        .send()
+        .await
+        .expect("get_usage_plan v2");
+    assert_eq!(plan2.name(), Some("cfn-plan-renamed"));
+    assert_eq!(plan2.throttle().expect("throttle v2").burst_limit(), 200);
+    assert_eq!(plan2.quota().expect("quota v2").limit(), 5000);
+    assert_eq!(
+        plan2.tags().expect("tags").get("tier").map(String::as_str),
+        Some("pro")
+    );
+
+    // ApiKey rename + disabled
+    let key2 = agw
+        .get_api_key()
+        .api_key(key_id)
+        .send()
+        .await
+        .expect("get_api_key v2");
+    assert_eq!(key2.name(), Some("cfn-key-renamed"));
+    assert!(!key2.enabled());
+    assert_eq!(
+        key2.tags().expect("tags").get("owner").map(String::as_str),
+        Some("fakecloud-v2")
+    );
+
+    // ---- DeleteStack: every resource is gone afterwards. ----
     cfn.delete_stack()
         .stack_name("apigw-stack")
         .send()
@@ -200,4 +715,13 @@ async fn cfn_provisions_apigateway_v1() {
 
     let after = agw.get_rest_api().rest_api_id(api_id).send().await;
     assert!(after.is_err(), "api should be gone after delete");
+    let after_plan = agw.get_usage_plan().usage_plan_id(plan_id).send().await;
+    assert!(
+        after_plan.is_err(),
+        "usage plan should be gone after delete"
+    );
+    let after_key = agw.get_api_key().api_key(key_id).send().await;
+    assert!(after_key.is_err(), "api key should be gone after delete");
+    let after_dom = agw.get_domain_name().domain_name(domain).send().await;
+    assert!(after_dom.is_err(), "domain should be gone after delete");
 }


### PR DESCRIPTION
## Summary
Round out the API Gateway v1 CFN surface across all 14 resource types.

- Create paths existed but ignored Tags / MinimumCompressionSize / Body imports / MutualTlsAuthentication / MethodSettings / StageKeys / GenerateDistinctId; wire those through to the apigateway state.
- Add update_resource paths for every type that supports in-place updates (everything except UsagePlanKey, whose properties are all requires-replacement in CFN) and route them through update_resource.
- Expand cfn_provisions_apigateway_v1 E2E into a single stack covering all 14 types: RestApi + Resource + Method + Deployment + Stage + Authorizer + RequestValidator + Model + GatewayResponse + UsagePlan + ApiKey + UsagePlanKey + DomainName + BasePathMapping.

## Test plan
- [x] cargo test -p fakecloud-e2e --test cloudformation_apigateway
- [x] cargo test -p fakecloud-cloudformation
- [x] cargo test -p fakecloud-apigateway
- [x] cargo test -p fakecloud-e2e --test cloudformation_apigatewayv2 (no regression)
- [x] cargo test -p fakecloud-e2e --test apigateway (no regression)
- [x] cargo clippy -p fakecloud-cloudformation -p fakecloud-e2e --all-targets -- -D warnings
- [x] cargo fmt --all

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complete API Gateway v1 CloudFormation support across all 14 `AWS::ApiGateway::*` resources with create and in-place update paths. Expands E2E tests to validate create/update/delete via the API Gateway SDK and fulfills BB9.

- **New Features**
  - Full coverage: RestApi, Resource, Method, Deployment, Stage, Authorizer, RequestValidator, Model, GatewayResponse, UsagePlan, ApiKey, UsagePlanKey, DomainName, BasePathMapping.
  - Update handlers for every in-place updatable type (all except `UsagePlanKey`, which is replacement-only in CFN).
  - Persist/translate CFN fields: Tags, MinimumCompressionSize, ApiKeySourceType, BinaryMediaTypes, DisableExecuteApiEndpoint, Body/BodyS3Location/CloneFrom (tracked as import source), MutualTlsAuthentication, MethodSettings (list → path/method map), Stage variables/tags, AccessLogSetting, CanarySetting, UsagePlan Quota, StageKeys (RestApiId/StageName → "restApiId/stageName"), GenerateDistinctId for `ApiKey`.
  - E2E: single stack covers all 14 types; verifies CreateStack, UpdateStack (mutates key props per type), and DeleteStack teardown via SDK. V2 tests run with no regressions.

<sup>Written for commit d307427483015a6f189e0d5a09160e83c5627b92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

