### PR TITLE
feat(dynamodb): real PartiQL WHERE evaluator + INSERT validation + stream emission (L4)

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/helpers.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers.rs
@@ -2386,6 +2386,22 @@ pub(crate) fn find_partiql_where_indices(
     where_clause: &str,
     parameters: &[Value],
 ) -> Result<Vec<usize>, AwsServiceError> {
+    // Try the full expression parser first — supports AND/OR/NOT and
+    // parenthesized groups. If the clause doesn't parse cleanly we
+    // fall back to the legacy AND-only path so older callers that
+    // emit non-standard syntax keep matching zero rows instead of
+    // 500-ing.
+    let expr = parse_partiql_where_expr(where_clause, parameters);
+    if let Some(expr) = expr {
+        let mut indices = Vec::new();
+        for (i, item) in table.items.iter().enumerate() {
+            if evaluate_partiql_expr(&expr, item) {
+                indices.push(i);
+            }
+        }
+        return Ok(indices);
+    }
+
     let conditions = split_partiql_and_clauses(where_clause);
     let parsed_conditions = parse_partiql_conditions(&conditions, parameters);
 
@@ -2400,6 +2416,317 @@ pub(crate) fn find_partiql_where_indices(
     }
 
     Ok(indices)
+}
+
+/// AST for a parsed PartiQL WHERE clause. Leaf conditions reuse
+/// [`PartiqlCond`]; the tree adds AND/OR/NOT/parens composition added
+/// in L4 so callers can express anything the DDB FilterExpression
+/// language can.
+#[derive(Debug, Clone)]
+pub(crate) enum PartiqlExpr {
+    Cond(PartiqlCond),
+    And(Box<PartiqlExpr>, Box<PartiqlExpr>),
+    Or(Box<PartiqlExpr>, Box<PartiqlExpr>),
+    Not(Box<PartiqlExpr>),
+}
+
+pub(crate) fn evaluate_partiql_expr(
+    expr: &PartiqlExpr,
+    item: &HashMap<String, AttributeValue>,
+) -> bool {
+    match expr {
+        PartiqlExpr::Cond(c) => evaluate_partiql_cond(c, item),
+        PartiqlExpr::And(l, r) => evaluate_partiql_expr(l, item) && evaluate_partiql_expr(r, item),
+        PartiqlExpr::Or(l, r) => evaluate_partiql_expr(l, item) || evaluate_partiql_expr(r, item),
+        PartiqlExpr::Not(e) => !evaluate_partiql_expr(e, item),
+    }
+}
+
+/// Tokens produced by [`tokenize_partiql_where`]. We keep the original
+/// source slice for `Atom` so the existing condition parser can be
+/// reused without a second tokenizer pass.
+#[derive(Debug, Clone)]
+enum WhereTok<'a> {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Atom(&'a str),
+}
+
+fn tokenize_partiql_where(where_clause: &str) -> Vec<WhereTok<'_>> {
+    let bytes = where_clause.as_bytes();
+    let upper = where_clause.to_ascii_uppercase();
+    let upper_bytes = upper.as_bytes();
+    let mut toks: Vec<WhereTok<'_>> = Vec::new();
+    let mut i = 0usize;
+    let mut atom_start: Option<usize> = None;
+    let mut paren_depth: i32 = 0;
+    let mut in_quote = false;
+    let mut in_atom_paren = 0i32; // tracks `(...)` inside an atom
+
+    fn push_atom<'a>(toks: &mut Vec<WhereTok<'a>>, src: &'a str, start: usize, end: usize) {
+        let slice = src[start..end].trim();
+        if !slice.is_empty() {
+            toks.push(WhereTok::Atom(&src[start..end]));
+        }
+    }
+
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if in_quote {
+            if c == '\'' {
+                in_quote = false;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '\'' {
+            if atom_start.is_none() {
+                atom_start = Some(i);
+            }
+            in_quote = true;
+            i += 1;
+            continue;
+        }
+
+        // Inside an atom, track parens so begins_with(name, 'a') keeps
+        // its inner `(` tied to the atom.
+        if let Some(start) = atom_start {
+            if c == '(' {
+                in_atom_paren += 1;
+                i += 1;
+                continue;
+            }
+            if c == ')' {
+                if in_atom_paren > 0 {
+                    in_atom_paren -= 1;
+                    i += 1;
+                    continue;
+                }
+                // Top-level `)` closes a group — flush the atom first.
+                push_atom(&mut toks, where_clause, start, i);
+                atom_start = None;
+                toks.push(WhereTok::RParen);
+                paren_depth -= 1;
+                i += 1;
+                continue;
+            }
+            // Look for keyword boundaries: AND / OR / NOT surrounded
+            // by whitespace.
+            if c.is_whitespace() && in_atom_paren == 0 {
+                if let Some((kw, len)) = match_where_keyword(upper_bytes, i) {
+                    push_atom(&mut toks, where_clause, start, i);
+                    atom_start = None;
+                    toks.push(kw);
+                    i += len;
+                    continue;
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // Not currently building an atom.
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        if c == '(' {
+            toks.push(WhereTok::LParen);
+            paren_depth += 1;
+            i += 1;
+            continue;
+        }
+        if c == ')' {
+            toks.push(WhereTok::RParen);
+            paren_depth -= 1;
+            i += 1;
+            continue;
+        }
+        // Could be a leading NOT.
+        if let Some((kw, len)) = match_where_keyword_at_start(upper_bytes, i) {
+            toks.push(kw);
+            i += len;
+            continue;
+        }
+        atom_start = Some(i);
+        i += 1;
+    }
+
+    if let Some(start) = atom_start {
+        push_atom(&mut toks, where_clause, start, bytes.len());
+    }
+
+    if paren_depth != 0 || in_quote {
+        return Vec::new();
+    }
+    toks
+}
+
+/// Match ` AND `, ` OR `, ` NOT ` starting at `i` (`i` is the leading
+/// whitespace). Returns the token plus the consumed length so the
+/// scanner can advance past the trailing whitespace too.
+fn match_where_keyword(upper: &[u8], i: usize) -> Option<(WhereTok<'static>, usize)> {
+    // Need: whitespace at i, then keyword, then whitespace or `(`.
+    if i >= upper.len() || !(upper[i] as char).is_whitespace() {
+        return None;
+    }
+    let after = i + 1;
+    let try_kw = |kw: &[u8], tok: WhereTok<'static>| -> Option<(WhereTok<'static>, usize)> {
+        if after + kw.len() > upper.len() {
+            return None;
+        }
+        if &upper[after..after + kw.len()] != kw {
+            return None;
+        }
+        let trail = after + kw.len();
+        if trail >= upper.len() {
+            return Some((tok, trail - i));
+        }
+        let next = upper[trail] as char;
+        if next.is_whitespace() || next == '(' {
+            Some((tok, trail - i))
+        } else {
+            None
+        }
+    };
+    if let Some(r) = try_kw(b"AND", WhereTok::And) {
+        return Some(r);
+    }
+    if let Some(r) = try_kw(b"OR", WhereTok::Or) {
+        return Some(r);
+    }
+    if let Some(r) = try_kw(b"NOT", WhereTok::Not) {
+        return Some(r);
+    }
+    None
+}
+
+/// Match a leading `NOT`/`AND`/`OR` (binary ops appear here when they
+/// follow a `)` token without preceding whitespace). No leading
+/// whitespace requirement — the caller has already skipped it.
+fn match_where_keyword_at_start(upper: &[u8], i: usize) -> Option<(WhereTok<'static>, usize)> {
+    let try_kw = |kw: &[u8], tok: WhereTok<'static>| -> Option<(WhereTok<'static>, usize)> {
+        if i + kw.len() > upper.len() {
+            return None;
+        }
+        if &upper[i..i + kw.len()] != kw {
+            return None;
+        }
+        let trail = i + kw.len();
+        if trail >= upper.len() {
+            return Some((tok, kw.len()));
+        }
+        let next = upper[trail] as char;
+        if next.is_whitespace() || next == '(' {
+            Some((tok, kw.len()))
+        } else {
+            None
+        }
+    };
+    if let Some(r) = try_kw(b"NOT", WhereTok::Not) {
+        return Some(r);
+    }
+    if let Some(r) = try_kw(b"AND", WhereTok::And) {
+        return Some(r);
+    }
+    if let Some(r) = try_kw(b"OR", WhereTok::Or) {
+        return Some(r);
+    }
+    None
+}
+
+/// Parse a WHERE clause into [`PartiqlExpr`]. Returns `None` when the
+/// clause has no logical operators OR fails to parse — callers fall
+/// back to the legacy AND-only evaluator in that case.
+pub(crate) fn parse_partiql_where_expr(
+    where_clause: &str,
+    parameters: &[Value],
+) -> Option<PartiqlExpr> {
+    let toks = tokenize_partiql_where(where_clause);
+    if toks.is_empty() {
+        return None;
+    }
+    let mut idx = 0usize;
+    let mut param_idx = 0usize;
+    let expr = parse_or(&toks, &mut idx, parameters, &mut param_idx)?;
+    if idx != toks.len() {
+        return None;
+    }
+    Some(expr)
+}
+
+fn parse_or(
+    toks: &[WhereTok<'_>],
+    i: &mut usize,
+    params: &[Value],
+    param_idx: &mut usize,
+) -> Option<PartiqlExpr> {
+    let mut left = parse_and(toks, i, params, param_idx)?;
+    while matches!(toks.get(*i), Some(WhereTok::Or)) {
+        *i += 1;
+        let right = parse_and(toks, i, params, param_idx)?;
+        left = PartiqlExpr::Or(Box::new(left), Box::new(right));
+    }
+    Some(left)
+}
+
+fn parse_and(
+    toks: &[WhereTok<'_>],
+    i: &mut usize,
+    params: &[Value],
+    param_idx: &mut usize,
+) -> Option<PartiqlExpr> {
+    let mut left = parse_not(toks, i, params, param_idx)?;
+    while matches!(toks.get(*i), Some(WhereTok::And)) {
+        *i += 1;
+        let right = parse_not(toks, i, params, param_idx)?;
+        left = PartiqlExpr::And(Box::new(left), Box::new(right));
+    }
+    Some(left)
+}
+
+fn parse_not(
+    toks: &[WhereTok<'_>],
+    i: &mut usize,
+    params: &[Value],
+    param_idx: &mut usize,
+) -> Option<PartiqlExpr> {
+    if matches!(toks.get(*i), Some(WhereTok::Not)) {
+        *i += 1;
+        let inner = parse_not(toks, i, params, param_idx)?;
+        return Some(PartiqlExpr::Not(Box::new(inner)));
+    }
+    parse_primary(toks, i, params, param_idx)
+}
+
+fn parse_primary(
+    toks: &[WhereTok<'_>],
+    i: &mut usize,
+    params: &[Value],
+    param_idx: &mut usize,
+) -> Option<PartiqlExpr> {
+    match toks.get(*i)? {
+        WhereTok::LParen => {
+            *i += 1;
+            let inner = parse_or(toks, i, params, param_idx)?;
+            if !matches!(toks.get(*i), Some(WhereTok::RParen)) {
+                return None;
+            }
+            *i += 1;
+            Some(inner)
+        }
+        WhereTok::Atom(s) => {
+            *i += 1;
+            // Each atom may consume one or more `?` parameters; track
+            // them globally so the order matches statement order.
+            let cond = parse_one_partiql_condition(s.trim(), params, param_idx)?;
+            Some(PartiqlExpr::Cond(cond))
+        }
+        _ => None,
+    }
 }
 
 /// A parsed PartiQL WHERE clause condition. Equality remains the

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -3700,6 +3700,223 @@ fn partiql_insert_rejects_wrong_key_type() {
     assert!(dbg.contains("Type mismatch for key pk"), "got {dbg}");
 }
 
+#[test]
+fn partiql_select_and_or_not_parens() {
+    // L4: WHERE composition with AND/OR/NOT and parens. The AND-only
+    // legacy splitter cannot express these, so this exercises the
+    // recursive expression parser.
+    let svc = make_service();
+    seed_partiql_corpus(&svc);
+
+    // OR — match the lower and upper edges.
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE score < 15 OR score > 35"
+        ),
+        vec!["a", "d"]
+    );
+    // NOT inverts a comparator predicate.
+    assert_eq!(
+        pks_from_select(&svc, "SELECT * FROM \"test-table\" WHERE NOT score >= 30"),
+        vec!["a", "b"]
+    );
+    // Parens force OR to bind tighter than AND.
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE (score < 15 OR score > 35) AND name <> 'unused'",
+        ),
+        vec!["a", "d"]
+    );
+    // Mixed AND/OR without parens — AND binds tighter.
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE score = 10 OR score = 20 AND name = 'beta'",
+        ),
+        vec!["a", "b"]
+    );
+}
+
+#[test]
+fn partiql_select_filter_with_like_and_gt() {
+    // L4 spec: `SELECT * FROM "T" WHERE n > 5 AND s LIKE 'foo%'`
+    // returns the right subset.
+    let svc = make_service();
+    create_test_table(&svc);
+    for (pk, n, s) in [
+        ("k1", 1, "foobar"),
+        ("k2", 6, "foobar"),
+        ("k3", 6, "barfoo"),
+        ("k4", 9, "fooz"),
+    ] {
+        svc.put_item(&make_request(
+            "PutItem",
+            json!({
+                "TableName": "test-table",
+                "Item": {
+                    "pk": {"S": pk},
+                    "n": {"N": n.to_string()},
+                    "s": {"S": s},
+                },
+            }),
+        ))
+        .unwrap();
+    }
+    assert_eq!(
+        pks_from_select(
+            &svc,
+            "SELECT * FROM \"test-table\" WHERE n > 5 AND s LIKE 'foo%'"
+        ),
+        vec!["k2", "k4"]
+    );
+}
+
+#[test]
+fn partiql_update_emits_stream_record() {
+    // L4: UPDATE statements on a stream-enabled table must emit a
+    // MODIFY stream record mirroring the UpdateItem path.
+    let svc = make_service();
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "T",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST",
+            "StreamSpecification": {
+                "StreamEnabled": true,
+                "StreamViewType": "NEW_AND_OLD_IMAGES"
+            }
+        }),
+    );
+    svc.create_table(&req).unwrap();
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({"TableName": "T", "Item": {"pk": {"S": "u1"}, "v": {"N": "1"}}}),
+    ))
+    .unwrap();
+
+    let baseline = {
+        let s = svc.state.read();
+        let n = s
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("T")
+            .unwrap()
+            .stream_records
+            .read()
+            .len();
+        n
+    };
+
+    svc.execute_statement(&make_request(
+        "ExecuteStatement",
+        json!({"Statement": "UPDATE \"T\" SET v = 99 WHERE pk = 'u1'"}),
+    ))
+    .unwrap();
+
+    let after = {
+        let s = svc.state.read();
+        let t = s.get("123456789012").unwrap().tables.get("T").unwrap();
+        let recs = t.stream_records.read();
+        let last = recs.last().cloned();
+        (recs.len(), last)
+    };
+    assert_eq!(after.0, baseline + 1);
+    assert_eq!(after.1.unwrap().event_name, "MODIFY");
+}
+
+#[test]
+fn partiql_delete_emits_stream_record() {
+    // L4: DELETE statements must emit a REMOVE stream record.
+    let svc = make_service();
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "T",
+            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "BillingMode": "PAY_PER_REQUEST",
+            "StreamSpecification": {
+                "StreamEnabled": true,
+                "StreamViewType": "NEW_AND_OLD_IMAGES"
+            }
+        }),
+    );
+    svc.create_table(&req).unwrap();
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({"TableName": "T", "Item": {"pk": {"S": "d1"}}}),
+    ))
+    .unwrap();
+
+    let baseline = {
+        let s = svc.state.read();
+        let n = s
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("T")
+            .unwrap()
+            .stream_records
+            .read()
+            .len();
+        n
+    };
+
+    svc.execute_statement(&make_request(
+        "ExecuteStatement",
+        json!({"Statement": "DELETE FROM \"T\" WHERE pk = 'd1'"}),
+    ))
+    .unwrap();
+
+    let after = {
+        let s = svc.state.read();
+        let t = s.get("123456789012").unwrap().tables.get("T").unwrap();
+        let recs = t.stream_records.read();
+        let last = recs.last().cloned();
+        (recs.len(), last)
+    };
+    assert_eq!(after.0, baseline + 1);
+    assert_eq!(after.1.unwrap().event_name, "REMOVE");
+}
+
+#[test]
+fn partiql_insert_rejects_missing_sort_key() {
+    // L4: composite-key tables must reject INSERTs that omit the sort
+    // key, matching the partition-key-only check.
+    let svc = make_service();
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "T",
+            "KeySchema": [
+                {"AttributeName": "pk", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"}
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"}
+            ],
+            "BillingMode": "PAY_PER_REQUEST"
+        }),
+    );
+    svc.create_table(&req).unwrap();
+    let err = svc
+        .execute_statement(&make_request(
+            "ExecuteStatement",
+            json!({"Statement": "INSERT INTO \"T\" VALUE {'pk': 'a'}"}),
+        ))
+        .err()
+        .expect("missing sort key");
+    let dbg = format!("{err:?}");
+    assert!(dbg.contains("ValidationException"), "got {dbg}");
+    assert!(dbg.contains("Missing the key sk"), "got {dbg}");
+}
+
 // ── Batch write with delete ──
 
 #[test]

