### PR TITLE
feat(ecs): EnableExecuteCommand + propagateTags + ProtectFromScaleIn enforcement (O15)

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_enforce.rs
+++ b/crates/fakecloud-e2e/tests/ecs_enforce.rs
@@ -1,0 +1,306 @@
+//! Verify ECS-side enforcement gates that until O15 only stored fields:
+//!
+//! 1. ExecuteCommand must reject when the target task did not opt in
+//!    via `enableExecuteCommand` at RunTask / Service-create time.
+//! 2. `propagateTags=TASK_DEFINITION` on a service must copy the task
+//!    definition's tags onto every task the service spawns; clients
+//!    can read them back via `ListTagsForResource`.
+//! 3. `UpdateService` scale-down must skip tasks marked with
+//!    `protectFromScaleIn` via `UpdateTaskProtection` and pick an
+//!    unprotected task instead.
+
+mod helpers;
+
+use aws_sdk_ecs::types::{ContainerDefinition, PropagateTags, Tag, TaskField};
+use helpers::TestServer;
+
+async fn bootstrap(client: &aws_sdk_ecs::Client, cluster: &str, family: &str, tags: Vec<Tag>) {
+    client
+        .create_cluster()
+        .cluster_name(cluster)
+        .send()
+        .await
+        .unwrap();
+    let mut td = client
+        .register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        );
+    for t in tags {
+        td = td.tags(t);
+    }
+    td.send().await.unwrap();
+}
+
+#[tokio::test]
+async fn execute_command_rejected_when_service_did_not_enable_it() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap(&client, "exec-off", "exec-off-td", vec![]).await;
+
+    client
+        .create_service()
+        .cluster("exec-off")
+        .service_name("web")
+        .task_definition("exec-off-td")
+        .desired_count(1)
+        // enable_execute_command intentionally omitted (default = false).
+        .send()
+        .await
+        .expect("create_service");
+
+    let tasks = client
+        .list_tasks()
+        .cluster("exec-off")
+        .send()
+        .await
+        .expect("list_tasks");
+    let task_arn = tasks.task_arns().first().expect("one task").clone();
+
+    let err = client
+        .execute_command()
+        .cluster("exec-off")
+        .task(&task_arn)
+        .command("/bin/sh -c 'echo hi'")
+        .interactive(false)
+        .send()
+        .await
+        .expect_err("ExecuteCommand should be rejected");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidParameterException")
+            || msg.contains("execute command was not enabled"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn execute_command_allowed_when_service_enabled_it() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap(&client, "exec-on", "exec-on-td", vec![]).await;
+
+    client
+        .create_service()
+        .cluster("exec-on")
+        .service_name("web")
+        .task_definition("exec-on-td")
+        .desired_count(1)
+        .enable_execute_command(true)
+        .send()
+        .await
+        .expect("create_service");
+
+    let tasks = client
+        .list_tasks()
+        .cluster("exec-on")
+        .send()
+        .await
+        .expect("list_tasks");
+    let task_arn = tasks.task_arns().first().expect("one task").clone();
+
+    // ExecuteCommand returns a session shape. We don't assert the
+    // session contents (docker exec may or may not be available in
+    // CI), only that the gate didn't reject the call.
+    let resp = client
+        .execute_command()
+        .cluster("exec-on")
+        .task(&task_arn)
+        .command("/bin/sh -c 'true'")
+        .interactive(false)
+        .send()
+        .await;
+    // In CI without docker, the runtime may surface a docker-exec
+    // failure; the gate itself must not return InvalidParameterException.
+    if let Err(err) = resp {
+        let msg = format!("{err:?}");
+        assert!(
+            !msg.contains("InvalidParameterException"),
+            "ExecuteCommand should not be gated when service enabled it: {msg}"
+        );
+    }
+
+    // Surface check: DescribeTasks should report enableExecuteCommand=true.
+    let described = client
+        .describe_tasks()
+        .cluster("exec-on")
+        .tasks(&task_arn)
+        .send()
+        .await
+        .expect("describe_tasks");
+    let task = described.tasks().first().expect("task present");
+    assert!(task.enable_execute_command());
+}
+
+#[tokio::test]
+async fn propagate_tags_task_definition_copies_td_tags_onto_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    let td_tags = vec![
+        Tag::builder().key("Project").value("alpha").build(),
+        Tag::builder().key("Env").value("test").build(),
+    ];
+    bootstrap(&client, "tag-cluster", "tag-td", td_tags.clone()).await;
+
+    client
+        .create_service()
+        .cluster("tag-cluster")
+        .service_name("web")
+        .task_definition("tag-td")
+        .desired_count(1)
+        .propagate_tags(PropagateTags::TaskDefinition)
+        .send()
+        .await
+        .expect("create_service");
+
+    let listed = client
+        .list_tasks()
+        .cluster("tag-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    let task_arn = listed.task_arns().first().expect("one task").clone();
+
+    let described = client
+        .describe_tasks()
+        .cluster("tag-cluster")
+        .tasks(&task_arn)
+        .include(TaskField::Tags)
+        .send()
+        .await
+        .expect("describe_tasks");
+    let task = described.tasks().first().expect("task present");
+    let tag_keys: Vec<_> = task.tags().iter().filter_map(|t| t.key()).collect();
+    assert!(
+        tag_keys.contains(&"Project") && tag_keys.contains(&"Env"),
+        "propagateTags=TASK_DEFINITION should copy TD tags onto tasks; got {tag_keys:?}"
+    );
+
+    // ListTagsForResource on the task ARN must surface them too.
+    let lt = client
+        .list_tags_for_resource()
+        .resource_arn(&task_arn)
+        .send()
+        .await
+        .expect("list_tags_for_resource");
+    let lt_keys: Vec<_> = lt.tags().iter().filter_map(|t| t.key()).collect();
+    assert!(
+        lt_keys.contains(&"Project") && lt_keys.contains(&"Env"),
+        "ListTagsForResource on the task should reflect propagated TD tags; got {lt_keys:?}"
+    );
+}
+
+#[tokio::test]
+async fn propagate_tags_service_copies_service_tags_onto_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap(&client, "svc-tag-cluster", "svc-tag-td", vec![]).await;
+
+    client
+        .create_service()
+        .cluster("svc-tag-cluster")
+        .service_name("web")
+        .task_definition("svc-tag-td")
+        .desired_count(1)
+        .propagate_tags(PropagateTags::Service)
+        .tags(Tag::builder().key("Owner").value("platform").build())
+        .send()
+        .await
+        .expect("create_service");
+
+    let listed = client
+        .list_tasks()
+        .cluster("svc-tag-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    let task_arn = listed.task_arns().first().expect("one task").clone();
+
+    let described = client
+        .describe_tasks()
+        .cluster("svc-tag-cluster")
+        .tasks(&task_arn)
+        .include(TaskField::Tags)
+        .send()
+        .await
+        .expect("describe_tasks");
+    let task = described.tasks().first().expect("task present");
+    let tag_keys: Vec<_> = task.tags().iter().filter_map(|t| t.key()).collect();
+    assert!(
+        tag_keys.contains(&"Owner"),
+        "propagateTags=SERVICE should copy Service tags onto tasks; got {tag_keys:?}"
+    );
+}
+
+#[tokio::test]
+async fn update_service_scale_in_skips_protected_tasks() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    bootstrap(&client, "prot-cluster", "prot-td", vec![]).await;
+
+    client
+        .create_service()
+        .cluster("prot-cluster")
+        .service_name("web")
+        .task_definition("prot-td")
+        .desired_count(2)
+        .send()
+        .await
+        .expect("create_service");
+
+    let listed = client
+        .list_tasks()
+        .cluster("prot-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    let task_arns: Vec<String> = listed.task_arns().to_vec();
+    assert_eq!(task_arns.len(), 2, "service should have spawned 2 tasks");
+    let protected_arn = &task_arns[1];
+
+    client
+        .update_task_protection()
+        .cluster("prot-cluster")
+        .tasks(protected_arn)
+        .protection_enabled(true)
+        .send()
+        .await
+        .expect("update_task_protection");
+
+    client
+        .update_service()
+        .cluster("prot-cluster")
+        .service("web")
+        .desired_count(1)
+        .send()
+        .await
+        .expect("update_service down");
+
+    // The protected task must still exist (RUNNING/PENDING — not STOPPED).
+    let described = client
+        .describe_tasks()
+        .cluster("prot-cluster")
+        .tasks(protected_arn)
+        .send()
+        .await
+        .expect("describe_tasks");
+    let task = described.tasks().first().expect("protected task present");
+    assert_ne!(
+        task.last_status(),
+        Some("STOPPED"),
+        "protected task must survive scale-in; got last_status={:?}",
+        task.last_status()
+    );
+    assert_ne!(
+        task.desired_status(),
+        Some("STOPPED"),
+        "protected task desired_status must not flip to STOPPED on scale-in; got {:?}",
+        task.desired_status()
+    );
+}

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -488,7 +488,10 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
             Value::Null
         },
     );
