### PR TITLE
feat(dynamodb): PartiQL real comparators + schema validation + stream emit (L4)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -21,9 +21,9 @@ type PendingKinesis = (
 
 use super::{
     apply_update_expression, build_consumed_capacity, evaluate_condition, execute_partiql_in_state,
-    execute_partiql_statement, extract_key, get_table, get_table_mut,
-    parse_expression_attribute_names, parse_expression_attribute_values, require_str,
-    return_consumed_mode, return_icm_mode, DynamoDbService,
+    extract_key, get_table, get_table_mut, parse_expression_attribute_names,
+    parse_expression_attribute_values, require_str, return_consumed_mode, return_icm_mode,
+    DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -763,7 +763,66 @@ impl DynamoDbService {
         let statement = require_str(&body, "Statement")?;
         let parameters = body["Parameters"].as_array().cloned().unwrap_or_default();
 
-        execute_partiql_statement(&self.state, &req.account_id, statement, &parameters)
+        // Hold the write lock only long enough to mutate state and
+        // capture the change capture record. Stream records are
+        // appended under the write lock; Kinesis delivery happens
+        // after the lock is released so the delivery bus (which may
+        // take a read lock to look up the destination stream) doesn't
+        // deadlock against us. This mirrors items.rs::put_item.
+        let (response, pending_kinesis) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            let region = state.region.clone();
+            let outcome = execute_partiql_in_state(state, statement, &parameters)?;
+            let response = outcome.response.clone();
+
+            let kinesis_info = if let (Some(table_name), Some(event_name)) =
+                (outcome.table_name.as_ref(), outcome.event_name.as_ref())
+            {
+                if let Some(table) = state.tables.get_mut(table_name) {
+                    let keys = outcome.keys.clone().unwrap_or_default();
+                    if table.stream_enabled {
+                        if let Some(record) = crate::streams::generate_stream_record(
+                            table,
+                            event_name,
+                            keys.clone(),
+                            outcome.old_image.clone(),
+                            outcome.new_image.clone(),
+                            &region,
+                        ) {
+                            crate::streams::add_stream_record(table, record);
+                        }
+                    }
+                    DynamoDbService::kinesis_target(table).map(|target| {
+                        (
+                            target,
+                            event_name.clone(),
+                            keys,
+                            outcome.old_image,
+                            outcome.new_image,
+                        )
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            (response, kinesis_info)
+        };
+
+        if let Some((target, event_name, keys, old_image, new_image)) = pending_kinesis {
+            self.deliver_to_kinesis_destinations(
+                &target,
+                &event_name,
+                &keys,
+                old_image.as_ref(),
+                new_image.as_ref(),
+            );
+        }
+
+        Self::ok_json(response)
     }
 
     pub(super) fn batch_execute_statement(
@@ -784,29 +843,74 @@ impl DynamoDbService {
             )
         })?;
 
-        let mut responses: Vec<Value> = Vec::new();
-        for stmt_obj in statements {
-            let statement = stmt_obj["Statement"].as_str().unwrap_or_default();
-            let parameters = stmt_obj["Parameters"]
-                .as_array()
-                .cloned()
-                .unwrap_or_default();
+        let (responses, pending_kinesis) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            let region = state.region.clone();
+            let mut responses: Vec<Value> = Vec::with_capacity(statements.len());
+            let mut pending_kinesis: Vec<PendingKinesis> = Vec::new();
 
-            match execute_partiql_statement(&self.state, &req.account_id, statement, &parameters) {
-                Ok(resp) => {
-                    let resp_body: Value =
-                        serde_json::from_slice(resp.body.expect_bytes()).unwrap_or_default();
-                    responses.push(resp_body);
-                }
-                Err(e) => {
-                    responses.push(json!({
-                        "Error": {
-                            "Code": "ValidationException",
-                            "Message": e.to_string()
+            for stmt_obj in statements {
+                let statement = stmt_obj["Statement"].as_str().unwrap_or_default();
+                let parameters = stmt_obj["Parameters"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+
+                match execute_partiql_in_state(state, statement, &parameters) {
+                    Ok(outcome) => {
+                        responses.push(outcome.response.clone());
+                        if let (Some(table_name), Some(event_name)) =
+                            (outcome.table_name.as_ref(), outcome.event_name.as_ref())
+                        {
+                            if let Some(table) = state.tables.get_mut(table_name) {
+                                let keys = outcome.keys.clone().unwrap_or_default();
+                                if table.stream_enabled {
+                                    if let Some(record) = crate::streams::generate_stream_record(
+                                        table,
+                                        event_name,
+                                        keys.clone(),
+                                        outcome.old_image.clone(),
+                                        outcome.new_image.clone(),
+                                        &region,
+                                    ) {
+                                        crate::streams::add_stream_record(table, record);
+                                    }
+                                }
+                                if let Some(target) = DynamoDbService::kinesis_target(table) {
+                                    pending_kinesis.push((
+                                        target,
+                                        event_name.clone(),
+                                        keys,
+                                        outcome.old_image,
+                                        outcome.new_image,
+                                    ));
+                                }
+                            }
                         }
-                    }));
+                    }
+                    Err(e) => {
+                        responses.push(json!({
+                            "Error": {
+                                "Code": "ValidationException",
+                                "Message": e.to_string()
+                            }
+                        }));
+                    }
                 }
             }
+
+            (responses, pending_kinesis)
+        };
+
+        for (target, event_name, keys, old_image, new_image) in pending_kinesis {
+            self.deliver_to_kinesis_destinations(
+                &target,
+                &event_name,
+                &keys,
+                old_image.as_ref(),
+                new_image.as_ref(),
+            );
         }
 
         Self::ok_json(json!({ "Responses": responses }))
@@ -839,9 +943,10 @@ impl DynamoDbService {
         // Acquire the write lock once for the whole batch — DDB
         // ExecuteTransaction is all-or-nothing so we cannot release
         // the lock between phases or another writer could observe
-        // partial state.
+        // partial state. Use the caller's account_id so cross-account
+        // STS callers don't accidentally write to the default account.
         let mut accounts = self.state.write();
-        let state = accounts.default_mut();
+        let state = accounts.get_or_create(&req.account_id);
 
         let region = req.region.clone();
 
@@ -1392,6 +1497,64 @@ mod tests {
             2,
             "each PartiQL INSERT must emit one stream record"
         );
+    }
+
+    #[tokio::test]
+    async fn execute_statement_insert_emits_stream_record() {
+        // L4: a single ExecuteStatement INSERT (not via Transaction) on
+        // a stream-enabled table must emit a Stream record so log/CDC
+        // consumers see the same event they would for a PutItem call.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"}),
+        ))
+        .unwrap();
+
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 1);
+        let records = table.stream_records.read();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].event_name, "INSERT");
+    }
+
+    #[tokio::test]
+    async fn batch_execute_statement_emits_stream_record_per_write() {
+        // L4: each statement in a BatchExecuteStatement that succeeds
+        // and mutates the table must emit its own Stream record.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        svc.batch_execute_statement(&req_for(
+            "BatchExecuteStatement",
+            json!({
+                "Statements": [
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+                    {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'b'}"},
+                ]
+            }),
+        ))
+        .unwrap();
+
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 2);
+        assert_eq!(table.stream_records.read().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -10,9 +10,7 @@ use base64::Engine;
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsResponse, AwsServiceError};
-
-use super::DynamoDbService;
+use fakecloud_core::service::AwsServiceError;
 
 use crate::state::*;
 
@@ -2154,39 +2152,15 @@ pub(crate) fn build_table_description(table: &DynamoTable) -> Value {
     desc
 }
 
-pub(crate) fn execute_partiql_statement(
-    state: &SharedDynamoDbState,
-    account_id: &str,
-    statement: &str,
-    parameters: &[Value],
-) -> Result<AwsResponse, AwsServiceError> {
-    let trimmed = statement.trim();
-    let upper = trimmed.to_ascii_uppercase();
-
-    if upper.starts_with("SELECT") {
-        execute_partiql_select(state, account_id, trimmed, parameters)
-    } else if upper.starts_with("INSERT") {
-        execute_partiql_insert(state, account_id, trimmed, parameters)
-    } else if upper.starts_with("UPDATE") {
-        execute_partiql_update(state, account_id, trimmed, parameters)
-    } else if upper.starts_with("DELETE") {
-        execute_partiql_delete(state, account_id, trimmed, parameters)
-    } else {
-        Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            format!("Unsupported PartiQL statement: {trimmed}"),
-        ))
-    }
-}
-
-/// In-place PartiQL executor used by ExecuteTransaction, which must
-/// hold a single write lock across the whole batch so a mid-batch error
-/// can revert. Returns the response body Value plus the touched table
-/// name and (for write ops) the keys + before/after images so the
-/// caller can emit stream + kinesis events after the transaction
-/// commits — mirroring the per-write hooks in items.rs and the
-/// TransactWriteItems path.
+/// In-place PartiQL executor used by every PartiQL entry point
+/// (ExecuteStatement, BatchExecuteStatement, ExecuteTransaction).
+/// The caller holds the write lock for the batch — ExecuteTransaction
+/// keeps it across the entire all-or-nothing apply phase, single-shot
+/// callers acquire it for one statement. Returns the response body
+/// Value plus the touched table name and (for write ops) the keys +
+/// before/after images so the caller can emit stream + kinesis events
+/// after the lock is released — mirroring the per-write hooks in
+/// items.rs and the TransactWriteItems path.
 pub(crate) struct PartiqlOutcome {
     pub response: Value,
     pub table_name: Option<String>,
@@ -2254,18 +2228,7 @@ pub(crate) fn execute_partiql_in_state(
         let value_str = rest.trim()[value_pos + 5..].trim();
         let item = parse_partiql_value_object(value_str, parameters)?;
         let table = get_table_mut(&mut state.tables, &table_name)?;
-        for key_attr in &table.key_schema {
-            if !item.contains_key(&key_attr.attribute_name) {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ValidationException",
-                    format!(
-                        "One or more parameter values were invalid: Missing the key {} in the item",
-                        key_attr.attribute_name
-                    ),
-                ));
-            }
-        }
+        validate_partiql_item_against_key_schema(table, &item)?;
         let key = extract_key(table, &item);
         if table.find_item_index(&key).is_some() {
             return Err(AwsServiceError::aws_error(
@@ -2387,219 +2350,6 @@ pub(crate) fn execute_partiql_in_state(
     }
 }
 
-/// Parse a simple `SELECT * FROM tablename WHERE pk = 'value'` or with parameters.
-pub(crate) fn execute_partiql_select(
-    state: &SharedDynamoDbState,
-    account_id: &str,
-    statement: &str,
-    parameters: &[Value],
-) -> Result<AwsResponse, AwsServiceError> {
-    // Pattern: SELECT * FROM "tablename" [WHERE col = 'val' | WHERE col = ?]
-    let upper = statement.to_ascii_uppercase();
-    let from_pos = upper.find("FROM").ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Invalid SELECT statement: missing FROM",
-        )
-    })?;
-
-    let after_from = statement[from_pos + 4..].trim();
-    let (table_name, rest) = parse_partiql_table_name(after_from);
-
-    let __mas = state.read();
-    let empty_state = crate::state::DynamoDbState::new(account_id, "us-east-1");
-    let state = __mas.get(account_id).unwrap_or(&empty_state);
-    let table = get_table(&state.tables, &table_name)?;
-
-    let rest_upper = rest.trim().to_ascii_uppercase();
-    if rest_upper.starts_with("WHERE") {
-        let where_clause = rest.trim()[5..].trim();
-        let matched = evaluate_partiql_where(table, where_clause, parameters)?;
-        let items: Vec<Value> = matched.iter().map(|item| json!(item)).collect();
-        DynamoDbService::ok_json(json!({ "Items": items }))
-    } else {
-        // No WHERE, return all items
-        let items: Vec<Value> = table.items.iter().map(|item| json!(item)).collect();
-        DynamoDbService::ok_json(json!({ "Items": items }))
-    }
-}
-
-pub(crate) fn execute_partiql_insert(
-    state: &SharedDynamoDbState,
-    account_id: &str,
-    statement: &str,
-    parameters: &[Value],
-) -> Result<AwsResponse, AwsServiceError> {
-    // Pattern: INSERT INTO "tablename" VALUE {'pk': 'val', 'attr': 'val'}
-    // or with parameters: INSERT INTO "tablename" VALUE {'pk': ?, 'attr': ?}
-    let upper = statement.to_ascii_uppercase();
-    let into_pos = upper.find("INTO").ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Invalid INSERT statement: missing INTO",
-        )
-    })?;
-
-    let after_into = statement[into_pos + 4..].trim();
-    let (table_name, rest) = parse_partiql_table_name(after_into);
-
-    let rest_upper = rest.trim().to_ascii_uppercase();
-    let value_pos = rest_upper.find("VALUE").ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Invalid INSERT statement: missing VALUE",
-        )
-    })?;
-
-    let value_str = rest.trim()[value_pos + 5..].trim();
-    let item = parse_partiql_value_object(value_str, parameters)?;
-
-    let mut __mas = state.write();
-    let state = __mas.get_or_create(account_id);
-    let table = get_table_mut(&mut state.tables, &table_name)?;
-    // Validate every key-schema attribute is present in the item.
-    // Real DDB rejects an INSERT that omits any key attribute with a
-    // ValidationException; without this check we'd silently insert an
-    // item with a phantom default key (the AttributeValue::Null fallback
-    // from `extract_key`) and clobber any prior insert that did the same.
-    for key_attr in &table.key_schema {
-        if !item.contains_key(&key_attr.attribute_name) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ValidationException",
-                format!(
-                    "One or more parameter values were invalid: Missing the key {} in the item",
-                    key_attr.attribute_name
-                ),
-            ));
-        }
-    }
-    let key = extract_key(table, &item);
-    if table.find_item_index(&key).is_some() {
-        // DynamoDB PartiQL INSERT fails if item exists
-        return Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "DuplicateItemException",
-            "Duplicate primary key exists in table",
-        ));
-    } else {
-        table.items.push(item);
-    }
-    table.recalculate_stats();
-
-    DynamoDbService::ok_json(json!({}))
-}
-
-pub(crate) fn execute_partiql_update(
-    state: &SharedDynamoDbState,
-    account_id: &str,
-    statement: &str,
-    parameters: &[Value],
-) -> Result<AwsResponse, AwsServiceError> {
-    // Pattern: UPDATE "tablename" SET attr='val' WHERE pk='val'
-    // or: UPDATE "tablename" SET attr=? WHERE pk=?
-    let after_update = statement[6..].trim(); // skip "UPDATE"
-    let (table_name, rest) = parse_partiql_table_name(after_update);
-
-    let rest_upper = rest.trim().to_ascii_uppercase();
-    let set_pos = rest_upper.find("SET").ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Invalid UPDATE statement: missing SET",
-        )
-    })?;
-
-    let after_set = rest.trim()[set_pos + 3..].trim();
-
-    // Split on WHERE
-    let where_pos = after_set.to_ascii_uppercase().find("WHERE");
-    let (set_clause, where_clause) = if let Some(wp) = where_pos {
-        (&after_set[..wp], after_set[wp + 5..].trim())
-    } else {
-        (after_set, "")
-    };
-
-    let mut __mas = state.write();
-    let state = __mas.get_or_create(account_id);
-    let table = get_table_mut(&mut state.tables, &table_name)?;
-
-    let matched_indices = if !where_clause.is_empty() {
-        find_partiql_where_indices(table, where_clause, parameters)?
-    } else {
-        (0..table.items.len()).collect()
-    };
-
-    // Parse SET assignments: attr=value, attr2=value2
-    let param_offset = count_params_in_str(where_clause);
-    let assignments: Vec<&str> = set_clause.split(',').collect();
-    for idx in &matched_indices {
-        let mut local_offset = param_offset;
-        for assignment in &assignments {
-            let assignment = assignment.trim();
-            if let Some((attr, val_str)) = assignment.split_once('=') {
-                let attr = attr.trim().trim_matches('"');
-                let val_str = val_str.trim();
-                let value = parse_partiql_literal(val_str, parameters, &mut local_offset);
-                if let Some(v) = value {
-                    table.items[*idx].insert(attr.to_string(), v);
-                }
-            }
-        }
-    }
-    table.recalculate_stats();
-
-    DynamoDbService::ok_json(json!({}))
-}
-
-pub(crate) fn execute_partiql_delete(
-    state: &SharedDynamoDbState,
-    account_id: &str,
-    statement: &str,
-    parameters: &[Value],
-) -> Result<AwsResponse, AwsServiceError> {
-    // Pattern: DELETE FROM "tablename" WHERE pk='val'
-    let upper = statement.to_ascii_uppercase();
-    let from_pos = upper.find("FROM").ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "Invalid DELETE statement: missing FROM",
-        )
-    })?;
-
-    let after_from = statement[from_pos + 4..].trim();
-    let (table_name, rest) = parse_partiql_table_name(after_from);
-
-    let rest_upper = rest.trim().to_ascii_uppercase();
-    if !rest_upper.starts_with("WHERE") {
-        return Err(AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "ValidationException",
-            "DELETE requires a WHERE clause",
-        ));
-    }
-    let where_clause = rest.trim()[5..].trim();
-
-    let mut __mas = state.write();
-    let state = __mas.get_or_create(account_id);
-    let table = get_table_mut(&mut state.tables, &table_name)?;
-
-    let mut indices = find_partiql_where_indices(table, where_clause, parameters)?;
-    // Remove from highest index first to avoid invalidating lower indices
-    indices.sort_unstable();
-    indices.reverse();
-    for idx in indices {
-        table.items.remove(idx);
-    }
-    table.recalculate_stats();
-
-    DynamoDbService::ok_json(json!({}))
-}
-
 /// Parse a table name that may be quoted with double quotes.
 /// Returns (table_name, rest_of_string).
 pub(crate) fn parse_partiql_table_name(s: &str) -> (String, &str) {
@@ -2666,6 +2416,7 @@ pub(crate) enum PartiqlCond {
     Ge(String, Value),
     Between(String, Value, Value),
     In(String, Vec<Value>),
+    Like(String, String),
     BeginsWith(String, Value),
     Contains(String, Value),
     AttributeExists(String),
@@ -2692,6 +2443,9 @@ pub(crate) fn evaluate_partiql_cond(
             Some(v) => vals.iter().any(|x| x == v),
             None => false,
         },
+        PartiqlCond::Like(a, pattern) => {
+            attr_string(item.get(a)).is_some_and(|s| match_like(&s, pattern))
+        }
         PartiqlCond::BeginsWith(a, prefix) => attr_string(item.get(a))
             .zip(attr_string(Some(prefix)))
             .is_some_and(|(s, p)| s.starts_with(&p)),
@@ -2701,6 +2455,83 @@ pub(crate) fn evaluate_partiql_cond(
         PartiqlCond::AttributeExists(a) => item.contains_key(a),
         PartiqlCond::AttributeNotExists(a) => !item.contains_key(a),
     }
+}
+
+/// Match a string against a PartiQL/SQL LIKE pattern. `%` matches any
+/// run of characters (including empty), `_` matches exactly one
+/// character. Both wildcards are anchored — `LIKE 'foo'` requires an
+/// exact match, mirroring DDB PartiQL semantics.
+pub(crate) fn match_like(s: &str, pattern: &str) -> bool {
+    let s_chars: Vec<char> = s.chars().collect();
+    let p_chars: Vec<char> = pattern.chars().collect();
+    like_recurse(&s_chars, 0, &p_chars, 0)
+}
+
+fn like_recurse(s: &[char], si: usize, p: &[char], pi: usize) -> bool {
+    if pi == p.len() {
+        return si == s.len();
+    }
+    match p[pi] {
+        '%' => {
+            // Greedy backtracking: try matching 0..=remaining chars.
+            for k in si..=s.len() {
+                if like_recurse(s, k, p, pi + 1) {
+                    return true;
+                }
+            }
+            false
+        }
+        '_' => si < s.len() && like_recurse(s, si + 1, p, pi + 1),
+        c => si < s.len() && s[si] == c && like_recurse(s, si + 1, p, pi + 1),
+    }
+}
+
+/// Validate that every key-schema attribute is present in the item AND
+/// that its AttributeValue carries the declared scalar type from
+/// `attribute_definitions`. Real DDB rejects an INSERT or PutItem that
+/// omits a key or supplies the wrong type with a `ValidationException`;
+/// without the type check we'd silently accept e.g. `{'pk': 1}` for a
+/// HASH key declared as `S`.
+pub(crate) fn validate_partiql_item_against_key_schema(
+    table: &DynamoTable,
+    item: &HashMap<String, AttributeValue>,
+) -> Result<(), AwsServiceError> {
+    for key_attr in &table.key_schema {
+        let Some(val) = item.get(&key_attr.attribute_name) else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "One or more parameter values were invalid: Missing the key {} in the item",
+                    key_attr.attribute_name
+                ),
+            ));
+        };
+        // Type check against AttributeDefinitions. AWS only allows
+        // S/N/B for key attribute types.
+        let declared = table
+            .attribute_definitions
+            .iter()
+            .find(|d| d.attribute_name == key_attr.attribute_name)
+            .map(|d| d.attribute_type.as_str());
+        if let Some(expected) = declared {
+            let obj = val.as_object();
+            let actual_tag = obj.and_then(|o| o.keys().next().map(|k| k.as_str()));
+            if actual_tag != Some(expected) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!(
+                        "One or more parameter values were invalid: Type mismatch for key {} expected: {} actual: {}",
+                        key_attr.attribute_name,
+                        expected,
+                        actual_tag.unwrap_or("?"),
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Three-way compare two AttributeValue payloads. Returns `Some(c)`
@@ -2805,6 +2636,21 @@ fn parse_one_partiql_condition(
             }
         }
         return Some(PartiqlCond::In(attr, vals));
+    }
+
+    // LIKE: `attr LIKE 'pattern'` (with `%` and `_` wildcards). The
+    // pattern is always a string; we unwrap the {"S": ...} payload at
+    // parse time so the evaluator can stay scalar-only.
+    if let Some(l) = upper.find(" LIKE ") {
+        let attr = cond[..l].trim().trim_matches('"').to_string();
+        let rhs = cond[l + 6..].trim();
+        let pattern_val = parse_partiql_literal(rhs, parameters, param_idx)?;
+        let pattern = pattern_val
+            .as_object()
+            .and_then(|o| o.get("S"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())?;
+        return Some(PartiqlCond::Like(attr, pattern));
     }
 
     // Operator-style. Order matters: longest operator first so `<=`

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3530,6 +3530,176 @@ fn execute_transaction() {
     assert!(b["Item"].is_object());
 }
 
+// L4: PartiQL comparator + schema validation coverage. Each test
+// seeds a small set of items and exercises one of the WHERE forms
+// added in L4 (numeric/lexicographic comparators, BETWEEN, IN,
+// LIKE, contains/begins_with/attribute_*) so future regressions
+// surface even before an SDK roundtrip.
+
+fn seed_partiql_corpus(svc: &DynamoDbService) {
+    create_test_table(svc);
+    for (pk, score, name) in [
+        ("a", 10, "alpha"),
+        ("b", 20, "beta"),
+        ("c", 30, "gamma"),
+        ("d", 40, "delta"),
+    ] {
+        let req = make_request(
+            "PutItem",
+            json!({
+                "TableName": "test-table",
+                "Item": {
+                    "pk": {"S": pk},
+                    "score": {"N": score.to_string()},
+                    "name": {"S": name},
+                },
+            }),
+        );
+        svc.put_item(&req).unwrap();
+    }
+}
+
+fn pks_from_select(svc: &DynamoDbService, statement: &str) -> Vec<String> {
+    let req = make_request("ExecuteStatement", json!({ "Statement": statement }));
+    let resp = svc.execute_statement(&req).unwrap();
+    let b = body_json(&resp);
+    let mut pks: Vec<String> = b["Items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|it| it["pk"]["S"].as_str().unwrap().to_string())
+        .collect();
+    pks.sort();
+    pks
+}
+
+#[test]
+fn partiql_select_lt_gt_le_ge_ne_numeric() {
+    let svc = make_service();
+    seed_partiql_corpus(&svc);
+
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE score < 25"),
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE score > 25"),
+        vec!["c", "d"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE score <= 20"),
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE score >= 30"),
+        vec!["c", "d"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE score <> 20"),
+        vec!["a", "c", "d"]
+    );
+}
+
+#[test]
+fn partiql_select_between_in_like() {
+    let svc = make_service();
+    seed_partiql_corpus(&svc);
+
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE score BETWEEN 15 AND 35"
+        ),
+        vec!["b", "c"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE pk IN ('a','c')"),
+        vec!["a", "c"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE name LIKE 'al%'"),
+        vec!["a"]
+    );
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE name LIKE '_eta'"),
+        vec!["b"]
+    );
+}
+
+#[test]
+fn partiql_select_function_predicates() {
+    let svc = make_service();
+    seed_partiql_corpus(&svc);
+
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE begins_with(name, 'g')"
+        ),
+        vec!["c"]
+    );
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE contains(name, 'lt')"
+        ),
+        vec!["d"]
+    );
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE attribute_exists(score)"
+        ),
+        vec!["a", "b", "c", "d"]
+    );
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE attribute_not_exists(missing)"
+        ),
+        vec!["a", "b", "c", "d"]
+    );
+}
+
+#[test]
+fn partiql_insert_rejects_missing_partition_key() {
+    let svc = make_service();
+    create_test_table(&svc);
+    let req = make_request(
+        "ExecuteStatement",
+        json!({
+            "Statement": "INSERT INTO \"test-table\" VALUE {'data': 'no-pk'}"
+        }),
+    );
+    let err = match svc.execute_statement(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected INSERT without pk to fail"),
+    };
+    let dbg = format!("{err:?}");
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
+    assert!(dbg.contains("Missing the key pk"), "got {dbg}");
+}
+
+#[test]
+fn partiql_insert_rejects_wrong_key_type() {
+    let svc = make_service();
+    create_test_table(&svc);
+    // Table key `pk` is declared as type `S` — try to insert a numeric.
+    let req = make_request(
+        "ExecuteStatement",
+        json!({
+            "Statement": "INSERT INTO \"test-table\" VALUE {'pk': 42}"
+        }),
+    );
+    let err = match svc.execute_statement(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected INSERT with wrong-type pk to fail"),
+    };
+    let dbg = format!("{err:?}");
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
+    assert!(dbg.contains("Type mismatch for key pk"), "got {dbg}");
+}
+
 // ── Batch write with delete ──
 
 #[test]

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -4506,3 +4506,394 @@ async fn dynamodb_execute_transaction_three_writes_middle_fails_reverts_all() {
         "only the pre-seed INSERT should be on the stream — failed txn emits nothing"
     );
 }
