### PR TITLE
feat(elasticache): real shard + replica count mutations (N4)

### DIFF
--- a/crates/fakecloud-conformance/tests/elasticache.rs
+++ b/crates/fakecloud-conformance/tests/elasticache.rs
@@ -1448,19 +1448,23 @@ async fn elasticache_cluster_modify_reboot_list() {
 async fn elasticache_modify_replication_group_shard_configuration() {
     let server = TestServer::start().await;
     let client = server.elasticache_client().await;
+    // ModifyReplicationGroupShardConfiguration is cluster-mode only, so
+    // create the group with multiple shards up front.
     client
         .create_replication_group()
         .replication_group_id("rg1")
         .replication_group_description("d")
         .engine("redis")
         .cache_node_type("cache.t4g.micro")
+        .num_node_groups(2)
+        .replicas_per_node_group(1)
         .send()
         .await
         .unwrap();
     client
         .modify_replication_group_shard_configuration()
         .replication_group_id("rg1")
-        .node_group_count(2)
+        .node_group_count(3)
         .apply_immediately(true)
         .send()
         .await

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2564,3 +2564,185 @@ async fn elasticache_create_cache_cluster_round_trips_extended_fields() {
         .await
         .unwrap();
 }
+
+// ── Replica + shard-count mutation tests ──
+
+#[tokio::test]
+async fn elasticache_modify_replication_group_shard_configuration_changes_shard_count() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("shard-rg")
+        .replication_group_description("multi-shard")
+        .num_node_groups(2)
+        .replicas_per_node_group(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Increase shard count: 2 -> 3.
+    client
+        .modify_replication_group_shard_configuration()
+        .replication_group_id("shard-rg")
+        .node_group_count(3)
+        .apply_immediately(true)
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_replication_groups()
+        .replication_group_id("shard-rg")
+        .send()
+        .await
+        .unwrap();
+    let group = &described.replication_groups()[0];
+    assert_eq!(
+        group.node_groups().len(),
+        3,
+        "ModifyReplicationGroupShardConfiguration must update NodeGroups"
+    );
+    let ids: Vec<&str> = group
+        .node_groups()
+        .iter()
+        .filter_map(|n| n.node_group_id())
+        .collect();
+    assert!(ids.contains(&"0001"));
+    assert!(ids.contains(&"0002"));
+    assert!(ids.contains(&"0003"));
+
+    // Decrease shard count: 3 -> 2 with NodeGroupsToRetain.
+    client
+        .modify_replication_group_shard_configuration()
+        .replication_group_id("shard-rg")
+        .node_group_count(2)
+        .apply_immediately(true)
+        .node_groups_to_retain("0001")
+        .node_groups_to_retain("0002")
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_replication_groups()
+        .replication_group_id("shard-rg")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(described.replication_groups()[0].node_groups().len(), 2);
+}
+
+#[tokio::test]
+async fn elasticache_modify_replication_group_shard_configuration_rejects_non_cluster_change() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("single-rg")
+        .replication_group_description("single shard")
+        .send()
+        .await
+        .unwrap();
+
+    // Non-cluster mode: NodeGroupCount must stay 1.
+    let result = client
+        .modify_replication_group_shard_configuration()
+        .replication_group_id("single-rg")
+        .node_group_count(3)
+        .apply_immediately(true)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "non-cluster replication group should reject NodeGroupCount change"
+    );
+}
+
+#[tokio::test]
+async fn elasticache_increase_replica_count_per_shard() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("rep-up-rg")
+        .replication_group_description("replica scale up")
+        .num_node_groups(2)
+        .replicas_per_node_group(1)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .increase_replica_count()
+        .replication_group_id("rep-up-rg")
+        .apply_immediately(true)
+        .new_replica_count(2)
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_replication_groups()
+        .replication_group_id("rep-up-rg")
+        .send()
+        .await
+        .unwrap();
+    let group = &described.replication_groups()[0];
+    // 2 shards × (1 primary + 2 replicas) = 6 member clusters.
+    assert_eq!(
+        group.member_clusters().len(),
+        6,
+        "IncreaseReplicaCount must rebuild member_clusters per shard"
+    );
+}
+
+#[tokio::test]
+async fn elasticache_decrease_replica_count_per_shard() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_replication_group()
+        .replication_group_id("rep-dn-rg")
+        .replication_group_description("replica scale down")
+        .num_node_groups(2)
+        .replicas_per_node_group(2)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .decrease_replica_count()
+        .replication_group_id("rep-dn-rg")
+        .apply_immediately(true)
+        .new_replica_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_replication_groups()
+        .replication_group_id("rep-dn-rg")
+        .send()
+        .await
+        .unwrap();
+    let group = &described.replication_groups()[0];
+    // 2 shards × (1 primary + 1 replica) = 4 member clusters.
+    assert_eq!(group.member_clusters().len(), 4);
+}

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -332,6 +332,90 @@ pub(crate) fn parse_query_list_param(
     indexed
 }
 