--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -1,0 +1,381 @@
+//! L4 — DynamoDB PartiQL WHERE-clause + INSERT validation + stream
+//! emission end-to-end coverage. Drives the live AWS Rust SDK against
+//! `ExecuteStatement` so any drift between our PartiQL evaluator and
+//! the SDK's wire format surfaces immediately. The unit tests in
+//! `crates/fakecloud-dynamodb/src/service/tests.rs` cover the same
+//! behaviors against the in-process service; this file proves the
+//! flow round-trips through the real HTTP layer.
+
+mod helpers;
+
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ScalarAttributeType, StreamSpecification, StreamViewType,
+};
+use helpers::TestServer;
+
+async fn create_streamed_table(ddb: &aws_sdk_dynamodb::Client, name: &str) {
+    ddb.create_table()
+        .table_name(name)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .stream_specification(
+            StreamSpecification::builder()
+                .stream_enabled(true)
+                .stream_view_type(StreamViewType::NewAndOldImages)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn put_row(ddb: &aws_sdk_dynamodb::Client, table: &str, pk: &str, n: i64, s: &str) {
+    ddb.put_item()
+        .table_name(table)
+        .item("pk", AttributeValue::S(pk.into()))
+        .item("n", AttributeValue::N(n.to_string()))
+        .item("s", AttributeValue::S(s.into()))
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn select_pks(ddb: &aws_sdk_dynamodb::Client, statement: &str) -> Vec<String> {
+    let resp = ddb
+        .execute_statement()
+        .statement(statement)
+        .send()
+        .await
+        .unwrap();
+    let mut pks: Vec<String> = resp
+        .items()
+        .iter()
+        .map(|it| it.get("pk").unwrap().as_s().unwrap().clone())
+        .collect();
+    pks.sort();
+    pks
+}
+
+#[tokio::test]
+async fn ddb_partiql_select_n_gt_5_and_s_like_foo() {
+    // L4 spec example: SELECT * FROM "T" WHERE n > 5 AND s LIKE 'foo%'
+    // returns the right subset.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "L4PartiqlSelectAnd";
+    create_streamed_table(&ddb, table).await;
+
+    put_row(&ddb, table, "k1", 1, "foobar").await; // n too low
+    put_row(&ddb, table, "k2", 6, "foobar").await; // matches
+    put_row(&ddb, table, "k3", 6, "barfoo").await; // wrong prefix
+    put_row(&ddb, table, "k4", 9, "fooz").await; // matches
+
+    let pks = select_pks(
+        &ddb,
+        &format!("SELECT * FROM \"{table}\" WHERE n > 5 AND s LIKE 'foo%'"),
+    )
+    .await;
+    assert_eq!(pks, vec!["k2", "k4"]);
+}
+
+#[tokio::test]
+async fn ddb_partiql_select_or_not_parens() {
+    // L4 spec: WHERE composition with AND/OR/NOT and parens. Each
+    // sub-form exercises a different branch of the recursive parser.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "L4PartiqlSelectOrNotParens";
+    create_streamed_table(&ddb, table).await;
+
+    for (pk, n) in [("a", 10_i64), ("b", 20), ("c", 30), ("d", 40)] {
+        ddb.put_item()
+            .table_name(table)
+            .item("pk", AttributeValue::S(pk.into()))
+            .item("n", AttributeValue::N(n.to_string()))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // OR — match the lower and upper edges.
+    assert_eq!(
+        select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE n < 15 OR n > 35")
+        )
+        .await,
+        vec!["a", "d"]
+    );
+    // NOT inverts a comparator.
+    assert_eq!(
+        select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE NOT n >= 30")
+        )
+        .await,
+        vec!["a", "b"]
+    );
+    // Parens force OR to bind tighter than AND.
+    assert_eq!(
+        select_pks(
+            &ddb,
+            &format!("SELECT * FROM \"{table}\" WHERE (n < 15 OR n > 35) AND attribute_exists(pk)"),
+        )
+        .await,
+        vec!["a", "d"]
+    );
+}
+
+#[tokio::test]
+async fn ddb_partiql_insert_missing_sort_key_validation() {
+    // L4 spec: INSERT with missing sort key returns ValidationException.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let table = "L4PartiqlMissingSk";
+
+    ddb.create_table()
+        .table_name(table)
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("sk")
+                .key_type(KeyType::Range)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("sk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let err = ddb
+        .execute_statement()
+        .statement(format!("INSERT INTO \"{table}\" VALUE {{'pk': 'a'}}"))
+        .send()
+        .await
+        .expect_err("insert without sort key must fail");
+    let msg = format!("{:?}", err.into_service_error());
+    assert!(msg.contains("ValidationException"), "got {msg}");
+    assert!(msg.contains("Missing the key sk"), "got {msg}");
+}
+
+#[tokio::test]
+async fn ddb_partiql_update_emits_stream_record() {
+    // L4 spec: UPDATE statement on a stream-enabled table emits a
+    // MODIFY stream record visible via the Streams data plane.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+    let table = "L4PartiqlUpdateStream";
+
+    create_streamed_table(&ddb, table).await;
+    put_row(&ddb, table, "u1", 1, "x").await;
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+    let shard_id = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap()
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+
+    // Snapshot baseline shard length so we count only what the UPDATE
+    // adds on top of the seeding PutItem.
+    let baseline_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let baseline_len = streams
+        .get_records()
+        .shard_iterator(baseline_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap()
+        .records()
+        .len();
+
+    ddb.execute_statement()
+        .statement(format!("UPDATE \"{table}\" SET n = 99 WHERE pk = 'u1'"))
+        .send()
+        .await
+        .unwrap();
+
+    let after_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let after = streams
+        .get_records()
+        .shard_iterator(after_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.records().len(),
+        baseline_len + 1,
+        "UPDATE must emit exactly one stream record"
+    );
+    assert_eq!(
+        after
+            .records()
+            .last()
+            .unwrap()
+            .event_name()
+            .unwrap()
+            .as_str(),
+        "MODIFY",
+    );
+}
+
+#[tokio::test]
+async fn ddb_partiql_delete_emits_stream_record() {
+    // L4 spec: DELETE statement on a stream-enabled table emits a
+    // REMOVE stream record visible via the Streams data plane.
+    let server = TestServer::start().await;
+    let ddb = server.dynamodb_client().await;
+    let streams = server.dynamodb_streams_client().await;
+    let table = "L4PartiqlDeleteStream";
+
+    create_streamed_table(&ddb, table).await;
+    put_row(&ddb, table, "d1", 1, "x").await;
+
+    let stream_arn = ddb
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .unwrap()
+        .table()
+        .unwrap()
+        .latest_stream_arn()
+        .unwrap()
+        .to_string();
+    let shard_id = streams
+        .describe_stream()
+        .stream_arn(&stream_arn)
+        .send()
+        .await
+        .unwrap()
+        .stream_description()
+        .unwrap()
+        .shards()
+        .first()
+        .unwrap()
+        .shard_id()
+        .unwrap()
+        .to_string();
+
+    let baseline_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let baseline_len = streams
+        .get_records()
+        .shard_iterator(baseline_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap()
+        .records()
+        .len();
+
+    ddb.execute_statement()
+        .statement(format!("DELETE FROM \"{table}\" WHERE pk = 'd1'"))
+        .send()
+        .await
+        .unwrap();
+
+    let after_iter = streams
+        .get_shard_iterator()
+        .stream_arn(&stream_arn)
+        .shard_id(&shard_id)
+        .shard_iterator_type(aws_sdk_dynamodbstreams::types::ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+    let after = streams
+        .get_records()
+        .shard_iterator(after_iter.shard_iterator().unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.records().len(),
+        baseline_len + 1,
+        "DELETE must emit exactly one stream record"
+    );
+    assert_eq!(
+        after
+            .records()
+            .last()
+            .unwrap()
+            .event_name()
+            .unwrap()
+            .as_str(),
+        "REMOVE",
+    );
+}


### PR DESCRIPTION
## Summary
- Recursive WHERE parser for PartiQL: AND / OR / NOT / parens compose on top of the existing leaf predicates (= <> < <= > >= IN BETWEEN LIKE contains begins_with attribute_exists attribute_not_exists).
- INSERT now validates the full key schema (partition + sort) and rejects ValidationException with the AWS-shaped message when either key attribute is missing.
- UPDATE / DELETE emit DDB stream records + Kinesis deliveries on every matched row, mirroring items.rs::put_item / delete_item.
- New E2E suite `crates/fakecloud-e2e/tests/ddb_partiql_filter.rs` covers AND/OR/NOT/parens, missing-sort-key validation, and UPDATE/DELETE stream emission via the real AWS SDK + DynamoDBStreams data plane.

The legacy AND-only evaluator stays as a fallback when the recursive parser can't grok a clause, so any shape today's SDKs already accept keeps matching the same rows.

## Test plan
- [x] `cargo test -p fakecloud-dynamodb` (263 tests, including 5 new partiql tests)
- [x] `cargo test -p fakecloud-e2e --test ddb_partiql_filter` (5 tests)
- [x] `cargo test -p fakecloud-e2e --test dynamodb` (63 tests, no regressions)
- [x] `cargo clippy -p fakecloud-dynamodb --all-targets -- -D warnings`
- [x] `cargo clippy -p fakecloud-e2e --tests -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real PartiQL WHERE evaluator with AND/OR/NOT and parentheses, plus INSERT key validation and Streams emission for UPDATE/DELETE to better match AWS DynamoDB behavior. Falls back to the old AND-only path when a clause can’t be parsed so existing clients keep working.

- **New Features**
  - Recursive WHERE parser supports AND/OR/NOT and parentheses over existing predicates.
  - INSERT validates both partition and sort keys; returns AWS-shaped ValidationException when missing.
  - UPDATE/DELETE emit DynamoDB Streams records and Kinesis deliveries for each matched item, mirroring PutItem/DeleteItem.
  - New unit and E2E tests cover logical composition, missing sort-key validation, and stream emission.

<sup>Written for commit 7fb12f179cdd2ebd698386f4a1b7c39a6888a5be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

