### PR TITLE
feat(cloudfront): real Status InProgress -> Deployed for streaming distributions + ETag stability (T2)

### DIFF
--- a/crates/fakecloud-cloudfront/src/service.rs
+++ b/crates/fakecloud-cloudfront/src/service.rs
@@ -197,18 +197,43 @@ pub struct CloudFrontService {
     pub(crate) state: SharedCloudFrontState,
     /// How long the propagation tick sleeps before flipping a freshly
     /// created or updated Distribution / DistributionTenant /
-    /// ConnectionGroup from `InProgress` to `Deployed`. Real CloudFront
-    /// takes ~15 minutes; the default of 1s keeps SDK-driven integration
-    /// tests fast while still simulating the async transition. Tests can
-    /// shrink it via [`CloudFrontService::with_propagation_delay`].
+    /// ConnectionGroup / StreamingDistribution from `InProgress` to
+    /// `Deployed`. Real CloudFront takes ~15 minutes; the default of 1s
+    /// keeps SDK-driven integration tests fast while still simulating the
+    /// async transition. Tests can shrink it via
+    /// [`CloudFrontService::with_propagation_delay`], and operators can
+    /// override the default via the
+    /// `FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC` env var.
     pub(crate) propagation_delay: std::time::Duration,
+}
+
+/// Resolve the default `InProgress` -> `Deployed` delay from the
+/// `FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC` env var, falling back to 1
+/// second. The value parses as either a non-negative integer (seconds) or
+/// a floating-point number; `0` keeps the transition synchronous, which is
+/// useful for fast unit tests. Invalid input falls back to 1 second so a
+/// typo in the env var can't accidentally hang the process.
+fn default_propagation_delay() -> std::time::Duration {
+    let Ok(raw) = std::env::var("FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC") else {
+        return std::time::Duration::from_secs(1);
+    };
+    let trimmed = raw.trim();
+    if let Ok(secs) = trimmed.parse::<u64>() {
+        return std::time::Duration::from_secs(secs);
+    }
+    if let Ok(secs) = trimmed.parse::<f64>() {
+        if secs.is_finite() && secs >= 0.0 {
+            return std::time::Duration::from_secs_f64(secs);
+        }
+    }
+    std::time::Duration::from_secs(1)
 }
 
 impl CloudFrontService {
     pub fn new(state: SharedCloudFrontState) -> Self {
         Self {
             state,
-            propagation_delay: std::time::Duration::from_secs(1),
+            propagation_delay: default_propagation_delay(),
         }
     }
 
@@ -627,6 +652,27 @@ impl CloudFrontService {
         });
     }
 
+    /// Same as [`schedule_distribution_deploy`] but for StreamingDistributions.
+    /// Real CloudFront mirrors the `InProgress` -> `Deployed` lifecycle for
+    /// RTMP streaming distributions, even though the resource is largely
+    /// deprecated.
+    pub(crate) fn schedule_streaming_distribution_deploy(&self, id: String) {
+        let state = Arc::clone(&self.state);
+        let delay = self.propagation_delay;
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let mut s = state.write();
+            for account in s.accounts.values_mut() {
+                if let Some(d) = account.streaming_distributions.get_mut(&id) {
+                    if d.status == "InProgress" {
+                        d.status = "Deployed".to_string();
+                    }
+                    return;
+                }
+            }
+        });
+    }
+
     fn get_distribution(&self, route: &Route) -> Result<AwsResponse, AwsServiceError> {
         let id = route
             .id
@@ -714,16 +760,26 @@ impl CloudFrontService {
                 "If-Match header does not match the current ETag",
             ));
         }
-        dist.config = new_config;
-        dist.etag = generate_etag();
-        dist.last_modified_time = Utc::now();
-        // UpdateDistribution kicks off a fresh edge propagation; AWS flips
-        // the status back to InProgress until the new config lands.
-        dist.status = "InProgress".to_string();
+        // ETag stability: only bump the ETag and flip status back to
+        // InProgress when the new config actually differs from what we
+        // have on disk. A no-op UpdateDistribution (PUT the same config
+        // back) leaves the ETag intact, matching AWS behavior.
+        let config_changed = !configs_equal(&dist.config, &new_config);
+        if config_changed {
+            dist.config = new_config;
+            dist.etag = generate_etag();
+            dist.last_modified_time = Utc::now();
+            // UpdateDistribution kicks off a fresh edge propagation; AWS
+            // flips the status back to InProgress until the new config
+            // lands.
+            dist.status = "InProgress".to_string();
+        }
         let snapshot = dist.clone();
         drop(state);
 
-        self.schedule_distribution_deploy(id.to_string());
+        if config_changed {
+            self.schedule_distribution_deploy(id.to_string());
+        }
 
         let body = build_distribution_xml(&snapshot);
         let mut headers = HeaderMap::new();
