### PR TITLE
feat(cognito): /oauth2/authorize endpoint with code+token response types (Y4)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -5,10 +5,12 @@ pub mod triggers;
 pub mod user_status;
 
 pub use service::{
-    ensure_pool_signing_key, handle_oauth2_revoke, handle_oauth2_token, handle_oauth2_userinfo,
-    mint_authorization_code, oidc_discovery_document, pool_existence_and_domain,
-    pool_jwks_document, CognitoService, MintAuthorizationCodeError, MintAuthorizationCodeRequest,
-    OAuthRevokeError, OAuthTokenError, OAuthTokenResponse, OAuthUserInfoError,
+    ensure_pool_signing_key, handle_oauth2_authorize, handle_oauth2_revoke, handle_oauth2_token,
+    handle_oauth2_userinfo, mint_authorization_code, oidc_discovery_document,
+    pool_existence_and_domain, pool_jwks_document, CognitoService, MintAuthorizationCodeError,
+    MintAuthorizationCodeRequest, OAuth2AuthorizeError, OAuth2AuthorizeOutcome,
+    OAuth2AuthorizeRequest, OAuthRevokeError, OAuthTokenError, OAuthTokenResponse,
+    OAuthUserInfoError,
 };
 pub use state::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig,

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -2542,5 +2542,433 @@ pub fn mint_authorization_code(
     Err(MintAuthorizationCodeError::InvalidClient)
 }
 
