### PR TITLE
feat(cloudformation): Glue Database + Table + Partition provisioner (BB33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "fakecloud-elasticache",
  "fakecloud-elbv2",
  "fakecloud-eventbridge",
+ "fakecloud-glue",
  "fakecloud-iam",
  "fakecloud-kinesis",
  "fakecloud-kms",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -41,6 +41,7 @@ fakecloud-apigatewayv2 = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
 fakecloud-athena = { workspace = true }
+fakecloud-glue = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -1211,6 +1211,7 @@ mod tests {
             athena: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
             )),
+            glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -17546,7 +17546,7 @@ impl ResourceProvisioner {
         if values.is_empty() {
             return Err("PartitionInput.Values is required".to_string());
         }
-        let key = values.join("/");
+        let key = values.join("\0");
 
         let mut accounts = self.glue_state.write();
         let state = accounts.get_or_create(&self.account_id, &self.region);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -17546,7 +17546,11 @@ impl ResourceProvisioner {
         if values.is_empty() {
             return Err("PartitionInput.Values is required".to_string());
         }
-        let key = values.join("\0");
+        let key = values
+            .iter()
+            .map(|v| v.replace('%', "%25").replace('/', "%2F"))
+            .collect::<Vec<_>>()
+            .join("/");
 
         let mut accounts = self.glue_state.write();
         let state = accounts.get_or_create(&self.account_id, &self.region);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -17548,7 +17548,11 @@ impl ResourceProvisioner {
         }
         let key = values
             .iter()
-            .map(|v| v.replace('%', "%25").replace('|', "%7C").replace('/', "%2F"))
+            .map(|v| {
+                v.replace('%', "%25")
+                    .replace('|', "%7C")
+                    .replace('/', "%2F")
+            })
             .collect::<Vec<_>>()
             .join("/");
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -17548,7 +17548,7 @@ impl ResourceProvisioner {
         }
         let key = values
             .iter()
-            .map(|v| v.replace('%', "%25").replace('/', "%2F"))
+            .map(|v| v.replace('%', "%25").replace('|', "%7C").replace('/', "%2F"))
             .collect::<Vec<_>>()
             .join("/");
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -854,6 +854,7 @@ pub struct ResourceProvisioner {
     pub ses_state: SharedSesState,
     pub app_autoscaling_state: AppasState,
     pub athena_state: SharedAthenaState,
+    pub glue_state: fakecloud_glue::SharedGlueState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -1066,6 +1067,9 @@ impl ResourceProvisioner {
             "AWS::Athena::NamedQuery" => self.create_athena_named_query(resource),
             "AWS::Athena::WorkGroup" => self.create_athena_work_group(resource),
             "AWS::Athena::PreparedStatement" => self.create_athena_prepared_statement(resource),
+            "AWS::Glue::Database" => self.create_glue_database(resource),
+            "AWS::Glue::Table" => self.create_glue_table(resource),
+            "AWS::Glue::Partition" => self.create_glue_partition(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -1894,6 +1898,11 @@ impl ResourceProvisioner {
             "AWS::Athena::WorkGroup" => self.delete_athena_work_group(&resource.physical_id),
             "AWS::Athena::PreparedStatement" => {
                 self.delete_athena_prepared_statement(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::Glue::Database" => self.delete_glue_database(&resource.physical_id),
+            "AWS::Glue::Table" => self.delete_glue_table(&resource.physical_id),
+            "AWS::Glue::Partition" => {
+                self.delete_glue_partition(&resource.physical_id, &resource.attributes)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
@@ -17369,6 +17378,227 @@ impl ResourceProvisioner {
         }
         out
     }
+
+    fn create_glue_database(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let input = props
+            .get("DatabaseInput")
+            .ok_or("DatabaseInput is required")?;
+        let name = input
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = input
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let location_uri = input
+            .get("LocationUri")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let parameters = input
+            .get("Parameters")
+            .and_then(|v| v.as_object())
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let dbs = state.dbs_in_mut(&self.region);
+        if dbs.contains_key(&name) {
+            return Err(format!("Database {name} already exists"));
+        }
+        dbs.insert(
+            name.clone(),
+            fakecloud_glue::Database {
+                name: name.clone(),
+                description,
+                location_uri,
+                parameters,
+                created_at: Utc::now(),
+                catalog_id: self.account_id.clone(),
+                tables: BTreeMap::new(),
+            },
+        );
+        Ok(ProvisionResult::new(name.clone()))
+    }
+
+    fn delete_glue_database(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        state.dbs_in_mut(&self.region).remove(physical_id);
+        Ok(())
+    }
+
+    fn create_glue_table(&self, resource: &ResourceDefinition) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let db_name = props
+            .get("DatabaseName")
+            .and_then(|v| v.as_str())
+            .ok_or("DatabaseName is required")?
+            .to_string();
+        let input = props.get("TableInput").ok_or("TableInput is required")?;
+        let name = input
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("TableInput.Name is required")?
+            .to_string();
+        let now = Utc::now();
+
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(&db_name)
+            .ok_or_else(|| format!("Database {db_name} not found"))?;
+        if db.tables.contains_key(&name) {
+            return Err(format!("Table {name} already exists"));
+        }
+        db.tables.insert(
+            name.clone(),
+            fakecloud_glue::Table {
+                name: name.clone(),
+                database_name: db_name.clone(),
+                description: input
+                    .get("Description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                owner: input
+                    .get("Owner")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                create_time: now,
+                update_time: now,
+                last_access_time: None,
+                retention: input.get("Retention").and_then(|v| v.as_i64()).unwrap_or(0),
+                storage_descriptor: None,
+                partition_keys: Vec::new(),
+                view_original_text: input
+                    .get("ViewOriginalText")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                view_expanded_text: input
+                    .get("ViewExpandedText")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                table_type: input
+                    .get("TableType")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                parameters: BTreeMap::new(),
+                partitions: BTreeMap::new(),
+            },
+        );
+        let physical_id = format!("{db_name}|{name}");
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    fn delete_glue_table(&self, physical_id: &str) -> Result<(), String> {
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let parts: Vec<&str> = physical_id.split('|').collect();
+        if parts.len() != 2 {
+            return Err(format!("Invalid Glue table physical id: {physical_id}"));
+        }
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(parts[0])
+            .ok_or_else(|| format!("Database {} not found", parts[0]))?;
+        db.tables.remove(parts[1]);
+        Ok(())
+    }
+
+    fn create_glue_partition(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let db_name = props
+            .get("DatabaseName")
+            .and_then(|v| v.as_str())
+            .ok_or("DatabaseName is required")?
+            .to_string();
+        let table_name = props
+            .get("TableName")
+            .and_then(|v| v.as_str())
+            .ok_or("TableName is required")?
+            .to_string();
+        let input = props
+            .get("PartitionInput")
+            .ok_or("PartitionInput is required")?;
+        let values: Vec<String> = input
+            .get("Values")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if values.is_empty() {
+            return Err("PartitionInput.Values is required".to_string());
+        }
+        let key = values.join("/");
+
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(&db_name)
+            .ok_or_else(|| format!("Database {db_name} not found"))?;
+        let table = db
+            .tables
+            .get_mut(&table_name)
+            .ok_or_else(|| format!("Table {table_name} not found"))?;
+        if table.partitions.contains_key(&key) {
+            return Err(format!("Partition {key} already exists"));
+        }
+        table.partitions.insert(
+            key.clone(),
+            fakecloud_glue::Partition {
+                values: values.clone(),
+                database_name: db_name.clone(),
+                table_name: table_name.clone(),
+                create_time: Utc::now(),
+                last_access_time: None,
+                storage_descriptor: None,
+                parameters: BTreeMap::new(),
+            },
+        );
+        let physical_id = format!("{db_name}|{table_name}|{key}");
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    fn delete_glue_partition(
+        &self,
+        physical_id: &str,
+        _attrs: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let parts: Vec<&str> = physical_id.split('|').collect();
+        if parts.len() != 3 {
+            return Err(format!("Invalid Glue partition physical id: {physical_id}"));
+        }
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(parts[0])
+            .ok_or_else(|| format!("Database {} not found", parts[0]))?;
+        let table = db
+            .tables
+            .get_mut(parts[1])
+            .ok_or_else(|| format!("Table {} not found", parts[1]))?;
+        table.partitions.remove(parts[2]);
+        Ok(())
+    }
 }
 
 /// Implements the CloudFormation `GenerateSecretString` shape on
@@ -17993,6 +18223,9 @@ mod tests {
             )),
             athena_state: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
+            )),
+            glue_state: Arc::new(parking_lot::RwLock::new(
+                fakecloud_glue::GlueAccounts::new(),
             )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -181,6 +181,7 @@ pub struct CloudFormationDeps {
     pub application_autoscaling:
         fakecloud_application_autoscaling::SharedApplicationAutoScalingState,
     pub athena: fakecloud_athena::SharedAthenaState,
+    pub glue: fakecloud_glue::SharedGlueState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -266,6 +267,7 @@ impl CloudFormationService {
             ses_state: self.deps.ses.clone(),
             app_autoscaling_state: self.deps.application_autoscaling.clone(),
             athena_state: self.deps.athena.clone(),
+            glue_state: self.deps.glue.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1829,6 +1831,7 @@ mod tests {
             athena: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
             )),
+            glue: Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new())),
             delivery: Arc::new(DeliveryBus::new()),
         };
         CloudFormationService::new(cf_state, deps)

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -789,6 +789,7 @@ async fn main() {
             ses: ses_state.clone(),
             application_autoscaling: app_autoscaling_state.clone(),
             athena: athena_state.clone(),
+            glue: glue_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

Add CloudFormation resource provisioner support for AWS::Glue::* resources:
- AWS::Glue::Database (create/delete)
- AWS::Glue::Table (create/delete)
- AWS::Glue::Partition (create/delete)

Includes unit tests for all three resource lifecycles.

## Test plan

- [x] `cargo test -p fakecloud-cloudformation --lib glue` passes (3 tests)
- [x] `cargo test -p fakecloud-cloudformation --lib` passes (192 tests)
- [x] `cargo test -p fakecloud --bin fakecloud` passes (38 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation provisioners for Glue Database, Table, and Partition in Fakecloud so stacks can manage Glue catalog metadata. Implements Linear BB33.

- **New Features**
  - Create/delete for `AWS::Glue::Database`, `AWS::Glue::Table`, and `AWS::Glue::Partition` with basic validation; lifecycle tests added.
  - Physical IDs: database `db`, table `db|table`, partition `db|table|<values>`; partition values percent-encode `%`, `/`, and `|`, then join with `/` to avoid collisions and delete parsing issues.
  - Wired `fakecloud-glue` into `ResourceProvisioner`, `CloudFormationService`, and `fakecloud-server`; added `fakecloud-glue` to the workspace.

<sup>Written for commit ee4eab5818f282a86f6dc54581a9d18116e650a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