@@ -1443,6 +1499,21 @@ fn validate_origins(config: &DistributionConfig) -> Result<(), AwsServiceError> 
         ));
     }
     Ok(())
+}
+
+/// Compare two `DistributionConfig`s by serializing them to canonical XML
+/// and comparing bytes. Used by `UpdateDistribution` to detect no-op writes
+/// so the ETag stays stable when the caller PUTs the same config back.
+/// Falls back to "not equal" if either serialization fails so we still
+/// honor the request rather than silently swallow a write.
+fn configs_equal(lhs: &DistributionConfig, rhs: &DistributionConfig) -> bool {
+    let Ok(a) = xml_io::to_xml_root("DistributionConfig", lhs) else {
+        return false;
+    };
+    let Ok(b) = xml_io::to_xml_root("DistributionConfig", rhs) else {
+        return false;
+    };
+    a == b
 }
 
 fn account_id(_req: &AwsRequest) -> &'static str {

--- a/crates/fakecloud-cloudfront/src/streaming_service.rs
+++ b/crates/fakecloud-cloudfront/src/streaming_service.rs
@@ -95,7 +95,10 @@ impl CloudFrontService {
         let stored = StoredStreamingDistribution {
             id: id.clone(),
             arn: arn.clone(),
-            status: "Deployed".to_string(),
+            // Real CloudFront returns `InProgress` for streaming
+            // distributions just like regular distributions and flips to
+            // `Deployed` once edge propagation completes.
+            status: "InProgress".to_string(),
             last_modified_time: now,
             domain_name: domain,
             etag: etag.clone(),
@@ -108,6 +111,8 @@ impl CloudFrontService {
             account.tags.insert(arn.clone(), tags);
         }
         drop(state);
+
+        self.schedule_streaming_distribution_deploy(id.clone());
 
         let body = render_streaming_distribution(&stored);
         let mut headers = HeaderMap::new();
@@ -183,11 +188,26 @@ impl CloudFrontService {
                 "CallerReference cannot change on UpdateStreamingDistribution",
             ));
         }
-        d.config = cfg;
-        d.etag = generate_etag();
-        d.last_modified_time = Utc::now();
+        // ETag stability: only bump when the config actually changes. A
+        // no-op UpdateStreamingDistribution leaves the ETag and status
+        // untouched, matching real CloudFront.
+        let config_changed = !streaming_configs_equal(&d.config, &cfg);
+        if config_changed {
+            d.config = cfg;
+            d.etag = generate_etag();
+            d.last_modified_time = Utc::now();
+            // UpdateStreamingDistribution kicks off fresh edge
+            // propagation; AWS flips status back to `InProgress` until
+            // the new config lands.
+            d.status = "InProgress".to_string();
+        }
         let snap = d.clone();
         drop(state);
+
+        if config_changed {
+            self.schedule_streaming_distribution_deploy(id.clone());
+        }
+
         let body = render_streaming_distribution(&snap);
         Ok(xml_with_etag(StatusCode::OK, body, &snap.etag, None))
     }
@@ -428,4 +448,21 @@ fn render_active_trusted_signers(cfg: &StreamingDistributionConfig) -> String {
     }
     out.push_str("</ActiveTrustedSigners>");
     out
+}
+
+/// Compare two `StreamingDistributionConfig`s by their canonical XML
+/// representation. Mirrors `service::configs_equal` for the streaming
+/// (RTMP) distribution variant; used so a no-op `UpdateStreamingDistribution`
+/// leaves the ETag stable.
+fn streaming_configs_equal(
+    lhs: &StreamingDistributionConfig,
+    rhs: &StreamingDistributionConfig,
+) -> bool {
+    let Ok(a) = xml_io::to_xml_root("StreamingDistributionConfig", lhs) else {
+        return false;
+    };
+    let Ok(b) = xml_io::to_xml_root("StreamingDistributionConfig", rhs) else {
+        return false;
+    };
+    a == b
 }

