### PR TITLE
feat(ses): real DKIM signing on outgoing emails (X4)

### DIFF
--- a/crates/fakecloud-e2e/tests/ses_dkim.rs
+++ b/crates/fakecloud-e2e/tests/ses_dkim.rs
@@ -1,0 +1,454 @@
+//! End-to-end coverage for SES DKIM signing.
+//!
+//! Real SES stamps a `DKIM-Signature` header onto every outgoing message
+//! whose `From` domain has signing enabled. The signature is computed
+//! over the message headers + body using relaxed/relaxed canonicalization
+//! and RSA-SHA256 (RFC 6376), and a downstream verifier resolves the
+//! public key via the `<selector>._domainkey.<domain>` TXT record. These
+//! tests verify the same end-to-end path: enable DKIM, send a message,
+//! pull the stored email back via introspection, then verify the
+//! signature against the public key fakecloud generated.
+
+mod helpers;
+
+use aws_sdk_ses::types::RawMessage;
+use aws_sdk_sesv2::types::{Body, Content, Destination, EmailContent, Message};
+use base64::Engine;
+use helpers::TestServer;
+use rsa::pkcs1v15::{Signature, VerifyingKey};
+use rsa::pkcs8::DecodePublicKey;
+use rsa::signature::Verifier;
+use rsa::RsaPublicKey;
+use sha2::{Digest, Sha256};
+
+/// Re-implementation of the verifier side of relaxed/relaxed
+/// canonicalization so the test trusts only the signature math, not the
+/// helpers it shares with the producer side.
+fn canonicalize_header_value(value: &str) -> String {
+    let unfolded = value.replace("\r\n", "\n");
+    let mut out = String::with_capacity(unfolded.len());
+    let mut prev_ws = false;
+    for c in unfolded.chars() {
+        if c == ' ' || c == '\t' || c == '\n' {
+            if !prev_ws {
+                out.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+fn canonicalize_header(name: &str, value: &str) -> String {
+    format!(
+        "{}:{}\r\n",
+        name.to_lowercase(),
+        canonicalize_header_value(value)
+    )
+}
+
+fn canonicalize_body(body: &str) -> String {
+    let normalized = body.replace("\r\n", "\n").replace('\r', "\n");
+    let mut lines: Vec<String> = normalized
+        .split('\n')
+        .map(|line| {
+            let mut out = String::with_capacity(line.len());
+            let mut prev_ws = false;
+            for c in line.chars() {
+                if c == ' ' || c == '\t' {
+                    if !prev_ws {
+                        out.push(' ');
+                    }
+                    prev_ws = true;
+                } else {
+                    out.push(c);
+                    prev_ws = false;
+                }
+            }
+            out.trim_end().to_string()
+        })
+        .collect();
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    if lines.is_empty() {
+        String::new()
+    } else {
+        let mut out = lines.join("\r\n");
+        out.push_str("\r\n");
+        out
+    }
+}
+
+/// Parse the `tag=value;` list out of a DKIM-Signature header value.
+fn parse_dkim_tags(value: &str) -> std::collections::HashMap<String, String> {
+    let mut tags = std::collections::HashMap::new();
+    for raw in value.split(';') {
+        let part = raw.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if let Some((k, v)) = part.split_once('=') {
+            tags.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    tags
+}
+
+#[tokio::test]
+async fn ses_dkim_signature_verifies_against_published_public_key() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    // Verify the sender's domain identity. The v2 surface auto-generates
+    // an Easy DKIM keypair on create, so signing is wired without a
+    // follow-up PutEmailIdentityDkimAttributes.
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    // Force-enable signing through the public attribute API the way real
+    // callers do — exercises the same code path as flipping it on later.
+    client
+        .put_email_identity_dkim_attributes()
+        .email_identity("example.com")
+        .signing_enabled(true)
+        .send()
+        .await
+        .unwrap();
+
+    // Send a simple email.
+    let resp = client
+        .send_email()
+        .from_email_address("alice@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("hello dkim").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(
+                                    Content::builder()
+                                        .data("the body of the message")
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let message_id = resp.message_id().unwrap().to_string();
+
+    // Pull the stored emails out of the introspection endpoint.
+    let http = reqwest::Client::new();
+    let emails: serde_json::Value = http
+        .get(format!("{}/_fakecloud/ses/emails", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let stored = emails["emails"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["messageId"] == message_id)
+        .unwrap();
+
+    // The DKIM signature value is exposed both as a top-level field and
+    // as the first entry in the synthesized headers list.
+    let dkim_value = stored["dkimSignature"].as_str().unwrap();
+    assert!(dkim_value.contains("v=1"));
+    assert!(dkim_value.contains("a=rsa-sha256"));
+    assert!(dkim_value.contains("c=relaxed/relaxed"));
+    assert!(dkim_value.contains("d=example.com"));
+    let headers = stored["headers"].as_array().unwrap();
+    assert_eq!(
+        headers[0][0].as_str().unwrap(),
+        "DKIM-Signature",
+        "DKIM-Signature must be the first stamped header"
+    );
+    assert_eq!(headers[0][1].as_str().unwrap(), dkim_value);
+
+    // Pull the published public DKIM key.
+    let dkim_pub: serde_json::Value = http
+        .get(format!(
+            "{}/_fakecloud/ses/identities/example.com/dkim-public-key",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(dkim_pub["signingEnabled"], true);
+    let pub_b64 = dkim_pub["publicKeyBase64"].as_str().unwrap();
+    let pub_der = base64::engine::general_purpose::STANDARD
+        .decode(pub_b64.as_bytes())
+        .unwrap();
+    let pub_key = RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+    let verifying_key: VerifyingKey<Sha256> = VerifyingKey::new(pub_key);
+
+    // Reconstruct the signing input: every header listed in `h=`,
+    // canonicalized + concatenated, then the DKIM-Signature header
+    // itself with `b=` set to empty and no trailing CRLF.
+    let tags = parse_dkim_tags(dkim_value);
+    let signed_names = tags["h"].clone();
+    let mut block = String::new();
+    let header_map: std::collections::HashMap<String, String> = headers
+        .iter()
+        .skip(1) // skip DKIM-Signature itself
+        .map(|pair| {
+            (
+                pair[0].as_str().unwrap().to_lowercase(),
+                pair[1].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    for name in signed_names.split(':') {
+        let value = header_map
+            .get(name)
+            .unwrap_or_else(|| panic!("header '{name}' listed in h= but not stored"));
+        block.push_str(&canonicalize_header(name, value));
+    }
+    let b_idx = dkim_value.rfind("b=").unwrap();
+    let unsigned = &dkim_value[..b_idx + 2];
+    block.push_str(&format!(
+        "dkim-signature:{}",
+        canonicalize_header_value(unsigned)
+    ));
+
+    // Decode the b= tag (the raw RSA signature).
+    let raw_b = dkim_value[b_idx + 2..].to_string();
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(raw_b.as_bytes())
+        .unwrap();
+    let signature = Signature::try_from(sig_bytes.as_slice()).unwrap();
+
+    verifying_key
+        .verify(block.as_bytes(), &signature)
+        .expect("DKIM signature must verify against the published public key");
+
+    // Body hash check: bh= must match SHA-256 of the relaxed-canonical body.
+    let body_text = stored["textBody"].as_str().unwrap();
+    let canonical_body = canonicalize_body(body_text);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_body.as_bytes());
+    let expected_bh = base64::engine::general_purpose::STANDARD.encode(hasher.finalize());
+    assert_eq!(
+        tags["bh"], expected_bh,
+        "bh= must match SHA-256(relaxed(body))"
+    );
+}
+
+#[tokio::test]
+async fn ses_dkim_skipped_when_signing_disabled() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    // Flip signing OFF for the sending domain.
+    client
+        .put_email_identity_dkim_attributes()
+        .email_identity("example.com")
+        .signing_enabled(false)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .send_email()
+        .from_email_address("alice@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@example.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("no dkim").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("plain").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let emails: serde_json::Value = http
+        .get(format!("{}/_fakecloud/ses/emails", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let stored = &emails["emails"][0];
+    assert!(
+        stored["dkimSignature"].is_null(),
+        "dkimSignature must be absent when signing is disabled"
+    );
+    assert!(stored["headers"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn ses_v1_dkim_signs_send_raw_email() {
+    let server = TestServer::start().await;
+    let client = server.ses_client().await;
+
+    // VerifyDomainDkim auto-generates the Easy DKIM keypair so that the
+    // very next SendRawEmail call stamps a real DKIM-Signature.
+    client
+        .verify_domain_identity()
+        .domain("example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .verify_domain_dkim()
+        .domain("example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .set_identity_dkim_enabled()
+        .identity("example.com")
+        .dkim_enabled(true)
+        .send()
+        .await
+        .unwrap();
+    client
+        .verify_email_identity()
+        .email_address("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let raw =
+        b"From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: hi\r\n\r\nbody\r\n";
+    client
+        .send_raw_email()
+        .raw_message(
+            RawMessage::builder()
+                .data(aws_smithy_types::Blob::new(raw.to_vec()))
+                .build()
+                .unwrap(),
+        )
+        .source("sender@example.com")
+        .destinations("recipient@example.com")
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let emails: serde_json::Value = http
+        .get(format!("{}/_fakecloud/ses/emails", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let stored = &emails["emails"][0];
+    let dkim = stored["dkimSignature"]
+        .as_str()
+        .expect("v1 SendRawEmail must produce a DKIM-Signature when signing is enabled");
+    assert!(dkim.contains("d=example.com"));
+    assert!(dkim.contains("c=relaxed/relaxed"));
+}
+
+/// Switching DKIM signing on via the public attribute API must lazily
+/// generate the Easy DKIM keypair if no caller-supplied key was loaded
+/// yet — otherwise SendEmail would silently skip signing despite
+/// `dkim_signing_enabled = true`.
+#[tokio::test]
+async fn ses_put_dkim_attributes_lazily_provisions_easy_dkim_key() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    // Domain identity created with signing already enabled at create
+    // time has a key. Disable, then re-enable: the existing key should
+    // be retained, not regenerated.
+    client
+        .create_email_identity()
+        .email_identity("example.com")
+        .send()
+        .await
+        .unwrap();
+    let http = reqwest::Client::new();
+    let url = format!(
+        "{}/_fakecloud/ses/identities/example.com/dkim-public-key",
+        server.endpoint()
+    );
+    let initial: serde_json::Value = http.get(&url).send().await.unwrap().json().await.unwrap();
+    let initial_pub = initial["publicKeyBase64"].as_str().unwrap().to_string();
+    assert!(!initial_pub.is_empty());
+
+    client
+        .put_email_identity_dkim_attributes()
+        .email_identity("example.com")
+        .signing_enabled(false)
+        .send()
+        .await
+        .unwrap();
+    client
+        .put_email_identity_dkim_attributes()
+        .email_identity("example.com")
+        .signing_enabled(true)
+        .send()
+        .await
+        .unwrap();
+    let after_toggle: serde_json::Value =
+        http.get(&url).send().await.unwrap().json().await.unwrap();
+    assert_eq!(
+        after_toggle["publicKeyBase64"].as_str().unwrap(),
+        initial_pub,
+        "toggling signing should not rotate the Easy DKIM key"
+    );
+    assert_eq!(after_toggle["signingEnabled"], true);
+}

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -120,6 +120,11 @@ pub struct SentEmail {
     pub template_data: Option<String>,
     #[serde(default)]
     pub dkim_signature: Option<String>,
+    /// Synthesized RFC 5322 headers stamped onto the message at send
+    /// time. When DKIM is on, the first entry is `DKIM-Signature`. Each
+    /// pair is `(name, value)`.
+    #[serde(default)]
+    pub headers: Vec<(String, String)>,
     pub timestamp: String,
 }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2752,6 +2752,7 @@ async fn main() {
                             template_name: email.template_name.clone(),
                             template_data: email.template_data.clone(),
                             dkim_signature: email.dkim_signature.clone(),
+                            headers: email.headers.clone(),
                             timestamp: email.timestamp.to_rfc3339(),
                         })
                         .collect();
@@ -2801,6 +2802,31 @@ async fn main() {
                         axum::Json(serde_json::json!({
                             "identity": name,
                             "mailFromDomainStatus": body.status,
+                        })),
+                    )
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ses/identities/{name}/dkim-public-key",
+            axum::routing::get({
+                let ss = ses_emails_state.clone();
+                move |axum::extract::Path(name): axum::extract::Path<String>| async move {
+                    let mas = ss.read();
+                    let state = mas.default_ref();
+                    let Some(identity) = state.identities.get(&name) else {
+                        return (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "identity not found"})),
+                        );
+                    };
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(serde_json::json!({
+                            "identity": name,
+                            "selector": identity.dkim_domain_signing_selector,
+                            "publicKeyBase64": identity.dkim_public_key_b64,
+                            "signingEnabled": identity.dkim_signing_enabled,
                         })),
                     )
                 }
@@ -3065,6 +3091,7 @@ async fn main() {
                                     template_name: None,
                                     template_data: None,
                                     dkim_signature: None,
+                                    headers: Vec::new(),
                                     timestamp: chrono::Utc::now(),
                                 };
                                 {
@@ -6004,6 +6031,7 @@ impl fakecloud_core::delivery::EmailDispatcher for SesEmailDispatcher {
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: chrono::Utc::now(),
         });
     }
@@ -6050,6 +6078,7 @@ impl fakecloud_core::delivery::SesSendEmailDispatcher for SesSendEmailDispatcher
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: chrono::Utc::now(),
         });
         Ok(())

--- a/crates/fakecloud-ses/src/dkim.rs
+++ b/crates/fakecloud-ses/src/dkim.rs
@@ -2,10 +2,11 @@
 //!
 //! When an `EmailIdentity` has DKIM enabled and a private key configured,
 //! every email sent through that identity gets a `DKIM-Signature` header
-//! computed over the message headers + body using simple/simple
-//! canonicalization with RSA-SHA256. Real receivers can verify against
-//! the matching public key (Easy DKIM publishes generated public keys via
-//! the per-identity `DkimTokens`; BYODKIM uses the caller-supplied key).
+//! computed over the message headers + body using relaxed/relaxed
+//! canonicalization (RFC 6376 §3.4.2/§3.4.4) with RSA-SHA256. Real
+//! verifiers can validate against the matching public key (Easy DKIM
+//! publishes generated public keys via the per-identity `DkimTokens`;
+//! BYODKIM uses the caller-supplied key).
 
 use base64::Engine;
 use rsa::pkcs1::DecodeRsaPrivateKey;
@@ -42,7 +43,8 @@ pub fn generate_easy_dkim_keypair() -> (String, String) {
 
 /// Sign the given message and return a fully-formed `DKIM-Signature`
 /// header value (without the leading `DKIM-Signature: ` prefix). Returns
-/// `None` when the private key cannot be parsed.
+/// `None` when the private key cannot be parsed. Uses relaxed/relaxed
+/// canonicalization per RFC 6376 §3.4.2 / §3.4.4.
 pub fn sign_message(
     private_key_pem: &str,
     domain: &str,
@@ -53,7 +55,7 @@ pub fn sign_message(
     let priv_key = parse_private_key(private_key_pem)?;
     let signing_key = SigningKey::<Sha256>::new(priv_key);
 
-    let canonical_body = canonicalize_body_simple(body);
+    let canonical_body = canonicalize_body_relaxed(body);
     let mut body_hasher = Sha256::new();
     body_hasher.update(canonical_body.as_bytes());
     let bh = base64::engine::general_purpose::STANDARD.encode(body_hasher.finalize());
@@ -70,13 +72,15 @@ pub fn sign_message(
 
     let mut header_block = String::new();
     for (h, v) in &signed_headers {
-        header_block.push_str(&format!("{}: {}\r\n", h, v.trim()));
+        header_block.push_str(&canonicalize_header_relaxed(h, v));
     }
     let dkim_unsigned = format!(
-        "v=1; a=rsa-sha256; c=simple/simple; d={}; s={}; h={}; bh={}; b=",
+        "v=1; a=rsa-sha256; c=relaxed/relaxed; d={}; s={}; h={}; bh={}; b=",
         domain, selector, header_list, bh
     );
-    header_block.push_str(&format!("DKIM-Signature: {}", dkim_unsigned));
+    // The signing input includes the canonicalized DKIM-Signature header
+    // itself with an empty `b=` tag and NO trailing CRLF (RFC 6376 §3.7).
+    header_block.push_str(&canonicalize_dkim_signature_for_signing(&dkim_unsigned));
 
     let signature = signing_key.sign(header_block.as_bytes());
     let b = base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
@@ -88,6 +92,18 @@ pub fn sign_message(
 /// is enabled and a key is on file. Returns `None` if no matching identity
 /// has DKIM signing wired.
 pub fn signature_for_sent_email(state: &SesState, sent: &SentEmail) -> Option<String> {
+    signed_headers_for_sent_email(state, sent).map(|(sig, _)| sig)
+}
+
+/// Variant of [`signature_for_sent_email`] that also returns the full
+/// header block we stamped onto the message: the `DKIM-Signature`
+/// header followed by the synthesized `From`/`To`/`Subject`/`Date`/
+/// `Message-ID` lines that were covered by the signature. Returns
+/// `None` when DKIM signing is disabled or no key is on file.
+pub fn signed_headers_for_sent_email(
+    state: &SesState,
+    sent: &SentEmail,
+) -> Option<(String, Vec<(String, String)>)> {
     let address = address_part(&sent.from);
     let domain = address.split('@').nth(1)?;
     let identity = state
@@ -113,7 +129,7 @@ pub fn signature_for_sent_email(state: &SesState, sent: &SentEmail) -> Option<St
         .timestamp
         .format("%a, %d %b %Y %H:%M:%S +0000")
         .to_string();
-    let headers = vec![
+    let signed_headers = vec![
         ("From".to_string(), sent.from.clone()),
         ("To".to_string(), to_header),
         (
@@ -126,7 +142,11 @@ pub fn signature_for_sent_email(state: &SesState, sent: &SentEmail) -> Option<St
             format!("<{}@fakecloud.local>", sent.message_id),
         ),
     ];
-    sign_message(private_key, domain, selector, &headers, &body_text)
+    let signature = sign_message(private_key, domain, selector, &signed_headers, &body_text)?;
+    let mut all_headers = Vec::with_capacity(signed_headers.len() + 1);
+    all_headers.push(("DKIM-Signature".to_string(), signature.clone()));
+    all_headers.extend(signed_headers);
+    Some((signature, all_headers))
 }
 
 fn address_part(from: &str) -> String {
@@ -144,14 +164,80 @@ fn parse_private_key(pem: &str) -> Option<RsaPrivateKey> {
         .or_else(|| RsaPrivateKey::from_pkcs1_pem(pem).ok())
 }
 
-fn canonicalize_body_simple(body: &str) -> String {
+/// Relaxed body canonicalization per RFC 6376 §3.4.4:
+/// - normalize line endings to CRLF
+/// - reduce all WSP sequences within a line to a single SP
+/// - strip trailing WSP from each line
+/// - strip trailing empty lines
+/// - if the body is non-empty, terminate with a single CRLF
+fn canonicalize_body_relaxed(body: &str) -> String {
     let normalized = body.replace("\r\n", "\n").replace('\r', "\n");
-    let trimmed = normalized.trim_end_matches('\n');
-    if trimmed.is_empty() {
-        "\r\n".to_string()
-    } else {
-        format!("{}\r\n", trimmed.replace('\n', "\r\n"))
+    let mut lines: Vec<String> = normalized
+        .split('\n')
+        .map(|line| {
+            let mut out = String::with_capacity(line.len());
+            let mut prev_ws = false;
+            for c in line.chars() {
+                if c == ' ' || c == '\t' {
+                    if !prev_ws {
+                        out.push(' ');
+                    }
+                    prev_ws = true;
+                } else {
+                    out.push(c);
+                    prev_ws = false;
+                }
+            }
+            out.trim_end().to_string()
+        })
+        .collect();
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
     }
+    if lines.is_empty() {
+        String::new()
+    } else {
+        let mut out = lines.join("\r\n");
+        out.push_str("\r\n");
+        out
+    }
+}
+
+/// Relaxed header canonicalization per RFC 6376 §3.4.2 for a single
+/// header, returning the line terminated by CRLF. Header name is
+/// lowercased; whitespace within the value is collapsed to a single
+/// SP and trailing WSP is stripped.
+fn canonicalize_header_relaxed(name: &str, value: &str) -> String {
+    let canonical_value = canonicalize_header_value_relaxed(value);
+    format!("{}:{}\r\n", name.to_lowercase(), canonical_value)
+}
+
+fn canonicalize_header_value_relaxed(value: &str) -> String {
+    // Unfold first (CRLF + WSP -> single SP per the spec).
+    let unfolded = value.replace("\r\n", "\n");
+    let mut out = String::with_capacity(unfolded.len());
+    let mut prev_ws = false;
+    for c in unfolded.chars() {
+        if c == ' ' || c == '\t' || c == '\n' {
+            if !prev_ws {
+                out.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Canonicalize the DKIM-Signature header for inclusion in the signing
+/// input: uses the relaxed header rules, but the value is supplied
+/// already-formatted with an empty `b=` tag and no trailing CRLF
+/// (RFC 6376 §3.7).
+fn canonicalize_dkim_signature_for_signing(unsigned_value: &str) -> String {
+    let canonical_value = canonicalize_header_value_relaxed(unsigned_value);
+    format!("dkim-signature:{}", canonical_value)
 }
 
 #[cfg(test)]
@@ -185,6 +271,7 @@ mod tests {
         let sig = sign_message(&pem, "example.com", "sel1", &headers, "hello world").unwrap();
         assert!(sig.contains("v=1"));
         assert!(sig.contains("a=rsa-sha256"));
+        assert!(sig.contains("c=relaxed/relaxed"));
         assert!(sig.contains("d=example.com"));
         assert!(sig.contains("s=sel1"));
         assert!(sig.contains("h=from:to:subject:date:message-id"));
@@ -199,9 +286,73 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_body_simple_normalizes_line_endings() {
-        assert_eq!(canonicalize_body_simple(""), "\r\n");
-        assert_eq!(canonicalize_body_simple("a"), "a\r\n");
-        assert_eq!(canonicalize_body_simple("a\nb\n\n\n"), "a\r\nb\r\n");
+    fn canonicalize_body_relaxed_normalizes_whitespace_and_endings() {
+        assert_eq!(canonicalize_body_relaxed(""), "");
+        assert_eq!(canonicalize_body_relaxed("a"), "a\r\n");
+        assert_eq!(canonicalize_body_relaxed("a\nb\n\n\n"), "a\r\nb\r\n");
+        // collapses internal WSP runs
+        assert_eq!(canonicalize_body_relaxed("a   b\tc"), "a b c\r\n");
+        // strips trailing WSP per line
+        assert_eq!(canonicalize_body_relaxed("a   \nb"), "a\r\nb\r\n");
+    }
+
+    #[test]
+    fn canonicalize_header_relaxed_lowercases_and_collapses() {
+        assert_eq!(
+            canonicalize_header_relaxed("From", "  Alice  <a@b.com>  "),
+            "from:Alice <a@b.com>\r\n"
+        );
+        assert_eq!(
+            canonicalize_header_relaxed("Subject", "  hello   world  "),
+            "subject:hello world\r\n"
+        );
+    }
+
+    #[test]
+    fn signed_signature_verifies_against_generated_public_key() {
+        use rsa::pkcs1v15::{Signature, VerifyingKey};
+        use rsa::pkcs8::DecodePublicKey;
+        use rsa::signature::Verifier;
+
+        let (pem, pub_b64) = generate_easy_dkim_keypair();
+        let headers = vec![
+            ("From".to_string(), "alice@example.com".to_string()),
+            ("To".to_string(), "bob@example.com".to_string()),
+            ("Subject".to_string(), "hello".to_string()),
+            (
+                "Date".to_string(),
+                "Mon, 01 Jan 2024 00:00:00 +0000".to_string(),
+            ),
+            ("Message-ID".to_string(), "<x@example.com>".to_string()),
+        ];
+        let body = "hello world\r\n";
+        let sig_value = sign_message(&pem, "example.com", "sel1", &headers, body).unwrap();
+
+        // Reconstruct the signing input the same way sign_message does.
+        let mut block = String::new();
+        for (h, v) in &headers {
+            block.push_str(&canonicalize_header_relaxed(h, v));
+        }
+        // Strip the b=<sig> tail off the DKIM-Signature value to recover
+        // the unsigned form.
+        let b_idx = sig_value.rfind("b=").unwrap();
+        let unsigned = &sig_value[..b_idx + 2];
+        block.push_str(&canonicalize_dkim_signature_for_signing(unsigned));
+
+        // Decode the b= tag to get the raw signature bytes.
+        let raw_b = sig_value[b_idx + 2..].to_string();
+        let sig_bytes = base64::engine::general_purpose::STANDARD
+            .decode(raw_b.as_bytes())
+            .unwrap();
+        let signature = Signature::try_from(sig_bytes.as_slice()).unwrap();
+
+        // Decode the public key from the SPKI DER we exposed.
+        let pub_der = base64::engine::general_purpose::STANDARD
+            .decode(pub_b64.as_bytes())
+            .unwrap();
+        let pub_key = RsaPublicKey::from_public_key_der(&pub_der).unwrap();
+        let verifying_key: VerifyingKey<Sha256> = VerifyingKey::new(pub_key);
+
+        verifying_key.verify(block.as_bytes(), &signature).unwrap();
     }
 }

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -395,6 +395,7 @@ mod tests {
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
         let event = build_ses_event(SesEventType::Send, &email);
@@ -419,6 +420,7 @@ mod tests {
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
         let event = build_ses_event(SesEventType::Bounce, &email);
@@ -442,6 +444,7 @@ mod tests {
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
         let event = build_ses_event(SesEventType::Delivery, &email);
@@ -465,6 +468,7 @@ mod tests {
             template_name: None,
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
         let event = build_ses_event(SesEventType::Complaint, &email);

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -426,6 +426,21 @@ impl SesV2Service {
         if let Some(enabled) = body["SigningEnabled"].as_bool() {
             identity.dkim_signing_enabled = enabled;
         }
+        // Lazily provision an Easy DKIM keypair the moment signing is
+        // enabled if no caller-supplied key is on file. Mirrors how real
+        // SES auto-generates the per-identity keypair on enable so the
+        // next SendEmail can stamp a real DKIM-Signature.
+        if identity.dkim_signing_enabled && identity.dkim_domain_signing_private_key.is_none() {
+            let (priv_pem, pub_b64) = crate::dkim::generate_easy_dkim_keypair();
+            identity.dkim_domain_signing_private_key = Some(priv_pem);
+            identity.dkim_public_key_b64 = Some(pub_b64);
+            if identity.dkim_domain_signing_selector.is_none() {
+                identity.dkim_domain_signing_selector = Some("fakecloudses".to_string());
+            }
+            if identity.dkim_next_signing_key_length.is_none() {
+                identity.dkim_next_signing_key_length = Some("RSA_2048_BIT".to_string());
+            }
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -451,6 +451,7 @@ impl SesV2Service {
             template_name: Some(template_name),
             template_data: None,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
 

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -90,10 +90,14 @@ impl SesV2Service {
         super::templates::render_template(template, data_str)
     }
 
-    fn compute_dkim_signature(&self, account_id: &str, sent: &SentEmail) -> Option<String> {
+    fn compute_dkim_signature(
+        &self,
+        account_id: &str,
+        sent: &SentEmail,
+    ) -> Option<(String, Vec<(String, String)>)> {
         let accounts = self.state.read();
         let state = accounts.get(account_id)?;
-        crate::dkim::signature_for_sent_email(state, sent)
+        crate::dkim::signed_headers_for_sent_email(state, sent)
     }
 
     /// Reject the send if either account-level sending or the resolved
@@ -355,13 +359,18 @@ impl SesV2Service {
             template_name,
             template_data,
             dkim_signature: None,
+            headers: Vec::new(),
             timestamp: Utc::now(),
         };
 
-        let dkim_signature = self.compute_dkim_signature(&req.account_id, &sent);
-        let sent = SentEmail {
-            dkim_signature,
-            ..sent
+        let signed = self.compute_dkim_signature(&req.account_id, &sent);
+        let sent = match signed {
+            Some((sig, hdrs)) => SentEmail {
+                dkim_signature: Some(sig),
+                headers: hdrs,
+                ..sent
+            },
+            None => sent,
         };
 
         // Event fanout: check suppression list, generate events, deliver to destinations
@@ -497,12 +506,17 @@ impl SesV2Service {
                 template_name,
                 template_data,
                 dkim_signature: None,
+                headers: Vec::new(),
                 timestamp: Utc::now(),
             };
-            let dkim_signature = self.compute_dkim_signature(&req.account_id, &sent);
-            let sent = SentEmail {
-                dkim_signature,
-                ..sent
+            let signed = self.compute_dkim_signature(&req.account_id, &sent);
+            let sent = match signed {
+                Some((sig, hdrs)) => SentEmail {
+                    dkim_signature: Some(sig),
+                    headers: hdrs,
+                    ..sent
+                },
+                None => sent,
             };
 
             // Event fanout for each bulk entry

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -94,6 +94,13 @@ pub struct SentEmail {
     /// DKIM not configured.
     #[serde(default)]
     pub dkim_signature: Option<String>,
+    /// Synthesized RFC 5322-style headers for the stored message. When
+    /// DKIM signing is active the `DKIM-Signature` header is the first
+    /// entry, ahead of the `From`/`To`/`Subject`/`Date`/`Message-ID`
+    /// headers covered by the signature. Empty for messages stored
+    /// before DKIM was wired up.
+    #[serde(default)]
+    pub headers: Vec<(String, String)>,
     pub timestamp: DateTime<Utc>,
 }
 

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -779,7 +779,8 @@ pub(crate) fn verify_domain_dkim(
     // Ensure identity exists
     let mut accounts = state.write();
     let st = accounts.get_or_create(&req.account_id);
-    st.identities
+    let id = st
+        .identities
         .entry(domain.to_string())
         .or_insert_with(|| EmailIdentity {
             identity_name: domain.to_string(),
@@ -798,6 +799,12 @@ pub(crate) fn verify_domain_dkim(
             mail_from_domain_status: "NotStarted".to_string(),
             configuration_set_name: None,
         });
+    // VerifyDomainDkim is the moment SES tells you "ok, I generated DKIM
+    // keys, here are the CNAMEs you must publish". Lazily create the
+    // keypair the first time the action runs so SendRawEmail can stamp
+    // a signature without a follow-up SetIdentityDkimEnabled call.
+    id.dkim_signing_enabled = true;
+    ensure_easy_dkim_keypair(id);
     // Return 3 DKIM tokens
     let mut inner = String::from("<DkimTokens>");
     for _ in 0..3 {
@@ -968,8 +975,32 @@ pub(crate) fn set_identity_dkim_enabled(
     let st = accounts.get_or_create(&req.account_id);
     if let Some(id) = st.identities.get_mut(identity) {
         id.dkim_signing_enabled = enabled;
+        ensure_easy_dkim_keypair(id);
     }
     Ok(xml_metadata_only("SetIdentityDkimEnabled", &req.request_id))
+}
+
+/// Lazily provision the Easy DKIM keypair for `id` when signing is
+/// enabled but no caller-supplied key is on file. Mirrors how real SES
+/// auto-generates the per-identity keypair the moment DKIM signing is
+/// switched on. No-op when the identity already has a key (Easy or
+/// BYODKIM) or when signing is disabled.
+fn ensure_easy_dkim_keypair(id: &mut EmailIdentity) {
+    if !id.dkim_signing_enabled {
+        return;
+    }
+    if id.dkim_domain_signing_private_key.is_some() {
+        return;
+    }
+    let (priv_pem, pub_b64) = crate::dkim::generate_easy_dkim_keypair();
+    id.dkim_domain_signing_private_key = Some(priv_pem);
+    id.dkim_public_key_b64 = Some(pub_b64);
+    if id.dkim_domain_signing_selector.is_none() {
+        id.dkim_domain_signing_selector = Some("fakecloudses".to_string());
+    }
+    if id.dkim_next_signing_key_length.is_none() {
+        id.dkim_next_signing_key_length = Some("RSA_2048_BIT".to_string());
+    }
 }
 
 pub(crate) fn set_identity_notification_topic(
@@ -1225,6 +1256,7 @@ pub(crate) fn send_email(
         template_name: None,
         template_data: None,
         dkim_signature: None,
+        headers: Vec::new(),
         timestamp: Utc::now(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
@@ -1250,15 +1282,19 @@ fn sign_sent_email(
     _region: &str,
     sent: SentEmail,
 ) -> SentEmail {
-    let dkim_signature = {
+    let signed = {
         let accounts = state.read();
         accounts
             .get(account_id)
-            .and_then(|st| crate::dkim::signature_for_sent_email(st, &sent))
+            .and_then(|st| crate::dkim::signed_headers_for_sent_email(st, &sent))
     };
-    SentEmail {
-        dkim_signature,
-        ..sent
+    match signed {
+        Some((sig, hdrs)) => SentEmail {
+            dkim_signature: Some(sig),
+            headers: hdrs,
+            ..sent
+        },
+        None => sent,
     }
 }
 
@@ -1298,6 +1334,7 @@ pub(crate) fn send_raw_email(
         template_name: None,
         template_data: None,
         dkim_signature: None,
+        headers: Vec::new(),
         timestamp: Utc::now(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
@@ -1388,6 +1425,7 @@ pub(crate) fn send_templated_email(
         template_name: Some(template_name.to_string()),
         template_data: Some(template_data.to_string()),
         dkim_signature: None,
+        headers: Vec::new(),
         timestamp: Utc::now(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
@@ -1550,6 +1588,7 @@ pub(crate) fn send_bulk_destination(
         template_name: Some(template_name.to_string()),
         template_data: Some(replacement_data),
         dkim_signature: None,
+        headers: Vec::new(),
         timestamp: Utc::now(),
     };
     let sent = sign_sent_email(state, account_id, "", sent);

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -136,18 +136,20 @@ type EvictContainerResponse struct {
 
 // SentEmail represents an email captured by the SES emulator.
 type SentEmail struct {
-	MessageID    string   `json:"messageId"`
-	From         string   `json:"from"`
-	To           []string `json:"to"`
-	CC           []string `json:"cc"`
-	BCC          []string `json:"bcc"`
-	Subject      *string  `json:"subject,omitempty"`
-	HTMLBody     *string  `json:"htmlBody,omitempty"`
-	TextBody     *string  `json:"textBody,omitempty"`
-	RawData      *string  `json:"rawData,omitempty"`
-	TemplateName *string  `json:"templateName,omitempty"`
-	TemplateData *string  `json:"templateData,omitempty"`
-	Timestamp    string   `json:"timestamp"`
+	MessageID     string      `json:"messageId"`
+	From          string      `json:"from"`
+	To            []string    `json:"to"`
+	CC            []string    `json:"cc"`
+	BCC           []string    `json:"bcc"`
+	Subject       *string     `json:"subject,omitempty"`
+	HTMLBody      *string     `json:"htmlBody,omitempty"`
+	TextBody      *string     `json:"textBody,omitempty"`
+	RawData       *string     `json:"rawData,omitempty"`
+	TemplateName  *string     `json:"templateName,omitempty"`
+	TemplateData  *string     `json:"templateData,omitempty"`
+	DKIMSignature *string     `json:"dkimSignature,omitempty"`
+	Headers       [][2]string `json:"headers,omitempty"`
+	Timestamp     string      `json:"timestamp"`
 }
 
 // SESEmailsResponse contains all sent emails.

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -133,6 +133,8 @@ public final class Types {
             String rawData,
             String templateName,
             String templateData,
+            String dkimSignature,
+            List<List<String>> headers,
             String timestamp) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -339,6 +339,9 @@ final class SentEmail
         public readonly ?string $rawData,
         public readonly ?string $templateName,
         public readonly ?string $templateData,
+        public readonly ?string $dkimSignature,
+        /** @var array<int, array{0: string, 1: string}> */
+        public readonly array $headers,
         public readonly string $timestamp,
     ) {}
 
@@ -356,6 +359,8 @@ final class SentEmail
             $data['rawData'] ?? null,
             $data['templateName'] ?? null,
             $data['templateData'] ?? null,
+            $data['dkimSignature'] ?? null,
+            $data['headers'] ?? [],
             $data['timestamp'],
         );
     }

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -301,6 +301,7 @@ class SentEmail:
     dkim_signature: Optional[str] = None
     dkim_domain: Optional[str] = None
     dkim_selector: Optional[str] = None
+    headers: List[List[str]] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> SentEmail:

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -136,6 +136,10 @@ export interface SentEmail {
   rawData: string | null;
   templateName: string | null;
   templateData: string | null;
+  /** DKIM-Signature header value when signing was active for this send. */
+  dkimSignature?: string | null;
+  /** Synthesized RFC 5322 headers (DKIM-Signature first when signing). */
+  headers?: [string, string][];
   timestamp: string;
 }
 

--- a/website/content/docs/services/ses.md
+++ b/website/content/docs/services/ses.md
@@ -10,8 +10,8 @@ fakecloud implements **110 of 110** SES v2 operations at 100% Smithy conformance
 
 ### Sending (SES v2)
 
-- **SendEmail, SendBulkEmail** — recorded at `/_fakecloud/ses/emails`
-- **Identities** — email identity and domain identity CRUD, DKIM, mail-from, feedback attributes, signing attributes
+- **SendEmail, SendBulkEmail** — recorded at `/_fakecloud/ses/emails`, including the stamped `DKIM-Signature` header when signing is enabled
+- **Identities** — email identity and domain identity CRUD, DKIM (real RSA-SHA256 signing with relaxed/relaxed canonicalization), mail-from, feedback attributes, signing attributes
 - **Configuration sets** — CRUD, event destinations, reputation options, sending options, tracking, suppression, VDM, archiving
 - **Templates** — email templates, custom verification templates, test rendering
 - **Contact lists** — CRUD, contacts, subscription topics
@@ -42,7 +42,8 @@ SES v2 uses REST. SES v1 inbound uses Query protocol.
 
 ## Introspection
 
-- `GET /_fakecloud/ses/emails` — list all sent emails with full body, headers, attachments
+- `GET /_fakecloud/ses/emails` — list all sent emails with full body, synthesized headers (DKIM-Signature first when signing was active), attachments
+- `GET /_fakecloud/ses/identities/{name}/dkim-public-key` — pull the published Easy DKIM public key (SPKI DER, base64) so tests can verify signatures end-to-end
 - `POST /_fakecloud/ses/inbound` — simulate receiving an inbound email, trigger receipt rule evaluation
 
 ## Cross-service delivery


### PR DESCRIPTION
## Summary

- SES outgoing messages now carry a real `DKIM-Signature` header when the sending domain identity has signing enabled. Signing uses RSA-SHA256 with relaxed/relaxed canonicalization (RFC 6376) and the per-identity Easy DKIM keypair fakecloud generates, so downstream verifiers can validate against the published public key.
- v1 (`SetIdentityDkimEnabled` / `VerifyDomainDkim`) and v2 (`PutEmailIdentityDkimAttributes`) now lazily provision an Easy DKIM keypair the moment signing is switched on, instead of leaving the identity enabled-but-keyless.
- `SentEmail` gains a synthesized `headers` list (DKIM-Signature first when signing fired); SDK types mirror this across Rust/Go/Java/PHP/Python/TypeScript. New `/_fakecloud/ses/identities/{name}/dkim-public-key` admin endpoint exposes the SPKI DER public key for tests.

## Test plan

- [x] `cargo test -p fakecloud-ses` (233 tests pass, including new dkim canonicalization + verification unit tests)
- [x] `cargo test -p fakecloud-e2e --test ses_dkim` (4 E2E tests pass: signature verifies against published public key, signing skipped when disabled, v1 SendRawEmail signs, lazy key provisioning across enable/disable toggles)
- [x] `cargo clippy -p fakecloud-ses -p fakecloud --no-deps`
- [x] `cargo fmt --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real DKIM signing to outgoing SES emails using RSA-SHA256 with relaxed/relaxed canonicalization, and exposes signed headers and the public key for end-to-end verification.

- **New Features**
  - Stamps a `DKIM-Signature` on `SendEmail`, `SendBulkEmail`, and v1 `SendRawEmail` when the sender domain has signing enabled.
  - Lazily provisions an Easy DKIM keypair when signing is enabled via v2 `PutEmailIdentityDkimAttributes` or v1 `SetIdentityDkimEnabled`/`VerifyDomainDkim`.
  - Adds `SentEmail.headers` with synthesized RFC 5322 headers (DKIM-Signature first) and `dkimSignature` for introspection.
  - New `/_fakecloud/ses/identities/{name}/dkim-public-key` endpoint returns the published SPKI DER public key (base64) and signing status.
  - Updates SDK `SentEmail` types across Rust/Go/Java/PHP/Python/TypeScript to include `dkimSignature` and `headers`.
  - Documents DKIM behavior in SES docs and adds E2E tests that verify signature and body-hash, plus disabled-signing and v1 paths.

<sup>Written for commit 54fc157d666120b1ae38ce91305c59cc77f76694. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

