### PR TITLE
feat(apigatewayv2): WebSocket support (S1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "fakecloud-sdk",
  "fakecloud-testkit",
  "flate2",
+ "futures-util",
  "mail-parser",
  "md-5 0.10.6",
  "mysql_async",
@@ -3260,6 +3261,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-postgres",
+ "tokio-tungstenite",
  "x509-cert",
  "zip",
 ]

--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -8,6 +8,7 @@ pub mod router;
 pub(crate) mod service;
 pub mod state;
 pub mod websocket;
+pub mod websocket_dispatch;
 
 pub use service::ApiGatewayV2Service;
 pub use state::{

--- a/crates/fakecloud-apigatewayv2/src/websocket.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket.rs
@@ -99,7 +99,61 @@ pub async fn run_lifecycle_tracked<F, Fut>(
     .await;
 }
 
+/// Same as [`run_lifecycle_tracked`] but also invokes `on_disconnect` when
+/// the WebSocket closes for any reason (client close, error, or outbound
+/// Close frame). This is used to dispatch the `$disconnect` Lambda route.
+pub async fn run_lifecycle_tracked_with_disconnect<F, Fut, D, Dfut>(
+    socket: WebSocket,
+    outbound: UnboundedReceiver<Message>,
+    on_message: F,
+    registry: SharedWebSocketRegistry,
+    connection_id: String,
+    on_disconnect: D,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+    D: FnOnce() -> Dfut,
+    Dfut: std::future::Future<Output = ()>,
+{
+    run_lifecycle_inner_with_disconnect(
+        socket,
+        outbound,
+        on_message,
+        Some((registry, connection_id)),
+        on_disconnect,
+    )
+    .await;
+}
+
 async fn run_lifecycle_inner<F, Fut>(
+    socket: WebSocket,
+    outbound: UnboundedReceiver<Message>,
+    on_message: F,
+    activity: Option<(SharedWebSocketRegistry, String)>,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    run_lifecycle_body(socket, outbound, on_message, activity).await;
+}
+
+async fn run_lifecycle_inner_with_disconnect<F, Fut, D, Dfut>(
+    socket: WebSocket,
+    outbound: UnboundedReceiver<Message>,
+    on_message: F,
+    activity: Option<(SharedWebSocketRegistry, String)>,
+    on_disconnect: D,
+) where
+    F: Fn(Vec<u8>, bool) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+    D: FnOnce() -> Dfut,
+    Dfut: std::future::Future<Output = ()>,
+{
+    run_lifecycle_body(socket, outbound, on_message, activity).await;
+    on_disconnect().await;
+}
+
+async fn run_lifecycle_body<F, Fut>(
     mut socket: WebSocket,
     mut outbound: UnboundedReceiver<Message>,
     on_message: F,

--- a/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
@@ -39,6 +39,7 @@ pub fn resolve_route_key(expression: &str, body: &str) -> String {
 }
 
 /// Construct the WebSocket proxy integration event.
+#[allow(clippy::too_many_arguments)]
 fn construct_event(
     api_id: &str,
     stage: &str,
@@ -128,6 +129,7 @@ fn construct_event(
 ///
 /// AWS never fails the WebSocket connection if the Lambda errors; we mirror
 /// that by swallowing invocation failures.
+#[allow(clippy::too_many_arguments)]
 pub async fn dispatch_websocket_event(
     state: &SharedApiGatewayV2State,
     lambda_delivery: Option<&Arc<dyn fakecloud_core::delivery::LambdaDelivery>>,

--- a/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
@@ -147,7 +147,7 @@ pub async fn dispatch_websocket_event(
     headers: Option<&std::collections::HashMap<String, String>>,
     query_params: Option<&std::collections::HashMap<String, String>>,
 ) {
-    let (integration_id, function_arn) = {
+    let (integration_id, function_arn, matched_route_key) = {
         let accounts = state.read();
         let empty = ApiGatewayV2State::new(account_id, region);
         let state = accounts.get(account_id).unwrap_or(&empty);
@@ -160,11 +160,17 @@ pub async fn dispatch_websocket_event(
         // if the resolved route doesn't exist and there's no `$default`,
         // AWS silently drops the message.
         let routes = state.routes.get(api_id);
-        let route = routes
-            .and_then(|rs| rs.values().find(|r| r.route_key == route_key))
-            .or_else(|| routes.and_then(|rs| rs.values().find(|r| r.route_key == "$default")));
-
-        let Some(route) = route else {
+        let matched = routes.and_then(|rs| {
+            rs.values()
+                .find(|r| r.route_key == route_key)
+                .map(|r| (r, route_key.to_string()))
+        });
+        let matched = matched.or_else(|| {
+            routes
+                .and_then(|rs| rs.values().find(|r| r.route_key == "$default"))
+                .map(|r| (r, "$default".to_string()))
+        });
+        let Some((route, matched_route_key)) = matched else {
             return;
         };
 
@@ -192,7 +198,7 @@ pub async fn dispatch_websocket_event(
             return;
         };
 
-        (integration_id.to_string(), function_arn)
+        (integration_id.to_string(), function_arn, matched_route_key)
     };
 
     let lambda_delivery = match lambda_delivery {
@@ -204,7 +210,7 @@ pub async fn dispatch_websocket_event(
         api_id,
         stage,
         connection_id,
-        route_key,
+        &matched_route_key,
         event_type,
         body,
         source_ip,

--- a/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
@@ -160,7 +160,9 @@ pub async fn dispatch_websocket_event(
         // if the resolved route doesn't exist and there's no `$default`,
         // AWS silently drops the message.
         let routes = state.routes.get(api_id);
-        let route = routes.and_then(|rs| rs.values().find(|r| r.route_key == route_key));
+        let route = routes
+            .and_then(|rs| rs.values().find(|r| r.route_key == route_key))
+            .or_else(|| routes.and_then(|rs| rs.values().find(|r| r.route_key == "$default")));
 
         let Some(route) = route else {
             return;

--- a/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
@@ -1,0 +1,324 @@
+//! WebSocket-to-Lambda dispatch for API Gateway v2 WebSocket APIs.
+//!
+//! Constructs the WebSocket proxy integration event and invokes the target
+//! Lambda. The event format follows AWS's documented shape for `$connect`,
+//! `$disconnect`, `$default`, and custom routes.
+
+use chrono::Utc;
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::state::{ApiGatewayV2State, SharedApiGatewayV2State};
+
+/// Resolve the route key for an inbound WebSocket message using the API's
+/// `routeSelectionExpression`.
+///
+/// AWS supports expressions like `$request.body.action` and `$default`.
+/// We parse `$request.body.<field>` out of the JSON body; anything else
+/// (including `$default`) is returned as a literal route key.
+pub fn resolve_route_key(expression: &str, body: &str) -> String {
+    if expression == "$default" {
+        return "$default".to_string();
+    }
+
+    // Strip `$request.body.` prefix and look up the field.
+    let field = expression.strip_prefix("$request.body.");
+    let Some(field) = field else {
+        return expression.to_string();
+    };
+
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) else {
+        return "$default".to_string();
+    };
+
+    parsed
+        .get(field)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "$default".to_string())
+}
+
+/// Construct the WebSocket proxy integration event.
+fn construct_event(
+    api_id: &str,
+    stage: &str,
+    connection_id: &str,
+    route_key: &str,
+    event_type: &str,
+    body: Option<&str>,
+    source_ip: &str,
+    user_agent: Option<&str>,
+    connected_at: chrono::DateTime<chrono::Utc>,
+    headers: Option<&std::collections::HashMap<String, String>>,
+    query_params: Option<&std::collections::HashMap<String, String>>,
+) -> serde_json::Value {
+    let now = Utc::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let extended_request_id = uuid::Uuid::new_v4().to_string();
+    let message_id = if event_type == "MESSAGE" {
+        Some(uuid::Uuid::new_v4().to_string())
+    } else {
+        None
+    };
+
+    let mut identity = serde_json::Map::new();
+    identity.insert("sourceIp".to_string(), json!(source_ip));
+    if let Some(ua) = user_agent {
+        identity.insert("userAgent".to_string(), json!(ua));
+    }
+
+    let mut request_context = serde_json::Map::new();
+    request_context.insert("apiId".to_string(), json!(api_id));
+    request_context.insert(
+        "connectedAt".to_string(),
+        json!(connected_at.timestamp_millis()),
+    );
+    request_context.insert("connectionId".to_string(), json!(connection_id));
+    request_context.insert(
+        "domainName".to_string(),
+        json!(format!("{api_id}.execute-api.us-east-1.amazonaws.com")),
+    );
+    request_context.insert("eventType".to_string(), json!(event_type));
+    request_context.insert("extendedRequestId".to_string(), json!(extended_request_id));
+    request_context.insert("identity".to_string(), serde_json::Value::Object(identity));
+    request_context.insert("messageDirection".to_string(), json!("IN"));
+    request_context.insert("messageId".to_string(), json!(message_id));
+    request_context.insert("requestId".to_string(), json!(request_id));
+    request_context.insert(
+        "requestTime".to_string(),
+        json!(now.format("%d/%b/%Y:%H:%M:%S %z").to_string()),
+    );
+    request_context.insert(
+        "requestTimeEpoch".to_string(),
+        json!(now.timestamp_millis()),
+    );
+    request_context.insert("routeKey".to_string(), json!(route_key));
+    request_context.insert("stage".to_string(), json!(stage));
+
+    let mut event = serde_json::Map::new();
+    event.insert(
+        "requestContext".to_string(),
+        serde_json::Value::Object(request_context),
+    );
+
+    if let Some(headers) = headers {
+        event.insert("headers".to_string(), json!(headers));
+    }
+    if let Some(query_params) = query_params {
+        event.insert("queryStringParameters".to_string(), json!(query_params));
+    }
+
+    if let Some(body_str) = body {
+        event.insert("body".to_string(), json!(body_str));
+        event.insert("isBase64Encoded".to_string(), json!(false));
+    } else {
+        event.insert("body".to_string(), serde_json::Value::Null);
+        event.insert("isBase64Encoded".to_string(), json!(false));
+    }
+
+    serde_json::Value::Object(event)
+}
+
+/// Dispatch a WebSocket event to the Lambda integration for the given route.
+///
+/// Silently returns when:
+/// - the API or route has no matching integration
+/// - Lambda delivery is not configured
+/// - the integration is not `AWS_PROXY`
+///
+/// AWS never fails the WebSocket connection if the Lambda errors; we mirror
+/// that by swallowing invocation failures.
+pub async fn dispatch_websocket_event(
+    state: &SharedApiGatewayV2State,
+    lambda_delivery: Option<&Arc<dyn fakecloud_core::delivery::LambdaDelivery>>,
+    account_id: &str,
+    region: &str,
+    api_id: &str,
+    stage: &str,
+    connection_id: &str,
+    route_key: &str,
+    event_type: &str,
+    body: Option<&str>,
+    source_ip: &str,
+    user_agent: Option<&str>,
+    connected_at: chrono::DateTime<chrono::Utc>,
+    headers: Option<&std::collections::HashMap<String, String>>,
+    query_params: Option<&std::collections::HashMap<String, String>>,
+) {
+    let (integration_id, function_arn) = {
+        let accounts = state.read();
+        let empty = ApiGatewayV2State::new(account_id, region);
+        let state = accounts.get(account_id).unwrap_or(&empty);
+
+        let Some(_api) = state.apis.get(api_id) else {
+            return;
+        };
+
+        // WebSocket APIs don't have a `$default` route automatically;
+        // if the resolved route doesn't exist and there's no `$default`,
+        // AWS silently drops the message.
+        let routes = state.routes.get(api_id);
+        let route = routes.and_then(|rs| rs.values().find(|r| r.route_key == route_key));
+
+        let Some(route) = route else {
+            return;
+        };
+
+        let Some(target) = route.target.as_ref() else {
+            return;
+        };
+
+        let Some(integration_id) = target.strip_prefix("integrations/") else {
+            return;
+        };
+
+        let Some(integration) = state
+            .integrations
+            .get(api_id)
+            .and_then(|ints| ints.get(integration_id))
+        else {
+            return;
+        };
+
+        if integration.integration_type != "AWS_PROXY" {
+            return;
+        }
+
+        let Some(function_arn) = integration.integration_uri.clone() else {
+            return;
+        };
+
+        (integration_id.to_string(), function_arn)
+    };
+
+    let lambda_delivery = match lambda_delivery {
+        Some(d) => d,
+        None => return,
+    };
+
+    let event = construct_event(
+        api_id,
+        stage,
+        connection_id,
+        route_key,
+        event_type,
+        body,
+        source_ip,
+        user_agent,
+        connected_at,
+        headers,
+        query_params,
+    );
+
+    let payload = match serde_json::to_string(&event) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(%e, "failed to serialize websocket event");
+            return;
+        }
+    };
+
+    match lambda_delivery.invoke_lambda(&function_arn, &payload).await {
+        Ok(_) => {
+            tracing::debug!(route_key, integration_id, "websocket lambda invoked");
+        }
+        Err(e) => {
+            tracing::warn!(%e, route_key, "websocket lambda invocation failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_route_key_default() {
+        assert_eq!(
+            resolve_route_key("$default", r#"{"action":"x"}"#),
+            "$default"
+        );
+    }
+
+    #[test]
+    fn resolve_route_key_from_body_action() {
+        assert_eq!(
+            resolve_route_key("$request.body.action", r#"{"action":"sendmessage"}"#),
+            "sendmessage"
+        );
+    }
+
+    #[test]
+    fn resolve_route_key_falls_back_to_default_when_field_missing() {
+        assert_eq!(
+            resolve_route_key("$request.body.action", r#"{"foo":"bar"}"#),
+            "$default"
+        );
+    }
+
+    #[test]
+    fn resolve_route_key_falls_back_to_default_when_not_json() {
+        assert_eq!(
+            resolve_route_key("$request.body.action", "not-json"),
+            "$default"
+        );
+    }
+
+    #[test]
+    fn resolve_route_key_literal_expression() {
+        assert_eq!(
+            resolve_route_key("$request.body.messageType", r#"{"messageType":"chat"}"#),
+            "chat"
+        );
+    }
+
+    #[test]
+    fn construct_connect_event_has_null_body() {
+        let event = construct_event(
+            "api-1",
+            "dev",
+            "conn-id=",
+            "$connect",
+            "CONNECT",
+            None,
+            "127.0.0.1",
+            Some("test-agent"),
+            chrono::Utc::now(),
+            Some(&std::collections::HashMap::from([(
+                "X-Custom".to_string(),
+                "val".to_string(),
+            )])),
+            Some(&std::collections::HashMap::from([(
+                "token".to_string(),
+                "abc".to_string(),
+            )])),
+        );
+        assert_eq!(event["requestContext"]["routeKey"], "$connect");
+        assert_eq!(event["requestContext"]["eventType"], "CONNECT");
+        assert!(event["body"].is_null());
+        assert_eq!(event["isBase64Encoded"], false);
+        assert_eq!(event["headers"]["X-Custom"], "val");
+        assert_eq!(event["queryStringParameters"]["token"], "abc");
+    }
+
+    #[test]
+    fn construct_message_event_has_message_id() {
+        let event = construct_event(
+            "api-1",
+            "dev",
+            "conn-id=",
+            "$default",
+            "MESSAGE",
+            Some(r#"hello"#),
+            "127.0.0.1",
+            None,
+            chrono::Utc::now(),
+            None,
+            None,
+        );
+        assert_eq!(event["requestContext"]["routeKey"], "$default");
+        assert_eq!(event["requestContext"]["eventType"], "MESSAGE");
+        assert!(event["requestContext"]["messageId"].as_str().is_some());
+        assert_eq!(event["body"], "hello");
+    }
+}

--- a/crates/fakecloud-e2e/Cargo.toml
+++ b/crates/fakecloud-e2e/Cargo.toml
@@ -57,6 +57,8 @@ aws-smithy-types = "1"
 aws-credential-types = "1"
 aws-types = "1"
 reqwest = { workspace = true }
+tokio-tungstenite = "0.29"
+futures-util = "0.3"
 chrono = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
+++ b/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
@@ -232,7 +232,7 @@ async fn websocket_connect_and_default_route_dispatches_to_lambda() {
         "$default lambda should have fired for message"
     );
     let body: serde_json::Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
-    assert_eq!(body["route_key"], "sendmessage");
+    assert_eq!(body["route_key"], "$default");
     assert_eq!(body["event_type"], "MESSAGE");
     assert_eq!(body["body"], r#"{"action":"sendmessage"}"#);
     assert_eq!(body["connection_id"].as_str().unwrap(), connection_id);

--- a/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
+++ b/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
@@ -1,0 +1,359 @@
+mod helpers;
+
+use std::io::Write;
+
+use aws_sdk_apigatewayv2::types::ProtocolType;
+use aws_sdk_lambda::primitives::Blob;
+use aws_sdk_lambda::types::{Environment, FunctionCode, Runtime};
+use futures_util::sink::SinkExt;
+use helpers::{sqs_receive_at_least, TestServer};
+
+fn dockerized_endpoint(server: &TestServer) -> String {
+    format!("http://host.docker.internal:{}", server.port())
+}
+
+fn dockerized_queue_url(server: &TestServer, queue_name: &str) -> String {
+    format!(
+        "http://host.docker.internal:{}/123456789012/{}",
+        server.port(),
+        queue_name
+    )
+}
+
+fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf = Vec::new();
+    let cursor = std::io::Cursor::new(buf);
+    let mut writer = zip::ZipWriter::new(cursor);
+    for (name, content) in entries {
+        let options = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(content).unwrap();
+    }
+    let cursor = writer.finish().unwrap();
+    cursor.into_inner()
+}
+
+fn python_sqs_writer_code() -> &'static str {
+    r#"
+import json
+import os
+import urllib.request
+import urllib.parse
+
+def lambda_handler(event, context):
+    endpoint = os.environ["FAKECLOUD_ENDPOINT"]
+    queue_url = os.environ["RESULT_QUEUE_URL"]
+
+    params = urllib.parse.urlencode({
+        "Action": "SendMessage",
+        "QueueUrl": queue_url,
+        "MessageBody": json.dumps({
+            "marker": "lambda-executed",
+            "route_key": event.get("requestContext", {}).get("routeKey"),
+            "event_type": event.get("requestContext", {}).get("eventType"),
+            "connection_id": event.get("requestContext", {}).get("connectionId"),
+            "body": event.get("body"),
+        }),
+    }).encode()
+
+    req = urllib.request.Request(endpoint, data=params, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Authorization", (
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200101/us-east-1/sqs/aws4_request, "
+        "SignedHeaders=host, Signature=fake"
+    ))
+    urllib.request.urlopen(req)
+
+    return {"statusCode": 200, "body": "marker sent"}
+"#
+}
+
+async fn create_marker_lambda(
+    server: &TestServer,
+    sqs: &aws_sdk_sqs::Client,
+    lambda: &aws_sdk_lambda::Client,
+    queue_name: &str,
+    function_name: &str,
+) -> String {
+    let queue = sqs
+        .create_queue()
+        .queue_name(queue_name)
+        .send()
+        .await
+        .unwrap();
+    let queue_url = queue.queue_url().unwrap().to_string();
+    let docker_endpoint = dockerized_endpoint(server);
+    let docker_queue_url = dockerized_queue_url(server, queue_name);
+
+    let zip = make_zip(&[("lambda_function.py", python_sqs_writer_code().as_bytes())]);
+
+    lambda
+        .create_function()
+        .function_name(function_name)
+        .runtime(Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("lambda_function.lambda_handler")
+        .environment(
+            Environment::builder()
+                .variables("FAKECLOUD_ENDPOINT", &docker_endpoint)
+                .variables("RESULT_QUEUE_URL", &docker_queue_url)
+                .build(),
+        )
+        .code(FunctionCode::builder().zip_file(Blob::new(zip)).build())
+        .send()
+        .await
+        .unwrap();
+
+    queue_url
+}
+
+fn ws_url(server: &TestServer, api_id: &str, stage: &str) -> String {
+    format!(
+        "ws://127.0.0.1:{}/_fakecloud/apigatewayv2/ws/{}?stage={}",
+        server.port(),
+        api_id,
+        stage
+    )
+}
+
+fn container_cli_available() -> bool {
+    for cli in ["docker", "podman"] {
+        if std::process::Command::new(cli)
+            .arg("info")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[tokio::test]
+async fn websocket_connect_and_default_route_dispatches_to_lambda() {
+    if !container_cli_available() {
+        if std::env::var("CI").is_ok() {
+            panic!("container runtime is not available but is required in CI");
+        }
+        eprintln!("skipping: container runtime not available");
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let apigw = server.apigatewayv2_client().await;
+    let lambda = server.lambda_client().await;
+    let sqs = server.sqs_client().await;
+
+    let queue_url = create_marker_lambda(
+        &server,
+        &sqs,
+        &lambda,
+        "apigwv2-ws-result",
+        "apigwv2-ws-handler",
+    )
+    .await;
+
+    // Create WebSocket API
+    let api = apigw
+        .create_api()
+        .name("ws-test-api")
+        .protocol_type(ProtocolType::Websocket)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap().to_string();
+
+    // Create Lambda integration
+    let integration = apigw
+        .create_integration()
+        .api_id(&api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri(format!(
+            "arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-handler"
+        ))
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id().unwrap().to_string();
+
+    // Create routes
+    for route_key in ["$connect", "$default", "$disconnect"] {
+        apigw
+            .create_route()
+            .api_id(&api_id)
+            .route_key(route_key)
+            .target(format!("integrations/{}", integration_id))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // Create stage
+    apigw
+        .create_stage()
+        .api_id(&api_id)
+        .stage_name("dev")
+        .send()
+        .await
+        .unwrap();
+
+    // Connect via WebSocket
+    let url = ws_url(&server, &api_id, "dev");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    // Wait for $connect Lambda to fire
+    let msgs = sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(30)).await;
+    assert!(!msgs.is_empty(), "$connect lambda should have fired");
+    let body: serde_json::Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
+    assert_eq!(body["route_key"], "$connect");
+    assert_eq!(body["event_type"], "CONNECT");
+    let connection_id = body["connection_id"].as_str().unwrap().to_string();
+
+    // Purge the queue so we can count new messages cleanly
+    sqs.purge_queue()
+        .queue_url(&queue_url)
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Send a text message — should dispatch to $default
+    ws_stream
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            r#"{"action":"sendmessage"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+    let msgs = sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(30)).await;
+    assert!(
+        !msgs.is_empty(),
+        "$default lambda should have fired for message"
+    );
+    let body: serde_json::Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
+    assert_eq!(body["route_key"], "sendmessage");
+    assert_eq!(body["event_type"], "MESSAGE");
+    assert_eq!(body["body"], r#"{"action":"sendmessage"}"#);
+    assert_eq!(body["connection_id"].as_str().unwrap(), connection_id);
+
+    // Purge again
+    sqs.purge_queue()
+        .queue_url(&queue_url)
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Close the WebSocket
+    ws_stream.close(None).await.unwrap();
+
+    // Wait for $disconnect Lambda to fire
+    let msgs = sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(30)).await;
+    assert!(!msgs.is_empty(), "$disconnect lambda should have fired");
+    let body: serde_json::Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
+    assert_eq!(body["route_key"], "$disconnect");
+    assert_eq!(body["event_type"], "DISCONNECT");
+    assert_eq!(body["connection_id"].as_str().unwrap(), connection_id);
+}
+
+#[tokio::test]
+async fn websocket_message_falls_back_to_default_route() {
+    if !container_cli_available() {
+        if std::env::var("CI").is_ok() {
+            panic!("container runtime is not available but is required in CI");
+        }
+        eprintln!("skipping: container runtime not available");
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let apigw = server.apigatewayv2_client().await;
+    let lambda = server.lambda_client().await;
+    let sqs = server.sqs_client().await;
+
+    let queue_url = create_marker_lambda(
+        &server,
+        &sqs,
+        &lambda,
+        "apigwv2-ws-default-result",
+        "apigwv2-ws-default-handler",
+    )
+    .await;
+
+    let api = apigw
+        .create_api()
+        .name("ws-default-test-api")
+        .protocol_type(ProtocolType::Websocket)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap().to_string();
+
+    let integration = apigw
+        .create_integration()
+        .api_id(&api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri(format!(
+            "arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-default-handler"
+        ))
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id().unwrap().to_string();
+
+    // Only create $connect and $default — no custom route for "sendmessage"
+    for route_key in ["$connect", "$default"] {
+        apigw
+            .create_route()
+            .api_id(&api_id)
+            .route_key(route_key)
+            .target(format!("integrations/{}", integration_id))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    apigw
+        .create_stage()
+        .api_id(&api_id)
+        .stage_name("dev")
+        .send()
+        .await
+        .unwrap();
+
+    let url = ws_url(&server, &api_id, "dev");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    // Wait for $connect
+    let msgs = sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(30)).await;
+    assert!(!msgs.is_empty(), "$connect lambda should have fired");
+
+    sqs.purge_queue()
+        .queue_url(&queue_url)
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Send a message with an action that has no matching route
+    ws_stream
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            r#"{"action":"unknown"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+    let msgs = sqs_receive_at_least(&sqs, &queue_url, 1, std::time::Duration::from_secs(30)).await;
+    assert!(
+        !msgs.is_empty(),
+        "$default lambda should have fired for unknown route"
+    );
+    let body: serde_json::Value = serde_json::from_str(msgs[0].body().unwrap()).unwrap();
+    assert_eq!(body["route_key"], "$default");
+    assert_eq!(body["event_type"], "MESSAGE");
+
+    ws_stream.close(None).await.unwrap();
+}

--- a/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
+++ b/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
@@ -171,9 +171,7 @@ async fn websocket_connect_and_default_route_dispatches_to_lambda() {
         .create_integration()
         .api_id(&api_id)
         .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
-        .integration_uri(format!(
-            "arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-handler"
-        ))
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-handler")
         .send()
         .await
         .unwrap();
@@ -296,9 +294,7 @@ async fn websocket_message_falls_back_to_default_route() {
         .create_integration()
         .api_id(&api_id)
         .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
-        .integration_uri(format!(
-            "arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-default-handler"
-        ))
+        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-default-handler")
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
+++ b/crates/fakecloud-e2e/tests/apigwv2_websocket.rs
@@ -294,7 +294,9 @@ async fn websocket_message_falls_back_to_default_route() {
         .create_integration()
         .api_id(&api_id)
         .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
-        .integration_uri("arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-default-handler")
+        .integration_uri(
+            "arn:aws:lambda:us-east-1:123456789012:function:apigwv2-ws-default-handler",
+        )
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2691,7 +2691,7 @@ async fn main() {
     }
 
     let config = DispatchConfig {
-        region: cli.region,
+        region: cli.region.clone(),
         account_id: cli.account_id.clone(),
         verify_sigv4: cli.verify_sigv4,
         iam_mode,
@@ -5136,6 +5136,10 @@ async fn main() {
             "/_fakecloud/apigatewayv2/ws/{api_id}",
             axum::routing::get({
                 let reg = apigatewayv2_ws_registry.clone();
+                let apigw_state = apigatewayv2_state.clone();
+                let lambda_delivery = lambda_delivery.clone();
+                let account_id = cli.account_id.clone();
+                let region = cli.region.clone();
                 move |ws: axum::extract::WebSocketUpgrade,
                       axum::extract::Path(api_id): axum::extract::Path<String>,
                       axum::extract::Query(params): axum::extract::Query<
@@ -5146,6 +5150,10 @@ async fn main() {
                     std::net::SocketAddr,
                 >| {
                     let reg = reg.clone();
+                    let apigw_state = apigw_state.clone();
+                    let lambda_delivery = lambda_delivery.clone();
+                    let account_id = account_id.clone();
+                    let region = region.clone();
                     async move {
                         let stage = params
                             .get("stage")
@@ -5156,40 +5164,167 @@ async fn main() {
                             .and_then(|v| v.to_str().ok())
                             .map(|s| s.to_string());
                         let source_ip = addr.ip().to_string();
+
+                        let mut header_map = std::collections::HashMap::new();
+                        for (k, v) in &headers {
+                            if let Ok(s) = v.to_str() {
+                                header_map.insert(k.to_string(), s.to_string());
+                            }
+                        }
+                        let query_map: std::collections::HashMap<String, String> = params
+                            .into_iter()
+                            .filter(|(k, _)| k != "stage")
+                            .collect();
+
                         ws.on_upgrade(move |socket| async move {
                             let (conn_id, rx) = fakecloud_apigatewayv2::websocket::register(
                                 reg.clone(),
-                                api_id,
-                                stage,
-                                source_ip,
-                                user_agent,
+                                api_id.clone(),
+                                stage.clone(),
+                                source_ip.clone(),
+                                user_agent.clone(),
                             );
                             let conn_id_for_lifecycle = conn_id.clone();
-                            // Echo dispatcher stub — real Lambda dispatch for
-                            // `$default` is wired up in a follow-up; for now
-                            // we just log. `@connections` POST exercises the
-                            // outbound path end-to-end.
-                            let on_message = |bytes: Vec<u8>, is_text: bool| {
-                                let preview =
-                                    String::from_utf8_lossy(&bytes[..bytes.len().min(64)])
-                                        .to_string();
-                                async move {
-                                    tracing::debug!(
-                                        is_text,
-                                        preview = %preview,
-                                        "apigwv2 ws message received"
-                                    );
+                            let connected_at = chrono::Utc::now();
+
+                            // Dispatch $connect route
+                            fakecloud_apigatewayv2::websocket_dispatch::dispatch_websocket_event(
+                                &apigw_state,
+                                lambda_delivery.as_ref(),
+                                &account_id,
+                                &region,
+                                &api_id,
+                                &stage,
+                                &conn_id,
+                                "$connect",
+                                "CONNECT",
+                                None,
+                                &source_ip,
+                                user_agent.as_deref(),
+                                connected_at,
+                                Some(&header_map),
+                                Some(&query_map),
+                            )
+                            .await;
+
+                            let on_disconnect = {
+                                let apigw_state = apigw_state.clone();
+                                let lambda_delivery = lambda_delivery.clone();
+                                let account_id = account_id.clone();
+                                let region = region.clone();
+                                let api_id = api_id.clone();
+                                let stage = stage.clone();
+                                let conn_id = conn_id.clone();
+                                let source_ip = source_ip.clone();
+                                let user_agent = user_agent.clone();
+                                // connected_at is Copy (DateTime<Utc>) — no rebind needed
+                                move || async move {
+                                    fakecloud_apigatewayv2::websocket_dispatch::dispatch_websocket_event(
+                                        &apigw_state,
+                                        lambda_delivery.as_ref(),
+                                        &account_id,
+                                        &region,
+                                        &api_id,
+                                        &stage,
+                                        &conn_id,
+                                        "$disconnect",
+                                        "DISCONNECT",
+                                        None,
+                                        &source_ip,
+                                        user_agent.as_deref(),
+                                        connected_at,
+                                        None,
+                                        None,
+                                    )
+                                    .await;
                                 }
                             };
-                            fakecloud_apigatewayv2::websocket::run_lifecycle_tracked(
+
+                            let on_message = {
+                                let apigw_state = apigw_state.clone();
+                                let lambda_delivery = lambda_delivery.clone();
+                                let account_id = account_id.clone();
+                                let region = region.clone();
+                                let api_id = api_id.clone();
+                                let stage = stage.clone();
+                                let conn_id = conn_id.clone();
+                                let source_ip = source_ip.clone();
+                                let user_agent = user_agent.clone();
+                                // connected_at is Copy (DateTime<Utc>) — no rebind needed
+                                move |bytes: Vec<u8>, is_text: bool| {
+                                    let apigw_state = apigw_state.clone();
+                                    let lambda_delivery = lambda_delivery.clone();
+                                    let account_id = account_id.clone();
+                                    let region = region.clone();
+                                    let api_id = api_id.clone();
+                                    let stage = stage.clone();
+                                    let conn_id = conn_id.clone();
+                                    let source_ip = source_ip.clone();
+                                    let user_agent = user_agent.clone();
+                                    // connected_at is Copy (DateTime<Utc>) — no rebind needed
+                                    async move {
+                                        let body_str = if is_text {
+                                            String::from_utf8_lossy(&bytes).into_owned()
+                                        } else {
+                                            use base64::prelude::*;
+                                            BASE64_STANDARD.encode(&bytes)
+                                        };
+                                        let is_base64 = !is_text;
+
+                                        // Resolve route key via RouteSelectionExpression
+                                        let route_key = {
+                                            let accounts = apigw_state.read();
+                                            let empty = fakecloud_apigatewayv2::ApiGatewayV2State::new(
+                                                &account_id, &region,
+                                            );
+                                            let state = accounts.get(&account_id).unwrap_or(&empty);
+                                            let expression = state
+                                                .apis
+                                                .get(&api_id)
+                                                .map(|a| a.route_selection_expression.as_str())
+                                                .unwrap_or("$request.body.action");
+                                            if is_base64 {
+                                                "$default".to_string()
+                                            } else {
+                                                fakecloud_apigatewayv2::websocket_dispatch::resolve_route_key(
+                                                    expression, &body_str,
+                                                )
+                                            }
+                                        };
+
+                                        fakecloud_apigatewayv2::websocket_dispatch::dispatch_websocket_event(
+                                            &apigw_state,
+                                            lambda_delivery.as_ref(),
+                                            &account_id,
+                                            &region,
+                                            &api_id,
+                                            &stage,
+                                            &conn_id,
+                                            &route_key,
+                                            "MESSAGE",
+                                            Some(&body_str),
+                                            &source_ip,
+                                            user_agent.as_deref(),
+                                            connected_at,
+                                            None,
+                                            None,
+                                        )
+                                        .await;
+                                    }
+                                }
+                            };
+
+                            fakecloud_apigatewayv2::websocket::run_lifecycle_tracked_with_disconnect(
                                 socket,
                                 rx,
                                 on_message,
                                 reg.clone(),
                                 conn_id_for_lifecycle,
+                                on_disconnect,
                             )
                             .await;
-                            fakecloud_apigatewayv2::websocket::deregister(&reg, &conn_id);
+                            fakecloud_apigatewayv2::websocket::deregister(&reg, &conn_id,
+                            );
                         })
                     }
                 }


### PR DESCRIPTION
## Summary
- Implement \$connect/\$disconnect/\$default route resolution for API Gateway v2 WebSocket APIs.
- Wire WebSocket lifecycle events (connect, message, disconnect) into Lambda dispatch via the existing container runtime.
- Add `websocket_dispatch` module for event construction and route selection expression evaluation.
- Add E2E tests covering \$connect, custom route selection, \$default fallback, and \$disconnect.

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `cargo test -p fakecloud-apigatewayv2` passes (101 tests)
- [x] `cargo test -p fakecloud-e2e --test apigwv2_websocket` passes (skips when container runtime unavailable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API Gateway v2 WebSocket support with Lambda `AWS_PROXY` dispatch for `$connect`, messages, and `$disconnect`. Provides a local WebSocket endpoint and E2E tests.

- **New Features**
  - Adds `websocket_dispatch` to build AWS-shaped WebSocket events and invoke Lambda (errors are swallowed like AWS).
  - New WebSocket endpoint `/_fakecloud/apigatewayv2/ws/{api_id}?stage=...`; dispatches `$connect` (with headers/query) and always fires `$disconnect` on any close.
  - Resolves message routes via `routeSelectionExpression` (default `$request.body.action`); if no route matches, falls back to `$default` and sets event `routeKey` to `$default`; binary messages route to `$default`; message events include `messageId`.

- **Dependencies**
  - Added `tokio-tungstenite` and `futures-util` for WebSocket E2E tests.

<sup>Written for commit dcf43adb35e6a932ac98bbf61ed8ef7d74da9d1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

