### PR TITLE
feat(application-autoscaling): ECS desiredCount scaling (EE2)

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/hooks.rs
+++ b/crates/fakecloud-application-autoscaling/src/hooks.rs
@@ -44,6 +44,32 @@ pub trait MetricReader: Send + Sync {
     ) -> Vec<String>;
 }
 
+/// Applies a desired-count change to an ECS service. Used when a scaling
+/// target's `ServiceNamespace == ecs`.
+pub trait EcsServiceHook: Send + Sync {
+    /// Returns the service's current `desiredCount`, or `None` when the
+    /// cluster or service doesn't exist.
+    fn current_desired_count(
+        &self,
+        account_id: &str,
+        region: &str,
+        cluster_name: &str,
+        service_name: &str,
+    ) -> Option<i32>;
+
+    /// Sets the service's `desiredCount` and returns `Ok(())` on success.
+    /// Returns `Err` when the cluster/service is missing so the caller
+    /// can log a `NotScaled` activity.
+    fn set_desired_count(
+        &self,
+        account_id: &str,
+        region: &str,
+        cluster_name: &str,
+        service_name: &str,
+        desired_count: i32,
+    ) -> Result<(), String>;
+}
+
 /// Applies a capacity change to a DynamoDB table. Used when a scaling
 /// target's `ServiceNamespace == dynamodb`. `dimension` is the AWS
 /// `ScalableDimension` string and selects read vs write capacity.

--- a/crates/fakecloud-application-autoscaling/src/lib.rs
+++ b/crates/fakecloud-application-autoscaling/src/lib.rs
@@ -4,7 +4,7 @@ pub(crate) mod service;
 pub(crate) mod state;
 pub mod ticker;
 
-pub use hooks::{DynamoDbCapacityHook, MetricReader};
+pub use hooks::{DynamoDbCapacityHook, EcsServiceHook, MetricReader};
 pub use scheduled_executor::ScheduledActionExecutor;
 pub use service::ApplicationAutoScalingService;
 pub use state::{ApplicationAutoScalingAccounts, SharedApplicationAutoScalingState};

--- a/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
+++ b/crates/fakecloud-application-autoscaling/src/scheduled_executor.rs
@@ -26,15 +26,18 @@ use std::time::Duration;
 use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc};
 use uuid::Uuid;
 
-use crate::hooks::DynamoDbCapacityHook;
+use crate::hooks::{DynamoDbCapacityHook, EcsServiceHook};
 use crate::state::{ScalingActivity, ScheduledAction, SharedApplicationAutoScalingState};
-use crate::ticker::{ddb_table_from_resource_public, DDB_READ_DIM, DDB_WRITE_DIM};
+use crate::ticker::{
+    ddb_table_from_resource_public, ecs_service_from_resource, DDB_READ_DIM, DDB_WRITE_DIM,
+};
 
 /// Background loop driver. Construction wires the shared state and the
 /// hooks that apply scaling decisions on real resources.
 pub struct ScheduledActionExecutor {
     state: SharedApplicationAutoScalingState,
     ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+    ecs_hook: Option<Arc<dyn EcsServiceHook>>,
     region: String,
     interval: Duration,
 }
@@ -48,6 +51,7 @@ impl ScheduledActionExecutor {
         Self {
             state,
             ddb_hook,
+            ecs_hook: None,
             region: region.into(),
             interval: Duration::from_secs(30),
         }
@@ -55,6 +59,11 @@ impl ScheduledActionExecutor {
 
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
+        self
+    }
+
+    pub fn with_ecs_hook(mut self, hook: Arc<dyn EcsServiceHook>) -> Self {
+        self.ecs_hook = Some(hook);
         self
     }
 
@@ -289,6 +298,37 @@ impl ScheduledActionExecutor {
                 };
                 self.ddb_hook
                     .set_capacity(account_id, &self.region, table, read, write)
+            }
+            "ecs" => {
+                let Some((cluster, service)) = ecs_service_from_resource(&action.resource_id)
+                else {
+                    return Err(format!(
+                        "Cannot derive ECS cluster/service from resource_id {}",
+                        action.resource_id
+                    ));
+                };
+                let Some(hook) = self.ecs_hook.as_ref() else {
+                    return Ok(());
+                };
+                let Some(current) =
+                    hook.current_desired_count(account_id, &self.region, cluster, service)
+                else {
+                    return Err(format!(
+                        "ECS service {service} not found in cluster {cluster}"
+                    ));
+                };
+                // Pin desired count into the new [min, max] window.
+                let mut desired = current as i64;
+                if desired < new_min as i64 {
+                    desired = new_min as i64;
+                }
+                if desired > new_max as i64 {
+                    desired = new_max as i64;
+                }
+                if desired == current as i64 {
+                    return Ok(());
+                }
+                hook.set_desired_count(account_id, &self.region, cluster, service, desired as i32)
             }
             // Other namespaces don't yet have a cross-service apply
             // hook in this crate. Updating the scalable target bounds

