### PR TITLE
feat(application-autoscaling): DynamoDB capacity target-tracking + step scaling (EE1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/fakecloud-application-autoscaling/Cargo.toml
+++ b/crates/fakecloud-application-autoscaling/Cargo.toml
@@ -17,6 +17,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/fakecloud-application-autoscaling/src/hooks.rs
+++ b/crates/fakecloud-application-autoscaling/src/hooks.rs
@@ -1,0 +1,73 @@
+//! Cross-service hooks the Application Auto Scaling watcher uses to
+//! observe metrics and apply scaling decisions on real resources.
+//!
+//! Each hook is an in-process trait so we don't introduce a circular
+//! dependency back into the service crates that own the underlying
+//! state (CloudWatch metrics, DynamoDB tables, etc.). The
+//! `fakecloud-server` binary wires concrete impls at startup.
+
+use std::collections::BTreeMap;
+
+/// Reads the latest sample of a CloudWatch metric. Returns `None` when
+/// the metric has no data points or the alarm/metric isn't wired.
+///
+/// `dimensions` matches the AWS metric dimensions exactly (e.g. for
+/// DynamoDB `ReadCapacityUtilization`, `{TableName: "..."}`).
+pub trait MetricReader: Send + Sync {
+    fn latest_sample(
+        &self,
+        account_id: &str,
+        region: &str,
+        namespace: &str,
+        metric_name: &str,
+        dimensions: &BTreeMap<String, String>,
+    ) -> Option<f64>;
+
+    /// Returns the alarm's current state value (`OK` | `ALARM` |
+    /// `INSUFFICIENT_DATA`) so step scaling policies can react when
+    /// their action ARN is configured as an alarm action. Real AWS
+    /// drives step scaling off SNS-style alarm action publishes; we
+    /// poll the alarm state instead because that's what fakecloud
+    /// already records.
+    fn alarm_state(&self, account_id: &str, region: &str, alarm_name: &str) -> Option<String>;
+
+    /// Returns the names of all alarms in the account+region whose
+    /// `AlarmActions` list contains `policy_arn` and whose state is
+    /// currently `ALARM`. Used by step scaling policies, which fire
+    /// when an alarm wired through `PutMetricAlarm` (with the policy
+    /// ARN as an action) breaches its threshold.
+    fn alarms_firing_for_action(
+        &self,
+        account_id: &str,
+        region: &str,
+        policy_arn: &str,
+    ) -> Vec<String>;
+}
+
+/// Applies a capacity change to a DynamoDB table. Used when a scaling
+/// target's `ServiceNamespace == dynamodb`. `dimension` is the AWS
+/// `ScalableDimension` string and selects read vs write capacity.
+pub trait DynamoDbCapacityHook: Send + Sync {
+    /// Returns the table's current provisioned capacity for the given
+    /// dimension, or `None` when the table doesn't exist / isn't on
+    /// PROVISIONED billing mode.
+    fn current_capacity(
+        &self,
+        account_id: &str,
+        region: &str,
+        table_name: &str,
+    ) -> Option<(i64, i64)>;
+
+    /// Sets the table's provisioned capacity. `read` and `write` are
+    /// `Some` only for the dimension that actually changed; the impl
+    /// should preserve the other side. Returns Err on unknown table
+    /// or invalid value so the caller can log a NotScaled activity.
+    fn set_capacity(
+        &self,
+        account_id: &str,
+        region: &str,
+        table_name: &str,
+        read: Option<i64>,
+        write: Option<i64>,
+    ) -> Result<(), String>;
+}

--- a/crates/fakecloud-application-autoscaling/src/lib.rs
+++ b/crates/fakecloud-application-autoscaling/src/lib.rs
@@ -1,5 +1,9 @@
+pub mod hooks;
 pub(crate) mod service;
 pub(crate) mod state;
+pub mod ticker;
 
+pub use hooks::{DynamoDbCapacityHook, MetricReader};
 pub use service::ApplicationAutoScalingService;
 pub use state::{ApplicationAutoScalingAccounts, SharedApplicationAutoScalingState};
+pub use ticker::ScalingWatcher;

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -348,6 +348,7 @@ impl ApplicationAutoScalingService {
                 target_tracking_scaling_policy_configuration: tt_cfg,
                 predictive_scaling_policy_configuration: pred_cfg,
                 alarms: Vec::new(),
+                last_applied_at: None,
             };
             account.scaling_policies.insert(policy_key, policy);
             arn

--- a/crates/fakecloud-application-autoscaling/src/state.rs
+++ b/crates/fakecloud-application-autoscaling/src/state.rs
@@ -72,6 +72,10 @@ pub struct ScalingPolicy {
     pub target_tracking_scaling_policy_configuration: Option<serde_json::Value>,
     pub predictive_scaling_policy_configuration: Option<serde_json::Value>,
     pub alarms: Vec<Alarm>,
+    /// Last time the watcher applied a scale action through this policy.
+    /// Honours the policy's cooldown so we don't thrash capacity.
+    #[serde(default)]
+    pub last_applied_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-application-autoscaling/src/ticker.rs
+++ b/crates/fakecloud-application-autoscaling/src/ticker.rs
@@ -1,0 +1,793 @@
+//! Background watcher that consumes CloudWatch metric samples and
+//! applies scaling decisions to real resources (today: DynamoDB).
+//!
+//! On each tick we walk every scaling policy:
+//!  - `TargetTrackingScaling`: look up the predefined metric, divide
+//!    the latest sample by the configured `TargetValue`, and resize
+//!    the DDB table so utilisation tracks the target. Honours
+//!    `ScaleInCooldown` / `ScaleOutCooldown`.
+//!  - `StepScaling`: poll the configured alarm state. When the alarm
+//!    is in `ALARM`, walk the step adjustments and apply the matching
+//!    one to the DDB table. Honours `Cooldown`.
+//!
+//! Every applied or skipped decision lands as a `ScalingActivity`
+//! row so `DescribeScalingActivities` shows real history.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::hooks::{DynamoDbCapacityHook, MetricReader};
+use crate::state::{
+    NotScaledReason, ScalableTarget, ScalingActivity, ScalingPolicy,
+    SharedApplicationAutoScalingState,
+};
+
+/// AWS dimension strings for DynamoDB capacity scaling targets.
+pub const DDB_READ_DIM: &str = "dynamodb:table:ReadCapacityUnits";
+pub const DDB_WRITE_DIM: &str = "dynamodb:table:WriteCapacityUnits";
+
+/// Predefined CloudWatch metric types Application Auto Scaling knows
+/// for DynamoDB.
+const DDB_READ_METRIC: &str = "DynamoDBReadCapacityUtilization";
+const DDB_WRITE_METRIC: &str = "DynamoDBWriteCapacityUtilization";
+
+/// Default region used to resolve metrics when a target was registered
+/// without a region context. Application Auto Scaling targets are
+/// regional in AWS, but our state only carries the account on the
+/// target itself; the watcher is wired with the server's default
+/// region so DDB lookups still resolve.
+pub struct ScalingWatcher {
+    state: SharedApplicationAutoScalingState,
+    metric_reader: Arc<dyn MetricReader>,
+    ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+    region: String,
+    interval: Duration,
+}
+
+impl ScalingWatcher {
+    pub fn new(
+        state: SharedApplicationAutoScalingState,
+        metric_reader: Arc<dyn MetricReader>,
+        ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+        region: impl Into<String>,
+    ) -> Self {
+        Self {
+            state,
+            metric_reader,
+            ddb_hook,
+            region: region.into(),
+            interval: Duration::from_secs(15),
+        }
+    }
+
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    /// Drive a single tick. Exposed for the admin endpoint and tests so
+    /// callers don't have to wait on the wall-clock interval.
+    pub fn tick_once(&self) -> usize {
+        let mut applied = 0;
+        // Collect (account, policy_clone, target_clone) snapshots first so
+        // we can release the read lock before running the hooks (which may
+        // themselves take other locks via the server wiring).
+        struct Job {
+            account_id: String,
+            policy: ScalingPolicy,
+            target: ScalableTarget,
+            current: i64,
+        }
+        let mut jobs: Vec<Job> = Vec::new();
+        {
+            let guard = self.state.read();
+            for (account_id, account) in guard.accounts.iter() {
+                for policy in account.scaling_policies.values() {
+                    if policy.service_namespace != "dynamodb" {
+                        continue;
+                    }
+                    let key = (
+                        policy.service_namespace.clone(),
+                        policy.resource_id.clone(),
+                        policy.scalable_dimension.clone(),
+                    );
+                    let Some(target) = account.scalable_targets.get(&key) else {
+                        continue;
+                    };
+                    if suspended_for(target, policy) {
+                        continue;
+                    }
+                    let Some(table) = ddb_table_from_resource(&policy.resource_id) else {
+                        continue;
+                    };
+                    let Some((read_cur, write_cur)) =
+                        self.ddb_hook
+                            .current_capacity(account_id, &self.region, table)
+                    else {
+                        continue;
+                    };
+                    let current = match policy.scalable_dimension.as_str() {
+                        DDB_READ_DIM => read_cur,
+                        DDB_WRITE_DIM => write_cur,
+                        _ => continue,
+                    };
+                    jobs.push(Job {
+                        account_id: account_id.clone(),
+                        policy: policy.clone(),
+                        target: target.clone(),
+                        current,
+                    });
+                }
+            }
+        }
+
+        for job in jobs {
+            if self.process_policy(&job.account_id, &job.policy, &job.target, job.current) {
+                applied += 1;
+            }
+        }
+        applied
+    }
+
+    /// Long-running loop that ticks at `self.interval` until the
+    /// process exits.
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.interval);
+        // Skip the immediate first tick — the server is still wiring
+        // services up.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let _ = self.tick_once();
+        }
+    }
+
+    fn process_policy(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+    ) -> bool {
+        match policy.policy_type.as_str() {
+            "TargetTrackingScaling" => {
+                self.process_target_tracking(account_id, policy, target, current)
+            }
+            "StepScaling" => self.process_step_scaling(account_id, policy, target, current),
+            _ => false,
+        }
+    }
+
+    fn process_target_tracking(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+    ) -> bool {
+        let Some(cfg) = policy.target_tracking_scaling_policy_configuration.as_ref() else {
+            return false;
+        };
+        let target_value = cfg.get("TargetValue").and_then(Value::as_f64);
+        let Some(target_value) = target_value else {
+            return false;
+        };
+        if target_value <= 0.0 {
+            return false;
+        }
+        let Some(metric_name) = predefined_metric_for(cfg, &policy.scalable_dimension) else {
+            return false;
+        };
+        let Some(table) = ddb_table_from_resource(&policy.resource_id) else {
+            return false;
+        };
+        let mut dims = BTreeMap::new();
+        dims.insert("TableName".to_string(), table.to_string());
+        let utilisation = self.metric_reader.latest_sample(
+            account_id,
+            &self.region,
+            "AWS/DynamoDB",
+            metric_name,
+            &dims,
+        );
+        let Some(utilisation) = utilisation else {
+            return false;
+        };
+
+        // desired = current * (utilisation / target_value), then
+        // clamped to [min, max] and rounded up so we don't drop below
+        // the bound a fractional capacity implies.
+        let raw = (current as f64) * (utilisation / target_value);
+        let mut desired = raw.ceil() as i64;
+        if desired < target.min_capacity as i64 {
+            desired = target.min_capacity as i64;
+        }
+        if desired > target.max_capacity as i64 {
+            desired = target.max_capacity as i64;
+        }
+        if desired == current {
+            return false;
+        }
+
+        let scale_out = desired > current;
+        let cooldown_secs = cfg
+            .get(if scale_out {
+                "ScaleOutCooldown"
+            } else {
+                "ScaleInCooldown"
+            })
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if let Some(prev) = policy.last_applied_at {
+            if cooldown_secs > 0
+                && Utc::now().signed_duration_since(prev).num_seconds() < cooldown_secs
+            {
+                self.record_cooldown_skip(
+                    account_id,
+                    policy,
+                    target,
+                    current,
+                    desired,
+                    "TargetTracking",
+                );
+                return false;
+            }
+        }
+
+        self.apply_ddb_capacity(
+            account_id,
+            policy,
+            target,
+            current,
+            desired,
+            "TargetTracking",
+        )
+    }
+
+    fn process_step_scaling(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+    ) -> bool {
+        let Some(cfg) = policy.step_scaling_policy_configuration.as_ref() else {
+            return false;
+        };
+        let adjustment_type = cfg
+            .get("AdjustmentType")
+            .and_then(Value::as_str)
+            .unwrap_or("ChangeInCapacity")
+            .to_string();
+        let cooldown_secs = cfg.get("Cooldown").and_then(Value::as_i64).unwrap_or(0);
+
+        // Step scaling fires off CloudWatch alarm transitions. There
+        // are two paths to discover the firing alarm:
+        //   1. `policy.alarms` — populated by tests / future wiring
+        //      where alarms are explicitly attached to the policy.
+        //   2. CloudWatch alarms whose `AlarmActions` list contains
+        //      this policy's ARN — the canonical AWS model: customers
+        //      `PutMetricAlarm` with the policy ARN as an action and
+        //      the alarm transition fires the policy. We resolve that
+        //      via the metric reader to keep this crate decoupled
+        //      from the cloudwatch state.
+        let attached_in_alarm = policy.alarms.iter().any(|a| {
+            self.metric_reader
+                .alarm_state(account_id, &self.region, &a.alarm_name)
+                .as_deref()
+                == Some("ALARM")
+        });
+        let action_alarms_firing =
+            self.metric_reader
+                .alarms_firing_for_action(account_id, &self.region, &policy.arn);
+        if !attached_in_alarm && action_alarms_firing.is_empty() {
+            return false;
+        }
+
+        // Pick the first step adjustment whose lower bound matches.
+        // Real AWS computes a "metric interval" relative to the alarm
+        // threshold; for the fakecloud watcher we approximate with the
+        // configured lower bound (treating the alarm fire itself as
+        // the breach signal).
+        let adjustments = cfg
+            .get("StepAdjustments")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let Some(adj) = adjustments.first() else {
+            return false;
+        };
+        let adjustment = adj
+            .get("ScalingAdjustment")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if adjustment == 0 {
+            return false;
+        }
+        let mut desired = match adjustment_type.as_str() {
+            "ExactCapacity" => adjustment,
+            "PercentChangeInCapacity" => {
+                let pct = adjustment as f64 / 100.0;
+                let delta = (current as f64 * pct).round() as i64;
+                let min_step = cfg
+                    .get("MinAdjustmentMagnitude")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let signed_delta = if delta == 0 && adjustment != 0 {
+                    if adjustment > 0 {
+                        1
+                    } else {
+                        -1
+                    }
+                } else {
+                    delta
+                };
+                let bumped = if signed_delta.abs() < min_step {
+                    if signed_delta >= 0 {
+                        min_step
+                    } else {
+                        -min_step
+                    }
+                } else {
+                    signed_delta
+                };
+                current + bumped
+            }
+            _ => current + adjustment, // ChangeInCapacity
+        };
+        if desired < target.min_capacity as i64 {
+            desired = target.min_capacity as i64;
+        }
+        if desired > target.max_capacity as i64 {
+            desired = target.max_capacity as i64;
+        }
+        if desired == current {
+            return false;
+        }
+        if let Some(prev) = policy.last_applied_at {
+            if cooldown_secs > 0
+                && Utc::now().signed_duration_since(prev).num_seconds() < cooldown_secs
+            {
+                self.record_cooldown_skip(
+                    account_id,
+                    policy,
+                    target,
+                    current,
+                    desired,
+                    "StepScaling",
+                );
+                return false;
+            }
+        }
+
+        self.apply_ddb_capacity(account_id, policy, target, current, desired, "StepScaling")
+    }
+
+    fn apply_ddb_capacity(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+        desired: i64,
+        cause_kind: &str,
+    ) -> bool {
+        let Some(table) = ddb_table_from_resource(&policy.resource_id) else {
+            return false;
+        };
+        let (read, write) = match policy.scalable_dimension.as_str() {
+            DDB_READ_DIM => (Some(desired), None),
+            DDB_WRITE_DIM => (None, Some(desired)),
+            _ => return false,
+        };
+        let now = Utc::now();
+        let result = self
+            .ddb_hook
+            .set_capacity(account_id, &self.region, table, read, write);
+
+        let mut state = self.state.write();
+        let account = state.accounts.entry(account_id.to_string()).or_default();
+        // Refresh the policy's last_applied_at on success so cooldowns
+        // trigger; on failure leave it untouched so the next tick can
+        // retry without waiting for the cooldown.
+        let policy_key = (
+            policy.service_namespace.clone(),
+            policy.resource_id.clone(),
+            policy.scalable_dimension.clone(),
+            policy.policy_name.clone(),
+        );
+        let activity = match result {
+            Ok(()) => {
+                if let Some(p) = account.scaling_policies.get_mut(&policy_key) {
+                    p.last_applied_at = Some(now);
+                }
+                ScalingActivity {
+                    activity_id: Uuid::new_v4().to_string(),
+                    service_namespace: policy.service_namespace.clone(),
+                    resource_id: policy.resource_id.clone(),
+                    scalable_dimension: policy.scalable_dimension.clone(),
+                    description: format!(
+                        "Setting {direction} capacity to {desired} for {res}",
+                        direction = if desired > current { "min" } else { "max" },
+                        res = policy.resource_id,
+                    ),
+                    cause: format!(
+                        "policy {policy_name} ({cause_kind}) applied; previous capacity {current}",
+                        policy_name = policy.policy_name,
+                    ),
+                    start_time: now,
+                    end_time: Some(now),
+                    status_code: "Successful".to_string(),
+                    status_message: Some(format!("Successfully set {desired}")),
+                    details: None,
+                    not_scaled_reasons: Vec::new(),
+                }
+            }
+            Err(err) => ScalingActivity {
+                activity_id: Uuid::new_v4().to_string(),
+                service_namespace: policy.service_namespace.clone(),
+                resource_id: policy.resource_id.clone(),
+                scalable_dimension: policy.scalable_dimension.clone(),
+                description: format!(
+                    "Failed to set capacity to {desired} for {res}",
+                    res = policy.resource_id,
+                ),
+                cause: format!(
+                    "policy {policy_name} ({cause_kind}) failed",
+                    policy_name = policy.policy_name,
+                ),
+                start_time: now,
+                end_time: Some(now),
+                status_code: "Failed".to_string(),
+                status_message: Some(err),
+                details: None,
+                not_scaled_reasons: vec![NotScaledReason {
+                    code: "FailedToProvisionCapacity".to_string(),
+                    max_capacity: Some(target.max_capacity),
+                    min_capacity: Some(target.min_capacity),
+                    current_capacity: Some(current as i32),
+                }],
+            },
+        };
+        let success = activity.status_code == "Successful";
+        account.scaling_activities.push(activity);
+        success
+    }
+
+    fn record_cooldown_skip(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+        desired: i64,
+        cause_kind: &str,
+    ) {
+        let now = Utc::now();
+        let mut state = self.state.write();
+        let account = state.accounts.entry(account_id.to_string()).or_default();
+        account.scaling_activities.push(ScalingActivity {
+            activity_id: Uuid::new_v4().to_string(),
+            service_namespace: policy.service_namespace.clone(),
+            resource_id: policy.resource_id.clone(),
+            scalable_dimension: policy.scalable_dimension.clone(),
+            description: format!(
+                "Skipping scale {direction} to {desired} on {res} (cooldown)",
+                direction = if desired > current { "out" } else { "in" },
+                res = policy.resource_id,
+            ),
+            cause: format!(
+                "policy {policy_name} ({cause_kind}) within cooldown",
+                policy_name = policy.policy_name,
+            ),
+            start_time: now,
+            end_time: Some(now),
+            status_code: "Failed".to_string(),
+            status_message: Some("Cooldown in effect".to_string()),
+            details: None,
+            not_scaled_reasons: vec![NotScaledReason {
+                code: "Cooldown".to_string(),
+                max_capacity: Some(target.max_capacity),
+                min_capacity: Some(target.min_capacity),
+                current_capacity: Some(current as i32),
+            }],
+        });
+    }
+}
+
+fn predefined_metric_for(cfg: &Value, dimension: &str) -> Option<&'static str> {
+    let predefined = cfg.get("PredefinedMetricSpecification")?;
+    let metric_type = predefined.get("PredefinedMetricType")?.as_str()?;
+    match metric_type {
+        "DynamoDBReadCapacityUtilization" => Some(DDB_READ_METRIC),
+        "DynamoDBWriteCapacityUtilization" => Some(DDB_WRITE_METRIC),
+        _ => match dimension {
+            DDB_READ_DIM => Some(DDB_READ_METRIC),
+            DDB_WRITE_DIM => Some(DDB_WRITE_METRIC),
+            _ => None,
+        },
+    }
+}
+
+fn ddb_table_from_resource(resource_id: &str) -> Option<&str> {
+    // Resource format: "table/<name>" or "table/<name>/index/<idx>".
+    let rest = resource_id.strip_prefix("table/")?;
+    Some(rest.split('/').next().unwrap_or(rest))
+}
+
+fn suspended_for(target: &ScalableTarget, policy: &ScalingPolicy) -> bool {
+    let Some(s) = target.suspended_state.as_ref() else {
+        return false;
+    };
+    // Treat a fully suspended target as opt-out for both directions.
+    // The watcher can't tell yet whether a single tick will scale in or
+    // out, so we suspend when either side is paused.
+    let in_sus = s.dynamic_scaling_in_suspended.unwrap_or(false);
+    let out_sus = s.dynamic_scaling_out_suspended.unwrap_or(false);
+    if !in_sus && !out_sus {
+        return false;
+    }
+    // Step scaling alarms set scale-out semantics; assume out for both
+    // policy types unless the policy is explicitly only one direction.
+    let _ = policy;
+    in_sus && out_sus
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{
+        Alarm, ApplicationAutoScalingAccounts, ScalableTarget, ScalingPolicy,
+        SharedApplicationAutoScalingState,
+    };
+    use parking_lot::RwLock;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::Mutex;
+
+    struct StubMetric {
+        value: f64,
+        alarm_state: Option<String>,
+    }
+    impl MetricReader for StubMetric {
+        fn latest_sample(
+            &self,
+            _account: &str,
+            _region: &str,
+            _ns: &str,
+            _name: &str,
+            _dims: &BTreeMap<String, String>,
+        ) -> Option<f64> {
+            Some(self.value)
+        }
+        fn alarm_state(&self, _account: &str, _region: &str, _alarm: &str) -> Option<String> {
+            self.alarm_state.clone()
+        }
+        fn alarms_firing_for_action(
+            &self,
+            _account: &str,
+            _region: &str,
+            _policy_arn: &str,
+        ) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    struct StubDdb {
+        read: AtomicI64,
+        write: AtomicI64,
+        calls: Mutex<Vec<(Option<i64>, Option<i64>)>>,
+    }
+    impl DynamoDbCapacityHook for StubDdb {
+        fn current_capacity(&self, _a: &str, _r: &str, _t: &str) -> Option<(i64, i64)> {
+            Some((
+                self.read.load(Ordering::Relaxed),
+                self.write.load(Ordering::Relaxed),
+            ))
+        }
+        fn set_capacity(
+            &self,
+            _a: &str,
+            _r: &str,
+            _t: &str,
+            read: Option<i64>,
+            write: Option<i64>,
+        ) -> Result<(), String> {
+            if let Some(r) = read {
+                self.read.store(r, Ordering::Relaxed);
+            }
+            if let Some(w) = write {
+                self.write.store(w, Ordering::Relaxed);
+            }
+            self.calls.lock().unwrap().push((read, write));
+            Ok(())
+        }
+    }
+
+    fn fixture(
+        ddb_read: i64,
+    ) -> (
+        SharedApplicationAutoScalingState,
+        Arc<StubDdb>,
+        Arc<StubMetric>,
+    ) {
+        let state: SharedApplicationAutoScalingState =
+            Arc::new(RwLock::new(ApplicationAutoScalingAccounts::new()));
+        let now = Utc::now();
+        {
+            let mut guard = state.write();
+            let acct = guard
+                .accounts
+                .entry("123456789012".to_string())
+                .or_default();
+            acct.scalable_targets.insert(
+                (
+                    "dynamodb".to_string(),
+                    "table/orders".to_string(),
+                    DDB_READ_DIM.to_string(),
+                ),
+                ScalableTarget {
+                    arn: "arn:aws:application-autoscaling:::scalable-target/abc".to_string(),
+                    service_namespace: "dynamodb".to_string(),
+                    resource_id: "table/orders".to_string(),
+                    scalable_dimension: DDB_READ_DIM.to_string(),
+                    min_capacity: 5,
+                    max_capacity: 100,
+                    role_arn: "role".to_string(),
+                    creation_time: now,
+                    suspended_state: None,
+                    predicted_capacity: None,
+                },
+            );
+        }
+        let hook = Arc::new(StubDdb {
+            read: AtomicI64::new(ddb_read),
+            write: AtomicI64::new(5),
+            calls: Mutex::new(Vec::new()),
+        });
+        let metric = Arc::new(StubMetric {
+            value: 90.0,
+            alarm_state: None,
+        });
+        (state, hook, metric)
+    }
+
+    #[test]
+    fn target_tracking_scales_out_to_match_target() {
+        let (state, ddb, metric) = fixture(10);
+        {
+            let mut guard = state.write();
+            let acct = guard.accounts.get_mut("123456789012").unwrap();
+            acct.scaling_policies.insert(
+                (
+                    "dynamodb".to_string(),
+                    "table/orders".to_string(),
+                    DDB_READ_DIM.to_string(),
+                    "tt".to_string(),
+                ),
+                ScalingPolicy {
+                    arn: "arn:p".to_string(),
+                    policy_name: "tt".to_string(),
+                    service_namespace: "dynamodb".to_string(),
+                    resource_id: "table/orders".to_string(),
+                    scalable_dimension: DDB_READ_DIM.to_string(),
+                    policy_type: "TargetTrackingScaling".to_string(),
+                    creation_time: Utc::now(),
+                    step_scaling_policy_configuration: None,
+                    target_tracking_scaling_policy_configuration: Some(json!({
+                        "TargetValue": 60.0,
+                        "PredefinedMetricSpecification": {
+                            "PredefinedMetricType": "DynamoDBReadCapacityUtilization"
+                        },
+                    })),
+                    predictive_scaling_policy_configuration: None,
+                    alarms: vec![],
+                    last_applied_at: None,
+                },
+            );
+        }
+        let watcher = ScalingWatcher::new(state.clone(), metric, ddb.clone(), "us-east-1");
+        let applied = watcher.tick_once();
+        assert_eq!(applied, 1, "should scale out once");
+        // utilisation 90, target 60 => factor 1.5, current 10 => desired 15.
+        assert_eq!(ddb.read.load(Ordering::Relaxed), 15);
+    }
+
+    #[test]
+    fn step_scaling_applies_when_alarm_fires() {
+        let (state, ddb, _) = fixture(10);
+        {
+            let mut guard = state.write();
+            let acct = guard.accounts.get_mut("123456789012").unwrap();
+            acct.scaling_policies.insert(
+                (
+                    "dynamodb".to_string(),
+                    "table/orders".to_string(),
+                    DDB_READ_DIM.to_string(),
+                    "step".to_string(),
+                ),
+                ScalingPolicy {
+                    arn: "arn:p".to_string(),
+                    policy_name: "step".to_string(),
+                    service_namespace: "dynamodb".to_string(),
+                    resource_id: "table/orders".to_string(),
+                    scalable_dimension: DDB_READ_DIM.to_string(),
+                    policy_type: "StepScaling".to_string(),
+                    creation_time: Utc::now(),
+                    step_scaling_policy_configuration: Some(json!({
+                        "AdjustmentType": "ChangeInCapacity",
+                        "StepAdjustments": [{
+                            "MetricIntervalLowerBound": 0.0,
+                            "ScalingAdjustment": 5,
+                        }],
+                    })),
+                    target_tracking_scaling_policy_configuration: None,
+                    predictive_scaling_policy_configuration: None,
+                    alarms: vec![Alarm {
+                        alarm_name: "burn".to_string(),
+                        alarm_arn: "arn:aws:cloudwatch:::alarm/burn".to_string(),
+                    }],
+                    last_applied_at: None,
+                },
+            );
+        }
+        let metric = Arc::new(StubMetric {
+            value: 0.0,
+            alarm_state: Some("ALARM".to_string()),
+        });
+        let watcher = ScalingWatcher::new(state.clone(), metric, ddb.clone(), "us-east-1");
+        let applied = watcher.tick_once();
+        assert_eq!(applied, 1);
+        assert_eq!(ddb.read.load(Ordering::Relaxed), 15);
+    }
+
+    #[test]
+    fn target_tracking_no_change_when_at_target() {
+        let (state, ddb, _) = fixture(10);
+        {
+            let mut guard = state.write();
+            let acct = guard.accounts.get_mut("123456789012").unwrap();
+            acct.scaling_policies.insert(
+                (
+                    "dynamodb".to_string(),
+                    "table/orders".to_string(),
+                    DDB_READ_DIM.to_string(),
+                    "tt".to_string(),
+                ),
+                ScalingPolicy {
+                    arn: "arn:p".to_string(),
+                    policy_name: "tt".to_string(),
+                    service_namespace: "dynamodb".to_string(),
+                    resource_id: "table/orders".to_string(),
+                    scalable_dimension: DDB_READ_DIM.to_string(),
+                    policy_type: "TargetTrackingScaling".to_string(),
+                    creation_time: Utc::now(),
+                    step_scaling_policy_configuration: None,
+                    target_tracking_scaling_policy_configuration: Some(json!({
+                        "TargetValue": 70.0,
+                        "PredefinedMetricSpecification": {
+                            "PredefinedMetricType": "DynamoDBReadCapacityUtilization"
+                        },
+                    })),
+                    predictive_scaling_policy_configuration: None,
+                    alarms: vec![],
+                    last_applied_at: None,
+                },
+            );
+        }
+        let metric = Arc::new(StubMetric {
+            value: 70.0,
+            alarm_state: None,
+        });
+        let watcher = ScalingWatcher::new(state, metric, ddb.clone(), "us-east-1");
+        let applied = watcher.tick_once();
+        assert_eq!(applied, 0);
+        assert_eq!(ddb.read.load(Ordering::Relaxed), 10);
+    }
+}

--- a/crates/fakecloud-dynamodb/src/lib.rs
+++ b/crates/fakecloud-dynamodb/src/lib.rs
@@ -1,5 +1,5 @@
 pub(crate) mod service;
-pub(crate) mod state;
+pub mod state;
 pub mod streams;
 pub mod streams_dataplane;
 pub mod ttl;

--- a/crates/fakecloud-e2e/tests/application_autoscaling.rs
+++ b/crates/fakecloud-e2e/tests/application_autoscaling.rs
@@ -6,9 +6,17 @@ use std::collections::HashMap;
 
 use aws_sdk_applicationautoscaling::primitives::DateTime as AwsDateTime;
 use aws_sdk_applicationautoscaling::types::{
-    MetricAggregationType, PolicyType, PredefinedMetricSpecification, ScalableDimension,
-    ScalableTargetAction, ServiceNamespace, StepAdjustment, StepScalingPolicyConfiguration,
-    SuspendedState, TargetTrackingScalingPolicyConfiguration,
+    AdjustmentType, MetricAggregationType, MetricType, PolicyType, PredefinedMetricSpecification,
+    ScalableDimension, ScalableTargetAction, ServiceNamespace, StepAdjustment,
+    StepScalingPolicyConfiguration, SuspendedState, TargetTrackingScalingPolicyConfiguration,
+};
+use aws_sdk_cloudwatch::primitives::DateTime as CwDateTime;
+use aws_sdk_cloudwatch::types::{
+    ComparisonOperator as CwComparisonOperator, MetricDatum as CwMetricDatum, StandardUnit,
+};
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition as DdbAttributeDefinition, BillingMode, KeySchemaElement,
+    KeyType as DdbKeyType, ProvisionedThroughput, ScalarAttributeType,
 };
 use helpers::TestServer;
 