+/// Per-shard replica config supplied via
+/// `ReplicaConfiguration.ConfigureShard.N.{NodeGroupId,NewReplicaCount}`.
+/// Used by IncreaseReplicaCount + DecreaseReplicaCount.
+pub(crate) struct ConfigureShard {
+    /// Captured from the request so future per-shard placement can target a
+    /// specific NodeGroupId; today we apply NewReplicaCount uniformly.
+    #[allow(dead_code)]
+    pub node_group_id: String,
+    pub new_replica_count: i32,
+}
+
+pub(crate) fn parse_replica_configuration(
+    req: &AwsRequest,
+) -> Result<Vec<ConfigureShard>, AwsServiceError> {
+    let prefix = "ReplicaConfiguration.ConfigureShard.";
+    let mut indices: Vec<usize> = req
+        .query_params
+        .keys()
+        .filter_map(|k| {
+            k.strip_prefix(prefix).and_then(|tail| {
+                tail.split_once('.')
+                    .and_then(|(idx, _)| idx.parse::<usize>().ok())
+            })
+        })
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+    let mut out = Vec::with_capacity(indices.len());
+    for idx in indices {
+        let id_key = format!("{prefix}{idx}.NodeGroupId");
+        let count_key = format!("{prefix}{idx}.NewReplicaCount");
+        let node_group_id = req.query_params.get(&id_key).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                format!("ReplicaConfiguration entry {idx} is missing NodeGroupId."),
+            )
+        })?;
+        let count_raw = req.query_params.get(&count_key).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MissingParameter",
+                format!("ReplicaConfiguration entry {idx} is missing NewReplicaCount."),
+            )
+        })?;
+        let new_replica_count: i32 = count_raw.parse().map_err(|_| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "ReplicaConfiguration entry {idx} has invalid NewReplicaCount '{count_raw}'."
+                ),
+            )
+        })?;
+        out.push(ConfigureShard {
+            node_group_id: node_group_id.clone(),
+            new_replica_count,
+        });
+    }
+    Ok(out)
+}
+
+/// Returns the current per-shard replica count, derived from
+/// `replicas_per_node_group` when set or back-computed from
+/// `num_cache_clusters / num_node_groups - 1` for legacy state created
+/// before that field was populated.
+pub(crate) fn current_replicas_per_shard(group: &ReplicationGroup) -> i32 {
+    if let Some(r) = group.replicas_per_node_group {
+        return r;
+    }
+    let shards = group.num_node_groups.max(1);
+    (group.num_cache_clusters / shards - 1).max(0)
+}
+
+/// Rebuild the flat `member_clusters` list as `<rg_id>-NNN` for the given
+/// total cluster count. Used by Increase/DecreaseReplicaCount and
+/// ModifyReplicationGroupShardConfiguration so DescribeReplicationGroups
+/// reflects the new shape.
+pub(crate) fn build_member_clusters(replication_group_id: &str, total: i32) -> Vec<String> {
+    (1..=total.max(0))
+        .map(|i| format!("{replication_group_id}-{i:03}"))
+        .collect()
+}
+
 pub(crate) fn optional_usize_param(
     req: &AwsRequest,
     name: &str,

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2798,100 +2798,27 @@ impl ElastiCacheService {
     }
 
     fn increase_replica_count(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let replication_group_id = required_query_param(request, "ReplicationGroupId")?;
-        let apply_str = required_query_param(request, "ApplyImmediately")?;
-        let _apply_immediately = parse_optional_bool(Some(&apply_str))?.ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!(
-                    "Invalid boolean value for ApplyImmediately: '{}'",
-                    apply_str
-                ),
-            )
-        })?;
-
-        let new_replica_count = optional_query_param(request, "NewReplicaCount")
-            .map(|v| {
-                v.parse::<i32>().map_err(|_| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidParameterValue",
-                        format!("Invalid value for NewReplicaCount: '{v}'"),
-                    )
-                })
-            })
-            .transpose()?
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "MissingParameter",
-                    "The request must contain the parameter NewReplicaCount.".to_string(),
-                )
-            })?;
-
-        if new_replica_count < 1 {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("NewReplicaCount must be a positive integer, got {new_replica_count}"),
-            ));
-        }
-
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
-
-        let group = state
-            .replication_groups
-            .get_mut(&replication_group_id)
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "ReplicationGroupNotFoundFault",
-                    format!("ReplicationGroup {replication_group_id} not found."),
-                )
-            })?;
-
-        // new_replica_count is number of replicas (excluding primary), so total clusters = replicas + 1
-        let new_total = new_replica_count.checked_add(1).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("NewReplicaCount value {new_replica_count} is too large"),
-            )
-        })?;
-        if new_total <= group.num_cache_clusters {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!(
-                    "NewReplicaCount ({new_replica_count}) must result in more clusters than current count ({}).",
-                    group.num_cache_clusters
-                ),
-            ));
-        }
-
-        group.num_cache_clusters = new_total;
-        group.member_clusters = (1..=new_total)
-            .map(|i| format!("{replication_group_id}-{i:03}"))
-            .collect();
-
-        let group = group.clone();
-        let region = state.region.clone();
-        let xml = replication_group_xml(&group, &region);
-
-        Ok(AwsResponse::xml(
-            StatusCode::OK,
-            query_response_xml(
-                "IncreaseReplicaCount",
-                ELASTICACHE_NS,
-                &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
-                &request.request_id,
-            ),
-        ))
+        self.modify_replica_count(request, true)
     }
 
     fn decrease_replica_count(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        self.modify_replica_count(request, false)
+    }
+
+    /// Shared core for IncreaseReplicaCount + DecreaseReplicaCount.
+    ///
+    /// Both AWS operations take either a uniform `NewReplicaCount` (applied to
+    /// every shard) or a per-shard `ReplicaConfiguration.ConfigureShard.N`
+    /// list. DecreaseReplicaCount additionally accepts `ReplicasToRemove`,
+    /// which we map onto a uniform `replicas_per_node_group - len(remove)`.
+    /// The struct fields we mutate are `num_cache_clusters`, `member_clusters`
+    /// and `replicas_per_node_group` so DescribeReplicationGroups reflects the
+    /// new shape immediately.
+    fn modify_replica_count(
+        &self,
+        request: &AwsRequest,
+        increase: bool,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let replication_group_id = required_query_param(request, "ReplicationGroupId")?;
         let apply_str = required_query_param(request, "ApplyImmediately")?;
         let _apply_immediately = parse_optional_bool(Some(&apply_str))?.ok_or_else(|| {
@@ -2915,21 +2842,52 @@ impl ElastiCacheService {
                     )
                 })
             })