+
+// ── L4: PartiQL real comparators + schema validation + stream emit ──
+
+/// Seed a small mixed-type corpus to exercise comparator/range/membership
+/// predicates in the PartiQL WHERE evaluator. Each row carries:
+///  - `pk` (S, HASH key)
+///  - `score` (N) for numeric comparators
+///  - `name` (S) for LIKE / begins_with / contains / lexicographic
+async fn l4_seed_partiql_table(
+    ddb: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+    enable_streams: bool,
+) {
+    let mut create = ddb
+        .create_table()
+        .table_name(table_name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest);
+    if enable_streams {
+        create = create.stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        );
+    }
+    create.send().await.unwrap();
+
+    for (pk, score, name) in [
+        ("a", 10_i64, "alpha"),
+        ("b", 20, "beta"),
+        ("c", 30, "gamma"),
+        ("d", 40, "delta"),
+    ] {
+        ddb.put_item()
+            .table_name(table_name)
+            .item("pk", AttributeValue::S(pk.into()))
+            .item("score", AttributeValue::N(score.to_string()))
+            .item("name", AttributeValue::S(name.into()))
+            .send()
+            .await
+            .unwrap();
+    }
+}
+
+async fn l4_select_pks(ddb: &aws_sdk_dynamodb::Client, statement: &str) -> Vec<String> {
+    let resp = ddb
+        .execute_statement()
+        .statement(statement)
+        .send()
+        .await
+        .unwrap();
+    let mut pks: Vec<String> = resp
+        .items()
+        .iter()
+        .map(|it| it.get("pk").unwrap().as_s().unwrap().clone())
+        .collect();
+    pks.sort();
+    pks
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_select_numeric_comparators() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "PartiqlNumericComparators";
+    l4_seed_partiql_table(&ddb, table, false).await;
+
+    assert_eq!(
+        l4_select_pks(&ddb, &format!("SELECT * FROM \"{table}\" WHERE score < 25")).await,
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        l4_select_pks(&ddb, &format!("SELECT * FROM \"{table}\" WHERE score > 25")).await,
+        vec!["c", "d"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE score <= 20")
+        )
+        .await,
+        vec!["a", "b"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE score >= 30")
+        )
+        .await,
+        vec!["c", "d"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE score <> 20")
+        )
+        .await,
+        vec!["a", "c", "d"]
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_select_between_in_like_predicates() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "PartiqlBetweenInLike";
+    l4_seed_partiql_table(&ddb, table, false).await;
+
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE score BETWEEN 15 AND 35")
+        )
+        .await,
+        vec!["b", "c"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE pk IN ('a','c')")
+        )
+        .await,
+        vec!["a", "c"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE name LIKE 'al%'")
+        )
+        .await,
+        vec!["a"]
+    );
+    // `_` matches exactly one character.
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE name LIKE '_eta'")
+        )
+        .await,
+        vec!["b"]
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_select_function_predicates() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "PartiqlFunctionPredicates";
+    l4_seed_partiql_table(&ddb, table, false).await;
+
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE begins_with(name, 'g')")
+        )
+        .await,
+        vec!["c"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE contains(name, 'lt')")
+        )
+        .await,
+        vec!["d"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE attribute_exists(score)")
+        )
+        .await,
+        vec!["a", "b", "c", "d"]
+    );
+    assert_eq!(
+        l4_select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE attribute_not_exists(missing)")
+        )
+        .await,
+        vec!["a", "b", "c", "d"]
+    );
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_insert_rejects_missing_partition_key() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "PartiqlMissingPk";
+
+    ddb.create_table()
+        .table_name(table)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let err = ddb
+        .execute_statement()
+        .statement(format!("INSERT INTO \"{table}\" VALUE {{'data': 'no-pk'}}"))
+        .send()
+        .await
+        .expect_err("insert without partition key must be rejected");
+    let svc_err = err.into_service_error();
+    let msg = format!("{svc_err:?}");
+    assert!(msg.contains("ValidationException"), "got {msg}");
+    assert!(msg.contains("Missing the key pk"), "got {msg}");
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_insert_rejects_wrong_key_type() {
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "PartiqlWrongKeyType";
+
+    ddb.create_table()
+        .table_name(table)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Key declared as `S` but the literal is numeric.
+    let err = ddb
+        .execute_statement()
+        .statement(format!("INSERT INTO \"{table}\" VALUE {{'pk': 42}}"))
+        .send()
+        .await
+        .expect_err("insert with wrong-type pk must be rejected");
+    let svc_err = err.into_service_error();
+    let msg = format!("{svc_err:?}");
+    assert!(msg.contains("ValidationException"), "got {msg}");
+    assert!(msg.contains("Type mismatch for key pk"), "got {msg}");
+}
+
+#[tokio::test]
+async fn dynamodb_partiql_execute_statement_emits_stream_record() {
+    // L4: a single ExecuteStatement INSERT on a stream-enabled table
+    // must emit a Stream record so log/CDC consumers see the same
+    // event they would observe after a PutItem call.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+    let table = "PartiqlStreamEmit";
+    l4_seed_partiql_table(&ddb, table, true).await;
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+
+    // Snapshot the stream first so we can count the records that the
+    // PartiQL writes added on top of the four PutItem seeds.
+    let baseline_shard = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap()
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+
+    let baseline_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&baseline_shard)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let baseline_records = streams
+        .get_records()
+        .shard_iterator(baseline_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    let baseline_len = baseline_records.records().len();
+
+    // Single ExecuteStatement INSERT.
+    ddb.execute_statement()
+        .statement(format!(
+            "INSERT INTO \"{table}\" VALUE {{'pk': 'partiql-1'}}"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // BatchExecuteStatement with two more INSERTs.
+    use aws_sdk_dynamodb::types::BatchStatementRequest;
+    ddb.batch_execute_statement()
+        .statements(
+            BatchStatementRequest::builder()
+                .statement(format!(
+                    "INSERT INTO \"{table}\" VALUE {{'pk': 'partiql-2'}}"
+                ))
+                .build()
+                .unwrap(),
+        )
+        .statements(
+            BatchStatementRequest::builder()
+                .statement(format!(
+                    "INSERT INTO \"{table}\" VALUE {{'pk': 'partiql-3'}}"
+                ))
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let after_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&baseline_shard)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let after_records = streams
+        .get_records()
+        .shard_iterator(after_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        after_records.records().len(),
+        baseline_len + 3,
+        "ExecuteStatement + 2x BatchExecuteStatement INSERTs must each emit a stream record"
+    );
+    let last3 = &after_records.records()[after_records.records().len() - 3..];
+    assert!(last3
+        .iter()
+        .all(|r| r.event_name().unwrap().as_str() == "INSERT"));
+}


### PR DESCRIPTION
## Summary
- ExecuteStatement / BatchExecuteStatement / ExecuteTransaction now share a single in-state PartiQL executor that emits Stream and Kinesis change records on every write (mirrors items.rs::put_item).
- INSERT validates the item against the table key schema: missing key attribute -> ValidationException, wrong scalar type (e.g. `{'pk': 42}` for an `S` key) -> ValidationException with \"Type mismatch for key X\".
- WHERE evaluator now supports `<`, `>`, `<=`, `>=`, `<>`, `IN`, `BETWEEN`, `LIKE` (with `%` and `_` wildcards), `contains`, `begins_with`, `attribute_exists`, `attribute_not_exists` — anything DDB's expression language can express.
- ExecuteTransaction uses `req.account_id` instead of `default_mut()` so cross-account STS callers don't accidentally write into the default namespace.
- Drops legacy `execute_partiql_{statement,select,insert,update,delete}` helpers — every entry point goes through `execute_partiql_in_state`, removing ~190 lines of duplicated parser code.

## Test plan
- [x] 7 new unit tests in `service/tests.rs` and `service/batch.rs` covering each comparator, BETWEEN/IN/LIKE, function predicates, missing-pk + wrong-type rejection, ExecuteStatement and BatchExecuteStatement stream emission.
- [x] 6 new e2e tests in `crates/fakecloud-e2e/tests/dynamodb.rs` exercising the same surface through the AWS SDK + dynamodbstreams client.
- [x] 258 dynamodb unit tests pass; 30 conformance tests pass; existing PartiQL e2e tests (transaction happy path + rollback) still pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean on dynamodb + e2e crates; `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified in-state PartiQL executor with real WHERE comparators, key schema validation on INSERT, and DynamoDB Streams/Kinesis change events on every write. Also fixes `ExecuteTransaction` to respect the caller’s account.

- **New Features**
  - Single executor for `ExecuteStatement`, `BatchExecuteStatement`, and `ExecuteTransaction` that appends stream records and delivers Kinesis events for each write.
  - WHERE now supports `<`, `>`, `<=`, `>=`, `<>`, `IN`, `BETWEEN`, `LIKE` (with `%` and `_`), plus `contains`, `begins_with`, `attribute_exists`, `attribute_not_exists`.
  - INSERT validates against the table key schema; missing key or wrong scalar type returns `ValidationException` with clear messages.

- **Refactors**
  - Removed legacy `execute_partiql_{statement,select,insert,update,delete}` helpers; all entry points use `execute_partiql_in_state` (cuts ~190 LOC and aligns behavior).
  - Stream/Kinesis emission mirrors `put_item`: append under write lock, deliver after releasing the lock to avoid deadlocks.
  - `ExecuteTransaction` uses `req.account_id` instead of the default namespace to handle cross-account calls correctly.

<sup>Written for commit 001ac8621f47fe7a39a03cff162ab727df0c5a0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

