### PR TITLE
feat(rds): real RestoreDBInstanceToPointInTime + RestoreDBClusterFromSnapshot (M7)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8428,6 +8428,10 @@ impl ResourceProvisioner {
                         .collect()
                 })
                 .unwrap_or_default(),
+            db_cluster_identifier: props
+                .get("DBClusterIdentifier")
+                .and_then(|v| v.as_str())
+                .map(String::from),
         };
         let endpoint = inst.endpoint_address.clone();
         let endpoint_port = inst.port;

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1486,3 +1486,313 @@ async fn rds_modify_db_cluster_unknown_cluster_errors() {
         Some("DBClusterNotFoundFault")
     );
 }
+
+/// Real RestoreDBClusterFromSnapshot path:
+///   1. Create cluster with a writer instance attached via DBClusterIdentifier.
+///   2. Write rows.
+///   3. CreateDBClusterSnapshot — dumps writer's database into the snapshot.
+///   4. Drop the writer (so source data is gone).
+///   5. RestoreDBClusterFromSnapshot to a new cluster id.
+///   6. Attach a fresh writer to the restored cluster — pending dump replays.
+///   7. Connect to new writer, verify rows survived.
+#[tokio::test]
+async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    // 1. Create source cluster.
+    client
+        .create_db_cluster()
+        .db_cluster_identifier("m7-source-cluster")
+        .engine("aurora-postgresql")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .send()
+        .await
+        .expect("create source cluster");
+
+    // Attach a writer instance bound to the cluster.
+    client
+        .create_db_instance()
+        .db_instance_identifier("m7-source-writer")
+        .db_cluster_identifier("m7-source-cluster")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create writer");
+
+    let writer = helpers::wait_for_db_available(&client, "m7-source-writer", 180).await;
+    let endpoint = writer.endpoint().expect("writer endpoint");
+
+    // 2. Write rows on the writer.
+    let (writer_client, conn) = connect_with_retry(
+        endpoint.address().unwrap(),
+        endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect to writer");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    writer_client
+        .execute("CREATE TABLE m7_rows (id INT, value TEXT)", &[])
+        .await
+        .expect("create table");
+    writer_client
+        .execute(
+            "INSERT INTO m7_rows VALUES (1, 'cluster-snapshot-survives')",
+            &[],
+        )
+        .await
+        .expect("insert row");
+
+    // 3. Snapshot the cluster (dumps writer into snapshot).
+    client
+        .create_db_cluster_snapshot()
+        .db_cluster_snapshot_identifier("m7-cluster-snap")
+        .db_cluster_identifier("m7-source-cluster")
+        .send()
+        .await
+        .expect("snapshot cluster");
+
+    // 4. Drop the source writer so the data only survives in the snapshot.
+    client
+        .delete_db_instance()
+        .db_instance_identifier("m7-source-writer")
+        .skip_final_snapshot(true)
+        .send()
+        .await
+        .expect("drop writer");
+
+    // 5. Restore the snapshot into a new cluster id.
+    client
+        .restore_db_cluster_from_snapshot()
+        .db_cluster_identifier("m7-restored-cluster")
+        .snapshot_identifier("m7-cluster-snap")
+        .engine("aurora-postgresql")
+        .send()
+        .await
+        .expect("restore cluster");
+
+    // 6. Create a writer in the restored cluster — the staged dump
+    //    replays into its container before status flips to available.
+    client
+        .create_db_instance()
+        .db_instance_identifier("m7-restored-writer")
+        .db_cluster_identifier("m7-restored-cluster")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create restored writer");
+
+    let restored = helpers::wait_for_db_available(&client, "m7-restored-writer", 180).await;
+    let restored_endpoint = restored.endpoint().expect("restored endpoint");
+
+    // 7. Verify rows survived.
+    let (restored_client, conn) = connect_with_retry(
+        restored_endpoint.address().unwrap(),
+        restored_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect to restored writer");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let row = restored_client
+        .query_one("SELECT value FROM m7_rows WHERE id = 1", &[])
+        .await
+        .expect("query restored row");
+    let value: String = row.get(0);
+    assert_eq!(value, "cluster-snapshot-survives");
+}
+
+/// Real RestoreDBClusterToPointInTime path: dumps the source cluster's
+/// writer live, stages the dump on the new cluster id, and the next
+/// CreateDBInstance attached to the new cluster replays the data.
+#[tokio::test]
+async fn rds_restore_db_cluster_to_point_in_time_clones_data() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_cluster()
+        .db_cluster_identifier("m7-pit-source")
+        .engine("aurora-postgresql")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .send()
+        .await
+        .expect("create source cluster");
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("m7-pit-writer")
+        .db_cluster_identifier("m7-pit-source")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create writer");
+
+    let writer = helpers::wait_for_db_available(&client, "m7-pit-writer", 180).await;
+    let endpoint = writer.endpoint().expect("writer endpoint");
+    let (writer_client, conn) = connect_with_retry(
+        endpoint.address().unwrap(),
+        endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    writer_client
+        .execute("CREATE TABLE m7_pit_rows (id INT, value TEXT)", &[])
+        .await
+        .expect("create table");
+    writer_client
+        .execute("INSERT INTO m7_pit_rows VALUES (42, 'pit-payload')", &[])
+        .await
+        .expect("insert");
+
+    client
+        .restore_db_cluster_to_point_in_time()
+        .db_cluster_identifier("m7-pit-target")
+        .source_db_cluster_identifier("m7-pit-source")
+        .use_latest_restorable_time(true)
+        .send()
+        .await
+        .expect("restore PIT cluster");
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("m7-pit-restored-writer")
+        .db_cluster_identifier("m7-pit-target")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .expect("create restored writer");
+
+    let restored = helpers::wait_for_db_available(&client, "m7-pit-restored-writer", 180).await;
+    let restored_endpoint = restored.endpoint().expect("restored endpoint");
+    let (restored_client, conn) = connect_with_retry(
+        restored_endpoint.address().unwrap(),
+        restored_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect to PIT writer");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let row = restored_client
+        .query_one("SELECT value FROM m7_pit_rows WHERE id = 42", &[])
+        .await
+        .expect("query restored row");
+    let value: String = row.get(0);
+    assert_eq!(value, "pit-payload");
+}
+
+/// Real RestoreDBInstanceToPointInTime path. The op already dumps the
+/// source instance live and replays into the target; this test pins the
+/// behavior end-to-end so regressions surface.
+#[tokio::test]
+async fn rds_restore_db_instance_to_point_in_time_clones_data() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    create_instance(&client, "m7-pit-instance-source").await;
+    let source = client
+        .describe_db_instances()
+        .db_instance_identifier("m7-pit-instance-source")
+        .send()
+        .await
+        .expect("describe source");
+    let source_endpoint = source.db_instances()[0].endpoint().unwrap();
+    let (writer_client, conn) = connect_with_retry(
+        source_endpoint.address().unwrap(),
+        source_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    writer_client
+        .execute("CREATE TABLE m7_inst_rows (id INT, value TEXT)", &[])
+        .await
+        .expect("create table");
+    writer_client
+        .execute(
+            "INSERT INTO m7_inst_rows VALUES (7, 'instance-pit-payload')",
+            &[],
+        )
+        .await
+        .expect("insert");
+
+    client
+        .restore_db_instance_to_point_in_time()
+        .source_db_instance_identifier("m7-pit-instance-source")
+        .target_db_instance_identifier("m7-pit-instance-target")
+        .use_latest_restorable_time(true)
+        .send()
+        .await
+        .expect("restore instance PIT");
+
+    let restored = helpers::wait_for_db_available(&client, "m7-pit-instance-target", 180).await;
+    let restored_endpoint = restored.endpoint().expect("restored endpoint");
+    let (restored_client, conn) = connect_with_retry(
+        restored_endpoint.address().unwrap(),
+        restored_endpoint.port().unwrap(),
+        "admin",
+        "secret123",
+        "appdb",
+    )
+    .await
+    .expect("connect to restored");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let row = restored_client
+        .query_one("SELECT value FROM m7_inst_rows WHERE id = 7", &[])
+        .await
+        .expect("query restored row");
+    let value: String = row.get(0);
+    assert_eq!(value, "instance-pit-payload");
+}

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -32,7 +32,7 @@ fn rand_id() -> String {
     )
 }
 
-fn xml_response(action: &str, inner: String, request_id: &str) -> AwsResponse {
+pub(crate) fn xml_response(action: &str, inner: String, request_id: &str) -> AwsResponse {
     let body = format!(
         r#"<{action}Response xmlns="{NS}">
   <{action}Result>
@@ -219,6 +219,12 @@ impl RdsService {
             }
 
             // ── DB Cluster snapshots ──
+            // CreateDBClusterSnapshot is implemented in service.rs because
+            // the real path needs the async runtime to dump the writer's
+            // database. We keep a metadata-only fallback here for unit
+            // tests that exercise the extras handler directly without a
+            // runtime wired up; the dispatcher in `RdsService::handle_request`
+            // routes the action through the async path before reaching us.
             "CreateDBClusterSnapshot" => {
                 let id = get_param(req, "DBClusterSnapshotIdentifier")
                     .ok_or_else(|| missing("DBClusterSnapshotIdentifier"))?;
@@ -1177,6 +1183,10 @@ impl RdsService {
                     .get("DBClusterIdentifier")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                let pending_dump_b64 = snapshot
+                    .get("DumpDataB64")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
                 let mut entry = state
                     .extras
                     .get("clusters")
@@ -1203,6 +1213,16 @@ impl RdsService {
                         json!(format!("{target}.cluster-ro-xxx.{region}.rds.amazonaws.com")),
                     );
                     obj.remove("ReplicationSourceIdentifier");
+                    // The new cluster starts empty; the user is expected
+                    // to call CreateDBInstance with DBClusterIdentifier
+                    // pointing here, at which point we replay the dump.
+                    obj.remove("DBClusterMembers");
+                    obj.remove("WriterDBInstanceIdentifier");
+                    // Drop snapshot bookkeeping that leaked in via the
+                    // source-cluster clone path.
+                    obj.remove("DBClusterSnapshotIdentifier");
+                    obj.remove("DBClusterSnapshotArn");
+                    obj.remove("DumpDataB64");
                     if let Some(engine) = get_param(req, "Engine") {
                         obj.insert("Engine".to_string(), json!(engine));
                     }
@@ -1211,6 +1231,12 @@ impl RdsService {
                     }
                     if let Some(port) = get_param(req, "Port").and_then(|p| p.parse::<i64>().ok()) {
                         obj.insert("Port".to_string(), json!(port));
+                    }
+                    // Stage the snapshot dump so the next CreateDBInstance
+                    // joining this cluster replays the data into its
+                    // fresh container.
+                    if let Some(b64) = pending_dump_b64 {
+                        obj.insert("PendingRestoreDumpB64".to_string(), json!(b64));
                     }
                 }
                 store(&mut state.extras, "clusters").insert(target.clone(), entry);
@@ -1229,6 +1255,9 @@ impl RdsService {
                     &rid,
                 ))
             }
+            // Sync metadata-only fallback for RestoreDBClusterToPointInTime;
+            // the dispatcher in `handle_request` routes the action to the
+            // async path that also dumps and stages the source writer.
             "RestoreDBClusterToPointInTime" => {
                 let target = get_param(req, "DBClusterIdentifier")
                     .ok_or_else(|| missing("DBClusterIdentifier"))?;
@@ -1261,6 +1290,8 @@ impl RdsService {
                         "ReaderEndpoint".to_string(),
                         json!(format!("{target}.cluster-ro-xxx.{region}.rds.amazonaws.com")),
                     );
+                    obj.remove("DBClusterMembers");
+                    obj.remove("WriterDBInstanceIdentifier");
                     if let Some(restore_time) = get_param(req, "RestoreToTime") {
                         obj.insert("RestoreToTime".to_string(), json!(restore_time));
                     }
@@ -2151,7 +2182,7 @@ fn switchover_read_replica_action(
 
 // ── XML helpers per resource ──
 
-fn db_cluster_xml(id: &str, arn: &str) -> String {
+pub(crate) fn db_cluster_xml(id: &str, arn: &str) -> String {
     format!(
         "    <DBCluster>\n      <DBClusterIdentifier>{}</DBClusterIdentifier>\n      <DBClusterArn>{}</DBClusterArn>\n      <Status>available</Status>\n    </DBCluster>",
         xml_escape(id), xml_escape(arn)
@@ -2353,7 +2384,7 @@ fn db_cluster_member_xml(v: &Value) -> String {
     out
 }
 
-fn cluster_snapshot_xml(id: &str, arn: &str, cluster: &str) -> String {
+pub(crate) fn cluster_snapshot_xml(id: &str, arn: &str, cluster: &str) -> String {
     format!(
         "    <DBClusterSnapshot>\n      <DBClusterSnapshotIdentifier>{}</DBClusterSnapshotIdentifier>\n      <DBClusterSnapshotArn>{}</DBClusterSnapshotArn>\n      <DBClusterIdentifier>{}</DBClusterIdentifier>\n      <Status>available</Status>\n    </DBClusterSnapshot>",
         xml_escape(id), xml_escape(arn), xml_escape(cluster),
@@ -3325,6 +3356,7 @@ mod tests {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: None,
             },
         );
         // Replica points at source.
@@ -3393,6 +3425,7 @@ mod tests {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: None,
             },
         );
     }
@@ -4160,6 +4193,7 @@ mod tests {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: None,
             },
         );
     }

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -267,6 +267,13 @@ impl RdsService {
         self
     }
 
+    /// Crate-internal accessor for the optional runtime; needed by the
+    /// extras handler so cluster snapshot/restore paths can dump and
+    /// replay member databases via the live container runtime.
+    pub(crate) fn runtime_ref(&self) -> Option<&Arc<RdsRuntime>> {
+        self.runtime.as_ref()
+    }
+
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
         self
@@ -411,6 +418,11 @@ impl AwsService for RdsService {
             "RestoreDBInstanceFromS3" => self.restore_db_instance_from_s3(&request).await,
             "DescribeDBLogFiles" => self.describe_db_log_files(&request).await,
             "DownloadDBLogFilePortion" => self.download_db_log_file_portion(&request).await,
+            "CreateDBClusterSnapshot" => self.create_db_cluster_snapshot(&request).await,
+            "RestoreDBClusterFromSnapshot" => self.restore_db_cluster_from_snapshot(&request).await,
+            "RestoreDBClusterToPointInTime" => {
+                self.restore_db_cluster_to_point_in_time(&request).await
+            }
             _ => self.handle_extra_action(&request),
         };
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
@@ -489,6 +501,7 @@ impl RdsService {
         )?;
         let copy_tags_to_snapshot =
             parse_optional_bool(optional_query_param(request, "CopyTagsToSnapshot").as_deref())?;
+        let db_cluster_identifier = optional_query_param(request, "DBClusterIdentifier");
 
         validate_create_request(
             &db_instance_identifier,
@@ -604,6 +617,7 @@ impl RdsService {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: db_cluster_identifier.clone(),
             };
             state.finish_instance_creation(placeholder.clone());
             placeholder
@@ -628,11 +642,13 @@ impl RdsService {
             let engine_version = engine_version.clone();
             let master_username = master_username.clone();
             let master_user_password = master_user_password.clone();
+            let logical_db_name_task = logical_db_name.clone();
             let account_id = request.account_id.clone();
             let region = request.region.clone();
             let arn = instance_arn.clone();
             let snapshot_store = self.snapshot_store.clone();
             let snapshot_lock = self.snapshot_lock.clone();
+            let cluster_id_for_attach = db_cluster_identifier.clone();
             tokio::spawn(async move {
                 match runtime
                     .ensure_postgres(
@@ -641,13 +657,54 @@ impl RdsService {
                         &engine_version,
                         &master_username,
                         &master_user_password,
-                        &logical_db_name,
+                        &logical_db_name_task,
                         &account_id,
                         &region,
                     )
                     .await
                 {
                     Ok(running) => {
+                        // If the cluster has a pending restore dump
+                        // staged by RestoreDBClusterFromSnapshot /
+                        // RestoreDBClusterToPointInTime, drain it and
+                        // replay onto this fresh instance. We do this
+                        // before flipping status to available so the
+                        // first read of "available" sees restored data.
+                        let pending_dump = if let Some(ref cid) = cluster_id_for_attach {
+                            let mut accounts = state_handle.write();
+                            let state = accounts.get_or_create(&account_id);
+                            state
+                                .extras
+                                .get_mut("clusters")
+                                .and_then(|m| m.get_mut(cid))
+                                .and_then(|entry| entry.as_object_mut())
+                                .and_then(|obj| obj.remove("PendingRestoreDumpB64"))
+                                .and_then(|v| v.as_str().map(str::to_string))
+                                .and_then(|b64| {
+                                    use base64::Engine;
+                                    base64::engine::general_purpose::STANDARD
+                                        .decode(b64.as_bytes())
+                                        .ok()
+                                })
+                        } else {
+                            None
+                        };
+                        if let Some(dump) = pending_dump {
+                            if let Err(error) = runtime
+                                .restore_database(
+                                    &id,
+                                    &engine,
+                                    &master_username,
+                                    &master_user_password,
+                                    &logical_db_name_task,
+                                    &dump,
+                                )
+                                .await
+                            {
+                                tracing::error!(%error, db_instance_identifier=%id, "cluster restore dump replay failed");
+                            }
+                        }
+
                         {
                             let mut accounts = state_handle.write();
                             let state = accounts.get_or_create(&account_id);
@@ -657,6 +714,11 @@ impl RdsService {
                                 inst.port = i32::from(running.host_port);
                                 inst.host_port = running.host_port;
                                 inst.container_id = running.container_id;
+                            }
+                            // Register as cluster member so failover /
+                            // restore paths can find the writer.
+                            if let Some(ref cid) = cluster_id_for_attach {
+                                attach_cluster_member(state, cid, &id);
                             }
                         }
                         // Persist the flipped status. Without this the
@@ -2543,6 +2605,400 @@ impl RdsService {
         ))
     }
 
+    /// Real CreateDBClusterSnapshot: locates the cluster's writer
+    /// member, dumps its database synchronously via the runtime, and
+    /// stores the dump alongside the snapshot's metadata so a later
+    /// RestoreDBClusterFromSnapshot can replay the exact state.
+    async fn create_db_cluster_snapshot(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        use serde_json::json;
+        let snapshot_id = required_query_param(request, "DBClusterSnapshotIdentifier")?;
+        let cluster_id = required_query_param(request, "DBClusterIdentifier")?;
+        let arn = format!(
+            "arn:aws:rds:{}:{}:cluster-snapshot:{}",
+            request.region, request.account_id, snapshot_id
+        );
+
+        let writer_info = {
+            let accounts = self.state.read();
+            accounts.get(&request.account_id).and_then(|state| {
+                let cluster_entry = state.extras.get("clusters")?.get(&cluster_id)?;
+                let writer_id = cluster_entry
+                    .get("WriterDBInstanceIdentifier")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        cluster_entry
+                            .get("DBClusterMembers")
+                            .and_then(|m| m.as_array())
+                            .and_then(|arr| {
+                                arr.iter()
+                                    .find(|m| m["IsClusterWriter"].as_bool() == Some(true))
+                                    .or_else(|| arr.first())
+                                    .and_then(|m| m["DBInstanceIdentifier"].as_str())
+                                    .map(str::to_string)
+                            })
+                    })?;
+                let inst = state.instances.get(&writer_id)?;
+                Some((
+                    inst.db_instance_identifier.clone(),
+                    inst.engine.clone(),
+                    inst.master_username.clone(),
+                    inst.master_user_password.clone(),
+                    inst.db_name
+                        .clone()
+                        .unwrap_or_else(|| default_db_name(&inst.engine).to_string()),
+                ))
+            })
+        };
+
+        let dump_b64 = if let Some((wid, eng, user, pass, db)) = writer_info {
+            if let Some(runtime) = self.runtime_ref() {
+                match runtime.dump_database(&wid, &eng, &user, &pass, &db).await {
+                    Ok(data) => {
+                        use base64::Engine;
+                        Some(base64::engine::general_purpose::STANDARD.encode(&data))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            cluster = %cluster_id,
+                            writer = %wid,
+                            "cluster snapshot dump failed; falling back to metadata-only snapshot"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let mut entry = state
+                .extras
+                .get("clusters")
+                .and_then(|m| m.get(&cluster_id))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert(
+                    "DBClusterSnapshotIdentifier".to_string(),
+                    json!(snapshot_id),
+                );
+                obj.insert("DBClusterSnapshotArn".to_string(), json!(arn));
+                obj.insert("DBClusterIdentifier".to_string(), json!(cluster_id));
+                obj.insert("Status".to_string(), json!("available"));
+                obj.insert("SnapshotType".to_string(), json!("manual"));
+                if let Some(b64) = dump_b64.as_ref() {
+                    obj.insert("DumpDataB64".to_string(), json!(b64));
+                }
+            }
+            state
+                .extras
+                .entry("cluster_snapshots".to_string())
+                .or_default()
+                .insert(snapshot_id.clone(), entry);
+        }
+
+        self.emit_event(
+            RdsSourceType::DbClusterSnapshot,
+            &snapshot_id,
+            &arn,
+            "RDS-EVENT-0074",
+            &["backup"],
+            "DB cluster snapshot created",
+        );
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml(
+                "CreateDBClusterSnapshot",
+                RDS_NS,
+                &crate::extras::cluster_snapshot_xml(&snapshot_id, &arn, &cluster_id),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    /// Real RestoreDBClusterFromSnapshot: clones the source cluster's
+    /// metadata into the new cluster id, strips member tracking so the
+    /// restored cluster starts empty, and stages the snapshot's dump
+    /// data on the new cluster so the next CreateDBInstance with this
+    /// cluster id replays it onto the fresh writer.
+    async fn restore_db_cluster_from_snapshot(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        use serde_json::json;
+        let target = required_query_param(request, "DBClusterIdentifier")?;
+        let snapshot_id = optional_query_param(request, "SnapshotIdentifier")
+            .or_else(|| optional_query_param(request, "DBClusterSnapshotIdentifier"))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MissingParameter",
+                    "SnapshotIdentifier is required",
+                )
+            })?;
+        let arn = format!(
+            "arn:aws:rds:{}:{}:cluster:{}",
+            request.region, request.account_id, target
+        );
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let snapshot = state
+            .extras
+            .get("cluster_snapshots")
+            .and_then(|m| m.get(&snapshot_id))
+            .cloned()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBClusterSnapshotNotFoundFault",
+                    format!("DBClusterSnapshot {snapshot_id} not found."),
+                )
+            })?;
+        let source_cluster_id = snapshot
+            .get("DBClusterIdentifier")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let pending_dump_b64 = snapshot
+            .get("DumpDataB64")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let mut entry = state
+            .extras
+            .get("clusters")
+            .and_then(|m| m.get(&source_cluster_id))
+            .cloned()
+            .unwrap_or_else(|| {
+                json!({
+                    "Engine": optional_query_param(request, "Engine").unwrap_or_else(|| "aurora-postgresql".to_string()),
+                    "EngineVersion": optional_query_param(request, "EngineVersion").unwrap_or_else(|| "15.3".to_string()),
+                    "MasterUsername": "postgres",
+                    "Port": 5432,
+                })
+            });
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert("DBClusterIdentifier".to_string(), json!(target));
+            obj.insert("DBClusterArn".to_string(), json!(arn));
+            obj.insert("Status".to_string(), json!("available"));
+            obj.insert(
+                "Endpoint".to_string(),
+                json!(format!(
+                    "{target}.cluster-xxx.{}.rds.amazonaws.com",
+                    request.region
+                )),
+            );
+            obj.insert(
+                "ReaderEndpoint".to_string(),
+                json!(format!(
+                    "{target}.cluster-ro-xxx.{}.rds.amazonaws.com",
+                    request.region
+                )),
+            );
+            obj.remove("ReplicationSourceIdentifier");
+            obj.remove("DBClusterMembers");
+            obj.remove("WriterDBInstanceIdentifier");
+            obj.remove("DBClusterSnapshotIdentifier");
+            obj.remove("DBClusterSnapshotArn");
+            obj.remove("DumpDataB64");
+            if let Some(engine) = optional_query_param(request, "Engine") {
+                obj.insert("Engine".to_string(), json!(engine));
+            }
+            if let Some(version) = optional_query_param(request, "EngineVersion") {
+                obj.insert("EngineVersion".to_string(), json!(version));
+            }
+            if let Some(port) =
+                optional_query_param(request, "Port").and_then(|p| p.parse::<i64>().ok())
+            {
+                obj.insert("Port".to_string(), json!(port));
+            }
+            if let Some(b64) = pending_dump_b64 {
+                obj.insert("PendingRestoreDumpB64".to_string(), json!(b64));
+            }
+        }
+        state
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(target.clone(), entry);
+        drop(accounts);
+
+        self.emit_event(
+            RdsSourceType::DbCluster,
+            &target,
+            &arn,
+            "RDS-EVENT-0170",
+            &["creation"],
+            "DB cluster restored from snapshot",
+        );
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml(
+                "RestoreDBClusterFromSnapshot",
+                RDS_NS,
+                &crate::extras::db_cluster_xml(&target, &arn),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    /// Real RestoreDBClusterToPointInTime: dumps the source cluster's
+    /// writer live, clones the source cluster's metadata to the new
+    /// id, and stages the dump on the new cluster so the first
+    /// CreateDBInstance attached to it replays the data.
+    async fn restore_db_cluster_to_point_in_time(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        use serde_json::json;
+        let target = required_query_param(request, "DBClusterIdentifier")?;
+        let source = required_query_param(request, "SourceDBClusterIdentifier")?;
+        let arn = format!(
+            "arn:aws:rds:{}:{}:cluster:{}",
+            request.region, request.account_id, target
+        );
+
+        let writer_info = {
+            let accounts = self.state.read();
+            accounts.get(&request.account_id).and_then(|state| {
+                let cluster_entry = state.extras.get("clusters")?.get(&source)?;
+                let writer_id = cluster_entry
+                    .get("WriterDBInstanceIdentifier")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        cluster_entry
+                            .get("DBClusterMembers")
+                            .and_then(|m| m.as_array())
+                            .and_then(|arr| {
+                                arr.iter()
+                                    .find(|m| m["IsClusterWriter"].as_bool() == Some(true))
+                                    .or_else(|| arr.first())
+                                    .and_then(|m| m["DBInstanceIdentifier"].as_str())
+                                    .map(str::to_string)
+                            })
+                    })?;
+                let inst = state.instances.get(&writer_id)?;
+                Some((
+                    inst.db_instance_identifier.clone(),
+                    inst.engine.clone(),
+                    inst.master_username.clone(),
+                    inst.master_user_password.clone(),
+                    inst.db_name
+                        .clone()
+                        .unwrap_or_else(|| default_db_name(&inst.engine).to_string()),
+                ))
+            })
+        };
+
+        let pending_dump_b64 = if let Some((wid, eng, user, pass, db)) = writer_info {
+            if let Some(runtime) = self.runtime_ref() {
+                match runtime.dump_database(&wid, &eng, &user, &pass, &db).await {
+                    Ok(data) => {
+                        use base64::Engine;
+                        Some(base64::engine::general_purpose::STANDARD.encode(&data))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            cluster = %source,
+                            writer = %wid,
+                            "cluster PIT dump failed; falling back to metadata-only restore"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let mut entry = state
+            .extras
+            .get("clusters")
+            .and_then(|m| m.get(&source))
+            .cloned()
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "DBClusterNotFoundFault",
+                    format!("DBCluster {source} not found."),
+                )
+            })?;
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert("DBClusterIdentifier".to_string(), json!(target));
+            obj.insert("DBClusterArn".to_string(), json!(arn));
+            obj.insert("Status".to_string(), json!("available"));
+            obj.insert(
+                "Endpoint".to_string(),
+                json!(format!(
+                    "{target}.cluster-xxx.{}.rds.amazonaws.com",
+                    request.region
+                )),
+            );
+            obj.insert(
+                "ReaderEndpoint".to_string(),
+                json!(format!(
+                    "{target}.cluster-ro-xxx.{}.rds.amazonaws.com",
+                    request.region
+                )),
+            );
+            obj.remove("DBClusterMembers");
+            obj.remove("WriterDBInstanceIdentifier");
+            if let Some(restore_time) = optional_query_param(request, "RestoreToTime") {
+                obj.insert("RestoreToTime".to_string(), json!(restore_time));
+            }
+            if let Some(latest) = optional_query_param(request, "UseLatestRestorableTime") {
+                obj.insert("UseLatestRestorableTime".to_string(), json!(latest));
+            }
+            if let Some(b64) = pending_dump_b64 {
+                obj.insert("PendingRestoreDumpB64".to_string(), json!(b64));
+            }
+        }
+        state
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(target.clone(), entry);
+        drop(accounts);
+
+        self.emit_event(
+            RdsSourceType::DbCluster,
+            &target,
+            &arn,
+            "RDS-EVENT-0171",
+            &["creation"],
+            "DB cluster restored to point in time",
+        );
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml(
+                "RestoreDBClusterToPointInTime",
+                RDS_NS,
+                &crate::extras::db_cluster_xml(&target, &arn),
+                &request.request_id,
+            ),
+        ))
+    }
+
     async fn describe_db_log_files(
         &self,
         request: &AwsRequest,
@@ -3368,6 +3824,50 @@ fn map_log_file_to_container_path(engine: &str, log_file_name: &str) -> String {
 pub(crate) struct PaginationResult<T> {
     items: Vec<T>,
     next_marker: Option<String>,
+}
+
+/// Attach `instance_id` to the cluster's `DBClusterMembers` array,
+/// promoting it to writer when the cluster has none. Idempotent:
+/// re-attaching an existing member is a no-op.
+fn attach_cluster_member(state: &mut RdsState, cluster_id: &str, instance_id: &str) {
+    use serde_json::{json, Value};
+    let Some(map) = state.extras.get_mut("clusters") else {
+        return;
+    };
+    let Some(entry) = map.get_mut(cluster_id) else {
+        return;
+    };
+    let Some(obj) = entry.as_object_mut() else {
+        return;
+    };
+    let mut members: Vec<Value> = obj
+        .get("DBClusterMembers")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if members
+        .iter()
+        .any(|m| m["DBInstanceIdentifier"].as_str() == Some(instance_id))
+    {
+        return;
+    }
+    let has_writer = members
+        .iter()
+        .any(|m| m["IsClusterWriter"].as_bool() == Some(true));
+    let promotion_tier = (members.len() as i64) + 1;
+    members.push(json!({
+        "DBInstanceIdentifier": instance_id,
+        "IsClusterWriter": !has_writer,
+        "DBClusterParameterGroupStatus": "in-sync",
+        "PromotionTier": promotion_tier,
+    }));
+    obj.insert("DBClusterMembers".to_string(), Value::Array(members));
+    if !has_writer {
+        obj.insert(
+            "WriterDBInstanceIdentifier".to_string(),
+            Value::String(instance_id.to_string()),
+        );
+    }
 }
 
 #[path = "service_helpers.rs"]

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -534,6 +534,7 @@ pub(crate) fn build_restored_instance(
         domain_iam_role_name: None,
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
+        db_cluster_identifier: None,
     }
 }
 
@@ -617,6 +618,7 @@ pub(crate) fn build_s3_restored_instance(
         domain_iam_role_name: None,
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
+        db_cluster_identifier: None,
     }
 }
 
@@ -694,6 +696,7 @@ pub(crate) fn build_pit_restored_instance(
         domain_iam_role_name: source.domain_iam_role_name.clone(),
         domain_auth_secret_arn: source.domain_auth_secret_arn.clone(),
         domain_dns_ips: source.domain_dns_ips.clone(),
+        db_cluster_identifier: source.db_cluster_identifier.clone(),
     }
 }
 
@@ -773,6 +776,7 @@ pub(crate) fn build_read_replica_instance(
         domain_iam_role_name: source.domain_iam_role_name.clone(),
         domain_auth_secret_arn: source.domain_auth_secret_arn.clone(),
         domain_dns_ips: source.domain_dns_ips.clone(),
+        db_cluster_identifier: source.db_cluster_identifier.clone(),
     }
 }
 

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -207,6 +207,7 @@ fn db_instance_xml_renders_endpoint_and_status() {
         domain_iam_role_name: None,
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
+        db_cluster_identifier: None,
     };
 
     let xml = db_instance_xml(&instance, Some("creating"));
@@ -388,6 +389,7 @@ fn make_instance_with_defaults(id: &str) -> DbInstance {
         domain_iam_role_name: None,
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
+        db_cluster_identifier: None,
     }
 }
 
@@ -665,6 +667,7 @@ fn seed_instance(svc: &RdsService, identifier: &str) -> String {
             domain_iam_role_name: None,
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
+            db_cluster_identifier: None,
         },
     );
     arn