-            .transpose()?
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "MissingParameter",
-                    "The request must contain the parameter NewReplicaCount.".to_string(),
-                )
-            })?;
+            .transpose()?;
 
-        if new_replica_count < 0 {
+        let replica_configuration = parse_replica_configuration(request)?;
+        let replicas_to_remove =
+            parse_query_list_param(request, "ReplicasToRemove", "ReplicaToRemove");
+
+        let action = if increase {
+            "IncreaseReplicaCount"
+        } else {
+            "DecreaseReplicaCount"
+        };
+
+        // AWS requires exactly one of NewReplicaCount or ReplicaConfiguration.
+        // DecreaseReplicaCount additionally accepts ReplicasToRemove (alone or
+        // with one of the others). We mirror the validation so callers don't
+        // accidentally race two configurations against each other.
+        let inputs_supplied = (new_replica_count.is_some() as u8)
+            + (!replica_configuration.is_empty() as u8)
+            + (!replicas_to_remove.is_empty() as u8);
+        if inputs_supplied == 0 {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "InvalidParameterValue",
-                format!("NewReplicaCount must be non-negative, got {new_replica_count}"),
+                "InvalidParameterCombination",
+                if increase {
+                    "IncreaseReplicaCount requires NewReplicaCount or ReplicaConfiguration."
+                        .to_string()
+                } else {
+                    "DecreaseReplicaCount requires NewReplicaCount, ReplicaConfiguration, or ReplicasToRemove.".to_string()
+                },
             ));
