### PR TITLE
feat(cloudformation): ELBv2 provisioner update + GetAtt (BB17)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1176,6 +1176,24 @@ impl ResourceProvisioner {
             "AWS::KMS::Key" => Some(self.update_kms_key(existing, new_def)?),
             "AWS::KMS::ReplicaKey" => Some(self.update_kms_replica_key(existing, new_def)?),
             "AWS::KMS::Alias" => Some(self.update_kms_alias(existing, new_def)?),
+            "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
+                Some(self.update_elbv2_load_balancer(existing, new_def)?)
+            }
+            "AWS::ElasticLoadBalancingV2::TargetGroup" => {
+                Some(self.update_elbv2_target_group(existing, new_def)?)
+            }
+            "AWS::ElasticLoadBalancingV2::Listener" => {
+                Some(self.update_elbv2_listener(existing, new_def)?)
+            }
+            "AWS::ElasticLoadBalancingV2::ListenerRule" => {
+                Some(self.update_elbv2_listener_rule(existing, new_def)?)
+            }
+            "AWS::ElasticLoadBalancingV2::ListenerCertificate" => {
+                Some(self.update_elbv2_listener_certificate(existing, new_def)?)
+            }
+            "AWS::ElasticLoadBalancingV2::TrustStore" => {
+                Some(self.update_elbv2_trust_store(existing, new_def)?)
+            }
             _ => None,
         };
 
@@ -1229,6 +1247,21 @@ impl ResourceProvisioner {
                 self.get_att_ecs_capacity_provider(&resource.physical_id, attribute)
             }
             "AWS::ECR::Repository" => self.get_att_ecr_repository(&resource.physical_id, attribute),
+            "AWS::ElasticLoadBalancingV2::LoadBalancer" => {
+                self.get_att_elbv2_load_balancer(&resource.physical_id, attribute)
+            }
+            "AWS::ElasticLoadBalancingV2::TargetGroup" => {
+                self.get_att_elbv2_target_group(&resource.physical_id, attribute)
+            }
+            "AWS::ElasticLoadBalancingV2::Listener" => {
+                self.get_att_elbv2_listener(&resource.physical_id, attribute)
+            }
+            "AWS::ElasticLoadBalancingV2::ListenerRule" => {
+                self.get_att_elbv2_listener_rule(&resource.physical_id, attribute)
+            }
+            "AWS::ElasticLoadBalancingV2::TrustStore" => {
+                self.get_att_elbv2_trust_store(&resource.physical_id, attribute)
+            }
             _ => None,
         }
     }