+/// Query parameters accepted by [`handle_oauth2_authorize`]. Mirrors
+/// the OAuth 2.0 Authorization Request shape (RFC 6749 §4.1.1 /
+/// §4.2.1) plus the synthetic `username`/`password` pair fakecloud
+/// uses in lieu of a real Hosted-UI login form. Real Cognito would
+/// render an HTML page that POSTs credentials back to itself; for
+/// scripted E2E tests it's simpler to accept the credentials inline
+/// on the initial GET.
+#[derive(Debug, Clone)]
+pub struct OAuth2AuthorizeRequest {
+    pub response_type: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub scope: Option<String>,
+    pub state: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub nonce: Option<String>,
+    /// Test-only synthetic login: when both supplied we attempt a
+    /// password-based auth against the user pool. AWS does this via
+    /// the Hosted UI HTML form; we collapse it into one query so E2E
+    /// tests don't have to scrape HTML.
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+/// Result of [`handle_oauth2_authorize`]. The HTTP wrapper turns
+/// `Redirect` into a 302 with the encoded URL, and `LoginRequired`
+/// into a 200 HTML form (or a JSON error if you'd rather skip the
+/// UI step).
+#[derive(Debug, Clone)]
+pub enum OAuth2AuthorizeOutcome {
+    /// Authorization succeeded; redirect the user agent to this
+    /// absolute URL. For `response_type=code` the params are in the
+    /// query string; for `response_type=token` they're in the URL
+    /// fragment per RFC 6749 §4.2.2.
+    Redirect(String),
+    /// Credentials weren't supplied (or weren't valid) — the wrapper
+    /// should render a synthetic login form pointing back at
+    /// `/oauth2/authorize` with the same query params plus
+    /// `username`/`password` fields.
+    LoginRequired { html: String },
+}
+
+/// Failure modes that bubble out of [`handle_oauth2_authorize`] before
+/// we know it's safe to redirect — i.e. the redirect_uri itself is
+/// untrusted, so per RFC 6749 §4.1.2.1 we MUST NOT bounce errors
+/// back to it. The wrapper returns these as 400 JSON bodies.
+#[derive(Debug, Clone)]
+pub enum OAuth2AuthorizeError {
+    /// `client_id` doesn't resolve to any registered app client.
+    InvalidClient,
+    /// `redirect_uri` isn't on the client's registered `CallbackURLs`.
+    InvalidRedirectUri,
+}
+
+/// Failure modes safe to return *via* the redirect_uri (RFC 6749
+/// §4.1.2.1 / §4.2.2.1) — these encode `error=...` back to the
+/// client's redirect URL with the original `state` preserved.
+#[derive(Debug, Clone, Copy)]
+enum AuthorizeRedirectError {
+    UnsupportedResponseType,
+    InvalidScope,
+    UnauthorizedClient,
+    AccessDenied,
+    InvalidRequest,
+}
+
+impl AuthorizeRedirectError {
+    fn as_oauth_code(self) -> &'static str {
+        match self {
+            Self::UnsupportedResponseType => "unsupported_response_type",
+            Self::InvalidScope => "invalid_scope",
+            Self::UnauthorizedClient => "unauthorized_client",
+            Self::AccessDenied => "access_denied",
+            Self::InvalidRequest => "invalid_request",
+        }
+    }
+}
+
+/// Handle a Cognito Hosted-UI `/oauth2/authorize` request. Implements
+/// both Authorization Code (`response_type=code`) and Implicit
+/// (`response_type=token`) flows.
+///
+/// Validation order matches the RFC: client_id and redirect_uri are
+/// checked first (failures here surface as 400 JSON, never as a
+/// redirect, because we can't trust the supplied redirect_uri yet).
+/// Anything past that point — bad scope, bad credentials, unsupported
+/// response_type — is encoded back via the redirect_uri so the
+/// client-side app can react gracefully.
+pub async fn handle_oauth2_authorize(
+    state: &SharedCognitoState,
+    req: &OAuth2AuthorizeRequest,
+    region: &str,
+) -> Result<OAuth2AuthorizeOutcome, OAuth2AuthorizeError> {
+    // Look up the client and validate redirect_uri *before* trusting
+    // anything else. RFC 6749 §3.1.2.4: an invalid redirect_uri MUST
+    // NOT be redirected to.
+    let (pool_id, callback_urls, allowed_flows, allowed_scopes, oauth_flows_enabled) = {
+        let mas = state.read();
+        let mut found = None;
+        for (_, account) in mas.iter() {
+            if let Some(client) = account.user_pool_clients.get(&req.client_id) {
+                found = Some((
+                    client.user_pool_id.clone(),
+                    client.callback_urls.clone(),
+                    client.allowed_o_auth_flows.clone(),
+                    client.allowed_o_auth_scopes.clone(),
+                    client.allowed_o_auth_flows_user_pool_client,
+                ));
+                break;
+            }
+        }
+        found.ok_or(OAuth2AuthorizeError::InvalidClient)?
+    };
+
+    // AWS allows callback_urls to be empty during early dev; only
+    // enforce when at least one URL is registered.
+    if !callback_urls.is_empty() && !callback_urls.iter().any(|u| u == &req.redirect_uri) {
+        return Err(OAuth2AuthorizeError::InvalidRedirectUri);
+    }
+
+    // From here on, every error redirects back to the client.
+    let response_type = req.response_type.as_str();
+    let requested_scopes: Vec<String> = req
+        .scope
+        .as_deref()
+        .unwrap_or("")
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect();
+
+    // Scope subset check (RFC 6749 §3.3). Skip when the client has
+    // no AllowedOAuthScopes registered (matches mint_authorization_code).
+    if !requested_scopes.is_empty() && !allowed_scopes.is_empty() {
+        for s in &requested_scopes {
+            if !allowed_scopes.iter().any(|a| a == s) {
+                return Ok(OAuth2AuthorizeOutcome::Redirect(build_error_redirect(
+                    &req.redirect_uri,
+                    AuthorizeRedirectError::InvalidScope,
+                    req.state.as_deref(),
+                    matches!(response_type, "token"),
+                )));
+            }
+        }
+    }
+
+    // Map response_type -> required flow (RFC 6749 §3.1.1). Cognito
+    // only honours `code`/`implicit` when the client opted into the
+    // Hosted UI flows.
+    let required_flow = match response_type {
+        "code" => "code",
+        "token" => "implicit",
+        _ => {
+            return Ok(OAuth2AuthorizeOutcome::Redirect(build_error_redirect(
+                &req.redirect_uri,
+                AuthorizeRedirectError::UnsupportedResponseType,
+                req.state.as_deref(),
+                false,
+            )));
+        }
+    };
+    if oauth_flows_enabled
+        && !allowed_flows.is_empty()
+        && !allowed_flows
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case(required_flow))
+    {
+        return Ok(OAuth2AuthorizeOutcome::Redirect(build_error_redirect(
+            &req.redirect_uri,
+            AuthorizeRedirectError::UnauthorizedClient,
+            req.state.as_deref(),
+            response_type == "token",
+        )));
+    }
+
+    // Synthetic login: real Cognito redirects to its hosted form, but
+    // for scripted E2E we accept username/password on the query.
+    let (Some(username), Some(password)) = (req.username.as_deref(), req.password.as_deref())
+    else {
+        return Ok(OAuth2AuthorizeOutcome::LoginRequired {
+            html: render_login_form(req),
+        });
+    };
+
+    // Verify credentials inline. We don't run the
+    // PreAuthentication/PostAuthentication Lambda triggers here —
+    // those fire from the AdminInitiateAuth path and the Hosted UI
+    // is meant to be a thin shell on top of it; we keep this handler
+    // self-contained to avoid the full delivery_ctx plumbing.
+    let credentials_ok = {
+        let mas = state.read();
+        let mut ok = false;
+        for (_, account) in mas.iter() {
+            if let Some(user) = account
+                .users
+                .get(&pool_id)
+                .and_then(|users| users.get(username))
+            {
+                if !user.enabled {
+                    break;
+                }
+                let matches = match (&user.password, &user.temporary_password) {
+                    (Some(p), _) if p == password => true,
+                    (_, Some(tp)) if tp == password => true,
+                    _ => false,
+                };
+                if matches {
+                    ok = true;
+                }
+                break;
+            }
+        }
+        ok
+    };
+    if !credentials_ok {
+        return Ok(OAuth2AuthorizeOutcome::Redirect(build_error_redirect(
+            &req.redirect_uri,
+            AuthorizeRedirectError::AccessDenied,
+            req.state.as_deref(),
+            response_type == "token",
+        )));
+    }
+
+    match response_type {
+        "code" => {
+            let mint_req = MintAuthorizationCodeRequest {
+                user_pool_id: pool_id.clone(),
+                client_id: req.client_id.clone(),
+                username: username.to_string(),
+                redirect_uri: req.redirect_uri.clone(),
+                scopes: requested_scopes,
+                code_challenge: req.code_challenge.clone(),
+                code_challenge_method: req.code_challenge_method.clone(),
+                nonce: req.nonce.clone(),
+            };
+            let code = match mint_authorization_code(state, &mint_req) {
+                Ok(c) => c,
+                // Already validated above; treat residual mismatches
+                // as access_denied to stay honest with the redirect.
+                Err(_) => {
+                    return Ok(OAuth2AuthorizeOutcome::Redirect(build_error_redirect(
+                        &req.redirect_uri,
+                        AuthorizeRedirectError::InvalidRequest,
+                        req.state.as_deref(),
+                        false,
+                    )));
+                }
+            };
+            let mut url = req.redirect_uri.clone();
+            url.push(if url.contains('?') { '&' } else { '?' });
+            url.push_str("code=");
+            url.push_str(&urlencoding_encode(&code));
+            if let Some(s) = req.state.as_deref() {
+                url.push_str("&state=");
+                url.push_str(&urlencoding_encode(s));
+            }
+            Ok(OAuth2AuthorizeOutcome::Redirect(url))
+        }
+        "token" => {
+            // Implicit grant: mint id_token + access_token, return in
+            // fragment per RFC 6749 §4.2.2. No refresh_token (RFC
+            // §4.2.2 explicitly forbids it on implicit).
+            let sub = {
+                let mas = state.read();
+                let mut sub = String::new();
+                for (_, account) in mas.iter() {
+                    if let Some(user) = account
+                        .users
+                        .get(&pool_id)
+                        .and_then(|users| users.get(username))
+                    {
+                        sub = user.sub.clone();
+                        break;
+                    }
+                }
+                sub
+            };
+            let scope_str = if requested_scopes.is_empty() {
+                None
+            } else {
+                Some(requested_scopes.join(" "))
+            };
+            let signing = ensure_pool_signing_key(state, &pool_id).await;
+            let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
+            let tokens = generate_tokens_with_scope(
+                &pool_id,
+                &req.client_id,
+                &sub,
+                username,
+                region,
+                signing_ref,
+                scope_str.as_deref(),
+                req.nonce.as_deref(),
+            );
+            // Persist the access_token so /oauth2/userInfo and
+            // /oauth2/revoke can resolve it back to the user.
+            {
+                let mut mas = state.write();
+                for (_, account) in mas.iter_mut() {
+                    if !account.user_pool_clients.contains_key(&req.client_id) {
+                        continue;
+                    }
+                    account.access_tokens.insert(
+                        tokens.access_token.clone(),
+                        crate::state::AccessTokenData {
+                            user_pool_id: pool_id.clone(),
+                            username: username.to_string(),
+                            client_id: req.client_id.clone(),
+                            issued_at: Utc::now(),
+                        },
+                    );
+                    break;
+                }
+            }
+            let mut fragment = format!(
+                "access_token={}&id_token={}&token_type=Bearer&expires_in=3600",
+                urlencoding_encode(&tokens.access_token),
+                urlencoding_encode(&tokens.id_token),
+            );
+            if let Some(s) = req.state.as_deref() {
+                fragment.push_str("&state=");
+                fragment.push_str(&urlencoding_encode(s));
+            }
+            let url = format!("{}#{fragment}", req.redirect_uri);
+            Ok(OAuth2AuthorizeOutcome::Redirect(url))
+        }
+        _ => unreachable!("response_type already validated"),
+    }
+}
+
+/// Append an `error` (and `state`) param to `redirect_uri` per RFC
+/// 6749 §4.1.2.1 (code flow uses query) / §4.2.2.1 (implicit flow
+/// uses fragment).
+fn build_error_redirect(
+    redirect_uri: &str,
+    err: AuthorizeRedirectError,
+    state: Option<&str>,
+    use_fragment: bool,
+) -> String {
+    let mut params = format!("error={}", err.as_oauth_code());
+    if let Some(s) = state {
+        params.push_str("&state=");
+        params.push_str(&urlencoding_encode(s));
+    }
+    if use_fragment {
+        format!("{redirect_uri}#{params}")
+    } else {
+        let sep = if redirect_uri.contains('?') { '&' } else { '?' };
+        format!("{redirect_uri}{sep}{params}")
+    }
+}
+
+/// Minimal HTML login page rendered when the user agent hits
+/// `/oauth2/authorize` without `username`/`password` query params.
+/// The form POSTs/GETs back to the same endpoint with all the
+/// original OAuth params preserved as hidden fields. Real Cognito's
+/// Hosted UI is far prettier; ours is enough to keep manual smoke
+/// tests honest.
+fn render_login_form(req: &OAuth2AuthorizeRequest) -> String {
+    fn hidden(name: &str, value: &str) -> String {
+        format!(
+            r#"<input type="hidden" name="{}" value="{}">"#,
+            html_escape(name),
+            html_escape(value),
+        )
+    }
+    let mut hiddens = String::new();
+    hiddens.push_str(&hidden("response_type", &req.response_type));
+    hiddens.push_str(&hidden("client_id", &req.client_id));
+    hiddens.push_str(&hidden("redirect_uri", &req.redirect_uri));
+    if let Some(s) = req.scope.as_deref() {
+        hiddens.push_str(&hidden("scope", s));
+    }
+    if let Some(s) = req.state.as_deref() {
+        hiddens.push_str(&hidden("state", s));
+    }
+    if let Some(c) = req.code_challenge.as_deref() {
+        hiddens.push_str(&hidden("code_challenge", c));
+    }
+    if let Some(m) = req.code_challenge_method.as_deref() {
+        hiddens.push_str(&hidden("code_challenge_method", m));
+    }
+    if let Some(n) = req.nonce.as_deref() {
+        hiddens.push_str(&hidden("nonce", n));
+    }
+    format!(
+        r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>fakecloud login</title></head>
+<body>
+<h1>fakecloud Cognito Hosted UI</h1>
+<p>This is a test stand-in for the real Cognito Hosted UI login form.</p>
+<form method="get" action="/oauth2/authorize">
+{hiddens}
+<label>Username <input name="username" autocomplete="username"></label><br>
+<label>Password <input name="password" type="password" autocomplete="current-password"></label><br>
+<button type="submit">Sign in</button>
+</form>
+</body></html>
+"#,
+    )
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+/// Minimal `application/x-www-form-urlencoded` value encoder. Avoids
+/// pulling in a new crate just for this — we only need the
+/// unreserved-set rule (RFC 3986 §2.3) plus space-as-`%20` (NOT `+`,
+/// since these values land in URL fragments and query strings where
+/// `+` is reserved on the fragment side).
+fn urlencoding_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.as_bytes() {
+        let c = *byte;
+        if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.' | b'~') {
+            out.push(c as char);
+        } else {
+            out.push_str(&format!("%{c:02X}"));
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/fakecloud-e2e/tests/cognito_authorize.rs
+++ b/crates/fakecloud-e2e/tests/cognito_authorize.rs
@@ -1,0 +1,669 @@
+//! E2E tests for the Cognito Hosted UI `/oauth2/authorize` endpoint
+//! (Y4). The endpoint is the first step of the Authorization Code and
+//! Implicit OAuth 2.0 flows; in real Cognito it serves an HTML login
+//! form, but our fakecloud variant accepts username/password directly
+//! on the query string so scripted E2E tests don't have to scrape HTML.
+
+mod helpers;
+use helpers::TestServer;
+
+use aws_sdk_cognitoidentityprovider::types::{PasswordPolicyType, UserPoolPolicyType};
+
+/// Percent-encode a URL component for inline query-string assembly.
+/// We don't pull in the `urlencoding` crate just for tests — RFC 3986
+/// unreserved set is enough for the values we care about (URLs, JWTs,
+/// usernames).
+fn encode_uri(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.as_bytes() {
+        let c = *byte;
+        if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.' | b'~') {
+            out.push(c as char);
+        } else {
+            out.push_str(&format!("%{c:02X}"));
+        }
+    }
+    out
+}
+
+/// Decode a percent-encoded fragment value. We only need to handle
+/// the ASCII subset we know our handler emits.
+fn decode_uri(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16).unwrap_or(0) as u8;
+            let lo = (bytes[i + 2] as char).to_digit(16).unwrap_or(0) as u8;
+            out.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Walk the full code grant: GET /oauth2/authorize -> follow the 302
+/// -> exchange the resulting `code` at /oauth2/token. This is the
+/// happy path real apps drive against a Cognito Hosted UI.
+#[tokio::test]
+async fn cognito_oauth2_authorize_code_flow_round_trip() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-code-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-code-client")
+        .callback_urls("https://app.test/cb")
+        .allowed_o_auth_flows("code".into())
+        .allowed_o_auth_scopes("openid")
+        .allowed_o_auth_scopes("email")
+        .allowed_o_auth_flows_user_pool_client(true)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("alice")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    // Build a non-redirect-following client so we can inspect the 302
+    // location the way a browser would.
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    let authorize_url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id={}&redirect_uri={}&scope=openid&state=xyz123&username=alice&password=hunter22",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://app.test/cb"),
+    );
+    let resp = http.get(&authorize_url).send().await.unwrap();
+    assert_eq!(resp.status(), 302, "expected redirect");
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .expect("Location header present")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        location.starts_with("https://app.test/cb?"),
+        "unexpected redirect target: {location}"
+    );
+    assert!(
+        location.contains("state=xyz123"),
+        "state must round-trip: {location}"
+    );
+
+    // Pull out the `code` query param.
+    let url = reqwest::Url::parse(&location).unwrap();
+    let code = url
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("code param present");
+    assert!(!code.is_empty());
+
+    // Exchange the code at /oauth2/token.
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    let body = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://app.test/cb"),
+    ])
+    .unwrap();
+    let token_resp = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(token_resp.status(), 200);
+    let json: serde_json::Value = token_resp.json().await.unwrap();
+    assert_eq!(json["token_type"], "Bearer");
+    assert_eq!(json["expires_in"], 3600);
+    let id_token = json["id_token"].as_str().unwrap();
+    assert_eq!(id_token.split('.').count(), 3);
+    assert!(json["access_token"].as_str().unwrap().split('.').count() == 3);
+    assert!(!json["refresh_token"].as_str().unwrap().is_empty());
+}
+
+/// `response_type=token` (Implicit) returns id_token + access_token
+/// in the URL fragment, no refresh_token, per RFC 6749 §4.2.2.
+#[tokio::test]
+async fn cognito_oauth2_authorize_implicit_flow_returns_fragment_tokens() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-implicit-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-implicit-client")
+        .callback_urls("https://app.test/cb")
+        .allowed_o_auth_flows("implicit".into())
+        .allowed_o_auth_scopes("openid")
+        .allowed_o_auth_flows_user_pool_client(true)
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("bob")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let authorize_url = format!(
+        "{}/oauth2/authorize?response_type=token&client_id={}&redirect_uri={}&scope=openid&state=frag1&nonce=nonce123&username=bob&password=hunter22",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://app.test/cb"),
+    );
+    let resp = http.get(&authorize_url).send().await.unwrap();
+    assert_eq!(resp.status(), 302);
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .expect("Location header present")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Implicit flow uses the URL fragment, not the query.
+    let (base, fragment) = location
+        .split_once('#')
+        .expect("implicit response uses fragment");
+    assert_eq!(base, "https://app.test/cb");
+    let pairs: std::collections::BTreeMap<String, String> = fragment
+        .split('&')
+        .filter_map(|kv| kv.split_once('='))
+        .map(|(k, v)| (decode_uri(k), decode_uri(v)))
+        .collect();
+    assert_eq!(pairs.get("token_type").map(String::as_str), Some("Bearer"));
+    assert_eq!(pairs.get("expires_in").map(String::as_str), Some("3600"));
+    assert_eq!(pairs.get("state").map(String::as_str), Some("frag1"));
+    let id_token = pairs.get("id_token").expect("id_token in fragment");
+    let access_token = pairs.get("access_token").expect("access_token in fragment");
+    assert_eq!(id_token.split('.').count(), 3);
+    assert_eq!(access_token.split('.').count(), 3);
+    // Implicit flow MUST NOT issue a refresh_token (RFC 6749 §4.2.2).
+    assert!(!pairs.contains_key("refresh_token"));
+
+    // The minted access_token must round-trip via /oauth2/userInfo so
+    // downstream code can introspect the user.
+    let userinfo_url = format!("{}/oauth2/userInfo", server.endpoint());
+    let info = http
+        .get(&userinfo_url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(info.status(), 200);
+    let info_json: serde_json::Value = info.json().await.unwrap();
+    assert_eq!(info_json["username"], "bob");
+}
+
+/// A redirect_uri that isn't on the client's CallbackURLs MUST be
+/// rejected with a 400 — RFC 6749 §3.1.2.4 forbids redirecting to an
+/// untrusted URL even to surface an error.
+#[tokio::test]
+async fn cognito_oauth2_authorize_unknown_redirect_uri_rejected() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-bad-redirect-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-bad-redirect-client")
+        .callback_urls("https://app.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id={}&redirect_uri={}",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://attacker.test/cb"),
+    );
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"], "invalid_request");
+}
+
+/// An unknown client_id is also a 400 (no redirect target to trust).
+#[tokio::test]
+async fn cognito_oauth2_authorize_unknown_client_rejected() {
+    let server = TestServer::start().await;
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id=ghost&redirect_uri={}",
+        server.endpoint(),
+        encode_uri("https://app.test/cb"),
+    );
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"], "invalid_client");
+}
+
+/// Without username/password we serve an HTML login page (200) rather
+/// than a redirect — keeps the door open for manual smoke tests.
+#[tokio::test]
+async fn cognito_oauth2_authorize_no_credentials_serves_login_form() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-loginform-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-loginform-client")
+        .callback_urls("https://app.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id={}&redirect_uri={}",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://app.test/cb"),
+    );
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let ctype = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(ctype.starts_with("text/html"));
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("<form"), "missing form: {body}");
+    assert!(body.contains("name=\"username\""));
+    assert!(body.contains("name=\"password\""));
+}
+
+/// Bad credentials must redirect back with `error=access_denied` so
+/// the SPA can render its own error UI. Per RFC 6749 §4.1.2.1, the
+/// state must round-trip on the error path too.
+#[tokio::test]
+async fn cognito_oauth2_authorize_bad_password_redirects_access_denied() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-baddpw-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-baddpw-client")
+        .callback_urls("https://app.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("carol")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id={}&redirect_uri={}&state=preserve&username=carol&password=wrong",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://app.test/cb"),
+    );
+    let resp = http.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 302);
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let parsed = reqwest::Url::parse(&location).unwrap();
+    let pairs: std::collections::BTreeMap<_, _> = parsed.query_pairs().into_owned().collect();
+    assert_eq!(
+        pairs.get("error").map(String::as_str),
+        Some("access_denied")
+    );
+    assert_eq!(pairs.get("state").map(String::as_str), Some("preserve"));
+}
+
+/// PKCE: a code minted with a `code_challenge` must require the
+/// matching `code_verifier` at /oauth2/token. This wires the Y4
+/// authorize endpoint up to the Y3 token endpoint's PKCE check.
+#[tokio::test]
+async fn cognito_oauth2_authorize_with_pkce_round_trips_to_token() {
+    let server = TestServer::start().await;
+    let client = server.cognito_client().await;
+    let pool = client
+        .create_user_pool()
+        .pool_name("y4-pkce-pool")
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create pool");
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+    let app = client
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("y4-pkce-client")
+        .callback_urls("https://app.test/cb")
+        .send()
+        .await
+        .expect("create client");
+    let client_id = app
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+    client
+        .sign_up()
+        .client_id(&client_id)
+        .username("dave")
+        .password("hunter22")
+        .send()
+        .await
+        .expect("sign up");
+    client
+        .confirm_sign_up()
+        .client_id(&client_id)
+        .username("dave")
+        .confirmation_code("123456")
+        .send()
+        .await
+        .expect("confirm");
+
+    // Verifier/challenge from RFC 7636 Appendix B.
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    let http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let authorize_url = format!(
+        "{}/oauth2/authorize?response_type=code&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method=S256&username=dave&password=hunter22",
+        server.endpoint(),
+        client_id,
+        encode_uri("https://app.test/cb"),
+        challenge,
+    );
+    let resp = http.get(&authorize_url).send().await.unwrap();
+    assert_eq!(resp.status(), 302);
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let url = reqwest::Url::parse(&location).unwrap();
+    let code = url
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("code param");
+
+    let token_url = format!("{}/oauth2/token", server.endpoint());
+    // Without verifier: /token MUST refuse (invalid_grant).
+    let body_bad = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code.as_str()),
+        ("redirect_uri", "https://app.test/cb"),
+    ])
+    .unwrap();
+    let resp_bad = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body_bad)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp_bad.status(), 400);
+    let bad_json: serde_json::Value = resp_bad.json().await.unwrap();
+    assert_eq!(bad_json["error"], "invalid_grant");
+
+    // /authorize must mint a fresh code; codes are single-use even
+    // when the previous redemption failed PKCE. Re-mint and retry
+    // with the correct verifier.
+    let resp2 = http.get(&authorize_url).send().await.unwrap();
+    let location2 = resp2
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let code2 = reqwest::Url::parse(&location2)
+        .unwrap()
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("second code");
+    let body_ok = serde_urlencoded::to_string([
+        ("grant_type", "authorization_code"),
+        ("client_id", client_id.as_str()),
+        ("code", code2.as_str()),
+        ("redirect_uri", "https://app.test/cb"),
+        ("code_verifier", verifier),
+    ])
+    .unwrap();
+    let resp_ok = http
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body_ok)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp_ok.status(), 200);
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -636,6 +636,7 @@ async fn main() {
     let cognito_token_state = cognito_state.clone();
     let cognito_userinfo_state = cognito_state.clone();
     let cognito_revoke_state = cognito_state.clone();
+    let cognito_authorize_state = cognito_state.clone();
 
     let glue_state: fakecloud_glue::SharedGlueState =
         Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new()));
