### PR TITLE
feat(cloudformation): real StackSets instance provisioning (BB37)

### DIFF
--- a/crates/fakecloud-cloudformation/Cargo.toml
+++ b/crates/fakecloud-cloudformation/Cargo.toml
@@ -43,6 +43,7 @@ fakecloud-application-autoscaling = { workspace = true }
 fakecloud-athena = { workspace = true }
 fakecloud-firehose = { workspace = true }
 fakecloud-glue = { workspace = true }
+bytes = { workspace = true }
 rcgen = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -142,6 +142,31 @@ fn extract_parameter_overrides(params: &BTreeMap<String, String>) -> BTreeMap<St
 
 impl CloudFormationService {
     /// Create or update a stack instance for a StackSet in a target account/region.
+    fn build_stack_instance_params(
+        stack_name: &str,
+        template_body: &str,
+        parameter_overrides: &BTreeMap<String, String>,
+        tags: &BTreeMap<String, String>,
+    ) -> HashMap<String, String> {
+        let mut params: HashMap<String, String> = HashMap::new();
+        params.insert("StackName".to_string(), stack_name.to_string());
+        params.insert("TemplateBody".to_string(), template_body.to_string());
+
+        for (i, (k, v)) in parameter_overrides.iter().enumerate() {
+            let idx = i + 1;
+            params.insert(format!("Parameters.member.{idx}.ParameterKey"), k.clone());
+            params.insert(format!("Parameters.member.{idx}.ParameterValue"), v.clone());
+        }
+
+        for (i, (k, v)) in tags.iter().enumerate() {
+            let idx = i + 1;
+            params.insert(format!("Tags.member.{idx}.Key"), k.clone());
+            params.insert(format!("Tags.member.{idx}.Value"), v.clone());
+        }
+
+        params
+    }
+
     fn provision_stack_instance(
         &self,
         stack_set_name: &str,
@@ -152,21 +177,12 @@ impl CloudFormationService {
         tags: &BTreeMap<String, String>,
     ) -> Result<String, AwsServiceError> {
         let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
-
-        // Build query params for CreateStack
-        let mut create_params: HashMap<String, String> = HashMap::new();
-        create_params.insert("StackName".to_string(), stack_name.clone());
-        create_params.insert("TemplateBody".to_string(), template_body.to_string());
-
-        for (k, v) in parameter_overrides {
-            create_params.insert(format!("Parameters.member.{k}.ParameterKey"), k.clone());
-            create_params.insert(format!("Parameters.member.{k}.ParameterValue"), v.clone());
-        }
-
-        for (k, v) in tags {
-            create_params.insert(format!("Tags.member.{k}.Key"), k.clone());
-            create_params.insert(format!("Tags.member.{k}.Value"), v.clone());
-        }
+        let create_params = Self::build_stack_instance_params(
+            &stack_name,
+            template_body,
+            parameter_overrides,
+            tags,
+        );
 
         let synthetic_req = AwsRequest {
             service: "cloudformation".to_string(),
@@ -188,6 +204,61 @@ impl CloudFormationService {
         };
 
         let resp = self.create_stack(&synthetic_req)?;
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap_or("");
+
+        // Extract StackId from response XML
+        let stack_id = body
+            .split("<StackId>")
+            .nth(1)
+            .and_then(|s| s.split("</StackId>").next())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                format!(
+                    "arn:aws:cloudformation:{target_region}:{target_account}:stack/{stack_name}/{}",
+                    rand_id()
+                )
+            });
+
+        Ok(stack_id)
+    }
+
+    fn update_stack_instance(
+        &self,
+        stack_set_name: &str,
+        target_account: &str,
+        target_region: &str,
+        template_body: &str,
+        parameter_overrides: &BTreeMap<String, String>,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<String, AwsServiceError> {
+        let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
+        let update_params = Self::build_stack_instance_params(
+            &stack_name,
+            template_body,
+            parameter_overrides,
+            tags,
+        );
+
+        let synthetic_req = AwsRequest {
+            service: "cloudformation".to_string(),
+            action: "UpdateStack".to_string(),
+            region: target_region.to_string(),
+            account_id: target_account.to_string(),
+            request_id: rand_id(),
+            headers: http::HeaderMap::new(),
+            query_params: update_params,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        };
+
+        let resp = self.update_stack(&synthetic_req)?;
         let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap_or("");
 
         // Extract StackId from response XML
@@ -867,14 +938,37 @@ impl CloudFormationService {
 
                 for target_account in &accounts_list {
                     for target_region in &regions_list {
-                        if let Ok(stack_id) = self.provision_stack_instance(
-                            &stack_set_name,
-                            target_account,
-                            target_region,
-                            &stack_set_template,
-                            &parameter_overrides,
-                            &BTreeMap::new(),
-                        ) {
+                        let key = format!("{stack_set_name}:{target_account}:{target_region}");
+                        let instance_exists = {
+                            let accounts_state = self.state.read();
+                            accounts_state
+                                .get(&aid)
+                                .and_then(|s| s.extras.get("stack_instances"))
+                                .and_then(|m| m.get(&key))
+                                .is_some()
+                        };
+
+                        let result = if instance_exists {
+                            self.update_stack_instance(
+                                &stack_set_name,
+                                target_account,
+                                target_region,
+                                &stack_set_template,
+                                &parameter_overrides,
+                                &BTreeMap::new(),
+                            )
+                        } else {
+                            self.provision_stack_instance(
+                                &stack_set_name,
+                                target_account,
+                                target_region,
+                                &stack_set_template,
+                                &parameter_overrides,
+                                &BTreeMap::new(),
+                            )
+                        };
+
+                        if let Ok(stack_id) = result {
                             let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
                             let record = json!({
                                 "Account": target_account,
@@ -886,7 +980,6 @@ impl CloudFormationService {
                             });
                             let mut accounts_state = self.state.write();
                             let state = accounts_state.get_or_create(&aid);
-                            let key = format!("{stack_set_name}:{target_account}:{target_region}");
                             store(&mut state.extras, "stack_instances").insert(key, record);
                         }
                     }

--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -10,10 +10,11 @@
 //! IDs so SDK callers can chain operations (e.g., `CreateChangeSet`
 //! -> `DescribeChangeSet` -> `ExecuteChangeSet`).
 
+use bytes::Bytes;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_aws::xml::xml_escape;
@@ -93,7 +94,118 @@ fn missing(name: &str) -> AwsServiceError {
     )
 }
 
+/// Extract a list of member values from query-style params.
+/// AWS list params are encoded as `Prefix.member.N=Value`.
+fn extract_member_list(params: &BTreeMap<String, String>, prefix: &str) -> Vec<String> {
+    let mut items: Vec<(usize, String)> = Vec::new();
+    for (k, v) in params {
+        let pat = format!("{prefix}.member.");
+        if let Some(rest) = k.strip_prefix(&pat) {
+            if let Ok(idx) = rest.parse::<usize>() {
+                items.push((idx, v.clone()));
+            }
+        }
+    }
+    items.sort_by_key(|(i, _)| *i);
+    items.into_iter().map(|(_, v)| v).collect()
+}
+
+/// Extract parameter overrides from query-style params.
+/// AWS encodes them as `ParameterOverrides.member.N.ParameterKey=K&ParameterOverrides.member.N.ParameterValue=V`.
+fn extract_parameter_overrides(params: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut result: BTreeMap<usize, (Option<String>, Option<String>)> = BTreeMap::new();
+    for (k, v) in params {
+        let prefix = "ParameterOverrides.member.";
+        if let Some(rest) = k.strip_prefix(prefix) {
+            // rest is like "1.ParameterKey" or "1.ParameterValue"
+            if let Some(dot_pos) = rest.find('.') {
+                if let Ok(idx) = rest[..dot_pos].parse::<usize>() {
+                    let suffix = &rest[dot_pos + 1..];
+                    let entry = result.entry(idx).or_insert((None, None));
+                    if suffix == "ParameterKey" {
+                        entry.0 = Some(v.clone());
+                    } else if suffix == "ParameterValue" {
+                        entry.1 = Some(v.clone());
+                    }
+                }
+            }
+        }
+    }
+    result
+        .into_values()
+        .filter_map(|(k, v)| match (k, v) {
+            (Some(key), Some(val)) => Some((key, val)),
+            _ => None,
+        })
+        .collect()
+}
+
 impl CloudFormationService {
+    /// Create or update a stack instance for a StackSet in a target account/region.
+    fn provision_stack_instance(
+        &self,
+        stack_set_name: &str,
+        target_account: &str,
+        target_region: &str,
+        template_body: &str,
+        parameter_overrides: &BTreeMap<String, String>,
+        tags: &BTreeMap<String, String>,
+    ) -> Result<String, AwsServiceError> {
+        let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
+
+        // Build query params for CreateStack
+        let mut create_params: HashMap<String, String> = HashMap::new();
+        create_params.insert("StackName".to_string(), stack_name.clone());
+        create_params.insert("TemplateBody".to_string(), template_body.to_string());
+
+        for (k, v) in parameter_overrides {
+            create_params.insert(format!("Parameters.member.{k}.ParameterKey"), k.clone());
+            create_params.insert(format!("Parameters.member.{k}.ParameterValue"), v.clone());
+        }
+
+        for (k, v) in tags {
+            create_params.insert(format!("Tags.member.{k}.Key"), k.clone());
+            create_params.insert(format!("Tags.member.{k}.Value"), v.clone());
+        }
+
+        let synthetic_req = AwsRequest {
+            service: "cloudformation".to_string(),
+            action: "CreateStack".to_string(),
+            region: target_region.to_string(),
+            account_id: target_account.to_string(),
+            request_id: rand_id(),
+            headers: http::HeaderMap::new(),
+            query_params: create_params,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        };
+
+        let resp = self.create_stack(&synthetic_req)?;
+        let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap_or("");
+
+        // Extract StackId from response XML
+        let stack_id = body
+            .split("<StackId>")
+            .nth(1)
+            .and_then(|s| s.split("</StackId>").next())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                format!(
+                    "arn:aws:cloudformation:{target_region}:{target_account}:stack/{stack_name}/{}",
+                    rand_id()
+                )
+            });
+
+        Ok(stack_id)
+    }
+
     pub(crate) fn handle_extra_action(
         &self,
         req: &AwsRequest,
@@ -688,22 +800,192 @@ impl CloudFormationService {
 
             // ── Stack instances ──
             "CreateStackInstances" => {
+                let stack_set_name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let accounts_list = extract_member_list(&params, "Accounts");
+                let regions_list = extract_member_list(&params, "Regions");
+                let parameter_overrides = extract_parameter_overrides(&params);
                 let op_id = rand_id();
+
+                // Read the StackSet template
+                let stack_set_template = {
+                    let accounts_state = self.state.read();
+                    let state = accounts_state.get(&aid);
+                    state
+                        .and_then(|s| s.extras.get("stack_sets"))
+                        .and_then(|m| m.get(&stack_set_name))
+                        .and_then(|v| v["TemplateBody"].as_str().map(|s| s.to_string()))
+                        .unwrap_or_default()
+                };
+
+                let mut instance_records: Vec<Value> = Vec::new();
+                for target_account in &accounts_list {
+                    for target_region in &regions_list {
+                        let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
+                        if let Ok(stack_id) = self.provision_stack_instance(
+                            &stack_set_name,
+                            target_account,
+                            target_region,
+                            &stack_set_template,
+                            &parameter_overrides,
+                            &BTreeMap::new(),
+                        ) {
+                            let record = json!({
+                                "Account": target_account,
+                                "Region": target_region,
+                                "StackId": stack_id,
+                                "StackName": stack_name,
+                                "Status": "CURRENT",
+                                "DriftStatus": "NOT_CHECKED",
+                            });
+                            instance_records.push(record.clone());
+                            let mut accounts_state = self.state.write();
+                            let state = accounts_state.get_or_create(&aid);
+                            let key = format!("{stack_set_name}:{target_account}:{target_region}");
+                            store(&mut state.extras, "stack_instances").insert(key, record);
+                        }
+                    }
+                }
+
                 Ok(xml_response("CreateStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
             }
             "UpdateStackInstances" => {
+                let stack_set_name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let accounts_list = extract_member_list(&params, "Accounts");
+                let regions_list = extract_member_list(&params, "Regions");
+                let parameter_overrides = extract_parameter_overrides(&params);
                 let op_id = rand_id();
+
+                let stack_set_template = {
+                    let accounts_state = self.state.read();
+                    let state = accounts_state.get(&aid);
+                    state
+                        .and_then(|s| s.extras.get("stack_sets"))
+                        .and_then(|m| m.get(&stack_set_name))
+                        .and_then(|v| v["TemplateBody"].as_str().map(|s| s.to_string()))
+                        .unwrap_or_default()
+                };
+
+                for target_account in &accounts_list {
+                    for target_region in &regions_list {
+                        if let Ok(stack_id) = self.provision_stack_instance(
+                            &stack_set_name,
+                            target_account,
+                            target_region,
+                            &stack_set_template,
+                            &parameter_overrides,
+                            &BTreeMap::new(),
+                        ) {
+                            let stack_name = format!("{stack_set_name}-{target_account}-{target_region}");
+                            let record = json!({
+                                "Account": target_account,
+                                "Region": target_region,
+                                "StackId": stack_id,
+                                "StackName": stack_name,
+                                "Status": "CURRENT",
+                                "DriftStatus": "NOT_CHECKED",
+                            });
+                            let mut accounts_state = self.state.write();
+                            let state = accounts_state.get_or_create(&aid);
+                            let key = format!("{stack_set_name}:{target_account}:{target_region}");
+                            store(&mut state.extras, "stack_instances").insert(key, record);
+                        }
+                    }
+                }
+
                 Ok(xml_response("UpdateStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
             }
             "DeleteStackInstances" => {
+                let stack_set_name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let accounts_list = extract_member_list(&params, "Accounts");
+                let regions_list = extract_member_list(&params, "Regions");
                 let op_id = rand_id();
+
+                for target_account in &accounts_list {
+                    for target_region in &regions_list {
+                        let mut accounts_state = self.state.write();
+                        let state = accounts_state.get_or_create(&aid);
+                        let key = format!("{stack_set_name}:{target_account}:{target_region}");
+                        if let Some(m) = state.extras.get_mut("stack_instances") {
+                            m.remove(&key);
+                        }
+                    }
+                }
+
                 Ok(xml_response("DeleteStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
             }
             "DescribeStackInstance" => {
-                let inner = "    <StackInstance>\n      <Status>CURRENT</Status>\n    </StackInstance>".to_string();
+                let stack_set_name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let account = params.get("StackInstanceAccount").cloned().unwrap_or_default();
+                let region = params.get("StackInstanceRegion").cloned().unwrap_or_default();
+                let key = format!("{stack_set_name}:{account}:{region}");
+
+                let accounts_state = self.state.read();
+                let state = accounts_state.get(&aid);
+                let record = state
+                    .and_then(|s| s.extras.get("stack_instances"))
+                    .and_then(|m| m.get(&key))
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        json!({
+                            "Account": account,
+                            "Region": region,
+                            "StackId": format!("arn:aws:cloudformation:{region}:{account}:stack/{stack_set_name}-{account}-{region}/{}", rand_id()),
+                            "StackName": format!("{stack_set_name}-{account}-{region}"),
+                            "Status": "CURRENT",
+                            "DriftStatus": "NOT_CHECKED",
+                        })
+                    });
+
+                let inner = format!(
+                    "    <StackInstance>\n      <Account>{}</Account>\n      <Region>{}</Region>\n      <StackId>{}</StackId>\n      <StackName>{}</StackName>\n      <Status>{}</Status>\n      <DriftStatus>{}</DriftStatus>\n    </StackInstance>",
+                    xml_escape(record["Account"].as_str().unwrap_or("")),
+                    xml_escape(record["Region"].as_str().unwrap_or("")),
+                    xml_escape(record["StackId"].as_str().unwrap_or("")),
+                    xml_escape(record["StackName"].as_str().unwrap_or("")),
+                    xml_escape(record["Status"].as_str().unwrap_or("CURRENT")),
+                    xml_escape(record["DriftStatus"].as_str().unwrap_or("NOT_CHECKED")),
+                );
                 Ok(xml_response("DescribeStackInstance", inner, &rid))
             }
-            "ListStackInstances" => Ok(xml_response("ListStackInstances", "    <Summaries/>".to_string(), &rid)),
+            "ListStackInstances" => {
+                let stack_set_name = params.get("StackSetName").cloned();
+                let accounts_state = self.state.read();
+                let items: Vec<Value> = accounts_state
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("stack_instances"))
+                    .map(|m| {
+                        m.values()
+                            .filter(|v| {
+                                stack_set_name.as_ref().is_none_or(|name| {
+                                    v["StackName"]
+                                        .as_str()
+                                        .map(|n| n.starts_with(name.as_str()))
+                                        .unwrap_or(false)
+                                })
+                            })
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let inner = if items.is_empty() {
+                    "    <Summaries/>".to_string()
+                } else {
+                    format!(
+                        "    <Summaries>\n{}\n    </Summaries>",
+                        members_xml(&items, |v| format!(
+                            "        <Account>{}</Account>\n        <Region>{}</Region>\n        <StackId>{}</StackId>\n        <StackName>{}</StackName>\n        <Status>{}</Status>\n        <DriftStatus>{}</DriftStatus>",
+                            xml_escape(v["Account"].as_str().unwrap_or("")),
+                            xml_escape(v["Region"].as_str().unwrap_or("")),
+                            xml_escape(v["StackId"].as_str().unwrap_or("")),
+                            xml_escape(v["StackName"].as_str().unwrap_or("")),
+                            xml_escape(v["Status"].as_str().unwrap_or("CURRENT")),
+                            xml_escape(v["DriftStatus"].as_str().unwrap_or("NOT_CHECKED")),
+                        )),
+                    )
+                };
+                Ok(xml_response("ListStackInstances", inner, &rid))
+            }
             "ListStackInstanceResourceDrifts" => Ok(xml_response("ListStackInstanceResourceDrifts", "    <Summaries/>".to_string(), &rid)),
 
             // ── Stack refactors ──
@@ -1288,12 +1570,33 @@ mod tests {
         ok("ListStackSetAutoDeploymentTargets", &[]);
         ok("StopStackSetOperation", &[]);
         ok("ImportStacksToStackSet", &[]);
-        ok("DeleteStackSet", &[("StackSetName", "ss")]);
-        ok("CreateStackInstances", &[]);
-        ok("UpdateStackInstances", &[]);
-        ok("DeleteStackInstances", &[]);
-        ok("DescribeStackInstance", &[]);
+        ok(
+            "CreateStackInstances",
+            &[
+                ("StackSetName", "ss"),
+                ("Accounts.member.1", "000000000000"),
+                ("Regions.member.1", "us-east-1"),
+            ],
+        );
+        ok(
+            "UpdateStackInstances",
+            &[
+                ("StackSetName", "ss"),
+                ("Accounts.member.1", "000000000000"),
+                ("Regions.member.1", "us-east-1"),
+            ],
+        );
+        ok("DescribeStackInstance", &[("StackSetName", "ss")]);
         ok("ListStackInstances", &[]);
+        ok(
+            "DeleteStackInstances",
+            &[
+                ("StackSetName", "ss"),
+                ("Accounts.member.1", "000000000000"),
+                ("Regions.member.1", "us-east-1"),
+            ],
+        );
+        ok("DeleteStackSet", &[("StackSetName", "ss")]);
         ok("ListStackInstanceResourceDrifts", &[]);
         ok("CreateStackRefactor", &[]);
         ok("DescribeStackRefactor", &[("StackRefactorId", "r")]);

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -564,7 +564,7 @@ impl CloudFormationService {
         Ok(())
     }
 
-    fn create_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    pub(crate) fn create_stack(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let params = Self::get_all_params(req);
 
         let stack_name = params.get("StackName").ok_or_else(|| {


### PR DESCRIPTION
## Summary
- CreateStackInstances provisions real stacks via synthetic CreateStack calls
- UpdateStackInstances re-provisions with new parameter overrides
- DeleteStackInstances removes instance records from state
- DescribeStackInstance reads stored instance state
- ListStackInstances filters by optional StackSetName
- Added `extract_member_list` + `extract_parameter_overrides` helpers for AWS query list encoding

## Test plan
- [x] `cargo test -p fakecloud-cloudformation --lib` passes (193 tests)
- [x] `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` clean
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real StackSet instance provisioning in `fakecloud-cloudformation` by issuing synthetic `CreateStack`/`UpdateStack` per target account and region. Aligns with BB37 by making StackSet instance APIs work end to end.

- **New Features**
  - Provision via synthetic `CreateStack`; `UpdateStackInstances` uses `UpdateStack` when an instance exists, or creates if missing.
  - `Create/Update/DeleteStackInstances` persist instance state; `DescribeStackInstance` returns it; `ListStackInstances` optionally filters by `StackSetName`.
  - Added `extract_member_list` and `extract_parameter_overrides`; made `create_stack` `pub(crate)` for synthetic calls.

- **Bug Fixes**
  - Use correct numeric indices for `Parameters.member.N` and `Tags.member.N` in synthetic requests.

<sup>Written for commit 3bb0c764c4a8cb73f920fe0098859a262be90fd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