+        }
+        if let Some(n) = new_replica_count {
+            if increase && n < 1 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("NewReplicaCount must be a positive integer, got {n}"),
+                ));
+            }
+            if !increase && n < 0 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!("NewReplicaCount must be non-negative, got {n}"),
+                ));
+            }
         }
 
         let mut accounts = self.state.write();
@@ -2946,29 +2904,80 @@ impl ElastiCacheService {
                 )
             })?;
 
-        // new_replica_count is number of replicas (excluding primary), so total clusters = replicas + 1
-        let new_total = new_replica_count.checked_add(1).ok_or_else(|| {
-            AwsServiceError::aws_error(
+        let shard_count = group.num_node_groups.max(1);
+        let current_replicas_per_shard = current_replicas_per_shard(group);
+
+        // Resolve the target per-shard replica count. ReplicaConfiguration takes
+        // precedence and must specify the same NewReplicaCount for every shard
+        // (we don't model per-shard replica counts; the value gets applied
+        // uniformly). Without it we fall back to NewReplicaCount, then to
+        // ReplicasToRemove for the decrease path.
+        let target_replicas = if !replica_configuration.is_empty() {
+            let mut counts: Vec<i32> = replica_configuration
+                .iter()
+                .map(|c| c.new_replica_count)
+                .collect();
+            counts.sort_unstable();
+            counts.dedup();
+            if counts.len() != 1 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    "ReplicaConfiguration entries must specify the same NewReplicaCount across shards.".to_string(),
+                ));
+            }
+            counts[0]
+        } else if let Some(n) = new_replica_count {
+            n
+        } else {
+            // ReplicasToRemove: drop the listed count from the current
+            // per-shard replica count, distributed evenly across shards.
+            let removed_per_shard =
+                (replicas_to_remove.len() as i32).div_euclid(shard_count.max(1));
+            current_replicas_per_shard - removed_per_shard
+        };
+
+        if target_replicas < 0 {
+            return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterValue",
-                format!("NewReplicaCount value {new_replica_count} is too large"),
-            )
-        })?;
-        if new_total >= group.num_cache_clusters {
+                format!("Replica count must be non-negative, got {target_replicas}"),
+            ));
+        }
+
+        if increase && target_replicas <= current_replicas_per_shard {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterValue",
                 format!(
-                    "NewReplicaCount ({new_replica_count}) must result in fewer clusters than current count ({}).",
-                    group.num_cache_clusters
+                    "NewReplicaCount ({target_replicas}) must be greater than the current replica count per shard ({current_replicas_per_shard})."
+                ),
+            ));
+        }
+        if !increase && target_replicas >= current_replicas_per_shard {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "NewReplicaCount ({target_replicas}) must be less than the current replica count per shard ({current_replicas_per_shard})."
                 ),
             ));
         }
 
+        let new_total = shard_count
+            .checked_mul(target_replicas + 1)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Replica count {target_replicas} across {shard_count} shards overflows."
+                    ),
+                )
+            })?;
         group.num_cache_clusters = new_total;
-        group.member_clusters = (1..=new_total)
-            .map(|i| format!("{replication_group_id}-{i:03}"))
-            .collect();
+        group.replicas_per_node_group = Some(target_replicas);
+        group.member_clusters = build_member_clusters(&replication_group_id, new_total);
 
         let group = group.clone();
         let region = state.region.clone();
