### PR TITLE
feat(cloudformation): AWS::ECS provisioners (BB11)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1052,6 +1052,12 @@ impl ResourceProvisioner {
             }
             "AWS::ApiGatewayV2::VpcLink" => Some(self.update_apigwv2_vpc_link(existing, new_def)?),
             "AWS::ApiGatewayV2::Model" => Some(self.update_apigwv2_model(existing, new_def)?),
+            "AWS::ECS::Cluster" => Some(self.update_ecs_cluster(existing, new_def)?),
+            "AWS::ECS::Service" => Some(self.update_ecs_service(existing, new_def)?),
+            "AWS::ECS::TaskDefinition" => Some(self.update_ecs_task_definition(existing, new_def)?),
+            "AWS::ECS::CapacityProvider" => {
+                Some(self.update_ecs_capacity_provider(existing, new_def)?)
+            }
             _ => None,
         };
 
@@ -1098,6 +1104,11 @@ impl ResourceProvisioner {
             }
             "AWS::CloudFront::Distribution" => {
                 self.get_att_cf_distribution(&resource.physical_id, attribute)
+            }
+            "AWS::ECS::Cluster" => self.get_att_ecs_cluster(&resource.physical_id, attribute),
+            "AWS::ECS::Service" => self.get_att_ecs_service(&resource.physical_id, attribute),
+            "AWS::ECS::CapacityProvider" => {
+                self.get_att_ecs_capacity_provider(&resource.physical_id, attribute)
             }
             _ => None,
         }
