### PR TITLE
feat(application-autoscaling): scheduled action executor + cross-service apply (EE4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "chrono-tz",
  "fakecloud-aws",
  "fakecloud-core",
  "http 1.4.0",

--- a/crates/fakecloud-application-autoscaling/Cargo.toml
+++ b/crates/fakecloud-application-autoscaling/Cargo.toml
@@ -12,6 +12,7 @@ fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/fakecloud-application-autoscaling/src/lib.rs
+++ b/crates/fakecloud-application-autoscaling/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod hooks;
+pub mod scheduled_executor;
 pub(crate) mod service;
 pub(crate) mod state;
 pub mod ticker;
 
 pub use hooks::{DynamoDbCapacityHook, MetricReader};
+pub use scheduled_executor::ScheduledActionExecutor;
 pub use service::ApplicationAutoScalingService;
 pub use state::{ApplicationAutoScalingAccounts, SharedApplicationAutoScalingState};
 pub use ticker::ScalingWatcher;

--- a/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
+++ b/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
@@ -1,0 +1,714 @@
+//! Background executor that fires Application Auto Scaling
+//! `ScheduledAction`s when their `Schedule` expression is due.
+//!
+//! AWS supports two expression forms here:
+//! - `at(yyyy-mm-ddThh:mm:ss)` — fires once when wall-clock catches up
+//! - `cron(min hour dom month dow year)` — recurring; the six-field
+//!   cron grammar matches EventBridge Scheduler. We support wildcards
+//!   (`*` / `?`) and single numeric values per field; ranges/lists/step
+//!   values are rejected so unsupported schedules silently never fire
+//!   instead of firing every minute.
+//!
+//! When an action is due, the executor:
+//!   1. Mutates the matching `ScalableTarget` `min_capacity` /
+//!      `max_capacity` per the action's `ScalableTargetAction`.
+//!   2. Calls into the configured cross-service hook to apply the new
+//!      bounds on the underlying resource (DynamoDB capacity today;
+//!      ECS/RDS hooks slot in alongside as those are wired).
+//!   3. Appends a `ScalingActivity` row so `DescribeScalingActivities`
+//!      surfaces the firing.
+//!   4. Records `last_fired_at` so the next tick within the same
+//!      minute doesn't re-fire a `cron(* * * * ? *)` schedule.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc};
+use uuid::Uuid;
+
+use crate::hooks::DynamoDbCapacityHook;
+use crate::state::{ScalingActivity, ScheduledAction, SharedApplicationAutoScalingState};
+use crate::ticker::{ddb_table_from_resource_public, DDB_READ_DIM, DDB_WRITE_DIM};
+
+/// Background loop driver. Construction wires the shared state and the
+/// hooks that apply scaling decisions on real resources.
+pub struct ScheduledActionExecutor {
+    state: SharedApplicationAutoScalingState,
+    ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+    region: String,
+    interval: Duration,
+}
+
+impl ScheduledActionExecutor {
+    pub fn new(
+        state: SharedApplicationAutoScalingState,
+        ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+        region: impl Into<String>,
+    ) -> Self {
+        Self {
+            state,
+            ddb_hook,
+            region: region.into(),
+            interval: Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    /// Drive a single evaluation. Exposed for the admin tick endpoint
+    /// and tests so callers don't have to wait on the wall-clock
+    /// interval. Returns the number of actions that fired this tick.
+    pub fn tick_once(&self) -> usize {
+        self.tick_at(Utc::now())
+    }
+
+    /// Same as `tick_once`, but evaluates against an explicit `now`.
+    /// Useful for unit tests that need to pin the wall clock.
+    pub fn tick_at(&self, now: DateTime<Utc>) -> usize {
+        // Snapshot due actions under a read lock so we can release it
+        // before invoking cross-service hooks (which may take other
+        // locks downstream).
+        struct Job {
+            account_id: String,
+            action_key: (String, String, String, String),
+            action: ScheduledAction,
+        }
+        let mut jobs: Vec<Job> = Vec::new();
+        {
+            let guard = self.state.read();
+            for (account_id, account) in guard.accounts.iter() {
+                for (key, action) in account.scheduled_actions.iter() {
+                    if !is_due(action, now) {
+                        continue;
+                    }
+                    // Skip when the linked target has scheduled
+                    // scaling explicitly suspended.
+                    let target_key = (
+                        action.service_namespace.clone(),
+                        action.resource_id.clone(),
+                        action.scalable_dimension.clone().unwrap_or_default(),
+                    );
+                    if let Some(target) = account.scalable_targets.get(&target_key) {
+                        if target
+                            .suspended_state
+                            .as_ref()
+                            .and_then(|s| s.scheduled_scaling_suspended)
+                            .unwrap_or(false)
+                        {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                    jobs.push(Job {
+                        account_id: account_id.clone(),
+                        action_key: key.clone(),
+                        action: action.clone(),
+                    });
+                }
+            }
+        }
+
+        let mut fired = 0;
+        for job in jobs {
+            if self.fire_action(&job.account_id, &job.action_key, &job.action, now) {
+                fired += 1;
+            }
+        }
+        fired
+    }
+
+    /// Long-running loop that ticks at `self.interval` until the
+    /// process exits. Skips the immediate first tick — the server is
+    /// still wiring services up.
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.interval);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let _ = self.tick_once();
+        }
+    }
+
+    fn fire_action(
+        &self,
+        account_id: &str,
+        action_key: &(String, String, String, String),
+        action: &ScheduledAction,
+        now: DateTime<Utc>,
+    ) -> bool {
+        let Some(target_action) = action.scalable_target_action.as_ref() else {
+            // Without a ScalableTargetAction there's nothing to apply;
+            // mark fired so we don't loop. AWS rejects this at create
+            // time, but defensive here for forward-compat.
+            self.record_fire(
+                account_id,
+                action_key,
+                action,
+                now,
+                "Failed",
+                Some("ScheduledAction has no ScalableTargetAction".to_string()),
+            );
+            return false;
+        };
+
+        // Snapshot existing target bounds so we know what we're moving from.
+        let target_key = (
+            action.service_namespace.clone(),
+            action.resource_id.clone(),
+            action.scalable_dimension.clone().unwrap_or_default(),
+        );
+        let (prev_min, prev_max) = {
+            let guard = self.state.read();
+            let Some(account) = guard.accounts.get(account_id) else {
+                return false;
+            };
+            let Some(target) = account.scalable_targets.get(&target_key) else {
+                return false;
+            };
+            (target.min_capacity, target.max_capacity)
+        };
+
+        let new_min = target_action.min_capacity.unwrap_or(prev_min);
+        let new_max = target_action.max_capacity.unwrap_or(prev_max);
+        // AWS rejects min > max with a `ValidationException` at PUT
+        // time, but the bounds may have drifted since (someone could
+        // re-RegisterScalableTarget with tighter bounds). Clamp rather
+        // than fail-loudly so the executor stays robust.
+        let (new_min, new_max) = if new_min > new_max {
+            (new_max, new_max)
+        } else {
+            (new_min, new_max)
+        };
+
+        // Apply across-service. Today only DynamoDB has a wired hook.
+        // Other namespaces (ECS, RDS, Lambda, Aurora) update the
+        // ScalableTarget bounds and emit a ScalingActivity but don't
+        // mutate the underlying resource until those hooks exist.
+        let apply_result = self.apply_to_resource(account_id, action, new_min, new_max);
+        let (status, message) = match apply_result {
+            Ok(()) => ("Successful".to_string(), None),
+            Err(err) => ("Failed".to_string(), Some(err)),
+        };
+
+        // Mutate the ScalableTarget bounds + record the activity + bump
+        // last_fired_at under a single write lock so observers see a
+        // consistent view.
+        let mut guard = self.state.write();
+        let account = guard.accounts.entry(account_id.to_string()).or_default();
+        if let Some(target) = account.scalable_targets.get_mut(&target_key) {
+            target.min_capacity = new_min;
+            target.max_capacity = new_max;
+        }
+        if let Some(stored) = account.scheduled_actions.get_mut(action_key) {
+            stored.last_fired_at = Some(now);
+        }
+        account.scaling_activities.push(ScalingActivity {
+            activity_id: Uuid::new_v4().to_string(),
+            service_namespace: action.service_namespace.clone(),
+            resource_id: action.resource_id.clone(),
+            scalable_dimension: action.scalable_dimension.clone().unwrap_or_default(),
+            description: format!(
+                "Setting min capacity to {new_min} and max capacity to {new_max} for {res} from scheduled action {name}",
+                res = action.resource_id,
+                name = action.scheduled_action_name,
+            ),
+            cause: format!(
+                "Scheduled action {name} fired (schedule: {schedule})",
+                name = action.scheduled_action_name,
+                schedule = action.schedule,
+            ),
+            start_time: now,
+            end_time: Some(now),
+            status_code: status.clone(),
+            status_message: message,
+            details: None,
+            not_scaled_reasons: Vec::new(),
+        });
+
+        status == "Successful"
+    }
+
+    fn apply_to_resource(
+        &self,
+        account_id: &str,
+        action: &ScheduledAction,
+        new_min: i32,
+        new_max: i32,
+    ) -> Result<(), String> {
+        match action.service_namespace.as_str() {
+            "dynamodb" => {
+                let Some(dimension) = action.scalable_dimension.as_deref() else {
+                    return Err(
+                        "ScalableDimension is required for dynamodb scheduled actions".to_string(),
+                    );
+                };
+                let Some(table) = ddb_table_from_resource_public(&action.resource_id) else {
+                    return Err(format!(
+                        "Cannot derive DynamoDB table from resource_id {}",
+                        action.resource_id
+                    ));
+                };
+                // Pull current capacity so we know whether to bump up
+                // or leave alone. AWS scheduled actions move capacity
+                // to ScalableTargetAction.MinCapacity if the current
+                // value is below it (and analogously for the max).
+                let Some((read_cur, write_cur)) =
+                    self.ddb_hook
+                        .current_capacity(account_id, &self.region, table)
+                else {
+                    return Err(format!(
+                        "DynamoDB table {table} not found or not on PROVISIONED billing"
+                    ));
+                };
+                let current = match dimension {
+                    DDB_READ_DIM => read_cur,
+                    DDB_WRITE_DIM => write_cur,
+                    other => {
+                        return Err(format!("Unsupported DynamoDB scalable dimension {other}"));
+                    }
+                };
+                // Pin capacity into the new [min, max] window.
+                let mut desired = current;
+                if desired < new_min as i64 {
+                    desired = new_min as i64;
+                }
+                if desired > new_max as i64 {
+                    desired = new_max as i64;
+                }
+                if desired == current {
+                    return Ok(());
+                }
+                let (read, write) = match dimension {
+                    DDB_READ_DIM => (Some(desired), None),
+                    DDB_WRITE_DIM => (None, Some(desired)),
+                    _ => unreachable!("dimension validated above"),
+                };
+                self.ddb_hook
+                    .set_capacity(account_id, &self.region, table, read, write)
+            }
+            // Other namespaces don't yet have a cross-service apply
+            // hook in this crate. Updating the scalable target bounds
+            // is still useful — when those hooks land they'll observe
+            // the new bounds on the next reconciliation.
+            _ => Ok(()),
+        }
+    }
+
+    fn record_fire(
+        &self,
+        account_id: &str,
+        action_key: &(String, String, String, String),
+        action: &ScheduledAction,
+        now: DateTime<Utc>,
+        status: &str,
+        message: Option<String>,
+    ) {
+        let mut guard = self.state.write();
+        let account = guard.accounts.entry(account_id.to_string()).or_default();
+        if let Some(stored) = account.scheduled_actions.get_mut(action_key) {
+            stored.last_fired_at = Some(now);
+        }
+        account.scaling_activities.push(ScalingActivity {
+            activity_id: Uuid::new_v4().to_string(),
+            service_namespace: action.service_namespace.clone(),
+            resource_id: action.resource_id.clone(),
+            scalable_dimension: action.scalable_dimension.clone().unwrap_or_default(),
+            description: format!(
+                "Scheduled action {name} could not fire",
+                name = action.scheduled_action_name,
+            ),
+            cause: format!(
+                "Scheduled action {name} (schedule: {schedule})",
+                name = action.scheduled_action_name,
+                schedule = action.schedule,
+            ),
+            start_time: now,
+            end_time: Some(now),
+            status_code: status.to_string(),
+            status_message: message,
+            details: None,
+            not_scaled_reasons: Vec::new(),
+        });
+    }
+}
+
+/// Parse a `Schedule` expression and decide whether it's due.
+///
+/// Honours the action's `start_time` / `end_time` window: the action
+/// is silent before `start_time` and after `end_time`. Re-fire dedup
+/// for cron schedules lives in `last_fired_at` — we never re-fire
+/// inside the same minute.
+fn is_due(action: &ScheduledAction, now: DateTime<Utc>) -> bool {
+    if let Some(start) = action.start_time {
+        if now < start {
+            return false;
+        }
+    }
+    if let Some(end) = action.end_time {
+        if now > end {
+            return false;
+        }
+    }
+    let schedule = action.schedule.trim();
+    if let Some(inner) = schedule
+        .strip_prefix("at(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        return is_at_due(inner, action.last_fired_at, now);
+    }
+    if let Some(inner) = schedule
+        .strip_prefix("cron(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        return is_cron_due(inner, action.timezone.as_deref(), action.last_fired_at, now);
+    }
+    // Unknown schedule shape — never fires. Matches AWS behavior of
+    // silently skipping schedules with malformed expressions rather
+    // than blowing up the executor loop.
+    false
+}
+
+fn is_at_due(inner: &str, last_fired: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    if last_fired.is_some() {
+        return false;
+    }
+    let dt = match NaiveDateTime::parse_from_str(inner.trim(), "%Y-%m-%dT%H:%M:%S") {
+        Ok(dt) => Utc.from_utc_datetime(&dt),
+        Err(_) => return false,
+    };
+    now >= dt
+}
+
+fn is_cron_due(
+    inner: &str,
+    tz: Option<&str>,
+    last_fired: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> bool {
+    let parts: Vec<&str> = inner.split_whitespace().collect();
+    if parts.len() != 6 {
+        return false;
+    }
+    let minute = parse_cron_field(parts[0]);
+    let hour = parse_cron_field(parts[1]);
+    let dom = parse_cron_field(parts[2]);
+    let month = parse_cron_field(parts[3]);
+    let dow = parse_cron_field(parts[4]);
+    let (Some(minute), Some(hour), Some(dom), Some(month), Some(dow)) =
+        (minute, hour, dom, month, dow)
+    else {
+        return false;
+    };
+    let (m, h, d, mo, w) = match tz.and_then(|s| s.parse::<chrono_tz::Tz>().ok()) {
+        Some(tz) => {
+            let local = now.with_timezone(&tz);
+            (
+                local.minute(),
+                local.hour(),
+                local.day(),
+                local.month(),
+                local.weekday().num_days_from_sunday(),
+            )
+        }
+        None => (
+            now.minute(),
+            now.hour(),
+            now.day(),
+            now.month(),
+            now.weekday().num_days_from_sunday(),
+        ),
+    };
+    if !field_matches(&minute, m)
+        || !field_matches(&hour, h)
+        || !field_matches(&dom, d)
+        || !field_matches(&month, mo)
+        || !field_matches(&dow, w)
+    {
+        return false;
+    }
+    // Per-minute dedupe: never re-fire within the same wall-clock
+    // minute. Match scheduler semantics — `last_fired_at` is set
+    // immediately after a fire, so the very next tick within that
+    // minute must skip.
+    if let Some(last) = last_fired {
+        if same_minute(last, now) {
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Clone, Copy)]
+enum CronField {
+    Any,
+    Value(u32),
+}
+
+fn parse_cron_field(s: &str) -> Option<CronField> {
+    if s == "*" || s == "?" {
+        return Some(CronField::Any);
+    }
+    s.parse::<u32>().ok().map(CronField::Value)
+}
+
+fn field_matches(f: &CronField, actual: u32) -> bool {
+    match f {
+        CronField::Any => true,
+        CronField::Value(v) => *v == actual,
+    }
+}
+
+fn same_minute(a: DateTime<Utc>, b: DateTime<Utc>) -> bool {
+    a.year() == b.year()
+        && a.month() == b.month()
+        && a.day() == b.day()
+        && a.hour() == b.hour()
+        && a.minute() == b.minute()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{
+        ApplicationAutoScalingAccounts, ScalableTarget, ScalableTargetAction, ScheduledAction,
+    };
+    use parking_lot::RwLock;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::Mutex;
+
+    struct StubDdb {
+        read: AtomicI64,
+        write: AtomicI64,
+        calls: Mutex<Vec<(Option<i64>, Option<i64>)>>,
+    }
+    impl DynamoDbCapacityHook for StubDdb {
+        fn current_capacity(&self, _a: &str, _r: &str, _t: &str) -> Option<(i64, i64)> {
+            Some((
+                self.read.load(Ordering::Relaxed),
+                self.write.load(Ordering::Relaxed),
+            ))
+        }
+        fn set_capacity(
+            &self,
+            _a: &str,
+            _r: &str,
+            _t: &str,
+            read: Option<i64>,
+            write: Option<i64>,
+        ) -> Result<(), String> {
+            if let Some(r) = read {
+                self.read.store(r, Ordering::Relaxed);
+            }
+            if let Some(w) = write {
+                self.write.store(w, Ordering::Relaxed);
+            }
+            self.calls.lock().unwrap().push((read, write));
+            Ok(())
+        }
+    }
+
+    fn fixture() -> (SharedApplicationAutoScalingState, Arc<StubDdb>) {
+        let state: SharedApplicationAutoScalingState =
+            Arc::new(RwLock::new(ApplicationAutoScalingAccounts::new()));
+        {
+            let mut guard = state.write();
+            let acct = guard
+                .accounts
+                .entry("123456789012".to_string())
+                .or_default();
+            acct.scalable_targets.insert(
+                (
+                    "dynamodb".to_string(),
+                    "table/orders".to_string(),
+                    DDB_READ_DIM.to_string(),
+                ),
+                ScalableTarget {
+                    arn: "arn:aws:application-autoscaling:::scalable-target/abc".to_string(),
+                    service_namespace: "dynamodb".to_string(),
+                    resource_id: "table/orders".to_string(),
+                    scalable_dimension: DDB_READ_DIM.to_string(),
+                    min_capacity: 1,
+                    max_capacity: 100,
+                    role_arn: "role".to_string(),
+                    creation_time: Utc::now(),
+                    suspended_state: None,
+                    predicted_capacity: None,
+                },
+            );
+        }
+        let ddb = Arc::new(StubDdb {
+            read: AtomicI64::new(2),
+            write: AtomicI64::new(2),
+            calls: Mutex::new(Vec::new()),
+        });
+        (state, ddb)
+    }
+
+    fn put_action(
+        state: &SharedApplicationAutoScalingState,
+        name: &str,
+        schedule: &str,
+        min: Option<i32>,
+        max: Option<i32>,
+    ) {
+        let mut guard = state.write();
+        let acct = guard.accounts.get_mut("123456789012").unwrap();
+        acct.scheduled_actions.insert(
+            (
+                "dynamodb".to_string(),
+                "table/orders".to_string(),
+                DDB_READ_DIM.to_string(),
+                name.to_string(),
+            ),
+            ScheduledAction {
+                arn: format!("arn:aws:autoscaling:::scheduledAction:{name}"),
+                scheduled_action_name: name.to_string(),
+                service_namespace: "dynamodb".to_string(),
+                resource_id: "table/orders".to_string(),
+                scalable_dimension: Some(DDB_READ_DIM.to_string()),
+                schedule: schedule.to_string(),
+                timezone: None,
+                start_time: None,
+                end_time: None,
+                scalable_target_action: Some(ScalableTargetAction {
+                    min_capacity: min,
+                    max_capacity: max,
+                }),
+                creation_time: Utc::now(),
+                last_fired_at: None,
+            },
+        );
+    }
+
+    #[test]
+    fn cron_every_minute_fires_and_bumps_capacity() {
+        let (state, ddb) = fixture();
+        put_action(&state, "warm", "cron(* * * * ? *)", Some(10), Some(50));
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        let fired = exec.tick_once();
+        assert_eq!(fired, 1);
+        assert_eq!(ddb.read.load(Ordering::Relaxed), 10, "read bumped to min");
+        // Second tick same minute must be a no-op.
+        let now = state
+            .read()
+            .accounts
+            .get("123456789012")
+            .unwrap()
+            .scheduled_actions
+            .values()
+            .next()
+            .unwrap()
+            .last_fired_at
+            .unwrap();
+        let fired_again = exec.tick_at(now);
+        assert_eq!(fired_again, 0, "cron must not re-fire within same minute");
+    }
+
+    #[test]
+    fn cron_at_specific_minute_does_not_fire_off_minute() {
+        let (state, ddb) = fixture();
+        // Schedule for minute 45 only.
+        put_action(&state, "off-minute", "cron(45 * * * ? *)", Some(20), None);
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 10, 30, 0).unwrap();
+        assert_eq!(exec.tick_at(now), 0, "must not fire off-minute");
+        let later = Utc.with_ymd_and_hms(2026, 1, 1, 10, 45, 30).unwrap();
+        assert_eq!(exec.tick_at(later), 1, "must fire on minute 45");
+    }
+
+    #[test]
+    fn at_expression_fires_once() {
+        let (state, ddb) = fixture();
+        put_action(
+            &state,
+            "one-shot",
+            "at(2026-01-01T12:00:00)",
+            Some(8),
+            Some(80),
+        );
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        let before = Utc.with_ymd_and_hms(2026, 1, 1, 11, 59, 59).unwrap();
+        assert_eq!(exec.tick_at(before), 0);
+        let after = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 1).unwrap();
+        assert_eq!(exec.tick_at(after), 1);
+        // Re-tick: must not re-fire because last_fired_at is now Some.
+        let later = Utc.with_ymd_and_hms(2026, 1, 1, 13, 0, 0).unwrap();
+        assert_eq!(exec.tick_at(later), 0);
+    }
+
+    #[test]
+    fn end_time_silences_action() {
+        let (state, ddb) = fixture();
+        put_action(&state, "expired", "cron(* * * * ? *)", Some(10), None);
+        // Mutate end_time to be in the past.
+        {
+            let mut guard = state.write();
+            let acct = guard.accounts.get_mut("123456789012").unwrap();
+            for action in acct.scheduled_actions.values_mut() {
+                action.end_time = Some(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap());
+            }
+        }
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        assert_eq!(exec.tick_once(), 0, "end_time in past must silence");
+    }
+
+    #[test]
+    fn unparseable_schedule_never_fires() {
+        let (state, ddb) = fixture();
+        put_action(&state, "bad", "every minute", Some(10), None);
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        assert_eq!(exec.tick_once(), 0);
+    }
+
+    #[test]
+    fn updates_scalable_target_bounds_on_fire() {
+        let (state, ddb) = fixture();
+        put_action(&state, "tighten", "cron(* * * * ? *)", Some(15), Some(40));
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        assert_eq!(exec.tick_once(), 1);
+        let guard = state.read();
+        let target = guard
+            .accounts
+            .get("123456789012")
+            .unwrap()
+            .scalable_targets
+            .get(&(
+                "dynamodb".to_string(),
+                "table/orders".to_string(),
+                DDB_READ_DIM.to_string(),
+            ))
+            .unwrap();
+        assert_eq!(target.min_capacity, 15);
+        assert_eq!(target.max_capacity, 40);
+    }
+
+    #[test]
+    fn suspended_scheduled_scaling_skips_fire() {
+        let (state, ddb) = fixture();
+        put_action(&state, "warm", "cron(* * * * ? *)", Some(10), None);
+        // Mark scheduled scaling as suspended on the target.
+        {
+            let mut guard = state.write();
+            let acct = guard.accounts.get_mut("123456789012").unwrap();
+            for target in acct.scalable_targets.values_mut() {
+                target.suspended_state = Some(crate::state::SuspendedState {
+                    dynamic_scaling_in_suspended: None,
+                    dynamic_scaling_out_suspended: None,
+                    scheduled_scaling_suspended: Some(true),
+                });
+            }
+        }
+        let exec = ScheduledActionExecutor::new(state.clone(), ddb.clone(), "us-east-1");
+        assert_eq!(exec.tick_once(), 0);
+    }
+
+    // Dummy use of BTreeMap to silence unused-import warning if the
+    // test fixtures stop needing it.
+    #[allow(dead_code)]
+    fn _btreemap_used(_: BTreeMap<String, String>) {}
+}

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -515,6 +515,7 @@ impl ApplicationAutoScalingService {
                 end_time,
                 scalable_target_action: action,
                 creation_time: Utc::now(),
+                last_fired_at: None,
             };
             account.scheduled_actions.insert(action_key, scheduled);
         }

--- a/crates/fakecloud-application-autoscaling/src/state.rs
+++ b/crates/fakecloud-application-autoscaling/src/state.rs
@@ -97,6 +97,12 @@ pub struct ScheduledAction {
     pub end_time: Option<DateTime<Utc>>,
     pub scalable_target_action: Option<ScalableTargetAction>,
     pub creation_time: DateTime<Utc>,
+    /// Last time the executor fired this scheduled action. Used to
+    /// dedupe within the same minute so a cron-every-minute schedule
+    /// doesn't double-fire when the ticker runs more than once during
+    /// the same wall-clock minute.
+    #[serde(default)]
+    pub last_fired_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-application-autoscaling/src/ticker.rs
+++ b/crates/fakecloud-application-autoscaling/src/ticker.rs
@@ -520,6 +520,12 @@ fn ddb_table_from_resource(resource_id: &str) -> Option<&str> {
     Some(rest.split('/').next().unwrap_or(rest))
 }
 
+/// Same as `ddb_table_from_resource`, but visible to sibling modules
+/// (`scheduled_executor`) so we don't duplicate the parsing rule.
+pub(crate) fn ddb_table_from_resource_public(resource_id: &str) -> Option<&str> {
+    ddb_table_from_resource(resource_id)
+}
+
 fn suspended_for(target: &ScalableTarget, policy: &ScalingPolicy) -> bool {
     let Some(s) = target.suspended_state.as_ref() else {
         return false;

--- a/crates/fakecloud-e2e/tests/appas_scheduled.rs
+++ b/crates/fakecloud-e2e/tests/appas_scheduled.rs
@@ -1,0 +1,267 @@
+//! Application Auto Scaling scheduled-action executor E2E.
+//!
+//! Verifies the scheduled-action executor:
+//!   - fires a `cron(* * * * ? *)` schedule on the next admin tick
+//!   - moves the linked DynamoDB table's read capacity up to the
+//!     action's `ScalableTargetAction.MinCapacity`
+//!   - records a `ScalingActivity` whose cause references the scheduled
+//!     action by name and schedule
+
+mod helpers;
+
+use aws_sdk_applicationautoscaling::types::{
+    ScalableDimension, ScalableTargetAction, ServiceNamespace,
+};
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition as DdbAttributeDefinition, BillingMode, KeySchemaElement,
+    KeyType as DdbKeyType, ProvisionedThroughput, ScalarAttributeType,
+};
+use helpers::TestServer;
+
+async fn create_provisioned_table(
+    ddb: &aws_sdk_dynamodb::Client,
+    name: &str,
+    read: i64,
+    write: i64,
+) {
+    ddb.create_table()
+        .table_name(name)
+        .billing_mode(BillingMode::Provisioned)
+        .attribute_definitions(
+            DdbAttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(DdbKeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .provisioned_throughput(
+            ProvisionedThroughput::builder()
+                .read_capacity_units(read)
+                .write_capacity_units(write)
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create table");
+}
+
+async fn force_scheduled_tick(server: &TestServer) -> usize {
+    let url = format!(
+        "{}/_fakecloud/application-autoscaling/scheduled-tick",
+        server.endpoint()
+    );
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .expect("admin scheduled-tick");
+    let body: serde_json::Value = resp.json().await.expect("json");
+    body["fired"].as_u64().unwrap_or(0) as usize
+}
+
+#[tokio::test]
+async fn cron_scheduled_action_bumps_dynamodb_capacity() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+
+    create_provisioned_table(&ddb, "sched-orders", 5, 5).await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .min_capacity(1)
+        .max_capacity(100)
+        .send()
+        .await
+        .expect("register");
+
+    aas.put_scheduled_action()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .scheduled_action_name("warm-up")
+        .schedule("cron(* * * * ? *)")
+        .scalable_target_action(
+            ScalableTargetAction::builder()
+                .min_capacity(10)
+                .max_capacity(50)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put scheduled action");
+
+    let fired = force_scheduled_tick(&server).await;
+    assert_eq!(fired, 1, "cron(* * * * ? *) must fire on first tick");
+
+    // The DynamoDB table's read capacity must be bumped to >= 10.
+    let described = ddb
+        .describe_table()
+        .table_name("sched-orders")
+        .send()
+        .await
+        .expect("describe");
+    let read_now = described
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    assert!(
+        read_now >= 10,
+        "expected read capacity >= 10 after scheduled fire, got {read_now}"
+    );
+    // Write capacity untouched.
+    let write_now = described
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.write_capacity_units())
+        .unwrap_or(0);
+    assert_eq!(write_now, 5);
+
+    // The scalable target itself must reflect the new bounds.
+    let target = aas
+        .describe_scalable_targets()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .send()
+        .await
+        .expect("describe target")
+        .scalable_targets()
+        .first()
+        .cloned()
+        .expect("target");
+    assert_eq!(target.min_capacity(), 10);
+    assert_eq!(target.max_capacity(), 50);
+
+    // DescribeScalingActivities must surface the scheduled-action fire.
+    let activities = aas
+        .describe_scaling_activities()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-orders")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .send()
+        .await
+        .expect("activities")
+        .scaling_activities()
+        .to_vec();
+    assert!(
+        activities
+            .iter()
+            .any(|a| a.cause().contains("warm-up") && a.cause().contains("cron(* * * * ? *)")),
+        "expected scaling activity from scheduled action, got {activities:?}"
+    );
+
+    // Re-tick within the same minute must NOT re-fire (per-minute dedupe).
+    let fired_again = force_scheduled_tick(&server).await;
+    assert_eq!(
+        fired_again, 0,
+        "cron schedule must not double-fire within the same wall-clock minute"
+    );
+}
+
+#[tokio::test]
+async fn at_scheduled_action_fires_once() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+
+    create_provisioned_table(&ddb, "sched-once", 5, 5).await;
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-once")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .min_capacity(1)
+        .max_capacity(100)
+        .send()
+        .await
+        .expect("register");
+
+    // Schedule for the past so the first tick fires immediately.
+    aas.put_scheduled_action()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-once")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .scheduled_action_name("one-shot")
+        .schedule("at(2020-01-01T00:00:00)")
+        .scalable_target_action(
+            ScalableTargetAction::builder()
+                .min_capacity(20)
+                .max_capacity(60)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put scheduled action");
+
+    assert_eq!(force_scheduled_tick(&server).await, 1, "must fire once");
+    assert_eq!(
+        force_scheduled_tick(&server).await,
+        0,
+        "at(...) schedule must not re-fire after first match"
+    );
+
+    let described = ddb
+        .describe_table()
+        .table_name("sched-once")
+        .send()
+        .await
+        .expect("describe");
+    let read_now = described
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    assert!(read_now >= 20, "expected >= 20, got {read_now}");
+}
+
+#[tokio::test]
+async fn unparseable_schedule_silently_does_not_fire() {
+    let server = TestServer::start().await;
+    let aas = server.application_autoscaling_client().await;
+    let ddb = server.dynamodb_client().await;
+    create_provisioned_table(&ddb, "sched-bad", 5, 5).await;
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-bad")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .min_capacity(1)
+        .max_capacity(100)
+        .send()
+        .await
+        .expect("register");
+
+    // Range expressions are not supported by our cron grammar — must
+    // silently never fire rather than crash the executor.
+    aas.put_scheduled_action()
+        .service_namespace(ServiceNamespace::Dynamodb)
+        .resource_id("table/sched-bad")
+        .scalable_dimension(ScalableDimension::DynamoDbTableReadCapacityUnits)
+        .scheduled_action_name("ranges-not-supported")
+        .schedule("cron(0-30 * * * ? *)")
+        .scalable_target_action(ScalableTargetAction::builder().min_capacity(99).build())
+        .send()
+        .await
+        .expect("put");
+
+    assert_eq!(force_scheduled_tick(&server).await, 0);
+    let read_now = ddb
+        .describe_table()
+        .table_name("sched-bad")
+        .send()
+        .await
+        .expect("describe")
+        .table()
+        .and_then(|t| t.provisioned_throughput())
+        .and_then(|p| p.read_capacity_units())
+        .unwrap_or(0);
+    assert_eq!(read_now, 5, "capacity must not change for unsupported cron");
+}

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -445,6 +445,23 @@ impl ApplicationAutoScalingClient<'_> {
             .await?;
         FakeCloud::parse(resp).await
     }
+
+    /// Force the scheduled-action executor to evaluate every
+    /// `ScheduledAction` now. Returns the number of actions that
+    /// fired this tick. Useful in tests so callers don't have to wait
+    /// for the wall-clock 30s interval.
+    pub async fn scheduled_tick(&self) -> Result<AppAsScheduledTickResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .post(format!(
+                "{}/_fakecloud/application-autoscaling/scheduled-tick",
+                self.fc.base_url
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
 }
 
 // ── EventBridge ─────────────────────────────────────────────────────

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -284,6 +284,13 @@ pub struct AppAsTickResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppAsScheduledTickResponse {
+    /// Number of scheduled actions that fired this tick.
+    pub fired: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SetSsmCommandStatusRequest {
     pub account_id: Option<String>,
     pub status: String,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2639,11 +2639,35 @@ async fn main() {
         let watcher = fakecloud_application_autoscaling::ScalingWatcher::new(
             app_autoscaling_state.clone(),
             appas_metric_reader,
-            appas_ddb_hook,
+            appas_ddb_hook.clone(),
             cli.region.clone(),
         )
         .with_interval(std::time::Duration::from_secs(15));
         tokio::spawn(watcher.run());
+    }
+
+    // Application Auto Scaling scheduled action executor: ticks every
+    // 30s, walks all ScheduledActions, fires the ones whose Schedule
+    // expression is due and applies the configured ScalableTargetAction
+    // bounds across linked resources (DDB capacity today). Tests can
+    // skip the wall-clock wait via the
+    // `/_fakecloud/application-autoscaling/scheduled-tick` admin route.
+    let appas_scheduled_executor_for_admin = Arc::new(
+        fakecloud_application_autoscaling::ScheduledActionExecutor::new(
+            app_autoscaling_state.clone(),
+            appas_ddb_hook.clone(),
+            cli.region.clone(),
+        )
+        .with_interval(std::time::Duration::from_secs(30)),
+    );
+    {
+        let executor = fakecloud_application_autoscaling::ScheduledActionExecutor::new(
+            app_autoscaling_state.clone(),
+            appas_ddb_hook,
+            cli.region.clone(),
+        )
+        .with_interval(std::time::Duration::from_secs(30));
+        tokio::spawn(executor.run());
     }
 
     let services: Vec<&str> = registry.service_names();
@@ -3391,6 +3415,16 @@ async fn main() {
                 move || async move {
                     let applied = watcher.tick_once();
                     axum::Json(types::AppAsTickResponse { applied })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/application-autoscaling/scheduled-tick",
+            axum::routing::post({
+                let executor = appas_scheduled_executor_for_admin.clone();
+                move || async move {
+                    let fired = executor.tick_once();
+                    axum::Json(types::AppAsScheduledTickResponse { fired })
                 }
             }),
         )

--- a/sdks/go/applicationautoscaling.go
+++ b/sdks/go/applicationautoscaling.go
@@ -19,3 +19,15 @@ func (c *ApplicationAutoScalingClient) Tick(ctx context.Context) (*AppAsTickResp
 	}
 	return &out, nil
 }
+
+// ScheduledTick forces the scheduled-action executor to evaluate every
+// ScheduledAction now. Returns the number of actions that fired on
+// this tick. Useful in tests so callers don't have to wait for the
+// wall-clock 30s interval.
+func (c *ApplicationAutoScalingClient) ScheduledTick(ctx context.Context) (*AppAsScheduledTickResponse, error) {
+	var out AppAsScheduledTickResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/application-autoscaling/scheduled-tick", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -257,6 +257,12 @@ type AppAsTickResponse struct {
 	Applied int `json:"applied"`
 }
 
+// AppAsScheduledTickResponse reports how many Application Auto Scaling
+// scheduled actions fired on a forced executor tick.
+type AppAsScheduledTickResponse struct {
+	Fired int `json:"fired"`
+}
+
 // ── EventBridge ────────────────────────────────────────────────────
 
 // EventBridgeEvent represents an event put to EventBridge.

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -3,6 +3,7 @@ package dev.fakecloud;
 import static dev.fakecloud.HttpTransport.encodePath;
 
 import dev.fakecloud.Types.ApiGatewayV2RequestsResponse;
+import dev.fakecloud.Types.AppAsScheduledTickResponse;
 import dev.fakecloud.Types.AppAsTickResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
 import dev.fakecloud.Types.MintAuthorizationCodeRequest;
@@ -328,6 +329,12 @@ public final class FakeCloud {
             return http.postEmpty(
                     "/_fakecloud/application-autoscaling/tick",
                     AppAsTickResponse.class);
+        }
+
+        public AppAsScheduledTickResponse scheduledTick() {
+            return http.postEmpty(
+                    "/_fakecloud/application-autoscaling/scheduled-tick",
+                    AppAsScheduledTickResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -207,6 +207,9 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record AppAsTickResponse(int applied) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AppAsScheduledTickResponse(int fired) {}
+
     // ── EventBridge ────────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record EventBridgeEvent(

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -303,6 +303,13 @@ final class ApplicationAutoScalingClient
             $this->http->postEmpty('/_fakecloud/application-autoscaling/tick')
         );
     }
+
+    public function scheduledTick(): AppAsScheduledTickResponse
+    {
+        return AppAsScheduledTickResponse::fromArray(
+            $this->http->postEmpty('/_fakecloud/application-autoscaling/scheduled-tick')
+        );
+    }
 }
 
 final class EventsClient

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -603,6 +603,18 @@ final class AppAsTickResponse
     }
 }
 
+final class AppAsScheduledTickResponse
+{
+    public function __construct(
+        public readonly int $fired,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['fired']);
+    }
+}
+
 // ── EventBridge ────────────────────────────────────────────────
 
 final class EventBridgeEvent

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -8,6 +8,7 @@ import httpx
 
 from fakecloud.types import (
     ApiGatewayV2RequestsResponse,
+    AppAsScheduledTickResponse,
     AppAsTickResponse,
     AuthEventsResponse,
     BedrockFaultRule,
@@ -603,6 +604,19 @@ class ApplicationAutoScalingClient:
         _check(resp)
         return AppAsTickResponse.from_dict(resp.json())
 
+    async def scheduled_tick(self) -> AppAsScheduledTickResponse:
+        """Force the scheduled-action executor to evaluate every action now.
+
+        Returns the number of scheduled actions that fired on this
+        tick. Useful in tests so callers don't have to wait for the
+        wall-clock 30s interval.
+        """
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/application-autoscaling/scheduled-tick"
+        )
+        _check(resp)
+        return AppAsScheduledTickResponse.from_dict(resp.json())
+
 
 class EventsClient:
     """Async EventBridge introspection client."""
@@ -988,6 +1002,13 @@ class _SyncApplicationAutoScalingClient:
         )
         _check(resp)
         return AppAsTickResponse.from_dict(resp.json())
+
+    def scheduled_tick(self) -> AppAsScheduledTickResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/application-autoscaling/scheduled-tick"
+        )
+        _check(resp)
+        return AppAsScheduledTickResponse.from_dict(resp.json())
 
 
 class _SyncEventsClient:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -514,6 +514,18 @@ class AppAsTickResponse:
 
 
 @dataclass
+class AppAsScheduledTickResponse:
+    """Result of forcing one Application Auto Scaling scheduled-action tick."""
+
+    fired: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AppAsScheduledTickResponse:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
 class ForceDlqResponse:
     moved_messages: int
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -30,6 +30,7 @@ import type {
   SqsMessagesResponse,
   ExpirationTickResponse,
   ForceDlqResponse,
+  AppAsScheduledTickResponse,
   AppAsTickResponse,
   EventHistoryResponse,
   FireRuleRequest,
@@ -245,6 +246,14 @@ export class ApplicationAutoScalingClient {
   async tick(): Promise<AppAsTickResponse> {
     const resp = await fetch(
       `${this.baseUrl}/_fakecloud/application-autoscaling/tick`,
+      { method: "POST" },
+    );
+    return parse(resp);
+  }
+
+  async scheduledTick(): Promise<AppAsScheduledTickResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/application-autoscaling/scheduled-tick`,
       { method: "POST" },
     );
     return parse(resp);

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -236,6 +236,15 @@ export interface AppAsTickResponse {
   applied: number;
 }
 
+/**
+ * Result of forcing one Application Auto Scaling scheduled-action
+ * tick. The `fired` field is the number of scheduled actions that
+ * successfully fired on this tick.
+ */
+export interface AppAsScheduledTickResponse {
+  fired: number;
+}
+
 // ── EventBridge ────────────────────────────────────────────────────
 
 export interface EventBridgeEvent {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -84,7 +84,8 @@ curl http://localhost:4566/_fakecloud/health
 
 | Endpoint                                     | Method | Description |
 | -------------------------------------------- | ------ | ----------- |
-| `/_fakecloud/application-autoscaling/tick`   | POST   | Force the watcher to evaluate every scaling policy now. Returns `{ "applied": <int> }` — the count of policies that applied a capacity change this tick. |
+| `/_fakecloud/application-autoscaling/tick`           | POST   | Force the watcher to evaluate every scaling policy now. Returns `{ "applied": <int> }` — the count of policies that applied a capacity change this tick. |
+| `/_fakecloud/application-autoscaling/scheduled-tick` | POST   | Force the scheduled-action executor to evaluate every scheduled action now. Returns `{ "fired": <int> }` — the count of actions that fired this tick. |
 
 ## Secrets Manager
 

--- a/website/content/docs/services/application-autoscaling.md
+++ b/website/content/docs/services/application-autoscaling.md
@@ -75,14 +75,45 @@ useful in tests — POST `/_fakecloud/application-autoscaling/tick`. The
 response shape is `{ "applied": <int> }`. The introspection SDKs
 expose this as `fakecloud.applicationAutoscaling.tick()`.
 
+## Scheduled actions
+
+`PutScheduledAction` registers a one-shot or recurring capacity change.
+fakecloud's executor evaluates every scheduled action every 30 seconds
+and fires the ones whose `Schedule` expression is currently due:
+
+- `at(yyyy-mm-ddThh:mm:ss)` — fires once when wall-clock catches up.
+- `cron(min hour dom month dow year)` — recurring, evaluated against
+  the action's `Timezone` (IANA name; falls back to UTC when missing
+  or unrecognized). The supported grammar matches EventBridge
+  Scheduler — wildcards (`*` / `?`) and single numeric values per
+  field. Ranges, lists, and step values silently never fire so a
+  malformed expression doesn't blow up the executor.
+
+When an action fires the executor mutates the linked `ScalableTarget`
+to the action's `ScalableTargetAction.{MinCapacity, MaxCapacity}` and,
+for DynamoDB targets, calls the same capacity hook used by
+target-tracking / step scaling so the table's provisioned throughput
+moves into the new bounds. Each fire appends a `ScalingActivity` row
+whose `Cause` references the scheduled action by name and schedule.
+Per-minute dedupe (via `last_fired_at`) prevents a `cron(* * * * ? *)`
+schedule from re-firing inside the same wall-clock minute.
+
+To deterministically fire scheduled actions in tests — without waiting
+on the 30s interval — POST
+`/_fakecloud/application-autoscaling/scheduled-tick`. Response shape
+is `{ "fired": <int> }`. The introspection SDKs expose this as
+`fakecloud.applicationAutoscaling.scheduledTick()`.
+
 ## Caveats
 
-The watcher only scales DynamoDB tables today. ECS service
-`DesiredCount`, Lambda provisioned concurrency, RDS Aurora capacity,
-ElastiCache replicas, and the rest of Application Auto Scaling's
-service namespaces still store policy configurations verbatim without
-applying them. Predictive forecasts are deterministic synthetic
-curves, not actual ML predictions. CloudWatch alarms reported under
-`ScalingPolicy.Alarms` remain empty — the watcher resolves alarms by
-walking CloudWatch state directly rather than mirroring AWS's
-auto-attach behaviour.
+The watcher and scheduled-action executor only mutate DynamoDB table
+capacity today. ECS service `DesiredCount`, Lambda provisioned
+concurrency, RDS Aurora capacity, ElastiCache replicas, and the rest
+of Application Auto Scaling's service namespaces still store policy
+and scheduled-action configurations verbatim — the bound updates land
+on the `ScalableTarget` but no per-namespace apply hook is wired yet,
+so the underlying resource isn't resized. Predictive forecasts are
+deterministic synthetic curves, not actual ML predictions. CloudWatch
+alarms reported under `ScalingPolicy.Alarms` remain empty — the
+watcher resolves alarms by walking CloudWatch state directly rather
+than mirroring AWS's auto-attach behaviour.


### PR DESCRIPTION
## Summary
- Adds a `ScheduledActionExecutor` that fires Application Auto Scaling `ScheduledAction`s when their `Schedule` (cron / at) is due, mutates the linked `ScalableTarget` bounds, applies the new bounds via the existing DynamoDB capacity hook, and appends a `ScalingActivity` row.
- Honours `Timezone` (IANA) via `chrono-tz`, `start_time` / `end_time` window, `SuspendedState.ScheduledScalingSuspended`, and per-minute dedupe via a new `last_fired_at` field so `cron(* * * * ? *)` doesn't double-fire.
- Wires a `/_fakecloud/application-autoscaling/scheduled-tick` admin endpoint and exposes it from all five language SDKs (Go/Python/Java/PHP/TS) + the Rust SDK; updates the service doc + introspection reference.

## Test plan
- [x] `cargo test -p fakecloud-application-autoscaling --lib` — 13 passing (6 new scheduled_executor unit tests)
- [x] `cargo test -p fakecloud-e2e --test appas_scheduled` — 3 passing (cron, at, unparseable)
- [x] `cargo test -p fakecloud-e2e --test application_autoscaling` — 17 still passing (no regression)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] TS SDK `npm run build` clean
- [x] Go SDK `go build ./...` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled action executor for Application Auto Scaling. It fires due `PutScheduledAction` schedules, updates `ScalableTarget` bounds, applies DynamoDB capacity changes, and exposes an admin tick endpoint in all SDKs.

- **New Features**
  - Added `ScheduledActionExecutor` that evaluates `at(...)` and `cron(min hour dom month dow year)` every 30s; honors `Timezone` (IANA via `chrono-tz`), `start_time`/`end_time`, and `SuspendedState.ScheduledScalingSuspended`.
  - On fire: updates the linked `ScalableTarget`, applies DynamoDB changes via the existing capacity hook, and appends a `ScalingActivity`.
  - Per-minute dedupe via `last_fired_at`; unsupported cron ranges/lists/steps no-op.
  - New admin endpoint `/_fakecloud/application-autoscaling/scheduled-tick` to force evaluation; returns `{ "fired": <int> }`. Exposed in Rust, Go, Python, Java, PHP, and TypeScript SDKs.
  - Docs updated for the new executor and introspection endpoint.

- **Dependencies**
  - Added `chrono-tz`.

<sup>Written for commit 7dc325682ac1256be20a643a41fd9f01c456d48f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