@@ -3887,6 +3888,108 @@ async fn main() {
                                 pool_domain.as_deref(),
                             )),
                         )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/oauth2/authorize",
+            axum::routing::get({
+                let cs = cognito_authorize_state;
+                move |axum::extract::Query(q): axum::extract::Query<
+                    std::collections::BTreeMap<String, String>,
+                >| {
+                    let cs = cs.clone();
+                    async move {
+                        let region = std::env::var("AWS_DEFAULT_REGION")
+                            .or_else(|_| std::env::var("AWS_REGION"))
+                            .unwrap_or_else(|_| "us-east-1".to_string());
+                        // RFC 6749 §4.1.1 / §4.2.1 mandate at minimum
+                        // `response_type` and `client_id`; `redirect_uri`
+                        // is required when the client has multiple
+                        // callbacks registered. We require it always
+                        // here because we use it as the trust anchor
+                        // for the redirect.
+                        let Some(response_type) = q.get("response_type") else {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::http::HeaderMap::new(),
+                                axum::Json(serde_json::json!({
+                                    "error": "invalid_request",
+                                    "error_description": "response_type is required"
+                                }))
+                                .into_response(),
+                            );
+                        };
+                        let Some(client_id) = q.get("client_id") else {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::http::HeaderMap::new(),
+                                axum::Json(serde_json::json!({
+                                    "error": "invalid_request",
+                                    "error_description": "client_id is required"
+                                }))
+                                .into_response(),
+                            );
+                        };
+                        let Some(redirect_uri) = q.get("redirect_uri") else {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::http::HeaderMap::new(),
+                                axum::Json(serde_json::json!({
+                                    "error": "invalid_request",
+                                    "error_description": "redirect_uri is required"
+                                }))
+                                .into_response(),
+                            );
+                        };
+                        let req = fakecloud_cognito::OAuth2AuthorizeRequest {
+                            response_type: response_type.clone(),
+                            client_id: client_id.clone(),
+                            redirect_uri: redirect_uri.clone(),
+                            scope: q.get("scope").cloned(),
+                            state: q.get("state").cloned(),
+                            code_challenge: q.get("code_challenge").cloned(),
+                            code_challenge_method: q.get("code_challenge_method").cloned(),
+                            nonce: q.get("nonce").cloned(),
+                            username: q.get("username").cloned(),
+                            password: q.get("password").cloned(),
+                        };
+                        match fakecloud_cognito::handle_oauth2_authorize(&cs, &req, &region).await {
+                            Ok(fakecloud_cognito::OAuth2AuthorizeOutcome::Redirect(url)) => {
+                                let mut headers = axum::http::HeaderMap::new();
+                                if let Ok(loc) = axum::http::HeaderValue::from_str(&url) {
+                                    headers.insert(axum::http::header::LOCATION, loc);
+                                }
+                                (axum::http::StatusCode::FOUND, headers, String::new().into_response())
+                            }
+                            Ok(fakecloud_cognito::OAuth2AuthorizeOutcome::LoginRequired {
+                                html,
+                            }) => {
+                                let mut headers = axum::http::HeaderMap::new();
+                                headers.insert(
+                                    axum::http::header::CONTENT_TYPE,
+                                    axum::http::HeaderValue::from_static("text/html; charset=utf-8"),
+                                );
+                                (axum::http::StatusCode::OK, headers, html.into_response())
+                            }
+                            Err(err) => {
+                                let code = match err {
+                                    fakecloud_cognito::OAuth2AuthorizeError::InvalidClient => {
+                                        "invalid_client"
+                                    }
+                                    fakecloud_cognito::OAuth2AuthorizeError::InvalidRedirectUri => {
+                                        "invalid_request"
+                                    }
+                                };
+                                (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    axum::http::HeaderMap::new(),
+                                    axum::Json(serde_json::json!({"error": code}))
+                                        .into_response(),
+                                )
+                            }
+                        }
                     }
                 }
             }),

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -133,7 +133,7 @@ func main() {
 | `GetTokens(ctx)` | List active tokens |
 | `ExpireTokens(ctx, req)` | Expire tokens |
 | `GetAuthEvents(ctx)` | List auth events |
-| `MintAuthorizationCode(ctx, req)` | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
+| `MintAuthorizationCode(ctx, req)` | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
 
 ### RDS - `fc.RDS()`
 

--- a/sdks/go/cognito.go
+++ b/sdks/go/cognito.go
@@ -108,7 +108,7 @@ func (c *CognitoClient) GetAuthEvents(ctx context.Context) (*AuthEventsResponse,
 
 // MintAuthorizationCode mints a single-use OAuth2 authorization code
 // that the /oauth2/token authorization_code grant can later redeem.
-// Test-only equivalent of /oauth2/authorize.
+// Programmatic alternative to driving /oauth2/authorize.
 func (c *CognitoClient) MintAuthorizationCode(ctx context.Context, req *MintAuthorizationCodeRequest) (*MintAuthorizationCodeResponse, error) {
 	var out MintAuthorizationCodeResponse
 	if err := c.fc.doPost(ctx, "/_fakecloud/cognito/authorization-codes", req, &out); err != nil {

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -141,7 +141,7 @@ FakeCloud fc = new FakeCloud("http://localhost:4566"); // explicit base URL
 | `getTokens()`                     | List all active tokens               |
 | `expireTokens(req)`               | Expire tokens (optionally filtered)  |
 | `getAuthEvents()`                 | List auth events                     |
-| `mintAuthorizationCode(req)`      | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
+| `mintAuthorizationCode(req)`      | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
 
 ### `fc.rds()`
 

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -125,7 +125,7 @@ $fc = new FakeCloud('http://localhost:4566'); // explicit base URL
 | `getTokens()`                     | List all active tokens               |
 | `expireTokens($req)`              | Expire tokens (optionally filtered)  |
 | `getAuthEvents()`                 | List auth events                     |
-| `mintAuthorizationCode($req)`     | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
+| `mintAuthorizationCode($req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
 
 ### `$fc->rds()`
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -124,7 +124,7 @@ Top-level client. Defaults to `http://localhost:4566`.
 | `getTokens()`                    | List all active tokens                                                                  |
 | `expireTokens(req)`              | Expire tokens (optionally filtered)                                                     |
 | `getAuthEvents()`                | List auth events                                                                        |
-| `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (test-only equivalent of /oauth2/authorize) |
+| `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
 
 ### `fc.rds`
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -116,14 +116,14 @@ Top-level client. Defaults to `http://localhost:4566`.
 
 ### `fc.cognito`
 
-| Method                           | Description                                                                             |
-| -------------------------------- | --------------------------------------------------------------------------------------- |
-| `getUserCodes(poolId, username)` | Get confirmation codes for a user                                                       |
-| `getConfirmationCodes()`         | List all confirmation codes                                                             |
-| `confirmUser(req)`               | Confirm a user (bypass verification)                                                    |
-| `getTokens()`                    | List all active tokens                                                                  |
-| `expireTokens(req)`              | Expire tokens (optionally filtered)                                                     |
-| `getAuthEvents()`                | List auth events                                                                        |
+| Method                           | Description                                                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `getUserCodes(poolId, username)` | Get confirmation codes for a user                                                                   |
+| `getConfirmationCodes()`         | List all confirmation codes                                                                         |
+| `confirmUser(req)`               | Confirm a user (bypass verification)                                                                |
+| `getTokens()`                    | List all active tokens                                                                              |
+| `expireTokens(req)`              | Expire tokens (optionally filtered)                                                                 |
+| `getAuthEvents()`                | List auth events                                                                                    |
 | `mintAuthorizationCode(req)`     | Mint a single-use OAuth2 authorization code (programmatic alternative to driving /oauth2/authorize) |
 
 ### `fc.rds`

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -29,6 +29,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
 ## OAuth2 / OIDC endpoints
 
+- `GET /oauth2/authorize` — Hosted UI authorization endpoint. Supports `response_type=code` (Authorization Code grant, with optional PKCE `S256`/`plain`) and `response_type=token` (Implicit grant). Validates `client_id`, `redirect_uri` (must match the client's `CallbackURLs`), and `scope` (must be a subset of `AllowedOAuthScopes`). For scripted tests, accepts `username`/`password` query params in lieu of the real Cognito Hosted UI HTML form.
 - `POST /oauth2/token` — token endpoint with `authorization_code`, `client_credentials`, and `refresh_token` grants. RFC 6749 §2.3.1 Basic auth supported. PKCE (S256/plain) verified for `authorization_code`.
 - `GET|POST /oauth2/userInfo` — RFC 7662 user info (bearer access token -> standard OIDC claims).
 - `POST /oauth2/revoke` — RFC 7009 token revocation.
@@ -43,7 +44,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 - `GET /_fakecloud/cognito/tokens` — list active tokens (without exposing strings)
 - `POST /_fakecloud/cognito/expire-tokens` — expire tokens for a pool/user
 - `GET /_fakecloud/cognito/auth-events` — list auth events (signup, signin, failures)
-- `POST /_fakecloud/cognito/authorization-codes` — mint a single-use OAuth2 authorization code for the `authorization_code` grant (test-only equivalent of `/oauth2/authorize`)
+- `POST /_fakecloud/cognito/authorization-codes` — mint a single-use OAuth2 authorization code for the `authorization_code` grant (programmatic alternative to driving `/oauth2/authorize`)
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

- Implements the Cognito Hosted UI `/oauth2/authorize` endpoint, completing the OAuth 2.0 Authorization Code and Implicit grant flows on top of the existing Y3 token endpoint.
- `response_type=code` mints a single-use authorization code (PKCE-aware), redirects to `redirect_uri?code=...&state=...`. Codes are consumed at `/oauth2/token`'s `authorization_code` grant.
- `response_type=token` (Implicit) mints an id_token + access_token pair, redirects to `redirect_uri#access_token=...&id_token=...&token_type=Bearer&expires_in=3600&state=...`. No refresh token, per RFC 6749 §4.2.2.
- Validation order matches the RFC: bad `client_id` / `redirect_uri` -> 400 JSON (never trust an unverified redirect target). Bad `scope` / `response_type` / credentials -> redirect with `error=...&state=...` so SPAs can render their own error UI.
- Synthetic login: in lieu of an HTML login page, fakecloud accepts `username`/`password` as query params (a test-only shortcut). Without them, returns a minimal HTML form pointing back at the same endpoint with all OAuth params preserved.

## Test plan

- [x] `cargo test -p fakecloud-e2e --test cognito_authorize` — 7 new E2E tests covering happy-path code grant, implicit grant, PKCE round-trip, unknown client/redirect rejections, login form rendering, and bad-password redirects.
- [x] `cargo test -p fakecloud-cognito` — 306 existing unit tests still green.
- [x] `cargo clippy -p fakecloud-cognito` clean.
- [x] `cargo clippy -p fakecloud --bin fakecloud` clean.
- [x] `cargo clippy -p fakecloud-e2e --tests` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Cognito Hosted UI `/oauth2/authorize` endpoint to complete the Authorization Code and Implicit flows on top of the existing token endpoint. Supports browser-style redirects and a simple HTML login form for manual testing.

- **New Features**
  - Supports `response_type=code` (single-use code, PKCE) and `response_type=token` (implicit: `id_token` + `access_token`, no refresh).
  - Validation: unknown `client_id` or bad `redirect_uri` return 400 JSON; other errors redirect with `error` and `state`. Enforces Allowed OAuth flows and scope subset.
  - Test-only login via `username`/`password`; otherwise serves a minimal HTML login form.
  - Server routing added in `fakecloud-server`; public handler and types exported from `fakecloud-cognito`.
  - Docs updated: service docs describe `/oauth2/authorize`; SDK READMEs now call `MintAuthorizationCode` a programmatic alternative to driving `/oauth2/authorize`.
  - New E2E tests cover code/implicit flows, PKCE, bad client/redirect, login form, and bad credentials.

- **Bug Fixes**
  - Re-aligned `sdks/typescript` README table columns after the wording change.

<sup>Written for commit eb02dee3f37f6f921b898f76ea14b015fa439e92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