@@ -6551,6 +6584,387 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.trust_stores.remove(physical_id);
         Ok(())
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::LoadBalancer. Name,
+    /// scheme, type and subnet topology are immutable in real AWS — CFN
+    /// would replace the resource. We only mutate fields the SetSubnets /
+    /// SetSecurityGroups / SetIpAddressType APIs would touch.
+    fn update_elbv2_load_balancer(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let lb = state
+            .load_balancers
+            .get_mut(&arn)
+            .ok_or_else(|| format!("LoadBalancer {arn} no longer exists"))?;
+        if let Some(arr) = props.get("SecurityGroups").and_then(|v| v.as_array()) {
+            lb.security_groups = arr
+                .iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+        if let Some(s) = props.get("IpAddressType").and_then(|v| v.as_str()) {
+            lb.ip_address_type = s.to_string();
+        }
+        if let Some(arr) = props.get("Subnets").and_then(|v| v.as_array()) {
+            let mut zones: Vec<fakecloud_elbv2::AvailabilityZone> = Vec::new();
+            for s in arr {
+                if let Some(subnet_id) = s.as_str() {
+                    zones.push(fakecloud_elbv2::AvailabilityZone {
+                        zone_name: format!("{}a", self.region),
+                        subnet_id: subnet_id.to_string(),
+                        outpost_id: None,
+                        load_balancer_addresses: Vec::new(),
+                        source_nat_ipv6_prefixes: Vec::new(),
+                    });
+                }
+            }
+            lb.availability_zones = zones;
+        }
+        if props.get("Tags").is_some() {
+            lb.tags = parse_elb_tags(props.get("Tags"));
+        }
+        let name = lb.name.clone();
+        let dns_name = lb.dns_name.clone();
+        let canonical = lb.canonical_hosted_zone_id.clone();
+        let lb_full = arn.rsplit("loadbalancer/").next().unwrap_or("").to_string();
+        Ok(ProvisionResult::new(arn.clone())
+            .with("LoadBalancerArn", arn)
+            .with("LoadBalancerFullName", lb_full)
+            .with("LoadBalancerName", name)
+            .with("DNSName", dns_name)
+            .with("CanonicalHostedZoneID", canonical))
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::TargetGroup. Mirrors
+    /// ModifyTargetGroup: only health-check fields and matcher are mutable.
+    fn update_elbv2_target_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let tg = state
+            .target_groups
+            .get_mut(&arn)
+            .ok_or_else(|| format!("TargetGroup {arn} no longer exists"))?;
+        if let Some(s) = props.get("HealthCheckProtocol").and_then(|v| v.as_str()) {
+            tg.health_check_protocol = Some(s.to_string());
+        }
+        if let Some(s) = props.get("HealthCheckPort").and_then(|v| v.as_str()) {
+            tg.health_check_port = Some(s.to_string());
+        }
+        if let Some(b) = props.get("HealthCheckEnabled").and_then(|v| v.as_bool()) {
+            tg.health_check_enabled = b;
+        }
+        if let Some(s) = props.get("HealthCheckPath").and_then(|v| v.as_str()) {
+            tg.health_check_path = Some(s.to_string());
+        }
+        if let Some(n) = props.get("HealthCheckIntervalSeconds").and_then(cfn_as_i64) {
+            tg.health_check_interval_seconds = n as i32;
+        }
+        if let Some(n) = props.get("HealthCheckTimeoutSeconds").and_then(cfn_as_i64) {
+            tg.health_check_timeout_seconds = n as i32;
+        }
+        if let Some(n) = props.get("HealthyThresholdCount").and_then(cfn_as_i64) {
+            tg.healthy_threshold_count = n as i32;
+        }
+        if let Some(n) = props.get("UnhealthyThresholdCount").and_then(cfn_as_i64) {
+            tg.unhealthy_threshold_count = n as i32;
+        }
+        if let Some(matcher) = props.get("Matcher") {
+            tg.matcher_http_code = matcher
+                .get("HttpCode")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            tg.matcher_grpc_code = matcher
+                .get("GrpcCode")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+        }
+        if props.get("Tags").is_some() {
+            tg.tags = parse_elb_tags(props.get("Tags"));
+        }
+        let name = tg.name.clone();
+        let tg_full = arn
+            .rsplit("targetgroup/")
+            .next()
+            .map(|s| format!("targetgroup/{s}"))
+            .unwrap_or_default();
+        Ok(ProvisionResult::new(arn.clone())
+            .with("TargetGroupArn", arn)
+            .with("TargetGroupName", name)
+            .with("TargetGroupFullName", tg_full))
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::Listener. Mirrors
+    /// ModifyListener: port, protocol, default actions, certs, ssl policy.
+    fn update_elbv2_listener(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let new_default_actions = props
+            .get("DefaultActions")
+            .map(|v| parse_elb_actions(Some(v)));
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let listener = state
+            .listeners
+            .get_mut(&arn)
+            .ok_or_else(|| format!("Listener {arn} no longer exists"))?;
+        if let Some(n) = props.get("Port").and_then(cfn_as_i64) {
+            listener.port = Some(n as i32);
+        }
+        if let Some(s) = props.get("Protocol").and_then(|v| v.as_str()) {
+            listener.protocol = Some(s.to_string());
+        }
+        if let Some(s) = props.get("SslPolicy").and_then(|v| v.as_str()) {
+            listener.ssl_policy = Some(s.to_string());
+        }
+        if let Some(actions) = new_default_actions {
+            listener.default_actions = actions;
+        }
+        if props.get("Tags").is_some() {
+            listener.tags = parse_elb_tags(props.get("Tags"));
+        }
+        Ok(ProvisionResult::new(arn.clone()).with("ListenerArn", arn))
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::ListenerRule. Mirrors
+    /// ModifyRule + SetRulePriorities.
+    fn update_elbv2_listener_rule(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let new_actions = props.get("Actions").map(|v| parse_elb_actions(Some(v)));
+        let new_conditions = props
+            .get("Conditions")
+            .map(|v| parse_elb_rule_conditions(Some(v)));
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let rule = state
+            .rules
+            .get_mut(&arn)
+            .ok_or_else(|| format!("ListenerRule {arn} no longer exists"))?;
+        if let Some(v) = props.get("Priority") {
+            rule.priority = if let Some(s) = v.as_str() {
+                s.to_string()
+            } else if let Some(n) = v.as_i64() {
+                n.to_string()
+            } else {
+                rule.priority.clone()
+            };
+        }
+        if let Some(actions) = new_actions {
+            rule.actions = actions;
+        }
+        if let Some(conditions) = new_conditions {
+            rule.conditions = conditions;
+        }
+        if props.get("Tags").is_some() {
+            rule.tags = parse_elb_tags(props.get("Tags"));
+        }
+        Ok(ProvisionResult::new(arn.clone()).with("RuleArn", arn))
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::ListenerCertificate.
+    /// CFN treats this as replace-on-cert-list-change in real AWS, but we
+    /// can rebuild the SNI cert set against the same physical id without
+    /// disrupting the listener.
+    fn update_elbv2_listener_certificate(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let listener_arn = props
+            .get("ListenerArn")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| physical_id.split_once('#').map(|(l, _)| l.to_string()))
+            .ok_or_else(|| "ListenerArn is required".to_string())?;
+        let new_certs: Vec<String> = props
+            .get("Certificates")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.get("CertificateArn").and_then(|v| v.as_str()))
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if new_certs.is_empty() {
+            return Err("Certificates must contain at least one CertificateArn".to_string());
+        }
+
+        // Strip the previously-managed certs, then attach the new set.
+        let prev_certs: Vec<String> = physical_id
+            .split_once('#')
+            .map(|(_, list)| list.split(',').map(|s| s.to_string()).collect())
+            .unwrap_or_default();
+
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let listener = state
+            .listeners
+            .get_mut(&listener_arn)
+            .ok_or_else(|| format!("Listener {listener_arn} does not exist"))?;
+        listener
+            .certificates
+            .retain(|c| !prev_certs.iter().any(|p| p == &c.certificate_arn));
+        for arn in &new_certs {
+            listener.certificates.retain(|c| &c.certificate_arn != arn);
+            listener.certificates.push(fakecloud_elbv2::Certificate {
+                certificate_arn: arn.clone(),
+                is_default: false,
+            });
+        }
+        Ok(ProvisionResult::new(format!(
+            "{}#{}",
+            listener_arn,
+            new_certs.join(",")
+        )))
+    }
+
+    /// In-place update for AWS::ElasticLoadBalancingV2::TrustStore. Only the
+    /// CA bundle and tags are mutable; name is immutable in real AWS.
+    fn update_elbv2_trust_store(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let ts = state
+            .trust_stores
+            .get_mut(&arn)
+            .ok_or_else(|| format!("TrustStore {arn} no longer exists"))?;
+        let new_bucket = props
+            .get("CaCertificatesBundleS3Bucket")
+            .and_then(|v| v.as_str());
+        let new_key = props
+            .get("CaCertificatesBundleS3Key")
+            .and_then(|v| v.as_str());
+        if let (Some(b), Some(k)) = (new_bucket, new_key) {
+            ts.ca_certificates_bundle = Some(format!("s3://{b}/{k}").into_bytes());
+        }
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            ts.tags = arr
+                .iter()
+                .filter_map(|t| {
+                    let k = t.get("Key").and_then(|v| v.as_str())?;
+                    let v = t.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+                    Some(fakecloud_elbv2::Tag {
+                        key: k.to_string(),
+                        value: v.to_string(),
+                    })
+                })
+                .collect();
+        }
+        let name = ts.name.clone();
+        let status = ts.status.clone();
+        Ok(ProvisionResult::new(arn.clone())
+            .with("TrustStoreArn", arn)
+            .with("Name", name)
+            .with("Status", status))
+    }
+
+    /// Live-state GetAtt fallback for AWS::ElasticLoadBalancingV2::LoadBalancer.
+    fn get_att_elbv2_load_balancer(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let lb = state.load_balancers.get(physical_id)?;
+        let lb_full = lb
+            .arn
+            .rsplit("loadbalancer/")
+            .next()
+            .unwrap_or("")
+            .to_string();
+        match attribute {
+            "Arn" | "LoadBalancerArn" => Some(lb.arn.clone()),
+            "DNSName" => Some(lb.dns_name.clone()),
+            "CanonicalHostedZoneID" => Some(lb.canonical_hosted_zone_id.clone()),
+            "LoadBalancerFullName" => Some(lb_full),
+            "LoadBalancerName" => Some(lb.name.clone()),
+            "SecurityGroups" => Some(lb.security_groups.join(",")),
+            _ => None,
+        }
+    }
+
+    /// Live-state GetAtt fallback for AWS::ElasticLoadBalancingV2::TargetGroup.
+    fn get_att_elbv2_target_group(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let tg = state.target_groups.get(physical_id)?;
+        let tg_full = tg
+            .arn
+            .rsplit("targetgroup/")
+            .next()
+            .map(|s| format!("targetgroup/{s}"))
+            .unwrap_or_default();
+        match attribute {
+            "TargetGroupArn" => Some(tg.arn.clone()),
+            "TargetGroupName" => Some(tg.name.clone()),
+            "TargetGroupFullName" => Some(tg_full),
+            "LoadBalancerArns" => Some(tg.load_balancer_arns.join(",")),
+            _ => None,
+        }
+    }
+
+    /// Live-state GetAtt fallback for AWS::ElasticLoadBalancingV2::Listener.
+    fn get_att_elbv2_listener(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let listener = state.listeners.get(physical_id)?;
+        match attribute {
+            "Arn" | "ListenerArn" => Some(listener.arn.clone()),
+            _ => None,
+        }
+    }
+
+    /// Live-state GetAtt fallback for AWS::ElasticLoadBalancingV2::ListenerRule.
+    fn get_att_elbv2_listener_rule(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let rule = state.rules.get(physical_id)?;
+        match attribute {
+            "RuleArn" => Some(rule.arn.clone()),
+            "IsDefault" => Some(rule.is_default.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Live-state GetAtt fallback for AWS::ElasticLoadBalancingV2::TrustStore.
+    fn get_att_elbv2_trust_store(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let mut accounts = self.elbv2_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let ts = state.trust_stores.get(physical_id)?;
+        match attribute {
+            "TrustStoreArn" => Some(ts.arn.clone()),
+            "Name" => Some(ts.name.clone()),
+            "Status" => Some(ts.status.clone()),
+            "NumberOfCaCertificates" => Some(ts.number_of_ca_certificates.to_string()),
+            "TotalRevokedEntries" => Some(ts.total_revoked_entries.to_string()),
+            _ => None,
+        }
     }
 
     // --- Organizations ---

--- a/crates/fakecloud-e2e/tests/cloudformation_elbv2.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_elbv2.rs
@@ -308,3 +308,279 @@ async fn cfn_provisions_elbv2_listener_certificate_and_trust_store() {
         "trust store should be deleted",
     );
 }
+
+const UPDATE_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Web": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "cfn-update-web",
+        "Scheme": "internet-facing",
+        "Type": "application",
+        "Subnets": ["subnet-aaa", "subnet-bbb"],
+        "SecurityGroups": ["sg-old"],
+        "IpAddressType": "ipv4"
+      }
+    },
+    "Tg": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Name": "cfn-update-tg",
+        "Protocol": "HTTP",
+        "Port": 80,
+        "VpcId": "vpc-1234",
+        "TargetType": "ip",
+        "HealthCheckPath": "/v1",
+        "HealthCheckIntervalSeconds": 30
+      }
+    },
+    "Listener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "LoadBalancerArn": {"Ref": "Web"},
+        "Port": 80,
+        "Protocol": "HTTP",
+        "DefaultActions": [
+          {"Type": "forward", "TargetGroupArn": {"Ref": "Tg"}}
+        ]
+      }
+    },
+    "Rule": {
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "Properties": {
+        "ListenerArn": {"Ref": "Listener"},
+        "Priority": 5,
+        "Conditions": [
+          {"Field": "host-header", "Values": ["v1.example.com"]}
+        ],
+        "Actions": [
+          {"Type": "forward", "TargetGroupArn": {"Ref": "Tg"}}
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "LbArn": {"Value": {"Ref": "Web"}},
+    "LbDns": {"Value": {"Fn::GetAtt": ["Web", "DNSName"]}},
+    "LbFullName": {"Value": {"Fn::GetAtt": ["Web", "LoadBalancerFullName"]}},
+    "TgArn": {"Value": {"Ref": "Tg"}},
+    "TgFullName": {"Value": {"Fn::GetAtt": ["Tg", "TargetGroupFullName"]}},
+    "ListenerArn": {"Value": {"Ref": "Listener"}},
+    "RuleArn": {"Value": {"Ref": "Rule"}}
+  }
+}"#;
+
+const UPDATE_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Web": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "cfn-update-web",
+        "Scheme": "internet-facing",
+        "Type": "application",
+        "Subnets": ["subnet-aaa", "subnet-bbb"],
+        "SecurityGroups": ["sg-new-1", "sg-new-2"],
+        "IpAddressType": "dualstack"
+      }
+    },
+    "Tg": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Name": "cfn-update-tg",
+        "Protocol": "HTTP",
+        "Port": 80,
+        "VpcId": "vpc-1234",
+        "TargetType": "ip",
+        "HealthCheckPath": "/healthz",
+        "HealthCheckIntervalSeconds": 15
+      }
+    },
+    "Listener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "LoadBalancerArn": {"Ref": "Web"},
+        "Port": 8080,
+        "Protocol": "HTTP",
+        "DefaultActions": [
+          {"Type": "forward", "TargetGroupArn": {"Ref": "Tg"}}
+        ]
+      }
+    },
+    "Rule": {
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "Properties": {
+        "ListenerArn": {"Ref": "Listener"},
+        "Priority": 20,
+        "Conditions": [
+          {"Field": "host-header", "Values": ["v2.example.com"]}
+        ],
+        "Actions": [
+          {"Type": "forward", "TargetGroupArn": {"Ref": "Tg"}}
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "LbArn": {"Value": {"Ref": "Web"}},
+    "LbDns": {"Value": {"Fn::GetAtt": ["Web", "DNSName"]}},
+    "LbFullName": {"Value": {"Fn::GetAtt": ["Web", "LoadBalancerFullName"]}},
+    "TgArn": {"Value": {"Ref": "Tg"}},
+    "TgFullName": {"Value": {"Fn::GetAtt": ["Tg", "TargetGroupFullName"]}},
+    "ListenerArn": {"Value": {"Ref": "Listener"}},
+    "RuleArn": {"Value": {"Ref": "Rule"}}
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_updates_propagate_to_elbv2_state() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let elb = server.elbv2_client().await;
+
+    cfn.create_stack()
+        .stack_name("elbv2-update-stack")
+        .template_body(UPDATE_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+
+    let described = cfn
+        .describe_stacks()
+        .stack_name("elbv2-update-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack = described.stacks().first().unwrap();
+    assert_eq!(stack.stack_status().unwrap().as_str(), "CREATE_COMPLETE");
+
+    let mut lb_arn = None;
+    let mut listener_arn = None;
+    let mut rule_arn = None;
+    let mut tg_arn = None;
+    let mut lb_dns = None;
+    let mut lb_full = None;
+    let mut tg_full = None;
+    for o in stack.outputs() {
+        match o.output_key() {
+            Some("LbArn") => lb_arn = o.output_value().map(|s| s.to_string()),
+            Some("ListenerArn") => listener_arn = o.output_value().map(|s| s.to_string()),
+            Some("RuleArn") => rule_arn = o.output_value().map(|s| s.to_string()),
+            Some("TgArn") => tg_arn = o.output_value().map(|s| s.to_string()),
+            Some("LbDns") => lb_dns = o.output_value().map(|s| s.to_string()),
+            Some("LbFullName") => lb_full = o.output_value().map(|s| s.to_string()),
+            Some("TgFullName") => tg_full = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    let lb_arn = lb_arn.expect("LbArn");
+    let listener_arn = listener_arn.expect("ListenerArn");
+    let rule_arn = rule_arn.expect("RuleArn");
+    let tg_arn = tg_arn.expect("TgArn");
+    let lb_dns = lb_dns.expect("LbDns");
+    let lb_full = lb_full.expect("LbFullName");
+    let tg_full = tg_full.expect("TgFullName");
+    assert!(
+        lb_dns.contains("cfn-update-web"),
+        "DNSName GetAtt: {lb_dns}"
+    );
+    assert!(lb_full.starts_with("app/cfn-update-web/"));
+    assert!(tg_full.starts_with("targetgroup/"));
+
+    cfn.update_stack()
+        .stack_name("elbv2-update-stack")
+        .template_body(UPDATE_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+
+    let described2 = cfn
+        .describe_stacks()
+        .stack_name("elbv2-update-stack")
+        .send()
+        .await
+        .expect("describe_stacks");
+    let stack2 = described2.stacks().first().unwrap();
+    assert_eq!(stack2.stack_status().unwrap().as_str(), "UPDATE_COMPLETE");
+
+    // Physical ids must be preserved (in-place updates).
+    let mut lb_arn2 = None;
+    let mut listener_arn2 = None;
+    let mut rule_arn2 = None;
+    for o in stack2.outputs() {
+        match o.output_key() {
+            Some("LbArn") => lb_arn2 = o.output_value().map(|s| s.to_string()),
+            Some("ListenerArn") => listener_arn2 = o.output_value().map(|s| s.to_string()),
+            Some("RuleArn") => rule_arn2 = o.output_value().map(|s| s.to_string()),
+            _ => {}
+        }
+    }
+    assert_eq!(lb_arn2.as_deref(), Some(lb_arn.as_str()));
+    assert_eq!(listener_arn2.as_deref(), Some(listener_arn.as_str()));
+    assert_eq!(rule_arn2.as_deref(), Some(rule_arn.as_str()));
+
+    // Verify the changes propagated to live ELBv2 state.
+    let lbs = elb
+        .describe_load_balancers()
+        .load_balancer_arns(&lb_arn)
+        .send()
+        .await
+        .expect("describe_load_balancers");
+    let lb = lbs.load_balancers().first().expect("lb");
+    let sgs: Vec<&str> = lb.security_groups().iter().map(|s| s.as_str()).collect();
+    assert!(sgs.contains(&"sg-new-1"), "sg updated: {sgs:?}");
+    assert!(sgs.contains(&"sg-new-2"), "sg updated: {sgs:?}");
+    assert_eq!(lb.ip_address_type().map(|s| s.as_str()), Some("dualstack"));
+
+    let tgs = elb
+        .describe_target_groups()
+        .target_group_arns(&tg_arn)
+        .send()
+        .await
+        .expect("describe_target_groups");
+    let tg = tgs.target_groups().first().expect("tg");
+    assert_eq!(tg.health_check_path(), Some("/healthz"));
+    assert_eq!(tg.health_check_interval_seconds(), Some(15));
+
+    let listeners = elb
+        .describe_listeners()
+        .listener_arns(&listener_arn)
+        .send()
+        .await
+        .expect("describe_listeners");
+    let listener = listeners.listeners().first().expect("listener");
+    assert_eq!(listener.port(), Some(8080));
+
+    let rules = elb
+        .describe_rules()
+        .rule_arns(&rule_arn)
+        .send()
+        .await
+        .expect("describe_rules");
+    let rule = rules.rules().first().expect("rule");
+    assert_eq!(rule.priority(), Some("20"));
+    let host_values: Vec<&str> = rule
+        .conditions()
+        .iter()
+        .flat_map(|c| c.values())
+        .map(|s| s.as_str())
+        .collect();
+    assert!(
+        host_values.contains(&"v2.example.com"),
+        "rule host updated: {host_values:?}"
+    );
+
+    cfn.delete_stack()
+        .stack_name("elbv2-update-stack")
+        .send()
+        .await
+        .expect("delete_stack");
+
+    let after = elb
+        .describe_load_balancers()
+        .load_balancer_arns(&lb_arn)
+        .send()
+        .await;
+    assert!(after.is_err(), "lb gone after stack deletion");
+}


### PR DESCRIPTION
## Summary

Rounds out CloudFormation provisioner support for the six AWS::ElasticLoadBalancingV2::* types whose create/delete arms already shipped in earlier batches. BB17 fills the remaining gaps: in-place updates and live-state GetAtt fallbacks.

- update_resource arms for LoadBalancer, TargetGroup, Listener, ListenerRule, ListenerCertificate, TrustStore. Each mirrors the corresponding Modify*/Set* control-plane API surface (e.g. ModifyTargetGroup health-check fields, ModifyListener default actions, ModifyRule conditions/priority, SetSecurityGroups, SetIpAddressType).
- get_att live-state fallbacks for the same types so attributes resolve correctly when CloudFormation re-reads after later provisioning passes (DNSName, CanonicalHostedZoneID, LoadBalancerFullName, TargetGroupFullName, LoadBalancerArns, RuleArn, IsDefault, TrustStoreArn, etc.).
- New E2E test ``cfn_updates_propagate_to_elbv2_state`` covering CreateStack -> UpdateStack -> DeleteStack with mutated SecurityGroups, IpAddressType, health-check path/interval, listener port, rule priority/host. Asserts physical-id stability across update and verifies GetAtt outputs (DNSName, LoadBalancerFullName, TargetGroupFullName).

## Test plan

- [x] ``cargo build -p fakecloud-cloudformation``
- [x] ``cargo build -p fakecloud-e2e --tests``
- [x] ``cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings``
- [x] ``cargo clippy -p fakecloud-e2e --tests -- -D warnings``
- [x] ``cargo fmt --all -- --check``
- [x] ``cargo test -p fakecloud-cloudformation --lib`` (171 passed)
- [x] ``cargo test -p fakecloud-e2e --test cloudformation_elbv2`` (3 passed including the new update test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-place UpdateStack support and GetAtt fallbacks for ELBv2 CloudFormation resources. Completes BB17 so ELBv2 updates propagate to live state with stable physical IDs and working outputs.

- **New Features**
  - Update handlers for AWS::ElasticLoadBalancingV2::{LoadBalancer, TargetGroup, Listener, ListenerRule, ListenerCertificate, TrustStore}, mirroring Modify*/Set* APIs (e.g., security groups, IpAddressType, health checks, listener port/actions, rule conditions/priority, certificate sets, trust store bundle/tags).
  - Live-state GetAtt resolvers for the same types (e.g., DNSName, CanonicalHostedZoneID, LoadBalancerFullName, TargetGroupFullName, LoadBalancerArns, RuleArn/IsDefault, TrustStoreArn/Status).
  - New e2e test `cfn_updates_propagate_to_elbv2_state` validating Create → Update → Delete, field mutations, physical-id stability, and GetAtt outputs.

<sup>Written for commit 6801c33b6f5d6be679cbc4320fa46561a32bb603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

