### PR TITLE
feat(cloudformation): AWS::SecretsManager::* provisioners (BB13)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -4578,13 +4578,21 @@ impl ResourceProvisioner {
         let now = Utc::now();
         let mut versions = BTreeMap::new();
         let mut current_version_id: Option<String> = None;
-        if let Some(secret_string) = props.get("SecretString").and_then(|v| v.as_str()) {
+        let initial_string: Option<String> =
+            if let Some(secret_string) = props.get("SecretString").and_then(|v| v.as_str()) {
+                Some(secret_string.to_string())
+            } else if let Some(gen) = props.get("GenerateSecretString") {
+                Some(generate_secret_string_payload(gen)?)
+            } else {
+                None
+            };
+        if let Some(secret_string) = initial_string {
             let version_id = Uuid::new_v4().to_string();
             versions.insert(
                 version_id.clone(),
                 SecretVersion {
                     version_id: version_id.clone(),
-                    secret_string: Some(secret_string.to_string()),
+                    secret_string: Some(secret_string),
                     secret_binary: None,
                     stages: vec!["AWSCURRENT".to_string()],
                     created_at: now,
@@ -15744,9 +15752,26 @@ impl ResourceProvisioner {
             .secrets
             .get_mut(&secret_arn)
             .ok_or_else(|| format!("Secret {secret_arn} not found"))?;
-        // Update SecretString JSON in current version with engine/host/port
-        // /username/password placeholders so it shows as "attached" via the
-        // RDS-style schema CFN expects.
+        // Patch the AWSCURRENT version with engine/host/dbInstanceIdentifier
+        // so it shows as "attached" via the RDS-style schema CFN expects.
+        // If the secret has no version yet (created without SecretString or
+        // GenerateSecretString), seed one — this matches CFN's behaviour of
+        // making the attachment usable on its own.
+        let now = Utc::now();
+        if secret.current_version_id.is_none() {
+            let version_id = Uuid::new_v4().to_string();
+            secret.versions.insert(
+                version_id.clone(),
+                SecretVersion {
+                    version_id: version_id.clone(),
+                    secret_string: Some("{}".to_string()),
+                    secret_binary: None,
+                    stages: vec!["AWSCURRENT".to_string()],
+                    created_at: now,
+                },
+            );
+            secret.current_version_id = Some(version_id);
+        }
         if let Some(version_id) = secret.current_version_id.clone() {
             if let Some(version) = secret.versions.get_mut(&version_id) {
                 let mut existing: serde_json::Value = version
@@ -15768,8 +15793,107 @@ impl ResourceProvisioner {
                 version.secret_string = Some(existing.to_string());
             }
         }
-        secret.last_changed_at = Utc::now();
+        secret.last_changed_at = now;
         Ok(ProvisionResult::new(secret_arn.clone()).with("SecretArn", secret_arn))
+    }
+}
+
+/// Implements the CloudFormation `GenerateSecretString` shape on
+/// `AWS::SecretsManager::Secret`. Produces the plaintext payload that
+/// will become the AWSCURRENT version of the secret.
+///
+/// When `SecretStringTemplate` is set together with `GenerateStringKey`,
+/// the generated password is inserted under `GenerateStringKey` in the
+/// JSON template (this is the standard "DB credential" pattern).
+/// Without those two, the bare generated password is returned.
+fn generate_secret_string_payload(gen: &serde_json::Value) -> Result<String, String> {
+    let length = gen
+        .get("PasswordLength")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(32) as usize;
+    let exclude_lowercase = gen
+        .get("ExcludeLowercase")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exclude_uppercase = gen
+        .get("ExcludeUppercase")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exclude_numbers = gen
+        .get("ExcludeNumbers")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exclude_punctuation = gen
+        .get("ExcludePunctuation")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let include_space = gen
+        .get("IncludeSpace")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exclude_chars = gen
+        .get("ExcludeCharacters")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let lowercase = "abcdefghijklmnopqrstuvwxyz";
+    let uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let digits = "0123456789";
+    let punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
+    let mut pool = String::new();
+    if !exclude_lowercase {
+        pool.extend(lowercase.chars().filter(|c| !exclude_chars.contains(*c)));
+    }
+    if !exclude_uppercase {
+        pool.extend(uppercase.chars().filter(|c| !exclude_chars.contains(*c)));
+    }
+    if !exclude_numbers {
+        pool.extend(digits.chars().filter(|c| !exclude_chars.contains(*c)));
+    }
+    if !exclude_punctuation {
+        pool.extend(punctuation.chars().filter(|c| !exclude_chars.contains(*c)));
+    }
+    if include_space && !exclude_chars.contains(' ') {
+        pool.push(' ');
+    }
+    if pool.is_empty() {
+        return Err("GenerateSecretString character pool is empty".to_string());
+    }
+
+    let pool_chars: Vec<char> = pool.chars().collect();
+    let mut password = String::with_capacity(length);
+    let mut counter: u64 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    while password.len() < length {
+        // Splitmix64 — deterministic, no_std-friendly, good enough for
+        // fake-cloud password generation. Real entropy isn't a goal here.
+        counter = counter.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = counter;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^= z >> 31;
+        let idx = (z as usize) % pool_chars.len();
+        password.push(pool_chars[idx]);
+    }
+
+    let template = gen.get("SecretStringTemplate").and_then(|v| v.as_str());
+    let key = gen.get("GenerateStringKey").and_then(|v| v.as_str());
+    match (template, key) {
+        (Some(tmpl), Some(k)) => {
+            let mut value: serde_json::Value = serde_json::from_str(tmpl)
+                .map_err(|e| format!("SecretStringTemplate is not valid JSON: {e}"))?;
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert(k.to_string(), serde_json::Value::String(password));
+                Ok(value.to_string())
+            } else {
+                Err("SecretStringTemplate must be a JSON object".to_string())
+            }
+        }
+        _ => Ok(password),
     }
 }
 

--- a/crates/fakecloud-e2e/tests/cloudformation_secretsmanager_target.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_secretsmanager_target.rs
@@ -1,0 +1,146 @@
+//! CloudFormation provisioner for AWS::SecretsManager::SecretTargetAttachment
+//! and the GenerateSecretString form of AWS::SecretsManager::Secret (BB13).
+//!
+//! Provisions a Secret with GenerateSecretString, an RDS instance, and a
+//! SecretTargetAttachment binding the two. Asserts via the runtime Secrets
+//! Manager SDK that:
+//!   * GenerateSecretString produced a JSON document including the template
+//!     fields and a generated password keyed by GenerateStringKey.
+//!   * SecretTargetAttachment patched host/engine/dbInstanceIdentifier into
+//!     the current secret string.
+
+mod helpers;
+
+use aws_sdk_cloudformation::types::{Capability, OnFailure};
+use helpers::TestServer;
+
+const TEMPLATE: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "DbInstance": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "DBInstanceIdentifier": "cfn-target-db",
+        "DBInstanceClass": "db.t4g.micro",
+        "Engine": "postgres",
+        "EngineVersion": "16.0",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "placeholder",
+        "AllocatedStorage": "20",
+        "Port": 5432
+      }
+    },
+    "DbSecret": {
+      "Type": "AWS::SecretsManager::Secret",
+      "Properties": {
+        "Name": "cfn-target-secret",
+        "Description": "DB credential secret",
+        "GenerateSecretString": {
+          "SecretStringTemplate": "{\"username\":\"admin\"}",
+          "GenerateStringKey": "password",
+          "PasswordLength": 24,
+          "ExcludeCharacters": "\"@/\\"
+        }
+      }
+    },
+    "DbSecretAttachment": {
+      "Type": "AWS::SecretsManager::SecretTargetAttachment",
+      "Properties": {
+        "SecretId": {"Ref": "DbSecret"},
+        "TargetId": {"Ref": "DbInstance"},
+        "TargetType": "AWS::RDS::DBInstance"
+      }
+    }
+  },
+  "Outputs": {
+    "SecretArn": {"Value": {"Ref": "DbSecret"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_provisions_secret_target_attachment_with_generated_string() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let sm = aws_sdk_secretsmanager::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("sm-target-stack")
+        .template_body(TEMPLATE)
+        .capabilities(Capability::CapabilityIam)
+        .on_failure(OnFailure::Rollback)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("sm-target-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().expect("stack present");
+    assert_eq!(
+        stack.stack_status().unwrap().as_str(),
+        "CREATE_COMPLETE",
+        "stack status reason: {:?}",
+        stack.stack_status_reason()
+    );
+
+    let secret_arn = stack
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some("SecretArn"))
+        .and_then(|o| o.output_value())
+        .expect("SecretArn output")
+        .to_string();
+
+    let value = sm
+        .get_secret_value()
+        .secret_id(&secret_arn)
+        .send()
+        .await
+        .expect("get_secret_value");
+    let body: serde_json::Value =
+        serde_json::from_str(value.secret_string().expect("secret_string"))
+            .expect("secret string is JSON");
+    let obj = body.as_object().expect("secret JSON object");
+
+    // Template field carried through.
+    assert_eq!(obj.get("username").and_then(|v| v.as_str()), Some("admin"));
+
+    // Generated password key present, length matches PasswordLength, no
+    // excluded characters.
+    let password = obj
+        .get("password")
+        .and_then(|v| v.as_str())
+        .expect("generated password");
+    assert_eq!(password.len(), 24, "PasswordLength honoured");
+    for ch in ['"', '@', '/', '\\'] {
+        assert!(
+            !password.contains(ch),
+            "ExcludeCharacters honoured: {ch} found in {password}"
+        );
+    }
+
+    // SecretTargetAttachment patched RDS connection details.
+    assert_eq!(
+        obj.get("engine").and_then(|v| v.as_str()),
+        Some("postgres"),
+        "TargetAttachment set engine"
+    );
+    assert_eq!(
+        obj.get("host").and_then(|v| v.as_str()),
+        Some("cfn-target-db"),
+        "TargetAttachment set host to TargetId"
+    );
+    assert_eq!(
+        obj.get("dbInstanceIdentifier").and_then(|v| v.as_str()),
+        Some("cfn-target-db"),
+    );
+
+    cfn.delete_stack()
+        .stack_name("sm-target-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+}


### PR DESCRIPTION
## Summary

Closes the AWS::SecretsManager::* CFN parity gap (BB13):

- **AWS::SecretsManager::Secret** now supports `GenerateSecretString` (`PasswordLength`, `ExcludeCharacters`, `Exclude{Lowercase,Uppercase,Numbers,Punctuation}`, `IncludeSpace`, `SecretStringTemplate` + `GenerateStringKey`) so the typical \"DB credential\" CFN pattern produces a usable secret without an inline `SecretString`.
- **AWS::SecretsManager::SecretTargetAttachment** seeds an `AWSCURRENT` version when the secret was created without one. Previously it silently no-op'd in that case, which broke the standard \"generated DB secret + attachment\" pattern.
- The other three resource types (Secret, RotationSchedule, ResourcePolicy) were already wired; this PR fills the remaining property gaps and adds the SecretTargetAttachment E2E.

## Test plan

- [x] `cargo test -p fakecloud-e2e --test cloudformation_secretsmanager_target` (new) - GenerateSecretString + SecretTargetAttachment patched the secret JSON correctly
- [x] `cargo test -p fakecloud-e2e --test cloudformation_secretsmanager` (regression)
- [x] `cargo test -p fakecloud-e2e --test cloudformation_secretsmanager_extras` (regression)
- [x] `cargo test -p fakecloud-cloudformation` (171 tests pass)
- [x] `cargo clippy -p fakecloud-cloudformation --tests --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full CFN parity for Secrets Manager (BB13): `AWS::SecretsManager::Secret` now supports `GenerateSecretString`, and `AWS::SecretsManager::SecretTargetAttachment` seeds and patches the `AWSCURRENT` version so the standard RDS credential pattern works end-to-end.

- **New Features**
  - `AWS::SecretsManager::Secret`: implements `GenerateSecretString` (PasswordLength, Exclude{Lowercase,Uppercase,Numbers,Punctuation}, ExcludeCharacters, IncludeSpace, `SecretStringTemplate` + `GenerateStringKey`). Creates the initial `AWSCURRENT` payload, inserting the generated password into the template when provided.

- **Bug Fixes**
  - `AWS::SecretsManager::SecretTargetAttachment`: if the secret has no version, seed an `AWSCURRENT` version and patch `engine`, `host`, and `dbInstanceIdentifier` into the current JSON. Previously no-op, which broke the generated-secret + attachment flow.

<sup>Written for commit 9b0a8b9e9f91f012ad30dfbb0739db2f3d001b0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