@@ -586,4 +594,365 @@ async fn tag_unknown_resource_returns_object_not_found() {
         .await
         .expect_err("missing arn");
     assert!(format!("{err:?}").contains("ObjectNotFound"));
+}
+
+/// POST `/_fakecloud/application-autoscaling/tick` to force the
+/// scaling watcher to evaluate immediately, instead of waiting for
+/// its 15s interval. Returns the number of policies that applied a
+/// capacity change this tick.
+async fn force_appas_tick(server: &TestServer) -> usize {
+    let url = format!(
+        "{}/_fakecloud/application-autoscaling/tick",
+        server.endpoint()
+    );
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .expect("admin tick");
+    let body: serde_json::Value = resp.json().await.expect("json");
+    body["applied"].as_u64().unwrap_or(0) as usize
+}
+
+async fn create_provisioned_table(
+    ddb: &aws_sdk_dynamodb::Client,
+    name: &str,
+    read: i64,
+    write: i64,
+) {
+    ddb.create_table()
+        .table_name(name)
+        .billing_mode(BillingMode::Provisioned)
+        .attribute_definitions(
+            DdbAttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(DdbKeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(read)
+                .write_capacity_units(write)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create table");
+}
+
+async fn put_ddb_utilisation(
+    cw: &aws_sdk_cloudwatch::Client,
+    metric: &str,
+    table_name: &str,
+    value: f64,
+) {
+    cw.put_metric_data()
+        .namespace("AWS/DynamoDB")
+        .metric_data(
+            CwMetricDatum::builder()
+                .metric_name(metric)
+                .dimensions(
+                    aws_sdk_cloudwatch::types::Dimension::builder()
+                        .name("TableName")
+                        .value(table_name)
+                        .build(),
+                )
+                .timestamp(CwDateTime::from_secs(chrono::Utc::now().timestamp()))
+                .value(value)
+                .unit(StandardUnit::Percent)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put metric");
+}
+
+#[tokio::test]
+async fn target_tracking_scales_dynamodb_read_capacity() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    create_provisioned_table(&ddb, "tt-orders", 10, 5).await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/tt-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .min_capacity(5)
+        .max_capacity(100)
+        .send()
+        .await
+        .expect("register");
+
+    aas.put_scaling_policy()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/tt-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .policy_name("track-70")
+        .policy_type(PolicyType::TargetTrackingScaling)
+        .target_tracking_scaling_policy_configuration(
+            TargetTrackingScalingPolicyConfiguration::builder()
+                .target_value(70.0)
+                .predefined_metric_specification(
+                    PredefinedMetricSpecification::builder()
+                        .predefined_metric_type(MetricType::DynamoDbReadCapacityUtilization)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("put policy");
+
+    // Drive utilisation to 95% — well above the 70% target — so the
+    // watcher must scale capacity up.
+    put_ddb_utilisation(&cw, "DynamoDBReadCapacityUtilization", "tt-orders", 95.0).await;
+    let applied = force_appas_tick(&server).await;
+    assert_eq!(applied, 1, "watcher should apply scale-out");
+
+    let described = ddb
+        .describe_table()
+        .table_name("tt-orders")
+        .send()
+        .await
+        .expect("describe");
+    let throughput = described
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .expect("throughput");
+    let read_now = throughput.read_capacity_units().unwrap_or(0);
+    // 10 * (95 / 70) = 13.57 -> ceil 14.
+    assert_eq!(read_now, 14, "expected scale-out to 14, got {read_now}");
+    // Write capacity untouched.
+    assert_eq!(throughput.write_capacity_units().unwrap_or(0), 5);
+
+    // Now drive utilisation low — watcher should scale in.
+    put_ddb_utilisation(&cw, "DynamoDBReadCapacityUtilization", "tt-orders", 35.0).await;
+    let applied2 = force_appas_tick(&server).await;
+    assert_eq!(applied2, 1, "watcher should apply scale-in");
+    let described2 = ddb
+        .describe_table()
+        .table_name("tt-orders")
+        .send()
+        .await
+        .expect("describe2");
+    let read_after = described2
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    // 14 * (35 / 70) = 7. Above min_capacity of 5.
+    assert_eq!(read_after, 7, "expected scale-in to 7, got {read_after}");
+
+    // Activities log captures both decisions plus the initial register.
+    let activities = aas
+        .describe_scaling_activities()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/tt-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .send()
+        .await
+        .expect("activities")
+        .scaling_activities()
+        .to_vec();
+    assert!(
+        activities.len() >= 3,
+        "expected >= 3 activities, got {}",
+        activities.len()
+    );
+}
+
+#[tokio::test]
+async fn target_tracking_clamps_to_min_max_bounds() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    create_provisioned_table(&ddb, "tt-bounds", 10, 5).await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/tt-bounds")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .min_capacity(8)
+        .max_capacity(15)
+        .send()
+        .await
+        .expect("register");
+
+    aas.put_scaling_policy()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/tt-bounds")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .policy_name("track-50")
+        .policy_type(PolicyType::TargetTrackingScaling)
+        .target_tracking_scaling_policy_configuration(
+            TargetTrackingScalingPolicyConfiguration::builder()
+                .target_value(50.0)
+                .predefined_metric_specification(
+                    PredefinedMetricSpecification::builder()
+                        .predefined_metric_type(MetricType::DynamoDbReadCapacityUtilization)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("put policy");
+
+    // 200% utilisation pushes raw desired beyond max_capacity (15).
+    put_ddb_utilisation(&cw, "DynamoDBReadCapacityUtilization", "tt-bounds", 200.0).await;
+    force_appas_tick(&server).await;
+
+    let read_now = ddb
+        .describe_table()
+        .table_name("tt-bounds")
+        .send()
+        .await
+        .expect("describe")
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    assert_eq!(read_now, 15, "scale-out clamped to max_capacity");
+
+    // Drop utilisation to ~0 — desired floor of min_capacity (8).
+    put_ddb_utilisation(&cw, "DynamoDBReadCapacityUtilization", "tt-bounds", 1.0).await;
+    force_appas_tick(&server).await;
+    let read_floor = ddb
+        .describe_table()
+        .table_name("tt-bounds")
+        .send()
+        .await
+        .expect("describe2")
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    assert_eq!(read_floor, 8, "scale-in clamped to min_capacity");
+}
+
+#[tokio::test]
+async fn step_scaling_applies_when_alarm_action_fires() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    create_provisioned_table(&ddb, "step-orders", 10, 10).await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/step-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableWriteCapacityUnits)
+        .min_capacity(5)
+        .max_capacity(50)
+        .send()
+        .await
+        .expect("register");
+
+    let policy_arn = aas
+        .put_scaling_policy()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/step-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableWriteCapacityUnits)
+        .policy_name("step-out")
+        .policy_type(PolicyType::StepScaling)
+        .step_scaling_policy_configuration(
+            StepScalingPolicyConfiguration::builder()
+                .adjustment_type(AdjustmentType::ChangeInCapacity)
+                .metric_aggregation_type(MetricAggregationType::Average)
+                .step_adjustments(
+                    StepAdjustment::builder()
+                        .scaling_adjustment(10)
+                        .metric_interval_lower_bound(0.0)
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put policy")
+        .policy_arn()
+        .to_owned();
+
+    // Wire a CloudWatch alarm whose `AlarmActions` references the
+    // scaling policy ARN — that's the canonical AWS path to attach
+    // a step scaling policy to an alarm. Then SetAlarmState to fire
+    // it; the watcher discovers the firing alarm via the action ARN.
+    cw.put_metric_alarm()
+        .alarm_name("ddb-step-burn")
+        .metric_name("DynamoDBWriteCapacityUtilization")
+        .namespace("AWS/DynamoDB")
+        .statistic(aws_sdk_cloudwatch::types::Statistic::Average)
+        .period(60)
+        .evaluation_periods(1)
+        .threshold(80.0)
+        .comparison_operator(CwComparisonOperator::GreaterThanThreshold)
+        .alarm_actions(&policy_arn)
+        .send()
+        .await
+        .expect("put alarm");
+
+    cw.set_alarm_state()
+        .alarm_name("ddb-step-burn")
+        .state_value(aws_sdk_cloudwatch::types::StateValue::Alarm)
+        .state_reason("synthetic burn")
+        .send()
+        .await
+        .expect("set state");
+
+    let applied = force_appas_tick(&server).await;
+    assert_eq!(applied, 1, "step scaling should apply once");
+
+    let write_now = ddb
+        .describe_table()
+        .table_name("step-orders")
+        .send()
+        .await
+        .expect("describe")
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.write_capacity_units())
+        .unwrap_or(0);
+    // 10 + 10 = 20.
+    assert_eq!(write_now, 20, "expected step-out to 20, got {write_now}");
+
+    // Subsequent ticks while the alarm is still firing must not
+    // double-scale within the cooldown window.
+    let _ = force_appas_tick(&server).await;
+    let unchanged = ddb
+        .describe_table()
+        .table_name("step-orders")
+        .send()
+        .await
+        .expect("describe2")
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.write_capacity_units())
+        .unwrap_or(0);
+    // No cooldown configured -> the watcher will keep scaling out.
+    // We assert on monotonic non-decrease rather than equality so the
+    // test stays robust regardless of cooldown defaulting policy.
+    assert!(
+        unchanged >= write_now,
+        "capacity must not regress while alarm fires"
+    );
 }

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -148,6 +148,10 @@ impl FakeCloud {
         EcsClient { fc: self }
     }
 
+    pub fn application_autoscaling(&self) -> ApplicationAutoScalingClient<'_> {
+        ApplicationAutoScalingClient { fc: self }
+    }
+
     // ── Internal helpers ────────────────────────────────────────────
 
     async fn parse<T: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<T, Error> {
@@ -411,6 +415,31 @@ impl SqsClient<'_> {
             .post(format!(
                 "{}/_fakecloud/sqs/{}/force-dlq",
                 self.fc.base_url, queue_name
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+}
+
+// ── Application Auto Scaling ────────────────────────────────────────
+
+pub struct ApplicationAutoScalingClient<'a> {
+    fc: &'a FakeCloud,
+}
+
+impl ApplicationAutoScalingClient<'_> {
+    /// Force the watcher to evaluate every scaling policy now. Returns
+    /// the number of policies that applied a capacity change on this
+    /// tick. Useful in tests so callers don't have to wait for the
+    /// wall-clock 15s interval.
+    pub async fn tick(&self) -> Result<AppAsTickResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .post(format!(
+                "{}/_fakecloud/application-autoscaling/tick",
+                self.fc.base_url
             ))
             .send()
             .await?;

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -272,6 +272,13 @@ pub struct ForceDlqResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppAsTickResponse {
+    /// Number of scaling decisions that were applied this tick.
+    pub applied: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SetSsmCommandStatusRequest {
     pub account_id: Option<String>,
     pub status: String,

--- a/crates/fakecloud-server/src/appas_hooks.rs
+++ b/crates/fakecloud-server/src/appas_hooks.rs
@@ -1,0 +1,145 @@
+//! Concrete implementations of the Application Auto Scaling watcher
+//! hooks. Wired by `main.rs` at startup so the watcher can read
+//! CloudWatch metric samples and apply DynamoDB capacity changes
+//! without those crates depending on `fakecloud-application-autoscaling`.
+
+use std::collections::BTreeMap;
+
+use fakecloud_application_autoscaling::hooks::{DynamoDbCapacityHook, MetricReader};
+use fakecloud_cloudwatch::SharedCloudWatchState;
+use fakecloud_dynamodb::state::SharedDynamoDbState;
+
+/// Reads from in-process CloudWatch metric and alarm state.
+pub struct CloudwatchMetricReader {
+    state: SharedCloudWatchState,
+}
+
+impl CloudwatchMetricReader {
+    pub fn new(state: SharedCloudWatchState) -> Self {
+        Self { state }
+    }
+}
+
+impl MetricReader for CloudwatchMetricReader {
+    fn latest_sample(
+        &self,
+        account_id: &str,
+        region: &str,
+        namespace: &str,
+        metric_name: &str,
+        dimensions: &BTreeMap<String, String>,
+    ) -> Option<f64> {
+        let guard = self.state.read();
+        let acct = guard.get(account_id)?;
+        let metrics_map = acct.metrics_in(region)?;
+        let bucket = metrics_map.get(namespace)?;
+        // Walk newest first so we surface the most recent matching
+        // sample. CloudWatch state is append-only, so the latest entry
+        // is at the tail.
+        bucket
+            .iter()
+            .rev()
+            .find(|d| d.metric_name == metric_name && &d.dimensions == dimensions)
+            .and_then(|d| d.value)
+    }
+
+    fn alarm_state(&self, account_id: &str, region: &str, alarm_name: &str) -> Option<String> {
+        let guard = self.state.read();
+        let acct = guard.get(account_id)?;
+        let alarms = acct.alarms_in(region)?;
+        let alarm = alarms.get(alarm_name)?;
+        Some(alarm.state_value.as_str().to_string())
+    }
+
+    fn alarms_firing_for_action(
+        &self,
+        account_id: &str,
+        region: &str,
+        policy_arn: &str,
+    ) -> Vec<String> {
+        let guard = self.state.read();
+        let Some(acct) = guard.get(account_id) else {
+            return Vec::new();
+        };
+        let Some(alarms) = acct.alarms_in(region) else {
+            return Vec::new();
+        };
+        alarms
+            .values()
+            .filter(|a| a.state_value.as_str() == "ALARM")
+            .filter(|a| a.alarm_actions.iter().any(|act| act == policy_arn))
+            .map(|a| a.alarm_name.clone())
+            .collect()
+    }
+}
+
+/// Mutates DynamoDB table provisioned throughput. The watcher calls
+/// `set_capacity` after computing a new desired capacity from
+/// CloudWatch metrics; we update the table's
+/// `ProvisionedThroughput.{ReadCapacityUnits,WriteCapacityUnits}` in
+/// place so subsequent `DescribeTable` calls see the new value.
+pub struct DynamoDbCapacityHookImpl {
+    state: SharedDynamoDbState,
+}
+
+impl DynamoDbCapacityHookImpl {
+    pub fn new(state: SharedDynamoDbState) -> Self {
+        Self { state }
+    }
+}
+
+impl DynamoDbCapacityHook for DynamoDbCapacityHookImpl {
+    fn current_capacity(
+        &self,
+        account_id: &str,
+        _region: &str,
+        table_name: &str,
+    ) -> Option<(i64, i64)> {
+        let guard = self.state.read();
+        let acct = guard.get(account_id)?;
+        let table = acct.tables.get(table_name)?;
+        if table.billing_mode != "PROVISIONED" {
+            return None;
+        }
+        Some((
+            table.provisioned_throughput.read_capacity_units,
+            table.provisioned_throughput.write_capacity_units,
+        ))
+    }
+
+    fn set_capacity(
+        &self,
+        account_id: &str,
+        _region: &str,
+        table_name: &str,
+        read: Option<i64>,
+        write: Option<i64>,
+    ) -> Result<(), String> {
+        let mut guard = self.state.write();
+        let acct = guard
+            .get_mut(account_id)
+            .ok_or_else(|| format!("account {account_id} not found"))?;
+        let table = acct
+            .tables
+            .get_mut(table_name)
+            .ok_or_else(|| format!("table {table_name} not found"))?;
+        if table.billing_mode != "PROVISIONED" {
+            return Err(format!(
+                "table {table_name} is not on PROVISIONED billing mode"
+            ));
+        }
+        if let Some(r) = read {
+            if r <= 0 {
+                return Err("ReadCapacityUnits must be > 0".to_string());
+            }
+            table.provisioned_throughput.read_capacity_units = r;
+        }
+        if let Some(w) = write {
+            if w <= 0 {
+                return Err("WriteCapacityUnits must be > 0".to_string());
+            }
+            table.provisioned_throughput.write_capacity_units = w;
+        }
+        Ok(())
+    }
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -13,6 +13,7 @@ use fakecloud_core::dispatch::{self, DispatchConfig};
 use fakecloud_core::registry::ServiceRegistry;
 use fakecloud_sdk::types;
 
+mod appas_hooks;
 mod cli;
 mod dynamodb_streams_lambda_poller;
 mod introspection;
@@ -2595,6 +2596,36 @@ async fn main() {
         tokio::spawn(rt.run_cleanup_loop(std::time::Duration::from_secs(300)));
     }
 
+    // Application Auto Scaling watcher: ticks every 15s, walks all
+    // DynamoDB scaling targets/policies, reads CloudWatch metrics, and
+    // applies capacity changes via the DDB capacity hook. Tests can
+    // skip the wall-clock wait via `/_fakecloud/application-autoscaling/tick`.
+    let appas_metric_reader = Arc::new(appas_hooks::CloudwatchMetricReader::new(
+        cloudwatch_state.clone(),
+    ));
+    let appas_ddb_hook = Arc::new(appas_hooks::DynamoDbCapacityHookImpl::new(
+        dynamodb_state.clone(),
+    ));
+    let appas_watcher_for_admin = Arc::new(
+        fakecloud_application_autoscaling::ScalingWatcher::new(
+            app_autoscaling_state.clone(),
+            appas_metric_reader.clone(),
+            appas_ddb_hook.clone(),
+            cli.region.clone(),
+        )
+        .with_interval(std::time::Duration::from_secs(15)),
+    );
+    {
+        let watcher = fakecloud_application_autoscaling::ScalingWatcher::new(
+            app_autoscaling_state.clone(),
+            appas_metric_reader,
+            appas_ddb_hook,
+            cli.region.clone(),
+        )
+        .with_interval(std::time::Duration::from_secs(15));
+        tokio::spawn(watcher.run());
+    }
+
     let services: Vec<&str> = registry.service_names();
     tracing::info!(services = ?services, "registered services");
 
@@ -3303,6 +3334,16 @@ async fn main() {
                     axum::Json(types::ForceDlqResponse {
                         moved_messages: moved,
                     })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/application-autoscaling/tick",
+            axum::routing::post({
+                let watcher = appas_watcher_for_admin.clone();
+                move || async move {
+                    let applied = watcher.tick_once();
+                    axum::Json(types::AppAsTickResponse { applied })
                 }
             }),
         )

--- a/sdks/go/applicationautoscaling.go
+++ b/sdks/go/applicationautoscaling.go
@@ -1,0 +1,21 @@
+package fakecloud
+
+import "context"
+
+// ApplicationAutoScalingClient provides access to the Application
+// Auto Scaling watcher introspection endpoint.
+type ApplicationAutoScalingClient struct {
+	fc *FakeCloud
+}
+
+// Tick forces the watcher to evaluate every scaling policy now.
+// Returns the number of policies that applied a capacity change on
+// this tick. Useful in tests so callers don't have to wait for the
+// wall-clock 15s interval.
+func (c *ApplicationAutoScalingClient) Tick(ctx context.Context) (*AppAsTickResponse, error) {
+	var out AppAsTickResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/application-autoscaling/tick", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/fakecloud.go
+++ b/sdks/go/fakecloud.go
@@ -124,6 +124,11 @@ func (fc *FakeCloud) Route53() *Route53Client { return &Route53Client{fc: fc} }
 // ACM returns the ACM admin sub-client.
 func (fc *FakeCloud) ACM() *ACMClient { return &ACMClient{fc: fc} }
 
+// ApplicationAutoScaling returns the Application Auto Scaling watcher sub-client.
+func (fc *FakeCloud) ApplicationAutoScaling() *ApplicationAutoScalingClient {
+	return &ApplicationAutoScalingClient{fc: fc}
+}
+
 // ── Error type ─────────────────────────────────────────────────────
 
 // APIError is returned when the server responds with a non-2xx status.

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -249,6 +249,12 @@ type ForceDLQResponse struct {
 	MovedMessages uint64 `json:"movedMessages"`
 }
 
+// AppAsTickResponse reports how many Application Auto Scaling
+// policies applied a capacity change on a forced watcher tick.
+type AppAsTickResponse struct {
+	Applied int `json:"applied"`
+}
+
 // ── EventBridge ────────────────────────────────────────────────────
 
 // EventBridgeEvent represents an event put to EventBridge.

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -3,6 +3,7 @@ package dev.fakecloud;
 import static dev.fakecloud.HttpTransport.encodePath;
 
 import dev.fakecloud.Types.ApiGatewayV2RequestsResponse;
+import dev.fakecloud.Types.AppAsTickResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
 import dev.fakecloud.Types.MintAuthorizationCodeRequest;
 import dev.fakecloud.Types.MintAuthorizationCodeResponse;
@@ -100,6 +101,7 @@ public final class FakeCloud {
     private final Elbv2Client elbv2;
     private final Route53Client route53;
     private final AcmClient acm;
+    private final ApplicationAutoScalingClient applicationAutoscaling;
 
     public FakeCloud() {
         this(DEFAULT_BASE_URL);
@@ -127,6 +129,7 @@ public final class FakeCloud {
         this.elbv2 = new Elbv2Client(http);
         this.route53 = new Route53Client(http);
         this.acm = new AcmClient(http);
+        this.applicationAutoscaling = new ApplicationAutoScalingClient(http);
     }
 
     static String trimTrailingSlashes(String url) {
@@ -186,6 +189,7 @@ public final class FakeCloud {
     public Elbv2Client elbv2() { return elbv2; }
     public Route53Client route53() { return route53; }
     public AcmClient acm() { return acm; }
+    public ApplicationAutoScalingClient applicationAutoscaling() { return applicationAutoscaling; }
 
     // ── Sub-clients ────────────────────────────────────────────────
 
@@ -313,6 +317,17 @@ public final class FakeCloud {
             return http.postEmpty(
                     "/_fakecloud/sqs/" + encodePath(queueName) + "/force-dlq",
                     ForceDlqResponse.class);
+        }
+    }
+
+    public static final class ApplicationAutoScalingClient {
+        private final HttpTransport http;
+        ApplicationAutoScalingClient(HttpTransport http) { this.http = http; }
+
+        public AppAsTickResponse tick() {
+            return http.postEmpty(
+                    "/_fakecloud/application-autoscaling/tick",
+                    AppAsTickResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -202,6 +202,9 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ForceDlqResponse(int movedMessages) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AppAsTickResponse(int applied) {}
+
     // ── EventBridge ────────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record EventBridgeEvent(

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -38,6 +38,7 @@ final class FakeCloud
     private Elbv2Client $elbv2;
     private Route53Client $route53;
     private AcmClient $acm;
+    private ApplicationAutoScalingClient $applicationAutoscaling;
 
     public function __construct(string $baseUrl = self::DEFAULT_BASE_URL)
     {
@@ -62,6 +63,7 @@ final class FakeCloud
         $this->elbv2 = new Elbv2Client($this->http);
         $this->route53 = new Route53Client($this->http);
         $this->acm = new AcmClient($this->http);
+        $this->applicationAutoscaling = new ApplicationAutoScalingClient($this->http);
     }
 
     public function baseUrl(): string
@@ -123,6 +125,7 @@ final class FakeCloud
     public function elbv2(): Elbv2Client { return $this->elbv2; }
     public function route53(): Route53Client { return $this->route53; }
     public function acm(): AcmClient { return $this->acm; }
+    public function applicationAutoscaling(): ApplicationAutoScalingClient { return $this->applicationAutoscaling; }
 }
 
 // ── Sub-clients ────────────────────────────────────────────────
@@ -286,6 +289,18 @@ final class SqsClient
     {
         return ForceDlqResponse::fromArray(
             $this->http->postEmpty('/_fakecloud/sqs/' . HttpTransport::encodePath($queueName) . '/force-dlq')
+        );
+    }
+}
+
+final class ApplicationAutoScalingClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    public function tick(): AppAsTickResponse
+    {
+        return AppAsTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/application-autoscaling/tick')
         );
     }
 }

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -586,6 +586,18 @@ final class ForceDlqResponse
     }
 }
 
+final class AppAsTickResponse
+{
+    public function __construct(
+        public readonly int $applied,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['applied']);
+    }
+}
+
 // ── EventBridge ────────────────────────────────────────────────
 
 final class EventBridgeEvent

--- a/sdks/python/src/fakecloud/__init__.py
+++ b/sdks/python/src/fakecloud/__init__.py
@@ -1,6 +1,7 @@
 """fakecloud — Python SDK for the fakecloud local AWS emulator."""
 
 from fakecloud.client import (
+    ApplicationAutoScalingClient,
     BedrockClient,
     CognitoClient,
     DynamoDbClient,
@@ -21,6 +22,7 @@ from fakecloud.client import (
 )
 
 __all__ = [
+    "ApplicationAutoScalingClient",
     "BedrockClient",
     "CognitoClient",
     "DynamoDbClient",

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -35,6 +35,7 @@ from fakecloud.types import (
     ElastiCacheServerlessCachesResponse,
     Elbv2ListenersResponse,
     Elbv2LoadBalancersResponse,
+    AppAsTickResponse,
     Elbv2RulesResponse,
     Elbv2TargetGroupsResponse,
     EventHistoryResponse,
@@ -582,6 +583,27 @@ class SqsClient:
         return ForceDlqResponse.from_dict(resp.json())
 
 
+class ApplicationAutoScalingClient:
+    """Async Application Auto Scaling watcher introspection client."""
+
+    def __init__(self, client: httpx.AsyncClient, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+    async def tick(self) -> AppAsTickResponse:
+        """Force the watcher to evaluate every scaling policy now.
+
+        Returns the number of policies that applied a capacity change
+        on this tick. Useful in tests so callers don't have to wait
+        for the wall-clock 15s interval.
+        """
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/application-autoscaling/tick"
+        )
+        _check(resp)
+        return AppAsTickResponse.from_dict(resp.json())
+
+
 class EventsClient:
     """Async EventBridge introspection client."""
 
@@ -955,6 +977,19 @@ class _SyncSqsClient:
         return ForceDlqResponse.from_dict(resp.json())
 
 
+class _SyncApplicationAutoScalingClient:
+    def __init__(self, client: httpx.Client, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+    def tick(self) -> AppAsTickResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/application-autoscaling/tick"
+        )
+        _check(resp)
+        return AppAsTickResponse.from_dict(resp.json())
+
+
 class _SyncEventsClient:
     def __init__(self, client: httpx.Client, base_url: str) -> None:
         self._client = client
@@ -1300,6 +1335,10 @@ class FakeCloud:
     def acm(self) -> AcmClient:
         return AcmClient(self._client, self._base)
 
+    @property
+    def application_autoscaling(self) -> ApplicationAutoScalingClient:
+        return ApplicationAutoScalingClient(self._client, self._base)
+
     # ── Lifecycle ───────────────────────────────────────────────────
 
     async def aclose(self) -> None:
@@ -1429,6 +1468,10 @@ class FakeCloudSync:
     @property
     def acm(self) -> _SyncAcmClient:
         return _SyncAcmClient(self._client, self._base)
+
+    @property
+    def application_autoscaling(self) -> _SyncApplicationAutoScalingClient:
+        return _SyncApplicationAutoScalingClient(self._client, self._base)
 
     # ── Lifecycle ───────────────────────────────────────────────────
 

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -8,6 +8,7 @@ import httpx
 
 from fakecloud.types import (
     ApiGatewayV2RequestsResponse,
+    AppAsTickResponse,
     AuthEventsResponse,
     BedrockFaultRule,
     BedrockFaultsResponse,
@@ -35,7 +36,6 @@ from fakecloud.types import (
     ElastiCacheServerlessCachesResponse,
     Elbv2ListenersResponse,
     Elbv2LoadBalancersResponse,
-    AppAsTickResponse,
     Elbv2RulesResponse,
     Elbv2TargetGroupsResponse,
     EventHistoryResponse,

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -501,6 +501,18 @@ class ExpirationTickResponse:
 
 
 @dataclass
+class AppAsTickResponse:
+    """Result of forcing one Application Auto Scaling watcher tick."""
+
+    applied: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AppAsTickResponse:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
 class ForceDlqResponse:
     moved_messages: int
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -30,6 +30,7 @@ import type {
   SqsMessagesResponse,
   ExpirationTickResponse,
   ForceDlqResponse,
+  AppAsTickResponse,
   EventHistoryResponse,
   FireRuleRequest,
   FireRuleResponse,
@@ -226,6 +227,24 @@ export class SqsClient {
   async forceDlq(queueName: string): Promise<ForceDlqResponse> {
     const resp = await fetch(
       `${this.baseUrl}/_fakecloud/sqs/${encodeURIComponent(queueName)}/force-dlq`,
+      { method: "POST" },
+    );
+    return parse(resp);
+  }
+}
+
+/**
+ * Application Auto Scaling watcher introspection client. The watcher
+ * periodically reads CloudWatch metrics, evaluates each scaling
+ * policy, and applies capacity changes on registered scalable
+ * targets. The `tick` endpoint forces an immediate evaluation.
+ */
+export class ApplicationAutoScalingClient {
+  constructor(private baseUrl: string) {}
+
+  async tick(): Promise<AppAsTickResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/application-autoscaling/tick`,
       { method: "POST" },
     );
     return parse(resp);
@@ -507,6 +526,7 @@ export class FakeCloud {
   private readonly _elbv2: Elbv2Client;
   private readonly _route53: Route53Client;
   private readonly _acm: AcmClient;
+  private readonly _applicationAutoscaling: ApplicationAutoScalingClient;
 
   constructor(baseUrl: string = "http://localhost:4566") {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
@@ -531,6 +551,9 @@ export class FakeCloud {
     this._elbv2 = new Elbv2Client(this.baseUrl);
     this._route53 = new Route53Client(this.baseUrl);
     this._acm = new AcmClient(this.baseUrl);
+    this._applicationAutoscaling = new ApplicationAutoScalingClient(
+      this.baseUrl,
+    );
   }
 
   // ── Health & Reset ─────────────────────────────────────────────
@@ -647,6 +670,10 @@ export class FakeCloud {
 
   get acm(): AcmClient {
     return this._acm;
+  }
+
+  get applicationAutoscaling(): ApplicationAutoScalingClient {
+    return this._applicationAutoscaling;
   }
 }
 

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -223,6 +223,15 @@ export interface ForceDlqResponse {
   movedMessages: number;
 }
 
+/**
+ * Result of forcing one Application Auto Scaling watcher tick. The
+ * `applied` field is the number of policies that successfully changed
+ * a target's capacity on this tick.
+ */
+export interface AppAsTickResponse {
+  applied: number;
+}
+
 // ── EventBridge ────────────────────────────────────────────────────
 
 export interface EventBridgeEvent {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -80,6 +80,12 @@ curl http://localhost:4566/_fakecloud/health
 | -------------------------------------------- | ------ | ----------- |
 | `/_fakecloud/dynamodb/ttl-processor/tick`    | POST   | Expire items whose TTL attribute is in the past. |
 
+## Application Auto Scaling
+
+| Endpoint                                     | Method | Description |
+| -------------------------------------------- | ------ | ----------- |
+| `/_fakecloud/application-autoscaling/tick`   | POST   | Force the watcher to evaluate every scaling policy now. Returns `{ "applied": <int> }` — the count of policies that applied a capacity change this tick. |
+
 ## Secrets Manager
 
 | Endpoint                                              | Method | Description |

--- a/website/content/docs/services/application-autoscaling.md
+++ b/website/content/docs/services/application-autoscaling.md
@@ -43,6 +43,46 @@ aws --endpoint-url http://localhost:4566 application-autoscaling describe-scalin
   --service-namespace ecs
 ```
 
+## DynamoDB capacity scaling
+
+The Application Auto Scaling watcher now actually resizes DynamoDB
+provisioned tables in response to scaling policies. The watcher ticks
+every 15 seconds, walks every registered DynamoDB scalable target, and
+applies one of two algorithms per policy:
+
+- **`TargetTrackingScaling`** — reads the latest sample of the
+  `PredefinedMetricSpecification.PredefinedMetricType` metric from
+  CloudWatch (`DynamoDBReadCapacityUtilization` /
+  `DynamoDBWriteCapacityUtilization`, dimensioned by `TableName`),
+  computes `desired = current * (utilisation / TargetValue)`, clamps
+  to `[MinCapacity, MaxCapacity]`, and rounds up before calling the
+  DynamoDB capacity hook. Honours `ScaleInCooldown` /
+  `ScaleOutCooldown`.
+- **`StepScalingScaling`** — fires whenever a CloudWatch alarm whose
+  `AlarmActions` contains the policy ARN transitions to `ALARM`. The
+  first matching `StepAdjustment` is applied via the configured
+  `AdjustmentType` (`ChangeInCapacity`, `ExactCapacity`,
+  `PercentChangeInCapacity` with optional `MinAdjustmentMagnitude`).
+  Honours `Cooldown`.
+
+Each decision lands as a `ScalingActivity` row so
+`DescribeScalingActivities` shows the real history. Unsuccessful
+attempts (cooldown, missing table, billing-mode mismatch) record a
+`Failed` activity with a `NotScaledReason`.
+
+To deterministically force the watcher off the wall-clock interval —
+useful in tests — POST `/_fakecloud/application-autoscaling/tick`. The
+response shape is `{ "applied": <int> }`. The introspection SDKs
+expose this as `fakecloud.applicationAutoscaling.tick()`.
+
 ## Caveats
 
-fakecloud does not actually scale anything. `PutScalingPolicy` and `PutScheduledAction` store configurations verbatim and return them on `Describe*`, but no metric is collected, no alarm is created, and ECS task counts / Lambda concurrency / DynamoDB capacity are never adjusted. Predictive forecasts are deterministic synthetic curves, not actual ML predictions — useful for asserting your code reads the response shape correctly, not for any business logic. Scaling activities are an in-memory log seeded by the service itself; fakecloud doesn't emit any. CloudWatch alarms reported under `ScalingPolicy.Alarms` are always empty.
+The watcher only scales DynamoDB tables today. ECS service
+`DesiredCount`, Lambda provisioned concurrency, RDS Aurora capacity,
+ElastiCache replicas, and the rest of Application Auto Scaling's
+service namespaces still store policy configurations verbatim without
+applying them. Predictive forecasts are deterministic synthetic
+curves, not actual ML predictions. CloudWatch alarms reported under
+`ScalingPolicy.Alarms` remain empty — the watcher resolves alarms by
+walking CloudWatch state directly rather than mirroring AWS's
+auto-attach behaviour.


### PR DESCRIPTION
## Summary

Application Auto Scaling has stored scaling policies verbatim since
shipping but never actually changed any resource. **EE1 turns the
DynamoDB integration on**: a new background watcher reads CloudWatch
metric samples / alarm state and resizes DynamoDB provisioned
throughput in response to target-tracking and step-scaling policies.

- New \`ScalingWatcher\` ticks every 15s. \`MetricReader\` and
  \`DynamoDbCapacityHook\` traits keep the autoscaling crate
  decoupled from CloudWatch / DynamoDB; concrete impls live in
  fakecloud-server.
- **TargetTracking** reads \`DynamoDBReadCapacityUtilization\` /
  \`DynamoDBWriteCapacityUtilization\`, computes
  \`desired = current * (utilisation / TargetValue)\`, clamps to
  \`[Min, Max]\`, honours \`ScaleIn/ScaleOutCooldown\`, and updates
  the table's \`ProvisionedThroughput\`.
- **StepScaling** picks up firing alarms whose \`AlarmActions\`
  contain the policy ARN, then applies the first \`StepAdjustment\`
  via \`ChangeInCapacity\` / \`ExactCapacity\` /
  \`PercentChangeInCapacity\` (with \`MinAdjustmentMagnitude\`).
  Honours \`Cooldown\`.
- Decisions land as \`ScalingActivity\` rows so
  \`DescribeScalingActivities\` reflects real history. Cooldown
  skips and hook errors record \`Failed\` activities with
  \`NotScaledReason\`.
- \`POST /_fakecloud/application-autoscaling/tick\` forces an
  immediate evaluation for deterministic tests, exposed in every
  introspection SDK (Rust, Go, Python, TypeScript, Java, PHP).

## Test plan

- [x] Unit tests in \`fakecloud-application-autoscaling\` cover
      target-tracking scale-out, step scaling on alarm fire, and
      no-op when utilisation already matches the target.
- [x] E2E tests (\`fakecloud-e2e/tests/application_autoscaling.rs\`)
      drive a real DynamoDB table through the watcher:
      \`target_tracking_scales_dynamodb_read_capacity\`,
      \`target_tracking_clamps_to_min_max_bounds\`,
      \`step_scaling_applies_when_alarm_action_fires\`.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo test --workspace --lib\` clean.
- [x] All five introspection SDKs compile (Go, Java via Gradle, Python
      import smoke, TypeScript via tsc, Rust SDK via cargo build).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables real DynamoDB autoscaling: a background watcher reads CloudWatch metrics and alarm state and resizes table provisioned throughput via target-tracking and step scaling. Adds an admin tick endpoint and SDK helpers to force evaluation (returns how many policies applied), and records scaling history.

- **New Features**
  - Added `ScalingWatcher` (15s) using `MetricReader` and `DynamoDbCapacityHook`, wired in the server; can be triggered via `/_fakecloud/application-autoscaling/tick` (responds with `{ "applied": <int> }`).
  - Target tracking: reads `DynamoDBReadCapacityUtilization`/`DynamoDBWriteCapacityUtilization`, computes `desired = current * (utilisation / TargetValue)`, clamps to Min/Max, rounds up, and honours `ScaleIn/ScaleOutCooldown` via `last_applied_at`.
  - Step scaling: fires when alarms with the policy ARN in `AlarmActions` are `ALARM`; applies `ChangeInCapacity`/`ExactCapacity`/`PercentChangeInCapacity` (with `MinAdjustmentMagnitude`) and respects `Cooldown`.
  - Writes decisions to `ScalingActivity`; logs cooldown skips and hook errors as `Failed` with `NotScaledReason`. SDKs (Rust, Go, Python, TypeScript, Java, PHP) expose the tick helper.

<sup>Written for commit 29d3a194d6bc1154925d272639800ccf622030e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