--- a/crates/fakecloud-application-autoscaling/src/ticker.rs
+++ b/crates/fakecloud-application-autoscaling/src/ticker.rs
@@ -21,7 +21,7 @@ use chrono::Utc;
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::hooks::{DynamoDbCapacityHook, MetricReader};
+use crate::hooks::{DynamoDbCapacityHook, EcsServiceHook, MetricReader};
 use crate::state::{
     NotScaledReason, ScalableTarget, ScalingActivity, ScalingPolicy,
     SharedApplicationAutoScalingState,
@@ -31,10 +31,18 @@ use crate::state::{
 pub const DDB_READ_DIM: &str = "dynamodb:table:ReadCapacityUnits";
 pub const DDB_WRITE_DIM: &str = "dynamodb:table:WriteCapacityUnits";
 
+/// AWS dimension string for ECS service desired-count scaling.
+pub const ECS_SERVICE_DIM: &str = "ecs:service:DesiredCount";
+
 /// Predefined CloudWatch metric types Application Auto Scaling knows
 /// for DynamoDB.
 const DDB_READ_METRIC: &str = "DynamoDBReadCapacityUtilization";
 const DDB_WRITE_METRIC: &str = "DynamoDBWriteCapacityUtilization";
+
+/// Predefined CloudWatch metric types for ECS service scaling.
+const ECS_CPU_METRIC: &str = "ECSServiceAverageCPUUtilization";
+const ECS_MEMORY_METRIC: &str = "ECSServiceAverageMemoryUtilization";
+const ECS_ALB_METRIC: &str = "ALBRequestCountPerTarget";
 
 /// Default region used to resolve metrics when a target was registered
 /// without a region context. Application Auto Scaling targets are
@@ -45,6 +53,7 @@ pub struct ScalingWatcher {
     state: SharedApplicationAutoScalingState,
     metric_reader: Arc<dyn MetricReader>,
     ddb_hook: Arc<dyn DynamoDbCapacityHook>,
+    ecs_hook: Option<Arc<dyn EcsServiceHook>>,
     region: String,
     interval: Duration,
 }
@@ -60,6 +69,7 @@ impl ScalingWatcher {
             state,
             metric_reader,
             ddb_hook,
+            ecs_hook: None,
             region: region.into(),
             interval: Duration::from_secs(15),
         }
@@ -67,6 +77,11 @@ impl ScalingWatcher {
 
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
+        self
+    }
+
+    pub fn with_ecs_hook(mut self, hook: Arc<dyn EcsServiceHook>) -> Self {
+        self.ecs_hook = Some(hook);
         self
     }
 
@@ -88,9 +103,6 @@ impl ScalingWatcher {
             let guard = self.state.read();
             for (account_id, account) in guard.accounts.iter() {
                 for policy in account.scaling_policies.values() {
-                    if policy.service_namespace != "dynamodb" {
-                        continue;
-                    }
                     let key = (
                         policy.service_namespace.clone(),
                         policy.resource_id.clone(),
@@ -102,26 +114,55 @@ impl ScalingWatcher {
                     if suspended_for(target, policy) {
                         continue;
                     }
-                    let Some(table) = ddb_table_from_resource(&policy.resource_id) else {
-                        continue;
-                    };
-                    let Some((read_cur, write_cur)) =
-                        self.ddb_hook
-                            .current_capacity(account_id, &self.region, table)
-                    else {
-                        continue;
-                    };
-                    let current = match policy.scalable_dimension.as_str() {
-                        DDB_READ_DIM => read_cur,
-                        DDB_WRITE_DIM => write_cur,
-                        _ => continue,
-                    };
-                    jobs.push(Job {
-                        account_id: account_id.clone(),
-                        policy: policy.clone(),
-                        target: target.clone(),
-                        current,
-                    });
+                    match policy.service_namespace.as_str() {
+                        "dynamodb" => {
+                            let Some(table) = ddb_table_from_resource(&policy.resource_id) else {
+                                continue;
+                            };
+                            let Some((read_cur, write_cur)) =
+                                self.ddb_hook
+                                    .current_capacity(account_id, &self.region, table)
+                            else {
+                                continue;
+                            };
+                            let current = match policy.scalable_dimension.as_str() {
+                                DDB_READ_DIM => read_cur,
+                                DDB_WRITE_DIM => write_cur,
+                                _ => continue,
+                            };
+                            jobs.push(Job {
+                                account_id: account_id.clone(),
+                                policy: policy.clone(),
+                                target: target.clone(),
+                                current,
+                            });
+                        }
+                        "ecs" => {
+                            let Some(hook) = self.ecs_hook.as_ref() else {
+                                continue;
+                            };
+                            let Some((cluster, service)) =
+                                ecs_service_from_resource(&policy.resource_id)
+                            else {
+                                continue;
+                            };
+                            let Some(current) = hook.current_desired_count(
+                                account_id,
+                                &self.region,
+                                cluster,
+                                service,
+                            ) else {
+                                continue;
+                            };
+                            jobs.push(Job {
+                                account_id: account_id.clone(),
+                                policy: policy.clone(),
+                                target: target.clone(),
+                                current: current as i64,
+                            });
+                        }
+                        _ => {}
+                    }
                 }
             }
         }
@@ -154,11 +195,21 @@ impl ScalingWatcher {
         target: &ScalableTarget,
         current: i64,
     ) -> bool {
-        match policy.policy_type.as_str() {
-            "TargetTrackingScaling" => {
-                self.process_target_tracking(account_id, policy, target, current)
-            }
-            "StepScaling" => self.process_step_scaling(account_id, policy, target, current),
+        match policy.service_namespace.as_str() {
+            "dynamodb" => match policy.policy_type.as_str() {
+                "TargetTrackingScaling" => {
+                    self.process_target_tracking(account_id, policy, target, current)
+                }
+                "StepScaling" => self.process_step_scaling(account_id, policy, target, current),
+                _ => false,
+            },
+            "ecs" => match policy.policy_type.as_str() {
+                "TargetTrackingScaling" => {
+                    self.process_ecs_target_tracking(account_id, policy, target, current)
+                }
+                "StepScaling" => self.process_ecs_step_scaling(account_id, policy, target, current),
+                _ => false,
+            },
             _ => false,
         }
     }
@@ -498,6 +549,281 @@ impl ScalingWatcher {
             }],
         });
     }
+
+    fn process_ecs_target_tracking(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+    ) -> bool {
+        let Some(cfg) = policy.target_tracking_scaling_policy_configuration.as_ref() else {
+            return false;
+        };
+        let target_value = cfg.get("TargetValue").and_then(Value::as_f64);
+        let Some(target_value) = target_value else {
+            return false;
+        };
+        if target_value <= 0.0 {
+            return false;
+        }
+        let Some(metric_name) = ecs_predefined_metric_for(cfg) else {
+            return false;
+        };
+        let Some((cluster, service)) = ecs_service_from_resource(&policy.resource_id) else {
+            return false;
+        };
+
+        // Build metric dimensions: ServiceName + ClusterName
+        let mut dims = BTreeMap::new();
+        dims.insert("ServiceName".to_string(), service.to_string());
+        dims.insert("ClusterName".to_string(), cluster.to_string());
+        let utilisation = self.metric_reader.latest_sample(
+            account_id,
+            &self.region,
+            "AWS/ECS",
+            metric_name,
+            &dims,
+        );
+        let Some(utilisation) = utilisation else {
+            return false;
+        };
+
+        // desired = current * (utilisation / target_value), clamped to [min, max]
+        let raw = (current as f64) * (utilisation / target_value);
+        let mut desired = raw.ceil() as i64;
+        if desired < target.min_capacity as i64 {
+            desired = target.min_capacity as i64;
+        }
+        if desired > target.max_capacity as i64 {
+            desired = target.max_capacity as i64;
+        }
+        if desired == current {
+            return false;
+        }
+
+        let scale_out = desired > current;
+        let cooldown_secs = cfg
+            .get(if scale_out {
+                "ScaleOutCooldown"
+            } else {
+                "ScaleInCooldown"
+            })
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if let Some(prev) = policy.last_applied_at {
+            if cooldown_secs > 0
+                && Utc::now().signed_duration_since(prev).num_seconds() < cooldown_secs
+            {
+                self.record_cooldown_skip(
+                    account_id,
+                    policy,
+                    target,
+                    current,
+                    desired,
+                    "TargetTracking",
+                );
+                return false;
+            }
+        }
+
+        self.apply_ecs_desired_count(
+            account_id,
+            policy,
+            target,
+            current,
+            desired,
+            "TargetTracking",
+        )
+    }
+
+    fn process_ecs_step_scaling(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+    ) -> bool {
+        let Some(cfg) = policy.step_scaling_policy_configuration.as_ref() else {
+            return false;
+        };
+        let adjustment_type = cfg
+            .get("AdjustmentType")
+            .and_then(Value::as_str)
+            .unwrap_or("ChangeInCapacity")
+            .to_string();
+        let cooldown_secs = cfg.get("Cooldown").and_then(Value::as_i64).unwrap_or(0);
+
+        let attached_in_alarm = policy.alarms.iter().any(|a| {
+            self.metric_reader
+                .alarm_state(account_id, &self.region, &a.alarm_name)
+                .as_deref()
+                == Some("ALARM")
+        });
+        let action_alarms_firing =
+            self.metric_reader
+                .alarms_firing_for_action(account_id, &self.region, &policy.arn);
+        if !attached_in_alarm && action_alarms_firing.is_empty() {
+            return false;
+        }
+
+        let adjustments = cfg
+            .get("StepAdjustments")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let Some(adj) = adjustments.first() else {
+            return false;
+        };
+        let adjustment = adj
+            .get("ScalingAdjustment")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        if adjustment == 0 {
+            return false;
+        }
+        let mut desired = match adjustment_type.as_str() {
+            "ExactCapacity" => adjustment,
+            "PercentChangeInCapacity" => {
+                let pct = adjustment as f64 / 100.0;
+                let delta = (current as f64 * pct).round() as i64;
+                let min_step = cfg
+                    .get("MinAdjustmentMagnitude")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let signed_delta = if delta == 0 && adjustment != 0 {
+                    if adjustment > 0 {
+                        1
+                    } else {
+                        -1
+                    }
+                } else {
+                    delta
+                };
+                let bumped = if signed_delta.abs() < min_step {
+                    if signed_delta >= 0 {
+                        min_step
+                    } else {
+                        -min_step
+                    }
+                } else {
+                    signed_delta
+                };
+                current + bumped
+            }
+            _ => current + adjustment, // ChangeInCapacity
+        };
+        if desired < target.min_capacity as i64 {
+            desired = target.min_capacity as i64;
+        }
+        if desired > target.max_capacity as i64 {
+            desired = target.max_capacity as i64;
+        }
+        if desired == current {
+            return false;
+        }
+        if let Some(prev) = policy.last_applied_at {
+            if cooldown_secs > 0
+                && Utc::now().signed_duration_since(prev).num_seconds() < cooldown_secs
+            {
+                self.record_cooldown_skip(
+                    account_id,
+                    policy,
+                    target,
+                    current,
+                    desired,
+                    "StepScaling",
+                );
+                return false;
+            }
+        }
+
+        self.apply_ecs_desired_count(account_id, policy, target, current, desired, "StepScaling")
+    }
+
+    fn apply_ecs_desired_count(
+        &self,
+        account_id: &str,
+        policy: &ScalingPolicy,
+        target: &ScalableTarget,
+        current: i64,
+        desired: i64,
+        cause_kind: &str,
+    ) -> bool {
+        let Some(hook) = self.ecs_hook.as_ref() else {
+            return false;
+        };
+        let Some((cluster, service)) = ecs_service_from_resource(&policy.resource_id) else {
+            return false;
+        };
+        let now = Utc::now();
+        let result =
+            hook.set_desired_count(account_id, &self.region, cluster, service, desired as i32);
+
+        let mut state = self.state.write();
+        let account = state.accounts.entry(account_id.to_string()).or_default();
+        let policy_key = (
+            policy.service_namespace.clone(),
+            policy.resource_id.clone(),
+            policy.scalable_dimension.clone(),
+            policy.policy_name.clone(),
+        );
+        let activity = match result {
+            Ok(()) => {
+                if let Some(p) = account.scaling_policies.get_mut(&policy_key) {
+                    p.last_applied_at = Some(now);
+                }
+                ScalingActivity {
+                    activity_id: Uuid::new_v4().to_string(),
+                    service_namespace: policy.service_namespace.clone(),
+                    resource_id: policy.resource_id.clone(),
+                    scalable_dimension: policy.scalable_dimension.clone(),
+                    description: format!(
+                        "Setting desired count to {desired} for {res}",
+                        res = policy.resource_id,
+                    ),
+                    cause: format!(
+                        "policy {policy_name} ({cause_kind}) applied; previous desired count {current}",
+                        policy_name = policy.policy_name,
+                    ),
+                    start_time: now,
+                    end_time: Some(now),
+                    status_code: "Successful".to_string(),
+                    status_message: Some(format!("Successfully set {desired}")),
+                    details: None,
+                    not_scaled_reasons: Vec::new(),
+                }
+            }
+            Err(err) => ScalingActivity {
+                activity_id: Uuid::new_v4().to_string(),
+                service_namespace: policy.service_namespace.clone(),
+                resource_id: policy.resource_id.clone(),
+                scalable_dimension: policy.scalable_dimension.clone(),
+                description: format!(
+                    "Failed to set desired count to {desired} for {res}",
+                    res = policy.resource_id,
+                ),
+                cause: format!(
+                    "policy {policy_name} ({cause_kind}) failed",
+                    policy_name = policy.policy_name,
+                ),
+                start_time: now,
+                end_time: Some(now),
+                status_code: "Failed".to_string(),
+                status_message: Some(err),
+                details: None,
+                not_scaled_reasons: vec![NotScaledReason {
+                    code: "FailedToSetDesiredCount".to_string(),
+                    max_capacity: Some(target.max_capacity),
+                    min_capacity: Some(target.min_capacity),
+                    current_capacity: Some(current as i32),
+                }],
+            },
+        };
+        let success = activity.status_code == "Successful";
+        account.scaling_activities.push(activity);
+        success
+    }
 }
 
 fn predefined_metric_for(cfg: &Value, dimension: &str) -> Option<&'static str> {
