### PR TITLE
feat(ses): real template rendering at SendEmail (v1 + v2) (X3)

### DIFF
--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -261,6 +261,7 @@ async fn ses_send_email_template() {
         .template_content(
             EmailTemplateContent::builder()
                 .subject("Hello {{name}}")
+                .html("<p>Hi {{name}}</p>")
                 .text("Hi {{name}}")
                 .build(),
         )
@@ -292,6 +293,61 @@ async fn ses_send_email_template() {
         .unwrap();
 
     assert!(!resp.message_id().unwrap().is_empty());
+
+    // Introspection should reveal the rendered subject/html/text, not
+    // the raw `{{name}}` source. This is the contract real SES
+    // recipients actually see downstream.
+    let url = format!("{}/_fakecloud/ses/emails", server.endpoint());
+    let resp: serde_json::Value = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    let emails = resp["emails"].as_array().unwrap();
+    assert_eq!(emails.len(), 1);
+    assert_eq!(emails[0]["templateName"], "greet");
+    assert_eq!(emails[0]["subject"], "Hello World");
+    assert_eq!(emails[0]["htmlBody"], "<p>Hi World</p>");
+    assert_eq!(emails[0]["textBody"], "Hi World");
+}
+
+#[tokio::test]
+async fn ses_send_email_template_missing() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    // SendEmail with a Content.Template referencing an undefined
+    // template must fail with TemplateDoesNotExistException.
+    let err = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .template(
+                    Template::builder()
+                        .template_name("nope")
+                        .template_data("{}")
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await;
+    assert!(err.is_err(), "expected error for missing template");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/ses_v1.rs
+++ b/crates/fakecloud-e2e/tests/ses_v1.rs
@@ -574,6 +574,10 @@ async fn test_send_templated_email_v1() {
     let emails = resp["emails"].as_array().unwrap();
     assert_eq!(emails.len(), 1);
     assert_eq!(emails[0]["templateName"], "greet");
+    // Subject + html_body must be the rendered output, not the raw
+    // template source. Real SES returns the substituted text downstream.
+    assert_eq!(emails[0]["subject"], "Hi World");
+    assert_eq!(emails[0]["htmlBody"], "<p>Hello World</p>");
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ses/src/service/mod.rs
+++ b/crates/fakecloud-ses/src/service/mod.rs
@@ -5,7 +5,7 @@ mod identities;
 mod misc;
 mod sending;
 mod suppression;
-mod templates;
+pub(crate) mod templates;
 
 use async_trait::async_trait;
 use http::{Method, StatusCode};

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -303,6 +303,24 @@ impl SesV2Service {
                 let tmpl = &body["Content"]["Template"];
                 let tmpl_name = tmpl["TemplateName"].as_str().map(|s| s.to_string());
                 let tmpl_data = tmpl["TemplateData"].as_str().map(|s| s.to_string());
+                // Real SES rejects sends that reference a missing template
+                // with `TemplateDoesNotExistException` (HTTP 400). Without
+                // this gate, we'd silently produce an empty rendered body.
+                if let Some(name) = tmpl_name.as_deref() {
+                    let accounts = self.state.read();
+                    let exists = accounts
+                        .get(&req.account_id)
+                        .map(|st| st.templates.contains_key(name))
+                        .unwrap_or(false);
+                    drop(accounts);
+                    if !exists {
+                        return Ok(Self::json_error(
+                            StatusCode::BAD_REQUEST,
+                            "TemplateDoesNotExistException",
+                            &format!("Template {name} does not exist"),
+                        ));
+                    }
+                }
                 // Render via the same engine RenderEmailTemplate uses so
                 // SentEmail captures the materialized subject/html/text.
                 let rendered = self.render_template_for_send(
@@ -386,6 +404,25 @@ impl SesV2Service {
                 ));
             }
         };
+
+        // Reject the whole batch up-front if the referenced template
+        // doesn't exist. Real SES surfaces this as
+        // `TemplateDoesNotExistException` (HTTP 400).
+        if let Some(name) = body["DefaultContent"]["Template"]["TemplateName"].as_str() {
+            let accounts = self.state.read();
+            let exists = accounts
+                .get(&req.account_id)
+                .map(|st| st.templates.contains_key(name))
+                .unwrap_or(false);
+            drop(accounts);
+            if !exists {
+                return Ok(Self::json_error(
+                    StatusCode::BAD_REQUEST,
+                    "TemplateDoesNotExistException",
+                    &format!("Template {name} does not exist"),
+                ));
+            }
+        }
 
         let mut results = Vec::new();
 

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -410,6 +410,21 @@ async fn test_send_email_template_content() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
     enable_production_access(&state);
+    {
+        use crate::state::EmailTemplate;
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.templates.insert(
+            "welcome".to_string(),
+            EmailTemplate {
+                template_name: "welcome".to_string(),
+                subject: Some("Hi {{name}}".to_string()),
+                html_body: None,
+                text_body: None,
+                created_at: chrono::Utc::now(),
+            },
+        );
+    }
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -542,6 +557,21 @@ async fn test_send_bulk_email() {
     let state = make_state();
     seed_identity(&state, "sender@example.com");
     enable_production_access(&state);
+    {
+        use crate::state::EmailTemplate;
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.templates.insert(
+            "bulk-template".to_string(),
+            EmailTemplate {
+                template_name: "bulk-template".to_string(),
+                subject: Some("hi".to_string()),
+                html_body: None,
+                text_body: None,
+                created_at: chrono::Utc::now(),
+            },
+        );
+    }
     let svc = SesV2Service::new(state.clone());
 
     let req = make_request(
@@ -4226,7 +4256,7 @@ async fn send_email_v2_rejects_when_config_set_sending_paused() {
 
 #[tokio::test]
 async fn send_email_v2_skips_suppressed_recipient() {
-    use crate::state::SuppressedDestination;
+    use crate::state::{EmailTemplate, SuppressedDestination};
     let state = make_state();
     seed_identity(&state, "sender@example.com");
     enable_production_access(&state);
@@ -4239,6 +4269,16 @@ async fn send_email_v2_skips_suppressed_recipient() {
                 email_address: "blocked@example.com".to_string(),
                 reason: "BOUNCE".to_string(),
                 last_update_time: chrono::Utc::now(),
+            },
+        );
+        st.templates.insert(
+            "t".to_string(),
+            EmailTemplate {
+                template_name: "t".to_string(),
+                subject: Some("hi".to_string()),
+                html_body: None,
+                text_body: None,
+                created_at: chrono::Utc::now(),
             },
         );
     }

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1329,19 +1329,24 @@ pub(crate) fn send_templated_email(
     let cc = parse_member_list(&req.query_params, "Destination.CcAddresses");
     let bcc = parse_member_list(&req.query_params, "Destination.BccAddresses");
 
-    // Verify template exists
-    {
+    // Verify template exists and capture a clone so we can render it
+    // outside the read lock. Real SES surfaces missing templates as
+    // `TemplateDoesNotExistException` (HTTP 400).
+    let template_clone = {
         let accounts = state.read();
         let empty = SesState::new(&req.account_id, &req.region);
         let st = accounts.get(&req.account_id).unwrap_or(&empty);
-        if !st.templates.contains_key(template_name) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "TemplateDoesNotExistException",
-                format!("Template '{template_name}' does not exist"),
-            ));
+        match st.templates.get(template_name) {
+            Some(t) => t.clone(),
+            None => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "TemplateDoesNotExistException",
+                    format!("Template '{template_name}' does not exist"),
+                ));
+            }
         }
-    }
+    };
 
     let recipients: Vec<String> = to
         .iter()