@@ -2977,7 +2986,7 @@ impl ElastiCacheService {
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
-                "DecreaseReplicaCount",
+                action,
                 ELASTICACHE_NS,
                 &format!("<ReplicationGroup>{xml}</ReplicationGroup>"),
                 &request.request_id,
@@ -4139,20 +4148,129 @@ impl ElastiCacheService {
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "ReplicationGroupId")?;
-        let _node_group_count = required_query_param(request, "NodeGroupCount")?;
-        let _apply = required_query_param(request, "ApplyImmediately")?;
-        let accounts = self.state.read();
-        let empty = ElastiCacheState::new(&request.account_id, &request.region);
-        let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let group = state.replication_groups.get(&id).ok_or_else(|| {
+        let node_group_count_str = required_query_param(request, "NodeGroupCount")?;
+        let node_group_count: i32 = node_group_count_str.parse().map_err(|_| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Invalid value for NodeGroupCount: '{node_group_count_str}'"),
+            )
+        })?;
+        if node_group_count < 1 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("NodeGroupCount must be a positive integer, got {node_group_count}"),
+            ));
+        }
+        let apply_str = required_query_param(request, "ApplyImmediately")?;
+        let _apply = parse_optional_bool(Some(&apply_str))?.ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!("Invalid boolean value for ApplyImmediately: '{apply_str}'"),
+            )
+        })?;
+        // Optional NodeGroupsToRemove / NodeGroupsToRetain — we accept and
+        // validate them but the actual data placement is opaque (single
+        // backing redis container), so they only affect bookkeeping.
+        let node_groups_to_remove =
+            parse_query_list_param(request, "NodeGroupsToRemove", "NodeGroupToRemove");
+        let node_groups_to_retain =
+            parse_query_list_param(request, "NodeGroupsToRetain", "NodeGroupToRetain");
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&request.account_id);
+        let group = state.replication_groups.get_mut(&id).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ReplicationGroupNotFoundFault",
                 format!("ReplicationGroup {id} not found."),
             )
         })?;
+
+        if !group.cluster_enabled && node_group_count != 1 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "NodeGroupCount can only be modified for cluster mode replication groups."
+                    .to_string(),
+            ));
+        }
+
+        let max_shards = max_node_groups_for(&group.engine, &group.engine_version);
+        if node_group_count > max_shards {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterValue",
+                format!(
+                    "NodeGroupCount must be between 1 and {max_shards} for {} {}, got {node_group_count}",
+                    group.engine, group.engine_version
+                ),
+            ));
+        }
+
+        let current_shards = group.num_node_groups.max(1);
+        if node_group_count < current_shards {
+            // Decrease: AWS requires either NodeGroupsToRemove or
+            // NodeGroupsToRetain whose length matches the delta or the new
+            // shape respectively.
+            let to_drop = (current_shards - node_group_count) as usize;
+            let supplied_remove = node_groups_to_remove.len();
+            let supplied_retain = node_groups_to_retain.len();
+            if supplied_remove == 0 && supplied_retain == 0 {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterCombination",
+                    "Decreasing NodeGroupCount requires NodeGroupsToRemove or NodeGroupsToRetain."
+                        .to_string(),
+                ));
+            }
+            if supplied_remove > 0 && supplied_remove != to_drop {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "NodeGroupsToRemove must contain exactly {to_drop} entries, got {supplied_remove}"
+                    ),
+                ));
+            }
+            if supplied_retain > 0 && supplied_retain != node_group_count as usize {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "NodeGroupsToRetain must contain exactly {node_group_count} entries, got {supplied_retain}"
+                    ),
+                ));
+            }
+        }
+
+        let replicas_per_shard = current_replicas_per_shard(group);
+        let new_total = node_group_count
+            .checked_mul(replicas_per_shard + 1)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValue",
+                    format!(
+                        "Shard count {node_group_count} with {replicas_per_shard} replicas per shard overflows."
+                    ),
+                )
+            })?;
+
+        group.num_node_groups = node_group_count;
+        group.num_cache_clusters = new_total;
+        group.member_clusters = build_member_clusters(&id, new_total);
+        // Cluster-mode flag tracks shard count > 1 unless the user already
+        // opted into cluster_mode=enabled at create time.
+        if node_group_count > 1 {
+            group.cluster_enabled = true;
+        }
+
+        let group = group.clone();
         let region = state.region.clone();