--- a/crates/fakecloud-e2e/tests/cloudfront_status.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_status.rs
@@ -1,0 +1,290 @@
+//! CloudFront `Status` lifecycle E2E tests.
+//!
+//! Real CloudFront returns `InProgress` immediately after Create/Update
+//! and flips to `Deployed` once the edge propagation completes. fakecloud
+//! mirrors that with a configurable delay defaulting to 1s; these tests
+//! pin the delay long enough to observe the `InProgress` state and then
+//! either wait for the auto-tick (short delay) or force the transition
+//! via the `_fakecloud` admin endpoint (long delay).
+#![allow(deprecated)]
+
+mod helpers;
+
+use aws_sdk_cloudfront::types::{
+    CookiePreference, DefaultCacheBehavior, DistributionConfig, ForwardedValues, Headers,
+    ItemSelection, Origin, Origins, ViewerProtocolPolicy,
+};
+use helpers::TestServer;
+
+fn minimal_config(caller_ref: &str) -> DistributionConfig {
+    DistributionConfig::builder()
+        .caller_reference(caller_ref)
+        .comment("e2e-status")
+        .enabled(true)
+        .origins(
+            Origins::builder()
+                .quantity(1)
+                .items(
+                    Origin::builder()
+                        .id("primary")
+                        .domain_name("example.com")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .default_cache_behavior(
+            DefaultCacheBehavior::builder()
+                .target_origin_id("primary")
+                .viewer_protocol_policy(ViewerProtocolPolicy::AllowAll)
+                .forwarded_values(
+                    ForwardedValues::builder()
+                        .query_string(false)
+                        .cookies(
+                            CookiePreference::builder()
+                                .forward(ItemSelection::None)
+                                .build()
+                                .unwrap(),
+                        )
+                        .headers(Headers::builder().quantity(0).build().unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .min_ttl(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+/// With a small auto-tick delay (0s), CreateDistribution still returns
+/// `InProgress` synchronously in the response body — but a subsequent
+/// `GetDistribution` after the tick has fired returns `Deployed`. This
+/// exercises the lazy/spawned transition path.
+#[tokio::test]
+async fn create_distribution_status_transitions_to_deployed() {
+    // 0s delay means the spawned task flips the status as soon as it gets
+    // scheduled. Ours is the fastest delivery the runtime can manage, so a
+    // short sleep below is enough for the deploy task to run.
+    let server =
+        TestServer::start_with_env(&[("FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC", "0")]).await;
+    let cf = server.cloudfront_client().await;
+
+    let create = cf
+        .create_distribution()
+        .distribution_config(minimal_config("status-tick-ref"))
+        .send()
+        .await
+        .expect("create_distribution");
+    let dist = create.distribution().expect("distribution returned");
+    let id = dist.id().to_string();
+    assert_eq!(
+        dist.status(),
+        "InProgress",
+        "CreateDistribution must return InProgress synchronously"
+    );
+
+    // Yield so the spawned `schedule_distribution_deploy` task gets a
+    // chance to run; 200ms is more than enough headroom for the 0s tick.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let got = cf
+        .get_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution");
+    assert_eq!(
+        got.distribution().unwrap().status(),
+        "Deployed",
+        "GetDistribution after the tick should report Deployed"
+    );
+}
+
+/// With a long delay, the auto-tick can't race the assertion, so we use
+/// the `_fakecloud` admin endpoint to force the flip. This proves both the
+/// admin endpoint and the per-request env-var override work.
+#[tokio::test]
+async fn admin_endpoint_flips_status_synchronously() {
+    let server =
+        TestServer::start_with_env(&[("FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC", "60")]).await;
+    let cf = server.cloudfront_client().await;
+
+    let create = cf
+        .create_distribution()
+        .distribution_config(minimal_config("status-admin-ref"))
+        .send()
+        .await
+        .expect("create_distribution");
+    let id = create.distribution().unwrap().id().to_string();
+
+    // Status must still be InProgress because the 60s delay won't fire
+    // during the test.
+    let got = cf
+        .get_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution");
+    assert_eq!(got.distribution().unwrap().status(), "InProgress");
+
+    // Force the flip via the admin endpoint.
+    let url = format!(
+        "{}/_fakecloud/cloudfront/distributions/{}/status",
+        server.endpoint(),
+        id
+    );
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({ "status": "Deployed" }))
+        .send()
+        .await
+        .expect("admin status POST");
+    assert_eq!(resp.status().as_u16(), 204);
+
+    let got = cf
+        .get_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution after flip");
+    assert_eq!(got.distribution().unwrap().status(), "Deployed");
+}
+
+/// `GetDistribution` issued back-to-back with no intervening writes must
+/// return the exact same ETag — clients depend on ETag stability for the
+/// optimistic-concurrency If-Match flow.
+#[tokio::test]
+async fn etag_stable_across_repeated_reads() {
+    let server = TestServer::start().await;
+    let cf = server.cloudfront_client().await;
+
+    let create = cf
+        .create_distribution()
+        .distribution_config(minimal_config("etag-stable-ref"))
+        .send()
+        .await
+        .expect("create_distribution");
+    let id = create.distribution().unwrap().id().to_string();
+    let etag1 = create.e_tag().expect("etag header").to_string();
+
+    let g1 = cf
+        .get_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution 1");
+    let g2 = cf
+        .get_distribution()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution 2");
+    assert_eq!(
+        g1.e_tag(),
+        g2.e_tag(),
+        "GetDistribution ETag must be stable"
+    );
+    assert_eq!(g1.e_tag().unwrap(), etag1.as_str());
+}
+
+/// A no-op `UpdateDistribution` (PUT the same config back) must leave the
+/// ETag unchanged. Real updates that mutate the config bump the ETag.
+#[tokio::test]
+async fn etag_only_bumps_on_real_changes() {
+    // Long delay so the propagation tick can't race the assertion below.
+    let server =
+        TestServer::start_with_env(&[("FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC", "60")]).await;
+    let cf = server.cloudfront_client().await;
+
+    let initial = minimal_config("etag-bump-ref");
+    let create = cf
+        .create_distribution()
+        .distribution_config(initial.clone())
+        .send()
+        .await
+        .expect("create_distribution");
+    let id = create.distribution().unwrap().id().to_string();
+    let etag1 = create.e_tag().expect("etag").to_string();
+
+    // Pull the current config + ETag back; this is what real callers use
+    // as the basis for an UpdateDistribution.
+    let cfg_resp = cf
+        .get_distribution_config()
+        .id(&id)
+        .send()
+        .await
+        .expect("get_distribution_config");
+    let if_match = cfg_resp.e_tag().unwrap().to_string();
+    let same_cfg = cfg_resp.distribution_config().unwrap().clone();
+
+    // No-op update: PUT the exact same config back. ETag must not change.
+    let noop = cf
+        .update_distribution()
+        .id(&id)
+        .if_match(&if_match)
+        .distribution_config(same_cfg.clone())
+        .send()
+        .await
+        .expect("update_distribution noop");
+    assert_eq!(
+        noop.e_tag().unwrap(),
+        etag1.as_str(),
+        "no-op UpdateDistribution must not bump the ETag"
+    );
+
+    // Real change: flip ViewerProtocolPolicy. ETag must bump.
+    let mutated = DistributionConfig::builder()
+        .caller_reference(same_cfg.caller_reference())
+        .comment(same_cfg.comment())
+        .enabled(same_cfg.enabled())
+        .origins(same_cfg.origins().unwrap().clone())
+        .default_cache_behavior(
+            DefaultCacheBehavior::builder()
+                .target_origin_id(
+                    same_cfg
+                        .default_cache_behavior()
+                        .unwrap()
+                        .target_origin_id(),
+                )
+                .viewer_protocol_policy(ViewerProtocolPolicy::HttpsOnly)
+                .forwarded_values(
+                    ForwardedValues::builder()
+                        .query_string(false)
+                        .cookies(
+                            CookiePreference::builder()
+                                .forward(ItemSelection::None)
+                                .build()
+                                .unwrap(),
+                        )
+                        .headers(Headers::builder().quantity(0).build().unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .min_ttl(0)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let real = cf
+        .update_distribution()
+        .id(&id)
+        .if_match(noop.e_tag().unwrap())
+        .distribution_config(mutated)
+        .send()
+        .await
+        .expect("update_distribution real");
+    assert_ne!(
+        real.e_tag().unwrap(),
+        etag1.as_str(),
+        "UpdateDistribution with a real config change must bump the ETag"
+    );
+    assert_eq!(
+        real.distribution().unwrap().status(),
+        "InProgress",
+        "real UpdateDistribution must flip status back to InProgress"
+    );
+}


### PR DESCRIPTION
## Summary

- StreamingDistributions now mirror the InProgress -> Deployed edge-propagation lifecycle that regular Distributions, DistributionTenants, and ConnectionGroups already use; scheduled via the same tokio tick on `propagation_delay`.
- The default propagation delay is now overridable through the `FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC` env var (parses integer or float seconds; falls back to 1s on invalid input).
- `UpdateDistribution` and `UpdateStreamingDistribution` are now ETag-stable on no-op writes: they canonical-XML-compare the new config against the stored one and only bump the ETag, flip status back to InProgress, and schedule a fresh deploy tick when the config actually changed.

## Test plan

- [x] `cargo test -p fakecloud-cloudfront --lib` (45 passed)
- [x] `cargo test -p fakecloud-e2e --test cloudfront_status` (4 passed)
- [x] `cargo test -p fakecloud-e2e --test cloudfront --test cloudfront_streaming` (11 passed, regression check)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streaming distributions now follow the real InProgress → Deployed lifecycle, and Update* calls keep the ETag stable on no-op writes. A new env var controls the propagation delay.

- **New Features**
  - `StreamingDistribution` now starts as InProgress and flips to Deployed after the same `propagation_delay` (scheduled on Tokio).
  - Default delay is configurable via `FAKECLOUD_CLOUDFRONT_STATUS_DELAY_SEC` (int/float seconds; 0 = sync; invalid → 1s).
  - `UpdateDistribution` and `UpdateStreamingDistribution` only bump the ETag and reschedule deploy when the config actually changed (canonical XML compare).

<sup>Written for commit 3ababa7e0e5529b56963c2a4d289999e31e21f08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

