### PR TITLE
feat(cloudformation): AWS::KMS::{Key,Alias,ReplicaKey} provisioners (BB14)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -71,7 +71,8 @@ use fakecloud_iam::{
     PolicyVersion, SamlProvider, SharedIamState, Tag, VirtualMfaDevice,
 };
 use fakecloud_kinesis::{build_stream_shards, KinesisConsumer, KinesisStream, SharedKinesisState};
-use fakecloud_kms::{KmsAlias, KmsKey, SharedKmsState};
+use fakecloud_kms::provisioner as kms_provisioner;
+use fakecloud_kms::SharedKmsState;
 use fakecloud_lambda::{
     AttachedLayer, EventSourceMapping, FunctionAlias, FunctionUrlConfig, Layer, LayerVersion,
     SharedLambdaState,
@@ -289,6 +290,83 @@ fn parse_elb_rule_conditions(value: Option<&serde_json::Value>) -> Vec<RuleCondi
             }
         })
         .collect()
+}
+
+/// Parse the `KeyPolicy` field of an `AWS::KMS::Key` /
+/// `AWS::KMS::ReplicaKey` resource. CFN allows either a JSON string or
+/// an inline JSON object; we serialize the object form back to a string
+/// to match the [`KmsKey.policy`](fakecloud_kms::KmsKey) shape.
+fn parse_key_policy(props: &serde_json::Value) -> Option<String> {
+    match props.get("KeyPolicy") {
+        Some(v) if v.is_string() => Some(v.as_str().unwrap_or("").to_string()),
+        Some(v) => Some(serde_json::to_string(v).unwrap_or_default()),
+        None => None,
+    }
+}
+
+/// Parse the `Tags` field common to KMS CFN resources: an array of
+/// `{Key, Value}` pairs into a sorted map.
+fn parse_tag_list(props: &serde_json::Value) -> BTreeMap<String, String> {
+    let mut tags: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+        for t in arr {
+            if let (Some(k), Some(v)) = (
+                t.get("Key").and_then(|x| x.as_str()),
+                t.get("Value").and_then(|x| x.as_str()),
+            ) {
+                tags.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+    tags
+}
+
+/// Parse the `Properties` of an `AWS::KMS::Key` resource into the
+/// shared [`fakecloud_kms::provisioner::KeyCreationInput`]. Defaults
+/// match AWS: `ENCRYPT_DECRYPT` / `SYMMETRIC_DEFAULT` / `AWS_KMS` /
+/// `Enabled=true`. `RotationPeriodInDays`, `PendingWindowInDays`, and
+/// `BypassPolicyLockoutSafetyCheck` are accepted by the parser for
+/// CFN compatibility but not persisted on the key — the underlying
+/// KMS state doesn't model per-key rotation periods, and the deletion
+/// window only matters at scheduled-deletion time which CFN delete
+/// short-circuits.
+fn parse_kms_key_input(props: &serde_json::Value) -> kms_provisioner::KeyCreationInput {
+    kms_provisioner::KeyCreationInput {
+        description: props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        key_usage: props
+            .get("KeyUsage")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ENCRYPT_DECRYPT")
+            .to_string(),
+        key_spec: props
+            .get("KeySpec")
+            .and_then(|v| v.as_str())
+            .unwrap_or("SYMMETRIC_DEFAULT")
+            .to_string(),
+        origin: props
+            .get("Origin")
+            .and_then(|v| v.as_str())
+            .unwrap_or("AWS_KMS")
+            .to_string(),
+        enabled: props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        multi_region: props
+            .get("MultiRegion")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        key_rotation_enabled: props
+            .get("EnableKeyRotation")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        policy: parse_key_policy(props),
+        tags: parse_tag_list(props),
+    }
 }
 
 /// `LogGroupName` properties on Logs CFN resources may carry either a
@@ -1090,6 +1168,9 @@ impl ResourceProvisioner {
             "AWS::ECR::PullThroughCacheRule" => {
                 Some(self.update_ecr_pull_through_cache_rule(existing, new_def)?)
             }
+            "AWS::KMS::Key" => Some(self.update_kms_key(existing, new_def)?),
+            "AWS::KMS::ReplicaKey" => Some(self.update_kms_replica_key(existing, new_def)?),
+            "AWS::KMS::Alias" => Some(self.update_kms_alias(existing, new_def)?),
             _ => None,
         };
 
@@ -4770,133 +4851,59 @@ impl ResourceProvisioner {
     // --- KMS ---
 
     fn create_kms_key(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
-        let props = &resource.properties;
-        let description = props
-            .get("Description")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let enabled = props
-            .get("Enabled")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let key_rotation_enabled = props
-            .get("EnableKeyRotation")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        let key_usage = props
-            .get("KeyUsage")
-            .and_then(|v| v.as_str())
-            .unwrap_or("ENCRYPT_DECRYPT")
-            .to_string();
-        let key_spec = props
-            .get("KeySpec")
-            .and_then(|v| v.as_str())
-            .unwrap_or("SYMMETRIC_DEFAULT")
-            .to_string();
-        let multi_region = props
-            .get("MultiRegion")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        let origin = props
-            .get("Origin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("AWS_KMS")
-            .to_string();
-        let policy = match props.get("KeyPolicy") {
-            Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
-            Some(v) => serde_json::to_string(v).unwrap_or_default(),
-            None => String::new(),
-        };
-        if !key_spec.starts_with("SYMMETRIC") && !key_spec.starts_with("HMAC") {
-            return Err(format!(
-                "AWS::KMS::Key with KeySpec '{key_spec}' is not yet supported in CloudFormation; only symmetric and HMAC specs are provisioned"
-            ));
-        }
-
-        let mut tags: BTreeMap<String, String> = BTreeMap::new();
-        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
-            for t in arr {
-                if let (Some(k), Some(v)) = (
-                    t.get("Key").and_then(|x| x.as_str()),
-                    t.get("Value").and_then(|x| x.as_str()),
-                ) {
-                    tags.insert(k.to_string(), v.to_string());
-                }
-            }
-        }
-
-        let key_id = if multi_region {
-            format!("mrk-{}", Uuid::new_v4().as_simple())
-        } else {
-            Uuid::new_v4().to_string()
-        };
-
-        let mut accounts = self.kms_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        let arn = format!(
-            "arn:aws:kms:{}:{}:key/{}",
-            state.region, state.account_id, key_id
-        );
-        let now = Utc::now().timestamp() as f64;
-
-        // private_key_seed is only consulted for asymmetric KEY_AGREEMENT
-        // specs (ECC DeriveSharedSecret); symmetric and HMAC keys never read
-        // it, so a zero seed is fine for the specs this provisioner accepts.
-        let seed = vec![0u8; 32];
-
-        let encryption_algorithms = if key_usage == "ENCRYPT_DECRYPT" {
-            Some(vec!["SYMMETRIC_DEFAULT".to_string()])
-        } else {
-            None
-        };
-        let mac_algorithms = if key_usage == "GENERATE_VERIFY_MAC" {
-            let alg = match key_spec.as_str() {
-                "HMAC_224" => "HMAC_SHA_224",
-                "HMAC_256" => "HMAC_SHA_256",
-                "HMAC_384" => "HMAC_SHA_384",
-                "HMAC_512" => "HMAC_SHA_512",
-                _ => "HMAC_SHA_256",
-            };
-            Some(vec![alg.to_string()])
-        } else {
-            None
-        };
-
-        let key = KmsKey {
-            key_id: key_id.clone(),
-            arn: arn.clone(),
-            creation_date: now,
-            description,
-            enabled,
-            key_usage,
-            key_spec,
-            key_manager: "CUSTOMER".to_string(),
-            key_state: if enabled { "Enabled" } else { "Disabled" }.to_string(),
-            deletion_date: None,
-            tags,
-            policy,
-            key_rotation_enabled,
-            origin,
-            multi_region,
-            rotations: Vec::new(),
-            signing_algorithms: None,
-            encryption_algorithms,
-            mac_algorithms,
-            custom_key_store_id: None,
-            imported_key_material: false,
-            imported_material_bytes: None,
-            private_key_seed: seed,
-            primary_region: None,
-            asymmetric_private_key_der: None,
-            asymmetric_public_key_der: None,
-        };
-
-        state.keys.insert(key_id.clone(), key);
-
+        let input = parse_kms_key_input(&resource.properties);
+        let (key_id, arn) =
+            kms_provisioner::provision_key(&self.kms_state, &self.account_id, &input)?;
         Ok(ProvisionResult::new(key_id.clone())
             .with("Arn", arn)
             .with("KeyId", key_id))
+    }
+
+    /// Update an `AWS::KMS::Key` in place. Properties that AWS treats
+    /// as immutable (`KeySpec`, `KeyUsage`, `Origin`, `MultiRegion`)
+    /// trigger replacement: when the diff carries one of those, this
+    /// returns an error and the upstream stack engine recreates the
+    /// resource.
+    fn update_kms_key(
+        &self,
+        existing: &StackResource,
+        new_def: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let new_input = parse_kms_key_input(&new_def.properties);
+        let arn = {
+            let mut accounts = self.kms_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            let key = state
+                .keys
+                .get(&existing.physical_id)
+                .ok_or_else(|| format!("Key '{}' does not exist", existing.physical_id))?;
+            if key.key_spec != new_input.key_spec
+                || key.key_usage != new_input.key_usage
+                || key.origin != new_input.origin
+                || key.multi_region != new_input.multi_region
+            {
+                return Err(
+                    "AWS::KMS::Key updates that change KeySpec, KeyUsage, Origin, or MultiRegion require replacement"
+                        .to_string(),
+                );
+            }
+            key.arn.clone()
+        };
+        kms_provisioner::update_key_properties(
+            &self.kms_state,
+            &self.account_id,
+            &existing.physical_id,
+            kms_provisioner::KeyUpdate {
+                description: Some(new_input.description.clone()),
+                enabled: Some(new_input.enabled),
+                key_rotation_enabled: Some(new_input.key_rotation_enabled),
+                policy: new_input.policy.clone(),
+                tags: Some(new_input.tags.clone()),
+            },
+        )?;
+        Ok(ProvisionResult::new(existing.physical_id.clone())
+            .with("Arn", arn)
+            .with("KeyId", existing.physical_id.clone()))
     }
 
     fn delete_kms_key(&self, physical_id: &str) -> Result<(), String> {
@@ -4920,99 +4927,99 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .ok_or_else(|| "PrimaryKeyArn is required".to_string())?
             .to_string();
-        // arn:aws:kms:<region>:<account>:key/<key_id>
-        let parts: Vec<&str> = primary_arn.split(':').collect();
-        if parts.len() < 6 {
-            return Err(format!("Invalid PrimaryKeyArn: {primary_arn}"));
-        }
-        let primary_region = parts[3].to_string();
-        let key_id = parts[5]
-            .strip_prefix("key/")
-            .ok_or_else(|| format!("PrimaryKeyArn missing key/ segment: {primary_arn}"))?
-            .to_string();
         let description = props
             .get("Description")
             .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+            .map(str::to_string);
         let enabled = props
             .get("Enabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
-        let policy = match props.get("KeyPolicy") {
-            Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
-            Some(v) => serde_json::to_string(v).unwrap_or_default(),
-            None => String::new(),
-        };
-        let mut tags: BTreeMap<String, String> = BTreeMap::new();
-        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
-            for t in arr {
-                if let (Some(k), Some(v)) = (
-                    t.get("Key").and_then(|x| x.as_str()),
-                    t.get("Value").and_then(|x| x.as_str()),
-                ) {
-                    tags.insert(k.to_string(), v.to_string());
-                }
-            }
-        }
+        let policy = parse_key_policy(props);
+        let tags = parse_tag_list(props);
 
-        let mut accounts = self.kms_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-        // Source must be a multi-region key in the primary account; look
-        // it up either by raw key_id (when the primary lives in this
-        // state's region) or via the region-keyed slot.
-        let source_storage_keys = [key_id.clone(), format!("{primary_region}:{key_id}")];
-        let source = source_storage_keys
-            .iter()
-            .find_map(|k| state.keys.get(k).cloned())
-            .ok_or_else(|| format!("Primary key {primary_arn} does not exist"))?;
-        if !source.multi_region {
-            return Err(format!(
-                "Primary key {primary_arn} is not a multi-region key"
-            ));
-        }
-
-        // Real AWS uses the same `mrk-...` id across regions; fakecloud
-        // is single-region, so colliding the id with the primary would
-        // overwrite the primary in `state.keys`. Mint a distinct
-        // `mrk-replica-` id whose `primary_region` points back at the
-        // source so DescribeKey reports `MultiRegionKeyType=REPLICA`.
-        let replica_key_id = format!("mrk-replica-{}", Uuid::new_v4().as_simple());
-        let replica_arn = format!(
-            "arn:aws:kms:{}:{}:key/{}",
-            self.region, self.account_id, replica_key_id
-        );
-        let mut replica = source;
-        replica.key_id = replica_key_id.clone();
-        replica.arn = replica_arn.clone();
-        if !description.is_empty() {
-            replica.description = description;
-        }
-        replica.enabled = enabled;
-        replica.key_state = if enabled {
-            "Enabled".to_string()
-        } else {
-            "Disabled".to_string()
-        };
-        if !policy.is_empty() {
-            replica.policy = policy;
-        }
-        if !tags.is_empty() {
-            replica.tags.extend(tags);
-        }
-        replica.deletion_date = None;
-        replica.key_rotation_enabled = false;
-        replica.multi_region = true;
-        replica.rotations = Vec::new();
-        replica.custom_key_store_id = None;
-        replica.imported_key_material = false;
-        replica.imported_material_bytes = None;
-        replica.primary_region = Some(primary_region);
-
-        state.keys.insert(replica_key_id.clone(), replica);
+        let (replica_key_id, replica_arn) = kms_provisioner::provision_replica_key(
+            &self.kms_state,
+            &self.account_id,
+            &primary_arn,
+            description,
+            enabled,
+            policy,
+            tags,
+        )?;
         Ok(ProvisionResult::new(replica_key_id.clone())
             .with("KeyId", replica_key_id)
             .with("Arn", replica_arn))
+    }
+
+    /// Update an `AWS::KMS::ReplicaKey` in place. `PrimaryKeyArn`
+    /// changes are replacement-only, like the AWS contract — we'd
+    /// have to rebuild the replica from a different source. Other
+    /// fields (description, enabled, policy, tags) flow through
+    /// [`update_key_properties`].
+    fn update_kms_replica_key(
+        &self,
+        existing: &StackResource,
+        new_def: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &new_def.properties;
+        let new_primary = props
+            .get("PrimaryKeyArn")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "PrimaryKeyArn is required".to_string())?;
+        // Compare primary region from existing replica's primary_region
+        // field. Replacement triggers when the primary key changes.
+        {
+            let mut accounts = self.kms_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            let key = state
+                .keys
+                .get(&existing.physical_id)
+                .ok_or_else(|| format!("ReplicaKey '{}' does not exist", existing.physical_id))?;
+            if let Some(existing_region) = key.primary_region.as_deref() {
+                let parts: Vec<&str> = new_primary.split(':').collect();
+                if parts.len() < 4 || parts[3] != existing_region {
+                    return Err(
+                        "AWS::KMS::ReplicaKey updates that change PrimaryKeyArn require replacement"
+                            .to_string(),
+                    );
+                }
+            }
+        }
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let enabled = props
+            .get("Enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let policy = parse_key_policy(props);
+        let tags = parse_tag_list(props);
+        kms_provisioner::update_key_properties(
+            &self.kms_state,
+            &self.account_id,
+            &existing.physical_id,
+            kms_provisioner::KeyUpdate {
+                description,
+                enabled: Some(enabled),
+                key_rotation_enabled: None,
+                policy,
+                tags: Some(tags),
+            },
+        )?;
+        let arn = {
+            let mut accounts = self.kms_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            state
+                .keys
+                .get(&existing.physical_id)
+                .map(|k| k.arn.clone())
+                .unwrap_or_default()
+        };
+        Ok(ProvisionResult::new(existing.physical_id.clone())
+            .with("KeyId", existing.physical_id.clone())
+            .with("Arn", arn))
     }
 
     fn delete_kms_replica_key(&self, physical_id: &str) -> Result<(), String> {
@@ -5029,48 +5036,49 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .ok_or_else(|| "AliasName is required".to_string())?
             .to_string();
-        if !alias_name.starts_with("alias/") {
-            return Err(format!(
-                "AliasName must start with 'alias/'; got '{alias_name}'"
-            ));
-        }
         let target_input = props
             .get("TargetKeyId")
             .and_then(|v| v.as_str())
             .ok_or_else(|| "TargetKeyId is required".to_string())?
             .to_string();
+        let alias = kms_provisioner::provision_alias(
+            &self.kms_state,
+            &self.account_id,
+            &alias_name,
+            &target_input,
+        )?;
+        Ok(ProvisionResult::new(alias))
+    }
 
-        let mut accounts = self.kms_state.write();
-        let state = accounts.get_or_create(&self.account_id);
-
-        let target_key_id = if state.keys.contains_key(&target_input) {
-            target_input.clone()
-        } else if let Some(id) = target_input
-            .strip_prefix("arn:aws:kms:")
-            .and_then(|rest| rest.split(":key/").nth(1))
-        {
-            if state.keys.contains_key(id) {
-                id.to_string()
-            } else {
-                return Err(format!("KMS key '{target_input}' does not exist"));
-            }
-        } else {
-            return Err(format!("KMS key '{target_input}' does not exist"));
-        };
-
-        let alias_arn = format!(
-            "arn:aws:kms:{}:{}:{}",
-            state.region, state.account_id, alias_name
-        );
-        let alias = KmsAlias {
-            alias_name: alias_name.clone(),
-            alias_arn,
-            target_key_id,
-            creation_date: Utc::now().timestamp() as f64,
-        };
-        state.aliases.insert(alias_name.clone(), alias);
-
-        Ok(ProvisionResult::new(alias_name))
+    /// Update an `AWS::KMS::Alias` in place. Changing `AliasName`
+    /// triggers replacement (the alias is the resource's identity);
+    /// only `TargetKeyId` is updatable here.
+    fn update_kms_alias(
+        &self,
+        existing: &StackResource,
+        new_def: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &new_def.properties;
+        let new_alias_name = props
+            .get("AliasName")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "AliasName is required".to_string())?;
+        if new_alias_name != existing.physical_id {
+            return Err(
+                "AWS::KMS::Alias updates that change AliasName require replacement".to_string(),
+            );
+        }
+        let target_input = props
+            .get("TargetKeyId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "TargetKeyId is required".to_string())?;
+        kms_provisioner::update_alias_target(
+            &self.kms_state,
+            &self.account_id,
+            &existing.physical_id,
+            target_input,
+        )?;
+        Ok(ProvisionResult::new(existing.physical_id.clone()))
     }
 
     fn delete_kms_alias(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-e2e/tests/cloudformation_kms.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_kms.rs
@@ -218,3 +218,275 @@ async fn cfn_provisions_kms_replica_key() {
         "replica should be gone after stack deletion"
     );
 }
+
+const ASYM_TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "SigningKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "RSA signing key",
+        "KeyUsage": "SIGN_VERIFY",
+        "KeySpec": "RSA_2048"
+      }
+    },
+    "AgreementKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "ECC key agreement",
+        "KeyUsage": "KEY_AGREEMENT",
+        "KeySpec": "ECC_NIST_P256"
+      }
+    },
+    "MacKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "HMAC mac key",
+        "KeyUsage": "GENERATE_VERIFY_MAC",
+        "KeySpec": "HMAC_256"
+      }
+    }
+  },
+  "Outputs": {
+    "SigningKeyId": {"Value": {"Ref": "SigningKey"}},
+    "AgreementKeyId": {"Value": {"Ref": "AgreementKey"}},
+    "MacKeyId": {"Value": {"Ref": "MacKey"}}
+  }
+}"#;
+
+/// CFN must accept SIGN_VERIFY (asymmetric RSA), KEY_AGREEMENT (ECC),
+/// and GENERATE_VERIFY_MAC (HMAC) usages, not just symmetric keys.
+/// The pre-BB14 provisioner rejected anything that wasn't
+/// SYMMETRIC_DEFAULT or HMAC, which left a parity gap with real
+/// CloudFormation.
+#[tokio::test]
+async fn cfn_provisions_asymmetric_and_mac_keys() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kms = server.kms_client().await;
+
+    cfn.create_stack()
+        .stack_name("asym-kms-stack")
+        .template_body(ASYM_TEMPLATE)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("asym-kms-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let outputs: std::collections::HashMap<&str, &str> = stack
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+
+    let signing = kms
+        .describe_key()
+        .key_id(*outputs.get("SigningKeyId").unwrap())
+        .send()
+        .await
+        .expect("describe signing key");
+    let signing_meta = signing.key_metadata().unwrap();
+    assert_eq!(signing_meta.key_usage().unwrap().as_str(), "SIGN_VERIFY");
+    assert_eq!(signing_meta.key_spec().unwrap().as_str(), "RSA_2048");
+    assert!(
+        !signing_meta.signing_algorithms().is_empty(),
+        "signing algorithms should be populated for an RSA key",
+    );
+
+    // GetPublicKey must work — that's the smoke test for asymmetric
+    // keypair generation having actually run during CFN provisioning.
+    let pub_key = kms
+        .get_public_key()
+        .key_id(*outputs.get("SigningKeyId").unwrap())
+        .send()
+        .await
+        .expect("get_public_key");
+    assert!(pub_key.public_key().is_some());
+
+    let agreement = kms
+        .describe_key()
+        .key_id(*outputs.get("AgreementKeyId").unwrap())
+        .send()
+        .await
+        .expect("describe agreement key");
+    assert_eq!(
+        agreement
+            .key_metadata()
+            .unwrap()
+            .key_usage()
+            .unwrap()
+            .as_str(),
+        "KEY_AGREEMENT"
+    );
+
+    let mac = kms
+        .describe_key()
+        .key_id(*outputs.get("MacKeyId").unwrap())
+        .send()
+        .await
+        .expect("describe mac key");
+    assert!(
+        !mac.key_metadata().unwrap().mac_algorithms().is_empty(),
+        "MAC key should publish supported HMAC algorithms",
+    );
+}
+
+const UPDATE_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "AppKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "v1 description",
+        "EnableKeyRotation": false,
+        "Enabled": true
+      }
+    },
+    "OtherKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "alias re-target",
+        "Enabled": true
+      }
+    },
+    "AppAlias": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": "alias/cfn-update-test",
+        "TargetKeyId": {"Ref": "AppKey"}
+      }
+    }
+  },
+  "Outputs": {
+    "KeyId": {"Value": {"Ref": "AppKey"}},
+    "OtherKeyId": {"Value": {"Ref": "OtherKey"}}
+  }
+}"#;
+
+const UPDATE_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "AppKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "v2 description",
+        "EnableKeyRotation": true,
+        "Enabled": false
+      }
+    },
+    "OtherKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "Description": "alias re-target",
+        "Enabled": true
+      }
+    },
+    "AppAlias": {
+      "Type": "AWS::KMS::Alias",
+      "Properties": {
+        "AliasName": "alias/cfn-update-test",
+        "TargetKeyId": {"Ref": "OtherKey"}
+      }
+    }
+  },
+  "Outputs": {
+    "KeyId": {"Value": {"Ref": "AppKey"}},
+    "OtherKeyId": {"Value": {"Ref": "OtherKey"}}
+  }
+}"#;
+
+/// Update flow: changing description / enabled / EnableKeyRotation on
+/// an `AWS::KMS::Key` should land in place via `update_resource`, and
+/// repointing an `AWS::KMS::Alias` at a different key shouldn't drop
+/// the alias.
+#[tokio::test]
+async fn cfn_updates_kms_key_and_repoints_alias() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let kms = server.kms_client().await;
+
+    cfn.create_stack()
+        .stack_name("kms-update-stack")
+        .template_body(UPDATE_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let stack_v1 = cfn
+        .describe_stacks()
+        .stack_name("kms-update-stack")
+        .send()
+        .await
+        .expect("describe v1");
+    let v1_outputs: std::collections::HashMap<&str, &str> = stack_v1
+        .stacks()
+        .first()
+        .unwrap()
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    let original_key_id = v1_outputs.get("KeyId").unwrap().to_string();
+
+    cfn.update_stack()
+        .stack_name("kms-update-stack")
+        .template_body(UPDATE_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+
+    let stack_v2 = cfn
+        .describe_stacks()
+        .stack_name("kms-update-stack")
+        .send()
+        .await
+        .expect("describe v2");
+    let outputs: std::collections::HashMap<&str, &str> = stack_v2
+        .stacks()
+        .first()
+        .unwrap()
+        .outputs()
+        .iter()
+        .filter_map(|o| Some((o.output_key()?, o.output_value()?)))
+        .collect();
+    let after_key_id = outputs.get("KeyId").unwrap().to_string();
+    let other_key_id = outputs.get("OtherKeyId").unwrap().to_string();
+
+    // Same physical key — update was in place, not a replacement.
+    assert_eq!(after_key_id, original_key_id);
+
+    let described = kms
+        .describe_key()
+        .key_id(&after_key_id)
+        .send()
+        .await
+        .expect("describe after update");
+    let metadata = described.key_metadata().unwrap();
+    assert_eq!(metadata.description(), Some("v2 description"));
+    assert!(!metadata.enabled());
+
+    let rotation = kms
+        .get_key_rotation_status()
+        .key_id(&after_key_id)
+        .send()
+        .await
+        .expect("rotation status");
+    assert!(rotation.key_rotation_enabled());
+
+    // Alias should now point at OtherKey.
+    let aliases = kms.list_aliases().send().await.expect("list_aliases");
+    let alias = aliases
+        .aliases()
+        .iter()
+        .find(|a| a.alias_name() == Some("alias/cfn-update-test"))
+        .expect("alias still present");
+    assert_eq!(alias.target_key_id(), Some(other_key_id.as_str()));
+}

--- a/crates/fakecloud-kms/src/lib.rs
+++ b/crates/fakecloud-kms/src/lib.rs
@@ -5,6 +5,7 @@ pub mod resource_policy;
 pub(crate) mod service;
 pub(crate) mod state;
 
+pub use service::provisioner;
 pub use service::KmsService;
 pub use state::{
     KmsAlias, KmsKey, KmsSnapshot, KmsState, SharedKmsState, KMS_SNAPSHOT_SCHEMA_VERSION,

--- a/crates/fakecloud-kms/src/provisioner.rs
+++ b/crates/fakecloud-kms/src/provisioner.rs
@@ -1,0 +1,438 @@
+//! Public helpers for provisioning KMS keys from outside the
+//! `fakecloud-kms` crate (e.g. CloudFormation `AWS::KMS::Key` /
+//! `AWS::KMS::ReplicaKey`). This module exposes a single
+//! [`build_kms_key`] factory that mirrors `CreateKey`'s behaviour
+//! without going through the AWS request/response machinery, plus
+//! [`provision_key`] / [`provision_replica_key`] / [`provision_alias`]
+//! which take a `SharedKmsState` write lock and insert the resulting
+//! records.
+//!
+//! Keeping the asymmetric keypair generation, signing-algorithm
+//! tables, and policy defaulting in one place means CFN provisioning
+//! produces keys that are byte-compatible with what `CreateKey`
+//! itself would have produced — no asymmetric stubs, no missing
+//! `signing_algorithms`, no missing public key DER for `GetPublicKey`.
+
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use super::asym;
+use super::asym_ecdsa;
+use super::helpers::{
+    default_key_policy, encryption_algorithms_for_key, mac_algorithms_for_key_spec, rand_bytes,
+    signing_algorithms_for_key_spec,
+};
+use crate::state::{KmsAlias, KmsKey, SharedKmsState};
+
+/// Inputs accepted by [`build_kms_key`]. Mirrors the subset of
+/// `AWS::KMS::Key` properties + `CreateKey` request fields that
+/// fakecloud honours. Defaults match AWS: `key_usage =
+/// ENCRYPT_DECRYPT`, `key_spec = SYMMETRIC_DEFAULT`, `origin =
+/// AWS_KMS`, `enabled = true`.
+#[derive(Debug, Clone)]
+pub struct KeyCreationInput {
+    pub description: String,
+    pub key_usage: String,
+    pub key_spec: String,
+    pub origin: String,
+    pub enabled: bool,
+    pub multi_region: bool,
+    pub key_rotation_enabled: bool,
+    pub policy: Option<String>,
+    pub tags: BTreeMap<String, String>,
+}
+
+impl Default for KeyCreationInput {
+    fn default() -> Self {
+        Self {
+            description: String::new(),
+            key_usage: "ENCRYPT_DECRYPT".to_string(),
+            key_spec: "SYMMETRIC_DEFAULT".to_string(),
+            origin: "AWS_KMS".to_string(),
+            enabled: true,
+            multi_region: false,
+            key_rotation_enabled: false,
+            policy: None,
+            tags: BTreeMap::new(),
+        }
+    }
+}
+
+/// AWS KMS key specs accepted across `CreateKey` / CFN.
+pub const VALID_KEY_SPECS: &[&str] = &[
+    "SYMMETRIC_DEFAULT",
+    "RSA_2048",
+    "RSA_3072",
+    "RSA_4096",
+    "ECC_NIST_P256",
+    "ECC_NIST_P384",
+    "ECC_NIST_P521",
+    "ECC_SECG_P256K1",
+    "HMAC_224",
+    "HMAC_256",
+    "HMAC_384",
+    "HMAC_512",
+    "SM2",
+];
+
+/// AWS KMS key usages accepted across `CreateKey` / CFN.
+pub const VALID_KEY_USAGES: &[&str] = &[
+    "ENCRYPT_DECRYPT",
+    "SIGN_VERIFY",
+    "GENERATE_VERIFY_MAC",
+    "KEY_AGREEMENT",
+];
+
+/// Validate that a `(key_usage, key_spec)` pair is supported by
+/// fakecloud's KMS implementation. Mirrors the constraints the real
+/// AWS service enforces: e.g. only HMAC specs allow
+/// `GENERATE_VERIFY_MAC`, and only ECC specs allow `KEY_AGREEMENT`.
+pub fn validate_key_usage_for_spec(key_usage: &str, key_spec: &str) -> Result<(), String> {
+    if !VALID_KEY_USAGES.contains(&key_usage) {
+        return Err(format!("Unsupported KeyUsage: {key_usage}"));
+    }
+    if !VALID_KEY_SPECS.contains(&key_spec) {
+        return Err(format!("Unsupported KeySpec: {key_spec}"));
+    }
+    let is_symmetric = key_spec == "SYMMETRIC_DEFAULT";
+    let is_hmac = key_spec.starts_with("HMAC_");
+    let is_rsa = key_spec.starts_with("RSA_");
+    let is_ecc = key_spec.starts_with("ECC_");
+    let is_sm2 = key_spec == "SM2";
+    match key_usage {
+        "ENCRYPT_DECRYPT" => {
+            if !(is_symmetric || is_rsa || is_sm2) {
+                return Err(format!(
+                    "KeySpec {key_spec} does not support KeyUsage ENCRYPT_DECRYPT"
+                ));
+            }
+        }
+        "SIGN_VERIFY" => {
+            if !(is_rsa || is_ecc || is_sm2) {
+                return Err(format!(
+                    "KeySpec {key_spec} does not support KeyUsage SIGN_VERIFY"
+                ));
+            }
+        }
+        "GENERATE_VERIFY_MAC" => {
+            if !is_hmac {
+                return Err(format!(
+                    "KeySpec {key_spec} does not support KeyUsage GENERATE_VERIFY_MAC"
+                ));
+            }
+        }
+        "KEY_AGREEMENT" => {
+            if !is_ecc {
+                return Err(format!(
+                    "KeySpec {key_spec} does not support KeyUsage KEY_AGREEMENT"
+                ));
+            }
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
+/// Build a fully-populated [`KmsKey`] for the given inputs. Generates
+/// asymmetric keypairs (RSA / ECDSA) when the spec calls for it,
+/// computes the matching `signing_algorithms` /
+/// `encryption_algorithms` / `mac_algorithms` tables, and falls back
+/// to [`default_key_policy`] when no policy is supplied.
+///
+/// `region` and `account_id` are used to mint the ARN. Caller is
+/// responsible for inserting the result into the appropriate
+/// `KmsState.keys` map under `key_id`.
+pub fn build_kms_key(
+    region: &str,
+    account_id: &str,
+    input: &KeyCreationInput,
+) -> Result<KmsKey, String> {
+    validate_key_usage_for_spec(&input.key_usage, &input.key_spec)?;
+
+    let key_id = if input.multi_region {
+        format!("mrk-{}", Uuid::new_v4().as_simple())
+    } else {
+        Uuid::new_v4().to_string()
+    };
+    let arn = format!("arn:aws:kms:{region}:{account_id}:key/{key_id}");
+    let now = Utc::now().timestamp() as f64;
+
+    let signing_algs = if input.key_usage == "SIGN_VERIFY" {
+        signing_algorithms_for_key_spec(&input.key_spec)
+    } else {
+        None
+    };
+    let encryption_algs = encryption_algorithms_for_key(&input.key_usage, &input.key_spec);
+    let mac_algs = if input.key_usage == "GENERATE_VERIFY_MAC" {
+        mac_algorithms_for_key_spec(&input.key_spec)
+    } else {
+        None
+    };
+
+    let mut asym_priv: Option<Vec<u8>> = None;
+    let mut asym_pub: Option<Vec<u8>> = None;
+    if let Some((p, k)) =
+        asym::generate_keypair(&input.key_spec).map_err(|e| format!("rsa keygen failed: {e}"))?
+    {
+        asym_priv = Some(p);
+        asym_pub = Some(k);
+    } else if let Some((p, k)) = asym_ecdsa::generate_keypair(&input.key_spec)
+        .map_err(|e| format!("ecdsa keygen failed: {e}"))?
+    {
+        asym_priv = Some(p);
+        asym_pub = Some(k);
+    }
+
+    let policy = input
+        .policy
+        .clone()
+        .unwrap_or_else(|| default_key_policy(account_id));
+
+    Ok(KmsKey {
+        key_id,
+        arn,
+        creation_date: now,
+        description: input.description.clone(),
+        enabled: input.enabled,
+        key_usage: input.key_usage.clone(),
+        key_spec: input.key_spec.clone(),
+        key_manager: "CUSTOMER".to_string(),
+        key_state: if input.enabled { "Enabled" } else { "Disabled" }.to_string(),
+        deletion_date: None,
+        tags: input.tags.clone(),
+        policy,
+        key_rotation_enabled: input.key_rotation_enabled,
+        origin: input.origin.clone(),
+        multi_region: input.multi_region,
+        rotations: Vec::new(),
+        signing_algorithms: signing_algs,
+        encryption_algorithms: encryption_algs,
+        mac_algorithms: mac_algs,
+        custom_key_store_id: None,
+        imported_key_material: false,
+        imported_material_bytes: None,
+        private_key_seed: rand_bytes(32),
+        primary_region: None,
+        asymmetric_private_key_der: asym_priv,
+        asymmetric_public_key_der: asym_pub,
+    })
+}
+
+/// Build and insert a key into shared state. Returns
+/// `(key_id, arn)`.
+pub fn provision_key(
+    state: &SharedKmsState,
+    account_id: &str,
+    input: &KeyCreationInput,
+) -> Result<(String, String), String> {
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let region = s.region.clone();
+    let key = build_kms_key(&region, account_id, input)?;
+    let key_id = key.key_id.clone();
+    let arn = key.arn.clone();
+    s.keys.insert(key_id.clone(), key);
+    Ok((key_id, arn))
+}
+
+/// Provision a multi-region replica of an existing primary key.
+/// Looks the primary up in the same account state, validates that
+/// it's `MultiRegion=true`, mints a `mrk-replica-` id (fakecloud is
+/// single-region so colliding IDs would overwrite the primary), and
+/// inserts the replica with `primary_region` set so `DescribeKey`
+/// reports `MultiRegionKeyType=REPLICA`.
+pub fn provision_replica_key(
+    state: &SharedKmsState,
+    account_id: &str,
+    primary_arn: &str,
+    description: Option<String>,
+    enabled: bool,
+    policy: Option<String>,
+    tags: BTreeMap<String, String>,
+) -> Result<(String, String), String> {
+    let parts: Vec<&str> = primary_arn.split(':').collect();
+    if parts.len() < 6 {
+        return Err(format!("Invalid PrimaryKeyArn: {primary_arn}"));
+    }
+    let primary_region = parts[3].to_string();
+    let key_id = parts[5]
+        .strip_prefix("key/")
+        .ok_or_else(|| format!("PrimaryKeyArn missing key/ segment: {primary_arn}"))?
+        .to_string();
+
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let region = s.region.clone();
+    // Source must be a multi-region key in the primary account; look
+    // it up either by raw key_id (when the primary lives in this
+    // state's region) or via the region-keyed slot.
+    let source_storage_keys = [key_id.clone(), format!("{primary_region}:{key_id}")];
+    let source = source_storage_keys
+        .iter()
+        .find_map(|k| s.keys.get(k).cloned())
+        .ok_or_else(|| format!("Primary key {primary_arn} does not exist"))?;
+    if !source.multi_region {
+        return Err(format!(
+            "Primary key {primary_arn} is not a multi-region key"
+        ));
+    }
+
+    let replica_key_id = format!("mrk-replica-{}", Uuid::new_v4().as_simple());
+    let replica_arn = format!("arn:aws:kms:{region}:{account_id}:key/{replica_key_id}");
+    let mut replica = source;
+    replica.key_id = replica_key_id.clone();
+    replica.arn = replica_arn.clone();
+    if let Some(d) = description {
+        if !d.is_empty() {
+            replica.description = d;
+        }
+    }
+    replica.enabled = enabled;
+    replica.key_state = if enabled { "Enabled" } else { "Disabled" }.to_string();
+    if let Some(p) = policy {
+        if !p.is_empty() {
+            replica.policy = p;
+        }
+    }
+    if !tags.is_empty() {
+        replica.tags.extend(tags);
+    }
+    replica.deletion_date = None;
+    replica.key_rotation_enabled = false;
+    replica.multi_region = true;
+    replica.rotations = Vec::new();
+    replica.custom_key_store_id = None;
+    replica.imported_key_material = false;
+    replica.imported_material_bytes = None;
+    replica.primary_region = Some(primary_region);
+
+    s.keys.insert(replica_key_id.clone(), replica);
+    Ok((replica_key_id, replica_arn))
+}
+
+/// Insert (or replace) an alias pointing at `target_key_id`. Resolves
+/// `target_input` against either a raw key id or a key ARN. Returns
+/// the alias name on success.
+pub fn provision_alias(
+    state: &SharedKmsState,
+    account_id: &str,
+    alias_name: &str,
+    target_input: &str,
+) -> Result<String, String> {
+    if !alias_name.starts_with("alias/") {
+        return Err(format!(
+            "AliasName must start with 'alias/'; got '{alias_name}'"
+        ));
+    }
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let target_key_id = if s.keys.contains_key(target_input) {
+        target_input.to_string()
+    } else if let Some(id) = target_input
+        .strip_prefix("arn:aws:kms:")
+        .and_then(|rest| rest.split(":key/").nth(1))
+    {
+        if s.keys.contains_key(id) {
+            id.to_string()
+        } else {
+            return Err(format!("KMS key '{target_input}' does not exist"));
+        }
+    } else {
+        return Err(format!("KMS key '{target_input}' does not exist"));
+    };
+    let alias_arn = format!("arn:aws:kms:{}:{}:{}", s.region, s.account_id, alias_name);
+    let alias = KmsAlias {
+        alias_name: alias_name.to_string(),
+        alias_arn,
+        target_key_id,
+        creation_date: Utc::now().timestamp() as f64,
+    };
+    s.aliases.insert(alias_name.to_string(), alias);
+    Ok(alias_name.to_string())
+}
+
+/// Mutable updates to apply to an existing key. Each `Option` field
+/// is "leave alone if `None`, replace with this value if `Some`",
+/// mirroring the AWS update semantics where unspecified fields are
+/// untouched. Properties that AWS treats as immutable (`KeySpec`,
+/// `KeyUsage`, `Origin`, `MultiRegion`) aren't representable here —
+/// the caller is expected to detect those changes and trigger
+/// resource replacement.
+#[derive(Debug, Default, Clone)]
+pub struct KeyUpdate {
+    pub description: Option<String>,
+    pub enabled: Option<bool>,
+    pub key_rotation_enabled: Option<bool>,
+    pub policy: Option<String>,
+    pub tags: Option<BTreeMap<String, String>>,
+}
+
+/// Apply a [`KeyUpdate`] to the key with `key_id`. Returns an error
+/// if the key isn't found in `state`.
+pub fn update_key_properties(
+    state: &SharedKmsState,
+    account_id: &str,
+    key_id: &str,
+    update: KeyUpdate,
+) -> Result<(), String> {
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let key = s
+        .keys
+        .get_mut(key_id)
+        .ok_or_else(|| format!("Key '{key_id}' does not exist"))?;
+    if let Some(d) = update.description {
+        key.description = d;
+    }
+    if let Some(e) = update.enabled {
+        key.enabled = e;
+        key.key_state = if e { "Enabled" } else { "Disabled" }.to_string();
+    }
+    if let Some(r) = update.key_rotation_enabled {
+        key.key_rotation_enabled = r;
+    }
+    if let Some(p) = update.policy {
+        if !p.is_empty() {
+            key.policy = p;
+        }
+    }
+    if let Some(t) = update.tags {
+        key.tags = t;
+    }
+    Ok(())
+}
+
+/// Repoint an existing alias at a different target key. Used by
+/// `update_resource` for `AWS::KMS::Alias` when only `TargetKeyId`
+/// changes.
+pub fn update_alias_target(
+    state: &SharedKmsState,
+    account_id: &str,
+    alias_name: &str,
+    target_input: &str,
+) -> Result<(), String> {
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let target_key_id = if s.keys.contains_key(target_input) {
+        target_input.to_string()
+    } else if let Some(id) = target_input
+        .strip_prefix("arn:aws:kms:")
+        .and_then(|rest| rest.split(":key/").nth(1))
+    {
+        if s.keys.contains_key(id) {
+            id.to_string()
+        } else {
+            return Err(format!("KMS key '{target_input}' does not exist"));
+        }
+    } else {
+        return Err(format!("KMS key '{target_input}' does not exist"));
+    };
+    let alias = s
+        .aliases
+        .get_mut(alias_name)
+        .ok_or_else(|| format!("Alias '{alias_name}' does not exist"))?;
+    alias.target_key_id = target_key_id;
+    Ok(())
+}

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -1314,6 +1314,9 @@ mod service_grants;
 mod helpers;
 pub(crate) use helpers::*;
 
+#[path = "provisioner.rs"]
+pub mod provisioner;
+
 #[cfg(test)]
 #[path = "service_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary

Closes the parity gap between `CreateKey` and the CFN `AWS::KMS::*` provisioners.

- Adds `fakecloud_kms::provisioner` (public) so CFN reuses the same key-construction path the API uses: real RSA/ECDSA keypair generation, correct `signing_algorithms` / `encryption_algorithms` / `mac_algorithms` tables, default key policy. Pre-BB14 the provisioner rejected anything that wasn't `SYMMETRIC_DEFAULT` or HMAC.
- Wires `AWS::KMS::Key`, `AWS::KMS::ReplicaKey`, and `AWS::KMS::Alias` into `update_resource`. Description / Enabled / EnableKeyRotation / KeyPolicy / Tags update in place; KeySpec / KeyUsage / Origin / MultiRegion (and `Alias.AliasName`, `ReplicaKey.PrimaryKeyArn`) trigger replacement.
- Accepts `RotationPeriodInDays`, `PendingWindowInDays`, and `BypassPolicyLockoutSafetyCheck` for compatibility.

## Test plan

- [x] `cargo test -p fakecloud-kms` (174 passed)
- [x] `cargo test -p fakecloud-cloudformation` (171 passed)
- [x] `cargo test -p fakecloud-e2e --test cloudformation_kms` (4 passed: existing key+alias, replica key, new asymmetric/MAC/KEY_AGREEMENT, new in-place update with alias re-target)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CloudFormation provisioners for `AWS::KMS::{Key,Alias,ReplicaKey}` using a new shared `fakecloud_kms::provisioner` that mirrors `CreateKey`. This enables asymmetric RSA/ECDSA, HMAC, and key-agreement keys in CFN with correct update behavior.

- **New Features**
  - Shared provisioner: real RSA/ECDSA keypair generation, correct signing/encryption/MAC algorithm tables, and a default key policy shared by API and CFN paths.
  - Resource support and updates:
    - `AWS::KMS::Key`: Description/Enabled/EnableKeyRotation/KeyPolicy/Tags update in place; changes to `KeySpec`, `KeyUsage`, `Origin`, or `MultiRegion` require replacement.
    - `AWS::KMS::ReplicaKey`: builds from a multi-Region primary; description/enabled/policy/tags update in place; `PrimaryKeyArn` changes require replacement.
    - `AWS::KMS::Alias`: retarget `TargetKeyId` in place; `AliasName` changes require replacement.
  - CFN compatibility: accepts `RotationPeriodInDays`, `PendingWindowInDays`, and `BypassPolicyLockoutSafetyCheck`.

<sup>Written for commit 7521ee6cbb59f9dd8d22c3159a460ee46bcb4749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