-        let xml = replication_group_xml(group, &region);
+        let xml = replication_group_xml(&group, &region);
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -4189,13 +4189,11 @@ impl ElastiCacheService {
             )
         })?;
 
-        if !group.cluster_enabled && node_group_count != 1 {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterCombination",
-                "NodeGroupCount can only be modified for cluster mode replication groups."
-                    .to_string(),
-            ));
+        // AWS rejects this on real non-cluster groups, but conformance fixtures
+        // create non-cluster groups and still call the op. Auto-promote so the
+        // call succeeds without diverging from the Smithy shape.
+        if !group.cluster_enabled && node_group_count > 1 {
+            group.cluster_enabled = true;
         }
 
         let max_shards = max_node_groups_for(&group.engine, &group.engine_version);

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -4189,11 +4189,13 @@ impl ElastiCacheService {
             )
         })?;
 
-        // AWS rejects this on real non-cluster groups, but conformance fixtures
-        // create non-cluster groups and still call the op. Auto-promote so the
-        // call succeeds without diverging from the Smithy shape.
-        if !group.cluster_enabled && node_group_count > 1 {
-            group.cluster_enabled = true;
+        if !group.cluster_enabled && node_group_count != 1 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidParameterCombination",
+                "NodeGroupCount can only be modified for cluster mode replication groups."
+                    .to_string(),
+            ));
         }
 
         let max_shards = max_node_groups_for(&group.engine, &group.engine_version);

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -2120,6 +2120,122 @@ fn decrease_replica_count_rejects_negative() {
 }
 
 #[test]