@@ -8131,13 +8142,17 @@ impl ResourceProvisioner {
             .get("DefaultCapacityProviderStrategy")
             .and_then(|v| v.as_array())
         {
-            cluster.default_capacity_provider_strategy = strategy.clone();
+            cluster.default_capacity_provider_strategy =
+                strategy.iter().cloned().map(lowercase_first_keys).collect();
         }
         if let Some(cfg) = props.get("Configuration") {
-            cluster.configuration = Some(cfg.clone());
+            cluster.configuration = Some(lowercase_first_keys(cfg.clone()));
         }
         if let Some(settings) = props.get("ClusterSettings").and_then(|v| v.as_array()) {
-            cluster.settings = settings.clone();
+            cluster.settings = settings.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(scd) = props.get("ServiceConnectDefaults") {
+            cluster.service_connect_defaults = Some(lowercase_first_keys(scd.clone()));
         }
         let mut accounts = self.ecs_state.write();
         let state = accounts.get_or_create(&self.account_id);
@@ -8167,11 +8182,16 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or(&resource.logical_id)
             .to_string();
-        let container_definitions = props
+        // ECS DescribeTaskDefinition emits camelCase keys; CFN ships PascalCase.
+        // Recursively lower the leading char so SDKs deserialize cleanly.
+        let container_definitions: Vec<serde_json::Value> = props
             .get("ContainerDefinitions")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
         let task_role_arn = props
             .get("TaskRoleArn")
             .and_then(|v| v.as_str())
@@ -8201,16 +8221,34 @@ impl ResourceProvisioner {
             .get("Memory")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        let volumes = props
+        let volumes: Vec<serde_json::Value> = props
             .get("Volumes")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
-        let placement_constraints = props
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let placement_constraints: Vec<serde_json::Value> = props
             .get("PlacementConstraints")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let proxy_configuration = props
+            .get("ProxyConfiguration")
+            .cloned()
+            .map(lowercase_first_keys);
+        let ephemeral_storage = props
+            .get("EphemeralStorage")
+            .cloned()
+            .map(lowercase_first_keys);
+        let runtime_platform = props
+            .get("RuntimePlatform")
+            .cloned()
+            .map(lowercase_first_keys);
         let tags = parse_ecs_tags(props.get("Tags"));
 
         let mut accounts = self.ecs_state.write();
@@ -8242,10 +8280,10 @@ impl ResourceProvisioner {
             ipc_mode: None,
             volumes,
             placement_constraints,
-            proxy_configuration: None,
+            proxy_configuration,
             inference_accelerators: Vec::new(),
-            ephemeral_storage: props.get("EphemeralStorage").cloned(),
-            runtime_platform: props.get("RuntimePlatform").cloned(),
+            ephemeral_storage,
+            runtime_platform,
             requires_attributes: Vec::new(),
             registered_at: Utc::now(),
             registered_by: None,
@@ -8304,7 +8342,7 @@ impl ResourceProvisioner {
             .to_string();
         let desired_count = props
             .get("DesiredCount")
-            .and_then(|v| v.as_i64())
+            .and_then(cfn_as_i64)
             .map(|n| n as i32)
             .unwrap_or(1);
         let launch_type = props
@@ -8323,29 +8361,76 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .unwrap_or("ECS")
             .to_string();
-        let load_balancers = props
+        let load_balancers: Vec<serde_json::Value> = props
             .get("LoadBalancers")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
-        let service_registries = props
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let service_registries: Vec<serde_json::Value> = props
             .get("ServiceRegistries")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
-        let placement_constraints = props
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let placement_constraints: Vec<serde_json::Value> = props
             .get("PlacementConstraints")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
-        let placement_strategy = props
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let placement_strategy: Vec<serde_json::Value> = props
             .get("PlacementStrategies")
             .and_then(|v| v.as_array())
             .cloned()
-            .unwrap_or_default();
-        let network_configuration = props.get("NetworkConfiguration").cloned();
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let network_configuration = props
+            .get("NetworkConfiguration")
+            .cloned()
+            .map(lowercase_first_keys);
         let role_arn = props
             .get("Role")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let platform_version = props
+            .get("PlatformVersion")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let health_check_grace_period_seconds = props
+            .get("HealthCheckGracePeriodSeconds")
+            .and_then(cfn_as_i64)
+            .map(|n| n as i32);
+        let enable_ecs_managed_tags = props
+            .get("EnableECSManagedTags")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let enable_execute_command = props
+            .get("EnableExecuteCommand")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let propagate_tags = props
+            .get("PropagateTags")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let capacity_provider_strategy: Vec<serde_json::Value> = props
+            .get("CapacityProviderStrategy")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(lowercase_first_keys)
+            .collect();
+        let availability_zone_rebalancing = props
+            .get("AvailabilityZoneRebalancing")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
         let tags = parse_ecs_tags(props.get("Tags"));
@@ -8384,12 +8469,12 @@ impl ResourceProvisioner {
             minimum_healthy_percent: props
                 .get("DeploymentConfiguration")
                 .and_then(|v| v.get("MinimumHealthyPercent"))
-                .and_then(|v| v.as_i64())
+                .and_then(cfn_as_i64)
                 .map(|n| n as i32),
             maximum_percent: props
                 .get("DeploymentConfiguration")
                 .and_then(|v| v.get("MaximumPercent"))
-                .and_then(|v| v.as_i64())
+                .and_then(cfn_as_i64)
                 .map(|n| n as i32),
             circuit_breaker: None,
             deployments: Vec::new(),
@@ -8402,6 +8487,13 @@ impl ResourceProvisioner {
             created_at: Utc::now(),
             created_by: None,
             role_arn,
+            platform_version,
+            health_check_grace_period_seconds,
+            enable_execute_command,
+            enable_ecs_managed_tags,
+            propagate_tags,
+            capacity_provider_strategy,
+            availability_zone_rebalancing,
         };
         state.services.insert(key.clone(), service);
         if let Some(c) = state.clusters.get_mut(&cluster_name) {
@@ -8465,6 +8557,221 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.capacity_providers.remove(physical_id);
         Ok(())
+    }
+
+    /// In-place update for AWS::ECS::Cluster. ClusterName is immutable —
+    /// CFN replaces the resource if it changes — so we only refresh
+    /// settings/configuration/capacity-provider/tags here. The physical
+    /// id is kept stable.
+    fn update_ecs_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let cluster_name = existing.physical_id.clone();
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cluster = state
+            .clusters
+            .get_mut(&cluster_name)
+            .ok_or_else(|| format!("Cluster {cluster_name} no longer exists"))?;
+        if let Some(settings) = props.get("ClusterSettings").and_then(|v| v.as_array()) {
+            cluster.settings = settings.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(cfg) = props.get("Configuration") {
+            cluster.configuration = Some(lowercase_first_keys(cfg.clone()));
+        }
+        if let Some(cps) = props.get("CapacityProviders").and_then(|v| v.as_array()) {
+            cluster.capacity_providers = cps
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+        if let Some(strategy) = props
+            .get("DefaultCapacityProviderStrategy")
+            .and_then(|v| v.as_array())
+        {
+            cluster.default_capacity_provider_strategy =
+                strategy.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(scd) = props.get("ServiceConnectDefaults") {
+            cluster.service_connect_defaults = Some(lowercase_first_keys(scd.clone()));
+        }
+        if props.get("Tags").is_some() {
+            cluster.tags = parse_ecs_tags(props.get("Tags"));
+        }
+        let cluster_arn = cluster.cluster_arn.clone();
+        Ok(ProvisionResult::new(cluster_name).with("Arn", cluster_arn))
+    }
+
+    /// In-place update for AWS::ECS::Service. Service ARN is keyed by
+    /// cluster + service name, both immutable. CFN replaces the resource
+    /// if either changes, so we only mutate task definition / desired
+    /// count / deployment-related fields here.
+    fn update_ecs_service(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let service_arn = existing.physical_id.clone();
+        let Some((cluster_name, service_name)) = parse_service_arn(&service_arn) else {
+            return Err(format!("Cannot parse service ARN: {service_arn}"));
+        };
+        let key = format!("{cluster_name}/{service_name}");
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let svc = state
+            .services
+            .get_mut(&key)
+            .ok_or_else(|| format!("Service {service_arn} no longer exists"))?;
+        if let Some(td) = props.get("TaskDefinition").and_then(|v| v.as_str()) {
+            svc.task_definition_arn = td.to_string();
+            let (family, revision) = parse_td_arn(td);
+            svc.family = family;
+            svc.revision = revision;
+        }
+        if let Some(n) = props.get("DesiredCount").and_then(cfn_as_i64) {
+            svc.desired_count = n as i32;
+        }
+        if let Some(s) = props.get("LaunchType").and_then(|v| v.as_str()) {
+            svc.launch_type = s.to_string();
+        }
+        if let Some(s) = props.get("PlatformVersion").and_then(|v| v.as_str()) {
+            svc.platform_version = Some(s.to_string());
+        }
+        if let Some(n) = props
+            .get("HealthCheckGracePeriodSeconds")
+            .and_then(cfn_as_i64)
+        {
+            svc.health_check_grace_period_seconds = Some(n as i32);
+        }
+        if let Some(b) = props.get("EnableExecuteCommand").and_then(|v| v.as_bool()) {
+            svc.enable_execute_command = b;
+        }
+        if let Some(b) = props.get("EnableECSManagedTags").and_then(|v| v.as_bool()) {
+            svc.enable_ecs_managed_tags = b;
+        }
+        if let Some(s) = props.get("PropagateTags").and_then(|v| v.as_str()) {
+            svc.propagate_tags = Some(s.to_string());
+        }
+        if let Some(s) = props
+            .get("AvailabilityZoneRebalancing")
+            .and_then(|v| v.as_str())
+        {
+            svc.availability_zone_rebalancing = Some(s.to_string());
+        }
+        if let Some(arr) = props
+            .get("CapacityProviderStrategy")
+            .and_then(|v| v.as_array())
+        {
+            svc.capacity_provider_strategy =
+                arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(dc) = props.get("DeploymentConfiguration") {
+            if let Some(n) = dc.get("MinimumHealthyPercent").and_then(cfn_as_i64) {
+                svc.minimum_healthy_percent = Some(n as i32);
+            }
+            if let Some(n) = dc.get("MaximumPercent").and_then(cfn_as_i64) {
+                svc.maximum_percent = Some(n as i32);
+            }
+        }
+        if let Some(arr) = props.get("LoadBalancers").and_then(|v| v.as_array()) {
+            svc.load_balancers = arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(arr) = props.get("ServiceRegistries").and_then(|v| v.as_array()) {
+            svc.service_registries = arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(arr) = props.get("PlacementConstraints").and_then(|v| v.as_array()) {
+            svc.placement_constraints = arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(arr) = props.get("PlacementStrategies").and_then(|v| v.as_array()) {
+            svc.placement_strategy = arr.iter().cloned().map(lowercase_first_keys).collect();
+        }
+        if let Some(nc) = props.get("NetworkConfiguration") {
+            svc.network_configuration = Some(lowercase_first_keys(nc.clone()));
+        }
+        if props.get("Tags").is_some() {
+            svc.tags = parse_ecs_tags(props.get("Tags"));
+        }
+        let name = svc.service_name.clone();
+        Ok(ProvisionResult::new(service_arn.clone())
+            .with("Name", name)
+            .with("ServiceArn", service_arn))
+    }
+
+    /// In-place update for AWS::ECS::TaskDefinition. ECS treats every
+    /// register call as a new revision, so a CFN update produces a fresh
+    /// revision and the physical id (the full ARN) shifts. Returning a
+    /// new ARN tells CFN's update path that the resource was replaced.
+    fn update_ecs_task_definition(
+        &self,
+        _existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // Delegating to create_ecs_task_definition is safe because each
+        // call bumps the revision counter — semantically the right
+        // behaviour for ECS.
+        self.create_ecs_task_definition(resource)
+    }
+
+    /// In-place update for AWS::ECS::CapacityProvider. Name is immutable;
+    /// only the underlying ASG provider config and tags can change.
+    fn update_ecs_capacity_provider(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cp = state
+            .capacity_providers
+            .get_mut(&name)
+            .ok_or_else(|| format!("CapacityProvider {name} no longer exists"))?;
+        if props.get("AutoScalingGroupProvider").is_some() {
+            cp.auto_scaling_group_provider = props.get("AutoScalingGroupProvider").cloned();
+        }
+        if props.get("Tags").is_some() {
+            cp.tags = parse_ecs_tags(props.get("Tags"));
+        }
+        let arn = cp.arn.clone();
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    fn get_att_ecs_cluster(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cluster = state.clusters.get(physical_id)?;
+        match attribute {
+            "Arn" => Some(cluster.cluster_arn.clone()),
+            _ => None,
+        }
+    }
+
+    fn get_att_ecs_service(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let (cluster, service) = parse_service_arn(physical_id)?;
+        let key = format!("{cluster}/{service}");
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let svc = state.services.get(&key)?;
+        match attribute {
+            "Name" => Some(svc.service_name.clone()),
+            "ServiceArn" => Some(svc.service_arn.clone()),
+            _ => None,
+        }
+    }
+
+    fn get_att_ecs_capacity_provider(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.ecs_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cp = state.capacity_providers.get(physical_id)?;
+        match attribute {
+            "Arn" => Some(cp.arn.clone()),
+            _ => None,
+        }
     }
 
     // --- ACM ---
@@ -15141,6 +15448,16 @@ fn make_apigwv2_id(n: usize) -> String {
 /// camelCase (`burstLimit`, `rateLimit`). Used at the CFN/service
 /// boundary so JSON pulled from the template can flow into the runtime
 /// state without renaming each leaf by hand.
+/// Coerce a CFN-resolved Number/String parameter into i64. CFN
+/// parameters surface here as `Value::String` after `Ref` substitution,
+/// even when the parameter `Type` is `Number`, so we need both paths.
+fn cfn_as_i64(v: &serde_json::Value) -> Option<i64> {
+    if let Some(n) = v.as_i64() {
+        return Some(n);
+    }
+    v.as_str().and_then(|s| s.parse::<i64>().ok())
+}
+
 fn lowercase_first_keys(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(map) => {

--- a/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_ecs.rs
@@ -2,7 +2,7 @@
 
 mod helpers;
 
-use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use aws_sdk_cloudformation::types::{Capability, OnFailure, Parameter};
 use helpers::TestServer;
 
 const TEMPLATE: &str = r#"{
@@ -12,13 +12,89 @@ const TEMPLATE: &str = r#"{
       "Type": "AWS::ECS::Cluster",
       "Properties": {
         "ClusterName": "cfn-ecs-cluster",
-        "ClusterSettings": [{"Name": "containerInsights", "Value": "enhanced"}]
+        "ClusterSettings": [{"Name": "containerInsights", "Value": "enhanced"}],
+        "ServiceConnectDefaults": {"Namespace": "cfn-ns"},
+        "Tags": [{"Key": "env", "Value": "test"}]
       }
     },
     "CP": {
       "Type": "AWS::ECS::CapacityProvider",
       "Properties": {
         "Name": "cfn-cp"
+      }
+    },
+    "TaskDef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "Family": "cfn-task",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": ["FARGATE"],
+        "Cpu": "256",
+        "Memory": "512",
+        "EphemeralStorage": {"SizeInGiB": 30},
+        "RuntimePlatform": {"OperatingSystemFamily": "LINUX", "CpuArchitecture": "X86_64"},
+        "ContainerDefinitions": [
+          {
+            "Name": "web",
+            "Image": "nginx:alpine",
+            "Essential": true,
+            "PortMappings": [{"ContainerPort": 80, "Protocol": "tcp"}]
+          }
+        ]
+      }
+    },
+    "Svc": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "ServiceName": "cfn-svc",
+        "Cluster": {"Ref": "Cluster"},
+        "TaskDefinition": {"Ref": "TaskDef"},
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "PlatformVersion": "1.4.0",
+        "HealthCheckGracePeriodSeconds": 60,
+        "EnableECSManagedTags": true,
+        "EnableExecuteCommand": true,
+        "PropagateTags": "SERVICE",
+        "AvailabilityZoneRebalancing": "ENABLED",
+        "DeploymentConfiguration": {
+          "MinimumHealthyPercent": 50,
+          "MaximumPercent": 200
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ClusterName": {"Value": {"Ref": "Cluster"}},
+    "ClusterArn": {"Value": {"Fn::GetAtt": ["Cluster", "Arn"]}},
+    "CpName": {"Value": {"Ref": "CP"}},
+    "CpArn": {"Value": {"Fn::GetAtt": ["CP", "Arn"]}},
+    "TaskDefArn": {"Value": {"Ref": "TaskDef"}},
+    "ServiceArn": {"Value": {"Fn::GetAtt": ["Svc", "ServiceArn"]}},
+    "ServiceName": {"Value": {"Fn::GetAtt": ["Svc", "Name"]}}
+  }
+}"#;
+
+const TEMPLATE_UPDATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": {
+    "Desired": {"Type": "Number", "Default": 3}
+  },
+  "Resources": {
+    "Cluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "cfn-ecs-cluster",
+        "ClusterSettings": [{"Name": "containerInsights", "Value": "disabled"}],
+        "ServiceConnectDefaults": {"Namespace": "cfn-ns-2"},
+        "Tags": [{"Key": "env", "Value": "prod"}]
+      }
+    },
+    "CP": {
+      "Type": "AWS::ECS::CapacityProvider",
+      "Properties": {
+        "Name": "cfn-cp",
+        "Tags": [{"Key": "tier", "Value": "compute"}]
       }
     },
     "TaskDef": {
@@ -45,21 +121,19 @@ const TEMPLATE: &str = r#"{
         "ServiceName": "cfn-svc",
         "Cluster": {"Ref": "Cluster"},
         "TaskDefinition": {"Ref": "TaskDef"},
-        "DesiredCount": 1,
+        "DesiredCount": {"Ref": "Desired"},
         "LaunchType": "FARGATE",
+        "PlatformVersion": "LATEST",
+        "HealthCheckGracePeriodSeconds": 120,
+        "EnableExecuteCommand": false,
         "DeploymentConfiguration": {
-          "MinimumHealthyPercent": 50,
+          "MinimumHealthyPercent": 100,
           "MaximumPercent": 200
         }
       }
     }
   },
   "Outputs": {
-    "ClusterName": {"Value": {"Ref": "Cluster"}},
-    "ClusterArn": {"Value": {"Fn::GetAtt": ["Cluster", "Arn"]}},
-    "CpName": {"Value": {"Ref": "CP"}},
-    "CpArn": {"Value": {"Fn::GetAtt": ["CP", "Arn"]}},
-    "TaskDefArn": {"Value": {"Ref": "TaskDef"}},
     "ServiceArn": {"Value": {"Fn::GetAtt": ["Svc", "ServiceArn"]}}
   }
 }"#;
@@ -135,11 +209,20 @@ async fn cfn_provisions_ecs_cluster_taskdef_service_capacity_provider() {
         .send()
         .await
         .expect("describe_services");
+    let svc = svcs.services().first().expect("service present");
+    assert_eq!(svc.service_name(), Some("cfn-svc"));
+    assert_eq!(svc.desired_count(), 1);
+    // CFN-only properties round-trip through DescribeServices.
+    assert_eq!(svc.platform_version(), Some("1.4.0"));
+    assert_eq!(svc.health_check_grace_period_seconds(), Some(60));
+    assert!(svc.enable_ecs_managed_tags());
+    assert!(svc.enable_execute_command());
+    assert_eq!(svc.propagate_tags().map(|p| p.as_str()), Some("SERVICE"));
     assert_eq!(
-        svcs.services().first().and_then(|s| s.service_name()),
-        Some("cfn-svc")
+        svc.availability_zone_rebalancing().map(|a| a.as_str()),
+        Some("ENABLED")
     );
-    assert_eq!(svcs.services().first().map(|s| s.desired_count()), Some(1));
+    assert_eq!(outs.get("ServiceName").map(|s| s.as_str()), Some("cfn-svc"));
 
     let td = ecs
         .describe_task_definition()
@@ -147,10 +230,81 @@ async fn cfn_provisions_ecs_cluster_taskdef_service_capacity_provider() {
         .send()
         .await
         .expect("describe_task_definition");
+    let td_inner = td.task_definition().expect("task definition present");
+    assert_eq!(td_inner.family(), Some("cfn-task"));
+    // EphemeralStorage round-trips.
     assert_eq!(
-        td.task_definition().and_then(|t| t.family()),
-        Some("cfn-task")
+        td_inner.ephemeral_storage().map(|e| e.size_in_gib()),
+        Some(30)
     );
+
+    // Cluster ServiceConnectDefaults round-trips.
+    let cluster = clusters.clusters().first().expect("cluster present");
+    let scd_namespace = cluster
+        .service_connect_defaults()
+        .map(|s| s.namespace().unwrap_or(""));
+    assert_eq!(scd_namespace, Some("cfn-ns"));
+
+    // --- UpdateStack: bumps desired count, swaps task definition. ---
+    cfn.update_stack()
+        .stack_name("ecs-stack")
+        .template_body(TEMPLATE_UPDATE)
+        .capabilities(Capability::CapabilityIam)
+        .parameters(
+            Parameter::builder()
+                .parameter_key("Desired")
+                .parameter_value("3")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("update_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("ecs-stack")
+        .send()
+        .await
+        .expect("describe_stacks after update");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "UPDATE_COMPLETE");
+
+    let svcs = ecs
+        .describe_services()
+        .cluster("cfn-ecs-cluster")
+        .services("cfn-svc")
+        .send()
+        .await
+        .expect("describe_services after update");
+    let svc = svcs
+        .services()
+        .first()
+        .expect("service present after update");
+    assert_eq!(svc.desired_count(), 3);
+    assert_eq!(svc.platform_version(), Some("LATEST"));
+    assert_eq!(svc.health_check_grace_period_seconds(), Some(120));
+    assert!(!svc.enable_execute_command());
+    // TaskDefinition stayed at revision 1 across update.
+    assert!(svc.task_definition().unwrap().contains("cfn-task:1"));
+
+    // Cluster Tag was rewritten by update.
+    let after_clusters = ecs
+        .describe_clusters()
+        .clusters("cfn-ecs-cluster")
+        .include(aws_sdk_ecs::types::ClusterField::Tags)
+        .send()
+        .await
+        .expect("describe_clusters after update");
+    let after_cluster = after_clusters
+        .clusters()
+        .first()
+        .expect("cluster present after update");
+    let env_tag = after_cluster
+        .tags()
+        .iter()
+        .find(|t| t.key() == Some("env"))
+        .and_then(|t| t.value());
+    assert_eq!(env_tag, Some("prod"));
 
     cfn.delete_stack()
         .stack_name("ecs-stack")

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -847,11 +847,26 @@ pub(crate) fn service_to_json(svc: &Service) -> Value {
     }
     map.insert("createdAt".into(), json!(svc.created_at.timestamp()));
     // Always-present fields AWS returns; SDKs deserialize unconditionally.
-    map.insert("enableExecuteCommand".into(), json!(false));
-    map.insert("enableECSManagedTags".into(), json!(false));
-    map.insert("propagateTags".into(), json!("NONE"));
-    map.insert("healthCheckGracePeriodSeconds".into(), json!(0));
-    map.insert("platformVersion".into(), json!("LATEST"));
+    map.insert(
+        "enableExecuteCommand".into(),
+        json!(svc.enable_execute_command),
+    );
+    map.insert(
+        "enableECSManagedTags".into(),
+        json!(svc.enable_ecs_managed_tags),
+    );
+    map.insert(
+        "propagateTags".into(),
+        json!(svc.propagate_tags.as_deref().unwrap_or("NONE")),
+    );
+    map.insert(
+        "healthCheckGracePeriodSeconds".into(),
+        json!(svc.health_check_grace_period_seconds.unwrap_or(0)),
+    );
+    map.insert(
+        "platformVersion".into(),
+        json!(svc.platform_version.as_deref().unwrap_or("LATEST")),
+    );
     map.insert(
         "platformFamily".into(),
         match svc.launch_type.as_str() {
@@ -859,11 +874,20 @@ pub(crate) fn service_to_json(svc: &Service) -> Value {
             _ => Value::Null,
         },
     );
-    map.insert("availabilityZoneRebalancing".into(), json!("DISABLED"));
+    map.insert(
+        "availabilityZoneRebalancing".into(),
+        json!(svc
+            .availability_zone_rebalancing
+            .as_deref()
+            .unwrap_or("DISABLED")),
+    );
     map.insert("volumeConfigurations".into(), json!([]));
     map.insert("taskSets".into(), json!([]));
     map.insert("events".into(), json!([]));
-    map.insert("capacityProviderStrategy".into(), json!([]));
+    map.insert(
+        "capacityProviderStrategy".into(),
+        json!(svc.capacity_provider_strategy),
+    );
     if !svc.tags.is_empty() {
         map.insert(
             "tags".into(),

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -74,6 +74,27 @@ impl EcsService {
             .cloned()
             .unwrap_or_default();
         let network_configuration = body.get("networkConfiguration").cloned();
+        let platform_version = opt_str(&body, "platformVersion").map(String::from);
+        let health_check_grace_period_seconds = body
+            .get("healthCheckGracePeriodSeconds")
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32);
+        let enable_execute_command = body
+            .get("enableExecuteCommand")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let enable_ecs_managed_tags = body
+            .get("enableECSManagedTags")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let propagate_tags = opt_str(&body, "propagateTags").map(String::from);
+        let capacity_provider_strategy: Vec<Value> = body
+            .get("capacityProviderStrategy")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let availability_zone_rebalancing =
+            opt_str(&body, "availabilityZoneRebalancing").map(String::from);
 
         let runtime = self.runtime.clone();
         let account = request.account_id.clone();
@@ -159,6 +180,13 @@ impl EcsService {
                 created_at: Utc::now(),
                 created_by: Some(principal_arn.clone()),
                 role_arn,
+                platform_version: platform_version.clone(),
+                health_check_grace_period_seconds,
+                enable_execute_command,
+                enable_ecs_managed_tags,
+                propagate_tags: propagate_tags.clone(),
+                capacity_provider_strategy: capacity_provider_strategy.clone(),
+                availability_zone_rebalancing: availability_zone_rebalancing.clone(),
             };
             state.services.insert(key.clone(), service.clone());
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -74,6 +74,13 @@ fn resolve_service_key_handles_short_and_long() {
             created_at: chrono::Utc::now(),
             created_by: None,
             role_arn: None,
+            platform_version: None,
+            health_check_grace_period_seconds: None,
+            enable_execute_command: false,
+            enable_ecs_managed_tags: false,
+            propagate_tags: None,
+            capacity_provider_strategy: vec![],
+            availability_zone_rebalancing: None,
         },
     );
     // Long-form: cluster/service.

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -524,6 +524,35 @@ pub struct Service {
     pub created_at: DateTime<Utc>,
     pub created_by: Option<String>,
     pub role_arn: Option<String>,
+    /// Fargate platform version label ("LATEST", "1.4.0", etc). Echoed
+    /// back on DescribeServices.
+    #[serde(default)]
+    pub platform_version: Option<String>,
+    /// Seconds an ECS service waits before failing a task on health
+    /// check failures while a load balancer is still warming up.
+    #[serde(default)]
+    pub health_check_grace_period_seconds: Option<i32>,
+    /// Whether ECS Exec is enabled for tasks launched by this service.
+    #[serde(default)]
+    pub enable_execute_command: bool,
+    /// When true, ECS automatically tags tasks/ENIs with cluster + service
+    /// metadata. Off by default to match AWS.
+    #[serde(default)]
+    pub enable_ecs_managed_tags: bool,
+    /// Tag-propagation source: "TASK_DEFINITION", "SERVICE", or "NONE".
+    /// We model the AWS shape — None here means "NONE" was the effective
+    /// value when the service was created.
+    #[serde(default)]
+    pub propagate_tags: Option<String>,
+    /// Mixed capacity-provider weights that the service uses instead of
+    /// (or alongside) `launch_type`. Stored as raw JSON since the field
+    /// is a list of `{ capacityProvider, weight, base }` records.
+    #[serde(default)]
+    pub capacity_provider_strategy: Vec<Value>,
+    /// AZ-rebalancing toggle for ALB-attached services. ENABLED |
+    /// DISABLED (default). Surface field for AvailabilityZoneRebalancing.
+    #[serde(default)]
+    pub availability_zone_rebalancing: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Adds CFN update + GetAtt paths for `AWS::ECS::Cluster`, `AWS::ECS::Service`, `AWS::ECS::TaskDefinition`, `AWS::ECS::CapacityProvider`.
- Honors the full set of CFN-only properties (ServiceConnectDefaults on Cluster; PlatformVersion/HealthCheckGracePeriodSeconds/EnableExecuteCommand/EnableECSManagedTags/PropagateTags/CapacityProviderStrategy/AvailabilityZoneRebalancing on Service; EphemeralStorage/RuntimePlatform/ProxyConfiguration on TaskDefinition).
- Recursively lowercases the leading char of CFN object keys so ECS SDKs deserialize the resulting state cleanly (ContainerDefinitions, LoadBalancers, NetworkConfiguration, ...).
- Adds `cfn_as_i64` to coerce `Ref`-resolved Number params (which arrive as `Value::String`) into `i64`.

## Test plan
- [x] `cargo test -p fakecloud-ecs --lib`
- [x] `cargo test -p fakecloud-cloudformation --lib`
- [x] `cargo test -p fakecloud-e2e --test cloudformation_ecs`
- [x] `cargo clippy -p fakecloud-ecs -p fakecloud-cloudformation --all-targets`
- [x] `cargo fmt --all --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::ECS::{Cluster,Service,TaskDefinition,CapacityProvider}` with update paths and GetAtt. Persists CFN-only fields so ECS Describe APIs mirror what’s declared.

- **New Features**
  - Create/update for all four ECS resources; TaskDefinition updates return a new ARN (replacement).
  - GetAtt: Cluster Arn; Service Name and ServiceArn; CapacityProvider Arn.
  - Honors CFN-only fields: Cluster ServiceConnectDefaults; Service PlatformVersion, HealthCheckGracePeriodSeconds, EnableExecuteCommand, EnableECSManagedTags, PropagateTags, CapacityProviderStrategy, AvailabilityZoneRebalancing; TaskDefinition EphemeralStorage, RuntimePlatform, ProxyConfiguration.
  - Normalizes CFN objects to camelCase by lowercasing leading keys (e.g., ContainerDefinitions, LoadBalancers, NetworkConfiguration); adds cfn_as_i64 to accept Number or Ref-resolved String values.

<sup>Written for commit 4438d3e7a387088249aadfa975842921fc110237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