-    map.insert("enableExecuteCommand".into(), json!(false));
+    map.insert(
+        "enableExecuteCommand".into(),
+        json!(task.enable_execute_command),
+    );
     map.insert("ephemeralStorage".into(), json!({ "sizeInGiB": 20 }));
     map.insert("healthStatus".into(), json!(aggregate_task_health(task)));
     map.insert("version".into(), json!(1));
@@ -652,6 +655,15 @@ pub(crate) fn spawn_service_tasks(
     let family = service.family.clone();
     let revision = service.revision;
     let service_tag = format!("ecs-svc/{}", service.service_name);
+    // Resolve task tags from the propagateTags strategy. AWS copies
+    // TaskDefinition.tags or Service.tags onto each spawned Task; the
+    // default ("NONE") leaves the task untagged.
+    let propagated_tags: Vec<TagEntry> = match service.propagate_tags.as_deref() {
+        Some("TASK_DEFINITION") => td.tags.clone(),
+        Some("SERVICE") => service.tags.clone(),
+        _ => Vec::new(),
+    };
+    let service_exec = service.enable_execute_command;
 
     let mut ids = Vec::with_capacity(count as usize);
     for _ in 0..count {
@@ -759,10 +771,11 @@ pub(crate) fn spawn_service_tasks(
             started_by_ref_id: None,
             execution_role_arn: exec_role.clone(),
             task_role_arn: task_role.clone(),
-            tags: Vec::new(),
+            tags: propagated_tags.clone(),
             awslogs,
             captured_logs: String::new(),
             protection: None,
+            enable_execute_command: service_exec,
         };
         state.tasks.insert(task_id.clone(), task);
         if let Some(cluster) = state.clusters.get_mut(&cluster_name) {

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -2114,6 +2114,7 @@ mod tests {
             awslogs: None,
             captured_logs: String::new(),
             protection: None,
+            enable_execute_command: false,
         }
     }
 

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -834,18 +834,28 @@ impl EcsService {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        // Resolve runtime container id.
+        // Resolve runtime container id and gate on the task's
+        // enableExecuteCommand flag. AWS rejects ExecuteCommand on
+        // tasks that didn't opt in (whether launched directly via
+        // RunTask or spawned by a service with enableExecuteCommand=false)
+        // with `InvalidParameterException`.
         let container_id = {
             let accounts = self.state.read();
             let state = accounts
                 .get(&request.account_id)
                 .ok_or_else(|| task_not_found(&task_ref))?;
             let id = task_id_from_ref(&task_ref);
-            state
+            let task = state
                 .tasks
                 .get(&id)
-                .and_then(|t| t.containers.first())
-                .and_then(|c| c.runtime_id.clone())
+                .ok_or_else(|| task_not_found(&task_ref))?;
+            if !task.enable_execute_command {
+                return Err(invalid_parameter(format!(
+                    "The execute command failed because execute command was not enabled when the task ({}) was run or the task is not running.",
+                    task.task_arn
+                )));
+            }
+            task.containers.first().and_then(|c| c.runtime_id.clone())
         };
 
         let session_id = format!("ecs-execute-command-{}", uuid::Uuid::new_v4());

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -331,9 +331,13 @@ impl EcsService {
             let mut spawn: Vec<String> = Vec::new();
             let mut stop: Vec<String> = Vec::new();
 
-            // Tasks belonging to this service (by startedBy convention):
+            // Tasks belonging to this service (by startedBy convention).
+            // Track per-task protection so scale-down skips protected ones
+            // (UpdateTaskProtection). Real AWS only terminates a protected
+            // task when nothing else is eligible.
             let service_tag = format!("ecs-svc/{}", service_name);
-            let current_tasks: Vec<(String, String)> = state
+            let now = Utc::now();
+            let current_tasks: Vec<(String, String, bool)> = state
                 .tasks
                 .iter()
                 .filter(|(_, t)| {
@@ -341,7 +345,14 @@ impl EcsService {
                         && t.cluster_name == cluster_name
                         && t.last_status != "STOPPED"
                 })
-                .map(|(id, t)| (id.clone(), t.task_definition_arn.clone()))
+                .map(|(id, t)| {
+                    let protected = t
+                        .protection
+                        .as_ref()
+                        .filter(|p| p.enabled && p.expiration.is_none_or(|exp| exp > now))
+                        .is_some();
+                    (id.clone(), t.task_definition_arn.clone(), protected)
+                })
                 .collect();
 
             let current_count = current_tasks.len() as i32;
@@ -357,9 +368,28 @@ impl EcsService {
                 );
                 spawn.append(&mut new_ids);
             } else if effective_desired < current_count {
-                let remove = (current_count - effective_desired) as usize;
-                for (id, _) in current_tasks.iter().take(remove) {
-                    stop.push(id.clone());
+                let mut remove = (current_count - effective_desired) as usize;
+                // First pass: drain unprotected tasks. Only fall back to
+                // protected ones when there's nothing else left to stop.
+                for (id, _, protected) in current_tasks.iter() {
+                    if remove == 0 {
+                        break;
+                    }
+                    if !*protected {
+                        stop.push(id.clone());
+                        remove -= 1;
+                    }
+                }
+                if remove > 0 {
+                    for (id, _, protected) in current_tasks.iter() {
+                        if remove == 0 {
+                            break;
+                        }
+                        if *protected && !stop.contains(id) {
+                            stop.push(id.clone());
+                            remove -= 1;
+                        }
+                    }
                 }
             }
 
@@ -380,10 +410,10 @@ impl EcsService {
                 // are skipped here via `stop.contains(id)`).
                 let kept_on_new_td: i32 = current_tasks
                     .iter()
-                    .filter(|(id, t_arn)| *t_arn == new_td_arn_match && !stop.contains(id))
+                    .filter(|(id, t_arn, _)| *t_arn == new_td_arn_match && !stop.contains(id))
                     .count() as i32;
-                for (id, t_arn) in &current_tasks {
-                    if *t_arn != new_td_arn_match && !stop.contains(id) {
+                for (id, t_arn, protected) in &current_tasks {
+                    if *t_arn != new_td_arn_match && !stop.contains(id) && !*protected {
                         stop.push(id.clone());
                     }
                 }

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -73,7 +73,12 @@ impl EcsService {
             .unwrap_or(1) as usize;
         let group = opt_str(&body, "group").map(String::from);
         let started_by = opt_str(&body, "startedBy").map(String::from);
-        let tags = parse_tags(&body);
+        let enable_execute_command = body
+            .get("enableExecuteCommand")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let propagate_tags = opt_str(&body, "propagateTags").map(String::from);
+        let mut tags = parse_tags(&body);
 
         // PassRole trust check on any role overrides supplied via the
         // overrides.taskRoleArn / overrides.executionRoleArn fields.
@@ -124,6 +129,15 @@ impl EcsService {
         let td_task_role = td.task_role_arn.clone();
         let td_exec_role = td.execution_role_arn.clone();
         let td_containers = td.container_definitions.clone();
+        // RunTask supports propagateTags=TASK_DEFINITION to copy the
+        // TaskDefinition's tags onto each spawned task, in addition to
+        // any tags supplied directly in the request body. Real AWS
+        // unions the two sets; explicit tags win on key conflicts.
+        if propagate_tags.as_deref() == Some("TASK_DEFINITION") {
+            let mut td_tags = td.tags.clone();
+            td_tags.retain(|t| !tags.iter().any(|x| x.key == t.key));
+            tags.extend(td_tags);
+        }
 
         let mut spawned_tasks: Vec<String> = Vec::new();
         let mut task_jsons: Vec<Value> = Vec::new();
@@ -253,6 +267,7 @@ impl EcsService {
                 awslogs,
                 captured_logs: String::new(),
                 protection: None,
+                enable_execute_command,
             };
             state.tasks.insert(task_id.clone(), task.clone());
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -637,6 +652,7 @@ mod multi_container_tests {
             awslogs: None,
             captured_logs: String::new(),
             protection: None,
+            enable_execute_command: false,
         };
         for name in ["app", "sidecar"] {
             task.containers.push(Container {
@@ -866,6 +882,7 @@ mod port_mapping_tests {
             awslogs: None,
             captured_logs: String::new(),
             protection: None,
+            enable_execute_command: false,
         };
         task.last_status = "PENDING".into();
         acct.tasks.insert("abc".into(), task);

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -425,6 +425,11 @@ pub struct Task {
     /// Task protection state (UpdateTaskProtection). When set, scale-in
     /// and update-service deployments skip this task until the expiry.
     pub protection: Option<TaskProtection>,
+    /// Whether ECS Exec is enabled on this task. Inherited from the
+    /// owning service's `enableExecuteCommand` flag (or supplied
+    /// directly on RunTask). Gated when `ExecuteCommand` is invoked.
+    #[serde(default)]
+    pub enable_execute_command: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Three ECS surface fields that until now were stored but never read are now enforced end-to-end:

- **ExecuteCommand gate**: rejects with `InvalidParameterException` when the target task did not opt in via `enableExecuteCommand` at RunTask / CreateService time. The flag is plumbed onto `Task` and surfaced through `DescribeTasks`.
- **propagateTags**: when a service is created with `propagateTags=TASK_DEFINITION`, every task it spawns inherits the task definition's tags; `=SERVICE` copies the service's own tags instead. `RunTask` also honors `propagateTags=TASK_DEFINITION` directly. Inherited tags are visible via `ListTagsForResource` on the task ARN and via `DescribeTasks` with `include=TAGS`.
- **ProtectFromScaleIn**: `UpdateService` scale-down now skips tasks whose `protection.enabled=true` (with non-expired window), only falling back to protected tasks when nothing else is left to terminate. Rolling-deployment task drains also respect protection.

## Test plan

- [x] `cargo test -p fakecloud-ecs` (71 unit tests pass)
- [x] `cargo test -p fakecloud-e2e --test ecs_enforce` covers all three behaviors:
  - `execute_command_rejected_when_service_did_not_enable_it`
  - `execute_command_allowed_when_service_enabled_it`
  - `propagate_tags_task_definition_copies_td_tags_onto_tasks`
  - `propagate_tags_service_copies_service_tags_onto_tasks`
  - `update_service_scale_in_skips_protected_tasks`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces ECS Exec opt-in, tag propagation, and task protection during scale-in to match AWS behavior. ExecuteCommand now checks task opt-in, services/RunTask propagate tags, and scale-in skips protected tasks.

- **New Features**
  - ExecuteCommand: rejects with InvalidParameterException if the task didn’t opt in via `enableExecuteCommand`. Flag is stored on `Task` and returned by DescribeTasks.
  - Tag propagation: `propagateTags=TASK_DEFINITION` copies task definition tags to tasks; `=SERVICE` copies service tags. RunTask also supports `TASK_DEFINITION`. Tags show up in ListTagsForResource and DescribeTasks with `include=TAGS`.
  - Task protection: UpdateService scale-in and rolling deployments skip tasks with active protection, only stopping them if nothing else is eligible.

- **Migration**
  - Set `enableExecuteCommand=true` on services or RunTask where tests or tools call ExecuteCommand.
  - Use `propagateTags` if you rely on task-level tags; otherwise behavior is unchanged.
  - No changes needed if you don’t use ExecuteCommand, tag propagation, or task protection.

<sup>Written for commit 7846fc70dad96ce98f49f30fa3d1a82f47deeba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

