### PR TITLE
feat(cloudformation): Firehose DeliveryStream provisioner (BB34)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "fakecloud-elasticache",
  "fakecloud-elbv2",
  "fakecloud-eventbridge",
+ "fakecloud-firehose",
  "fakecloud-glue",
  "fakecloud-iam",
  "fakecloud-kinesis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "fakecloud-elasticache",
  "fakecloud-elbv2",
  "fakecloud-eventbridge",
+ "fakecloud-firehose",
  "fakecloud-iam",
  "fakecloud-kinesis",
  "fakecloud-kms",

--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -41,6 +41,7 @@ fakecloud-apigatewayv2 = { workspace = true }
 fakecloud-ses = { workspace = true }
 fakecloud-application-autoscaling = { workspace = true }
 fakecloud-athena = { workspace = true }
+fakecloud-firehose = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -1211,6 +1211,9 @@ mod tests {
             athena: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
             )),
+            firehose: Arc::new(parking_lot::RwLock::new(
+                fakecloud_firehose::FirehoseAccounts::new(),
+            )),
             delivery: Arc::new(DeliveryBus::new()),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8614,11 +8614,18 @@ impl ResourceProvisioner {
             .unwrap_or("DirectPut")
             .to_string();
 
+        let has_s3 = props.get("S3DestinationConfiguration").is_some();
+        let has_extended_s3 = props.get("ExtendedS3DestinationConfiguration").is_some();
+        if has_s3 && has_extended_s3 {
+            return Err("Only one of S3DestinationConfiguration or ExtendedS3DestinationConfiguration may be set".to_string());
+        }
         let mut destination = None;
         if let Some(s3) = props.get("S3DestinationConfiguration") {
             destination = Some(parse_firehose_s3_destination(s3)?);
         } else if let Some(s3) = props.get("ExtendedS3DestinationConfiguration") {
             destination = Some(parse_firehose_s3_destination(s3)?);
+        } else if stream_type != "DirectPut" {
+            return Err("Delivery stream requires a destination configuration".to_string());
         }
 
         let mut tags = BTreeMap::new();
@@ -17968,12 +17975,12 @@ fn parse_firehose_s3_destination(value: &serde_json::Value) -> Result<S3Destinat
     let role_arn = value
         .get("RoleARN")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
+        .ok_or("S3 destination requires RoleARN")?
         .to_string();
     let bucket_arn = value
         .get("BucketARN")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
+        .ok_or("S3 destination requires BucketARN")?
         .to_string();
     let prefix = value
         .get("Prefix")

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -1906,6 +1906,7 @@ impl ResourceProvisioner {
             }
             "AWS::KinesisFirehose::DeliveryStream" => {
                 self.delete_firehose_delivery_stream(&resource.physical_id)
+            }
             "AWS::Glue::Database" => self.delete_glue_database(&resource.physical_id),
             "AWS::Glue::Table" => self.delete_glue_table(&resource.physical_id),
             "AWS::Glue::Partition" => {
@@ -18366,6 +18367,7 @@ mod tests {
             )),
             firehose_state: Arc::new(parking_lot::RwLock::new(
                 fakecloud_firehose::FirehoseAccounts::new(),
+            )),
             glue_state: Arc::new(parking_lot::RwLock::new(
                 fakecloud_glue::GlueAccounts::new(),
             )),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -72,6 +72,7 @@ use fakecloud_elbv2::{
 use fakecloud_eventbridge::{
     ApiDestination, Archive, Connection, Endpoint, EventBus, EventRule, SharedEventBridgeState,
 };
+use fakecloud_firehose::state::{DeliveryStream, S3Destination};
 use fakecloud_iam::{
     IamAccessKey, IamGroup, IamInstanceProfile, IamPolicy, IamRole, IamUser, OidcProvider,
     PolicyVersion, SamlProvider, SharedIamState, Tag, VirtualMfaDevice,
@@ -854,6 +855,7 @@ pub struct ResourceProvisioner {
     pub ses_state: SharedSesState,
     pub app_autoscaling_state: AppasState,
     pub athena_state: SharedAthenaState,
+    pub firehose_state: fakecloud_firehose::SharedFirehoseState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -1066,6 +1068,9 @@ impl ResourceProvisioner {
             "AWS::Athena::NamedQuery" => self.create_athena_named_query(resource),
             "AWS::Athena::WorkGroup" => self.create_athena_work_group(resource),
             "AWS::Athena::PreparedStatement" => self.create_athena_prepared_statement(resource),
+            "AWS::KinesisFirehose::DeliveryStream" => {
+                self.create_firehose_delivery_stream(resource)
+            }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
                 .create_custom_resource(resource)
                 .map(ProvisionResult::new),
@@ -1894,6 +1899,9 @@ impl ResourceProvisioner {
             "AWS::Athena::WorkGroup" => self.delete_athena_work_group(&resource.physical_id),
             "AWS::Athena::PreparedStatement" => {
                 self.delete_athena_prepared_statement(&resource.physical_id, &resource.attributes)
+            }
+            "AWS::KinesisFirehose::DeliveryStream" => {
+                self.delete_firehose_delivery_stream(&resource.physical_id)
             }
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => {
                 self.delete_custom_resource(resource)
@@ -8580,6 +8588,83 @@ impl ResourceProvisioner {
         let mut state = self.app_autoscaling_state.write();
         let account = state.accounts.entry(self.account_id.clone()).or_default();
         account.scaling_policies.remove(&key);
+        Ok(())
+    }
+
+    // --- Firehose ---
+
+    fn create_firehose_delivery_stream(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("DeliveryStreamName")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+
+        let arn = format!(
+            "arn:aws:firehose:{}:{}:deliverystream/{}",
+            self.region, self.account_id, name
+        );
+        let stream_type = props
+            .get("DeliveryStreamType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("DirectPut")
+            .to_string();
+
+        let mut destination = None;
+        if let Some(s3) = props.get("S3DestinationConfiguration") {
+            destination = Some(parse_firehose_s3_destination(s3)?);
+        } else if let Some(s3) = props.get("ExtendedS3DestinationConfiguration") {
+            destination = Some(parse_firehose_s3_destination(s3)?);
+        }
+
+        let mut tags = BTreeMap::new();
+        if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+            for tag in arr {
+                if let (Some(k), Some(v)) = (
+                    tag.get("Key").and_then(|v| v.as_str()),
+                    tag.get("Value").and_then(|v| v.as_str()),
+                ) {
+                    tags.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        let stream = DeliveryStream {
+            name: name.clone(),
+            arn: arn.clone(),
+            status: "ACTIVE".to_string(),
+            stream_type: stream_type.clone(),
+            created_at: Utc::now(),
+            last_update: Utc::now(),
+            version_id: "1".to_string(),
+            destination,
+            tags,
+        };
+
+        let mut state = self.firehose_state.write();
+        let account = state.get_or_create(&self.account_id, &self.region);
+        account
+            .streams_mut(&self.region)
+            .insert(name.clone(), stream);
+
+        let mut attributes = BTreeMap::new();
+        attributes.insert("Arn".to_string(), arn.clone());
+        attributes.insert("DeliveryStreamName".to_string(), name.clone());
+
+        Ok(ProvisionResult {
+            physical_id: name,
+            attributes,
+        })
+    }
+
+    fn delete_firehose_delivery_stream(&self, physical_id: &str) -> Result<(), String> {
+        let mut state = self.firehose_state.write();
+        let account = state.get_or_create(&self.account_id, &self.region);
+        account.streams_mut(&self.region).remove(physical_id);
         Ok(())
     }
 
@@ -17879,6 +17964,48 @@ fn parse_cognito_account_recovery(
     })
 }
 
+fn parse_firehose_s3_destination(value: &serde_json::Value) -> Result<S3Destination, String> {
+    let role_arn = value
+        .get("RoleARN")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let bucket_arn = value
+        .get("BucketARN")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let prefix = value
+        .get("Prefix")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let error_output_prefix = value
+        .get("ErrorOutputPrefix")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let mut buffering_size_mb = None;
+    let mut buffering_interval_seconds = None;
+    if let Some(hints) = value.get("BufferingHints") {
+        buffering_size_mb = hints.get("SizeInMBs").and_then(|v| v.as_i64());
+        buffering_interval_seconds = hints.get("IntervalInSeconds").and_then(|v| v.as_i64());
+    }
+    let compression_format = value
+        .get("CompressionFormat")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok(S3Destination {
+        destination_id: "destination-1".to_string(),
+        role_arn,
+        bucket_arn,
+        prefix,
+        error_output_prefix,
+        buffering_size_mb,
+        buffering_interval_seconds,
+        compression_format,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -17993,6 +18120,9 @@ mod tests {
             )),
             athena_state: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
+            )),
+            firehose_state: Arc::new(parking_lot::RwLock::new(
+                fakecloud_firehose::FirehoseAccounts::new(),
             )),
             delivery: Arc::new(DeliveryBus::new()),
             account_id: "123456789012".to_string(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8619,14 +8619,13 @@ impl ResourceProvisioner {
         if has_s3 && has_extended_s3 {
             return Err("Only one of S3DestinationConfiguration or ExtendedS3DestinationConfiguration may be set".to_string());
         }
-        let mut destination = None;
-        if let Some(s3) = props.get("S3DestinationConfiguration") {
-            destination = Some(parse_firehose_s3_destination(s3)?);
+        let destination = Some(if let Some(s3) = props.get("S3DestinationConfiguration") {
+            parse_firehose_s3_destination(s3)?
         } else if let Some(s3) = props.get("ExtendedS3DestinationConfiguration") {
-            destination = Some(parse_firehose_s3_destination(s3)?);
+            parse_firehose_s3_destination(s3)?
         } else {
             return Err("Delivery stream requires a destination configuration".to_string());
-        }
+        });
 
         let mut tags = BTreeMap::new();
         if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8624,7 +8624,7 @@ impl ResourceProvisioner {
             destination = Some(parse_firehose_s3_destination(s3)?);
         } else if let Some(s3) = props.get("ExtendedS3DestinationConfiguration") {
             destination = Some(parse_firehose_s3_destination(s3)?);
-        } else if stream_type != "DirectPut" {
+        } else {
             return Err("Delivery stream requires a destination configuration".to_string());
         }
 

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -181,6 +181,7 @@ pub struct CloudFormationDeps {
     pub application_autoscaling:
         fakecloud_application_autoscaling::SharedApplicationAutoScalingState,
     pub athena: fakecloud_athena::SharedAthenaState,
+    pub firehose: fakecloud_firehose::SharedFirehoseState,
     pub delivery: Arc<DeliveryBus>,
 }
 
@@ -266,6 +267,7 @@ impl CloudFormationService {
             ses_state: self.deps.ses.clone(),
             app_autoscaling_state: self.deps.application_autoscaling.clone(),
             athena_state: self.deps.athena.clone(),
+            firehose_state: self.deps.firehose.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -1828,6 +1830,9 @@ mod tests {
             )),
             athena: Arc::new(parking_lot::RwLock::new(
                 fakecloud_athena::AthenaAccounts::new(),
+            )),
+            firehose: Arc::new(parking_lot::RwLock::new(
+                fakecloud_firehose::FirehoseAccounts::new(),
             )),
             delivery: Arc::new(DeliveryBus::new()),
         };

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -789,6 +789,7 @@ async fn main() {
             ses: ses_state.clone(),
             application_autoscaling: app_autoscaling_state.clone(),
             athena: athena_state.clone(),
+            firehose: firehose_state.clone(),
             delivery: delivery_for_cf,
         },
     );


### PR DESCRIPTION
## Summary

Add CloudFormation resource provisioner support for AWS::KinesisFirehose::DeliveryStream:
- create/delete with S3DestinationConfiguration and ExtendedS3DestinationConfiguration
- captures Arn and DeliveryStreamName attributes

## Test plan

- [x] `cargo test -p fakecloud-cloudformation --lib firehose` passes (1 test)
- [x] `cargo test -p fakecloud-cloudformation --lib` passes (190 tests)
- [x] `cargo test -p fakecloud --bin fakecloud` passes (38 tests)
- [x] `cargo clippy -p fakecloud-cloudformation -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudFormation support for `AWS::KinesisFirehose::DeliveryStream` (BB34). Create/delete S3-backed streams and expose `Arn` and `DeliveryStreamName`.

- **New Features**
  - Support `S3DestinationConfiguration` or `ExtendedS3DestinationConfiguration`; require exactly one; require `RoleARN` and `BucketARN`; parse `Prefix`, `ErrorOutputPrefix`, `BufferingHints`, `CompressionFormat`, and `Tags`.
  - Default `DeliveryStreamType` to `DirectPut`; require a destination for all streams; use `DeliveryStreamName` if provided (else logical ID); wire `fakecloud-firehose` into CloudFormation deps and the server.

- **Refactors**
  - Fixed clippy warning by building the destination option inline (removed unused assignment).
  - Resolved merge conflicts with the Glue provisioner.

<sup>Written for commit 94a9121efd1d4629de7e8e63deb2653e04de8da8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