+fn modify_replication_group_shard_configuration_changes_shard_count() {
+    // Cluster-mode replication group, 2 shards -> 4 shards. Asserts the
+    // server actually mutates `num_node_groups` and rebuilds member_clusters,
+    // not the legacy echo behaviour.
+    let service = service_with_replication_group("shard-rg", 1);
+    {
+        let mut accounts = service.state.write();
+        let g = accounts
+            .default_mut()
+            .replication_groups
+            .get_mut("shard-rg")
+            .unwrap();
+        g.num_node_groups = 2;
+        g.cluster_enabled = true;
+        g.replicas_per_node_group = Some(1);
+    }
+    let req = request(
+        "ModifyReplicationGroupShardConfiguration",
+        &[
+            ("ReplicationGroupId", "shard-rg"),
+            ("NodeGroupCount", "4"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    let resp = service
+        .modify_replication_group_shard_configuration(&req)
+        .unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    // 4 shards * (1+1) = 8 member clusters in the rebuilt list.
+    assert!(body.contains("<ClusterId>shard-rg-008</ClusterId>"));
+    assert!(!body.contains("<ClusterId>shard-rg-009</ClusterId>"));
+    // 4 NodeGroup XML elements.
+    assert_eq!(body.matches("<NodeGroup>").count(), 4);
+}
+
+#[test]
+fn modify_replication_group_shard_configuration_rejects_non_cluster_change() {
+    let service = service_with_replication_group("solo-rg", 1);
+    let req = request(
+        "ModifyReplicationGroupShardConfiguration",
+        &[
+            ("ReplicationGroupId", "solo-rg"),
+            ("NodeGroupCount", "3"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    assert!(
+        service
+            .modify_replication_group_shard_configuration(&req)
+            .is_err(),
+        "non-cluster replication group must reject NodeGroupCount changes"
+    );
+}
+
+#[test]
+fn modify_replication_group_shard_configuration_decrease_requires_remove_or_retain() {
+    let service = service_with_replication_group("dec-rg", 1);
+    {
+        let mut accounts = service.state.write();
+        let g = accounts
+            .default_mut()
+            .replication_groups
+            .get_mut("dec-rg")
+            .unwrap();
+        g.num_node_groups = 3;
+        g.cluster_enabled = true;
+    }
+    let req = request(
+        "ModifyReplicationGroupShardConfiguration",
+        &[
+            ("ReplicationGroupId", "dec-rg"),
+            ("NodeGroupCount", "1"),
+            ("ApplyImmediately", "true"),
+        ],
+    );
+    assert!(
+        service
+            .modify_replication_group_shard_configuration(&req)
+            .is_err(),
+        "decrease without NodeGroupsToRetain/Remove must fail"
+    );
+}
+
+#[test]
+fn increase_replica_count_supports_replica_configuration() {
+    let service = service_with_replication_group("conf-rg", 1);
+    {
+        let mut accounts = service.state.write();
+        let g = accounts
+            .default_mut()
+            .replication_groups
+            .get_mut("conf-rg")
+            .unwrap();
+        g.num_node_groups = 2;
+        g.cluster_enabled = true;
+        g.replicas_per_node_group = Some(0);
+    }
+    let req = request(
+        "IncreaseReplicaCount",
+        &[
+            ("ReplicationGroupId", "conf-rg"),
+            ("ApplyImmediately", "true"),
+            ("ReplicaConfiguration.ConfigureShard.1.NodeGroupId", "0001"),
+            ("ReplicaConfiguration.ConfigureShard.1.NewReplicaCount", "2"),
+            ("ReplicaConfiguration.ConfigureShard.2.NodeGroupId", "0002"),
+            ("ReplicaConfiguration.ConfigureShard.2.NewReplicaCount", "2"),
+        ],
+    );
+    let resp = service.increase_replica_count(&req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    // 2 shards × (1 + 2 replicas) = 6 member clusters.
+    assert!(body.contains("<ClusterId>conf-rg-006</ClusterId>"));
+    assert!(!body.contains("<ClusterId>conf-rg-007</ClusterId>"));
+}
+
+#[test]
 fn test_failover_validates_node_group() {
     let service = service_with_replication_group("my-rg", 1);
     let req = request(


### PR DESCRIPTION
## Summary

- ModifyReplicationGroupShardConfiguration mutates state instead of echoing: parses NodeGroupCount, validates against engine ceiling + cluster_enabled, requires NodeGroupsToRetain/Remove on decrease, rebuilds num_node_groups + member_clusters so subsequent DescribeReplicationGroups returns the new shape.
- IncreaseReplicaCount + DecreaseReplicaCount share a core helper that accepts NewReplicaCount (uniform across shards), ReplicaConfiguration.ConfigureShard.N, or (decrease only) ReplicasToRemove. Per-shard replica count is tracked via replicas_per_node_group; num_cache_clusters becomes shard_count * (1 + replicas).
- Cluster-mode safety: non-cluster (single-shard) replication groups reject NodeGroupCount changes.

## Test plan

- [x] cargo fmt + cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings
- [x] cargo test -p fakecloud-elasticache --lib (212 passed, 4 new unit tests)
- [x] cargo test -p fakecloud-e2e --test elasticache for the four new docker-gated tests (changes_shard_count, rejects_non_cluster_change, increase_per_shard, decrease_per_shard)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real shard and replica count mutations for ElastiCache replication groups so API calls update state and DescribeReplicationGroups returns the new shape. Adds uniform per-shard replica management, strict cluster-mode validation, and consistent cluster ID rebuilding.

- **New Features**
  - ModifyReplicationGroupShardConfiguration parses NodeGroupCount, validates engine ceilings and cluster mode, requires NodeGroupsToRetain/Remove on decreases, and updates num_node_groups, num_cache_clusters, and member_clusters.
  - IncreaseReplicaCount/DecreaseReplicaCount share a core handler that accepts NewReplicaCount, per-shard `ReplicaConfiguration.ConfigureShard.N`, or `ReplicasToRemove`. Validates parameter combos and direction, applies a uniform per-shard replica count, persists it via replicas_per_node_group, and rebuilds member_clusters.
  - Helpers to parse ReplicaConfiguration, compute current replicas per shard, and build member cluster IDs.

- **Bug Fixes**
  - Keep strict cluster-mode validation: reject NodeGroupCount changes on non-cluster groups (no auto-promote).

<sup>Written for commit 994a58e451ea179835bd5928741d51e1d8bfd40d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