@@ -2582,6 +2585,7 @@ async fn save_snapshot_static_persists_status_flip_from_bg_task() {
             domain_iam_role_name: None,
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
+            db_cluster_identifier: None,
         }
     }
 

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -130,6 +130,11 @@ pub struct DbInstance {
     pub domain_auth_secret_arn: Option<String>,
     #[serde(default)]
     pub domain_dns_ips: Vec<String>,
+    /// Aurora cluster the instance is a member of, when set. Mirrors
+    /// `DBClusterIdentifier` on CreateDBInstance / RestoreDB* requests so
+    /// snapshot/restore paths can find the writer for a given cluster.
+    #[serde(default)]
+    pub db_cluster_identifier: Option<String>,
 }
 
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -969,6 +974,7 @@ mod tests {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: None,
             },
         );
 
@@ -1114,6 +1120,7 @@ mod tests {
             domain_iam_role_name: None,
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
+            db_cluster_identifier: None,
         }
     }
 

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -392,6 +392,7 @@ mod tests {
             domain_iam_role_name: None,
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
+            db_cluster_identifier: None,
         };
 
         let response = rds_instance_response(&instance);

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -647,6 +647,7 @@ mod tests {
                 domain_iam_role_name: None,
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
+                db_cluster_identifier: None,
             },
         );
 


