### PR TITLE
feat(athena): minimal SQL parser + Glue catalog reads + S3 CSV result write (DD1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,13 +2906,17 @@ name = "fakecloud-athena"
 version = "0.13.3"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
  "fakecloud-aws",
  "fakecloud-core",
+ "fakecloud-glue",
+ "fakecloud-s3",
  "http 1.4.0",
  "parking_lot",
  "serde",
  "serde_json",
+ "sqlparser",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -5380,6 +5393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,6 +5858,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6035,6 +6067,26 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6795,10 +6847,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ zip = "2"
 tempfile = "3"
 regex = "1"
 tokio-postgres = "0.7"
+sqlparser = "0.61"
 
 # Internal crates
 fakecloud-core = { path = "crates/fakecloud-core", version = "0.13.3" }

--- a/crates/fakecloud-athena/Cargo.toml
+++ b/crates/fakecloud-athena/Cargo.toml
@@ -10,12 +10,16 @@ version.workspace = true
 [dependencies]
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
+fakecloud-glue = { workspace = true }
+fakecloud-s3 = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sqlparser = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/fakecloud-athena/src/lib.rs
+++ b/crates/fakecloud-athena/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod service;
+pub(crate) mod sql;
 pub(crate) mod state;
 
 pub use service::AthenaService;

--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -12,7 +12,10 @@ use uuid::Uuid;
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::pagination::paginate;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
+use fakecloud_glue::SharedGlueState;
+use fakecloud_s3::SharedS3State;
 
+use crate::sql::{self, ExecutedQuery};
 use crate::state::{
     AccountState, AthenaAccounts, Calculation, CapacityAssignmentConfiguration,
     CapacityReservation, DataCatalog, NamedQuery, Notebook, PreparedStatement, QueryExecution,
@@ -94,11 +97,27 @@ const SUPPORTED_ACTIONS: &[&str] = &[
 
 pub struct AthenaService {
     state: SharedAthenaState,
+    glue: Option<SharedGlueState>,
+    s3: Option<SharedS3State>,
 }
 
 impl AthenaService {
     pub fn new(state: SharedAthenaState) -> Self {
-        Self { state }
+        Self {
+            state,
+            glue: None,
+            s3: None,
+        }
+    }
+
+    pub fn with_glue(mut self, glue: SharedGlueState) -> Self {
+        self.glue = Some(glue);
+        self
+    }
+
+    pub fn with_s3(mut self, s3: SharedS3State) -> Self {
+        self.s3 = Some(s3);
+        self
     }
 
     pub fn shared_state(&self) -> SharedAthenaState {
@@ -879,36 +898,107 @@ impl AthenaService {
             .to_string();
         let context = body.get("QueryExecutionContext").cloned();
         let result_configuration = body.get("ResultConfiguration").cloned();
-        let mut state = self.state.write();
-        let account = account_mut(&mut state, &req.account_id);
-        if !account.work_groups.contains_key(&work_group) {
-            return Err(invalid_request(format!("Workgroup {work_group} not found")));
+        let default_database = context
+            .as_ref()
+            .and_then(|c| c.get("Database"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let output_location = result_configuration
+            .as_ref()
+            .and_then(|c| c.get("OutputLocation"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+
+        // Workgroup existence check before kicking off SQL execution so we
+        // surface the same error users hit on real Athena.
+        {
+            let mut state = self.state.write();
+            let account = account_mut(&mut state, &req.account_id);
+            if !account.work_groups.contains_key(&work_group) {
+                return Err(invalid_request(format!("Workgroup {work_group} not found")));
+            }
         }
+
         let id = synth_uuid();
         let now = Utc::now();
-        // Synthesize a successful query result instantly so callers can
-        // immediately fetch it via GetQueryResults.
+
+        // Try real SQL execution. Only SELECT is implemented today; anything
+        // else lands in QueryExecution with a structured failure reason
+        // (state=FAILED, state_change_reason=<error>) so callers see the real
+        // outcome instead of a fabricated SUCCEEDED.
+        let executed = sql::execute(
+            &query,
+            default_database.as_deref(),
+            output_location.as_deref(),
+            &req.account_id,
+            &req.region,
+            self.glue.as_ref(),
+            self.s3.as_ref(),
+        );
+
+        let (state_str, state_reason, columns, rows, scanned, output) = match executed {
+            Ok(ExecutedQuery {
+                columns,
+                rows,
+                data_scanned_bytes,
+                output_location,
+            }) => (
+                "SUCCEEDED".to_string(),
+                None,
+                columns,
+                rows,
+                data_scanned_bytes,
+                output_location,
+            ),
+            Err(err) => {
+                tracing::debug!(query = %query, error = %err, "athena: query failed");
+                (
+                    "FAILED".to_string(),
+                    Some(err.to_string()),
+                    Vec::new(),
+                    Vec::new(),
+                    0i64,
+                    None,
+                )
+            }
+        };
+
+        // Re-merge the executed output_location back into ResultConfiguration
+        // so GetQueryExecution echoes the resolved s3:// key back to the
+        // caller (real Athena does this).
+        let mut effective_result_config = result_configuration.clone();
+        if let Some(ref out) = output {
+            let cfg = effective_result_config
+                .get_or_insert_with(|| json!({}))
+                .as_object_mut();
+            if let Some(obj) = cfg {
+                obj.insert("OutputLocation".to_string(), Value::String(out.clone()));
+            }
+        }
+
+        let mut state = self.state.write();
+        let account = account_mut(&mut state, &req.account_id);
         let qe = QueryExecution {
             query_execution_id: id.clone(),
             query: query.clone(),
             statement_type: classify_statement(&query),
             work_group,
-            state: "SUCCEEDED".to_string(),
-            state_change_reason: None,
+            state: state_str,
+            state_change_reason: state_reason,
             submission_time: now,
             completion_time: Some(now),
             query_execution_context: context,
-            result_configuration,
+            result_configuration: effective_result_config,
             engine_version: Some(json!({
                 "SelectedEngineVersion": "AUTO",
                 "EffectiveEngineVersion": "Athena engine version 3",
             })),
-            data_scanned_bytes: 0,
+            data_scanned_bytes: scanned,
             engine_execution_time_ms: 1,
             query_planning_time_ms: 1,
             total_execution_time_ms: 2,
-            result_rows: vec![vec!["1".to_string()]],
-            result_columns: vec![("_col0".to_string(), "integer".to_string())],
+            result_rows: rows,
+            result_columns: columns,
         };
         account.query_executions.insert(id.clone(), qe);
         Ok(AwsResponse::ok_json(json!({ "QueryExecutionId": id })))

--- a/crates/fakecloud-athena/src/sql.rs
+++ b/crates/fakecloud-athena/src/sql.rs
@@ -1,0 +1,817 @@
+//! Minimal SQL execution for Athena `StartQueryExecution`.
+//!
+//! Parses the query with `sqlparser` (Generic dialect), resolves the source
+//! table via the Glue catalog (cross-account state shared with `fakecloud-glue`),
+//! reads the CSV-backed data from S3 (cross-account state shared with
+//! `fakecloud-s3`), applies projection / single-equality `WHERE` / `LIMIT`
+//! in-memory, and writes the result back to the configured
+//! `ResultConfiguration.OutputLocation` as CSV.
+//!
+//! Scope: enough to back the common `SELECT col FROM db.table WHERE c='v' LIMIT N`
+//! shape that real callers use for smoke-tests against Athena. Joins, GROUP BY,
+//! aggregates, ORDER BY, subqueries and Parquet/JSON SerDes are out of scope —
+//! we return a structured error so callers see a real failure instead of fake
+//! data.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use chrono::Utc;
+use fakecloud_glue::{SharedGlueState, StorageDescriptor};
+use fakecloud_s3::{memory_body, S3Object, SharedS3State};
+use sqlparser::ast::{
+    BinaryOperator, Expr, GroupByExpr, LimitClause, ObjectName, Query, SelectItem, SetExpr,
+    Statement, TableFactor, Value as SqlValue, ValueWithSpan,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+use uuid::Uuid;
+
+/// Result of executing a query: in-memory rows ready for `GetQueryResults`,
+/// plus the S3 location where we wrote the CSV result.
+#[derive(Debug, Clone)]
+pub struct ExecutedQuery {
+    pub columns: Vec<(String, String)>,
+    pub rows: Vec<Vec<String>>,
+    pub data_scanned_bytes: i64,
+    /// Resolved s3:// URL (`output_location` joined with the result key).
+    pub output_location: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SqlError {
+    #[error("syntax error: {0}")]
+    Parse(String),
+    #[error("only SELECT statements are supported (got {0})")]
+    UnsupportedStatement(&'static str),
+    #[error("only single-table SELECTs are supported")]
+    UnsupportedJoin,
+    #[error("unsupported clause: {0}")]
+    UnsupportedClause(&'static str),
+    #[error("table reference must be `<database>.<table>` or `<table>` with a default database")]
+    InvalidTableRef,
+    #[error("database `{0}` not found in catalog")]
+    DatabaseNotFound(String),
+    #[error("table `{database}.{table}` not found in catalog")]
+    TableNotFound { database: String, table: String },
+    #[error("table `{database}.{table}` has no Storage.Location")]
+    MissingLocation { database: String, table: String },
+    #[error("table `{database}.{table}` location `{location}` is not an s3:// URL")]
+    InvalidLocation {
+        database: String,
+        table: String,
+        location: String,
+    },
+    #[error("S3 bucket `{0}` not found")]
+    BucketNotFound(String),
+    #[error("S3 object body unreadable: {0}")]
+    S3Read(String),
+    #[error("output location `{0}` is not an s3:// URL")]
+    InvalidOutputLocation(String),
+    #[error("only CSV-backed Glue tables are supported (got serde `{0}`)")]
+    UnsupportedSerde(String),
+    #[error("column `{0}` is not in the table schema")]
+    UnknownColumn(String),
+    #[error("WHERE only supports `<column> = <literal>` for now")]
+    UnsupportedWhere,
+}
+
+/// Parse and execute the query. Returns either the executed result or a
+/// structured error so the caller can mark the query `FAILED` with a real
+/// reason.
+pub fn execute(
+    query: &str,
+    default_database: Option<&str>,
+    output_location: Option<&str>,
+    account_id: &str,
+    region: &str,
+    glue: Option<&SharedGlueState>,
+    s3: Option<&SharedS3State>,
+) -> Result<ExecutedQuery, SqlError> {
+    let dialect = GenericDialect {};
+    let mut statements =
+        Parser::parse_sql(&dialect, query).map_err(|e| SqlError::Parse(e.to_string()))?;
+    if statements.len() != 1 {
+        return Err(SqlError::Parse(format!(
+            "expected 1 statement, got {}",
+            statements.len()
+        )));
+    }
+    let stmt = statements.remove(0);
+    let select_query = match stmt {
+        Statement::Query(q) => q,
+        Statement::Insert { .. } => return Err(SqlError::UnsupportedStatement("INSERT")),
+        Statement::Update { .. } => return Err(SqlError::UnsupportedStatement("UPDATE")),
+        Statement::Delete { .. } => return Err(SqlError::UnsupportedStatement("DELETE")),
+        Statement::CreateTable { .. } => {
+            return Err(SqlError::UnsupportedStatement("CREATE TABLE"))
+        }
+        _ => return Err(SqlError::UnsupportedStatement("non-SELECT")),
+    };
+
+    let plan = build_plan(&select_query, default_database)?;
+
+    // Literal-only SELECT (no FROM): evaluate inline. Real Athena supports
+    // this for `SELECT 1`, `SELECT 'foo'`, etc.
+    if plan.source.is_none() {
+        return execute_literal_select(&plan, output_location, account_id, s3);
+    }
+    let source = plan.source.as_ref().expect("source is Some by check above");
+
+    // Resolve the table via Glue.
+    let glue_state = glue.ok_or_else(|| SqlError::TableNotFound {
+        database: source.database.clone(),
+        table: source.table.clone(),
+    })?;
+    let table = {
+        let g = glue_state.read();
+        let acct = g
+            .get(account_id)
+            .ok_or_else(|| SqlError::DatabaseNotFound(source.database.clone()))?;
+        let dbs = acct
+            .dbs_in(region)
+            .ok_or_else(|| SqlError::DatabaseNotFound(source.database.clone()))?;
+        let db = dbs
+            .get(&source.database)
+            .ok_or_else(|| SqlError::DatabaseNotFound(source.database.clone()))?;
+        db.tables
+            .get(&source.table)
+            .cloned()
+            .ok_or_else(|| SqlError::TableNotFound {
+                database: source.database.clone(),
+                table: source.table.clone(),
+            })?
+    };
+
+    let storage = table
+        .storage_descriptor
+        .as_ref()
+        .ok_or_else(|| SqlError::MissingLocation {
+            database: source.database.clone(),
+            table: source.table.clone(),
+        })?;
+
+    require_csv_serde(storage)?;
+
+    let location = storage
+        .location
+        .clone()
+        .ok_or_else(|| SqlError::MissingLocation {
+            database: source.database.clone(),
+            table: source.table.clone(),
+        })?;
+    let (bucket, prefix) = parse_s3_url(&location).ok_or_else(|| SqlError::InvalidLocation {
+        database: source.database.clone(),
+        table: source.table.clone(),
+        location: location.clone(),
+    })?;
+
+    let s3_state = s3.ok_or_else(|| SqlError::BucketNotFound(bucket.clone()))?;
+
+    // Read all CSV rows under the prefix.
+    let (raw_rows, scanned) = read_csv_under_prefix(s3_state, account_id, &bucket, &prefix)?;
+
+    let table_columns: Vec<(String, String)> = storage
+        .columns
+        .iter()
+        .map(|c| (c.name.clone(), c.column_type.clone()))
+        .collect();
+
+    // Build header mapping: column name -> index. CSVs may or may not have a
+    // header; for now we assume no header and assume the column order matches
+    // the table's column order.
+    let column_index: BTreeMap<String, usize> = table_columns
+        .iter()
+        .enumerate()
+        .map(|(i, (n, _))| (n.to_lowercase(), i))
+        .collect();
+
+    // Validate WHERE column.
+    if let Some(ref f) = plan.filter {
+        if !column_index.contains_key(&f.column.to_lowercase()) {
+            return Err(SqlError::UnknownColumn(f.column.clone()));
+        }
+    }
+
+    // Resolve projection: either * or list of columns.
+    let projected: Vec<(String, String)> = match &plan.projection {
+        Projection::All => table_columns.clone(),
+        Projection::Columns(cols) => cols
+            .iter()
+            .map(|c| {
+                let idx = column_index
+                    .get(&c.to_lowercase())
+                    .ok_or_else(|| SqlError::UnknownColumn(c.clone()))?;
+                Ok((table_columns[*idx].0.clone(), table_columns[*idx].1.clone()))
+            })
+            .collect::<Result<_, SqlError>>()?,
+    };
+    let projected_indices: Vec<usize> = projected
+        .iter()
+        .map(|(name, _)| column_index[&name.to_lowercase()])
+        .collect();
+
+    // Apply filter + projection + limit.
+    let mut out_rows: Vec<Vec<String>> = Vec::new();
+    for raw in &raw_rows {
+        if let Some(ref f) = plan.filter {
+            let idx = column_index[&f.column.to_lowercase()];
+            let cell = raw.get(idx).map(String::as_str).unwrap_or("");
+            if cell != f.value {
+                continue;
+            }
+        }
+        let mut projected_row = Vec::with_capacity(projected_indices.len());
+        for &i in &projected_indices {
+            projected_row.push(raw.get(i).cloned().unwrap_or_default());
+        }
+        out_rows.push(projected_row);
+        if let Some(limit) = plan.limit {
+            if out_rows.len() as u64 >= limit {
+                break;
+            }
+        }
+    }
+
+    // Write CSV result back to OutputLocation if configured.
+    let output = output_location
+        .and_then(|loc| write_result_csv(s3_state, account_id, loc, &projected, &out_rows).ok());
+
+    Ok(ExecutedQuery {
+        columns: projected,
+        rows: out_rows,
+        data_scanned_bytes: scanned as i64,
+        output_location: output,
+    })
+}
+
+#[derive(Debug)]
+struct Plan {
+    /// `None` for literal-only `SELECT 1` style queries (no FROM clause).
+    source: Option<TableSource>,
+    projection: Projection,
+    filter: Option<Filter>,
+    limit: Option<u64>,
+    /// Raw projection items as parsed; used for literal SELECTs to evaluate
+    /// expressions directly (the table-backed path uses `projection`).
+    literal_items: Vec<LiteralProjectionItem>,
+}
+
+#[derive(Debug, Clone)]
+struct TableSource {
+    database: String,
+    table: String,
+}
+
+#[derive(Debug, Clone)]
+struct LiteralProjectionItem {
+    /// Output column name (`_col0`, alias, or identifier text).
+    name: String,
+    /// Pre-evaluated string value if this is a literal; `None` means we don't
+    /// support evaluating it without a source table.
+    value: Option<String>,
+    /// Athena type label for `ResultSetMetadata.ColumnInfo`.
+    type_label: String,
+}
+
+#[derive(Debug)]
+enum Projection {
+    All,
+    Columns(Vec<String>),
+}
+
+#[derive(Debug)]
+struct Filter {
+    column: String,
+    value: String,
+}
+
+fn build_plan(query: &Query, default_database: Option<&str>) -> Result<Plan, SqlError> {
+    if query.with.is_some() {
+        return Err(SqlError::UnsupportedClause("WITH"));
+    }
+    if query.order_by.is_some() {
+        return Err(SqlError::UnsupportedClause("ORDER BY"));
+    }
+    let limit = match &query.limit_clause {
+        None => None,
+        Some(LimitClause::LimitOffset {
+            limit:
+                Some(Expr::Value(ValueWithSpan {
+                    value: SqlValue::Number(n, _),
+                    ..
+                })),
+            offset,
+            limit_by,
+        }) if offset.is_none() && limit_by.is_empty() => Some(n.parse::<u64>().map_err(|_| {
+            SqlError::Parse(format!("LIMIT must be a non-negative integer (got {n})"))
+        })?),
+        Some(LimitClause::LimitOffset {
+            limit: None,
+            offset: None,
+            limit_by,
+        }) if limit_by.is_empty() => None,
+        Some(_) => return Err(SqlError::UnsupportedClause("non-literal LIMIT/OFFSET")),
+    };
+
+    let select = match query.body.as_ref() {
+        SetExpr::Select(s) => s,
+        _ => return Err(SqlError::UnsupportedStatement("set operation")),
+    };
+    if select.distinct.is_some() {
+        return Err(SqlError::UnsupportedClause("DISTINCT"));
+    }
+    if !matches!(select.group_by, GroupByExpr::Expressions(ref e, _) if e.is_empty()) {
+        return Err(SqlError::UnsupportedClause("GROUP BY"));
+    }
+    if select.having.is_some() {
+        return Err(SqlError::UnsupportedClause("HAVING"));
+    }
+    if !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+    {
+        return Err(SqlError::UnsupportedClause("CLUSTER/DISTRIBUTE/SORT BY"));
+    }
+
+    let source = if select.from.is_empty() {
+        None
+    } else {
+        if select.from.len() != 1 {
+            return Err(SqlError::UnsupportedJoin);
+        }
+        let from = &select.from[0];
+        if !from.joins.is_empty() {
+            return Err(SqlError::UnsupportedJoin);
+        }
+        let (database, table) = match &from.relation {
+            TableFactor::Table { name, .. } => parse_table_ident(name, default_database)?,
+            _ => return Err(SqlError::UnsupportedClause("non-table FROM")),
+        };
+        Some(TableSource { database, table })
+    };
+
+    let (projection, literal_items) = if source.is_some() {
+        (build_projection(&select.projection)?, Vec::new())
+    } else {
+        // No FROM clause: skip column-name projection validation entirely;
+        // `execute_literal_select` evaluates the items as constant expressions.
+        (Projection::All, build_literal_items(&select.projection)?)
+    };
+    let filter = if source.is_some() {
+        match &select.selection {
+            None => None,
+            Some(expr) => Some(build_filter(expr)?),
+        }
+    } else {
+        if select.selection.is_some() {
+            return Err(SqlError::UnsupportedClause("WHERE without FROM"));
+        }
+        None
+    };
+
+    Ok(Plan {
+        source,
+        projection,
+        filter,
+        limit,
+        literal_items,
+    })
+}
+
+fn build_literal_items(items: &[SelectItem]) -> Result<Vec<LiteralProjectionItem>, SqlError> {
+    let mut out = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        let (alias_opt, expr) = match item {
+            SelectItem::UnnamedExpr(e) => (None, e),
+            SelectItem::ExprWithAlias { expr, alias } => (Some(alias.value.clone()), expr),
+            SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
+                return Err(SqlError::UnsupportedClause("`*` without FROM"));
+            }
+        };
+        let (value, type_label) = literal_value(expr)?;
+        let name = alias_opt.unwrap_or_else(|| match expr {
+            Expr::Identifier(id) => id.value.clone(),
+            _ => format!("_col{idx}"),
+        });
+        out.push(LiteralProjectionItem {
+            name,
+            value: Some(value),
+            type_label,
+        });
+    }
+    Ok(out)
+}
+
+fn literal_value(expr: &Expr) -> Result<(String, String), SqlError> {
+    match expr {
+        Expr::Value(ValueWithSpan { value, .. }) => match value {
+            SqlValue::Number(n, _) => Ok((n.clone(), "integer".to_string())),
+            SqlValue::SingleQuotedString(s) | SqlValue::DoubleQuotedString(s) => {
+                Ok((s.clone(), "varchar".to_string()))
+            }
+            SqlValue::Boolean(b) => Ok((b.to_string(), "boolean".to_string())),
+            SqlValue::Null => Ok((String::new(), "varchar".to_string())),
+            _ => Err(SqlError::UnsupportedClause("non-literal expression")),
+        },
+        Expr::UnaryOp {
+            op: sqlparser::ast::UnaryOperator::Minus,
+            expr,
+        } => {
+            let (v, t) = literal_value(expr)?;
+            Ok((format!("-{v}"), t))
+        }
+        _ => Err(SqlError::UnsupportedClause("non-literal expression")),
+    }
+}
+
+fn execute_literal_select(
+    plan: &Plan,
+    output_location: Option<&str>,
+    account_id: &str,
+    s3: Option<&SharedS3State>,
+) -> Result<ExecutedQuery, SqlError> {
+    let columns: Vec<(String, String)> = plan
+        .literal_items
+        .iter()
+        .map(|i| (i.name.clone(), i.type_label.clone()))
+        .collect();
+    let row: Vec<String> = plan
+        .literal_items
+        .iter()
+        .map(|i| i.value.clone().unwrap_or_default())
+        .collect();
+    let rows = if plan.limit == Some(0) {
+        vec![]
+    } else {
+        vec![row]
+    };
+
+    let output = match (output_location, s3) {
+        (Some(loc), Some(state)) => write_result_csv(state, account_id, loc, &columns, &rows).ok(),
+        _ => None,
+    };
+    Ok(ExecutedQuery {
+        columns,
+        rows,
+        data_scanned_bytes: 0,
+        output_location: output,
+    })
+}
+
+fn build_projection(items: &[SelectItem]) -> Result<Projection, SqlError> {
+    if items.iter().any(|i| matches!(i, SelectItem::Wildcard(_))) {
+        if items.len() == 1 {
+            return Ok(Projection::All);
+        }
+        return Err(SqlError::UnsupportedClause("mixed `*` and named columns"));
+    }
+    let mut cols = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            SelectItem::UnnamedExpr(Expr::Identifier(id)) => cols.push(id.value.clone()),
+            SelectItem::UnnamedExpr(Expr::CompoundIdentifier(parts)) => {
+                let last = parts
+                    .last()
+                    .ok_or_else(|| SqlError::Parse("empty compound identifier".into()))?;
+                cols.push(last.value.clone());
+            }
+            SelectItem::ExprWithAlias {
+                expr: Expr::Identifier(id),
+                ..
+            } => cols.push(id.value.clone()),
+            _ => return Err(SqlError::UnsupportedClause("non-column select item")),
+        }
+    }
+    Ok(Projection::Columns(cols))
+}
+
+fn build_filter(expr: &Expr) -> Result<Filter, SqlError> {
+    let (left, op, right) = match expr {
+        Expr::BinaryOp { left, op, right } => (left.as_ref(), op, right.as_ref()),
+        _ => return Err(SqlError::UnsupportedWhere),
+    };
+    if !matches!(op, BinaryOperator::Eq) {
+        return Err(SqlError::UnsupportedWhere);
+    }
+    let column = match left {
+        Expr::Identifier(id) => id.value.clone(),
+        Expr::CompoundIdentifier(parts) => parts
+            .last()
+            .ok_or(SqlError::UnsupportedWhere)?
+            .value
+            .clone(),
+        _ => return Err(SqlError::UnsupportedWhere),
+    };
+    let value = match right {
+        Expr::Value(ValueWithSpan { value, .. }) => match value {
+            SqlValue::SingleQuotedString(s) | SqlValue::DoubleQuotedString(s) => s.clone(),
+            SqlValue::Number(n, _) => n.clone(),
+            SqlValue::Boolean(b) => b.to_string(),
+            _ => return Err(SqlError::UnsupportedWhere),
+        },
+        _ => return Err(SqlError::UnsupportedWhere),
+    };
+    Ok(Filter { column, value })
+}
+
+fn parse_table_ident(
+    name: &ObjectName,
+    default_database: Option<&str>,
+) -> Result<(String, String), SqlError> {
+    let parts: Vec<String> = name
+        .0
+        .iter()
+        .filter_map(|p| p.as_ident().map(|i| i.value.clone()))
+        .collect();
+    match parts.as_slice() {
+        [t] => default_database
+            .map(|d| (d.to_string(), t.clone()))
+            .ok_or(SqlError::InvalidTableRef),
+        [d, t] => Ok((d.clone(), t.clone())),
+        [_, d, t] => Ok((d.clone(), t.clone())), // catalog.db.table
+        _ => Err(SqlError::InvalidTableRef),
+    }
+}
+
+fn require_csv_serde(storage: &StorageDescriptor) -> Result<(), SqlError> {
+    let lib = storage
+        .serde_info
+        .as_ref()
+        .and_then(|s| s.serialization_library.as_deref())
+        .unwrap_or("");
+    let lib_lower = lib.to_lowercase();
+    // Accept the common Hadoop CSV/LazySimple SerDe names; reject Parquet/JSON
+    // up front so callers see why the query failed instead of getting silently
+    // wrong data.
+    let csv_serdes = ["lazysimpleserde", "opencsvserde"];
+    if lib.is_empty() || csv_serdes.iter().any(|s| lib_lower.contains(s)) {
+        Ok(())
+    } else {
+        Err(SqlError::UnsupportedSerde(lib.to_string()))
+    }
+}
+
+fn parse_s3_url(url: &str) -> Option<(String, String)> {
+    let rest = url.strip_prefix("s3://")?;
+    let (bucket, key_prefix) = match rest.split_once('/') {
+        Some((b, k)) => (b.to_string(), k.to_string()),
+        None => (rest.to_string(), String::new()),
+    };
+    Some((bucket, key_prefix))
+}
+
+fn read_csv_under_prefix(
+    s3: &SharedS3State,
+    account_id: &str,
+    bucket_name: &str,
+    prefix: &str,
+) -> Result<(Vec<Vec<String>>, usize), SqlError> {
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut scanned: usize = 0;
+    let s3_guard = s3.read();
+    let acct = s3_guard
+        .get(account_id)
+        .ok_or_else(|| SqlError::BucketNotFound(bucket_name.to_string()))?;
+    let bucket = acct
+        .buckets
+        .get(bucket_name)
+        .ok_or_else(|| SqlError::BucketNotFound(bucket_name.to_string()))?;
+
+    // Sort keys so result ordering is deterministic across re-runs.
+    let mut keys: Vec<&String> = bucket
+        .objects
+        .keys()
+        .filter(|k| prefix.is_empty() || k.starts_with(prefix))
+        .collect();
+    keys.sort();
+
+    for key in keys {
+        let obj = &bucket.objects[key];
+        if obj.is_delete_marker {
+            continue;
+        }
+        let body = acct
+            .read_body(&obj.body)
+            .map_err(|e| SqlError::S3Read(format!("{key}: {e}")))?;
+        scanned += body.len();
+        for line in csv_lines(&body) {
+            rows.push(parse_csv_line(&line));
+        }
+    }
+    Ok((rows, scanned))
+}
+
+/// Split bytes into lines stripping trailing CR/LF; skip empty lines.
+fn csv_lines(bytes: &Bytes) -> Vec<String> {
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    text.lines()
+        .map(str::to_string)
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+/// Parse one CSV line. Honors `"`-quoted fields (with `""` escape) and a
+/// comma delimiter. Enough for the smoke-test corpus we serve; not RFC 4180
+/// complete (no embedded newlines inside quoted fields).
+fn parse_csv_line(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' if in_quotes => {
+                if chars.peek() == Some(&'"') {
+                    current.push('"');
+                    chars.next();
+                } else {
+                    in_quotes = false;
+                }
+            }
+            '"' => in_quotes = true,
+            ',' if !in_quotes => {
+                out.push(std::mem::take(&mut current));
+            }
+            other => current.push(other),
+        }
+    }
+    out.push(current);
+    out
+}
+
+fn write_result_csv(
+    s3: &SharedS3State,
+    account_id: &str,
+    output_location: &str,
+    columns: &[(String, String)],
+    rows: &[Vec<String>],
+) -> Result<String, SqlError> {
+    let (bucket_name, prefix) = parse_s3_url(output_location)
+        .ok_or_else(|| SqlError::InvalidOutputLocation(output_location.to_string()))?;
+    let mut prefix = prefix;
+    if !prefix.is_empty() && !prefix.ends_with('/') {
+        prefix.push('/');
+    }
+    let key = format!("{prefix}{}.csv", Uuid::new_v4());
+
+    let mut body = String::new();
+    body.push_str(
+        &columns
+            .iter()
+            .map(|(n, _)| escape_csv(n))
+            .collect::<Vec<_>>()
+            .join(","),
+    );
+    body.push('\n');
+    for row in rows {
+        body.push_str(
+            &row.iter()
+                .map(|v| escape_csv(v))
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        body.push('\n');
+    }
+
+    let bytes = Bytes::from(body.into_bytes());
+    let size = bytes.len() as u64;
+    let etag = format!("\"{}\"", Uuid::new_v4().simple());
+
+    let mut s3_state = s3.write();
+    let acct = s3_state.get_or_create(account_id);
+    let bucket = acct
+        .buckets
+        .get_mut(&bucket_name)
+        .ok_or_else(|| SqlError::BucketNotFound(bucket_name.clone()))?;
+    bucket.objects.insert(
+        key.clone(),
+        S3Object {
+            key: key.clone(),
+            body: memory_body(bytes),
+            content_type: "text/csv".to_string(),
+            etag,
+            size,
+            last_modified: Utc::now(),
+            storage_class: "STANDARD".to_string(),
+            ..Default::default()
+        },
+    );
+    Ok(format!("s3://{bucket_name}/{key}"))
+}
+
+fn escape_csv(field: &str) -> String {
+    if field.contains(',') || field.contains('"') || field.contains('\n') {
+        let escaped = field.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    } else {
+        field.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_select_star_with_db_table() {
+        let dialect = GenericDialect {};
+        let mut stmts = Parser::parse_sql(&dialect, "SELECT * FROM db.t").unwrap();
+        let q = match stmts.remove(0) {
+            Statement::Query(q) => q,
+            _ => panic!(),
+        };
+        let plan = build_plan(&q, None).unwrap();
+        let src = plan.source.unwrap();
+        assert_eq!(src.database, "db");
+        assert_eq!(src.table, "t");
+        assert!(matches!(plan.projection, Projection::All));
+    }
+
+    #[test]
+    fn parses_columns_where_limit() {
+        let dialect = GenericDialect {};
+        let mut stmts =
+            Parser::parse_sql(&dialect, "SELECT a, b FROM db.t WHERE a = 'x' LIMIT 2").unwrap();
+        let q = match stmts.remove(0) {
+            Statement::Query(q) => q,
+            _ => panic!(),
+        };
+        let plan = build_plan(&q, None).unwrap();
+        assert!(
+            matches!(plan.projection, Projection::Columns(ref c) if c == &vec!["a".to_string(), "b".to_string()])
+        );
+        let f = plan.filter.unwrap();
+        assert_eq!(f.column, "a");
+        assert_eq!(f.value, "x");
+        assert_eq!(plan.limit, Some(2));
+    }
+
+    #[test]
+    fn parses_select_literal() {
+        let result = execute(
+            "SELECT 1",
+            None,
+            None,
+            "111111111111",
+            "us-east-1",
+            None,
+            None,
+        );
+        let exec = result.expect("execute");
+        assert_eq!(exec.rows.len(), 1);
+        assert_eq!(exec.rows[0], vec!["1".to_string()]);
+        assert_eq!(exec.columns[0].1, "integer");
+    }
+
+    #[test]
+    fn rejects_join() {
+        let dialect = GenericDialect {};
+        let mut stmts =
+            Parser::parse_sql(&dialect, "SELECT * FROM db.t JOIN db.u ON t.id = u.id").unwrap();
+        let q = match stmts.remove(0) {
+            Statement::Query(q) => q,
+            _ => panic!(),
+        };
+        assert!(matches!(
+            build_plan(&q, None),
+            Err(SqlError::UnsupportedJoin)
+        ));
+    }
+
+    #[test]
+    fn parse_csv_line_handles_quotes() {
+        assert_eq!(
+            parse_csv_line("a,\"b,c\",d"),
+            vec!["a".to_string(), "b,c".to_string(), "d".to_string()],
+        );
+        assert_eq!(
+            parse_csv_line("a,\"he said \"\"hi\"\"\",b"),
+            vec![
+                "a".to_string(),
+                "he said \"hi\"".to_string(),
+                "b".to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_s3_url_splits_bucket_and_prefix() {
+        assert_eq!(
+            parse_s3_url("s3://bkt/path/to/data/"),
+            Some(("bkt".into(), "path/to/data/".into()))
+        );
+        assert_eq!(parse_s3_url("s3://bkt"), Some(("bkt".into(), "".into())));
+        assert_eq!(parse_s3_url("https://example.com"), None);
+    }
+
+    #[test]
+    fn escape_csv_quotes_when_needed() {
+        assert_eq!(escape_csv("plain"), "plain");
+        assert_eq!(escape_csv("a,b"), "\"a,b\"");
+        assert_eq!(escape_csv("a\"b"), "\"a\"\"b\"");
+    }
+}

--- a/crates/fakecloud-e2e/tests/athena.rs
+++ b/crates/fakecloud-e2e/tests/athena.rs
@@ -5,6 +5,8 @@ mod helpers;
 use aws_sdk_athena::types::{
     DataCatalogType, QueryExecutionContext, ResultConfiguration, Tag, WorkGroupConfiguration,
 };
+use aws_sdk_glue::types as glue_types;
+use aws_sdk_s3::primitives::ByteStream;
 use helpers::TestServer;
 
 #[tokio::test]
@@ -375,5 +377,222 @@ async fn list_engine_versions_returns_known_versions() {
     assert!(
         names.iter().any(|n| n.contains("Athena engine")),
         "expected at least one Athena engine version, got {names:?}"
+    );
+}
+
+/// End-to-end: pre-seed a Glue table that points at CSV objects in S3,
+/// `StartQueryExecution` with a `SELECT col FROM db.t WHERE col='x'`, and
+/// confirm `GetQueryResults` returns the matched rows from the underlying
+/// CSV — exercising the SQL parser + Glue catalog read + S3 read + result
+/// CSV write path.
+#[tokio::test]
+async fn select_with_filter_reads_csv_via_glue_catalog() {
+    let server = TestServer::start().await;
+    let athena = server.athena_client().await;
+    let glue = server.glue_client().await;
+    let s3 = server.s3_client().await;
+
+    // 1. Seed S3 with a CSV file under the table's storage prefix.
+    s3.create_bucket()
+        .bucket("dl-bucket")
+        .send()
+        .await
+        .expect("create bucket");
+    let csv = "1,alice,active\n2,bob,inactive\n3,carol,active\n";
+    s3.put_object()
+        .bucket("dl-bucket")
+        .key("users/data.csv")
+        .body(ByteStream::from_static(csv.as_bytes()))
+        .send()
+        .await
+        .expect("put csv");
+
+    // 2. Register a Glue database + CSV-backed table over that prefix.
+    glue.create_database()
+        .database_input(
+            glue_types::DatabaseInput::builder()
+                .name("warehouse")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create db");
+    let table_input = glue_types::TableInput::builder()
+        .name("users")
+        .table_type("EXTERNAL_TABLE")
+        .storage_descriptor(
+            glue_types::StorageDescriptor::builder()
+                .columns(
+                    glue_types::Column::builder()
+                        .name("id")
+                        .r#type("bigint")
+                        .build()
+                        .unwrap(),
+                )
+                .columns(
+                    glue_types::Column::builder()
+                        .name("name")
+                        .r#type("string")
+                        .build()
+                        .unwrap(),
+                )
+                .columns(
+                    glue_types::Column::builder()
+                        .name("status")
+                        .r#type("string")
+                        .build()
+                        .unwrap(),
+                )
+                .location("s3://dl-bucket/users/")
+                .input_format("org.apache.hadoop.mapred.TextInputFormat")
+                .output_format("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat")
+                .serde_info(
+                    glue_types::SerDeInfo::builder()
+                        .serialization_library("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+        .expect("table input");
+    glue.create_table()
+        .database_name("warehouse")
+        .table_input(table_input)
+        .send()
+        .await
+        .expect("create table");
+
+    // 3. Result location bucket so Athena can write the CSV result back.
+    s3.create_bucket()
+        .bucket("athena-results")
+        .send()
+        .await
+        .expect("create results bucket");
+
+    // 4. Run the query.
+    let started = athena
+        .start_query_execution()
+        .query_string("SELECT id, name FROM warehouse.users WHERE status = 'active' LIMIT 10")
+        .work_group("primary")
+        .query_execution_context(
+            QueryExecutionContext::builder()
+                .database("warehouse")
+                .build(),
+        )
+        .result_configuration(
+            ResultConfiguration::builder()
+                .output_location("s3://athena-results/queries/")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("start");
+    let qid = started.query_execution_id().expect("qid").to_owned();
+
+    // 5. Verify the execution completed successfully.
+    let exec = athena
+        .get_query_execution()
+        .query_execution_id(&qid)
+        .send()
+        .await
+        .expect("get exec");
+    let qe = exec.query_execution().expect("qe");
+    let state = qe
+        .status()
+        .and_then(|s| s.state())
+        .expect("status state")
+        .as_str()
+        .to_string();
+    assert_eq!(state, "SUCCEEDED", "qe failed: {qe:?}");
+    let resolved_output = qe
+        .result_configuration()
+        .and_then(|rc| rc.output_location())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        resolved_output.starts_with("s3://athena-results/queries/")
+            && resolved_output.ends_with(".csv"),
+        "expected resolved CSV output_location, got `{resolved_output}`"
+    );
+
+    // 6. GetQueryResults: header row + matched rows, projected to (id, name).
+    let results = athena
+        .get_query_results()
+        .query_execution_id(&qid)
+        .send()
+        .await
+        .expect("results");
+    let rs = results.result_set().expect("rs");
+    let rows: Vec<Vec<String>> = rs
+        .rows()
+        .iter()
+        .map(|row| {
+            row.data()
+                .iter()
+                .map(|d| d.var_char_value().unwrap_or("").to_string())
+                .collect()
+        })
+        .collect();
+    assert_eq!(rows.len(), 3, "header + 2 matches; got {rows:?}");
+    assert_eq!(rows[0], vec!["id".to_string(), "name".to_string()]);
+    assert_eq!(rows[1], vec!["1".to_string(), "alice".to_string()]);
+    assert_eq!(rows[2], vec!["3".to_string(), "carol".to_string()]);
+
+    // 7. The result CSV was written back to S3 — fetch and verify.
+    let result_key = resolved_output
+        .strip_prefix("s3://athena-results/")
+        .expect("strip");
+    let got = s3
+        .get_object()
+        .bucket("athena-results")
+        .key(result_key)
+        .send()
+        .await
+        .expect("get result csv");
+    let body = got.body.collect().await.expect("body").into_bytes();
+    let body_str = String::from_utf8(body.to_vec()).expect("utf8");
+    assert!(
+        body_str.contains("id,name\n1,alice\n3,carol"),
+        "result CSV missing expected payload: {body_str:?}"
+    );
+}
+
+/// SELECT against a non-existent table: Athena marks the execution `FAILED`
+/// with a structured reason rather than synthesizing a fake row.
+#[tokio::test]
+async fn select_failing_against_unknown_table_marks_query_failed() {
+    let server = TestServer::start().await;
+    let athena = server.athena_client().await;
+    let started = athena
+        .start_query_execution()
+        .query_string("SELECT * FROM nodb.notable")
+        .work_group("primary")
+        .send()
+        .await
+        .expect("start");
+    let qid = started.query_execution_id().expect("qid").to_owned();
+    let exec = athena
+        .get_query_execution()
+        .query_execution_id(&qid)
+        .send()
+        .await
+        .expect("get exec");
+    let qe = exec.query_execution().expect("qe");
+    let state = qe
+        .status()
+        .and_then(|s| s.state())
+        .expect("state")
+        .as_str()
+        .to_string();
+    assert_eq!(state, "FAILED");
+    let reason = qe
+        .status()
+        .and_then(|s| s.state_change_reason())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        reason.to_lowercase().contains("not found"),
+        "expected `not found` in reason, got `{reason}`"
     );
 }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2158,7 +2158,9 @@ async fn main() {
     );
     registry.register(Arc::new(wafv2_service));
 
-    let athena_service = fakecloud_athena::AthenaService::new(athena_state.clone());
+    let athena_service = fakecloud_athena::AthenaService::new(athena_state.clone())
+        .with_glue(glue_state.clone())
+        .with_s3(s3_state.clone());
     registry.register(Arc::new(athena_service));
 
     let mut sfn_service = StepFunctionsService::new(stepfunctions_state.clone());


### PR DESCRIPTION
## Summary

Replaces the canned \`SELECT 1\`-shaped response in Athena's
\`StartQueryExecution\` with real SQL execution:

- Parses SELECT via \`sqlparser\` (Generic dialect)
- Resolves the source table via the Glue catalog (cross-account state shared
  with \`fakecloud-glue\`)
- Reads CSV-backed data from S3 per \`StorageDescriptor.Location\` /
  \`SerdeInfo\` (LazySimpleSerDe / OpenCSVSerDe / unset)
- Applies projection, single-equality \`WHERE\`, \`LIMIT\` in-memory
- Writes the result CSV back to \`ResultConfiguration.OutputLocation\` so
  callers can fetch it via S3 like real Athena
- \`GetQueryResults\` now returns the real engine output

Anything outside the supported surface (joins, aggregates, GROUP BY, ORDER BY,
subqueries, Parquet/JSON SerDes) lands as a \`FAILED\` QueryExecution with a
structured \`state_change_reason\` instead of fabricating success.

## Test plan
- [x] \`cargo test -p fakecloud-athena\` — 7 passing unit tests cover SQL
      parser, plan builder, CSV parser, S3 URL helper, escape helper, literal
      SELECT path
- [x] \`cargo test -p fakecloud-e2e --test athena\` — 14 passing including the
      new \`select_with_filter_reads_csv_via_glue_catalog\` (full
      Glue+S3+Athena round trip) and \`select_failing_against_unknown_table_marks_query_failed\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`cargo test --workspace --lib\` — full lib suite green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real SELECT execution to Athena: queries are parsed, resolved via Glue, read from S3 CSV, filtered in memory, and results are written back to the configured S3 output. `GetQueryResults` now returns the engine’s rows; unsupported queries are marked FAILED with a clear reason.

- **New Features**
  - Parse `SELECT` via `sqlparser` (Generic). Support literal SELECTs.
  - Apply projection, single `=` WHERE, and LIMIT in memory.
  - Resolve tables from Glue; read CSV from S3 using `StorageDescriptor.Location` and CSV SerDes (`LazySimpleSerDe`, `OpenCSVSerDe`, or unset).
  - Write result CSV to `ResultConfiguration.OutputLocation` and echo the resolved S3 path in `GetQueryExecution`.
  - Mark unsupported features (joins, aggregates, ORDER BY, subqueries, non-CSV SerDes) as FAILED with `state_change_reason`.

- **Dependencies**
  - Add `sqlparser`, `fakecloud-glue`, `fakecloud-s3`, and `bytes`.
  - Wire `AthenaService` with Glue and S3 shared state in the server.

<sup>Written for commit 8e55a916277337280540c42afc97d0d8dd565d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

