### PR TITLE
feat(stepfunctions): generic aws-sdk:* integration via service registry (CC1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,7 @@ version = "0.13.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",

--- a/crates/fakecloud-e2e/tests/stepfunctions.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions.rs
@@ -3727,3 +3727,223 @@ async fn sfn_activity_failure_propagates_to_execution() {
     worker.await.unwrap();
     assert_eq!(status, "FAILED");
 }
+
+// --- Generic aws-sdk:* integration tests (CC1) ---
+//
+// These cover the generalised
+// `arn:aws:states:::aws-sdk:<service>:<action>` form that AWS Step
+// Functions supports for ~250 SDK actions, dispatched in fakecloud
+// through the central ServiceRegistry. The legacy `optimized` ARNs
+// (e.g. `arn:aws:states:::dynamodb:getItem`) are exercised above.
+
+#[tokio::test]
+async fn sfn_aws_sdk_dynamodb_get_item() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let ddb = server.dynamodb_client().await;
+
+    ddb.create_table()
+        .table_name("aws-sdk-ddb-table")
+        .attribute_definitions(
+            aws_sdk_dynamodb::types::AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            aws_sdk_dynamodb::types::KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(aws_sdk_dynamodb::types::KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    // Pre-seed an item so the Task's GetItem returns it.
+    ddb.put_item()
+        .table_name("aws-sdk-ddb-table")
+        .item(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("seed-1".to_string()),
+        )
+        .item(
+            "payload",
+            aws_sdk_dynamodb::types::AttributeValue::S("hello-via-aws-sdk".to_string()),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let definition = json!({
+        "StartAt": "Lookup",
+        "States": {
+            "Lookup": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:dynamodb:getItem",
+                "Parameters": {
+                    "TableName": "aws-sdk-ddb-table",
+                    "Key": {"pk": {"S": "seed-1"}}
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("aws-sdk-ddb-getitem-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "SUCCEEDED");
+
+    let desc = sfn
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert_eq!(output["Item"]["pk"]["S"], "seed-1");
+    assert_eq!(output["Item"]["payload"]["S"], "hello-via-aws-sdk");
+}
+
+#[tokio::test]
+async fn sfn_aws_sdk_sqs_send_message() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    let queue = sqs
+        .create_queue()
+        .queue_name("aws-sdk-sqs-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    let definition = json!({
+        "StartAt": "Send",
+        "States": {
+            "Send": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:sqs:sendMessage",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody": "hello-via-aws-sdk-sqs"
+                },
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("aws-sdk-sqs-send-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    let desc = sfn
+        .describe_execution()
+        .execution_arn(start.execution_arn())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        "SUCCEEDED",
+        "execution failed: error={:?} cause={:?}",
+        desc.error(),
+        desc.cause()
+    );
+
+    // Output should carry the SendMessage response (MessageId,
+    // MD5OfMessageBody) and the message must land in SQS.
+    let output: serde_json::Value = serde_json::from_str(desc.output().unwrap_or("{}")).unwrap();
+    assert!(
+        output["MessageId"].is_string(),
+        "expected MessageId in output, got {output:?}"
+    );
+
+    let receive = sqs
+        .receive_message()
+        .queue_url(queue_url)
+        .send()
+        .await
+        .unwrap();
+    let messages = receive.messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].body().unwrap(), "hello-via-aws-sdk-sqs");
+}
+
+#[tokio::test]
+async fn sfn_aws_sdk_unknown_service_fails_task() {
+    // An unmapped `aws-sdk:<service>:<action>` should surface as a
+    // TaskFailed with a States.TaskFailed-style error code, not
+    // crash the interpreter.
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+
+    let definition = json!({
+        "StartAt": "Boom",
+        "States": {
+            "Boom": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:nosuchservice:doNothing",
+                "Parameters": {},
+                "End": true
+            }
+        }
+    })
+    .to_string();
+
+    let create = sfn
+        .create_state_machine()
+        .name("aws-sdk-unknown-sm")
+        .definition(definition)
+        .role_arn("arn:aws:iam::123456789012:role/test-role")
+        .send()
+        .await
+        .unwrap();
+
+    let start = sfn
+        .start_execution()
+        .state_machine_arn(create.state_machine_arn())
+        .input(r#"{}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let status = wait_for_execution(&sfn, start.execution_arn()).await;
+    assert_eq!(status, "FAILED");
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -288,6 +288,16 @@ async fn main() {
         ),
     ));
 
+    // Deferred-fill handle to the central ServiceRegistry. We construct
+    // the cell up front, hand it to StepFunctionsService and the
+    // EventBridge/Scheduler-side StepFunctionsDelivery impls, then
+    // populate it after every service has been registered. The
+    // interpreter snapshots the inner `Arc<ServiceRegistry>` only when
+    // dispatching `arn:aws:states:::aws-sdk:*` Tasks, so unrelated
+    // executions never touch it.
+    let sfn_registry_handle: fakecloud_stepfunctions::SharedServiceRegistry =
+        Arc::new(std::sync::OnceLock::new());
+
     let apigatewayv2_state = Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new(
             &cli.account_id,
@@ -464,11 +474,14 @@ async fn main() {
         if let Some(ref ld) = lambda_delivery {
             sfn_interpreter_bus = sfn_interpreter_bus.with_lambda(ld.clone());
         }
-        Arc::new(stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
-            stepfunctions_state.clone(),
-            Some(Arc::new(sfn_interpreter_bus)),
-            Some(dynamodb_state.clone()),
-        ))
+        Arc::new(
+            stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
+                stepfunctions_state.clone(),
+                Some(Arc::new(sfn_interpreter_bus)),
+                Some(dynamodb_state.clone()),
+            )
+            .with_registry(sfn_registry_handle.clone()),
+        )
     };
 
     let delivery_for_eb = Arc::new(
@@ -2184,7 +2197,8 @@ async fn main() {
     };
     sfn_service = sfn_service
         .with_delivery(sfn_delivery_bus.clone())
-        .with_dynamodb(dynamodb_state.clone());
+        .with_dynamodb(dynamodb_state.clone())
+        .with_registry(sfn_registry_handle.clone());
     let sfn_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
             let data_path = persistence_config
@@ -2511,11 +2525,14 @@ async fn main() {
         if let Some(ref ld) = lambda_delivery {
             sfn_interpreter_bus = sfn_interpreter_bus.with_lambda(ld.clone());
         }
-        Arc::new(stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
-            stepfunctions_state.clone(),
-            Some(Arc::new(sfn_interpreter_bus)),
-            Some(dynamodb_state.clone()),
-        ))
+        Arc::new(
+            stepfunctions_delivery::StepFunctionsDeliveryImpl::new(
+                stepfunctions_state.clone(),
+                Some(Arc::new(sfn_interpreter_bus)),
+                Some(dynamodb_state.clone()),
+            )
+            .with_registry(sfn_registry_handle.clone()),
+        )
     };
     let eb_delivery_for_scheduler = {
         let mut inner = DeliveryBus::new()
@@ -5562,7 +5579,17 @@ async fn main() {
             }),
         )
         .fallback(dispatch::dispatch)
-        .layer(Extension(Arc::new(registry)))
+        .layer({
+            let registry_arc = Arc::new(registry);
+            // Now that every service has been registered, give the
+            // Step Functions interpreter a handle to the finalised
+            // registry so `arn:aws:states:::aws-sdk:*` Tasks can
+            // dispatch back into other services. `set` returns Err
+            // if already populated (only possible on hot reload),
+            // which we silently ignore.
+            let _ = sfn_registry_handle.set(registry_arc.clone());
+            Extension(registry_arc)
+        })
         .layer(Extension(Arc::new(config)))
         .layer(TraceLayer::new_for_http());
 

--- a/crates/fakecloud-server/src/stepfunctions_delivery.rs
+++ b/crates/fakecloud-server/src/stepfunctions_delivery.rs
@@ -4,13 +4,14 @@ use std::sync::Arc;
 
 use fakecloud_core::delivery::{DeliveryBus, StepFunctionsDelivery};
 use fakecloud_dynamodb::SharedDynamoDbState;
-use fakecloud_stepfunctions::SharedStepFunctionsState;
+use fakecloud_stepfunctions::{SharedServiceRegistry, SharedStepFunctionsState};
 
 /// Starts Step Functions executions from cross-service delivery (EventBridge, Scheduler).
 pub struct StepFunctionsDeliveryImpl {
     state: SharedStepFunctionsState,
     delivery: Option<Arc<DeliveryBus>>,
     dynamodb_state: Option<SharedDynamoDbState>,
+    registry: Option<SharedServiceRegistry>,
 }
 
 impl StepFunctionsDeliveryImpl {
@@ -23,7 +24,13 @@ impl StepFunctionsDeliveryImpl {
             state,
             delivery,
             dynamodb_state,
+            registry: None,
         }
+    }
+
+    pub fn with_registry(mut self, registry: SharedServiceRegistry) -> Self {
+        self.registry = Some(registry);
+        self
     }
 }
 
@@ -37,6 +44,7 @@ impl StepFunctionsDelivery for StepFunctionsDeliveryImpl {
             &self.state,
             &self.delivery,
             &self.dynamodb_state,
+            &self.registry,
             state_machine_arn,
             input,
         );

--- a/crates/fakecloud-stepfunctions/Cargo.toml
+++ b/crates/fakecloud-stepfunctions/Cargo.toml
@@ -13,6 +13,7 @@ fakecloud-core = { workspace = true }
 fakecloud-dynamodb = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -12,6 +12,7 @@ use fakecloud_dynamodb::SharedDynamoDbState;
 use crate::choice::evaluate_choice;
 use crate::error_handling::{find_catcher, should_retry};
 use crate::io_processing::{apply_input_path, apply_output_path, apply_result_path};
+use crate::service::SharedServiceRegistry;
 use crate::state::{ExecutionStatus, HistoryEvent, SharedStepFunctionsState};
 
 /// Execute a state machine definition with the given input.
@@ -23,6 +24,7 @@ pub async fn execute_state_machine(
     input: Option<String>,
     delivery: Option<Arc<DeliveryBus>>,
     dynamodb_state: Option<SharedDynamoDbState>,
+    registry: Option<SharedServiceRegistry>,
 ) {
     let def: Value = match serde_json::from_str(&definition) {
         Ok(v) => v,
@@ -64,12 +66,14 @@ pub async fn execute_state_machine(
     let execution_arn_clone = execution_arn.clone();
     let delivery_clone = delivery.clone();
     let dynamodb_state_clone = dynamodb_state.clone();
+    let registry_clone = registry.clone();
     let handle = tokio::spawn(async move {
         run_states(
             &def_owned,
             raw_input,
             &delivery_clone,
             &dynamodb_state_clone,
+            &registry_clone,
             &state_clone,
             &execution_arn_clone,
         )
@@ -161,6 +165,7 @@ async fn run_task_state(
     input: Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Advance {
@@ -180,6 +185,7 @@ async fn run_task_state(
         &input,
         delivery,
         dynamodb_state,
+        registry,
         shared_state,
         execution_arn,
         entered_event_id,
@@ -211,6 +217,7 @@ async fn run_parallel_state(
     input: Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Advance {
@@ -230,6 +237,7 @@ async fn run_parallel_state(
         &input,
         delivery,
         dynamodb_state,
+        registry,
         shared_state,
         execution_arn,
     )
@@ -260,6 +268,7 @@ async fn run_map_state(
     input: Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Advance {
@@ -279,6 +288,7 @@ async fn run_map_state(
         &input,
         delivery,
         dynamodb_state,
+        registry,
         shared_state,
         execution_arn,
     )
@@ -351,11 +361,13 @@ async fn execute_wait_state(state_def: &Value, input: &Value) {
 
 /// Execute a Task state: invoke the resource (Lambda, SQS, SNS, EventBridge, DynamoDB),
 /// apply I/O processing, handle Retry.
+#[allow(clippy::too_many_arguments)]
 async fn execute_task_state(
     state_def: &Value,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
     entered_event_id: i64,
@@ -409,6 +421,8 @@ async fn execute_task_state(
             &task_input,
             delivery,
             dynamodb_state,
+            registry,
+            execution_arn,
             timeout_seconds,
             heartbeat_seconds,
             shared_state,
@@ -476,6 +490,7 @@ async fn execute_parallel_state(
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Result<Value, (String, String)> {
@@ -508,11 +523,12 @@ async fn execute_parallel_state(
         let branch_input = effective_input.clone();
         let delivery = delivery.clone();
         let ddb = dynamodb_state.clone();
+        let reg = registry.clone();
         let state = shared_state.clone();
         let arn = execution_arn.to_string();
 
         handles.push(tokio::spawn(async move {
-            run_states(&branch, branch_input, &delivery, &ddb, &state, &arn).await
+            run_states(&branch, branch_input, &delivery, &ddb, &reg, &state, &arn).await
         }));
     }
 
@@ -560,6 +576,7 @@ async fn execute_map_state(
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     shared_state: &SharedStepFunctionsState,
     execution_arn: &str,
 ) -> Result<Value, (String, String)> {
@@ -605,6 +622,7 @@ async fn execute_map_state(
         let iter_def = iterator_def.clone();
         let delivery = delivery.clone();
         let ddb = dynamodb_state.clone();
+        let reg = registry.clone();
         let state = shared_state.clone();
         let arn = execution_arn.to_string();
         let sem = semaphore.clone();
@@ -632,7 +650,8 @@ async fn execute_map_state(
                 .acquire()
                 .await
                 .map_err(|_| ("States.Runtime".to_string(), "Semaphore closed".to_string()))?;
-            let result = run_states(&iter_def, item_input, &delivery, &ddb, &state, &arn).await;
+            let result =
+                run_states(&iter_def, item_input, &delivery, &ddb, &reg, &state, &arn).await;
             Ok::<(usize, Result<Value, (String, String)>), (String, String)>((index, result))
         }));
     }
@@ -706,6 +725,8 @@ async fn invoke_resource(
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
+    execution_arn: &str,
     timeout_seconds: Option<u64>,
     heartbeat_seconds: Option<u64>,
     shared_state: &SharedStepFunctionsState,
@@ -766,10 +787,189 @@ async fn invoke_resource(
         return invoke_dynamodb_update_item(input, dynamodb_state);
     }
 
+    // Generic AWS SDK integration: arn:aws:states:::aws-sdk:<service>:<action>[.<wait>]
+    // Routes the call to the registered service via the central
+    // ServiceRegistry, passing the Task's `Parameters` block as the
+    // request body. Mirrors the AWS SDK service integration pattern in
+    // real Step Functions.
+    if let Some(rest) = resource.strip_prefix("arn:aws:states:::aws-sdk:") {
+        let account_id = account_from_execution_arn(execution_arn);
+        return invoke_aws_sdk_integration(rest, input, registry, &account_id).await;
+    }
+
     Err((
         "States.TaskFailed".to_string(),
         format!("Unsupported resource: {resource}"),
     ))
+}
+
+/// Convert an SDK integration action (camelCase, e.g. `getItem`) to its
+/// PascalCase wire form (`GetItem`). Step Functions Task ARNs use
+/// camelCase, but the underlying AWS service handlers expect PascalCase
+/// `X-Amz-Target`-style action names.
+fn camel_to_pascal(action: &str) -> String {
+    let mut chars = action.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+/// Map a Step Functions SDK integration service id to the corresponding
+/// fakecloud `service_name()`. Most match 1:1, but a handful of AWS SDK
+/// service ids differ from the SigV4 service identifier we register
+/// services under (e.g. `sfn` -> `states`, `cloudwatchlogs` -> `logs`).
+fn map_sdk_service_id(service_id: &str) -> &str {
+    match service_id {
+        "sfn" => "states",
+        "cloudwatchlogs" => "logs",
+        "elasticloadbalancingv2" => "elasticloadbalancingv2",
+        // Default: pass through unchanged.
+        other => other,
+    }
+}
+
+/// Dispatch a Step Functions `aws-sdk:<service>:<action>` Task to the
+/// registered service via the central [`fakecloud_core::registry::ServiceRegistry`].
+/// `tail` is the trailing portion of the resource ARN after the
+/// `aws-sdk:` prefix (e.g. `dynamodb:getItem` or `sqs:sendMessage.waitForTaskToken`).
+/// Extract the AWS account id from a Step Functions execution ARN
+/// (`arn:aws:states:<region>:<account>:execution:...`). Falls back to
+/// the AWS-conventional fixture id if the ARN is malformed.
+fn account_from_execution_arn(execution_arn: &str) -> String {
+    execution_arn
+        .split(':')
+        .nth(4)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("123456789012")
+        .to_string()
+}
+
+async fn invoke_aws_sdk_integration(
+    tail: &str,
+    input: &Value,
+    registry: &Option<SharedServiceRegistry>,
+    account_id: &str,
+) -> Result<Value, (String, String)> {
+    use bytes::Bytes;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+
+    let registry_handle = registry.as_ref().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "No service registry configured for aws-sdk integration".to_string(),
+        )
+    })?;
+    let registry_arc = registry_handle.get().ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "Service registry not yet initialised; aws-sdk integration unavailable".to_string(),
+        )
+    })?;
+
+    // Split `<service>:<action>[.<modifier>]`. Modifiers like
+    // `.waitForTaskToken` and `.sync` are accepted but ignored — the
+    // integration runs synchronously regardless.
+    let mut parts = tail.splitn(2, ':');
+    let service_id = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Invalid aws-sdk Resource ARN: missing service in '{tail}'"),
+        )
+    })?;
+    let action_with_mod = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Invalid aws-sdk Resource ARN: missing action in '{tail}'"),
+        )
+    })?;
+    let action_camel = action_with_mod
+        .split('.')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            (
+                "States.TaskFailed".to_string(),
+                format!("Invalid aws-sdk Resource ARN: empty action in '{tail}'"),
+            )
+        })?;
+
+    let action_pascal = camel_to_pascal(action_camel);
+    let service_name = map_sdk_service_id(service_id).to_string();
+
+    let service = registry_arc.get(&service_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Unknown aws-sdk service '{service_id}'"),
+        )
+    })?;
+
+    // Serialize the Parameters block as the JSON request body. Most
+    // fakecloud services accept JSON for any action (DynamoDB JSON,
+    // SQS+SNS+SES JSON, EventBridge JSON), so the same encoding works
+    // across the board.
+    let body_bytes = Bytes::from(
+        serde_json::to_vec(input).expect("serde_json::Value serialization is infallible"),
+    );
+
+    let req = AwsRequest {
+        service: service_name.clone(),
+        action: action_pascal.clone(),
+        region: "us-east-1".to_string(),
+        account_id: account_id.to_string(),
+        request_id: uuid::Uuid::new_v4().to_string(),
+        headers: HeaderMap::new(),
+        query_params: std::collections::HashMap::new(),
+        body: body_bytes,
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec![],
+        raw_path: "/".to_string(),
+        raw_query: String::new(),
+        method: Method::POST,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+
+    let response = service.handle(req).await.map_err(|err| {
+        // Surface the AWS error code as the State error so Catch/Retry
+        // can match on it (e.g. `DynamoDb.ResourceNotFoundException`).
+        let code = err.code().to_string();
+        let msg = err.message();
+        let prefix_service = match service_name.as_str() {
+            "dynamodb" => "DynamoDb".to_string(),
+            "states" => "Sfn".to_string(),
+            other => camel_to_pascal(other),
+        };
+        (
+            format!("{prefix_service}.{code}"),
+            format!("{action_pascal} failed: {msg}"),
+        )
+    })?;
+
+    // Read the response body and parse as JSON. Tasks always return JSON.
+    let response_bytes = match response.body {
+        fakecloud_core::service::ResponseBody::Bytes(b) => b,
+        fakecloud_core::service::ResponseBody::File { .. } => {
+            return Err((
+                "States.TaskFailed".to_string(),
+                "aws-sdk integration: file-backed response not supported".to_string(),
+            ));
+        }
+    };
+
+    if response_bytes.is_empty() {
+        return Ok(json!({}));
+    }
+    let parsed: Value = serde_json::from_slice(&response_bytes).map_err(|e| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("aws-sdk integration: failed to parse response JSON: {e}"),
+        )
+    })?;
+
+    Ok(parsed)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -823,16 +823,11 @@ fn map_sdk_service_id(service_id: &str) -> &str {
     match service_id {
         "sfn" => "states",
         "cloudwatchlogs" => "logs",
-        "elasticloadbalancingv2" => "elasticloadbalancingv2",
         // Default: pass through unchanged.
         other => other,
     }
 }
 
-/// Dispatch a Step Functions `aws-sdk:<service>:<action>` Task to the
-/// registered service via the central [`fakecloud_core::registry::ServiceRegistry`].
-/// `tail` is the trailing portion of the resource ARN after the
-/// `aws-sdk:` prefix (e.g. `dynamodb:getItem` or `sqs:sendMessage.waitForTaskToken`).
 /// Extract the AWS account id from a Step Functions execution ARN
 /// (`arn:aws:states:<region>:<account>:execution:...`). Falls back to
 /// the AWS-conventional fixture id if the ARN is malformed.
@@ -845,6 +840,10 @@ fn account_from_execution_arn(execution_arn: &str) -> String {
         .to_string()
 }
 
+/// Dispatch a Step Functions `aws-sdk:<service>:<action>` Task to the
+/// registered service via the central [`fakecloud_core::registry::ServiceRegistry`].
+/// `tail` is the trailing portion of the resource ARN after the
+/// `aws-sdk:` prefix (e.g. `dynamodb:getItem` or `sqs:sendMessage.waitForTaskToken`).
 async fn invoke_aws_sdk_integration(
     tail: &str,
     input: &Value,

--- a/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
@@ -7,6 +7,7 @@ pub(crate) fn run_states<'a>(
     input: Value,
     delivery: &'a Option<Arc<DeliveryBus>>,
     dynamodb_state: &'a Option<SharedDynamoDbState>,
+    registry: &'a Option<crate::service::SharedServiceRegistry>,
     shared_state: &'a SharedStepFunctionsState,
     execution_arn: &'a str,
 ) -> StatesResult<'a> {
@@ -112,6 +113,7 @@ pub(crate) fn run_states<'a>(
                         effective_input,
                         delivery,
                         dynamodb_state,
+                        registry,
                         shared_state,
                         execution_arn,
                     )
@@ -124,6 +126,7 @@ pub(crate) fn run_states<'a>(
                         effective_input,
                         delivery,
                         dynamodb_state,
+                        registry,
                         shared_state,
                         execution_arn,
                     )
@@ -136,6 +139,7 @@ pub(crate) fn run_states<'a>(
                         effective_input,
                         delivery,
                         dynamodb_state,
+                        registry,
                         shared_state,
                         execution_arn,
                     )

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -57,6 +57,7 @@ async fn test_simple_pass_state() {
         Some(r#"{"hello":"world"}"#.to_string()),
         None,
         None,
+        None,
     )
     .await;
 
@@ -101,6 +102,7 @@ async fn test_pass_chain() {
         Some("{}".to_string()),
         None,
         None,
+        None,
     )
     .await;
 
@@ -136,6 +138,7 @@ async fn test_succeed_state() {
         Some(r#"{"data": "value"}"#.to_string()),
         None,
         None,
+        None,
     )
     .await;
 
@@ -163,7 +166,16 @@ async fn test_fail_state() {
     })
     .to_string();
 
-    execute_state_machine(state.clone(), arn.to_string(), definition, None, None, None).await;
+    execute_state_machine(
+        state.clone(),
+        arn.to_string(),
+        definition,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     let __a = state.read();
     let s = __a.default_ref();
@@ -197,6 +209,7 @@ async fn test_history_events_recorded() {
         Some("{}".to_string()),
         None,
         None,
+        None,
     )
     .await;
 
@@ -226,6 +239,7 @@ fn drive(state: &SharedStepFunctionsState, arn: &str, def: Value, input: Option<
         arn.to_string(),
         def.to_string(),
         input.map(|s| s.to_string()),
+        None,
         None,
         None,
     );
@@ -619,6 +633,7 @@ fn invalid_definition_json_fails_execution() {
         state.clone(),
         arn.clone(),
         "not json{".to_string(),
+        None,
         None,
         None,
         None,

--- a/crates/fakecloud-stepfunctions/src/lib.rs
+++ b/crates/fakecloud-stepfunctions/src/lib.rs
@@ -6,7 +6,7 @@ pub mod io_processing;
 pub(crate) mod service;
 pub mod state;
 
-pub use service::{start_execution_from_delivery, StepFunctionsService};
+pub use service::{start_execution_from_delivery, SharedServiceRegistry, StepFunctionsService};
 pub use state::{
     Activity, AliasRoute, SharedStepFunctionsState, StateMachine, StateMachineAlias,
     StateMachineStatus, StateMachineType, StateMachineVersion, StepFunctionsSnapshot,

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::pagination::paginate;
+use fakecloud_core::registry::ServiceRegistry;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_core::validation::*;
 use fakecloud_dynamodb::SharedDynamoDbState;
@@ -61,10 +62,18 @@ const SUPPORTED: &[&str] = &[
     "ValidateStateMachineDefinition",
 ];
 
+/// Handle to the central service registry, set by `main.rs` after every service
+/// has been registered. Wrapped in `OnceLock` so `StepFunctionsService` can be
+/// constructed (and registered into the very registry it later reads back) before
+/// the registry itself is finalized. The interpreter snapshots the inner `Arc`
+/// when it needs to dispatch generic `aws-sdk:*` Task integrations.
+pub type SharedServiceRegistry = Arc<std::sync::OnceLock<Arc<ServiceRegistry>>>;
+
 pub struct StepFunctionsService {
     state: SharedStepFunctionsState,
     delivery: Option<Arc<DeliveryBus>>,
     dynamodb_state: Option<SharedDynamoDbState>,
+    registry: Option<SharedServiceRegistry>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
 }
@@ -75,6 +84,7 @@ impl StepFunctionsService {
             state,
             delivery: None,
             dynamodb_state: None,
+            registry: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
         }
@@ -87,6 +97,15 @@ impl StepFunctionsService {
 
     pub fn with_dynamodb(mut self, dynamodb_state: SharedDynamoDbState) -> Self {
         self.dynamodb_state = Some(dynamodb_state);
+        self
+    }
+
+    /// Hand the service a deferred-fill handle to the central [`ServiceRegistry`].
+    /// `main.rs` calls [`OnceLock::set`] on the inner cell after every service
+    /// has been registered; until then the interpreter falls back to its
+    /// hand-coded SDK integrations (lambda invoke, sqs sendMessage, …).
+    pub fn with_registry(mut self, registry: SharedServiceRegistry) -> Self {
+        self.registry = Some(registry);
         self
     }
 
@@ -493,6 +512,7 @@ impl StepFunctionsService {
         let input_clone = input;
         let delivery = self.delivery.clone();
         let dynamodb_state = self.dynamodb_state.clone();
+        let registry = self.registry.clone();
         tokio::spawn(async move {
             interpreter::execute_state_machine(
                 shared_state,
@@ -501,6 +521,7 @@ impl StepFunctionsService {
                 input_clone,
                 delivery,
                 dynamodb_state,
+                registry,
             )
             .await;
         });
@@ -1666,6 +1687,7 @@ pub fn start_execution_from_delivery(
     state: &SharedStepFunctionsState,
     delivery: &Option<Arc<DeliveryBus>>,
     dynamodb_state: &Option<SharedDynamoDbState>,
+    registry: &Option<SharedServiceRegistry>,
     state_machine_arn: &str,
     input: &str,
 ) {
@@ -1726,6 +1748,7 @@ pub fn start_execution_from_delivery(
     let shared_state = state.clone();
     let delivery = delivery.clone();
     let dynamodb_state = dynamodb_state.clone();
+    let registry = registry.clone();
     let input = Some(input.to_string());
     tokio::spawn(async move {
         interpreter::execute_state_machine(
@@ -1735,6 +1758,7 @@ pub fn start_execution_from_delivery(
             input,
             delivery,
             dynamodb_state,
+            registry,
         )
         .await;
     });


### PR DESCRIPTION
## Summary

- Step Functions Task states with `Resource = "arn:aws:states:::aws-sdk:<service>:<action>"` now dispatch through the central `ServiceRegistry` instead of failing with `UnsupportedResource`.
- The interpreter parses the service id and action from the ARN, PascalCases the action (`getItem` -> `GetItem`), maps the SDK service id to the registered `service_name()` (with `sfn` -> `states` and `cloudwatchlogs` -> `logs` aliases), serialises `Parameters` as JSON, and synthesises an `AwsRequest` dispatched directly to the service handler. The response body is parsed as JSON and returned as Task output, so `ResultPath` / `ResultSelector` / `Catch` / `Retry` all keep working.
- `StepFunctionsService` gains a deferred-fill `SharedServiceRegistry` handle (`Arc<OnceLock<Arc<ServiceRegistry>>>`) so it can be registered into the very registry it later reads back; `main.rs` populates the cell after every service has registered. Both the REST `StartExecution` path and the cross-service `StepFunctionsDelivery` path (EventBridge, Scheduler) propagate the handle.
- This is the same generic SDK integration pattern AWS Step Functions supports for ~250 actions, with the existing optimised ARNs (`arn:aws:states:::sqs:sendMessage`, `arn:aws:states:::dynamodb:getItem`, …) untouched.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` (all crates green, 151 stepfunctions unit tests included)
- [x] `cargo test -p fakecloud-e2e --test stepfunctions` — 66 stepfunctions e2e tests pass, including three new ones:
  - `sfn_aws_sdk_dynamodb_get_item` — pre-seed a table, dispatch `arn:aws:states:::aws-sdk:dynamodb:getItem`, assert the seeded item flows back as Task output
  - `sfn_aws_sdk_sqs_send_message` — dispatch `arn:aws:states:::aws-sdk:sqs:sendMessage`, assert the message lands in SQS and the `MessageId` shows up in the execution output
  - `sfn_aws_sdk_unknown_service_fails_task` — unmapped service id surfaces as `FAILED` (not an interpreter panic)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generic `arn:aws:states:::aws-sdk:<service>:<action>` support in Step Functions by routing requests through the central `ServiceRegistry`. This enables broad AWS SDK-style Task integrations while keeping existing optimized ARNs unchanged.

- **New Features**
  - Task states with `aws-sdk:*` resources are parsed and dispatched via `ServiceRegistry`; the interpreter maps service ids (e.g., `sfn`→`states`, `cloudwatchlogs`→`logs`), converts actions to PascalCase, serializes `Parameters` as JSON, and sends an `AwsRequest`. JSON response bodies are returned as Task output.
  - `StepFunctionsService` now holds a deferred `SharedServiceRegistry` (`Arc<OnceLock<Arc<ServiceRegistry>>>`); `main.rs` sets it after all services register, and both REST `StartExecution` and cross-service `StepFunctionsDelivery` propagate it.
  - Unknown services fail the Task with `FAILED` (no crash). E2E tests cover `dynamodb:getItem`, `sqs:sendMessage`, and unknown service failure.
  - Minor cleanup: doc comment ordering fixed and a redundant Map case removed.

- **Dependencies**
  - Add `bytes` (workspace) for request body handling.

<sup>Written for commit 9dd4730050e615e920d866e1bd51a81db11b2a0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