@@ -1365,15 +1370,20 @@ pub(crate) fn send_templated_email(
         rand_u16(),
     );
 
+    // Render subject/html/text via the same engine TestRenderTemplate /
+    // TestRenderEmailTemplate uses so introspection callers see the
+    // materialized message, not the raw `{{placeholder}}` source.
+    let rendered = crate::service::templates::render_template(&template_clone, template_data);
+
     let sent = SentEmail {
         message_id: message_id.clone(),
         from: from.to_string(),
         to,
         cc,
         bcc,
-        subject: None,
-        html_body: None,
-        text_body: None,
+        subject: rendered.subject,
+        html_body: rendered.html,
+        text_body: rendered.text,
         raw_data: None,
         template_name: Some(template_name.to_string()),
         template_data: Some(template_data.to_string()),
@@ -1515,15 +1525,27 @@ pub(crate) fn send_bulk_destination(
         rand_u16(),
     );
 
+    // Look up the template once to render the destination's substitutions.
+    // The caller has already checked that the template exists.
+    let template_clone = {
+        let accounts = state.read();
+        accounts
+            .get(account_id)
+            .and_then(|st| st.templates.get(template_name).cloned())
+    };
+    let rendered = template_clone
+        .as_ref()
+        .map(|t| crate::service::templates::render_template(t, &replacement_data));
+
     let sent = SentEmail {
         message_id: message_id.clone(),
         from: from.to_string(),
         to,
         cc: Vec::new(),
         bcc: Vec::new(),
-        subject: None,
-        html_body: None,
-        text_body: None,
+        subject: rendered.as_ref().and_then(|r| r.subject.clone()),
+        html_body: rendered.as_ref().and_then(|r| r.html.clone()),
+        text_body: rendered.as_ref().and_then(|r| r.text.clone()),
         raw_data: None,
         template_name: Some(template_name.to_string()),
         template_data: Some(replacement_data),


### PR DESCRIPTION
## Summary
- v1 SendTemplatedEmail / SendBulkTemplatedEmail and v2 SendEmail (Content.Template) / SendBulkEmail now render the template's subject/html/text via the existing `render_template` engine and store the materialized strings on `SentEmail`, so `/_fakecloud/ses/emails` shows what recipients would actually see instead of the raw `{{placeholder}}` source.
- Both surfaces now reject sends that reference a missing template with `TemplateDoesNotExistException` (HTTP 400). v2 already had a silent fallthrough; v2 `SendBulkEmail` now also gates the whole batch up-front when the `DefaultContent` template is missing.

## Test plan
- [x] `cargo test -p fakecloud-ses` (231 unit tests pass)
- [x] `cargo test -p fakecloud-e2e --test ses ses_send_email_template ses_send_email_template_missing` — asserts rendered subject/html/text + the missing-template rejection on v2
- [x] `cargo test -p fakecloud-e2e --test ses_v1 send_templated` — asserts rendered subject/html on v1
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render SES templates during v1 SendTemplatedEmail/SendBulkTemplatedEmail and v2 SendEmail (Content.Template)/SendBulkEmail, storing the rendered subject/html/text on SentEmail so `/_fakecloud/ses/emails` shows what recipients actually see. Both APIs now return TemplateDoesNotExistException (HTTP 400) when the referenced template is missing, and v2 SendBulkEmail validates the default template up front for the whole batch.

<sup>Written for commit 51b385ef0ea16856c05e185134fb2d32ada217f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

