### PR TITLE
feat(lambda): real eventstream chunks in InvokeWithResponseStream (GG1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32fast",
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",

--- a/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
+++ b/crates/fakecloud-e2e/src/bin/e2e_nextest_partitions.rs
@@ -35,7 +35,9 @@ const LAMBDA_RUNTIME_NODEJS_FILTER: &str = concat!(
     "test(test_invoke_nodejs18) | ",
     "test(test_invoke_nodejs20) | ",
     "test(test_invoke_nodejs22) | ",
-    "test(test_invoke_nodejs24)",
+    "test(test_invoke_nodejs24) | ",
+    "test(test_invoke_with_response_stream_emits_payload_chunks_and_invoke_complete) | ",
+    "test(test_invoke_with_response_stream_surfaces_handler_errors)",
     ")"
 );
 const LAMBDA_RUNTIME_RUBY_FILTER: &str = concat!(

--- a/crates/fakecloud-e2e/tests/lambda_invoke.rs
+++ b/crates/fakecloud-e2e/tests/lambda_invoke.rs
@@ -618,3 +618,148 @@ async fn test_invoke_no_code() {
         .await;
     assert!(result.is_err());
 }
+
+// ---- InvokeWithResponseStream ----
+
+const NODEJS_STREAMING_HANDLER: &str = r#"
+exports.handler = awslambda.streamifyResponse
+    ? awslambda.streamifyResponse(async (event, responseStream, context) => {
+        // Emit three discrete chunks; the RIE flushes each `write`
+        // separately so fakecloud should observe three payload chunks.
+        responseStream.setContentType("text/plain");
+        responseStream.write("chunk-one|");
+        responseStream.write("chunk-two|");
+        responseStream.write("chunk-three");
+        responseStream.end();
+    })
+    : async (event) => {
+        // Older runtime without streamifyResponse — return a buffered
+        // body. fakecloud will still surface this as a single
+        // PayloadChunk + InvokeComplete, exercising the same code path.
+        return "chunk-one|chunk-two|chunk-three";
+    };
+"#;
+
+#[tokio::test]
+async fn test_invoke_with_response_stream_emits_payload_chunks_and_invoke_complete() {
+    use aws_sdk_lambda::types::InvokeWithResponseStreamResponseEvent;
+
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    let zip = make_zip(&[("index.js", NODEJS_STREAMING_HANDLER.as_bytes())]);
+
+    client
+        .create_function()
+        .function_name("stream-func")
+        .runtime(Runtime::Nodejs22x)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let mut resp = client
+        .invoke_with_response_stream()
+        .function_name("stream-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .expect("InvokeWithResponseStream should succeed");
+
+    // The SDK parses our eventstream frames into typed events. Walk
+    // the stream collecting payload bytes until we see InvokeComplete.
+    let mut payload = Vec::<u8>::new();
+    let mut payload_chunk_count = 0;
+    let mut saw_invoke_complete = false;
+    while let Some(event) = resp
+        .event_stream
+        .recv()
+        .await
+        .expect("event stream should not error")
+    {
+        match event {
+            InvokeWithResponseStreamResponseEvent::PayloadChunk(chunk) => {
+                payload_chunk_count += 1;
+                if let Some(blob) = chunk.payload {
+                    payload.extend_from_slice(blob.as_ref());
+                }
+            }
+            InvokeWithResponseStreamResponseEvent::InvokeComplete(complete) => {
+                saw_invoke_complete = true;
+                assert!(
+                    complete.error_code.is_none(),
+                    "expected no error, got {:?}",
+                    complete.error_code
+                );
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_invoke_complete, "missing InvokeComplete event");
+    assert!(
+        payload_chunk_count >= 1,
+        "expected at least one PayloadChunk, got {payload_chunk_count}"
+    );
+    let text = String::from_utf8(payload).expect("payload is utf-8");
+    assert!(
+        text.contains("chunk-one") && text.contains("chunk-two") && text.contains("chunk-three"),
+        "payload missing expected chunks: {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_invoke_with_response_stream_surfaces_handler_errors() {
+    use aws_sdk_lambda::types::InvokeWithResponseStreamResponseEvent;
+
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    // Handler that always throws — we expect to see the error
+    // surface inside the terminal InvokeComplete event.
+    let throwing = r#"
+exports.handler = async (event) => {
+    throw new Error("boom from streaming handler");
+};
+"#;
+    let zip = make_zip(&[("index.js", throwing.as_bytes())]);
+
+    client
+        .create_function()
+        .function_name("stream-err-func")
+        .runtime(Runtime::Nodejs22x)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    let mut resp = client
+        .invoke_with_response_stream()
+        .function_name("stream-err-func")
+        .payload(Blob::new(b"{}".to_vec()))
+        .send()
+        .await
+        .expect("InvokeWithResponseStream should reach handler");
+
+    let mut saw_error_complete = false;
+    while let Some(event) = resp
+        .event_stream
+        .recv()
+        .await
+        .expect("event stream should not error")
+    {
+        if let InvokeWithResponseStreamResponseEvent::InvokeComplete(complete) = event {
+            // The handler threw — the buffered body Lambda returns
+            // contains errorMessage/errorType, which our handler maps
+            // to ErrorCode + ErrorDetails on the terminal event.
+            assert!(
+                complete.error_code.is_some(),
+                "expected ErrorCode to be set on handler error"
+            );
+            saw_error_complete = true;
+        }
+    }
+    assert!(saw_error_complete, "missing InvokeComplete with error");
+}

--- a/crates/fakecloud-lambda/Cargo.toml
+++ b/crates/fakecloud-lambda/Cargo.toml
@@ -27,6 +27,8 @@ tracing = { workspace = true }
 zip = { workspace = true }
 tempfile = { workspace = true }
 percent-encoding = { workspace = true }
+crc32fast = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/fakecloud-lambda/src/eventstream.rs
+++ b/crates/fakecloud-lambda/src/eventstream.rs
@@ -1,0 +1,235 @@
+//! Minimal `application/vnd.amazon.eventstream` frame encoder.
+//!
+//! This is the wire format AWS uses for streaming responses on
+//! `InvokeWithResponseStream`, S3 SelectObjectContent, Kinesis
+//! SubscribeToShard, Transcribe, etc. Each frame is:
+//!
+//! ```text
+//! +-----------------------------------+
+//! | total length        (u32 BE)      |
+//! | headers length      (u32 BE)      |
+//! | prelude CRC32       (u32 BE)      |  CRC of the two preceding u32s
+//! | headers bytes       (raw)         |
+//! | payload bytes       (raw)         |
+//! | message CRC32       (u32 BE)      |  CRC of the whole frame so far
+//! +-----------------------------------+
+//! ```
+//!
+//! Each header is encoded as:
+//!
+//! ```text
+//! +---------------------------------------+
+//! | name length     (u8)                  |
+//! | name bytes                            |
+//! | value type      (u8)                  |  7 = string
+//! | value length    (u16 BE) [for strings]|
+//! | value bytes                           |
+//! +---------------------------------------+
+//! ```
+//!
+//! Only the string header type (7) is needed for Lambda's response
+//! stream — `:event-type`, `:content-type`, `:message-type` are all
+//! short ASCII strings. Other value types (bool, int, byte_array,
+//! timestamp, uuid) aren't required here and are intentionally omitted
+//! to keep the surface minimal.
+
+const HEADER_TYPE_STRING: u8 = 7;
+
+/// Encode a single eventstream frame from a list of `(name, value)`
+/// string headers and a payload byte slice. Returns the bytes ready to
+/// be written to the response body.
+pub fn encode_frame(headers: &[(&str, &str)], payload: &[u8]) -> Vec<u8> {
+    let headers_bytes = encode_headers(headers);
+    let headers_len = headers_bytes.len() as u32;
+    // total = 4 (total) + 4 (headers_len) + 4 (prelude CRC) + headers + payload + 4 (msg CRC)
+    let total_len = 12u32 + headers_len + payload.len() as u32 + 4;
+
+    let mut out = Vec::with_capacity(total_len as usize);
+    out.extend_from_slice(&total_len.to_be_bytes());
+    out.extend_from_slice(&headers_len.to_be_bytes());
+
+    let prelude_crc = crc32fast::hash(&out[..8]);
+    out.extend_from_slice(&prelude_crc.to_be_bytes());
+
+    out.extend_from_slice(&headers_bytes);
+    out.extend_from_slice(payload);
+
+    let msg_crc = crc32fast::hash(&out);
+    out.extend_from_slice(&msg_crc.to_be_bytes());
+
+    out
+}
+
+fn encode_headers(headers: &[(&str, &str)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (name, value) in headers {
+        let name_bytes = name.as_bytes();
+        let value_bytes = value.as_bytes();
+        debug_assert!(name_bytes.len() <= u8::MAX as usize, "header name too long");
+        debug_assert!(
+            value_bytes.len() <= u16::MAX as usize,
+            "header value too long"
+        );
+        buf.push(name_bytes.len() as u8);
+        buf.extend_from_slice(name_bytes);
+        buf.push(HEADER_TYPE_STRING);
+        buf.extend_from_slice(&(value_bytes.len() as u16).to_be_bytes());
+        buf.extend_from_slice(value_bytes);
+    }
+    buf
+}
+
+/// Build a `PayloadChunk` event frame carrying a slice of the function's
+/// streamed response. AWS sends one of these per logical chunk emitted
+/// by the function (e.g. each `responseStream.write(...)` call in a
+/// Node.js streaming handler). The body is the raw chunk bytes — AWS
+/// does **not** wrap them in JSON; clients reconstruct the response by
+/// concatenating the payloads of every `PayloadChunk` event.
+pub fn payload_chunk_frame(chunk: &[u8]) -> Vec<u8> {
+    encode_frame(
+        &[
+            (":event-type", "PayloadChunk"),
+            (":content-type", "application/octet-stream"),
+            (":message-type", "event"),
+        ],
+        chunk,
+    )
+}
+
+/// Build the terminal `InvokeComplete` event frame. `error_code` /
+/// `error_details` are `None` on success; `log_result_b64` is the
+/// base64-encoded last 4 KiB of the function's tail log (empty string
+/// when no log was captured).
+pub fn invoke_complete_frame(
+    error_code: Option<&str>,
+    error_details: Option<&str>,
+    log_result_b64: &str,
+) -> Vec<u8> {
+    let payload = serde_json::json!({
+        "ErrorCode": error_code,
+        "ErrorDetails": error_details,
+        "LogResult": log_result_b64,
+    });
+    let body = serde_json::to_vec(&payload).expect("static JSON shape never fails to serialize");
+    encode_frame(
+        &[
+            (":event-type", "InvokeComplete"),
+            (":content-type", "application/json"),
+            (":message-type", "event"),
+        ],
+        &body,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Decode a single eventstream frame back into `(headers, payload)`,
+    /// validating both CRCs. Used by the tests below to round-trip the
+    /// encoder; mirrors what an AWS SDK does when parsing the response.
+    fn decode_frame(buf: &[u8]) -> (Vec<(String, String)>, Vec<u8>) {
+        assert!(buf.len() >= 16, "frame too short");
+        let total_len = u32::from_be_bytes(buf[0..4].try_into().unwrap()) as usize;
+        assert_eq!(total_len, buf.len(), "total length mismatch");
+        let headers_len = u32::from_be_bytes(buf[4..8].try_into().unwrap()) as usize;
+        let prelude_crc = u32::from_be_bytes(buf[8..12].try_into().unwrap());
+        assert_eq!(prelude_crc, crc32fast::hash(&buf[0..8]), "prelude CRC bad");
+
+        let headers_start = 12;
+        let headers_end = headers_start + headers_len;
+        let payload_end = total_len - 4;
+        let msg_crc = u32::from_be_bytes(buf[payload_end..total_len].try_into().unwrap());
+        assert_eq!(msg_crc, crc32fast::hash(&buf[..payload_end]), "msg CRC bad");
+
+        let mut headers = Vec::new();
+        let hbuf = &buf[headers_start..headers_end];
+        let mut i = 0;
+        while i < hbuf.len() {
+            let nl = hbuf[i] as usize;
+            i += 1;
+            let name = std::str::from_utf8(&hbuf[i..i + nl]).unwrap().to_string();
+            i += nl;
+            let vt = hbuf[i];
+            i += 1;
+            assert_eq!(vt, HEADER_TYPE_STRING, "only string headers supported");
+            let vl = u16::from_be_bytes(hbuf[i..i + 2].try_into().unwrap()) as usize;
+            i += 2;
+            let value = std::str::from_utf8(&hbuf[i..i + vl]).unwrap().to_string();
+            i += vl;
+            headers.push((name, value));
+        }
+
+        let payload = buf[headers_end..payload_end].to_vec();
+        (headers, payload)
+    }
+
+    #[test]
+    fn round_trip_payload_chunk() {
+        let frame = payload_chunk_frame(b"hello world");
+        let (headers, payload) = decode_frame(&frame);
+        assert_eq!(payload, b"hello world");
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":event-type" && v == "PayloadChunk"));
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":message-type" && v == "event"));
+    }
+
+    #[test]
+    fn round_trip_invoke_complete_success() {
+        let frame = invoke_complete_frame(None, None, "");
+        let (headers, payload) = decode_frame(&frame);
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":event-type" && v == "InvokeComplete"));
+        let v: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert!(v["ErrorCode"].is_null());
+        assert!(v["ErrorDetails"].is_null());
+        assert_eq!(v["LogResult"], "");
+    }
+
+    #[test]
+    fn round_trip_invoke_complete_error() {
+        let frame = invoke_complete_frame(Some("Runtime.UserError"), Some("boom"), "bG9n");
+        let (headers, payload) = decode_frame(&frame);
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":event-type" && v == "InvokeComplete"));
+        let v: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(v["ErrorCode"], "Runtime.UserError");
+        assert_eq!(v["ErrorDetails"], "boom");
+        assert_eq!(v["LogResult"], "bG9n");
+    }
+
+    #[test]
+    fn empty_chunk_still_well_formed() {
+        let frame = payload_chunk_frame(b"");
+        let (_headers, payload) = decode_frame(&frame);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn multiple_frames_concatenate_cleanly() {
+        let mut out = Vec::new();
+        out.extend(payload_chunk_frame(b"chunk-1"));
+        out.extend(payload_chunk_frame(b"chunk-2"));
+        out.extend(invoke_complete_frame(None, None, ""));
+
+        // Decode each frame in sequence by reading total_len.
+        let mut frames = Vec::new();
+        let mut cursor = 0;
+        while cursor < out.len() {
+            let total = u32::from_be_bytes(out[cursor..cursor + 4].try_into().unwrap()) as usize;
+            frames.push(decode_frame(&out[cursor..cursor + total]));
+            cursor += total;
+        }
+        assert_eq!(frames.len(), 3);
+        assert_eq!(frames[0].1, b"chunk-1");
+        assert_eq!(frames[1].1, b"chunk-2");
+        // Last is InvokeComplete with JSON body
+        let v: serde_json::Value = serde_json::from_slice(&frames[2].1).unwrap();
+        assert!(v["ErrorCode"].is_null());
+    }
+}

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -191,7 +191,7 @@ impl LambdaService {
             "UpdateEventSourceMapping" => self.update_event_source_mapping_handler(res, req),
             "GetAccountSettings" => self.get_account_settings(aid),
             "InvokeAsync" => Ok(AwsResponse::json(StatusCode::ACCEPTED, "{}".to_string())),
-            "InvokeWithResponseStream" => Ok(AwsResponse::json(StatusCode::OK, "{}".to_string())),
+            "InvokeWithResponseStream" => self.invoke_with_response_stream(res, aid, req).await,
 
             // Versions
             "ListVersionsByFunction" => self.list_versions_by_function(res, aid, req),
@@ -2076,6 +2076,194 @@ impl LambdaService {
             .map(|s| s.region.clone())
             .unwrap_or_else(|| "us-east-1".to_string())
     }
+
+    /// `InvokeWithResponseStream` — invoke the function and serialize
+    /// its response as a sequence of `application/vnd.amazon.eventstream`
+    /// frames. AWS uses this protocol for response-streaming Lambda
+    /// invocations (Node.js `awslambda.streamifyResponse`, Python
+    /// streaming handlers, custom runtimes that flush mid-handler).
+    ///
+    /// On success: zero or more `PayloadChunk` events (one per chunk
+    /// the RIE flushed) followed by an `InvokeComplete` event with
+    /// `ErrorCode = null`. On a function error (uncaught exception in
+    /// the handler) or an infrastructure error (timeout, container
+    /// crash): an `InvokeComplete` with non-null `ErrorCode`/
+    /// `ErrorDetails`. The HTTP status itself is always 200 — failures
+    /// surface inside the trailing event, matching AWS.
+    pub(crate) async fn invoke_with_response_stream(
+        &self,
+        function_name: &str,
+        account_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        // Resolve the function under the same rules as buffered Invoke
+        // — qualifier, version snapshots, attached layers, code-zip
+        // presence — but without the InvocationType branch (streaming
+        // is always synchronous).
+        let qualifier = req.query_params.get("Qualifier").map(String::as_str);
+
+        let resolved_version: Option<String> = {
+            let accounts = self.state.read();
+            let empty = LambdaState::new(account_id, "");
+            let state = accounts.get(account_id).unwrap_or(&empty);
+            crate::service::resolve_qualifier_to_version(state, function_name, qualifier)
+        };
+        let executed_version = resolved_version
+            .clone()
+            .unwrap_or_else(|| "$LATEST".to_string());
+
+        let (func, layer_zips) = {
+            let accounts = self.state.read();
+            let empty = LambdaState::new(account_id, "");
+            let state = accounts.get(account_id).unwrap_or(&empty);
+            let func = match resolved_version.as_deref() {
+                Some(v) => state
+                    .function_version_snapshots
+                    .get(function_name)
+                    .and_then(|m| m.get(v))
+                    .cloned()
+                    .or_else(|| state.functions.get(function_name).cloned()),
+                None => state.functions.get(function_name).cloned(),
+            }
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ResourceNotFoundException",
+                    format!(
+                        "Function not found: arn:aws:lambda:{}:{}:function:{}",
+                        state.region, state.account_id, function_name
+                    ),
+                )
+            })?;
+            let mut zips: Vec<Vec<u8>> = Vec::with_capacity(func.layers.len());
+            for attached in &func.layers {
+                if let Some(b) =
+                    parse_layer_version_arn(&attached.arn).and_then(|(acct, name, ver)| {
+                        accounts
+                            .get(&acct)
+                            .and_then(|s| s.layers.get(&name))
+                            .and_then(|l| l.versions.iter().find(|v| v.version == ver))
+                            .and_then(|v| v.code_zip.clone())
+                    })
+                {
+                    zips.push(b);
+                }
+            }
+            (func, zips)
+        };
+
+        if func.code_zip.is_none() && func.package_type != "Image" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValueException",
+                "Function has no deployment package",
+            ));
+        }
+
+        let runtime = self.runtime.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "ServiceException",
+                "Docker/Podman is required for Lambda execution but is not available",
+            )
+        })?;
+
+        // Drive the streaming RIE call and assemble the eventstream
+        // body. We buffer all frames before returning — `AwsResponse`
+        // is byte-buffered today — but the chunk boundaries the RIE
+        // flushed are preserved as separate `PayloadChunk` events, so
+        // SDK parsers see exactly the streaming structure they expect.
+        let mut frames: Vec<u8> = Vec::new();
+        let invoke_result = runtime
+            .invoke_streaming(&func, &req.body, &layer_zips)
+            .await;
+
+        let (error_code, error_details) = match invoke_result {
+            Ok(mut stream) => {
+                let mut last_chunk: Option<bytes::Bytes> = None;
+                let mut had_chunks = false;
+                loop {
+                    match stream.next_chunk().await {
+                        Ok(Some(chunk)) => {
+                            had_chunks = true;
+                            frames.extend_from_slice(&crate::eventstream::payload_chunk_frame(
+                                &chunk,
+                            ));
+                            last_chunk = Some(chunk);
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            tracing::error!(function = %function_name, error = %e, "Lambda streaming chunk read failed");
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "ServiceException",
+                                format!("Lambda streaming read failed: {e}"),
+                            ));
+                        }
+                    }
+                }
+
+                // The Lambda runtime returns 200 even when the user
+                // handler threw, packing `errorMessage`/`errorType`
+                // into the buffered body. Streaming handlers do the
+                // same on the final chunk. Inspect the last chunk we
+                // saw and surface that as a function error in the
+                // terminal `InvokeComplete` event.
+                let mut error: Option<(String, String)> = None;
+                if had_chunks {
+                    if let Some(bytes) = last_chunk {
+                        if let Ok(v) = serde_json::from_slice::<Value>(&bytes) {
+                            if let Some(obj) = v.as_object() {
+                                if obj.contains_key("errorMessage") || obj.contains_key("errorType")
+                                {
+                                    let etype = obj
+                                        .get("errorType")
+                                        .and_then(|x| x.as_str())
+                                        .unwrap_or("Runtime.Unknown")
+                                        .to_string();
+                                    let emsg = obj
+                                        .get("errorMessage")
+                                        .and_then(|x| x.as_str())
+                                        .unwrap_or("function error")
+                                        .to_string();
+                                    error = Some((etype, emsg));
+                                }
+                            }
+                        }
+                    }
+                }
+                match error {
+                    Some((code, details)) => (Some(code), Some(details)),
+                    None => (None, None),
+                }
+            }
+            Err(e) => {
+                tracing::error!(function = %function_name, error = %e, "Lambda streaming invocation failed");
+                (
+                    Some("Runtime.InvocationFailure".to_string()),
+                    Some(e.to_string()),
+                )
+            }
+        };
+
+        frames.extend_from_slice(&crate::eventstream::invoke_complete_frame(
+            error_code.as_deref(),
+            error_details.as_deref(),
+            "",
+        ));
+
+        let mut resp = AwsResponse {
+            status: StatusCode::OK,
+            content_type: "application/vnd.amazon.eventstream".to_string(),
+            body: fakecloud_core::service::ResponseBody::Bytes(bytes::Bytes::from(frames)),
+            headers: http::HeaderMap::new(),
+        };
+        if let Ok(v) = http::HeaderValue::from_str(&executed_version) {
+            resp.headers
+                .insert(http::HeaderName::from_static("x-amz-executed-version"), v);
+        }
+        Ok(resp)
+    }
 }
 
 fn extract_csc_id(input: &str) -> String {
@@ -2182,7 +2370,6 @@ mod tests {
         let s = svc();
         run(&s, "GetAccountSettings", "", None, &[]).await;
         run(&s, "InvokeAsync", r#"{}"#, Some("fn"), &[]).await;
-        run(&s, "InvokeWithResponseStream", r#"{}"#, Some("fn"), &[]).await;
         run(&s, "ListLayers", "", None, &[]).await;
         run(&s, "ListLayerVersions", "", Some("layer"), &[]).await;
     }

--- a/crates/fakecloud-lambda/src/lib.rs
+++ b/crates/fakecloud-lambda/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod eventstream;
 pub mod extras;
 pub mod filter;
 pub mod resource_policy;

--- a/crates/fakecloud-lambda/src/runtime.rs
+++ b/crates/fakecloud-lambda/src/runtime.rs
@@ -59,6 +59,28 @@ pub struct ContainerRuntime {
     docker_config: Option<Arc<TempDir>>,
 }
 
+/// Wrapper around an in-flight streaming invocation. Yields raw body
+/// chunks via [`Self::next_chunk`] until the RIE closes the response,
+/// at which point the final `Ok(None)` signals the caller to emit the
+/// terminal `InvokeComplete` frame.
+pub struct StreamingInvocation {
+    resp: reqwest::Response,
+}
+
+impl StreamingInvocation {
+    /// Read the next chunk of the function's response body. Returns
+    /// `Ok(None)` once the RIE has finished streaming. Buffered
+    /// handlers tend to deliver a single chunk; streaming handlers
+    /// deliver one chunk per `responseStream.write(...)` call.
+    pub async fn next_chunk(&mut self) -> Result<Option<bytes::Bytes>, RuntimeError> {
+        match self.resp.chunk().await {
+            Ok(Some(b)) => Ok(Some(b)),
+            Ok(None) => Ok(None),
+            Err(e) => Err(RuntimeError::InvocationFailed(e.to_string())),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     #[error("no code ZIP provided for function {0}")]
@@ -142,6 +164,70 @@ impl ContainerRuntime {
         payload: &[u8],
         layers: &[Vec<u8>],
     ) -> Result<Vec<u8>, RuntimeError> {
+        let port = self.ensure_warm_container(func, layers).await?;
+
+        // POST to the RIE endpoint
+        let url = format!(
+            "http://localhost:{}/2015-03-31/functions/function/invocations",
+            port
+        );
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(&url)
+            .body(payload.to_vec())
+            .timeout(Duration::from_secs(func.timeout as u64 + 5))
+            .send()
+            .await
+            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+
+        Ok(body.to_vec())
+    }
+
+    /// Invoke a Lambda function and yield the raw HTTP body as a stream
+    /// of byte chunks. Each chunk corresponds to one HTTP frame the RIE
+    /// flushed to the wire — for streaming-aware handlers (Node.js
+    /// `awslambda.streamifyResponse`, Python streaming response, custom
+    /// runtimes that flush mid-handler) this preserves the chunk
+    /// boundaries the function emitted. Buffered handlers come back as
+    /// a single chunk, which is still a valid streamed response.
+    pub async fn invoke_streaming(
+        &self,
+        func: &LambdaFunction,
+        payload: &[u8],
+        layers: &[Vec<u8>],
+    ) -> Result<StreamingInvocation, RuntimeError> {
+        let port = self.ensure_warm_container(func, layers).await?;
+
+        let url = format!(
+            "http://localhost:{}/2015-03-31/functions/function/invocations",
+            port
+        );
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(&url)
+            .body(payload.to_vec())
+            .timeout(Duration::from_secs(func.timeout as u64 + 5))
+            .send()
+            .await
+            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+
+        Ok(StreamingInvocation { resp })
+    }
+
+    /// Resolve a warm container for `func`, starting one if its
+    /// fingerprint doesn't match (or there isn't one yet). Returns the
+    /// host port the RIE is bound to. Shared by `invoke` and
+    /// `invoke_streaming` so both paths use the same warm-pool logic.
+    async fn ensure_warm_container(
+        &self,
+        func: &LambdaFunction,
+        layers: &[Vec<u8>],
+    ) -> Result<u16, RuntimeError> {
         // Zip-based functions need code bytes; image-based functions have
         // everything baked into the image. Defer the zip check until we
         // know we need to start a fresh container.
@@ -167,73 +253,51 @@ impl ContainerRuntime {
             }
         };
 
-        let port = match port {
-            Some(p) => p,
-            None => {
-                // Serialize container startup per function to prevent duplicates
-                let startup_lock = {
-                    let mut starting = self.starting.write();
-                    starting
-                        .entry(func.function_name.clone())
-                        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-                        .clone()
-                };
-                let _guard = startup_lock.lock().await;
+        if let Some(p) = port {
+            return Ok(p);
+        }
 
-                // Re-check after acquiring lock — another task may have started it
-                let existing_port = {
-                    let containers = self.containers.read();
-                    containers
-                        .get(&func.function_name)
-                        .filter(|c| c.deploy_id == deploy_id)
-                        .map(|c| {
-                            *c.last_used.write() = Instant::now();
-                            c.host_port
-                        })
-                };
-                if let Some(p) = existing_port {
-                    p
-                } else {
-                    self.stop_container(&func.function_name).await;
-                    let container = if is_image {
-                        self.start_image_container(func, layers, &deploy_id).await?
-                    } else {
-                        let zip_bytes = func
-                            .code_zip
-                            .as_ref()
-                            .ok_or_else(|| RuntimeError::NoCodeZip(func.function_name.clone()))?;
-                        self.start_container(func, zip_bytes, layers, &deploy_id)
-                            .await?
-                    };
-                    let p = container.host_port;
-                    self.containers
-                        .write()
-                        .insert(func.function_name.clone(), container);
-                    p
-                }
-            }
+        // Serialize container startup per function to prevent duplicates
+        let startup_lock = {
+            let mut starting = self.starting.write();
+            starting
+                .entry(func.function_name.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
         };
+        let _guard = startup_lock.lock().await;
 
-        // POST to the RIE endpoint
-        let url = format!(
-            "http://localhost:{}/2015-03-31/functions/function/invocations",
-            port
-        );
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .body(payload.to_vec())
-            .timeout(Duration::from_secs(func.timeout as u64 + 5))
-            .send()
-            .await
-            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
+        // Re-check after acquiring lock — another task may have started it
+        let existing_port = {
+            let containers = self.containers.read();
+            containers
+                .get(&func.function_name)
+                .filter(|c| c.deploy_id == deploy_id)
+                .map(|c| {
+                    *c.last_used.write() = Instant::now();
+                    c.host_port
+                })
+        };
+        if let Some(p) = existing_port {
+            return Ok(p);
+        }
 
-        let body = resp
-            .bytes()
-            .await
-            .map_err(|e| RuntimeError::InvocationFailed(e.to_string()))?;
-
-        Ok(body.to_vec())
+        self.stop_container(&func.function_name).await;
+        let container = if is_image {
+            self.start_image_container(func, layers, &deploy_id).await?
+        } else {
+            let zip_bytes = func
+                .code_zip
+                .as_ref()
+                .ok_or_else(|| RuntimeError::NoCodeZip(func.function_name.clone()))?;
+            self.start_container(func, zip_bytes, layers, &deploy_id)
+                .await?
+        };
+        let p = container.host_port;
+        self.containers
+            .write()
+            .insert(func.function_name.clone(), container);
+        Ok(p)
     }
 
     /// Start a container for a `PackageType=Image` function. The image is

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -590,7 +590,7 @@ pub(crate) fn resolve_qualifier_to_version(
 
 pub struct LambdaService {
     pub(crate) state: SharedLambdaState,
-    runtime: Option<Arc<ContainerRuntime>>,
+    pub(crate) runtime: Option<Arc<ContainerRuntime>>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
     pub(crate) delivery_bus: Option<Arc<fakecloud_core::delivery::DeliveryBus>>,
@@ -2040,6 +2040,7 @@ impl AwsService for LambdaService {
             "GetFunction" => "GetFunction",
             "DeleteFunction" => "DeleteFunction",
             "Invoke" => "InvokeFunction",
+            "InvokeWithResponseStream" => "InvokeFunctionWithResponseStream",
             "PublishVersion" => "PublishVersion",
             "AddPermission" => "AddPermission",
             "RemovePermission" => "RemovePermission",
@@ -2054,8 +2055,14 @@ impl AwsService for LambdaService {
         let empty = LambdaState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
         let resource = match action {
-            "GetFunction" | "DeleteFunction" | "InvokeFunction" | "PublishVersion"
-            | "AddPermission" | "RemovePermission" | "GetPolicy" => {
+            "GetFunction"
+            | "DeleteFunction"
+            | "InvokeFunction"
+            | "InvokeFunctionWithResponseStream"
+            | "PublishVersion"
+            | "AddPermission"
+            | "RemovePermission"
+            | "GetPolicy" => {
                 let name = resource_name.unwrap_or_default();
                 if name.is_empty() {
                     "*".to_string()


### PR DESCRIPTION
## Summary

`InvokeWithResponseStream` previously returned an empty JSON body, ignoring the AWS `application/vnd.amazon.eventstream` protocol. SDKs that decode the response stream (Node.js, Rust, Python, Java) all rejected the response. This PR replaces the canned reply with a real eventstream encoder driven by the function's actual RIE response.

- New `eventstream` module: minimal frame encoder for the AWS wire format (total_len + headers_len + prelude CRC + headers + payload + msg CRC), supporting the string header type Lambda needs. Five round-trip unit tests cover success, handler error, empty chunk, and multi-frame streams.
- New `StreamingInvocation` on `ContainerRuntime`: reads the RIE HTTP response as a chunk stream (`reqwest::Response::chunk`) so each fragment the function flushed becomes its own `PayloadChunk` frame. Buffered handlers come back as a single chunk — still a valid streaming response.
- `invoke_with_response_stream` handler resolves qualifier + version snapshot + attached layers exactly like buffered `Invoke`, walks the chunk stream, inspects the final chunk for the AWS `errorMessage`/`errorType` marker, and closes with a terminal `InvokeComplete` (`ErrorCode = null` on success, populated on handler error).
- Warm-container reuse refactored into a shared `ensure_warm_container` helper so streaming and buffered invocations hit the same per-deploy fingerprint pool.
- IAM action maps to `lambda:InvokeFunctionWithResponseStream` (AWS uses a distinct action from `lambda:InvokeFunction`).
- Response `Content-Type: application/vnd.amazon.eventstream`, plus `x-amz-executed-version` for parity with buffered invoke.

## Test plan

- [x] `cargo test -p fakecloud-lambda` — 136 unit tests pass, including 5 new eventstream encoder round-trip tests
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] `lambda_invoke.rs` E2E (Docker required, runs in CI): `streamifyResponse` Node handler emits multiple chunks reassembled by the AWS Rust SDK eventstream parser; throwing handler surfaces `ErrorCode` on the terminal event

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real AWS eventstream for `InvokeWithResponseStream`, streaming each RIE chunk as a `PayloadChunk` and ending with `InvokeComplete` so AWS SDKs can parse the response correctly.

- **New Features**
  - `InvokeWithResponseStream` now returns `application/vnd.amazon.eventstream`. Each RIE chunk becomes a `PayloadChunk`; the stream ends with `InvokeComplete` (includes `ErrorCode` on handler error) and sets `x-amz-executed-version`. IAM maps to `lambda:InvokeFunctionWithResponseStream`.
  - New `eventstream` encoder with CRCs and string headers, plus `StreamingInvocation` to read HTTP body chunks. Unit and E2E tests cover success, errors, empty chunk, and multi-frame cases; the new streaming tests are added to the Node.js nextest partition so they run in CI.

- **Refactors**
  - Introduced `ensure_warm_container` so streaming and buffered invokes reuse the same warm container pool.

<sup>Written for commit 41fa1486e2b8c8ab7096245103168be93fabd4fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

