### PR TITLE
feat(stepfunctions): waitForTaskToken pattern (CC3)

### DIFF
--- a/crates/fakecloud-e2e/tests/stepfunctions_task_token.rs
+++ b/crates/fakecloud-e2e/tests/stepfunctions_task_token.rs
@@ -1,0 +1,321 @@
+mod helpers;
+
+use helpers::TestServer;
+use serde_json::{json, Value};
+use tokio::time::{sleep, Duration};
+
+async fn wait_for_execution(
+    client: &aws_sdk_sfn::Client,
+    arn: &str,
+) -> aws_sdk_sfn::operation::describe_execution::DescribeExecutionOutput {
+    for _ in 0..400 {
+        sleep(Duration::from_millis(50)).await;
+        let desc = client
+            .describe_execution()
+            .execution_arn(arn)
+            .send()
+            .await
+            .unwrap();
+        if desc.status().as_str() != "RUNNING" {
+            return desc;
+        }
+    }
+    panic!("Execution did not complete in time: {arn}");
+}
+
+#[tokio::test]
+async fn sfn_wait_for_task_token_sqs_send_message() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    // Create a queue to receive the token.
+    let queue = sqs
+        .create_queue()
+        .queue_name("task-token-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    let definition = json!({
+        "StartAt": "SendToken",
+        "States": {
+            "SendToken": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody.$": "$$.Task.Token"
+                },
+                "End": true
+            }
+        }
+    });
+
+    let created = sfn
+        .create_state_machine()
+        .name("token-sm")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/sfn-role")
+        .send()
+        .await
+        .unwrap();
+
+    let started = sfn
+        .start_execution()
+        .state_machine_arn(created.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    // Poll SQS for the message containing the task token.
+    let mut token: Option<String> = None;
+    for _ in 0..100 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        let messages = recv.messages();
+        if let Some(m) = messages.first() {
+            if let Some(body) = m.body() {
+                token = Some(body.to_string());
+                // Delete the message so the queue is clean.
+                if let Some(receipt) = m.receipt_handle() {
+                    let _ = sqs
+                        .delete_message()
+                        .queue_url(queue_url)
+                        .receipt_handle(receipt)
+                        .send()
+                        .await;
+                }
+                break;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let token = token.expect("task token should have been sent to SQS");
+    assert!(
+        token.starts_with("FCToken-"),
+        "token should start with FCToken- prefix"
+    );
+
+    // Send task success with a custom output.
+    let expected_output = json!({"result": "ok"});
+    sfn.send_task_success()
+        .task_token(&token)
+        .output(expected_output.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    let desc = wait_for_execution(&sfn, started.execution_arn()).await;
+    assert_eq!(
+        desc.status().as_str(),
+        "SUCCEEDED",
+        "execution should succeed; output={:?}, cause={:?}",
+        desc.output(),
+        desc.cause(),
+    );
+
+    let output: Value = serde_json::from_str(desc.output().expect("output")).unwrap();
+    assert_eq!(
+        output, expected_output,
+        "output should match SendTaskSuccess payload"
+    );
+}
+
+#[tokio::test]
+async fn sfn_wait_for_task_token_send_task_failure() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    let queue = sqs
+        .create_queue()
+        .queue_name("token-fail-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    let definition = json!({
+        "StartAt": "SendToken",
+        "States": {
+            "SendToken": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody.$": "$$.Task.Token"
+                },
+                "End": true
+            }
+        }
+    });
+
+    let created = sfn
+        .create_state_machine()
+        .name("token-fail-sm")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/sfn-role")
+        .send()
+        .await
+        .unwrap();
+
+    let started = sfn
+        .start_execution()
+        .state_machine_arn(created.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let mut token: Option<String> = None;
+    for _ in 0..100 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        let messages = recv.messages();
+        if let Some(m) = messages.first() {
+            if let Some(body) = m.body() {
+                token = Some(body.to_string());
+                if let Some(receipt) = m.receipt_handle() {
+                    let _ = sqs
+                        .delete_message()
+                        .queue_url(queue_url)
+                        .receipt_handle(receipt)
+                        .send()
+                        .await;
+                }
+                break;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let token = token.expect("task token should have been sent to SQS");
+
+    sfn.send_task_failure()
+        .task_token(&token)
+        .error("CustomError")
+        .cause("worker failed")
+        .send()
+        .await
+        .unwrap();
+
+    let desc = wait_for_execution(&sfn, started.execution_arn()).await;
+    assert_eq!(desc.status().as_str(), "FAILED");
+    assert_eq!(desc.error(), Some("CustomError"));
+    assert_eq!(desc.cause(), Some("worker failed"));
+}
+
+#[tokio::test]
+async fn sfn_wait_for_task_token_heartbeat_resets_timeout() {
+    let server = TestServer::start().await;
+    let sfn = server.sfn_client().await;
+    let sqs = server.sqs_client().await;
+
+    let queue = sqs
+        .create_queue()
+        .queue_name("token-hb-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap();
+
+    let definition = json!({
+        "StartAt": "SendToken",
+        "States": {
+            "SendToken": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                "Parameters": {
+                    "QueueUrl": queue_url,
+                    "MessageBody.$": "$$.Task.Token"
+                },
+                "HeartbeatSeconds": 2,
+                "End": true
+            }
+        }
+    });
+
+    let created = sfn
+        .create_state_machine()
+        .name("token-hb-sm")
+        .definition(definition.to_string())
+        .role_arn("arn:aws:iam::123456789012:role/sfn-role")
+        .send()
+        .await
+        .unwrap();
+
+    let started = sfn
+        .start_execution()
+        .state_machine_arn(created.state_machine_arn())
+        .send()
+        .await
+        .unwrap();
+
+    let mut token: Option<String> = None;
+    for _ in 0..100 {
+        let recv = sqs
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(1)
+            .send()
+            .await
+            .unwrap();
+        let messages = recv.messages();
+        if let Some(m) = messages.first() {
+            if let Some(body) = m.body() {
+                token = Some(body.to_string());
+                if let Some(receipt) = m.receipt_handle() {
+                    let _ = sqs
+                        .delete_message()
+                        .queue_url(queue_url)
+                        .receipt_handle(receipt)
+                        .send()
+                        .await;
+                }
+                break;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let token = token.expect("task token should have been sent to SQS");
+
+    // Send heartbeat to keep the task alive.
+    sfn.send_task_heartbeat()
+        .task_token(&token)
+        .send()
+        .await
+        .unwrap();
+
+    sleep(Duration::from_secs(1)).await;
+
+    // Send another heartbeat.
+    sfn.send_task_heartbeat()
+        .task_token(&token)
+        .send()
+        .await
+        .unwrap();
+
+    // Complete the task.
+    sfn.send_task_success()
+        .task_token(&token)
+        .output(json!({"done": true}).to_string())
+        .send()
+        .await
+        .unwrap();
+
+    let desc = wait_for_execution(&sfn, started.execution_arn()).await;
+    assert_eq!(desc.status().as_str(), "SUCCEEDED");
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -181,6 +181,7 @@ async fn run_task_state(
     );
 
     let result = execute_task_state(
+        name,
         state_def,
         &input,
         delivery,
@@ -363,6 +364,7 @@ async fn execute_wait_state(state_def: &Value, input: &Value) {
 /// apply I/O processing, handle Retry.
 #[allow(clippy::too_many_arguments)]
 async fn execute_task_state(
+    name: &str,
     state_def: &Value,
     input: &Value,
     delivery: &Option<Arc<DeliveryBus>>,
@@ -384,16 +386,57 @@ async fn execute_task_state(
         apply_input_path(input, input_path)
     };
 
-    let task_input = if let Some(params) = state_def.get("Parameters") {
-        apply_parameters(params, &effective_input)
-    } else {
-        effective_input
-    };
-
     let retriers = state_def["Retry"].as_array().cloned().unwrap_or_default();
     let timeout_seconds = state_def["TimeoutSeconds"].as_u64();
     let heartbeat_seconds = state_def["HeartbeatSeconds"].as_u64();
     let mut attempt = 0u32;
+
+    let is_wait_for_task_token = resource.contains(".waitForTaskToken");
+    let task_token = if is_wait_for_task_token {
+        let token = format!(
+            "FCToken-{}-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+            uuid::Uuid::new_v4().simple(),
+        );
+        let account_id = account_id_from_arn(execution_arn);
+        let context = json!({
+            "Task": { "Token": token.clone() },
+            "Execution": { "Id": execution_arn },
+            "State": { "Name": name },
+        });
+        {
+            let mut accounts = shared_state.write();
+            let state = accounts.get_or_create(account_id);
+            state.task_tokens.insert(
+                token.clone(),
+                crate::state::TaskTokenState {
+                    activity_arn: String::new(),
+                    status: "PENDING".to_string(),
+                    output: None,
+                    error: None,
+                    cause: None,
+                    input: None,
+                    created_at: chrono::Utc::now(),
+                    last_heartbeat_at: None,
+                    heartbeat_seconds: heartbeat_seconds.map(|s| s as i64),
+                    timeout_seconds: timeout_seconds.map(|s| s as i64),
+                },
+            );
+        }
+        Some((token, context))
+    } else {
+        None
+    };
+
+    let task_input = if let Some(params) = state_def.get("Parameters") {
+        if let Some((_, ctx)) = &task_token {
+            apply_parameters(params, &effective_input, Some(ctx))
+        } else {
+            apply_parameters(params, &effective_input, None)
+        }
+    } else {
+        effective_input
+    };
 
     loop {
         add_event(
@@ -431,6 +474,73 @@ async fn execute_task_state(
 
         match invoke_result {
             Ok(result) => {
+                if let Some((token, _)) = &task_token {
+                    let account_id = account_id_from_arn(execution_arn);
+                    match poll_task_token(
+                        shared_state,
+                        account_id,
+                        token,
+                        timeout_seconds,
+                        heartbeat_seconds,
+                    )
+                    .await
+                    {
+                        Ok(output) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "TaskSucceeded",
+                                entered_event_id,
+                                json!({
+                                    "resource": resource,
+                                    "output": serde_json::to_string(&output).expect("serde_json::Value serialization is infallible"),
+                                }),
+                            );
+
+                            let selected = if let Some(selector) = state_def.get("ResultSelector") {
+                                apply_parameters(selector, &output, None)
+                            } else {
+                                output
+                            };
+
+                            let after_result = if result_path == Some("null") {
+                                input.clone()
+                            } else {
+                                apply_result_path(input, &selected, result_path)
+                            };
+
+                            let output = if output_path == Some("null") {
+                                json!({})
+                            } else {
+                                apply_output_path(&after_result, output_path)
+                            };
+
+                            return Ok(output);
+                        }
+                        Err((error, cause)) => {
+                            add_event(
+                                shared_state,
+                                execution_arn,
+                                "TaskFailed",
+                                entered_event_id,
+                                json!({ "error": error, "cause": cause }),
+                            );
+
+                            if let Some(delay_ms) = should_retry(&retriers, &error, attempt) {
+                                attempt += 1;
+                                let actual_delay = delay_ms.min(5000);
+                                tokio::time::sleep(tokio::time::Duration::from_millis(
+                                    actual_delay,
+                                ))
+                                .await;
+                                continue;
+                            }
+
+                            return Err((error, cause));
+                        }
+                    }
+                }
+
                 add_event(
                     shared_state,
                     execution_arn,
@@ -443,7 +553,7 @@ async fn execute_task_state(
                 );
 
                 let selected = if let Some(selector) = state_def.get("ResultSelector") {
-                    apply_parameters(selector, &result)
+                    apply_parameters(selector, &result, None)
                 } else {
                     result
                 };
@@ -548,7 +658,7 @@ async fn execute_parallel_state(
 
     // Apply ResultSelector if present
     let selected = if let Some(selector) = state_def.get("ResultSelector") {
-        apply_parameters(selector, &branch_output)
+        apply_parameters(selector, &branch_output, None)
     } else {
         branch_output
     };
@@ -632,7 +742,7 @@ async fn execute_map_state(
             let mut ctx = serde_json::Map::new();
             ctx.insert("value".to_string(), item.clone());
             ctx.insert("index".to_string(), json!(index));
-            apply_parameters(selector, &Value::Object(ctx))
+            apply_parameters(selector, &Value::Object(ctx), None)
         } else {
             item
         };
@@ -696,7 +806,7 @@ async fn execute_map_state(
 
     // Apply ResultSelector if present
     let selected = if let Some(selector) = state_def.get("ResultSelector") {
-        apply_parameters(selector, &map_output)
+        apply_parameters(selector, &map_output, None)
     } else {
         map_output
     };
@@ -1420,67 +1530,14 @@ async fn invoke_activity(
         );
     }
 
-    // Poll for completion. Default poll cadence 200ms; 1 hour absolute
-    // ceiling so a stuck activity can't block the interpreter forever
-    // when no TimeoutSeconds is set on the Task state.
-    let absolute_deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(timeout_seconds.unwrap_or(3600));
-    loop {
-        let now_ts = chrono::Utc::now();
-        let snapshot = {
-            let accounts = shared_state.read();
-            accounts
-                .get(&activity_account)
-                .and_then(|s| s.task_tokens.get(&token).cloned())
-        };
-        let Some(entry) = snapshot else {
-            return Err((
-                "States.TaskFailed".to_string(),
-                "Activity task token disappeared".to_string(),
-            ));
-        };
-        match entry.status.as_str() {
-            "SUCCEEDED" => {
-                cleanup_token(shared_state, &activity_account, &token);
-                let output = entry.output.unwrap_or_else(|| "{}".to_string());
-                let value: Value = serde_json::from_str(&output).unwrap_or(Value::String(output));
-                return Ok(value);
-            }
-            "FAILED" => {
-                cleanup_token(shared_state, &activity_account, &token);
-                return Err((
-                    entry
-                        .error
-                        .unwrap_or_else(|| "States.TaskFailed".to_string()),
-                    entry.cause.unwrap_or_default(),
-                ));
-            }
-            _ => {}
-        }
-        // Heartbeat timeout: only enforced once a worker has picked up the
-        // task (status == IN_PROGRESS) and a heartbeat window is set.
-        if entry.status == "IN_PROGRESS" {
-            if let Some(hb) = entry.heartbeat_seconds {
-                let last = entry.last_heartbeat_at.unwrap_or(entry.created_at);
-                if (now_ts - last).num_seconds() > hb {
-                    cleanup_token(shared_state, &activity_account, &token);
-                    return Err((
-                        "States.HeartbeatTimeout".to_string(),
-                        format!("Activity worker missed heartbeat ({hb}s window)"),
-                    ));
-                }
-            }
-        }
-        if std::time::Instant::now() >= absolute_deadline {
-            cleanup_token(shared_state, &activity_account, &token);
-            let secs = timeout_seconds.unwrap_or(3600);
-            return Err((
-                "States.Timeout".to_string(),
-                format!("Activity timed out after {secs} seconds"),
-            ));
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    }
+    poll_task_token(
+        shared_state,
+        &activity_account,
+        &token,
+        timeout_seconds,
+        heartbeat_seconds,
+    )
+    .await
 }
 
 pub(crate) enum NextState {

--- a/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
@@ -1042,10 +1042,86 @@ pub(crate) fn cleanup_token(
     }
 }
 
+/// Poll a task token until the worker calls `SendTaskSuccess`,
+/// `SendTaskFailure`, or the heartbeat / timeout windows expire.
+/// Mirrors the polling loop used by `invoke_activity` but is shared
+/// for `.waitForTaskToken` SDK integrations.
+pub(crate) async fn poll_task_token(
+    shared_state: &SharedStepFunctionsState,
+    account_id: &str,
+    token: &str,
+    timeout_seconds: Option<u64>,
+    heartbeat_seconds: Option<u64>,
+) -> Result<Value, (String, String)> {
+    let absolute_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(timeout_seconds.unwrap_or(3600));
+    loop {
+        let now_ts = chrono::Utc::now();
+        let snapshot = {
+            let accounts = shared_state.read();
+            accounts
+                .get(account_id)
+                .and_then(|s| s.task_tokens.get(token).cloned())
+        };
+        let Some(entry) = snapshot else {
+            return Err((
+                "States.TaskFailed".to_string(),
+                "Task token disappeared".to_string(),
+            ));
+        };
+        match entry.status.as_str() {
+            "SUCCEEDED" => {
+                cleanup_token(shared_state, account_id, token);
+                let output = entry.output.unwrap_or_else(|| "{}".to_string());
+                let value: Value = serde_json::from_str(&output).unwrap_or(Value::String(output));
+                return Ok(value);
+            }
+            "FAILED" => {
+                cleanup_token(shared_state, account_id, token);
+                return Err((
+                    entry
+                        .error
+                        .unwrap_or_else(|| "States.TaskFailed".to_string()),
+                    entry.cause.unwrap_or_default(),
+                ));
+            }
+            _ => {}
+        }
+        // Heartbeat timeout: only enforced once the worker has picked up the
+        // task (status == IN_PROGRESS) and a heartbeat window is set.
+        if entry.status == "IN_PROGRESS" {
+            if let Some(hb) = heartbeat_seconds {
+                let last = entry.last_heartbeat_at.unwrap_or(entry.created_at);
+                if (now_ts - last).num_seconds() > hb as i64 {
+                    cleanup_token(shared_state, account_id, token);
+                    return Err((
+                        "States.HeartbeatTimeout".to_string(),
+                        format!("Worker missed heartbeat ({hb}s window)"),
+                    ));
+                }
+            }
+        }
+        if std::time::Instant::now() >= absolute_deadline {
+            cleanup_token(shared_state, account_id, token);
+            let secs = timeout_seconds.unwrap_or(3600);
+            return Err((
+                "States.Timeout".to_string(),
+                format!("Task timed out after {secs} seconds"),
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
 /// Apply Parameters template: keys ending with .$ are treated as
 /// JsonPath references *or* ASL intrinsic invocations
 /// (`States.Foo(...)`).
-pub(crate) fn apply_parameters(template: &Value, input: &Value) -> Value {
+///
+/// When `context` is provided, expressions starting with `$$.` resolve
+/// against the context object (Step Functions context object) instead of
+/// the state input. This is how `$$.Task.Token` is substituted for
+/// `.waitForTaskToken` integrations.
+pub(crate) fn apply_parameters(template: &Value, input: &Value, context: Option<&Value>) -> Value {
     match template {
         Value::Object(map) => {
             let mut result = serde_json::Map::new();
@@ -1057,18 +1133,29 @@ pub(crate) fn apply_parameters(template: &Value, input: &Value) -> Value {
                                 tracing::warn!(error = %err, "States intrinsic failed");
                                 Value::Null
                             })
+                        } else if expr.starts_with("$$.") {
+                            if let Some(ctx) = context {
+                                let path = expr.strip_prefix("$$.").unwrap_or(expr);
+                                crate::io_processing::resolve_path(ctx, path)
+                            } else {
+                                Value::Null
+                            }
                         } else {
                             crate::io_processing::resolve_path(input, expr)
                         };
                         result.insert(stripped.to_string(), resolved);
                     }
                 } else {
-                    result.insert(key.clone(), apply_parameters(value, input));
+                    result.insert(key.clone(), apply_parameters(value, input, context));
                 }
             }
             Value::Object(result)
         }
-        Value::Array(arr) => Value::Array(arr.iter().map(|v| apply_parameters(v, input)).collect()),
+        Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|v| apply_parameters(v, input, context))
+                .collect(),
+        ),
         other => other.clone(),
     }
 }
@@ -1221,7 +1308,7 @@ mod tests {
             "literal": "static",
         });
         let input = json!({"name": "Eve", "n": 7});
-        let out = apply_parameters(&template, &input);
+        let out = apply_parameters(&template, &input, None);
         assert_eq!(out["greeting"], json!("Hello Eve, count is 7"));
         assert_eq!(out["literal"], json!("static"));
     }
@@ -1230,7 +1317,7 @@ mod tests {
     fn apply_parameters_falls_back_to_jsonpath_for_non_intrinsics() {
         let template = json!({"x.$": "$.value"});
         let input = json!({"value": 42});
-        let out = apply_parameters(&template, &input);
+        let out = apply_parameters(&template, &input, None);
         assert_eq!(out["x"], json!(42));
     }
 
@@ -1238,7 +1325,7 @@ mod tests {
     fn apply_parameters_intrinsic_failure_yields_null() {
         // Bad call: missing closing paren.
         let template = json!({"y.$": "States.Format('{}'"});
-        let out = apply_parameters(&template, &Value::Null);
+        let out = apply_parameters(&template, &Value::Null, None);
         // Falls through resolve_path since not detected as intrinsic
         // (no `(` after States.Format... actually has `(`, so this *is*
         // an intrinsic and should return Null on failure).

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -706,11 +706,32 @@ fn apply_parameters_substitutes_json_path_refs() {
         "list": [ { "x.$": "$.user.id" } ]
     });
     let input = json!({ "user": { "id": 42, "name": "zoe" } });
-    let out = apply_parameters(&template, &input);
+    let out = apply_parameters(&template, &input, None);
     assert_eq!(out["literal"], json!("constant"));
     assert_eq!(out["ref"], json!(42));
     assert_eq!(out["nested"]["inner"], json!("zoe"));
     assert_eq!(out["list"][0]["x"], json!(42));
+}
+
+#[test]
+fn apply_parameters_resolves_context_object() {
+    let template = json!({
+        "token.$": "$$.Task.Token",
+        "exec.$": "$$.Execution.Id",
+        "literal": "static"
+    });
+    let input = json!({ "user": { "id": 42 } });
+    let context = json!({
+        "Task": { "Token": "abc123" },
+        "Execution": { "Id": "arn:aws:states:us-east-1:123:execution:sm:exec" }
+    });
+    let out = apply_parameters(&template, &input, Some(&context));
+    assert_eq!(out["token"], json!("abc123"));
+    assert_eq!(
+        out["exec"],
+        json!("arn:aws:states:us-east-1:123:execution:sm:exec")
+    );
+    assert_eq!(out["literal"], json!("static"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Injects `$$.Task.Token` into Task Parameters via a Step Functions context object when `.waitForTaskToken` is detected on a resource ARN.
- Suspends execution after the SDK/service call succeeds and polls the minted token until `SendTaskSuccess`/`SendTaskFailure` arrives (or timeout/heartbeat expiry).
- Extracts shared token-polling logic from `invoke_activity` into a new `poll_task_token` helper used by both activities and `.waitForTaskToken` integrations.
- Adds 3 E2E tests covering success, failure, and heartbeat paths using the SQS `sendMessage.waitForTaskToken` integration.

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `cargo test -p fakecloud-stepfunctions` (152 passed)
- [x] `cargo test -p fakecloud-e2e --test stepfunctions_task_token` (3 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Step Functions `.waitForTaskToken` pattern. Tasks now inject `$$.Task.Token` via the context object and pause until `SendTaskSuccess` or `SendTaskFailure`, with heartbeat and timeout handling.

- **New Features**
  - Detects `.waitForTaskToken` on Task `Resource`, mints a token, exposes it as `$$.Task.Token`, and suspends after the SDK call until completion.
  - Adds context-object resolution (`$$.`) to `apply_parameters`, including `$$.Task.Token` and `$$.Execution.Id`.
  - E2E coverage for SQS `sendMessage.waitForTaskToken`: success, failure, and heartbeat flows (`fakecloud-e2e`).

- **Refactors**
  - Extracts shared token polling into `poll_task_token` and reuses it in activities and `.waitForTaskToken` integrations (`fakecloud-stepfunctions`).

<sup>Written for commit 1e573db938e12a4465c9e3f5d9c384b91a75daea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

