### PR TITLE
feat(logs): CreateExportTask + CreateDelivery write to real S3 (Z2)

### DIFF
--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -1439,6 +1439,232 @@ async fn logs_export_task_writes_to_storage() {
     assert!(data.contains("export event B"));
 }
 
+/// Z2: CreateExportTask must write a real, gzipped object into the
+/// destination S3 bucket so callers can `GetObject` + decompress + read
+/// the events the same way they would against AWS.
+#[tokio::test]
+async fn logs_export_task_writes_gzipped_object_to_real_s3() {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let server = TestServer::start().await;
+    let logs = server.logs_client().await;
+    let s3 = server.s3_client().await;
+
+    // Bucket must exist upfront — S3 put_object refuses unknown buckets.
+    s3.create_bucket()
+        .bucket("logs-export-real-s3")
+        .send()
+        .await
+        .unwrap();
+
+    logs.create_log_group()
+        .log_group_name("/export-real-s3/e2e")
+        .send()
+        .await
+        .unwrap();
+    logs.create_log_stream()
+        .log_group_name("/export-real-s3/e2e")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now().timestamp_millis();
+    logs.put_log_events()
+        .log_group_name("/export-real-s3/e2e")
+        .log_stream_name("s1")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("real-s3-evt-1")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1)
+                .message("real-s3-evt-2")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = logs
+        .create_export_task()
+        .log_group_name("/export-real-s3/e2e")
+        .from(now - 1000)
+        .to(now + 10000)
+        .destination("logs-export-real-s3")
+        .destination_prefix("exports")
+        .send()
+        .await
+        .unwrap();
+    let task_id = resp.task_id().unwrap().to_string();
+
+    // ListObjectsV2 should surface a single gzipped key under the prefix.
+    let listed = s3
+        .list_objects_v2()
+        .bucket("logs-export-real-s3")
+        .prefix(format!("exports/{task_id}/"))
+        .send()
+        .await
+        .unwrap();
+    let objects = listed.contents();
+    assert_eq!(objects.len(), 1, "expected one exported object");
+    let key = objects[0].key().unwrap().to_string();
+    assert!(
+        key.ends_with("/000000.gz"),
+        "expected key to end with /000000.gz, got {key}",
+    );
+
+    // GetObject + gunzip + verify both events round-trip.
+    let obj = s3
+        .get_object()
+        .bucket("logs-export-real-s3")
+        .key(&key)
+        .send()
+        .await
+        .unwrap();
+    let body = obj.body.collect().await.unwrap().into_bytes();
+    let mut decoded = String::new();
+    GzDecoder::new(&body[..])
+        .read_to_string(&mut decoded)
+        .unwrap();
+    assert!(decoded.contains("real-s3-evt-1"));
+    assert!(decoded.contains("real-s3-evt-2"));
+    // JSONL shape: each line is a JSON object with timestamp + message.
+    let line_count = decoded.lines().filter(|l| !l.is_empty()).count();
+    assert_eq!(line_count, 2);
+}
+
+/// Z2: CreateDelivery wires log group -> S3 bucket; subsequent
+/// PutLogEvents calls deliver gzipped objects we can fetch via the
+/// real S3 GetObject API.
+#[tokio::test]
+async fn logs_delivery_pipeline_writes_gzipped_object_to_real_s3() {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let server = TestServer::start().await;
+    let logs = server.logs_client().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("logs-delivery-real-s3")
+        .send()
+        .await
+        .unwrap();
+
+    logs.create_log_group()
+        .log_group_name("/delivery-real-s3/e2e")
+        .send()
+        .await
+        .unwrap();
+    logs.create_log_stream()
+        .log_group_name("/delivery-real-s3/e2e")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = logs
+        .describe_log_groups()
+        .log_group_name_prefix("/delivery-real-s3/e2e")
+        .send()
+        .await
+        .unwrap();
+    let group_arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    logs.put_delivery_source()
+        .name("real-src")
+        .resource_arn(&group_arn)
+        .log_type("APPLICATION_LOGS")
+        .send()
+        .await
+        .unwrap();
+
+    let dest_resp = logs
+        .put_delivery_destination()
+        .name("real-dest")
+        .delivery_destination_configuration(
+            aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+                .destination_resource_arn("arn:aws:s3:::logs-delivery-real-s3")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let dest_arn = dest_resp
+        .delivery_destination()
+        .unwrap()
+        .arn()
+        .unwrap()
+        .to_string();
+
+    logs.create_delivery()
+        .delivery_source_name("real-src")
+        .delivery_destination_arn(&dest_arn)
+        .send()
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now().timestamp_millis();
+    logs.put_log_events()
+        .log_group_name("/delivery-real-s3/e2e")
+        .log_stream_name("s1")
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now)
+                .message("delivered-real-1")
+                .build()
+                .unwrap(),
+        )
+        .log_events(
+            InputLogEvent::builder()
+                .timestamp(now + 1)
+                .message("delivered-real-2")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let listed = s3
+        .list_objects_v2()
+        .bucket("logs-delivery-real-s3")
+        .prefix("aws-logs-write/")
+        .send()
+        .await
+        .unwrap();
+    let objects = listed.contents();
+    assert!(
+        !objects.is_empty(),
+        "expected delivery object under aws-logs-write/",
+    );
+    let key = objects[0].key().unwrap().to_string();
+    assert!(key.ends_with(".gz"), "delivery key should be .gz: {key}");
+
+    let obj = s3
+        .get_object()
+        .bucket("logs-delivery-real-s3")
+        .key(&key)
+        .send()
+        .await
+        .unwrap();
+    let body = obj.body.collect().await.unwrap().into_bytes();
+    let mut decoded = String::new();
+    GzDecoder::new(&body[..])
+        .read_to_string(&mut decoded)
+        .unwrap();
+    assert!(decoded.contains("delivered-real-1"));
+    assert!(decoded.contains("delivered-real-2"));
+}
+
 #[tokio::test]
 async fn logs_delivery_pipeline_forwards_events() {
     let server = TestServer::start().await;
@@ -1541,13 +1767,15 @@ async fn logs_delivery_pipeline_forwards_events() {
             "Authorization",
             "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/logs/aws4_request, SignedHeaders=host, Signature=dummy",
         )
-        .body(r#"{"keyPrefix": "e2e-delivery-bucket/delivery"}"#)
+        .body(r#"{"keyPrefix": "e2e-delivery-bucket/aws-logs-write"}"#)
         .send()
         .await
         .unwrap();
     let body: Value = resp.json().await.unwrap();
     let entries = body["entries"].as_array().unwrap();
     assert!(!entries.is_empty(), "Should have delivery data");
+    // The internal GetExportedData endpoint transparently decompresses
+    // gzip payloads back to the JSONL text we wrote.
     let data = entries[0]["data"].as_str().unwrap();
     assert!(data.contains("delivered msg 1"));
     assert!(data.contains("delivered msg 2"));

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -1034,10 +1034,11 @@ mod tests {
         );
         svc.put_log_events(&req).unwrap();
 
-        // Verify data was written to export storage under the S3 bucket path
+        // Verify data was written to export storage under the S3 bucket path.
+        // GetExportedData transparently decompresses gzip payloads back to JSONL.
         let req = make_request(
             "GetExportedData",
-            json!({ "keyPrefix": "delivery-test-bucket/delivery" }),
+            json!({ "keyPrefix": "delivery-test-bucket/aws-logs-write" }),
         );
         let resp = svc.get_exported_data(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -4,8 +4,42 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::io::Write;
+
 use super::LogsService;
 use crate::state::ExportTask;
+
+/// Gzip-encode a JSONL payload. CloudWatch Logs writes export task and
+/// delivery output as gzip-compressed objects (`.gz`); downstream
+/// consumers (Athena, S3 SELECT, custom readers) expect that wire shape.
+fn gzip_jsonl(data: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).expect("gzip write");
+    encoder.finish().expect("gzip finish")
+}
+
+/// Build the S3 key real CloudWatch uses for export task output:
+/// `<destinationPrefix>/<exportTaskId>/<32-hex-hash>/000000.gz`. The
+/// hash segment is unique per file so reruns of the same task don't
+/// collide; we derive it from the stream name + completion timestamp.
+fn export_object_key(prefix: &str, task_id: &str, stream_name: &str, ts: i64) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h1 = std::collections::hash_map::DefaultHasher::new();
+    let mut h2 = std::collections::hash_map::DefaultHasher::new();
+    stream_name.hash(&mut h1);
+    ts.hash(&mut h1);
+    task_id.hash(&mut h2);
+    stream_name.hash(&mut h2);
+    let hash = format!("{:016x}{:016x}", h1.finish(), h2.finish());
+    let prefix = prefix.trim_end_matches('/');
+    if prefix.is_empty() {
+        format!("{task_id}/{hash}/000000.gz")
+    } else {
+        format!("{prefix}/{task_id}/{hash}/000000.gz")
+    }
+}
 
 impl LogsService {
     // ---- Export Tasks ----
@@ -125,8 +159,12 @@ impl LogsService {
                     data.push_str(&line);
                     data.push('\n');
                 }
-                let s3_key = format!("{destination_prefix}/{task_id}/{stream_name}-{now}");
-                let body = data.into_bytes();
+                // CloudWatch Logs export tasks deliver gzip-compressed
+                // JSONL under `<prefix>/<taskId>/<hash>/000000.gz`. We
+                // mirror that shape so downstream readers (Athena, S3
+                // SELECT, custom decompressors) work without changes.
+                let s3_key = export_object_key(&destination_prefix, &task_id, stream_name, now);
+                let body = gzip_jsonl(data.as_bytes());
                 if self
                     .delivery_bus
                     .put_object_to_s3(
@@ -134,7 +172,7 @@ impl LogsService {
                         &destination,
                         &s3_key,
                         body.clone(),
-                        Some("application/x-ndjson"),
+                        Some("application/x-gzip"),
                     )
                     .is_err()
                 {
@@ -299,9 +337,24 @@ impl LogsService {
             .iter()
             .filter(|(k, _)| k.starts_with(key_prefix))
             .map(|(k, v)| {
+                // Stored payloads are gzipped JSONL on the AWS path; for
+                // this introspection endpoint we transparently decompress
+                // when we recognize the gzip magic so callers keep getting
+                // raw text back.
+                let data = if v.len() >= 2 && v[0] == 0x1f && v[1] == 0x8b {
+                    use flate2::read::GzDecoder;
+                    use std::io::Read;
+                    let mut out = String::new();
+                    GzDecoder::new(&v[..])
+                        .read_to_string(&mut out)
+                        .unwrap_or_default();
+                    out
+                } else {
+                    String::from_utf8_lossy(v).to_string()
+                };
                 json!({
                     "key": k,
-                    "data": String::from_utf8_lossy(v).to_string(),
+                    "data": data,
                 })
             })
             .collect();
@@ -527,15 +580,29 @@ mod tests {
         assert_eq!(objects.len(), 1, "expected one S3 object");
         let (_, bucket, key, body, content_type) = &objects[0];
         assert_eq!(bucket, "exp-bucket");
-        assert!(key.starts_with("p/"));
-        assert!(key.contains("/s1-"));
-        assert_eq!(content_type.as_deref(), Some("application/x-ndjson"));
-        let text = String::from_utf8_lossy(body);
+        // AWS-format key: <prefix>/<taskId>/<hash>/000000.gz
+        assert!(key.starts_with("p/"), "key should start with prefix: {key}");
+        assert!(
+            key.ends_with("/000000.gz"),
+            "key should end with .gz: {key}"
+        );
+        let segments: Vec<&str> = key.split('/').collect();
+        assert_eq!(segments.len(), 4, "expected 4 segments in {key}");
+        assert_eq!(content_type.as_deref(), Some("application/x-gzip"));
+        let text = decompress_gzip(body);
         let lines: Vec<&str> = text.trim().lines().collect();
         assert_eq!(lines.len(), 3);
         let first: Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(first["timestamp"].as_i64().unwrap(), now);
         assert_eq!(first["message"].as_str().unwrap(), "evt-a");
+    }
+
+    fn decompress_gzip(body: &[u8]) -> String {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut out = String::new();
+        GzDecoder::new(body).read_to_string(&mut out).unwrap();
+        out
     }
 
     #[test]
@@ -579,7 +646,7 @@ mod tests {
 
         let objects = recorder.objects.lock();
         assert_eq!(objects.len(), 1);
-        let body = String::from_utf8_lossy(&objects[0].3);
+        let body = decompress_gzip(&objects[0].3);
         assert!(body.contains("\"mid\""));
         assert!(!body.contains("\"low\""));
         assert!(!body.contains("\"high\""));
@@ -751,9 +818,11 @@ mod tests {
 
         let objects = recorder.objects.lock();
         assert!(!objects.is_empty(), "expected delivery to write S3 objects");
-        let (_, bucket, _, body, _) = &objects[0];
+        let (_, bucket, key, body, content_type) = &objects[0];
         assert_eq!(bucket, "live-bucket");
-        let text = String::from_utf8_lossy(body);
+        assert!(key.ends_with(".gz"), "delivery key should be .gz: {key}");
+        assert_eq!(content_type.as_deref(), Some("application/x-gzip"));
+        let text = decompress_gzip(body);
         assert!(text.contains("live-a"));
         assert!(text.contains("live-b"));
     }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -488,7 +488,9 @@ impl LogsService {
         // Write delivery pipeline events to the destination S3 bucket
         // via the delivery bus so subscribers can read them with real
         // S3 GetObject. Falls back to the internal export_storage map
-        // when no S3 writer is wired (in-process tests).
+        // when no S3 writer is wired (in-process tests). Output is
+        // gzip-compressed JSONL (`.gz`), matching real CloudWatch Logs
+        // delivery to S3.
         if !delivery_targets.is_empty() && !accepted_events.is_empty() {
             let mut data = String::new();
             for event in &accepted_events {
@@ -500,35 +502,34 @@ impl LogsService {
                 data.push_str(&line);
                 data.push('\n');
             }
-            let now_str = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(data.as_bytes()).expect("gzip write");
+            let gz_body = encoder.finish().expect("gzip finish");
+            let now_dt = Utc::now();
+            let date_part = now_dt.format("%Y/%m/%d").to_string();
+            let now_str = now_dt.format("%Y%m%dT%H%M%SZ").to_string();
             let account_id_owned = state.account_id.clone();
             for dest_arn in &delivery_targets {
                 let bucket = dest_arn.strip_prefix("arn:aws:s3:::").unwrap_or(dest_arn);
+                // Mirror the CloudWatch Logs delivery key shape:
+                // `aws-logs-write/<accountId>/<group>/<date>/<stream>-<ts>.gz`.
                 let s3_key = format!(
-                    "delivery/{}/{}/{}",
-                    group_name_owned, stream_name_owned, now_str
+                    "aws-logs-write/{}/{}/{}/{}-{}.gz",
+                    account_id_owned, group_name_owned, date_part, stream_name_owned, now_str,
                 );
-                let body = data.clone().into_bytes();
                 if self
                     .delivery_bus
                     .put_object_to_s3(
                         &account_id_owned,
                         bucket,
                         &s3_key,
-                        body.clone(),
-                        Some("application/x-ndjson"),
+                        gz_body.clone(),
+                        Some("application/x-gzip"),
                     )
                     .is_err()
                 {
-                    let fallback_key = format!(
-                        "{}/delivery/{}/{}/{}",
-                        bucket, group_name_owned, stream_name_owned, now_str
-                    );
-                    let entry = state.export_storage.entry(fallback_key).or_default();
-                    if !entry.is_empty() {
-                        entry.push(b'\n');
-                    }
-                    entry.extend_from_slice(data.as_bytes());
+                    let fallback_key = format!("{bucket}/{s3_key}");
+                    state.export_storage.insert(fallback_key, gz_body.clone());
                 }
             }
         }


### PR DESCRIPTION
## Summary

Z2 from the parity-gap loop. Brings CloudWatch Logs export task + delivery output up to AWS wire format so callers that S3 GetObject + gunzip the data the same way they would against AWS get the same shape back.

- CreateExportTask writes gzip-compressed JSONL under \`<destinationPrefix>/<exportTaskId>/<hash>/000000.gz\` (one object per matching log stream). Content-Type is \`application/x-gzip\`.
- PutLogEvents -> S3 deliveries write gzipped JSONL under \`aws-logs-write/<accountId>/<group>/<YYYY/MM/DD>/<stream>-<ts>.gz\`.
- Both paths cross-call into fakecloud-s3 via \`DeliveryBus::put_object_to_s3\` (same pattern CFN provisioner uses) and fall back to the in-process \`export_storage\` map when no S3 writer is wired (unit tests). The internal \`GetExportedData\` introspection action transparently gunzips so existing tests still see raw JSONL.

## Test plan

- [x] \`cargo test -p fakecloud-logs --lib\` (282 passed)
- [x] \`cargo test -p fakecloud-e2e --test logs\` — new \`logs_export_task_writes_gzipped_object_to_real_s3\` and \`logs_delivery_pipeline_writes_gzipped_object_to_real_s3\` exercise the full S3 round-trip (CreateBucket -> CreateExportTask/CreateDelivery -> ListObjectsV2 -> GetObject -> gunzip -> assert events).
- [x] \`cargo clippy -p fakecloud-logs -p fakecloud-e2e --all-targets -- -D warnings\`
- [x] \`cargo fmt\`
- Pre-existing \`logs_subscription_filter_invokes_lambda\` flakes locally on main with no Docker daemon; not related to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write CloudWatch Logs export tasks and deliveries to real S3 using AWS-style gzip JSONL and key formats. Callers can List/GetObject and gunzip data exactly like AWS.

- **New Features**
  - Export tasks: gzip JSONL per stream at `<prefix>/<exportTaskId>/<hash>/000000.gz` with `Content-Type: application/x-gzip`.
  - Deliveries: gzip JSONL to `aws-logs-write/<accountId>/<group>/<YYYY/MM/DD>/<stream>-<ts>.gz` with `Content-Type: application/x-gzip`.
  - Both paths use `DeliveryBus::put_object_to_s3`; fallback stores gzipped payloads in in-process storage, and `GetExportedData` auto-decompresses for tests.
  - E2E tests cover CreateBucket → CreateExportTask/CreateDelivery → ListObjectsV2 → GetObject → gunzip round trip.

<sup>Written for commit d3a28afdddc998e24b7b38ae85ffe2a5c07bdb03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

