### PR TITLE
feat(cognito): /oauth2/token with all 3 grants (Y3)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -6,14 +6,16 @@ pub mod user_status;
 
 pub use service::{
     ensure_pool_signing_key, handle_oauth2_revoke, handle_oauth2_token, handle_oauth2_userinfo,
-    oidc_discovery_document, pool_existence_and_domain, pool_jwks_document, CognitoService,
+    mint_authorization_code, oidc_discovery_document, pool_existence_and_domain,
+    pool_jwks_document, CognitoService, MintAuthorizationCodeError, MintAuthorizationCodeRequest,
     OAuthRevokeError, OAuthTokenError, OAuthTokenResponse, OAuthUserInfoError,
 };
 pub use state::{
-    default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig, CognitoSnapshot,
-    CognitoState, CustomDomainConfig, EmailConfiguration, PasswordPolicy, PoolPolicies,
-    RecoveryOption, SchemaAttribute, SharedCognitoState, SignInPolicy, SmsConfiguration, UserPool,
-    UserPoolClient, UserPoolDomain, COGNITO_SNAPSHOT_SCHEMA_VERSION,
+    default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig,
+    AuthorizationCodeData, CognitoSnapshot, CognitoState, CustomDomainConfig, EmailConfiguration,
+    PasswordPolicy, PoolPolicies, RecoveryOption, SchemaAttribute, SharedCognitoState,
+    SignInPolicy, SmsConfiguration, UserPool, UserPoolClient, UserPoolDomain,
+    COGNITO_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// `CognitoJwtVerifier` impl backed by the in-process Cognito state.

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1537,6 +1537,26 @@ fn generate_tokens(
     region: &str,
     signing: Option<(&str, &str)>,
 ) -> TokenSet {
+    generate_tokens_with_scope(
+        pool_id, client_id, sub, username, region, signing, None, None,
+    )
+}
+
+/// Like [`generate_tokens`] but lets callers stamp custom `scope` and
+/// `nonce` claims into the issued tokens — used by the
+/// `authorization_code` grant which carries the scopes and nonce the
+/// user originally consented to at `/oauth2/authorize`.
+#[allow(clippy::too_many_arguments)]
+fn generate_tokens_with_scope(
+    pool_id: &str,
+    client_id: &str,
+    sub: &str,
+    username: &str,
+    region: &str,
+    signing: Option<(&str, &str)>,
+    scope: Option<&str>,
+    nonce: Option<&str>,
+) -> TokenSet {
     let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
@@ -1552,7 +1572,7 @@ fn generate_tokens(
     let kid = owned_signing.1.as_str();
 
     let id_header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
-    let id_payload = json!({
+    let mut id_payload = json!({
         "sub": sub,
         "iss": iss,
         "aud": client_id,
@@ -1563,16 +1583,25 @@ fn generate_tokens(
         "iat": now,
         "jti": jti,
     });
+    if let Some(n) = nonce {
+        id_payload
+            .as_object_mut()
+            .expect("id_payload is always a JSON object")
+            .insert("nonce".to_string(), Value::String(n.to_string()));
+    }
     let id_token = sign_jwt(&id_header, &id_payload, pem);
 
     let access_jti = Uuid::new_v4().to_string();
     let access_header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
+    let access_scope = scope
+        .filter(|s| !s.is_empty())
+        .unwrap_or("aws.cognito.signin.user.admin");
     let access_payload = json!({
         "sub": sub,
         "iss": iss,
         "client_id": client_id,
         "token_use": "access",
-        "scope": "aws.cognito.signin.user.admin",
+        "scope": access_scope,
         "jti": access_jti,
         "exp": now + 3600,
         "iat": now,
@@ -1784,6 +1813,12 @@ pub enum OAuthTokenError {
     UnsupportedGrantType,
     InvalidClient,
     InvalidGrant,
+    /// The client is recognised but isn't allowed to use the requested
+    /// grant_type (RFC 6749 §5.2).
+    UnauthorizedClient,
+    /// The requested `scope` is not a subset of what the client is
+    /// allowed (RFC 6749 §5.2).
+    InvalidScope,
 }
 
 impl OAuthTokenError {
@@ -1800,6 +1835,8 @@ impl OAuthTokenError {
             OAuthTokenError::UnsupportedGrantType => "unsupported_grant_type",
             OAuthTokenError::InvalidClient => "invalid_client",
             OAuthTokenError::InvalidGrant => "invalid_grant",
+            OAuthTokenError::UnauthorizedClient => "unauthorized_client",
+            OAuthTokenError::InvalidScope => "invalid_scope",
         }
     }
 
@@ -1837,150 +1874,443 @@ impl OAuthTokenResponse {
     }
 }
 
-/// Handle a Cognito `/oauth2/token` POST. Implements the
-/// `refresh_token` and `client_credentials` grants. The
-/// `authorization_code` grant lands in Y4 alongside the
-/// `/oauth2/authorize` endpoint.
+/// Handle a Cognito `/oauth2/token` POST. Implements all three Cognito
+/// Hosted-UI grants — `authorization_code`, `client_credentials`, and
+/// `refresh_token` — with optional HTTP Basic client authentication
+/// (RFC 6749 §2.3.1) layered on top of form-body credentials.
 ///
 /// `params` is the form-decoded body (Cognito uses
-/// `application/x-www-form-urlencoded`). `region` is the AWS region
-/// for `iss` claim composition.
+/// `application/x-www-form-urlencoded`). `basic_auth` is the optional
+/// `(client_id, client_secret)` parsed from a `Authorization: Basic …`
+/// header — when both that header and a form `client_secret`/`client_id`
+/// are present, AWS treats the Basic header as authoritative and fails
+/// on conflict; we follow the same rule here.
+/// `region` is the AWS region used for the JWT `iss` claim.
 pub async fn handle_oauth2_token(
     state: &SharedCognitoState,
     params: &BTreeMap<String, String>,
+    basic_auth: Option<(&str, &str)>,
     region: &str,
 ) -> Result<OAuthTokenResponse, OAuthTokenError> {
     let grant_type = params
         .get("grant_type")
         .map(String::as_str)
         .ok_or(OAuthTokenError::InvalidRequest("grant_type is required"))?;
-    let client_id = params
-        .get("client_id")
-        .map(String::as_str)
-        .ok_or(OAuthTokenError::InvalidRequest("client_id is required"))?;
 
-    let (pool_id, stored_secret) = {
+    // Per RFC 6749 §2.3.1 a single client MUST NOT use more than one
+    // authentication mechanism in the same request. When a Basic
+    // header is supplied AND a form `client_id`/`client_secret`, both
+    // must point to the same client and same secret — anything else
+    // is an `invalid_client`.
+    let form_client_id = params.get("client_id").map(String::as_str);
+    let form_client_secret = params.get("client_secret").map(String::as_str);
+    let client_id = match (basic_auth, form_client_id) {
+        (Some((b_id, _)), Some(f_id)) if b_id != f_id => {
+            return Err(OAuthTokenError::InvalidClient);
+        }
+        (Some((b_id, _)), _) => b_id,
+        (None, Some(f_id)) => f_id,
+        (None, None) => {
+            return Err(OAuthTokenError::InvalidRequest("client_id is required"));
+        }
+    };
+    let supplied_secret = match (basic_auth, form_client_secret) {
+        (Some((_, b_sec)), Some(f_sec)) if b_sec != f_sec => {
+            return Err(OAuthTokenError::InvalidClient);
+        }
+        (Some((_, b_sec)), _) => Some(b_sec),
+        (None, Some(f_sec)) => Some(f_sec),
+        (None, None) => None,
+    };
+
+    let (pool_id, stored_secret, allowed_flows, allowed_scopes, oauth_flows_enabled) = {
         let mas = state.read();
         let mut found = None;
         for (_, account) in mas.iter() {
             if let Some(client) = account.user_pool_clients.get(client_id) {
-                found = Some((client.user_pool_id.clone(), client.client_secret.clone()));
+                found = Some((
+                    client.user_pool_id.clone(),
+                    client.client_secret.clone(),
+                    client.allowed_o_auth_flows.clone(),
+                    client.allowed_o_auth_scopes.clone(),
+                    client.allowed_o_auth_flows_user_pool_client,
+                ));
                 break;
             }
         }
         found.ok_or(OAuthTokenError::InvalidClient)?
     };
 
+    // SECRET_HASH equivalence: when an app client has a secret the
+    // request MUST present it (Basic header or `client_secret` form
+    // field). RFC 6749 §2.3.1.
     if let Some(secret) = stored_secret.as_ref() {
-        let supplied = params.get("client_secret").map(String::as_str);
-        if supplied != Some(secret.as_str()) {
+        if supplied_secret != Some(secret.as_str()) {
             return Err(OAuthTokenError::InvalidClient);
         }
     }
 
     match grant_type {
+        "authorization_code" => {
+            handle_authorization_code_grant(
+                state,
+                params,
+                client_id,
+                &pool_id,
+                &allowed_flows,
+                oauth_flows_enabled,
+                region,
+            )
+            .await
+        }
         "refresh_token" => {
-            let refresh_token = params
-                .get("refresh_token")
-                .map(String::as_str)
-                .ok_or(OAuthTokenError::InvalidRequest("refresh_token is required"))?;
-            let (username, sub) = {
-                let mas = state.read();
-                let mut found = Err(OAuthTokenError::InvalidGrant);
-                for (_, account) in mas.iter() {
-                    if let Some(rt) = account.refresh_tokens.get(refresh_token) {
-                        if rt.client_id != client_id {
-                            found = Err(OAuthTokenError::InvalidGrant);
-                            break;
-                        }
-                        let sub = account
-                            .users
-                            .get(&rt.user_pool_id)
-                            .and_then(|users| users.get(&rt.username))
-                            .map(|u| u.sub.clone())
-                            .unwrap_or_default();
-                        found = Ok((rt.username.clone(), sub));
-                        break;
+            handle_refresh_token_grant(state, params, client_id, &pool_id, region).await
+        }
+        "client_credentials" => {
+            handle_client_credentials_grant(
+                state,
+                params,
+                client_id,
+                &pool_id,
+                stored_secret.as_deref(),
+                &allowed_flows,
+                &allowed_scopes,
+                oauth_flows_enabled,
+                region,
+            )
+            .await
+        }
+        _ => Err(OAuthTokenError::UnsupportedGrantType),
+    }
+}
+
+async fn handle_authorization_code_grant(
+    state: &SharedCognitoState,
+    params: &BTreeMap<String, String>,
+    client_id: &str,
+    pool_id: &str,
+    allowed_flows: &[String],
+    oauth_flows_enabled: bool,
+    region: &str,
+) -> Result<OAuthTokenResponse, OAuthTokenError> {
+    // Cognito only accepts authorization_code on app clients that have
+    // explicitly opted into Hosted-UI OAuth flows. When the client
+    // declares any flows at all, `code` must be on the list.
+    if oauth_flows_enabled
+        && !allowed_flows.is_empty()
+        && !allowed_flows.iter().any(|f| f.eq_ignore_ascii_case("code"))
+    {
+        return Err(OAuthTokenError::UnauthorizedClient);
+    }
+    let code = params
+        .get("code")
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or(OAuthTokenError::InvalidRequest("code is required"))?;
+    let redirect_uri = params
+        .get("redirect_uri")
+        .map(String::as_str)
+        .ok_or(OAuthTokenError::InvalidRequest("redirect_uri is required"))?;
+    let code_verifier = params.get("code_verifier").map(String::as_str);
+
+    let consumed = {
+        let mut mas = state.write();
+        let mut found: Option<crate::state::AuthorizationCodeData> = None;
+        for (_, account) in mas.iter_mut() {
+            if let Some(stored) = account.authorization_codes.get(code).cloned() {
+                if stored.client_id != client_id || stored.user_pool_id != pool_id {
+                    return Err(OAuthTokenError::InvalidGrant);
+                }
+                if stored.redirect_uri != redirect_uri {
+                    return Err(OAuthTokenError::InvalidGrant);
+                }
+                // Codes expire after 5 minutes per Cognito docs.
+                let age = Utc::now()
+                    .signed_duration_since(stored.issued_at)
+                    .num_seconds();
+                if age > 300 {
+                    account.authorization_codes.remove(code);
+                    return Err(OAuthTokenError::InvalidGrant);
+                }
+                if let Some(challenge) = stored.code_challenge.as_deref() {
+                    let verifier = code_verifier.ok_or(OAuthTokenError::InvalidGrant)?;
+                    if !verify_pkce(challenge, stored.code_challenge_method.as_deref(), verifier) {
+                        return Err(OAuthTokenError::InvalidGrant);
                     }
                 }
-                found?
-            };
-            let signing = ensure_pool_signing_key(state, &pool_id).await;
-            let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
-            let tokens = generate_tokens(&pool_id, client_id, &sub, &username, region, signing_ref);
-            let rotated_refresh = {
-                let mut mas = state.write();
-                let mut new_rt = None;
-                for (_, account) in mas.iter_mut() {
-                    if !account.user_pool_clients.contains_key(client_id) {
-                        continue;
-                    }
-                    let rotation_enabled = account
-                        .user_pool_clients
-                        .get(client_id)
-                        .and_then(|c| c.refresh_token_rotation.as_ref())
-                        .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
-                        .unwrap_or(false);
-                    if rotation_enabled {
-                        if let Some(old) = account.refresh_tokens.get(refresh_token).cloned() {
-                            let token = format!("rt-{}", Uuid::new_v4());
-                            account.refresh_tokens.insert(
-                                token.clone(),
-                                crate::state::RefreshTokenData {
-                                    user_pool_id: old.user_pool_id,
-                                    username: old.username,
-                                    client_id: old.client_id,
-                                    issued_at: Utc::now(),
-                                },
-                            );
-                            account.refresh_tokens.remove(refresh_token);
-                            new_rt = Some(token);
-                        }
-                    }
-                    account.access_tokens.insert(
-                        tokens.access_token.clone(),
-                        crate::state::AccessTokenData {
-                            user_pool_id: pool_id.clone(),
-                            username: username.clone(),
-                            client_id: client_id.to_string(),
+                // Single-use: remove on consumption.
+                account.authorization_codes.remove(code);
+                found = Some(stored);
+                break;
+            }
+        }
+        found.ok_or(OAuthTokenError::InvalidGrant)?
+    };
+
+    let sub = {
+        let mas = state.read();
+        let mut sub = String::new();
+        for (_, account) in mas.iter() {
+            if let Some(user) = account
+                .users
+                .get(&consumed.user_pool_id)
+                .and_then(|users| users.get(&consumed.username))
+            {
+                sub = user.sub.clone();
+                break;
+            }
+        }
+        sub
+    };
+
+    let signing = ensure_pool_signing_key(state, pool_id).await;
+    let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+    let scope_str = if consumed.scopes.is_empty() {
+        None
+    } else {
+        Some(consumed.scopes.join(" "))
+    };
+    let tokens = generate_tokens_with_scope(
+        pool_id,
+        client_id,
+        &sub,
+        &consumed.username,
+        region,
+        signing_ref,
+        scope_str.as_deref(),
+        consumed.nonce.as_deref(),
+    );
+
+    {
+        let mut mas = state.write();
+        for (_, account) in mas.iter_mut() {
+            if !account.user_pool_clients.contains_key(client_id) {
+                continue;
+            }
+            account.refresh_tokens.insert(
+                tokens.refresh_token.clone(),
+                crate::state::RefreshTokenData {
+                    user_pool_id: pool_id.to_string(),
+                    username: consumed.username.clone(),
+                    client_id: client_id.to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+            account.access_tokens.insert(
+                tokens.access_token.clone(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.to_string(),
+                    username: consumed.username.clone(),
+                    client_id: client_id.to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+            break;
+        }
+    }
+
+    Ok(OAuthTokenResponse {
+        access_token: tokens.access_token,
+        id_token: Some(tokens.id_token),
+        refresh_token: Some(tokens.refresh_token),
+        expires_in: 3600,
+        token_type: "Bearer".to_string(),
+    })
+}
+
+async fn handle_refresh_token_grant(
+    state: &SharedCognitoState,
+    params: &BTreeMap<String, String>,
+    client_id: &str,
+    pool_id: &str,
+    region: &str,
+) -> Result<OAuthTokenResponse, OAuthTokenError> {
+    let refresh_token = params
+        .get("refresh_token")
+        .map(String::as_str)
+        .ok_or(OAuthTokenError::InvalidRequest("refresh_token is required"))?;
+    let (username, sub) = {
+        let mas = state.read();
+        let mut found = Err(OAuthTokenError::InvalidGrant);
+        for (_, account) in mas.iter() {
+            if let Some(rt) = account.refresh_tokens.get(refresh_token) {
+                if rt.client_id != client_id {
+                    found = Err(OAuthTokenError::InvalidGrant);
+                    break;
+                }
+                let sub = account
+                    .users
+                    .get(&rt.user_pool_id)
+                    .and_then(|users| users.get(&rt.username))
+                    .map(|u| u.sub.clone())
+                    .unwrap_or_default();
+                found = Ok((rt.username.clone(), sub));
+                break;
+            }
+        }
+        found?
+    };
+    let signing = ensure_pool_signing_key(state, pool_id).await;
+    let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+    let tokens = generate_tokens(pool_id, client_id, &sub, &username, region, signing_ref);
+    let rotated_refresh = {
+        let mut mas = state.write();
+        let mut new_rt = None;
+        for (_, account) in mas.iter_mut() {
+            if !account.user_pool_clients.contains_key(client_id) {
+                continue;
+            }
+            let rotation_enabled = account
+                .user_pool_clients
+                .get(client_id)
+                .and_then(|c| c.refresh_token_rotation.as_ref())
+                .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
+                .unwrap_or(false);
+            if rotation_enabled {
+                if let Some(old) = account.refresh_tokens.get(refresh_token).cloned() {
+                    let token = format!("rt-{}", Uuid::new_v4());
+                    account.refresh_tokens.insert(
+                        token.clone(),
+                        crate::state::RefreshTokenData {
+                            user_pool_id: old.user_pool_id,
+                            username: old.username,
+                            client_id: old.client_id,
                             issued_at: Utc::now(),
                         },
                     );
-                    break;
+                    account.refresh_tokens.remove(refresh_token);
+                    new_rt = Some(token);
                 }
-                new_rt
-            };
-            Ok(OAuthTokenResponse {
-                access_token: tokens.access_token,
-                id_token: Some(tokens.id_token),
-                refresh_token: rotated_refresh,
-                expires_in: 3600,
-                token_type: "Bearer".to_string(),
-            })
-        }
-        "client_credentials" => {
-            // Machine-to-machine: just an access token, no id_token,
-            // no refresh_token. `sub` is the client_id per OIDC core.
-            let signing = ensure_pool_signing_key(state, &pool_id).await;
-            let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
-            let scope = params.get("scope").cloned();
-            let access_token = build_client_credentials_access_token(
-                &pool_id,
-                client_id,
-                scope.as_deref(),
-                region,
-                signing_ref,
+            }
+            account.access_tokens.insert(
+                tokens.access_token.clone(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.to_string(),
+                    username: username.clone(),
+                    client_id: client_id.to_string(),
+                    issued_at: Utc::now(),
+                },
             );
-            Ok(OAuthTokenResponse {
-                access_token,
-                id_token: None,
-                refresh_token: None,
-                expires_in: 3600,
-                token_type: "Bearer".to_string(),
-            })
+            break;
         }
-        "authorization_code" => Err(OAuthTokenError::UnsupportedGrantType),
-        _ => Err(OAuthTokenError::UnsupportedGrantType),
+        new_rt
+    };
+    Ok(OAuthTokenResponse {
+        access_token: tokens.access_token,
+        id_token: Some(tokens.id_token),
+        refresh_token: rotated_refresh,
+        expires_in: 3600,
+        token_type: "Bearer".to_string(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_client_credentials_grant(
+    state: &SharedCognitoState,
+    params: &BTreeMap<String, String>,
+    client_id: &str,
+    pool_id: &str,
+    stored_secret: Option<&str>,
+    allowed_flows: &[String],
+    allowed_scopes: &[String],
+    oauth_flows_enabled: bool,
+    region: &str,
+) -> Result<OAuthTokenResponse, OAuthTokenError> {
+    // client_credentials demands a confidential client (always has a
+    // secret) and an explicit `client_credentials` flow allowance.
+    if stored_secret.is_none() {
+        return Err(OAuthTokenError::InvalidClient);
+    }
+    if oauth_flows_enabled
+        && !allowed_flows.is_empty()
+        && !allowed_flows
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case("client_credentials"))
+    {
+        return Err(OAuthTokenError::UnauthorizedClient);
+    }
+
+    // Per RFC 6749 §3.3 the requested scope MUST be a subset of what
+    // the client is allowed to use; AWS Cognito enforces this against
+    // resource-server scopes registered on the pool.
+    let requested = params
+        .get("scope")
+        .map(String::as_str)
+        .unwrap_or("")
+        .split_whitespace()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    if !requested.is_empty() && !allowed_scopes.is_empty() {
+        for scope in &requested {
+            if !allowed_scopes.iter().any(|s| s == scope) {
+                return Err(OAuthTokenError::InvalidScope);
+            }
+        }
+    }
+    let granted = if requested.is_empty() {
+        allowed_scopes.join(" ")
+    } else {
+        requested.join(" ")
+    };
+
+    let signing = ensure_pool_signing_key(state, pool_id).await;
+    let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+    let access_token = build_client_credentials_access_token(
+        pool_id,
+        client_id,
+        Some(&granted),
+        region,
+        signing_ref,
+    );
+
+    {
+        let mut mas = state.write();
+        for (_, account) in mas.iter_mut() {
+            if !account.user_pool_clients.contains_key(client_id) {
+                continue;
+            }
+            // client_credentials access tokens have no associated
+            // user; record `username = client_id` so revoke/userInfo
+            // can still resolve the token owner.
+            account.access_tokens.insert(
+                access_token.clone(),
+                crate::state::AccessTokenData {
+                    user_pool_id: pool_id.to_string(),
+                    username: client_id.to_string(),
+                    client_id: client_id.to_string(),
+                    issued_at: Utc::now(),
+                },
+            );
+            break;
+        }
+    }
+
+    Ok(OAuthTokenResponse {
+        access_token,
+        id_token: None,
+        refresh_token: None,
+        expires_in: 3600,
+        token_type: "Bearer".to_string(),
+    })
+}
+
+/// Verify a PKCE `code_verifier` against the stored `code_challenge`
+/// and `code_challenge_method`. Implements RFC 7636 §4.6 — only
+/// `S256` and `plain` are recognised; an unknown method is treated
+/// as a verification failure rather than silently downgrading.
+fn verify_pkce(challenge: &str, method: Option<&str>, verifier: &str) -> bool {
+    let method = method.unwrap_or("S256");
+    match method {
+        "plain" => challenge == verifier,
+        "S256" => {
+            use rsa::sha2::{Digest, Sha256};
+            let mut hasher = Sha256::new();
+            hasher.update(verifier.as_bytes());
+            let digest = hasher.finalize();
+            let computed = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+            challenge == computed
+        }
+        _ => false,
     }
 }
 
@@ -2125,6 +2455,91 @@ pub fn handle_oauth2_revoke(
         }
     }
     Ok(())
+}
+
+/// Inputs accepted by [`mint_authorization_code`]. Mirrors the
+/// authorization-code request shape from RFC 6749 §4.1.1: the values
+/// the user agent originally sent to `/oauth2/authorize`. Y4 will fill
+/// these in from the consent flow; for now it's used by the admin
+/// `/_fakecloud/cognito/authorization-codes` endpoint and by tests.
+#[derive(Debug, Clone)]
+pub struct MintAuthorizationCodeRequest {
+    pub user_pool_id: String,
+    pub client_id: String,
+    pub username: String,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub nonce: Option<String>,
+}
+
+/// Validation failures from [`mint_authorization_code`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MintAuthorizationCodeError {
+    /// `client_id` doesn't exist in any pool, or the supplied
+    /// `user_pool_id` doesn't match the client's pool.
+    InvalidClient,
+    /// `redirect_uri` isn't one of the client's registered
+    /// `callback_urls`.
+    InvalidRedirectUri,
+    /// User isn't enrolled in the pool.
+    UserNotFound,
+}
+
+/// Issue a single-use authorization code and store it in pool state so
+/// the next `/oauth2/token` `authorization_code` POST can consume it.
+/// Returns the opaque code string.
+///
+/// Validates the request the same way real Cognito does at
+/// `/oauth2/authorize`: client must exist, `user_pool_id` must match,
+/// `redirect_uri` must be one of the client's registered callback URLs,
+/// and the user must exist in the pool.
+pub fn mint_authorization_code(
+    state: &SharedCognitoState,
+    req: &MintAuthorizationCodeRequest,
+) -> Result<String, MintAuthorizationCodeError> {
+    let mut mas = state.write();
+    for (_, account) in mas.iter_mut() {
+        let Some(client) = account.user_pool_clients.get(&req.client_id) else {
+            continue;
+        };
+        if client.user_pool_id != req.user_pool_id {
+            return Err(MintAuthorizationCodeError::InvalidClient);
+        }
+        // AWS allows callback_urls to be empty during early dev, so we
+        // only enforce the match when at least one URL is registered.
+        if !client.callback_urls.is_empty()
+            && !client.callback_urls.iter().any(|u| u == &req.redirect_uri)
+        {
+            return Err(MintAuthorizationCodeError::InvalidRedirectUri);
+        }
+        let user_exists = account
+            .users
+            .get(&req.user_pool_id)
+            .map(|users| users.contains_key(&req.username))
+            .unwrap_or(false);
+        if !user_exists {
+            return Err(MintAuthorizationCodeError::UserNotFound);
+        }
+        let code = format!("ac-{}", Uuid::new_v4());
+        account.authorization_codes.insert(
+            code.clone(),
+            crate::state::AuthorizationCodeData {
+                user_pool_id: req.user_pool_id.clone(),
+                client_id: req.client_id.clone(),
+                username: req.username.clone(),
+                redirect_uri: req.redirect_uri.clone(),
+                scopes: req.scopes.clone(),
+                code_challenge: req.code_challenge.clone(),
+                code_challenge_method: req.code_challenge_method.clone(),
+                nonce: req.nonce.clone(),
+                issued_at: Utc::now(),
+            },
+        );
+        return Ok(code);
+    }
+    Err(MintAuthorizationCodeError::InvalidClient)
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -45,6 +45,11 @@ pub struct CognitoState {
     /// access_token -> AccessTokenData
     #[serde(default)]
     pub access_tokens: BTreeMap<String, AccessTokenData>,
+    /// One-time authorization codes issued by `/oauth2/authorize` (Y4) and
+    /// the admin mint endpoint, consumed exactly once by `/oauth2/token`'s
+    /// `authorization_code` grant.
+    #[serde(default)]
+    pub authorization_codes: BTreeMap<String, AuthorizationCodeData>,
     /// pool_id -> (group_name -> Group)
     #[serde(default)]
     pub groups: BTreeMap<String, BTreeMap<String, Group>>,
@@ -130,6 +135,7 @@ impl CognitoState {
             refresh_tokens: BTreeMap::new(),
             sessions: BTreeMap::new(),
             access_tokens: BTreeMap::new(),
+            authorization_codes: BTreeMap::new(),
             groups: BTreeMap::new(),
             user_groups: BTreeMap::new(),
             identity_providers: BTreeMap::new(),
@@ -154,6 +160,7 @@ impl CognitoState {
         self.refresh_tokens.clear();
         self.sessions.clear();
         self.access_tokens.clear();
+        self.authorization_codes.clear();
         self.groups.clear();
         self.user_groups.clear();
         self.identity_providers.clear();
@@ -176,6 +183,32 @@ pub struct RefreshTokenData {
     pub user_pool_id: String,
     pub username: String,
     pub client_id: String,
+    pub issued_at: DateTime<Utc>,
+}
+
+/// Single-use OAuth2 authorization code minted by `/oauth2/authorize`
+/// (or the `_fakecloud` admin endpoint pre-Y4). Carries everything the
+/// `/oauth2/token` `authorization_code` grant needs to bind the code
+/// back to the original `(client_id, redirect_uri, scope, PKCE)` tuple
+/// it was issued for.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthorizationCodeData {
+    pub user_pool_id: String,
+    pub client_id: String,
+    pub username: String,
+    pub redirect_uri: String,
+    /// Space-separated scopes requested by the client at /authorize time.
+    pub scopes: Vec<String>,
+    /// Optional PKCE challenge — when present the token endpoint must
+    /// verify the supplied `code_verifier` against this value per RFC
+    /// 7636.
+    pub code_challenge: Option<String>,
+    /// `S256` (default) or `plain`. Stored as-supplied so token endpoint
+    /// can replay the right transform.
+    pub code_challenge_method: Option<String>,
+    /// Optional OIDC `nonce` claim, propagated into the issued id_token
+    /// per OIDC core §3.1.2.1.
+    pub nonce: Option<String>,
     pub issued_at: DateTime<Utc>,
 }
 

--- a/crates/fakecloud-e2e/tests/cognito.rs
+++ b/crates/fakecloud-e2e/tests/cognito.rs
@@ -5232,15 +5232,29 @@ async fn cognito_oauth2_token_unsupported_grant_type() {
 }
 
 #[tokio::test]
-async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
-    // /oauth2/authorize lands in Y4; until then authorization_code returns
-    // unsupported_grant_type rather than crashing.
+async fn cognito_oauth2_token_authorization_code_grant_issues_tokens() {
+    // Y3: authorization_code grant exchanges a single-use code minted
+    // via the admin endpoint for real RS256-signed id_token + access_token
+    // + refresh_token.
     let server = TestServer::start().await;
     let client = server.cognito_client().await;
 
     let pool = client
         .create_user_pool()
         .pool_name("oauth2-ac-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
         .send()
         .await
         .expect("create pool");
@@ -5250,6 +5264,477 @@ async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
         .create_user_pool_client()
         .user_pool_id(&pool_id)
         .client_name("oauth2-ac-client")
+        .callback_urls("https://example.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let http = reqwest::Client::new();
+    // Mint an authorization code via the admin endpoint (Y4 will land
+    // /oauth2/authorize; the admin path is the test-only equivalent).
+    let mint_url = format!(
+        "{}/_fakecloud/cognito/authorization-codes",
+        server.endpoint()
+    );
+    let mint_resp = http
+        .post(&mint_url)
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "clientId": client_id,
+            "username": "alice",
+            "redirectUri": "https://example.test/cb",
+            "scopes": ["openid", "email"],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(mint_resp.status(), 200);
+    let code = mint_resp.json::<serde_json::Value>().await.unwrap()["code"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    let body = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://example.test/cb"),
+    ])
+    .unwrap();
+    let resp = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    let id_token = json["id_token"].as_str().unwrap();
+    let access_token = json["access_token"].as_str().unwrap();
+    let refresh_token = json["refresh_token"].as_str().unwrap();
+    assert_eq!(id_token.split('.').count(), 3);
+    assert_eq!(access_token.split('.').count(), 3);
+    assert!(!refresh_token.is_empty());
+    assert_eq!(json["token_type"], "Bearer");
+    assert_eq!(json["expires_in"], 3600);
+
+    // Code is single-use — the second redemption MUST fail invalid_grant.
+    let body2 = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://example.test/cb"),
+    ])
+    .unwrap();
+    let resp2 = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp2.status(), 400);
+    assert_eq!(
+        resp2.json::<serde_json::Value>().await.unwrap()["error"],
+        "invalid_grant"
+    );
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_authorization_code_redirect_uri_mismatch() {
+    // Tampering with redirect_uri at /token must invalidate the code
+    // (RFC 6749 §4.1.3).
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-ac-redir-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-ac-redir-client")
+        .callback_urls("https://example.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let http = reqwest::Client::new();
+    let mint_url = format!(
+        "{}/_fakecloud/cognito/authorization-codes",
+        server.endpoint()
+    );
+    let code = http
+        .post(&mint_url)
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "clientId": client_id,
+            "username": "bob",
+            "redirectUri": "https://example.test/cb",
+            "scopes": ["openid"],
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["code"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    let body = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://attacker.test/cb"),
+    ])
+    .unwrap();
+    let resp = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["error"],
+        "invalid_grant"
+    );
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_authorization_code_with_pkce_s256() {
+    // RFC 7636: when /authorize stored a code_challenge, /token must
+    // verify the supplied code_verifier hashes back to it.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-ac-pkce-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-ac-pkce-client")
+        .callback_urls("https://example.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    // verifier from RFC 7636 example.
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    let http = reqwest::Client::new();
+    let mint_url = format!(
+        "{}/_fakecloud/cognito/authorization-codes",
+        server.endpoint()
+    );
+    let code = http
+        .post(&mint_url)
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "clientId": client_id,
+            "username": "carol",
+            "redirectUri": "https://example.test/cb",
+            "scopes": ["openid"],
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["code"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    // Wrong verifier rejected.
+    let bad_body = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://example.test/cb"),
+        ("code_verifier", "not-the-real-verifier"),
+    ])
+    .unwrap();
+    let bad = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(bad_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), 400);
+    assert_eq!(
+        bad.json::<serde_json::Value>().await.unwrap()["error"],
+        "invalid_grant"
+    );
+
+    // Mint another code (the previous one was consumed by the failed
+    // attempt? No — we only consume on success). To be safe re-mint.
+    let code2 = http
+        .post(&mint_url)
+        .json(&serde_json::json!({
+            "userPoolId": pool_id,
+            "clientId": client_id,
+            "username": "carol",
+            "redirectUri": "https://example.test/cb",
+            "scopes": ["openid"],
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["code"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let good_body = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code2.as_str()),
+        ("redirect_uri", "https://example.test/cb"),
+        ("code_verifier", verifier),
+    ])
+    .unwrap();
+    let good = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(good_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(good.status(), 200);
+    let json: serde_json::Value = good.json().await.unwrap();
+    assert_eq!(json["access_token"].as_str().unwrap().split('.').count(), 3);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_basic_auth_header() {
+    // RFC 6749 §2.3.1 — confidential clients MAY send credentials
+    // through `Authorization: Basic`. fakecloud accepts both that and
+    // form-body credentials and treats Basic as authoritative.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-basic-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-basic-client")
+        .generate_secret(true)
+        .send()
+        .await
+        .expect("create client");
+    let app_client = app.user_pool_client().unwrap();
+    let client_id = app_client.client_id().unwrap().to_string();
+    let client_secret = app_client.client_secret().unwrap().to_string();
+
+    use base64::Engine as _;
+    let basic =
+        base64::engine::general_purpose::STANDARD.encode(format!("{client_id}:{client_secret}"));
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = "grant_type=client_credentials&scope=api%2Fread";
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Basic {basic}"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["access_token"].as_str().unwrap().split('.').count(), 3);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_basic_auth_wrong_secret_401() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-basic-bad-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-basic-bad-client")
+        .generate_secret(true)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    use base64::Engine as _;
+    let basic =
+        base64::engine::general_purpose::STANDARD.encode(format!("{client_id}:wrong-secret"));
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Basic {basic}"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body("grant_type=client_credentials")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_client_credentials_no_secret_rejected() {
+    // client_credentials grant requires a confidential client (one
+    // with a secret). Public clients without a secret get
+    // invalid_client.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-cc-public-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-cc-public-client")
         .send()
         .await
         .expect("create client");
@@ -5262,7 +5747,61 @@ async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
 
     let http = reqwest::Client::new();
     let url = format!("{}/oauth2/token", server.endpoint());
-    let body = format!("grant_type=authorization_code&client_id={client_id}&code=abc");
+    let body = format!("grant_type=client_credentials&client_id={client_id}");
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["error"],
+        "invalid_client"
+    );
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_client_credentials_invalid_scope() {
+    // Requested scope must be a subset of the app client's allowed
+    // scopes; anything else gets invalid_scope.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-cc-scope-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-cc-scope-client")
+        .generate_secret(true)
+        .allowed_o_auth_flows_user_pool_client(true)
+        .allowed_o_auth_flows(
+            aws_sdk_cognitoidentityprovider::types::OAuthFlowType::ClientCredentials,
+        )
+        .allowed_o_auth_scopes("api/read")
+        .send()
+        .await
+        .expect("create client");
+    let app_client = app.user_pool_client().unwrap();
+    let client_id = app_client.client_id().unwrap().to_string();
+    let client_secret = app_client.client_secret().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = serde_urlencoded::to_string([
+        ("grant_type", "client_credentials"),
+        ("client_id", client_id.as_str()),
+        ("client_secret", client_secret.as_str()),
+        ("scope", "api/admin"),
+    ])
+    .unwrap();
     let resp = http
         .post(&url)
         .header("Content-Type", "application/x-www-form-urlencoded")
@@ -5271,8 +5810,60 @@ async fn cognito_oauth2_token_authorization_code_grant_unsupported() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 400);
-    let json: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(json["error"], "unsupported_grant_type");
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["error"],
+        "invalid_scope"
+    );
+}
+
+#[tokio::test]
+async fn cognito_oauth2_token_client_credentials_disallowed_flow() {
+    // Even with a valid secret, a client whose AllowedOAuthFlows omits
+    // client_credentials must be rejected with unauthorized_client.
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("oauth2-cc-flow-pool")
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("oauth2-cc-flow-client")
+        .generate_secret(true)
+        .allowed_o_auth_flows_user_pool_client(true)
+        .allowed_o_auth_flows(aws_sdk_cognitoidentityprovider::types::OAuthFlowType::Code)
+        .send()
+        .await
+        .expect("create client");
+    let app_client = app.user_pool_client().unwrap();
+    let client_id = app_client.client_id().unwrap().to_string();
+    let client_secret = app_client.client_secret().unwrap().to_string();
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/oauth2/token", server.endpoint());
+    let body = serde_urlencoded::to_string([
+        ("grant_type", "client_credentials"),
+        ("client_id", client_id.as_str()),
+        ("client_secret", client_secret.as_str()),
+    ])
+    .unwrap();
+    let resp = http
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    assert_eq!(
+        resp.json::<serde_json::Value>().await.unwrap()["error"],
+        "unauthorized_client"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -744,6 +744,35 @@ pub struct AuthEventsResponse {
     pub events: Vec<AuthEvent>,
 }
 
+/// Request body for the `/_fakecloud/cognito/authorization-codes` admin
+/// mint endpoint. Lets test harnesses (and any caller that wants to
+/// drive the `authorization_code` grant before the Y4 hosted-UI lands)
+/// pre-allocate the same `(client_id, redirect_uri, scopes, PKCE)`
+/// binding the real `/oauth2/authorize` endpoint will eventually
+/// produce.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintAuthorizationCodeRequest {
+    pub user_pool_id: String,
+    pub client_id: String,
+    pub username: String,
+    pub redirect_uri: String,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_challenge: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_challenge_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintAuthorizationCodeResponse {
+    pub code: String,
+}
+
 // ── API Gateway v2 ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3793,7 +3793,7 @@ async fn main() {
             "/oauth2/token",
             axum::routing::post({
                 let cs = cognito_token_state;
-                move |body: String| {
+                move |headers: axum::http::HeaderMap, body: String| {
                     let cs = cs.clone();
                     async move {
                         let params: std::collections::BTreeMap<String, String> =
@@ -3801,10 +3801,21 @@ async fn main() {
                                 Ok(pairs) => pairs.into_iter().collect(),
                                 Err(_) => std::collections::BTreeMap::new(),
                             };
+                        // RFC 6749 §2.3.1 — confidential clients MAY send
+                        // their credentials in the Authorization header
+                        // (`Basic base64(client_id:client_secret)`); we
+                        // treat that header as authoritative and fail
+                        // when it disagrees with the body.
+                        let basic = parse_basic_auth(&headers);
                         let region = std::env::var("AWS_DEFAULT_REGION")
                             .or_else(|_| std::env::var("AWS_REGION"))
                             .unwrap_or_else(|_| "us-east-1".to_string());
-                        match fakecloud_cognito::handle_oauth2_token(&cs, &params, &region).await {
+                        let basic_ref = basic.as_ref().map(|(i, s)| (i.as_str(), s.as_str()));
+                        match fakecloud_cognito::handle_oauth2_token(
+                            &cs, &params, basic_ref, &region,
+                        )
+                        .await
+                        {
                             Ok(resp) => (axum::http::StatusCode::OK, axum::Json(resp.to_json())),
                             Err(err) => {
                                 let status = axum::http::StatusCode::from_u16(err.status_code())
@@ -3970,6 +3981,55 @@ async fn main() {
                             })
                             .collect();
                         axum::Json(types::AuthEventsResponse { events })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/authorization-codes",
+            axum::routing::post({
+                let cs = cognito_state.clone();
+                move |axum::Json(body): axum::Json<types::MintAuthorizationCodeRequest>| {
+                    let cs = cs.clone();
+                    async move {
+                        let req = fakecloud_cognito::MintAuthorizationCodeRequest {
+                            user_pool_id: body.user_pool_id,
+                            client_id: body.client_id,
+                            username: body.username,
+                            redirect_uri: body.redirect_uri,
+                            scopes: body.scopes,
+                            code_challenge: body.code_challenge,
+                            code_challenge_method: body.code_challenge_method,
+                            nonce: body.nonce,
+                        };
+                        match fakecloud_cognito::mint_authorization_code(&cs, &req) {
+                            Ok(code) => (
+                                axum::http::StatusCode::OK,
+                                axum::Json(serde_json::json!(
+                                    types::MintAuthorizationCodeResponse { code }
+                                )),
+                            ),
+                            Err(err) => {
+                                let (status, msg) = match err {
+                                    fakecloud_cognito::MintAuthorizationCodeError::InvalidClient => (
+                                        axum::http::StatusCode::NOT_FOUND,
+                                        "client_id not found in any pool",
+                                    ),
+                                    fakecloud_cognito::MintAuthorizationCodeError::InvalidRedirectUri => (
+                                        axum::http::StatusCode::BAD_REQUEST,
+                                        "redirect_uri is not a registered callback URL",
+                                    ),
+                                    fakecloud_cognito::MintAuthorizationCodeError::UserNotFound => (
+                                        axum::http::StatusCode::NOT_FOUND,
+                                        "user not found in pool",
+                                    ),
+                                };
+                                (
+                                    status,
+                                    axum::Json(serde_json::json!({"error": msg})),
+                                )
+                            }
+                        }
                     }
                 }
             }),
@@ -5634,6 +5694,28 @@ impl fakecloud_core::delivery::KmsHook for KmsHookAdapter {
             )
             .map_err(|e| e.to_string())
     }
+}
+
+/// Parse a `Authorization: Basic <b64(client_id:client_secret)>` header
+/// into `(client_id, client_secret)`. Returns `None` when the header is
+/// absent, malformed, or the credential pair doesn't contain a colon.
+/// Tolerates URL-encoded credentials per RFC 6749 §2.3.1 by treating
+/// the raw decoded form as the canonical pair.
+fn parse_basic_auth(headers: &axum::http::HeaderMap) -> Option<(String, String)> {
+    use base64::Engine as _;
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = value
+        .strip_prefix("Basic ")
+        .or_else(|| value.strip_prefix("basic "))?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(token.trim())
+        .ok()?;
+    let raw = String::from_utf8(decoded).ok()?;
+    let (id, secret) = raw.split_once(':')?;
+    Some((id.to_string(), secret.to_string()))
 }
 
 /// Emit a fatal error through the tracing pipeline, flush stderr so the

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -133,6 +133,7 @@ func main() {
 | `GetTokens(ctx)` | List active tokens |
 | `ExpireTokens(ctx, req)` | Expire tokens |
 | `GetAuthEvents(ctx)` | List auth events |
+| `MintAuthorizationCode(ctx, req)` | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
 
 ### RDS - `fc.RDS()`
 

--- a/sdks/go/cognito.go
+++ b/sdks/go/cognito.go
@@ -105,3 +105,14 @@ func (c *CognitoClient) GetAuthEvents(ctx context.Context) (*AuthEventsResponse,
 	}
 	return &out, nil
 }
+
+// MintAuthorizationCode mints a single-use OAuth2 authorization code
+// that the /oauth2/token authorization_code grant can later redeem.
+// Test-only equivalent of /oauth2/authorize.
+func (c *CognitoClient) MintAuthorizationCode(ctx context.Context, req *MintAuthorizationCodeRequest) (*MintAuthorizationCodeResponse, error) {
+	var out MintAuthorizationCodeResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/cognito/authorization-codes", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -440,6 +440,26 @@ type AuthEventsResponse struct {
 	Events []AuthEvent `json:"events"`
 }
 
+// MintAuthorizationCodeRequest is the payload for the
+// /_fakecloud/cognito/authorization-codes admin endpoint. Lets test
+// harnesses mint a single-use OAuth2 authorization code that the
+// /oauth2/token authorization_code grant can later consume.
+type MintAuthorizationCodeRequest struct {
+	UserPoolID          string   `json:"userPoolId"`
+	ClientID            string   `json:"clientId"`
+	Username            string   `json:"username"`
+	RedirectURI         string   `json:"redirectUri"`
+	Scopes              []string `json:"scopes,omitempty"`
+	CodeChallenge       *string  `json:"codeChallenge,omitempty"`
+	CodeChallengeMethod *string  `json:"codeChallengeMethod,omitempty"`
+	Nonce               *string  `json:"nonce,omitempty"`
+}
+
+// MintAuthorizationCodeResponse is returned after minting a code.
+type MintAuthorizationCodeResponse struct {
+	Code string `json:"code"`
+}
+
 // ── Step Functions ─────────────────────────────────────────────────
 
 // StepFunctionsExecution represents a state machine execution.

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -141,6 +141,7 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | `getTokens()`                     | List all active tokens               |
 | `expireTokens(req)`               | Expire tokens (optionally filtered)  |
 | `getAuthEvents()`                 | List auth events                     |
+| `mintAuthorizationCode(req)`      | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
 
 ### `fc.rds()`
 

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -4,6 +4,8 @@ import static dev.fakecloud.HttpTransport.encodePath;
 
 import dev.fakecloud.Types.ApiGatewayV2RequestsResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
+import dev.fakecloud.Types.MintAuthorizationCodeRequest;
+import dev.fakecloud.Types.MintAuthorizationCodeResponse;
 import dev.fakecloud.Types.BedrockFaultRule;
 import dev.fakecloud.Types.BedrockFaultsResponse;
 import dev.fakecloud.Types.BedrockInvocationsResponse;
@@ -445,6 +447,14 @@ public final class FakeCloud {
 
         public AuthEventsResponse getAuthEvents() {
             return http.get("/_fakecloud/cognito/auth-events", AuthEventsResponse.class);
+        }
+
+        public MintAuthorizationCodeResponse mintAuthorizationCode(
+                MintAuthorizationCodeRequest req) {
+            return http.postJson(
+                    "/_fakecloud/cognito/authorization-codes",
+                    req,
+                    MintAuthorizationCodeResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -327,6 +327,26 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record AuthEventsResponse(List<AuthEvent> events) {}
 
+    /**
+     * Payload for {@code POST /_fakecloud/cognito/authorization-codes}.
+     * Lets test harnesses pre-allocate a single-use OAuth2 authorization
+     * code that the {@code /oauth2/token} {@code authorization_code}
+     * grant later consumes.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record MintAuthorizationCodeRequest(
+            String userPoolId,
+            String clientId,
+            String username,
+            String redirectUri,
+            List<String> scopes,
+            String codeChallenge,
+            String codeChallengeMethod,
+            String nonce) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record MintAuthorizationCodeResponse(String code) {}
+
     // ── Step Functions ─────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record StepFunctionsExecution(

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -125,6 +125,7 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | `getTokens()`                     | List all active tokens               |
 | `expireTokens($req)`              | Expire tokens (optionally filtered)  |
 | `getAuthEvents()`                 | List auth events                     |
+| `mintAuthorizationCode($req)`     | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
 
 ### `$fc->rds()`
 

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -436,6 +436,17 @@ final class CognitoClient
             $this->http->get('/_fakecloud/cognito/auth-events')
         );
     }
+
+    public function mintAuthorizationCode(
+        MintAuthorizationCodeRequest $req
+    ): MintAuthorizationCodeResponse {
+        return MintAuthorizationCodeResponse::fromArray(
+            $this->http->postJson(
+                '/_fakecloud/cognito/authorization-codes',
+                $req->toArray()
+            )
+        );
+    }
 }
 
 final class ApiGatewayV2Client

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1008,6 +1008,57 @@ final class AuthEventsResponse
     }
 }
 
+/**
+ * Payload for `POST /_fakecloud/cognito/authorization-codes`. Lets
+ * test harnesses pre-allocate a single-use OAuth2 authorization code
+ * that the `/oauth2/token` `authorization_code` grant later consumes.
+ */
+final class MintAuthorizationCodeRequest
+{
+    public function __construct(
+        public readonly string $userPoolId,
+        public readonly string $clientId,
+        public readonly string $username,
+        public readonly string $redirectUri,
+        /** @var string[] */
+        public readonly array $scopes = [],
+        public readonly ?string $codeChallenge = null,
+        public readonly ?string $codeChallengeMethod = null,
+        public readonly ?string $nonce = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        $out = [
+            'userPoolId' => $this->userPoolId,
+            'clientId' => $this->clientId,
+            'username' => $this->username,
+            'redirectUri' => $this->redirectUri,
+            'scopes' => $this->scopes,
+        ];
+        if ($this->codeChallenge !== null) {
+            $out['codeChallenge'] = $this->codeChallenge;
+        }
+        if ($this->codeChallengeMethod !== null) {
+            $out['codeChallengeMethod'] = $this->codeChallengeMethod;
+        }
+        if ($this->nonce !== null) {
+            $out['nonce'] = $this->nonce;
+        }
+        return $out;
+    }
+}
+
+final class MintAuthorizationCodeResponse
+{
+    public function __construct(public readonly string $code) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['code']);
+    }
+}
+
 // ── Step Functions ─────────────────────────────────────────────
 
 final class StepFunctionsExecution

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -85,7 +85,7 @@ Access via properties on the main client:
 | `s3` | S3 | `get_notifications()`, `tick_lifecycle()` |
 | `dynamodb` | DynamoDB | `tick_ttl()` |
 | `secretsmanager` | SecretsManager | `tick_rotation()` |
-| `cognito` | Cognito | `get_user_codes(pool_id, username)`, `get_confirmation_codes()`, `confirm_user(req)`, `get_tokens()`, `expire_tokens(req)`, `get_auth_events()` |
+| `cognito` | Cognito | `get_user_codes(pool_id, username)`, `get_confirmation_codes()`, `confirm_user(req)`, `get_tokens()`, `expire_tokens(req)`, `get_auth_events()`, `mint_authorization_code(req)` |
 | `rds` | RDS | `get_instances()` |
 | `elasticache` | ElastiCache | `get_clusters()`, `get_replication_groups()`, `get_serverless_caches()` |
 | `stepfunctions` | Step Functions | `get_executions()` |

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -51,6 +51,8 @@ from fakecloud.types import (
     InboundEmailResponse,
     LambdaInvocationsResponse,
     LifecycleTickResponse,
+    MintAuthorizationCodeRequest,
+    MintAuthorizationCodeResponse,
     PendingConfirmationsResponse,
     RdsInstancesResponse,
     ResetResponse,
@@ -719,6 +721,16 @@ class CognitoClient:
         _check(resp)
         return AuthEventsResponse.from_dict(resp.json())
 
+    async def mint_authorization_code(
+        self, req: MintAuthorizationCodeRequest
+    ) -> MintAuthorizationCodeResponse:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/cognito/authorization-codes",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return MintAuthorizationCodeResponse.from_dict(resp.json())
+
 
 class ApiGatewayV2Client:
     """Async API Gateway v2 introspection client."""
@@ -1061,6 +1073,16 @@ class _SyncCognitoClient:
         resp = self._client.get(f"{self._base}/_fakecloud/cognito/auth-events")
         _check(resp)
         return AuthEventsResponse.from_dict(resp.json())
+
+    def mint_authorization_code(
+        self, req: MintAuthorizationCodeRequest
+    ) -> MintAuthorizationCodeResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/cognito/authorization-codes",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return MintAuthorizationCodeResponse.from_dict(resp.json())
 
 
 class _SyncApiGatewayV2Client:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -878,6 +878,51 @@ class AuthEventsResponse:
         )
 
 
+@dataclass
+class MintAuthorizationCodeRequest:
+    """Payload for `POST /_fakecloud/cognito/authorization-codes`.
+
+    Lets test harnesses pre-allocate a single-use OAuth2 authorization
+    code that the `/oauth2/token` `authorization_code` grant will
+    later consume.
+    """
+
+    user_pool_id: str
+    client_id: str
+    username: str
+    redirect_uri: str
+    scopes: Optional[List[str]] = None
+    code_challenge: Optional[str] = None
+    code_challenge_method: Optional[str] = None
+    nonce: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "userPoolId": self.user_pool_id,
+            "clientId": self.client_id,
+            "username": self.username,
+            "redirectUri": self.redirect_uri,
+        }
+        if self.scopes is not None:
+            out["scopes"] = self.scopes
+        if self.code_challenge is not None:
+            out["codeChallenge"] = self.code_challenge
+        if self.code_challenge_method is not None:
+            out["codeChallengeMethod"] = self.code_challenge_method
+        if self.nonce is not None:
+            out["nonce"] = self.nonce
+        return out
+
+
+@dataclass
+class MintAuthorizationCodeResponse:
+    code: str
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> MintAuthorizationCodeResponse:
+        return cls(code=data["code"])
+
+
 # ── Step Functions ──────────────────────────────────────────────────
 
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -124,6 +124,7 @@ Top-level client. Defaults to `http://localhost:4566`.
 | `getTokens()`                    | List all active tokens               |
 | `expireTokens(req)`              | Expire tokens (optionally filtered)  |
 | `getAuthEvents()`                | List auth events                     |
+| `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
 
 ### `fc.rds`
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -47,6 +47,8 @@ import type {
   ExpireTokensRequest,
   ExpireTokensResponse,
   AuthEventsResponse,
+  MintAuthorizationCodeRequest,
+  MintAuthorizationCodeResponse,
   StepFunctionsExecutionsResponse,
   EcsClustersResponse,
   Elbv2LoadBalancersResponse,
@@ -365,6 +367,20 @@ export class CognitoClient {
 
   async getAuthEvents(): Promise<AuthEventsResponse> {
     const resp = await fetch(`${this.baseUrl}/_fakecloud/cognito/auth-events`);
+    return parse(resp);
+  }
+
+  async mintAuthorizationCode(
+    req: MintAuthorizationCodeRequest,
+  ): Promise<MintAuthorizationCodeResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/cognito/authorization-codes`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      },
+    );
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -364,6 +364,26 @@ export interface AuthEventsResponse {
   events: AuthEvent[];
 }
 
+/**
+ * Payload for `POST /_fakecloud/cognito/authorization-codes`. Lets
+ * test harnesses pre-allocate a single-use OAuth2 authorization code
+ * that the `/oauth2/token` `authorization_code` grant later consumes.
+ */
+export interface MintAuthorizationCodeRequest {
+  userPoolId: string;
+  clientId: string;
+  username: string;
+  redirectUri: string;
+  scopes?: string[];
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  nonce?: string;
+}
+
+export interface MintAuthorizationCodeResponse {
+  code: string;
+}
+
 // ── Step Functions ────────────────────────────────────────────────
 
 export interface StepFunctionsExecution {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -112,6 +112,7 @@ curl http://localhost:4566/_fakecloud/health
 | `/_fakecloud/cognito/tokens`                                  | GET    | List all active tokens (without exposing strings). |
 | `/_fakecloud/cognito/expire-tokens`                           | POST   | Expire tokens for a pool/user. |
 | `/_fakecloud/cognito/auth-events`                             | GET    | List auth events (signup, signin, failures). |
+| `/_fakecloud/cognito/authorization-codes`                     | POST   | Mint a single-use OAuth2 authorization code for the `authorization_code` grant. Test-only equivalent of `/oauth2/authorize`. |
 
 ## Step Functions
 

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -27,6 +27,14 @@ fakecloud implements **122 of 122** Cognito User Pools operations at 100% Smithy
 
 JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
+## OAuth2 / OIDC endpoints
+
+- `POST /oauth2/token` — token endpoint with `authorization_code`, `client_credentials`, and `refresh_token` grants. RFC 6749 §2.3.1 Basic auth supported. PKCE (S256/plain) verified for `authorization_code`.
+- `GET|POST /oauth2/userInfo` — RFC 7662 user info (bearer access token -> standard OIDC claims).
+- `POST /oauth2/revoke` — RFC 7009 token revocation.
+- `GET /<pool_id>/.well-known/jwks.json` — RS256 public key for token verification.
+- `GET /<pool_id>/.well-known/openid-configuration` — OIDC discovery document.
+
 ## Introspection
 
 - `GET /_fakecloud/cognito/confirmation-codes` — list all pending confirmation codes across pools
@@ -35,6 +43,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 - `GET /_fakecloud/cognito/tokens` — list active tokens (without exposing strings)
 - `POST /_fakecloud/cognito/expire-tokens` — expire tokens for a pool/user
 - `GET /_fakecloud/cognito/auth-events` — list auth events (signup, signin, failures)
+- `POST /_fakecloud/cognito/authorization-codes` — mint a single-use OAuth2 authorization code for the `authorization_code` grant (test-only equivalent of `/oauth2/authorize`)
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

Y3 of the parity-gap loop: Cognito's `/oauth2/token` endpoint now implements all three Hosted-UI OAuth2 grants end-to-end.

- **authorization_code** — validates code+client_id+pool+redirect_uri match the `/authorize` binding, enforces 5-minute expiry, consumes the code on success, optionally verifies PKCE (S256/plain), issues id_token+access_token+refresh_token. Codes minted via `/_fakecloud/cognito/authorization-codes` admin endpoint pre-Y4 (or programmatically via `mint_authorization_code`).
- **client_credentials** — requires confidential client, validates flow allow-list + scope subset against `allowed_o_auth_scopes`, issues access_token only (no id_token, no refresh_token), `sub = client_id` per OIDC core.
- **refresh_token** — rotation honors pool's `RefreshTokenRotation=ENABLED` config (already shipped; left untouched for the new helper structure).
- **Basic auth (RFC 6749 §2.3.1)** — `Authorization: Basic <b64(id:secret)>` parsed and treated as authoritative when supplied alongside form credentials; conflict -> `invalid_client`.

New `OAuthTokenError` variants: `UnauthorizedClient`, `InvalidScope`. New state field `authorization_codes` is `serde-default` so existing snapshots load without migration.

SDK + docs synced in the same batch:
- Go / Java / PHP / Python / TypeScript clients gain `mintAuthorizationCode` method.
- Cognito service docs + introspection reference list `/oauth2/*` and `/_fakecloud/cognito/authorization-codes`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test -p fakecloud-cognito --lib` (306 pass)
- [x] `cargo test -p fakecloud-e2e --test cognito` (87 pass; 8 new oauth2 tests cover happy path, single-use enforcement, redirect_uri mismatch, PKCE S256, Basic auth good+bad secret, client_credentials no-secret rejection, invalid_scope, unauthorized_client)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for Cognito `/oauth2/token` with `authorization_code`, `client_credentials`, and `refresh_token` grants, including Basic auth and PKCE. Adds an admin endpoint to mint authorization codes and updates SDKs with `mintAuthorizationCode`.

- **New Features**
  - `authorization_code`: validates `code` + `client_id` + pool + `redirect_uri`, enforces 5‑min expiry, single-use, verifies PKCE (`S256`/`plain`), issues `id_token` + `access_token` + `refresh_token`, propagates `scope` and `nonce`.
  - `client_credentials`: requires confidential client, enforces allowed flows and scope subset, issues `access_token` only (`sub = client_id`).
  - `refresh_token`: rotates tokens when pool `RefreshTokenRotation=ENABLED`.
  - Basic auth (RFC 6749 §2.3.1): `Authorization: Basic …` supported; header wins over form; conflicts return `invalid_client`.
  - New admin endpoint `/_fakecloud/cognito/authorization-codes` and helper `mint_authorization_code` to pre-mint codes; new state map `authorization_codes` (serde-default).
  - New errors: `UnauthorizedClient`, `InvalidScope`. SDKs (Go/Java/PHP/Python/TypeScript) add `mintAuthorizationCode`.

<sup>Written for commit b0dffe64136b1286275843ed2c591b5392d48787. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

