### PR TITLE
feat(bedrock): echo mode + dynamic token counts (FF1)

### DIFF
--- a/crates/fakecloud-bedrock/src/converse.rs
+++ b/crates/fakecloud-bedrock/src/converse.rs
@@ -35,7 +35,21 @@ pub(crate) fn converse(
                 custom
             }
         }
-        None => "This is a test response from the emulated model.".to_string(),
+        None => {
+            // Echo mode short-circuits the canned phrase: reflect the
+            // caller's prompt back as the assistant text so tests can
+            // assert against their own input.
+            if crate::prompt::echo_enabled() {
+                let echoed = crate::prompt::extract_prompt_text(model_id, body);
+                if echoed.is_empty() {
+                    "(empty prompt)".to_string()
+                } else {
+                    echoed
+                }
+            } else {
+                "This is a test response from the emulated model.".to_string()
+            }
+        }
     };
 
     // Respect maxTokens by truncating (rough approximation: 1 token ~= 4 chars)
@@ -84,7 +98,7 @@ pub(crate) fn converse(
     };
 
     let input_tokens = estimate_tokens(&input);
-    let output_tokens = truncated_text.split_whitespace().count().max(1) as u64;
+    let output_tokens = crate::prompt::count_tokens(&truncated_text).max(1);
 
     let response = json!({
         "output": {
@@ -158,9 +172,17 @@ mod tests {
     use bytes::Bytes;
     use fakecloud_core::multi_account::MultiAccountState;
     use http::{HeaderMap, Method};
-    use parking_lot::RwLock;
+    use parking_lot::{Mutex, RwLock};
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::OnceLock;
+
+    /// Serialize tests in this module that observe the process-global
+    /// `FAKECLOUD_BEDROCK_ECHO` flag.
+    fn echo_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn shared() -> SharedBedrockState {
         let multi: MultiAccountState<BedrockState> =
@@ -288,6 +310,52 @@ mod tests {
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["output"]["message"]["content"][0]["text"], "nested-hello");
+    }
+
+    #[test]
+    fn converse_echo_mode_reflects_prompt() {
+        let _g = echo_lock().lock();
+        let prev = std::env::var("FAKECLOUD_BEDROCK_ECHO").ok();
+        // SAFETY: the lock above pins us to a single mutation window.
+        unsafe { std::env::set_var("FAKECLOUD_BEDROCK_ECHO", "1") };
+
+        let s = shared();
+        let body = br#"{"messages":[{"role":"user","content":[{"text":"hello echo"}]}]}"#;
+        let resp = converse(&s, &req(), "anthropic.claude-v2", body).unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let text = v["output"]["message"]["content"][0]["text"]
+            .as_str()
+            .unwrap();
+        assert!(text.contains("hello echo"), "echo missing prompt: {text}");
+
+        // SAFETY: see above.
+        unsafe {
+            match prev {
+                Some(p) => std::env::set_var("FAKECLOUD_BEDROCK_ECHO", p),
+                None => std::env::remove_var("FAKECLOUD_BEDROCK_ECHO"),
+            }
+        }
+    }
+
+    #[test]
+    fn converse_token_counts_scale_with_input_length() {
+        let _g = echo_lock().lock();
+        let s = shared();
+        let short = br#"{"messages":[{"content":[{"text":"hi"}]}]}"#;
+        let long = br#"{"messages":[{"content":[{"text":"please count many words across this longer message body"}]}]}"#;
+        let r1 = converse(&s, &req(), "m", short).unwrap();
+        let r2 = converse(&s, &req(), "m", long).unwrap();
+        let v1: Value =
+            serde_json::from_str(std::str::from_utf8(r1.body.expect_bytes()).unwrap()).unwrap();
+        let v2: Value =
+            serde_json::from_str(std::str::from_utf8(r2.body.expect_bytes()).unwrap()).unwrap();
+        let in1 = v1["usage"]["inputTokens"].as_u64().unwrap();
+        let in2 = v2["usage"]["inputTokens"].as_u64().unwrap();
+        assert!(
+            in2 > in1,
+            "longer prompt should produce more input tokens (got {in1} vs {in2})"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -50,8 +50,8 @@ pub(crate) fn invoke_model(
     // Real Bedrock returns dynamic input/output token counts. Approximate
     // each by whitespace-splitting the relevant text — close enough for
     // SDKs that gate on usage.input_tokens / usage.output_tokens metering.
-    let input_tokens = approximate_token_count(&extract_input_text(&input));
-    let output_tokens = approximate_token_count(&extract_output_text(model_id, &response_body));
+    let input_tokens = crate::prompt::count_tokens(&extract_input_text(&input));
+    let output_tokens = crate::prompt::count_tokens(&extract_output_text(model_id, &response_body));
 
     let mut headers = http::HeaderMap::new();
     headers.insert(
@@ -77,17 +77,10 @@ pub(crate) fn invoke_model(
     })
 }
 
-/// Whitespace-tokenize approximation. Real Bedrock uses the model's BPE
-/// tokenizer; we don't carry one. SDKs almost always treat usage as
-/// opaque metering, so a reasonable scalar is enough.
-pub(crate) fn approximate_token_count(text: &str) -> usize {
-    text.split_whitespace().count()
-}
-
 /// Pull the user-supplied prompt out of an InvokeModel request body.
 /// Each provider lays it out differently; we cover the most common
 /// shapes and fall back to the raw body length when nothing matches.
-fn extract_input_text(input: &Value) -> String {
+pub(crate) fn extract_input_text(input: &Value) -> String {
     // Anthropic: messages[] with role+content (string or array of content blocks)
     if let Some(messages) = input.get("messages").and_then(|m| m.as_array()) {
         let mut text = String::new();
@@ -243,12 +236,7 @@ pub(crate) fn count_tokens(
         serde_json::to_string(&input).unwrap_or_default()
     };
 
-    // Rough token count: split by whitespace
-    let token_count = if text.is_empty() {
-        0
-    } else {
-        text.split_whitespace().count()
-    };
+    let token_count = crate::prompt::count_tokens(&text);
 
     Ok(AwsResponse::ok_json(json!({
         "inputTokens": token_count
@@ -256,11 +244,12 @@ pub(crate) fn count_tokens(
 }
 
 /// Generate a deterministic canned response based on the model provider.
-/// When `BEDROCK_ECHO=1` is set in the environment, the assistant text
-/// reflects the user-supplied prompt instead of the canned phrase, so
-/// tests can pin assertions against their own input.
+/// When `FAKECLOUD_FAKECLOUD_BEDROCK_ECHO=1` (or legacy `FAKECLOUD_BEDROCK_ECHO=1`) is set in
+/// the environment, the assistant text reflects the user-supplied prompt
+/// instead of the canned phrase, so tests can pin assertions against
+/// their own input.
 fn generate_canned_response(model_id: &str, input: &Value) -> String {
-    if std::env::var("BEDROCK_ECHO").as_deref() == Ok("1") {
+    if crate::prompt::echo_enabled() {
         return echo_response(model_id, input);
     }
     canned_response_inner(model_id, input)
@@ -281,19 +270,23 @@ fn canned_response_inner(model_id: &str, input: &Value) -> String {
         "generic"
     };
 
+    let prompt = extract_input_text(input);
+    let in_tokens = crate::prompt::count_tokens(&prompt);
     match provider {
-        "anthropic" => anthropic_response(model_id, input),
-        "amazon" => amazon_titan_response(model_id, input),
-        "meta" => meta_llama_response(input),
-        "cohere" => cohere_response(input),
-        "mistral" => mistral_response(input),
-        _ => generic_response(input),
+        "anthropic" => anthropic_response(model_id, in_tokens),
+        "amazon" => amazon_titan_response(model_id, in_tokens),
+        "meta" => meta_llama_response(in_tokens),
+        "cohere" => cohere_response(),
+        "mistral" => mistral_response(),
+        _ => generic_response(),
     }
 }
 
 /// Build a response that echoes the caller's prompt instead of the
 /// canned phrase. The shape matches the same provider-specific JSON that
 /// `canned_response_inner` produces — only the assistant text changes.
+/// Usage fields inside the body are populated via `count_tokens` against
+/// the actual input prompt and echoed output.
 fn echo_response(model_id: &str, input: &Value) -> String {
     let prompt = extract_input_text(input);
     let echoed = if prompt.is_empty() {
@@ -301,6 +294,8 @@ fn echo_response(model_id: &str, input: &Value) -> String {
     } else {
         prompt
     };
+    let in_tokens = crate::prompt::count_tokens(&echoed);
+    let out_tokens = crate::prompt::count_tokens(&echoed);
     if model_id.starts_with("anthropic.") {
         return serde_json::to_string(&json!({
             "id": "msg_fakecloudtest01",
@@ -310,15 +305,15 @@ fn echo_response(model_id: &str, input: &Value) -> String {
             "model": model_id,
             "stop_reason": "end_turn",
             "stop_sequence": null,
-            "usage": { "input_tokens": 0, "output_tokens": 0 }
+            "usage": { "input_tokens": in_tokens, "output_tokens": out_tokens }
         }))
         .expect("serde_json::Value serialization is infallible");
     }
     if model_id.starts_with("amazon.") {
         return serde_json::to_string(&json!({
-            "inputTextTokenCount": 0,
+            "inputTextTokenCount": in_tokens,
             "results": [{
-                "tokenCount": 0,
+                "tokenCount": out_tokens,
                 "outputText": echoed,
                 "completionReason": "FINISH"
             }]
@@ -328,8 +323,8 @@ fn echo_response(model_id: &str, input: &Value) -> String {
     if model_id.starts_with("meta.") {
         return serde_json::to_string(&json!({
             "generation": echoed,
-            "prompt_token_count": 0,
-            "generation_token_count": 0,
+            "prompt_token_count": in_tokens,
+            "generation_token_count": out_tokens,
             "stop_reason": "stop"
         }))
         .expect("serde_json::Value serialization is infallible");
@@ -352,7 +347,13 @@ fn echo_response(model_id: &str, input: &Value) -> String {
         .expect("serde_json::Value serialization is infallible")
 }
 
-fn anthropic_response(model_id: &str, _input: &Value) -> String {
+/// Canned text every provider's non-echo branch returns. Centralized so
+/// the body and the corresponding `usage.output_tokens` come from the
+/// same source.
+const CANNED_OUTPUT_TEXT: &str = "This is a test response from the emulated model.";
+
+fn anthropic_response(model_id: &str, in_tokens: u64) -> String {
+    let out_tokens = crate::prompt::count_tokens(CANNED_OUTPUT_TEXT);
     serde_json::to_string(&json!({
         "id": "msg_fakecloudtest01",
         "type": "message",
@@ -360,37 +361,38 @@ fn anthropic_response(model_id: &str, _input: &Value) -> String {
         "content": [
             {
                 "type": "text",
-                "text": "This is a test response from the emulated model."
+                "text": CANNED_OUTPUT_TEXT
             }
         ],
         "model": model_id,
         "stop_reason": "end_turn",
         "stop_sequence": null,
         "usage": {
-            "input_tokens": 10,
-            "output_tokens": 20
+            "input_tokens": in_tokens,
+            "output_tokens": out_tokens
         }
     }))
     .expect("serde_json::Value serialization is infallible")
 }
 
-fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
+fn amazon_titan_response(model_id: &str, in_tokens: u64) -> String {
     // Titan embed models return embedding vectors, not text completions
     if model_id.starts_with("amazon.titan-embed") {
         let embedding: Vec<f64> = (0..256).map(|i| (i as f64 * 0.001).sin()).collect();
         return serde_json::to_string(&json!({
             "embedding": embedding,
-            "inputTextTokenCount": 10
+            "inputTextTokenCount": in_tokens
         }))
         .expect("serde_json::Value serialization is infallible");
     }
 
+    let out_tokens = crate::prompt::count_tokens(CANNED_OUTPUT_TEXT);
     serde_json::to_string(&json!({
-        "inputTextTokenCount": 10,
+        "inputTextTokenCount": in_tokens,
         "results": [
             {
-                "tokenCount": 20,
-                "outputText": "This is a test response from the emulated model.",
+                "tokenCount": out_tokens,
+                "outputText": CANNED_OUTPUT_TEXT,
                 "completionReason": "FINISH"
             }
         ]
@@ -398,24 +400,25 @@ fn amazon_titan_response(model_id: &str, _input: &Value) -> String {
     .expect("serde_json::Value serialization is infallible")
 }
 
-fn meta_llama_response(_input: &Value) -> String {
+fn meta_llama_response(in_tokens: u64) -> String {
+    let out_tokens = crate::prompt::count_tokens(CANNED_OUTPUT_TEXT);
     serde_json::to_string(&json!({
-        "generation": "This is a test response from the emulated model.",
+        "generation": CANNED_OUTPUT_TEXT,
         "prompt_logprobs": null,
         "generation_logprobs": null,
         "stop_reason": "stop",
-        "generation_token_count": 20,
-        "prompt_token_count": 10
+        "generation_token_count": out_tokens,
+        "prompt_token_count": in_tokens
     }))
     .expect("serde_json::Value serialization is infallible")
 }
 
-fn cohere_response(_input: &Value) -> String {
+fn cohere_response() -> String {
     serde_json::to_string(&json!({
         "generations": [
             {
                 "id": "gen-fakecloud-01",
-                "text": "This is a test response from the emulated model.",
+                "text": CANNED_OUTPUT_TEXT,
                 "finish_reason": "COMPLETE",
                 "token_likelihoods": []
             }
@@ -425,11 +428,11 @@ fn cohere_response(_input: &Value) -> String {
     .expect("serde_json::Value serialization is infallible")
 }
 
-fn mistral_response(_input: &Value) -> String {
+fn mistral_response() -> String {
     serde_json::to_string(&json!({
         "outputs": [
             {
-                "text": "This is a test response from the emulated model.",
+                "text": CANNED_OUTPUT_TEXT,
                 "stop_reason": "stop"
             }
         ]
@@ -437,9 +440,9 @@ fn mistral_response(_input: &Value) -> String {
     .expect("serde_json::Value serialization is infallible")
 }
 
-fn generic_response(_input: &Value) -> String {
+fn generic_response() -> String {
     serde_json::to_string(&json!({
-        "output": "This is a test response from the emulated model."
+        "output": CANNED_OUTPUT_TEXT
     }))
     .expect("serde_json::Value serialization is infallible")
 }
@@ -457,7 +460,7 @@ mod tests {
     use std::sync::OnceLock;
 
     /// Global mutex to serialize tests that mutate the process-wide
-    /// `BEDROCK_ECHO` env var with sibling tests in the same binary that
+    /// `FAKECLOUD_BEDROCK_ECHO` env var with sibling tests in the same binary that
     /// observe model behavior. Without it the parallel test harness
     /// races: e.g. `invoke_amazon_titan_embed_returns_vector` runs while
     /// `invoke_echo_mode_reflects_prompt` still has the flag flipped, and
@@ -531,13 +534,13 @@ mod tests {
 
     #[test]
     fn invoke_echo_mode_reflects_prompt() {
-        // BEDROCK_ECHO mutation is process-global; the lock serializes
+        // FAKECLOUD_BEDROCK_ECHO mutation is process-global; the lock serializes
         // this test with sibling tests in the same binary that observe
         // model output (e.g. titan-embed) so they don't race the flag.
         let _g = echo_lock().lock();
-        let prev = std::env::var("BEDROCK_ECHO").ok();
+        let prev = std::env::var("FAKECLOUD_BEDROCK_ECHO").ok();
         // SAFETY: lock above pins us to a single mutation window.
-        unsafe { std::env::set_var("BEDROCK_ECHO", "1") };
+        unsafe { std::env::set_var("FAKECLOUD_BEDROCK_ECHO", "1") };
 
         let s = shared();
         let body = br#"{"messages":[{"role":"user","content":"hello world from echo mode"}]}"#;
@@ -553,8 +556,8 @@ mod tests {
         // SAFETY: see comment above.
         unsafe {
             match prev {
-                Some(p) => std::env::set_var("BEDROCK_ECHO", p),
-                None => std::env::remove_var("BEDROCK_ECHO"),
+                Some(p) => std::env::set_var("FAKECLOUD_BEDROCK_ECHO", p),
+                None => std::env::remove_var("FAKECLOUD_BEDROCK_ECHO"),
             }
         }
     }
@@ -563,7 +566,7 @@ mod tests {
     fn invoke_anthropic_returns_message_format() {
         // Body-shape tests in this module observe the response payload,
         // so they all must serialize with `invoke_echo_mode_reflects_prompt`,
-        // which mutates the process-global `BEDROCK_ECHO` flag and would
+        // which mutates the process-global `FAKECLOUD_BEDROCK_ECHO` flag and would
         // otherwise have them observe the echo branch mid-flip.
         let _g = echo_lock().lock();
         let s = shared();

--- a/crates/fakecloud-bedrock/src/prompt.rs
+++ b/crates/fakecloud-bedrock/src/prompt.rs
@@ -4,6 +4,29 @@ use fakecloud_core::service::AwsRequest;
 
 use crate::state::{ResponseRule, SharedBedrockState};
 
+/// Approximate token count for an arbitrary text using a whitespace
+/// heuristic. Real Bedrock invokes the model's tokenizer; we don't ship
+/// one, but SDKs only treat usage as opaque metering, so a stable
+/// length-proportional scalar (minimum 1 for any non-empty input) is
+/// sufficient. Used everywhere we need to populate `usage.input_tokens`
+/// / `usage.output_tokens` from the actual prompt and generated text.
+pub(crate) fn count_tokens(text: &str) -> u64 {
+    let n = text.split_whitespace().count() as u64;
+    if n == 0 && !text.is_empty() {
+        1
+    } else {
+        n
+    }
+}
+
+/// Read the echo-mode flag from the environment. Accepts either
+/// `FAKECLOUD_BEDROCK_ECHO=1` (preferred, matches the project's
+/// `FAKECLOUD_*` env-var convention) or the legacy `BEDROCK_ECHO=1`.
+pub(crate) fn echo_enabled() -> bool {
+    std::env::var("FAKECLOUD_BEDROCK_ECHO").as_deref() == Ok("1")
+        || std::env::var("BEDROCK_ECHO").as_deref() == Ok("1")
+}
+
 /// Extract the user-visible prompt text from a runtime request body.
 ///
 /// Handles both InvokeModel (provider-specific shapes) and Converse bodies.
@@ -272,5 +295,55 @@ mod tests {
     fn resolve_override_none_when_nothing_configured() {
         let state = shared();
         assert!(resolve_override(&state, &req(), "m", b"{}").is_none());
+    }
+
+    #[test]
+    fn count_tokens_basic_whitespace_split() {
+        assert_eq!(count_tokens(""), 0);
+        assert_eq!(count_tokens("hi"), 1);
+        assert_eq!(count_tokens("hello world"), 2);
+        assert_eq!(count_tokens("a b c d e"), 5);
+    }
+
+    #[test]
+    fn count_tokens_proportional_to_input_length() {
+        // FF1 acceptance: token counts should grow with input size.
+        let short = count_tokens("one two");
+        let long = count_tokens("one two three four five six seven eight");
+        assert!(long > short);
+    }
+
+    #[test]
+    fn count_tokens_no_whitespace_input_returns_at_least_one() {
+        // Pathological input (e.g. one giant word) shouldn't report
+        // zero tokens — SDKs treat 0 as "this didn't run".
+        assert_eq!(count_tokens("supercalifragilistic"), 1);
+    }
+
+    #[test]
+    fn echo_enabled_reads_canonical_var() {
+        let prev_canonical = std::env::var("FAKECLOUD_BEDROCK_ECHO").ok();
+        let prev_legacy = std::env::var("BEDROCK_ECHO").ok();
+        // SAFETY: env is process-global; we restore both vars below.
+        unsafe {
+            std::env::remove_var("FAKECLOUD_BEDROCK_ECHO");
+            std::env::remove_var("BEDROCK_ECHO");
+        }
+        assert!(!echo_enabled());
+        // SAFETY: see above.
+        unsafe { std::env::set_var("FAKECLOUD_BEDROCK_ECHO", "1") };
+        assert!(echo_enabled());
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_canonical {
+                Some(v) => std::env::set_var("FAKECLOUD_BEDROCK_ECHO", v),
+                None => std::env::remove_var("FAKECLOUD_BEDROCK_ECHO"),
+            }
+            match prev_legacy {
+                Some(v) => std::env::set_var("BEDROCK_ECHO", v),
+                None => std::env::remove_var("BEDROCK_ECHO"),
+            }
+        }
     }
 }

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -1511,7 +1511,14 @@ impl AwsService for BedrockService {
                 }
                 let response_text =
                     crate::streaming::get_response_text(&self.state, &req, &model_id, &req.body);
-                let body = crate::streaming::build_converse_stream_response(&response_text);
+                let prompt = crate::prompt::extract_prompt_text(&model_id, &req.body);
+                let input_tokens = crate::prompt::count_tokens(&prompt);
+                let output_tokens = crate::prompt::count_tokens(&response_text);
+                let body = crate::streaming::build_converse_stream_response(
+                    &response_text,
+                    input_tokens,
+                    output_tokens,
+                );
 
                 // Record invocation
                 {

--- a/crates/fakecloud-bedrock/src/streaming.rs
+++ b/crates/fakecloud-bedrock/src/streaming.rs
@@ -117,7 +117,15 @@ pub(crate) fn build_invoke_stream_response(model_id: &str, response_text: &str) 
 }
 
 /// Build the complete event stream body for ConverseStream.
-pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
+///
+/// `input_tokens` and `output_tokens` are surfaced verbatim in the
+/// terminating `metadata` event so callers see real, prompt-derived
+/// usage figures instead of the historical 10/20 placeholder.
+pub(crate) fn build_converse_stream_response(
+    response_text: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+) -> Vec<u8> {
     let mut body = Vec::new();
 
     // messageStart event
@@ -172,9 +180,9 @@ pub(crate) fn build_converse_stream_response(response_text: &str) -> Vec<u8> {
     // metadata event
     let metadata = json!({
         "usage": {
-            "inputTokens": 10,
-            "outputTokens": 20,
-            "totalTokens": 30
+            "inputTokens": input_tokens,
+            "outputTokens": output_tokens,
+            "totalTokens": input_tokens + output_tokens
         },
         "metrics": {
             "latencyMs": 100
@@ -198,7 +206,9 @@ pub(crate) fn default_stream_text() -> &'static str {
 }
 
 /// Generate the canned response text, checking for prompt-conditional and
-/// legacy custom overrides for the given call.
+/// legacy custom overrides for the given call. When neither is set and
+/// `FAKECLOUD_BEDROCK_ECHO=1` is exported, the caller's prompt is
+/// reflected back so streaming tests can assert against their own input.
 pub(crate) fn get_response_text(
     state: &crate::state::SharedBedrockState,
     req: &fakecloud_core::service::AwsRequest,
@@ -206,6 +216,14 @@ pub(crate) fn get_response_text(
     body: &[u8],
 ) -> String {
     let Some(custom) = crate::prompt::resolve_override(state, req, model_id, body) else {
+        if crate::prompt::echo_enabled() {
+            let echoed = crate::prompt::extract_prompt_text(model_id, body);
+            return if echoed.is_empty() {
+                "(empty prompt)".to_string()
+            } else {
+                echoed
+            };
+        }
         return default_stream_text().to_string();
     };
     // Try to extract text from a JSON response body.
@@ -325,7 +343,7 @@ mod tests {
 
     #[test]
     fn build_converse_stream_emits_all_events() {
-        let out = build_converse_stream_response("hello world");
+        let out = build_converse_stream_response("hello world", 5, 7);
         let s = String::from_utf8_lossy(&out);
         for marker in [
             "messageStart",
@@ -338,6 +356,10 @@ mod tests {
         ] {
             assert!(s.contains(marker), "missing marker {marker}");
         }
+        // Token counts surface via metadata, not a hardcoded 10/20.
+        assert!(s.contains("\"inputTokens\":5"));
+        assert!(s.contains("\"outputTokens\":7"));
+        assert!(s.contains("\"totalTokens\":12"));
     }
 
     #[test]
@@ -397,5 +419,38 @@ mod tests {
         install_rule(&s, "anthropic.claude", "plain raw");
         let out = get_response_text(&s, &req(), "anthropic.claude", b"{}");
         assert_eq!(out, "plain raw");
+    }
+
+    /// Echo mode test mutates the process-global env var; we don't
+    /// share a lock with sibling test files (the `cargo test` binary
+    /// is per-crate and these are different modules), so we restore
+    /// the previous value as a defensive cleanup.
+    #[test]
+    fn get_response_text_echo_mode_reflects_prompt() {
+        let prev = std::env::var("FAKECLOUD_BEDROCK_ECHO").ok();
+        // SAFETY: scoped mutation below restores the previous value.
+        unsafe { std::env::set_var("FAKECLOUD_BEDROCK_ECHO", "1") };
+
+        let s = shared();
+        let body = br#"{"messages":[{"role":"user","content":"hello stream"}]}"#;
+        let out = get_response_text(&s, &req(), "anthropic.claude-3", body);
+        assert!(out.contains("hello stream"), "echo missing prompt: {out}");
+
+        // SAFETY: see above.
+        unsafe {
+            match prev {
+                Some(p) => std::env::set_var("FAKECLOUD_BEDROCK_ECHO", p),
+                None => std::env::remove_var("FAKECLOUD_BEDROCK_ECHO"),
+            }
+        }
+    }
+
+    #[test]
+    fn build_converse_stream_response_emits_dynamic_token_counts() {
+        let out = build_converse_stream_response("text", 42, 7);
+        let s = String::from_utf8_lossy(&out);
+        assert!(s.contains("\"inputTokens\":42"));
+        assert!(s.contains("\"outputTokens\":7"));
+        assert!(s.contains("\"totalTokens\":49"));
     }
 }

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1327,6 +1327,117 @@ async fn bedrock_invoke_model_response_headers() {
     );
 }
 
+// FF1: echo mode + dynamic token counts
+//
+// `FAKECLOUD_BEDROCK_ECHO=1` reflects the user's prompt back as the
+// assistant text, and the response token counts scale with the actual
+// input length instead of the historical 10/20 placeholder.
+
+#[tokio::test]
+async fn bedrock_invoke_model_echo_mode_reflects_prompt() {
+    let server = TestServer::start_with_env(&[("FAKECLOUD_BEDROCK_ECHO", "1")]).await;
+    let client = server.bedrock_runtime_client().await;
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 100,
+        "messages": [{"role": "user", "content": "hello"}]
+    }))
+    .unwrap();
+
+    let resp = client
+        .invoke_model()
+        .model_id("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        .content_type("application/json")
+        .accept("application/json")
+        .body(Blob::new(body))
+        .send()
+        .await
+        .unwrap();
+
+    let response_body: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
+    let text = response_body["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text.contains("hello"),
+        "echo response missing prompt: {text}"
+    );
+}
+
+#[tokio::test]
+async fn bedrock_invoke_model_default_no_echo_when_var_unset() {
+    let server = TestServer::start().await;
+    let client = server.bedrock_runtime_client().await;
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 100,
+        "messages": [{"role": "user", "content": "hello"}]
+    }))
+    .unwrap();
+
+    let resp = client
+        .invoke_model()
+        .model_id("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        .content_type("application/json")
+        .accept("application/json")
+        .body(Blob::new(body))
+        .send()
+        .await
+        .unwrap();
+
+    let response_body: serde_json::Value = serde_json::from_slice(resp.body().as_ref()).unwrap();
+    let text = response_body["content"][0]["text"].as_str().unwrap();
+    // Default canned phrase, not the prompt.
+    assert!(text.contains("test response from the emulated model"));
+}
+
+#[tokio::test]
+async fn bedrock_invoke_model_token_counts_scale_with_input() {
+    let server = TestServer::start().await;
+    let http_client = reqwest::Client::new();
+
+    let do_call = |prompt: &'static str| {
+        let endpoint = server.endpoint().to_string();
+        let client = http_client.clone();
+        async move {
+            let body = serde_json::json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": prompt}]
+            });
+            let resp = client
+                .post(format!(
+                    "{endpoint}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke"
+                ))
+                .header("content-type", "application/json")
+                .header(
+                    "authorization",
+                    "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260411/us-east-1/bedrock/aws4_request, SignedHeaders=host, Signature=fake",
+                )
+                .body(serde_json::to_string(&body).unwrap())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), 200);
+            resp.headers()
+                .get("x-amzn-bedrock-input-token-count")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .parse::<u64>()
+                .unwrap()
+        }
+    };
+
+    let short_count = do_call("hi").await;
+    let long_count =
+        do_call("please count many words across this longer message body for tokens").await;
+    assert!(
+        long_count > short_count,
+        "token count should scale with input length (short={short_count}, long={long_count})"
+    );
+}
+
 // Streaming (via raw HTTP — AWS SDK event stream parsing is complex)
 
 #[tokio::test]

--- a/website/content/docs/guides/testing-bedrock.md
+++ b/website/content/docs/guides/testing-bedrock.md
@@ -152,6 +152,18 @@ Provider defaults are shipped for:
 
 All follow the same shape as real model responses. They're not useful if your code inspects the output, but they're fine for tests that just verify "did my code call Bedrock at all."
 
+### Echo mode
+
+If you want every model call to reflect the caller's prompt back as the assistant text, set `FAKECLOUD_BEDROCK_ECHO=1` on the fakecloud process. This skips the canned phrase and instead pins the response on whatever the test sent in, which is convenient for assertions that don't care about model behavior — only that the prompt round-tripped through your code.
+
+```bash
+FAKECLOUD_BEDROCK_ECHO=1 fakecloud
+```
+
+Echo mode applies to InvokeModel, Converse, InvokeModelWithResponseStream, and ConverseStream, and covers all five provider shapes (Anthropic, Amazon, Meta, Cohere, Mistral). It is bypassed by any prompt-conditional rule or single-model override you configure, so explicit responses always win.
+
+Token counts in headers and `usage` fields are derived from the actual prompt and generated text in all modes — they scale with input length rather than returning a fixed placeholder.
+
 ## Fault injection
 
 Real Bedrock throws a specific set of errors. Production code has retry, fallback, and circuit-breaker logic for them — and that logic is normally untestable because you can't make real Bedrock fail on command.

--- a/website/content/docs/services/bedrock.md
+++ b/website/content/docs/services/bedrock.md
@@ -65,6 +65,12 @@ REST. Path-based routing for runtime operations, JSON bodies per provider.
 - `GET /_fakecloud/bedrock/faults` — list queued faults
 - `DELETE /_fakecloud/bedrock/faults` — clear all faults
 
+## Echo mode
+
+Set `FAKECLOUD_BEDROCK_ECHO=1` on the fakecloud process to make every InvokeModel / Converse / streaming call reflect the user's prompt back as the assistant text in the provider-correct shape. Useful for tests that just need the prompt to round-trip through application code without configuring an explicit response per call. Explicit overrides still win.
+
+Token counts in headers and `usage` fields scale with the actual input length in all modes.
+
 ## The full test loop
 
 Configure a response, run code, assert on what was called — see [Testing Bedrock](/docs/guides/testing-bedrock/) for complete examples including fault injection for retry testing.


### PR DESCRIPTION
## Summary

Bedrock fidelity batch FF1.

- **Echo mode**: when `FAKECLOUD_BEDROCK_ECHO=1` is exported, InvokeModel / Converse / InvokeModelWithResponseStream / ConverseStream all reflect the user's prompt back as the assistant text in the provider-correct shape. Tests can pin assertions on their own input. Legacy `BEDROCK_ECHO=1` still works for back-compat.
- **Dynamic token counts**: `usage.input_tokens`, `usage.output_tokens`, `x-amzn-bedrock-*-token-count` headers, and ConverseStream metadata events are now derived from the actual prompt + generated text via a single `count_tokens` helper in `prompt.rs`. The historical 10 / 20 / 30 placeholders are gone.

## Test plan

- [x] Unit tests for `count_tokens`, `echo_enabled`, echo branches in invoke / converse / streaming
- [x] E2E: `FAKECLOUD_BEDROCK_ECHO=1` -> Anthropic Claude prompt "hello" reflects back; default response without env var
- [x] E2E: token-count header scales with input length
- [x] `cargo clippy -D warnings` clean across `fakecloud-bedrock` + `fakecloud-e2e`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds echo mode and real token metering to the Bedrock emulator for InvokeModel, Converse, and both streaming variants, improving testability and making usage numbers scale with input/output.

- **New Features**
  - Echo mode: set `FAKECLOUD_BEDROCK_ECHO=1` to mirror the user’s prompt as assistant text in provider-correct shapes for InvokeModel, Converse, InvokeModelWithResponseStream, and ConverseStream. Legacy `BEDROCK_ECHO=1` is still accepted. Explicit overrides still take precedence.
  - Dynamic token counts: all `usage.input_tokens`/`usage.output_tokens`, `x-amzn-bedrock-*-token-count` headers, and ConverseStream `metadata` (including `totalTokens`) now use a shared `count_tokens` helper based on actual prompt/output.
  - Docs: added echo mode and token metering notes to the Bedrock testing guide and service docs.

- **Migration**
  - Update tests that expected fixed token counts; they now vary with input length. Use echo mode to assert against your own prompt when needed.
  - Prefer `FAKECLOUD_BEDROCK_ECHO`; `BEDROCK_ECHO` remains for back-compat.

<sup>Written for commit 4d26cea96f06f521ce4f4392f77f1d531f63c21f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