@@ -524,6 +850,24 @@ fn ddb_table_from_resource(resource_id: &str) -> Option<&str> {
 /// (`scheduled_executor`) so we don't duplicate the parsing rule.
 pub(crate) fn ddb_table_from_resource_public(resource_id: &str) -> Option<&str> {
     ddb_table_from_resource(resource_id)
+}
+
+/// Parse an ECS resource_id: "service/<cluster>/<service>".
+pub(crate) fn ecs_service_from_resource(resource_id: &str) -> Option<(&str, &str)> {
+    let rest = resource_id.strip_prefix("service/")?;
+    let (cluster, service) = rest.split_once('/')?;
+    Some((cluster, service))
+}
+
+fn ecs_predefined_metric_for(cfg: &Value) -> Option<&'static str> {
+    let predefined = cfg.get("PredefinedMetricSpecification")?;
+    let metric_type = predefined.get("PredefinedMetricType")?.as_str()?;
+    match metric_type {
+        "ECSServiceAverageCPUUtilization" => Some(ECS_CPU_METRIC),
+        "ECSServiceAverageMemoryUtilization" => Some(ECS_MEMORY_METRIC),
+        "ALBRequestCountPerTarget" => Some(ECS_ALB_METRIC),
+        _ => None,
+    }
 }
 
 fn suspended_for(target: &ScalableTarget, policy: &ScalingPolicy) -> bool {

--- a/crates/fakecloud-e2e/tests/appas_ecs.rs
+++ b/crates/fakecloud-e2e/tests/appas_ecs.rs
@@ -1,0 +1,287 @@
+//! Application Auto Scaling ECS desired-count scaling E2E.
+//!
+//! Verifies the scaling watcher:
+//!   - TargetTracking scales ECS service desiredCount based on published
+//!     CloudWatch ECSServiceAverageCPUUtilization metric.
+//!   - StepScaling scales ECS service desiredCount when a CloudWatch alarm
+//!     wired to the policy's ARN transitions to ALARM.
+//!   - ScalingActivity rows are emitted for both paths.
+
+mod helpers;
+
+use aws_sdk_applicationautoscaling::types::{ScalableDimension, ServiceNamespace};
+use aws_sdk_cloudwatch::types::{Dimension, MetricDatum};
+use aws_sdk_ecs::types::ContainerDefinition;
+use helpers::TestServer;
+
+async fn bootstrap_ecs_service(
+    ecs: &aws_sdk_ecs::Client,
+    cluster: &str,
+    family: &str,
+    service: &str,
+    desired_count: i32,
+) {
+    ecs.create_cluster()
+        .cluster_name(cluster)
+        .send()
+        .await
+        .expect("create cluster");
+    ecs.register_task_definition()
+        .family(family)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("register td");
+    ecs.create_service()
+        .cluster(cluster)
+        .service_name(service)
+        .task_definition(family)
+        .desired_count(desired_count)
+        .send()
+        .await
+        .expect("create service");
+}
+
+async fn force_watcher_tick(server: &TestServer) -> usize {
+    let url = format!(
+        "{}/_fakecloud/application-autoscaling/tick",
+        server.endpoint()
+    );
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .expect("admin tick");
+    let body: serde_json::Value = resp.json().await.expect("json");
+    body["applied"].as_u64().unwrap_or(0) as usize
+}
+
+#[tokio::test]
+async fn target_tracking_scales_ecs_service_desired_count() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    let aas = server.application_autoscaling_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    bootstrap_ecs_service(&ecs, "appas-ecs-cluster", "appas-ecs-td", "web", 1).await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .min_capacity(1)
+        .max_capacity(5)
+        .send()
+        .await
+        .expect("register scalable target");
+
+    let policy_resp = aas
+        .put_scaling_policy()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .policy_name("cpu-tracking")
+        .policy_type(aws_sdk_applicationautoscaling::types::PolicyType::TargetTrackingScaling)
+        .target_tracking_scaling_policy_configuration(
+            aws_sdk_applicationautoscaling::types::TargetTrackingScalingPolicyConfiguration::builder()
+                .target_value(70.0)
+                .predefined_metric_specification(
+                    aws_sdk_applicationautoscaling::types::PredefinedMetricSpecification::builder()
+                        .predefined_metric_type(
+                            aws_sdk_applicationautoscaling::types::MetricType::EcsServiceAverageCpuUtilization,
+                        )
+                        .build()
+                        .expect("build predefined metric spec"),
+                )
+                .scale_out_cooldown(0)
+                .scale_in_cooldown(0)
+                .build()
+                .expect("build target tracking config"),
+        )
+        .send()
+        .await
+        .expect("put scaling policy");
+    assert!(!policy_resp.policy_arn().is_empty(), "expected policy ARN");
+
+    // Publish high CPU metric to trigger scale-out.
+    cw.put_metric_data()
+        .namespace("AWS/ECS")
+        .metric_data(
+            MetricDatum::builder()
+                .metric_name("ECSServiceAverageCPUUtilization")
+                .dimensions(
+                    Dimension::builder()
+                        .name("ServiceName")
+                        .value("web")
+                        .build(),
+                )
+                .dimensions(
+                    Dimension::builder()
+                        .name("ClusterName")
+                        .value("appas-ecs-cluster")
+                        .build(),
+                )
+                .value(90.0)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put metric data");
+
+    let applied = force_watcher_tick(&server).await;
+    assert_eq!(applied, 1, "expected scaling policy to apply");
+
+    // Verify ECS service desiredCount scaled up.
+    // utilisation 90, target 70 => factor 1.28, current 1 => ceil = 2.
+    let described = ecs
+        .describe_services()
+        .cluster("appas-ecs-cluster")
+        .services("web")
+        .send()
+        .await
+        .expect("describe services");
+    let svc = described.services().first().expect("service");
+    assert_eq!(
+        svc.desired_count(),
+        2,
+        "expected desired_count=2 after scale-out"
+    );
+
+    // Verify scaling activity.
+    let activities = aas
+        .describe_scaling_activities()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .send()
+        .await
+        .expect("activities")
+        .scaling_activities()
+        .to_vec();
+    assert!(
+        activities.iter().any(|a| {
+            a.description().contains("desired count") && a.status_code().as_str() == "Successful"
+        }),
+        "expected Successful scaling activity, got {activities:?}"
+    );
+}
+
+#[tokio::test]
+async fn step_scaling_scales_ecs_service_desired_count() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+    let aas = server.application_autoscaling_client().await;
+    let cw = server.cloudwatch_client().await;
+
+    bootstrap_ecs_service(
+        &ecs,
+        "appas-ecs-step-cluster",
+        "appas-ecs-step-td",
+        "web",
+        1,
+    )
+    .await;
+
+    aas.register_scalable_target()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-step-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .min_capacity(1)
+        .max_capacity(5)
+        .send()
+        .await
+        .expect("register scalable target");
+
+    let policy_resp = aas
+        .put_scaling_policy()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-step-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .policy_name("step-up")
+        .policy_type(aws_sdk_applicationautoscaling::types::PolicyType::StepScaling)
+        .step_scaling_policy_configuration(
+            aws_sdk_applicationautoscaling::types::StepScalingPolicyConfiguration::builder()
+                .adjustment_type(
+                    aws_sdk_applicationautoscaling::types::AdjustmentType::ChangeInCapacity,
+                )
+                .cooldown(0)
+                .step_adjustments(
+                    aws_sdk_applicationautoscaling::types::StepAdjustment::builder()
+                        .metric_interval_lower_bound(0.0)
+                        .scaling_adjustment(2)
+                        .build()
+                        .expect("build step adjustment"),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("put scaling policy");
+    let policy_arn = policy_resp.policy_arn();
+
+    // Create alarm with the policy ARN as an action.
+    cw.put_metric_alarm()
+        .alarm_name("ecs-high-cpu")
+        .metric_name("ECSServiceAverageCPUUtilization")
+        .namespace("AWS/ECS")
+        .statistic(aws_sdk_cloudwatch::types::Statistic::Average)
+        .period(60)
+        .evaluation_periods(1)
+        .threshold(80.0)
+        .comparison_operator(aws_sdk_cloudwatch::types::ComparisonOperator::GreaterThanThreshold)
+        .alarm_actions(policy_arn)
+        .send()
+        .await
+        .expect("put metric alarm");
+
+    // Force alarm to ALARM.
+    cw.set_alarm_state()
+        .alarm_name("ecs-high-cpu")
+        .state_value(aws_sdk_cloudwatch::types::StateValue::Alarm)
+        .state_reason("test")
+        .send()
+        .await
+        .expect("set alarm state");
+
+    let applied = force_watcher_tick(&server).await;
+    assert_eq!(applied, 1, "expected step scaling to apply");
+
+    // ChangeInCapacity +2 from current 1 => desired 3.
+    let described = ecs
+        .describe_services()
+        .cluster("appas-ecs-step-cluster")
+        .services("web")
+        .send()
+        .await
+        .expect("describe services");
+    let svc = described.services().first().expect("service");
+    assert_eq!(
+        svc.desired_count(),
+        3,
+        "expected desired_count=3 after step scaling"
+    );
+
+    // Verify scaling activity.
+    let activities = aas
+        .describe_scaling_activities()
+        .service_namespace(ServiceNamespace::Ecs)
+        .resource_id("service/appas-ecs-step-cluster/web")
+        .scalable_dimension(ScalableDimension::EcsServiceDesiredCount)
+        .send()
+        .await
+        .expect("activities")
+        .scaling_activities()
+        .to_vec();
+    assert!(
+        activities.iter().any(|a| {
+            a.description().contains("desired count") && a.status_code().as_str() == "Successful"
+        }),
+        "expected Successful scaling activity, got {activities:?}"
+    );
+}

--- a/crates/fakecloud-server/src/appas_hooks.rs
+++ b/crates/fakecloud-server/src/appas_hooks.rs
@@ -5,9 +5,12 @@
 
 use std::collections::BTreeMap;
 
-use fakecloud_application_autoscaling::hooks::{DynamoDbCapacityHook, MetricReader};
+use fakecloud_application_autoscaling::hooks::{
+    DynamoDbCapacityHook, EcsServiceHook, MetricReader,
+};
 use fakecloud_cloudwatch::SharedCloudWatchState;
 use fakecloud_dynamodb::state::SharedDynamoDbState;
+use fakecloud_ecs::SharedEcsState;
 
 /// Reads from in-process CloudWatch metric and alarm state.
 pub struct CloudwatchMetricReader {
@@ -139,6 +142,66 @@ impl DynamoDbCapacityHook for DynamoDbCapacityHookImpl {
                 return Err("WriteCapacityUnits must be > 0".to_string());
             }
             table.provisioned_throughput.write_capacity_units = w;
+        }
+        Ok(())
+    }
+}
+
+/// Mutates an ECS service's desiredCount. The watcher calls
+/// `set_desired_count` after computing a new desired count from
+/// CloudWatch metrics; we update the service's `desired_count` in
+/// place and trigger task spawns/stops via the ECS service's
+/// `UpdateService` path so subsequent `DescribeServices` calls see
+/// the new value.
+pub struct EcsServiceHookImpl {
+    state: SharedEcsState,
+}
+
+impl EcsServiceHookImpl {
+    pub fn new(state: SharedEcsState) -> Self {
+        Self { state }
+    }
+}
+
+impl EcsServiceHook for EcsServiceHookImpl {
+    fn current_desired_count(
+        &self,
+        account_id: &str,
+        _region: &str,
+        cluster_name: &str,
+        service_name: &str,
+    ) -> Option<i32> {
+        let guard = self.state.read();
+        let acct = guard.get(account_id)?;
+        let key = fakecloud_ecs::EcsState::service_key(cluster_name, service_name);
+        acct.services.get(&key).map(|s| s.desired_count)
+    }
+
+    fn set_desired_count(
+        &self,
+        account_id: &str,
+        _region: &str,
+        cluster_name: &str,
+        service_name: &str,
+        desired_count: i32,
+    ) -> Result<(), String> {
+        let mut guard = self.state.write();
+        let acct = guard
+            .get_mut(account_id)
+            .ok_or_else(|| format!("account {account_id} not found"))?;
+        let key = fakecloud_ecs::EcsState::service_key(cluster_name, service_name);
+        let service = acct
+            .services
+            .get_mut(&key)
+            .ok_or_else(|| format!("service {service_name} not found in cluster {cluster_name}"))?;
+        service.desired_count = desired_count;
+        if let Some(d) = service
+            .deployments
+            .iter_mut()
+            .find(|d| d.status == "PRIMARY")
+        {
+            d.desired_count = desired_count;
+            d.updated_at = chrono::Utc::now();
         }
         Ok(())
     }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2626,6 +2626,7 @@ async fn main() {
     let appas_ddb_hook = Arc::new(appas_hooks::DynamoDbCapacityHookImpl::new(
         dynamodb_state.clone(),
     ));
+    let appas_ecs_hook = Arc::new(appas_hooks::EcsServiceHookImpl::new(ecs_state.clone()));
     let appas_watcher_for_admin = Arc::new(
         fakecloud_application_autoscaling::ScalingWatcher::new(
             app_autoscaling_state.clone(),
@@ -2633,6 +2634,7 @@ async fn main() {
             appas_ddb_hook.clone(),
             cli.region.clone(),
         )
+        .with_ecs_hook(appas_ecs_hook.clone())
         .with_interval(std::time::Duration::from_secs(15)),
     );
     {
@@ -2642,6 +2644,7 @@ async fn main() {
             appas_ddb_hook.clone(),
             cli.region.clone(),
         )
+        .with_ecs_hook(appas_ecs_hook.clone())
         .with_interval(std::time::Duration::from_secs(15));
         tokio::spawn(watcher.run());
     }
@@ -2649,8 +2652,8 @@ async fn main() {
     // Application Auto Scaling scheduled action executor: ticks every
     // 30s, walks all ScheduledActions, fires the ones whose Schedule
     // expression is due and applies the configured ScalableTargetAction
-    // bounds across linked resources (DDB capacity today). Tests can
-    // skip the wall-clock wait via the
+    // bounds across linked resources (DDB capacity today; ECS desired
+    // count wired alongside). Tests can skip the wall-clock wait via the
     // `/_fakecloud/application-autoscaling/scheduled-tick` admin route.
     let appas_scheduled_executor_for_admin = Arc::new(
         fakecloud_application_autoscaling::ScheduledActionExecutor::new(
@@ -2658,6 +2661,7 @@ async fn main() {
             appas_ddb_hook.clone(),
             cli.region.clone(),
         )
+        .with_ecs_hook(appas_ecs_hook.clone())
         .with_interval(std::time::Duration::from_secs(30)),
     );
     {
@@ -2666,6 +2670,7 @@ async fn main() {
             appas_ddb_hook,
             cli.region.clone(),
         )
+        .with_ecs_hook(appas_ecs_hook)
         .with_interval(std::time::Duration::from_secs(30));
         tokio::spawn(executor.run());
     }


### PR DESCRIPTION
## Summary
- Add `EcsServiceHook` trait to `fakecloud-application-autoscaling` for cross-service ECS desired-count mutations.
- Extend `ScalingWatcher` to process ECS `TargetTrackingScaling` and `StepScaling` policies.
- Extend `ScheduledActionExecutor` to apply ECS scheduled actions via the new hook.
- Implement `EcsServiceHookImpl` in `fakecloud-server` appas_hooks.rs and wire it in main.rs.
- Add E2E tests covering both TargetTracking (CloudWatch metric-driven) and StepScaling (alarm-driven) ECS desiredCount scaling.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] `cargo test -p fakecloud-application-autoscaling` all 13 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test appas_ecs` both E2E tests pass
- [x] `cargo test -p fakecloud-e2e --test appas_scheduled` existing scheduled tests still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ECS service desiredCount scaling to Application Auto Scaling. The watcher now scales ECS via TargetTracking and StepScaling, and scheduled actions update desiredCount through a new cross-service hook.

- **New Features**
  - Introduced `EcsServiceHook` in `fakecloud-application-autoscaling` and `EcsServiceHookImpl` in `fakecloud-server`; wired into the watcher and scheduled executor.
  - `ScalingWatcher` scales ECS `DesiredCount` for TargetTracking (CPU/Memory/ALB metrics) and StepScaling (alarm-driven), with cooldowns and activity logging.
  - `ScheduledActionExecutor` applies ECS scheduled actions and clamps desiredCount within target min/max.
  - Added ECS helpers (resource parsing and predefined metric mapping) and exported the hook type.
  - New E2E tests in `fakecloud-e2e` covering ECS TargetTracking and StepScaling; existing scheduled tests still pass.

<sup>Written for commit 7601b69d9fb628c21a4f8dcd31ba107699d41a12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