### PR DESCRIPTION
## Summary

- Cluster snapshot now dumps the writer's database via the runtime and stores the result as base64; restore stages the dump on the new cluster so the first instance attached replays it
- RestoreDBClusterToPointInTime takes a live dump from the source writer and stages it the same way
- CreateDBInstance honors DBClusterIdentifier: registers the instance as a member and drains any pending cluster restore dump before status flips to available
- Adds db_cluster_identifier to DbInstance (#[serde(default)]) so cluster membership rides through state

## Test plan

- [x] cargo check + cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo test -p fakecloud-rds: 205 unit tests pass
- [x] cargo build --workspace --all-targets succeeds
- [ ] CI runs new e2e tests: rds_restore_db_instance_to_point_in_time_clones_data, rds_restore_db_cluster_from_snapshot_recovers_data, rds_restore_db_cluster_to_point_in_time_clones_data (each writes rows through real Postgres, snapshots/PIT-clones, then re-queries through the new instance to confirm the data survived)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes RDS cluster snapshot and PIT restores actually move data by dumping the writer and staging/replaying it via the runtime. `CreateDBInstance` now honors `DBClusterIdentifier`, joins the cluster, and replays any pending dump before it becomes available.

- **New Features**
  - Real `CreateDBClusterSnapshot`: dumps the writer’s database and stores it base64-encoded with the snapshot.
  - Real `RestoreDBClusterFromSnapshot` and `RestoreDBClusterToPointInTime`: clone cluster metadata, stage dump as `PendingRestoreDumpB64`, and let the first `CreateDBInstance` replay it.
  - `CreateDBInstance` honors `DBClusterIdentifier`: registers the instance as a cluster member and drains any staged dump before reporting `available`; adds `db_cluster_identifier` to `DbInstance` and wires it through CloudFormation.
  - Added e2e tests proving data survives for instance PIT, cluster snapshot restore, and cluster PIT with real Postgres.

<sup>Written for commit 54060b58ebbf5ec6eac6a23758195f4fb0de2e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

