### PR TITLE
feat(sns): HTTP/HTTPS SubscriptionConfirmation POST + ConfirmSubscription (K3)

### DIFF
--- a/crates/fakecloud-e2e/tests/sns_http_confirm.rs
+++ b/crates/fakecloud-e2e/tests/sns_http_confirm.rs
@@ -1,0 +1,248 @@
+//! End-to-end coverage for SNS HTTP/HTTPS subscription confirmation.
+//!
+//! Real AWS POSTs a SubscriptionConfirmation envelope to the subscriber
+//! endpoint when an HTTP/HTTPS subscription is created. The subscriber
+//! is then expected to call `ConfirmSubscription` with the embedded
+//! Token before any notifications fan out. These tests spin up a tiny
+//! TCP server, subscribe it to a topic, capture the inbound POST, and
+//! drive the round-trip end-to-end.
+
+mod helpers;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use helpers::TestServer;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+/// Inbound HTTP request captured by `MockSubscriber`. Stores the raw
+/// bytes; tests parse out headers and body as needed.
+#[derive(Clone, Debug)]
+struct CapturedRequest {
+    raw: String,
+}
+
+impl CapturedRequest {
+    fn header(&self, name: &str) -> Option<String> {
+        let lower = name.to_ascii_lowercase();
+        for line in self.raw.lines().skip(1) {
+            if line.is_empty() {
+                break;
+            }
+            if let Some((k, v)) = line.split_once(':') {
+                if k.trim().to_ascii_lowercase() == lower {
+                    return Some(v.trim().to_string());
+                }
+            }
+        }
+        None
+    }
+
+    fn body(&self) -> &str {
+        self.raw
+            .split_once("\r\n\r\n")
+            .map(|(_, b)| b)
+            .unwrap_or("")
+    }
+}
+
+/// Tiny HTTP server that records every inbound request and replies
+/// 200 OK. Stays alive for the duration of the test via `tokio::spawn`.
+struct MockSubscriber {
+    url: String,
+    received: Arc<Mutex<Vec<CapturedRequest>>>,
+}
+
+impl MockSubscriber {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/sns-hook");
+        let received: Arc<Mutex<Vec<CapturedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_for_task = received.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let received = received_for_task.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 16 * 1024];
+                    let n = sock.read(&mut buf).await.unwrap_or(0);
+                    let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+                    received.lock().await.push(CapturedRequest { raw });
+                    let resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+        Self { url, received }
+    }
+
+    /// Wait up to `timeout` for at least `n` requests to arrive.
+    async fn wait_for(&self, n: usize, timeout: Duration) -> Vec<CapturedRequest> {
+        let start = std::time::Instant::now();
+        loop {
+            {
+                let guard = self.received.lock().await;
+                if guard.len() >= n {
+                    return guard.clone();
+                }
+            }
+            if start.elapsed() > timeout {
+                let guard = self.received.lock().await;
+                panic!("timed out waiting for {n} requests; got {}", guard.len());
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn sns_http_subscribe_posts_confirmation_envelope_and_publish_routes_after_confirm() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let subscriber = MockSubscriber::start().await;
+
+    let topic = sns
+        .create_topic()
+        .name("http-confirm-e2e")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    // Subscribe with HTTP — fakecloud should POST a
+    // SubscriptionConfirmation envelope to the endpoint asynchronously.
+    let sub = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("http")
+        .endpoint(&subscriber.url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(sub.subscription_arn().unwrap(), "pending confirmation");
+
+    // Wait for the confirmation POST.
+    let requests = subscriber.wait_for(1, Duration::from_secs(5)).await;
+    let confirmation = &requests[0];
+
+    // Headers must match AWS conventions.
+    assert_eq!(
+        confirmation.header("x-amz-sns-message-type").as_deref(),
+        Some("SubscriptionConfirmation")
+    );
+    assert_eq!(
+        confirmation.header("x-amz-sns-topic-arn").as_deref(),
+        Some(topic_arn.as_str())
+    );
+    assert_eq!(
+        confirmation.header("content-type").as_deref(),
+        Some("text/plain; charset=UTF-8")
+    );
+
+    // Body shape — JSON with the standard SNS confirmation fields.
+    let body: serde_json::Value =
+        serde_json::from_str(confirmation.body()).expect("confirmation body is JSON");
+    assert_eq!(body["Type"], "SubscriptionConfirmation");
+    assert_eq!(body["TopicArn"], topic_arn);
+    assert!(body["Message"]
+        .as_str()
+        .unwrap()
+        .contains("You have chosen to subscribe"));
+    let token = body["Token"].as_str().expect("Token present").to_string();
+    assert_eq!(token.len(), 256, "token should be 256 chars");
+    assert!(token.chars().all(|c| c.is_ascii_alphanumeric()));
+    assert!(body["MessageId"].is_string());
+    assert!(body["Timestamp"].is_string());
+    assert_eq!(body["SignatureVersion"], "1");
+    let subscribe_url = body["SubscribeURL"].as_str().unwrap();
+    assert!(subscribe_url.contains("Action=ConfirmSubscription"));
+    assert!(subscribe_url.contains(&token));
+
+    // Publish before confirmation — endpoint must NOT receive it.
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("blocked")
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert_eq!(
+        subscriber.received.lock().await.len(),
+        1,
+        "publish before confirmation must not fan out"
+    );
+
+    // Confirm with the issued token.
+    let confirmed = sns
+        .confirm_subscription()
+        .topic_arn(&topic_arn)
+        .token(&token)
+        .send()
+        .await
+        .unwrap();
+    let confirmed_arn = confirmed.subscription_arn().unwrap();
+    assert!(
+        confirmed_arn.starts_with(&topic_arn),
+        "confirmation should return the real subscription ARN, got {confirmed_arn}"
+    );
+
+    // Now publish — the endpoint should receive a Notification POST.
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("after-confirm")
+        .send()
+        .await
+        .unwrap();
+    let requests = subscriber.wait_for(2, Duration::from_secs(5)).await;
+    let notification = &requests[1];
+    assert_eq!(
+        notification.header("x-amz-sns-message-type").as_deref(),
+        Some("Notification")
+    );
+    let n_body: serde_json::Value =
+        serde_json::from_str(notification.body()).expect("notification body is JSON");
+    assert_eq!(n_body["Type"], "Notification");
+    assert_eq!(n_body["TopicArn"], topic_arn);
+    assert_eq!(n_body["Message"], "after-confirm");
+}
+
+#[tokio::test]
+async fn sns_http_confirm_rejects_bad_token() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let subscriber = MockSubscriber::start().await;
+
+    let topic = sns
+        .create_topic()
+        .name("bad-token-e2e")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    sns.subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("http")
+        .endpoint(&subscriber.url)
+        .send()
+        .await
+        .unwrap();
+
+    let err = sns
+        .confirm_subscription()
+        .topic_arn(&topic_arn)
+        .token("not-a-real-token")
+        .send()
+        .await
+        .expect_err("bad token must reject");
+    let dbg = format!("{err:?}");
+    assert!(
+        dbg.contains("InvalidParameter") || dbg.contains("Invalid token"),
+        "expected InvalidParameter, got {dbg}"
+    );
+}

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -248,8 +248,16 @@ pub(crate) fn build_sns_lambda_event(input: &SnsLambdaEventInput<'_>) -> String 
 
 /// Build an SNS SubscriptionConfirmation envelope as a JSON string.
 /// AWS POSTs this to HTTP/HTTPS endpoints right after Subscribe so the
-/// subscriber can echo the Token back via ConfirmSubscription.
-pub(crate) fn build_subscription_confirmation_envelope(topic_arn: &str, token: &str) -> String {
+/// subscriber can echo the Token back via ConfirmSubscription. The
+/// `server_endpoint` is the public URL of this fakecloud instance and
+/// is used to build a SubscribeURL the subscriber can actually GET to
+/// confirm — pointing at sns.amazonaws.com would defeat the purpose of
+/// running locally.
+pub(crate) fn build_subscription_confirmation_envelope(
+    topic_arn: &str,
+    token: &str,
+    server_endpoint: &str,
+) -> String {
     let mut map = serde_json::Map::new();
     map.insert(
         "Type".to_string(),
@@ -267,10 +275,11 @@ pub(crate) fn build_subscription_confirmation_envelope(topic_arn: &str, token: &
             "You have chosen to subscribe to the topic {topic_arn}.\nTo confirm the subscription, visit the SubscribeURL included in this message."
         )),
     );
+    let base = server_endpoint.trim_end_matches('/');
     map.insert(
         "SubscribeURL".to_string(),
         Value::String(format!(
-            "https://sns.amazonaws.com/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+            "{base}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
         )),
     );
     map.insert(
@@ -281,7 +290,26 @@ pub(crate) fn build_subscription_confirmation_envelope(topic_arn: &str, token: &
         "SignatureVersion".to_string(),
         Value::String("1".to_string()),
     );
+    map.insert(
+        "SigningCertURL".to_string(),
+        Value::String(format!("{base}/SimpleNotificationService.pem")),
+    );
+    map.insert(
+        "Signature".to_string(),
+        Value::String(crate::signing::sign(&format!(
+            "Message\n{topic_arn}\nSubscriptionConfirmation\n{token}\n"
+        ))),
+    );
     Value::Object(map).to_string()
+}
+
+/// Generate a 256-character alphanumeric token for SNS subscription
+/// confirmation. AWS issues opaque base64 tokens of similar length;
+/// matching the shape keeps client libraries that validate token
+/// length happy.
+pub(crate) fn generate_confirmation_token() -> String {
+    use rand::distributions::{Alphanumeric, DistString};
+    Alphanumeric.sample_string(&mut rand::thread_rng(), 256)
 }
 
 /// Build an SNS notification envelope as JSON string.
@@ -1296,23 +1324,53 @@ pub(crate) fn validate_numeric_filter(arr: &[Value]) -> Result<(), AwsServiceErr
 
 #[cfg(test)]
 mod confirmation_envelope_tests {
-    use super::build_subscription_confirmation_envelope;
+    use super::{build_subscription_confirmation_envelope, generate_confirmation_token};
     use serde_json::Value;
 
     #[test]
     fn envelope_carries_token_and_subscribe_url() {
         let topic = "arn:aws:sns:us-east-1:123456789012:test-topic";
         let token = "tok-abc";
-        let body = build_subscription_confirmation_envelope(topic, token);
+        let server = "http://localhost:4566";
+        let body = build_subscription_confirmation_envelope(topic, token, server);
         let parsed: Value = serde_json::from_str(&body).expect("valid JSON");
         assert_eq!(parsed["Type"], "SubscriptionConfirmation");
         assert_eq!(parsed["TopicArn"], topic);
         assert_eq!(parsed["Token"], token);
         let url = parsed["SubscribeURL"].as_str().unwrap();
+        assert!(url.starts_with(server));
         assert!(url.contains("Action=ConfirmSubscription"));
         assert!(url.contains(token));
         assert!(url.contains(topic));
         assert!(parsed["Timestamp"].is_string());
         assert!(parsed["MessageId"].is_string());
+        assert_eq!(parsed["SignatureVersion"], "1");
+        assert!(!parsed["Signature"].as_str().unwrap().is_empty());
+        assert!(parsed["SigningCertURL"]
+            .as_str()
+            .unwrap()
+            .starts_with(server));
+    }
+
+    #[test]
+    fn envelope_trims_trailing_slash() {
+        let body = build_subscription_confirmation_envelope(
+            "arn:aws:sns:us-east-1:123456789012:t",
+            "tok",
+            "http://localhost:4566/",
+        );
+        let parsed: Value = serde_json::from_str(&body).expect("valid JSON");
+        let url = parsed["SubscribeURL"].as_str().unwrap();
+        assert!(!url.contains("//?"), "must not double-up the slash: {url}");
+    }
+
+    #[test]
+    fn confirmation_token_is_256_alphanumeric() {
+        let t = generate_confirmation_token();
+        assert_eq!(t.len(), 256);
+        assert!(t.chars().all(|c| c.is_ascii_alphanumeric()));
+        // Two calls should differ.
+        let t2 = generate_confirmation_token();
+        assert_ne!(t, t2);
     }
 }

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -848,12 +848,18 @@ impl SnsService {
             "pending confirmation".to_string()
         };
 
-        // Generate a confirmation token for pending subscriptions
+        // Generate a confirmation token for pending subscriptions. AWS
+        // issues a 256-character opaque token; matching the length keeps
+        // clients that validate it happy.
         let confirmation_token = if !confirmed {
-            Some(uuid::Uuid::new_v4().to_string())
+            Some(self::helpers::generate_confirmation_token())
         } else {
             None
         };
+        // Snapshot the server endpoint while we still hold the lock so
+        // the spawned POST can build a SubscribeURL pointing at *this*
+        // fakecloud instance, not the public AWS endpoint.
+        let server_endpoint = state.endpoint.clone();
 
         let sub = SnsSubscription {
             subscription_arn: sub_arn.clone(),
@@ -883,14 +889,22 @@ impl SnsService {
             } else if let Some(token) = confirmation_token {
                 let endpoint_url = endpoint.clone();
                 let topic = topic_arn.clone();
+                let sub_arn_for_header = sub_arn.clone();
+                let server_url = server_endpoint.clone();
                 tokio::spawn(async move {
-                    let body = build_subscription_confirmation_envelope(&topic, &token);
+                    let body =
+                        build_subscription_confirmation_envelope(&topic, &token, &server_url);
                     let client = reqwest::Client::new();
                     let result = client
                         .post(&endpoint_url)
-                        .header("Content-Type", "application/json")
+                        // AWS sends SNS notifications with text/plain content
+                        // type even though the body is JSON. Subscriber SDKs
+                        // (e.g. notification handlers) match on this exactly.
+                        .header("Content-Type", "text/plain; charset=UTF-8")
                         .header("x-amz-sns-message-type", "SubscriptionConfirmation")
                         .header("x-amz-sns-topic-arn", &topic)
+                        .header("x-amz-sns-subscription-arn", &sub_arn_for_header)
+                        .header("User-Agent", "Amazon Simple Notification Service Agent")
                         .body(body)
                         .send()
                         .await;
@@ -939,10 +953,13 @@ impl SnsService {
             })
             .map(|s| s.subscription_arn.clone())
             .ok_or_else(|| {
+                // AWS returns InvalidParameterException for unknown or
+                // expired confirmation tokens; matching the wire format
+                // lets client SDKs surface the right error type.
                 AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "NotFound",
-                    format!("No pending subscription found for token: {token}"),
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    format!("Invalid token: {token}"),
                 )
             })?;
 


### PR DESCRIPTION
## Summary

Brings fakecloud's SNS HTTP/HTTPS subscription flow in line with real AWS:

- `Subscribe` with `Protocol=http`/`https` now spawns a real HTTP POST to the endpoint carrying a `SubscriptionConfirmation` envelope with the standard fields (`Type`, `MessageId`, `Token`, `TopicArn`, `Message`, `SubscribeURL`, `Timestamp`, `SignatureVersion`, `Signature`, `SigningCertURL`).
- Tokens are now 256-char alphanumeric strings (matching AWS shape) instead of short UUIDs.
- The `SubscribeURL` points back at the running fakecloud instance so subscribers can actually GET it to confirm — not at `sns.amazonaws.com`.
- POST headers match AWS: `Content-Type: text/plain; charset=UTF-8`, `x-amz-sns-message-type`, `x-amz-sns-topic-arn`, `x-amz-sns-subscription-arn`, `User-Agent: Amazon Simple Notification Service Agent`.
- `ConfirmSubscription` rejects unknown tokens with `InvalidParameter` (AWS-compatible) instead of `NotFound`.
- `Publish` already skipped unconfirmed HTTP subscribers via `confirmed_for_topic`; behavior preserved.

## Test plan

- [x] Unit tests for envelope shape + token generator (`fakecloud-sns`)
- [x] New E2E `sns_http_confirm.rs` spins a local TCP server, captures the inbound POST, asserts headers + body shape, verifies pre-confirm Publish is dropped, confirms with the issued token, then verifies a post-confirm Publish lands as a Notification
- [x] Existing `sns_confirm_subscription` E2E (pending-confirmations admin endpoint flow) still passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings SNS HTTP/HTTPS subscription flow in line with AWS so HTTP endpoints receive real SubscriptionConfirmation POSTs and only get messages after confirming. This improves local parity and makes links and headers match what clients expect.

- New Features
  - `Subscribe` with `http`/`https` sends a POST to the endpoint with a SubscriptionConfirmation JSON envelope (Type, MessageId, Token, TopicArn, Message, SubscribeURL, Timestamp, SignatureVersion, Signature, SigningCertURL).
  - Headers match AWS: `Content-Type: text/plain; charset=UTF-8`, `x-amz-sns-message-type`, `x-amz-sns-topic-arn`, `x-amz-sns-subscription-arn`, `User-Agent: Amazon Simple Notification Service Agent`.
  - `SubscribeURL` points to this `fakecloud` instance so the link is clickable locally.
  - Tokens are 256-character alphanumeric strings (AWS-shaped).
  - `ConfirmSubscription` returns `InvalidParameter` (400) for unknown tokens.
  - Unconfirmed HTTP subscribers do not receive publishes (unchanged).
  - Added E2E `sns_http_confirm.rs` and unit tests for envelope and token generator.

<sup>Written for commit bfb65b342b3dfb75d689903dc143d8c2826202b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

