### PR TITLE
feat(cloudformation): nested stacks + SAM transform + drift/events (BB38)

### DIFF
--- a/crates/fakecloud-cloudformation/src/extras.rs
+++ b/crates/fakecloud-cloudformation/src/extras.rs
@@ -20,6 +20,7 @@ use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::CloudFormationService;
+use crate::state::StackResource;
 use crate::template;
 
 const NS: &str = "http://cloudformation.amazonaws.com/doc/2010-05-15/";
@@ -106,8 +107,14 @@ impl CloudFormationService {
         match action.as_str() {
             // ── Change sets ──
             "CreateChangeSet" => {
-                let stack_name = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
-                let cs_name = params.get("ChangeSetName").ok_or_else(|| missing("ChangeSetName"))?.clone();
+                let stack_name = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
+                let cs_name = params
+                    .get("ChangeSetName")
+                    .ok_or_else(|| missing("ChangeSetName"))?
+                    .clone();
                 let template_body = params.get("TemplateBody").cloned().unwrap_or_default();
 
                 let cs_params = CloudFormationService::extract_parameters(&params);
@@ -160,15 +167,14 @@ impl CloudFormationService {
                 // only exercise the route still see success.
                 let mut changes: Vec<Value> = Vec::new();
                 if !template_body.trim().is_empty() {
-                    let parsed = template::parse_template(&template_body, &full_params).map_err(
-                        |e| {
+                    let parsed =
+                        template::parse_template(&template_body, &full_params).map_err(|e| {
                             AwsServiceError::aws_error(
                                 StatusCode::BAD_REQUEST,
                                 "ValidationError",
                                 e,
                             )
-                        },
-                    )?;
+                        })?;
 
                     let existing_resources = stack_lookup
                         .as_ref()
@@ -275,7 +281,10 @@ impl CloudFormationService {
                 ))
             }
             "DescribeChangeSet" => {
-                let cs = params.get("ChangeSetName").ok_or_else(|| missing("ChangeSetName"))?.clone();
+                let cs = params
+                    .get("ChangeSetName")
+                    .ok_or_else(|| missing("ChangeSetName"))?
+                    .clone();
                 let stack_filter = params.get("StackName").cloned();
                 let accounts = self.state.read();
                 let entry = accounts.get(&aid)
@@ -352,11 +361,16 @@ impl CloudFormationService {
                 &rid,
             )),
             "DeleteChangeSet" => {
-                let cs = params.get("ChangeSetName").ok_or_else(|| missing("ChangeSetName"))?.clone();
+                let cs = params
+                    .get("ChangeSetName")
+                    .ok_or_else(|| missing("ChangeSetName"))?
+                    .clone();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 if let Some(m) = state.extras.get_mut("change_sets") {
-                    m.retain(|_, v| v["Id"].as_str() != Some(&cs) && v["ChangeSetName"].as_str() != Some(&cs));
+                    m.retain(|_, v| {
+                        v["Id"].as_str() != Some(&cs) && v["ChangeSetName"].as_str() != Some(&cs)
+                    });
                 }
                 Ok(xml_response("DeleteChangeSet", String::new(), &rid))
             }
@@ -500,9 +514,7 @@ impl CloudFormationService {
                     let stack = state
                         .stacks
                         .values_mut()
-                        .find(|st| {
-                            st.stack_id == found_stack_id && st.status != "DELETE_COMPLETE"
-                        })
+                        .find(|st| st.stack_id == found_stack_id && st.status != "DELETE_COMPLETE")
                         .ok_or_else(|| {
                             AwsServiceError::aws_error(
                                 StatusCode::BAD_REQUEST,
@@ -592,25 +604,31 @@ impl CloudFormationService {
             }
             "ListChangeSets" => {
                 let accounts = self.state.read();
-                let items: Vec<Value> = accounts.get(&aid)
+                let items: Vec<Value> = accounts
+                    .get(&aid)
                     .and_then(|s| s.extras.get("change_sets"))
                     .map(|m| m.values().cloned().collect())
                     .unwrap_or_default();
                 let inner = format!(
                     "    <Summaries>\n{}\n    </Summaries>",
-                    members_xml(&items, |v| format!(
+                    members_xml(&items, |v| {
+                        format!(
                         "        <ChangeSetId>{}</ChangeSetId>\n        <ChangeSetName>{}</ChangeSetName>\n        <Status>{}</Status>",
                         xml_escape(v["Id"].as_str().unwrap_or("")),
                         xml_escape(v["ChangeSetName"].as_str().unwrap_or("")),
                         xml_escape(v["Status"].as_str().unwrap_or("CREATE_COMPLETE")),
-                    )),
+                    )
+                    }),
                 );
                 Ok(xml_response("ListChangeSets", inner, &rid))
             }
 
             // ── Stack sets ──
             "CreateStackSet" => {
-                let name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let name = params
+                    .get("StackSetName")
+                    .ok_or_else(|| missing("StackSetName"))?
+                    .clone();
                 let id = format!("{name}:{}", rand_id());
                 let entry = json!({
                     "StackSetId": id,
@@ -621,12 +639,20 @@ impl CloudFormationService {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "stack_sets").insert(name.clone(), entry);
-                Ok(xml_response("CreateStackSet", format!("    <StackSetId>{}</StackSetId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "CreateStackSet",
+                    format!("    <StackSetId>{}</StackSetId>", xml_escape(&id)),
+                    &rid,
+                ))
             }
             "DescribeStackSet" => {
-                let name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let name = params
+                    .get("StackSetName")
+                    .ok_or_else(|| missing("StackSetName"))?
+                    .clone();
                 let accounts = self.state.read();
-                let entry = accounts.get(&aid)
+                let entry = accounts
+                    .get(&aid)
                     .and_then(|s| s.extras.get("stack_sets"))
                     .and_then(|m| m.get(&name))
                     .cloned()
@@ -641,27 +667,37 @@ impl CloudFormationService {
             }
             "ListStackSets" => {
                 let accounts = self.state.read();
-                let items: Vec<Value> = accounts.get(&aid)
+                let items: Vec<Value> = accounts
+                    .get(&aid)
                     .and_then(|s| s.extras.get("stack_sets"))
                     .map(|m| m.values().cloned().collect())
                     .unwrap_or_default();
                 let inner = format!(
                     "    <Summaries>\n{}\n    </Summaries>",
-                    members_xml(&items, |v| format!(
+                    members_xml(&items, |v| {
+                        format!(
                         "        <StackSetName>{}</StackSetName>\n        <StackSetId>{}</StackSetId>\n        <Status>{}</Status>",
                         xml_escape(v["StackSetName"].as_str().unwrap_or("")),
                         xml_escape(v["StackSetId"].as_str().unwrap_or("")),
                         xml_escape(v["Status"].as_str().unwrap_or("ACTIVE")),
-                    )),
+                    )
+                    }),
                 );
                 Ok(xml_response("ListStackSets", inner, &rid))
             }
             "UpdateStackSet" => {
                 let op_id = rand_id();
-                Ok(xml_response("UpdateStackSet", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "UpdateStackSet",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
             "DeleteStackSet" => {
-                let name = params.get("StackSetName").ok_or_else(|| missing("StackSetName"))?.clone();
+                let name = params
+                    .get("StackSetName")
+                    .ok_or_else(|| missing("StackSetName"))?
+                    .clone();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 if let Some(m) = state.extras.get_mut("stack_sets") {
@@ -677,34 +713,74 @@ impl CloudFormationService {
                 );
                 Ok(xml_response("DescribeStackSetOperation", inner, &rid))
             }
-            "ListStackSetOperations" => Ok(xml_response("ListStackSetOperations", "    <Summaries/>".to_string(), &rid)),
-            "ListStackSetOperationResults" => Ok(xml_response("ListStackSetOperationResults", "    <Summaries/>".to_string(), &rid)),
-            "ListStackSetAutoDeploymentTargets" => Ok(xml_response("ListStackSetAutoDeploymentTargets", "    <Summaries/>".to_string(), &rid)),
-            "StopStackSetOperation" => Ok(xml_response("StopStackSetOperation", String::new(), &rid)),
+            "ListStackSetOperations" => Ok(xml_response(
+                "ListStackSetOperations",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
+            "ListStackSetOperationResults" => Ok(xml_response(
+                "ListStackSetOperationResults",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
+            "ListStackSetAutoDeploymentTargets" => Ok(xml_response(
+                "ListStackSetAutoDeploymentTargets",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
+            "StopStackSetOperation" => {
+                Ok(xml_response("StopStackSetOperation", String::new(), &rid))
+            }
             "ImportStacksToStackSet" => {
                 let op_id = rand_id();
-                Ok(xml_response("ImportStacksToStackSet", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "ImportStacksToStackSet",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
 
             // ── Stack instances ──
             "CreateStackInstances" => {
                 let op_id = rand_id();
-                Ok(xml_response("CreateStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "CreateStackInstances",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
             "UpdateStackInstances" => {
                 let op_id = rand_id();
-                Ok(xml_response("UpdateStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "UpdateStackInstances",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
             "DeleteStackInstances" => {
                 let op_id = rand_id();
-                Ok(xml_response("DeleteStackInstances", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "DeleteStackInstances",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
             "DescribeStackInstance" => {
-                let inner = "    <StackInstance>\n      <Status>CURRENT</Status>\n    </StackInstance>".to_string();
+                let inner =
+                    "    <StackInstance>\n      <Status>CURRENT</Status>\n    </StackInstance>"
+                        .to_string();
                 Ok(xml_response("DescribeStackInstance", inner, &rid))
             }
-            "ListStackInstances" => Ok(xml_response("ListStackInstances", "    <Summaries/>".to_string(), &rid)),
-            "ListStackInstanceResourceDrifts" => Ok(xml_response("ListStackInstanceResourceDrifts", "    <Summaries/>".to_string(), &rid)),
+            "ListStackInstances" => Ok(xml_response(
+                "ListStackInstances",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
+            "ListStackInstanceResourceDrifts" => Ok(xml_response(
+                "ListStackInstanceResourceDrifts",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
 
             // ── Stack refactors ──
             "CreateStackRefactor" => {
@@ -713,10 +789,17 @@ impl CloudFormationService {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "refactors").insert(id.clone(), entry);
-                Ok(xml_response("CreateStackRefactor", format!("    <StackRefactorId>{}</StackRefactorId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "CreateStackRefactor",
+                    format!("    <StackRefactorId>{}</StackRefactorId>", xml_escape(&id)),
+                    &rid,
+                ))
             }
             "DescribeStackRefactor" => {
-                let id = params.get("StackRefactorId").ok_or_else(|| missing("StackRefactorId"))?.clone();
+                let id = params
+                    .get("StackRefactorId")
+                    .ok_or_else(|| missing("StackRefactorId"))?
+                    .clone();
                 let inner = format!(
                     "    <StackRefactorId>{}</StackRefactorId>\n    <Status>CREATE_COMPLETE</Status>",
                     xml_escape(&id),
@@ -724,8 +807,16 @@ impl CloudFormationService {
                 Ok(xml_response("DescribeStackRefactor", inner, &rid))
             }
             "ExecuteStackRefactor" => Ok(xml_response("ExecuteStackRefactor", String::new(), &rid)),
-            "ListStackRefactors" => Ok(xml_response("ListStackRefactors", "    <StackRefactorSummaries/>".to_string(), &rid)),
-            "ListStackRefactorActions" => Ok(xml_response("ListStackRefactorActions", "    <StackRefactorActions/>".to_string(), &rid)),
+            "ListStackRefactors" => Ok(xml_response(
+                "ListStackRefactors",
+                "    <StackRefactorSummaries/>".to_string(),
+                &rid,
+            )),
+            "ListStackRefactorActions" => Ok(xml_response(
+                "ListStackRefactorActions",
+                "    <StackRefactorActions/>".to_string(),
+                &rid,
+            )),
 
             // ── Types / extensions ──
             "ActivateType" => {
@@ -736,18 +827,17 @@ impl CloudFormationService {
                     &format!("type/resource/{}", rand_id()),
                 )
                 .to_string();
-                Ok(xml_response("ActivateType", format!("    <Arn>{}</Arn>", xml_escape(&arn)), &rid))
+                Ok(xml_response(
+                    "ActivateType",
+                    format!("    <Arn>{}</Arn>", xml_escape(&arn)),
+                    &rid,
+                ))
             }
             "DeactivateType" => Ok(xml_response("DeactivateType", String::new(), &rid)),
             "DescribeType" => {
                 let arn = params.get("Arn").cloned().unwrap_or_else(|| {
-                    Arn::new(
-                        "cloudformation",
-                        "us-east-1",
-                        &aid,
-                        "type/resource/Default",
-                    )
-                    .to_string()
+                    Arn::new("cloudformation", "us-east-1", &aid, "type/resource/Default")
+                        .to_string()
                 });
                 let inner = format!(
                     "    <Arn>{}</Arn>\n    <Type>RESOURCE</Type>\n    <TypeName>AWS::Custom::Type</TypeName>",
@@ -765,12 +855,31 @@ impl CloudFormationService {
             }
             "RegisterType" => {
                 let token = rand_id();
-                Ok(xml_response("RegisterType", format!("    <RegistrationToken>{}</RegistrationToken>", xml_escape(&token)), &rid))
+                Ok(xml_response(
+                    "RegisterType",
+                    format!(
+                        "    <RegistrationToken>{}</RegistrationToken>",
+                        xml_escape(&token)
+                    ),
+                    &rid,
+                ))
             }
             "DeregisterType" => Ok(xml_response("DeregisterType", String::new(), &rid)),
-            "ListTypes" => Ok(xml_response("ListTypes", "    <TypeSummaries/>".to_string(), &rid)),
-            "ListTypeRegistrations" => Ok(xml_response("ListTypeRegistrations", "    <RegistrationTokenList/>".to_string(), &rid)),
-            "ListTypeVersions" => Ok(xml_response("ListTypeVersions", "    <TypeVersionSummaries/>".to_string(), &rid)),
+            "ListTypes" => Ok(xml_response(
+                "ListTypes",
+                "    <TypeSummaries/>".to_string(),
+                &rid,
+            )),
+            "ListTypeRegistrations" => Ok(xml_response(
+                "ListTypeRegistrations",
+                "    <RegistrationTokenList/>".to_string(),
+                &rid,
+            )),
+            "ListTypeVersions" => Ok(xml_response(
+                "ListTypeVersions",
+                "    <TypeVersionSummaries/>".to_string(),
+                &rid,
+            )),
             "BatchDescribeTypeConfigurations" => Ok(xml_response(
                 "BatchDescribeTypeConfigurations",
                 "    <Errors/>\n    <TypeConfigurations/>".to_string(),
@@ -784,9 +893,18 @@ impl CloudFormationService {
                     &format!("type-config/{}", rand_id()),
                 )
                 .to_string();
-                Ok(xml_response("SetTypeConfiguration", format!("    <ConfigurationArn>{}</ConfigurationArn>", xml_escape(&arn)), &rid))
+                Ok(xml_response(
+                    "SetTypeConfiguration",
+                    format!(
+                        "    <ConfigurationArn>{}</ConfigurationArn>",
+                        xml_escape(&arn)
+                    ),
+                    &rid,
+                ))
             }
-            "SetTypeDefaultVersion" => Ok(xml_response("SetTypeDefaultVersion", String::new(), &rid)),
+            "SetTypeDefaultVersion" => {
+                Ok(xml_response("SetTypeDefaultVersion", String::new(), &rid))
+            }
             "TestType" => {
                 let arn = Arn::new(
                     "cloudformation",
@@ -795,7 +913,11 @@ impl CloudFormationService {
                     &format!("type/resource/{}", rand_id()),
                 )
                 .to_string();
-                Ok(xml_response("TestType", format!("    <TypeVersionArn>{}</TypeVersionArn>", xml_escape(&arn)), &rid))
+                Ok(xml_response(
+                    "TestType",
+                    format!("    <TypeVersionArn>{}</TypeVersionArn>", xml_escape(&arn)),
+                    &rid,
+                ))
             }
             "PublishType" => {
                 let arn = Arn::new(
@@ -805,14 +927,25 @@ impl CloudFormationService {
                     &format!("type/resource/{}", rand_id()),
                 )
                 .to_string();
-                Ok(xml_response("PublishType", format!("    <PublicTypeArn>{}</PublicTypeArn>", xml_escape(&arn)), &rid))
+                Ok(xml_response(
+                    "PublishType",
+                    format!("    <PublicTypeArn>{}</PublicTypeArn>", xml_escape(&arn)),
+                    &rid,
+                ))
             }
             "RegisterPublisher" => {
                 let id = rand_id();
-                Ok(xml_response("RegisterPublisher", format!("    <PublisherId>{}</PublisherId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "RegisterPublisher",
+                    format!("    <PublisherId>{}</PublisherId>", xml_escape(&id)),
+                    &rid,
+                ))
             }
             "DescribePublisher" => {
-                let id = params.get("PublisherId").cloned().unwrap_or_else(|| "default-publisher".to_string());
+                let id = params
+                    .get("PublisherId")
+                    .cloned()
+                    .unwrap_or_else(|| "default-publisher".to_string());
                 let inner = format!(
                     "    <PublisherId>{}</PublisherId>\n    <PublisherStatus>VERIFIED</PublisherStatus>\n    <IdentityProvider>AWS_Marketplace</IdentityProvider>",
                     xml_escape(&id),
@@ -822,7 +955,10 @@ impl CloudFormationService {
 
             // ── Generated templates ──
             "CreateGeneratedTemplate" => {
-                let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
+                let name = params
+                    .get("GeneratedTemplateName")
+                    .ok_or_else(|| missing("GeneratedTemplateName"))?
+                    .clone();
                 let id = Arn::new(
                     "cloudformation",
                     "us-east-1",
@@ -834,10 +970,20 @@ impl CloudFormationService {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "generated_templates").insert(name.clone(), entry);
-                Ok(xml_response("CreateGeneratedTemplate", format!("    <GeneratedTemplateId>{}</GeneratedTemplateId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "CreateGeneratedTemplate",
+                    format!(
+                        "    <GeneratedTemplateId>{}</GeneratedTemplateId>",
+                        xml_escape(&id)
+                    ),
+                    &rid,
+                ))
             }
             "UpdateGeneratedTemplate" => {
-                let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
+                let name = params
+                    .get("GeneratedTemplateName")
+                    .ok_or_else(|| missing("GeneratedTemplateName"))?
+                    .clone();
                 let id = Arn::new(
                     "cloudformation",
                     "us-east-1",
@@ -845,10 +991,20 @@ impl CloudFormationService {
                     &format!("generatedtemplate/{name}"),
                 )
                 .to_string();
-                Ok(xml_response("UpdateGeneratedTemplate", format!("    <GeneratedTemplateId>{}</GeneratedTemplateId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "UpdateGeneratedTemplate",
+                    format!(
+                        "    <GeneratedTemplateId>{}</GeneratedTemplateId>",
+                        xml_escape(&id)
+                    ),
+                    &rid,
+                ))
             }
             "DescribeGeneratedTemplate" => {
-                let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
+                let name = params
+                    .get("GeneratedTemplateName")
+                    .ok_or_else(|| missing("GeneratedTemplateName"))?
+                    .clone();
                 let inner = format!(
                     "    <GeneratedTemplateId>arn:aws:cloudformation:us-east-1:{}:generatedtemplate/{}</GeneratedTemplateId>\n    <GeneratedTemplateName>{}</GeneratedTemplateName>\n    <Status>COMPLETE</Status>",
                     xml_escape(&aid),
@@ -857,9 +1013,16 @@ impl CloudFormationService {
                 );
                 Ok(xml_response("DescribeGeneratedTemplate", inner, &rid))
             }
-            "GetGeneratedTemplate" => Ok(xml_response("GetGeneratedTemplate", "    <Status>COMPLETE</Status>\n    <TemplateBody>{}</TemplateBody>".to_string(), &rid)),
+            "GetGeneratedTemplate" => Ok(xml_response(
+                "GetGeneratedTemplate",
+                "    <Status>COMPLETE</Status>\n    <TemplateBody>{}</TemplateBody>".to_string(),
+                &rid,
+            )),
             "DeleteGeneratedTemplate" => {
-                let name = params.get("GeneratedTemplateName").ok_or_else(|| missing("GeneratedTemplateName"))?.clone();
+                let name = params
+                    .get("GeneratedTemplateName")
+                    .ok_or_else(|| missing("GeneratedTemplateName"))?
+                    .clone();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 if let Some(m) = state.extras.get_mut("generated_templates") {
@@ -867,7 +1030,11 @@ impl CloudFormationService {
                 }
                 Ok(xml_response("DeleteGeneratedTemplate", String::new(), &rid))
             }
-            "ListGeneratedTemplates" => Ok(xml_response("ListGeneratedTemplates", "    <Summaries/>".to_string(), &rid)),
+            "ListGeneratedTemplates" => Ok(xml_response(
+                "ListGeneratedTemplates",
+                "    <Summaries/>".to_string(),
+                &rid,
+            )),
 
             // ── Resource scans ──
             "StartResourceScan" => {
@@ -878,7 +1045,11 @@ impl CloudFormationService {
                     &format!("resourceScan/{}", rand_id()),
                 )
                 .to_string();
-                Ok(xml_response("StartResourceScan", format!("    <ResourceScanId>{}</ResourceScanId>", xml_escape(&id)), &rid))
+                Ok(xml_response(
+                    "StartResourceScan",
+                    format!("    <ResourceScanId>{}</ResourceScanId>", xml_escape(&id)),
+                    &rid,
+                ))
             }
             "DescribeResourceScan" => {
                 let id = params.get("ResourceScanId").cloned().unwrap_or_default();
@@ -888,42 +1059,349 @@ impl CloudFormationService {
                 );
                 Ok(xml_response("DescribeResourceScan", inner, &rid))
             }
-            "ListResourceScans" => Ok(xml_response("ListResourceScans", "    <ResourceScanSummaries/>".to_string(), &rid)),
-            "ListResourceScanResources" => Ok(xml_response("ListResourceScanResources", "    <Resources/>".to_string(), &rid)),
-            "ListResourceScanRelatedResources" => Ok(xml_response("ListResourceScanRelatedResources", "    <RelatedResources/>".to_string(), &rid)),
+            "ListResourceScans" => Ok(xml_response(
+                "ListResourceScans",
+                "    <ResourceScanSummaries/>".to_string(),
+                &rid,
+            )),
+            "ListResourceScanResources" => Ok(xml_response(
+                "ListResourceScanResources",
+                "    <Resources/>".to_string(),
+                &rid,
+            )),
+            "ListResourceScanRelatedResources" => Ok(xml_response(
+                "ListResourceScanRelatedResources",
+                "    <RelatedResources/>".to_string(),
+                &rid,
+            )),
 
             // ── Drift detection ──
             "DetectStackDrift" => {
+                let stack_name = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
                 let id = rand_id();
-                Ok(xml_response("DetectStackDrift", format!("    <StackDriftDetectionId>{}</StackDriftDetectionId>", xml_escape(&id)), &rid))
+
+                let resources: Vec<StackResource> = {
+                    let accounts = self.state.read();
+                    let stack = accounts.get(&aid).and_then(|s| {
+                        s.stacks.values().find(|st| {
+                            (st.name == stack_name || st.stack_id == stack_name)
+                                && st.status != "DELETE_COMPLETE"
+                        })
+                    });
+                    stack.map(|s| s.resources.clone()).unwrap_or_default()
+                };
+
+                let mut drifted_resources: Vec<Value> = Vec::new();
+
+                for resource in &resources {
+                    let exists = match resource.resource_type.as_str() {
+                        "AWS::SQS::Queue" => self
+                            .deps
+                            .sqs
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.queues.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::SNS::Topic" => self
+                            .deps
+                            .sns
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.topics.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::S3::Bucket" => self
+                            .deps
+                            .s3
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.buckets.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::Lambda::Function" => self
+                            .deps
+                            .lambda
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.functions.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::IAM::Role" => self
+                            .deps
+                            .iam
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.roles.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::DynamoDB::Table" => self
+                            .deps
+                            .dynamodb
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.tables.values().any(|t| t.arn == resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::KMS::Key" => self
+                            .deps
+                            .kms
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.keys.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        "AWS::SecretsManager::Secret" => self
+                            .deps
+                            .secretsmanager
+                            .read()
+                            .get(&aid)
+                            .map(|s| s.secrets.contains_key(&resource.physical_id))
+                            .unwrap_or(false),
+                        _ => true, // NOT_CHECKED — assume exists
+                    };
+                    if !exists {
+                        drifted_resources.push(json!({
+                            "LogicalResourceId": resource.logical_id,
+                            "PhysicalResourceId": resource.physical_id,
+                            "ResourceType": resource.resource_type,
+                            "StackResourceDriftStatus": "DELETED",
+                            "PropertyDifferences": [],
+                        }));
+                    }
+                }
+
+                let stack_drift_status = if drifted_resources.is_empty() {
+                    "IN_SYNC"
+                } else {
+                    "DRIFTED"
+                };
+
+                let record = json!({
+                    "StackDriftDetectionId": id,
+                    "StackName": stack_name,
+                    "StackDriftStatus": stack_drift_status,
+                    "DetectionStatus": "DETECTION_COMPLETE",
+                    "DriftedResources": drifted_resources,
+                });
+
+                {
+                    let mut accounts = self.state.write();
+                    let state = accounts.get_or_create(&aid);
+                    store(&mut state.extras, "drift_detection").insert(id.clone(), record);
+                }
+
+                Ok(xml_response(
+                    "DetectStackDrift",
+                    format!(
+                        "    <StackDriftDetectionId>{}</StackDriftDetectionId>",
+                        xml_escape(&id)
+                    ),
+                    &rid,
+                ))
             }
-            "DetectStackResourceDrift" => Ok(xml_response(
-                "DetectStackResourceDrift",
-                "    <StackResourceDrift>\n      <StackResourceDriftStatus>IN_SYNC</StackResourceDriftStatus>\n    </StackResourceDrift>".to_string(),
-                &rid,
-            )),
+            "DetectStackResourceDrift" => {
+                let stack_name = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
+                let logical = params
+                    .get("LogicalResourceId")
+                    .ok_or_else(|| missing("LogicalResourceId"))?
+                    .clone();
+                let accounts = self.state.read();
+                let resource_drift = accounts
+                    .get(&aid)
+                    .and_then(|s| {
+                        s.stacks.values().find(|st| {
+                            (st.name == stack_name || st.stack_id == stack_name)
+                                && st.status != "DELETE_COMPLETE"
+                        })
+                    })
+                    .and_then(|stack| stack.resources.iter().find(|r| r.logical_id == logical))
+                    .map(|resource| {
+                        let exists = match resource.resource_type.as_str() {
+                            "AWS::SQS::Queue" => self
+                                .deps
+                                .sqs
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.queues.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::SNS::Topic" => self
+                                .deps
+                                .sns
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.topics.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::S3::Bucket" => self
+                                .deps
+                                .s3
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.buckets.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::Lambda::Function" => self
+                                .deps
+                                .lambda
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.functions.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::IAM::Role" => self
+                                .deps
+                                .iam
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.roles.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::DynamoDB::Table" => self
+                                .deps
+                                .dynamodb
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.tables.values().any(|t| t.arn == resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::KMS::Key" => self
+                                .deps
+                                .kms
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.keys.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            "AWS::SecretsManager::Secret" => self
+                                .deps
+                                .secretsmanager
+                                .read()
+                                .get(&aid)
+                                .map(|s| s.secrets.contains_key(&resource.physical_id))
+                                .unwrap_or(false),
+                            _ => true,
+                        };
+                        if exists {
+                            "IN_SYNC"
+                        } else {
+                            "DELETED"
+                        }
+                    })
+                    .unwrap_or("NOT_CHECKED");
+
+                let inner = format!(
+                    "    <StackResourceDrift>\n      <LogicalResourceId>{}</LogicalResourceId>\n      <StackResourceDriftStatus>{}</StackResourceDriftStatus>\n    </StackResourceDrift>",
+                    xml_escape(&logical),
+                    xml_escape(resource_drift),
+                );
+                Ok(xml_response("DetectStackResourceDrift", inner, &rid))
+            }
             "DetectStackSetDrift" => {
                 let op_id = rand_id();
-                Ok(xml_response("DetectStackSetDrift", format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)), &rid))
+                Ok(xml_response(
+                    "DetectStackSetDrift",
+                    format!("    <OperationId>{}</OperationId>", xml_escape(&op_id)),
+                    &rid,
+                ))
             }
             "DescribeStackDriftDetectionStatus" => {
-                let id = params.get("StackDriftDetectionId").cloned().unwrap_or_default();
-                let inner = format!(
-                    "    <StackDriftDetectionId>{}</StackDriftDetectionId>\n    <DetectionStatus>DETECTION_COMPLETE</DetectionStatus>\n    <StackDriftStatus>IN_SYNC</StackDriftStatus>",
-                    xml_escape(&id),
-                );
-                Ok(xml_response("DescribeStackDriftDetectionStatus", inner, &rid))
-            }
-            "DescribeStackResourceDrifts" => Ok(xml_response("DescribeStackResourceDrifts", "    <StackResourceDrifts/>".to_string(), &rid)),
-            "DescribeStackResource" => {
-                let stack_name = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
-                let logical = params.get("LogicalResourceId").ok_or_else(|| missing("LogicalResourceId"))?.clone();
+                let id = params
+                    .get("StackDriftDetectionId")
+                    .ok_or_else(|| missing("StackDriftDetectionId"))?
+                    .clone();
                 let accounts = self.state.read();
-                let detail = accounts.get(&aid)
+                let record = accounts
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("drift_detection"))
+                    .and_then(|m| m.get(&id))
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        json!({
+                            "StackDriftDetectionId": id,
+                            "StackDriftStatus": "IN_SYNC",
+                            "DetectionStatus": "DETECTION_COMPLETE",
+                        })
+                    });
+
+                let inner = format!(
+                    "    <StackDriftDetectionId>{}</StackDriftDetectionId>\n    <DetectionStatus>{}</DetectionStatus>\n    <StackDriftStatus>{}</StackDriftStatus>",
+                    xml_escape(record["StackDriftDetectionId"].as_str().unwrap_or("")),
+                    xml_escape(record["DetectionStatus"].as_str().unwrap_or("DETECTION_COMPLETE")),
+                    xml_escape(record["StackDriftStatus"].as_str().unwrap_or("IN_SYNC")),
+                );
+                Ok(xml_response(
+                    "DescribeStackDriftDetectionStatus",
+                    inner,
+                    &rid,
+                ))
+            }
+            "DescribeStackResourceDrifts" => {
+                let stack_name = params.get("StackName").cloned().unwrap_or_default();
+                let accounts = self.state.read();
+                let drifted: Vec<Value> = accounts
+                    .get(&aid)
+                    .and_then(|s| {
+                        let found = s
+                            .stacks
+                            .values()
+                            .find(|st| {
+                                (st.name == stack_name || st.stack_id == stack_name)
+                                    && st.status != "DELETE_COMPLETE"
+                            })
+                            .is_some();
+                        if !found {
+                            return None;
+                        }
+                        s.extras
+                            .get("drift_detection")
+                            .and_then(|m| {
+                                m.values()
+                                    .find(|v| v["StackName"].as_str() == Some(stack_name.as_str()))
+                            })
+                            .and_then(|v| v["DriftedResources"].as_array().cloned())
+                    })
+                    .unwrap_or_default();
+
+                let inner = if drifted.is_empty() {
+                    "    <StackResourceDrifts/>".to_string()
+                } else {
+                    format!(
+                        "    <StackResourceDrifts>\n{}\n    </StackResourceDrifts>",
+                        members_xml(&drifted, |v| {
+                            format!(
+                            "        <StackResourceDrift>\n          <LogicalResourceId>{}</LogicalResourceId>\n          <PhysicalResourceId>{}</PhysicalResourceId>\n          <ResourceType>{}</ResourceType>\n          <StackResourceDriftStatus>{}</StackResourceDriftStatus>\n        </StackResourceDrift>",
+                            xml_escape(v["LogicalResourceId"].as_str().unwrap_or("")),
+                            xml_escape(v["PhysicalResourceId"].as_str().unwrap_or("")),
+                            xml_escape(v["ResourceType"].as_str().unwrap_or("")),
+                            xml_escape(v["StackResourceDriftStatus"].as_str().unwrap_or("IN_SYNC")),
+                        )
+                        }),
+                    )
+                };
+                Ok(xml_response("DescribeStackResourceDrifts", inner, &rid))
+            }
+            "DescribeStackResource" => {
+                let stack_name = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
+                let logical = params
+                    .get("LogicalResourceId")
+                    .ok_or_else(|| missing("LogicalResourceId"))?
+                    .clone();
+                let accounts = self.state.read();
+                let detail = accounts
+                    .get(&aid)
                     .and_then(|s| s.stacks.get(&stack_name))
                     .and_then(|s| s.resources.iter().find(|r| r.logical_id == logical))
-                    .map(|r| (r.physical_id.clone(), r.resource_type.clone(), r.status.clone()))
-                    .unwrap_or_else(|| ("pid".to_string(), "AWS::Custom".to_string(), "CREATE_COMPLETE".to_string()));
+                    .map(|r| {
+                        (
+                            r.physical_id.clone(),
+                            r.resource_type.clone(),
+                            r.status.clone(),
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        (
+                            "pid".to_string(),
+                            "AWS::Custom".to_string(),
+                            "CREATE_COMPLETE".to_string(),
+                        )
+                    });
                 let inner = format!(
                     "    <StackResourceDetail>\n      <StackName>{}</StackName>\n      <LogicalResourceId>{}</LogicalResourceId>\n      <PhysicalResourceId>{}</PhysicalResourceId>\n      <ResourceType>{}</ResourceType>\n      <ResourceStatus>{}</ResourceStatus>\n      <LastUpdatedTimestamp>{}</LastUpdatedTimestamp>\n    </StackResourceDetail>",
                     xml_escape(&stack_name),
@@ -970,7 +1448,8 @@ impl CloudFormationService {
                 } else {
                     format!(
                         "    <StackEvents>\n{}\n    </StackEvents>",
-                        members_xml(&events, |v| format!(
+                        members_xml(&events, |v| {
+                            format!(
                             "        <EventId>{}</EventId>\n        <StackId>{}</StackId>\n        <StackName>{}</StackName>\n        <LogicalResourceId>{}</LogicalResourceId>\n        <PhysicalResourceId>{}</PhysicalResourceId>\n        <ResourceType>{}</ResourceType>\n        <ResourceStatus>{}</ResourceStatus>\n        <Timestamp>{}</Timestamp>",
                             xml_escape(v["EventId"].as_str().unwrap_or("")),
                             xml_escape(v["StackId"].as_str().unwrap_or("")),
@@ -980,12 +1459,17 @@ impl CloudFormationService {
                             xml_escape(v["ResourceType"].as_str().unwrap_or("")),
                             xml_escape(v["ResourceStatus"].as_str().unwrap_or("")),
                             xml_escape(v["Timestamp"].as_str().unwrap_or("")),
-                        )),
+                        )
+                        }),
                     )
                 };
                 Ok(xml_response("DescribeStackEvents", inner, &rid))
             }
-            "DescribeEvents" => Ok(xml_response("DescribeEvents", "    <Events/>".to_string(), &rid)),
+            "DescribeEvents" => Ok(xml_response(
+                "DescribeEvents",
+                "    <Events/>".to_string(),
+                &rid,
+            )),
 
             // ── Hooks ──
             "GetHookResult" => Ok(xml_response(
@@ -993,7 +1477,11 @@ impl CloudFormationService {
                 "    <Status>HOOK_COMPLETE_SUCCEEDED</Status>".to_string(),
                 &rid,
             )),
-            "ListHookResults" => Ok(xml_response("ListHookResults", "    <HookResults/>".to_string(), &rid)),
+            "ListHookResults" => Ok(xml_response(
+                "ListHookResults",
+                "    <HookResults/>".to_string(),
+                &rid,
+            )),
             "RecordHandlerProgress" => Ok(xml_response_no_result("RecordHandlerProgress", &rid)),
 
             // ── Imports / exports ──
@@ -1044,17 +1532,26 @@ impl CloudFormationService {
 
             // ── Stack policies ──
             "GetStackPolicy" => {
-                let stack = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
+                let stack = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
                 let accounts = self.state.read();
                 let body = accounts.get(&aid)
                     .and_then(|s| s.stack_policies.get(&stack))
                     .cloned()
                     .unwrap_or_else(|| r#"{"Statement":[{"Effect":"Allow","Action":"Update:*","Principal":"*","Resource":"*"}]}"#.to_string());
-                let inner = format!("    <StackPolicyBody>{}</StackPolicyBody>", xml_escape(&body));
+                let inner = format!(
+                    "    <StackPolicyBody>{}</StackPolicyBody>",
+                    xml_escape(&body)
+                );
                 Ok(xml_response("GetStackPolicy", inner, &rid))
             }
             "SetStackPolicy" => {
-                let stack = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
+                let stack = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
                 let body = params.get("StackPolicyBody").cloned().unwrap_or_default();
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
@@ -1064,17 +1561,29 @@ impl CloudFormationService {
 
             // ── Termination protection ──
             "UpdateTerminationProtection" => {
-                let stack = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
-                let enabled = params.get("EnableTerminationProtection")
+                let stack = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
+                let enabled = params
+                    .get("EnableTerminationProtection")
                     .map(|v| v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false);
                 let stack_id = {
                     let mut accounts = self.state.write();
                     let state = accounts.get_or_create(&aid);
                     state.termination_protection.insert(stack.clone(), enabled);
-                    state.stacks.get(&stack).map(|s| s.stack_id.clone()).unwrap_or_else(|| stack.clone())
+                    state
+                        .stacks
+                        .get(&stack)
+                        .map(|s| s.stack_id.clone())
+                        .unwrap_or_else(|| stack.clone())
                 };
-                Ok(xml_response("UpdateTerminationProtection", format!("    <StackId>{}</StackId>", xml_escape(&stack_id)), &rid))
+                Ok(xml_response(
+                    "UpdateTerminationProtection",
+                    format!("    <StackId>{}</StackId>", xml_escape(&stack_id)),
+                    &rid,
+                ))
             }
 
             // ── Account / org / validation / utilities ──
@@ -1085,33 +1594,51 @@ impl CloudFormationService {
         <Name>StackLimit</Name>
         <Value>2000</Value>
       </member>
-    </AccountLimits>"#.to_string(),
+    </AccountLimits>"#
+                    .to_string(),
                 &rid,
             )),
             "ActivateOrganizationsAccess" => {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 state.orgs_access_enabled = true;
-                Ok(xml_response("ActivateOrganizationsAccess", String::new(), &rid))
+                Ok(xml_response(
+                    "ActivateOrganizationsAccess",
+                    String::new(),
+                    &rid,
+                ))
             }
             "DeactivateOrganizationsAccess" => {
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(&aid);
                 state.orgs_access_enabled = false;
-                Ok(xml_response("DeactivateOrganizationsAccess", String::new(), &rid))
+                Ok(xml_response(
+                    "DeactivateOrganizationsAccess",
+                    String::new(),
+                    &rid,
+                ))
             }
             "DescribeOrganizationsAccess" => {
                 let accounts = self.state.read();
-                let status = if accounts.get(&aid).map(|s| s.orgs_access_enabled).unwrap_or(false) {
+                let status = if accounts
+                    .get(&aid)
+                    .map(|s| s.orgs_access_enabled)
+                    .unwrap_or(false)
+                {
                     "ENABLED"
                 } else {
                     "DISABLED"
                 };
-                Ok(xml_response("DescribeOrganizationsAccess", format!("    <Status>{}</Status>", status), &rid))
+                Ok(xml_response(
+                    "DescribeOrganizationsAccess",
+                    format!("    <Status>{}</Status>", status),
+                    &rid,
+                ))
             }
             "ValidateTemplate" => Ok(xml_response(
                 "ValidateTemplate",
-                "    <Description>Validated</Description>\n    <Capabilities/>\n    <Parameters/>".to_string(),
+                "    <Description>Validated</Description>\n    <Capabilities/>\n    <Parameters/>"
+                    .to_string(),
                 &rid,
             )),
             "EstimateTemplateCost" => Ok(xml_response(
@@ -1125,18 +1652,34 @@ impl CloudFormationService {
                 &rid,
             )),
             "CancelUpdateStack" => Ok(xml_response_no_result("CancelUpdateStack", &rid)),
-            "ContinueUpdateRollback" => Ok(xml_response("ContinueUpdateRollback", String::new(), &rid)),
+            "ContinueUpdateRollback" => {
+                Ok(xml_response("ContinueUpdateRollback", String::new(), &rid))
+            }
             "RollbackStack" => {
-                let stack = params.get("StackName").ok_or_else(|| missing("StackName"))?.clone();
+                let stack = params
+                    .get("StackName")
+                    .ok_or_else(|| missing("StackName"))?
+                    .clone();
                 let stack_id = {
                     let accounts = self.state.read();
-                    accounts.get(&aid).and_then(|s| s.stacks.get(&stack)).map(|s| s.stack_id.clone()).unwrap_or_else(|| stack.clone())
+                    accounts
+                        .get(&aid)
+                        .and_then(|s| s.stacks.get(&stack))
+                        .map(|s| s.stack_id.clone())
+                        .unwrap_or_else(|| stack.clone())
                 };
-                Ok(xml_response("RollbackStack", format!("    <StackId>{}</StackId>", xml_escape(&stack_id)), &rid))
+                Ok(xml_response(
+                    "RollbackStack",
+                    format!("    <StackId>{}</StackId>", xml_escape(&stack_id)),
+                    &rid,
+                ))
             }
             "SignalResource" => Ok(xml_response_no_result("SignalResource", &rid)),
 
-            _ => Err(AwsServiceError::action_not_implemented("cloudformation", &action)),
+            _ => Err(AwsServiceError::action_not_implemented(
+                "cloudformation",
+                &action,
+            )),
         }
     }
 }
@@ -1347,11 +1890,17 @@ mod tests {
         ok("ListResourceScans", &[]);
         ok("ListResourceScanResources", &[]);
         ok("ListResourceScanRelatedResources", &[]);
-        ok("DetectStackDrift", &[]);
-        ok("DetectStackResourceDrift", &[]);
-        ok("DetectStackSetDrift", &[]);
-        ok("DescribeStackDriftDetectionStatus", &[]);
-        ok("DescribeStackResourceDrifts", &[]);
+        ok("DetectStackDrift", &[("StackName", "s")]);
+        ok(
+            "DetectStackResourceDrift",
+            &[("StackName", "s"), ("LogicalResourceId", "L")],
+        );
+        ok("DetectStackSetDrift", &[("StackSetName", "ss")]);
+        ok(
+            "DescribeStackDriftDetectionStatus",
+            &[("StackDriftDetectionId", "id")],
+        );
+        ok("DescribeStackResourceDrifts", &[("StackName", "s")]);
         ok(
             "DescribeStackResource",
             &[("StackName", "s"), ("LogicalResourceId", "L")],

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::state::SharedCloudFormationState;
 use fakecloud_acm::{
     CertificateOptions as AcmCertificateOptions, DomainValidation as AcmDomainValidation,
     RenewalSummary as AcmRenewalSummary, SharedAcmState, StoredCertificate as AcmStoredCertificate,
@@ -857,6 +858,7 @@ pub struct ResourceProvisioner {
     pub athena_state: SharedAthenaState,
     pub firehose_state: fakecloud_firehose::SharedFirehoseState,
     pub glue_state: fakecloud_glue::SharedGlueState,
+    pub cloudformation_state: SharedCloudFormationState,
     pub delivery: Arc<DeliveryBus>,
     pub account_id: String,
     pub region: String,
@@ -1073,6 +1075,7 @@ impl ResourceProvisioner {
                 self.create_firehose_delivery_stream(resource)
             }
             "AWS::Glue::Database" => self.create_glue_database(resource),
+            "AWS::CloudFormation::Stack" => self.create_cloudformation_stack(resource),
             "AWS::Glue::Table" => self.create_glue_table(resource),
             "AWS::Glue::Partition" => self.create_glue_partition(resource),
             t if t.starts_with("Custom::") || t == "AWS::CloudFormation::CustomResource" => self
@@ -1327,6 +1330,9 @@ impl ResourceProvisioner {
             }
             "AWS::Athena::PreparedStatement" => {
                 self.get_att_athena_prepared_statement(&resource.physical_id, attribute)
+            }
+            "AWS::CloudFormation::Stack" => {
+                self.get_att_cloudformation_stack(&resource.physical_id, attribute)
             }
             _ => None,
         }
@@ -1908,6 +1914,7 @@ impl ResourceProvisioner {
                 self.delete_firehose_delivery_stream(&resource.physical_id)
             }
             "AWS::Glue::Database" => self.delete_glue_database(&resource.physical_id),
+            "AWS::CloudFormation::Stack" => self.delete_cloudformation_stack(&resource.physical_id),
             "AWS::Glue::Table" => self.delete_glue_table(&resource.physical_id),
             "AWS::Glue::Partition" => {
                 self.delete_glue_partition(&resource.physical_id, &resource.attributes)
@@ -17698,6 +17705,315 @@ impl ResourceProvisioner {
         table.partitions.remove(parts[2]);
         Ok(())
     }
+
+    // --- CloudFormation Nested Stack ---
+
+    fn create_cloudformation_stack(
+        &self,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+
+        let template_body = if let Some(body) = props.get("TemplateBody").and_then(|v| v.as_str()) {
+            body.to_string()
+        } else if let Some(url) = props.get("TemplateURL").and_then(|v| v.as_str()) {
+            self.fetch_template_from_url(url)?
+        } else {
+            return Err(
+                "AWS::CloudFormation::Stack requires TemplateURL or TemplateBody".to_string(),
+            );
+        };
+
+        let child_parameters =
+            if let Some(params) = props.get("Parameters").and_then(|v| v.as_object()) {
+                let mut map = BTreeMap::new();
+                for (k, v) in params {
+                    if let Some(s) = v.as_str() {
+                        map.insert(k.clone(), s.to_string());
+                    } else {
+                        map.insert(k.clone(), v.to_string());
+                    }
+                }
+                map
+            } else {
+                BTreeMap::new()
+            };
+
+        let child_tags = if let Some(tags) = props.get("Tags").and_then(|v| v.as_object()) {
+            let mut map = BTreeMap::new();
+            for (k, v) in tags {
+                if let Some(s) = v.as_str() {
+                    map.insert(k.clone(), s.to_string());
+                }
+            }
+            map
+        } else {
+            BTreeMap::new()
+        };
+
+        let parsed = crate::template::parse_template(&template_body, &child_parameters)
+            .map_err(|e| format!("Failed to parse nested template: {e}"))?;
+
+        let child_stack_name = format!(
+            "{}-Nested-{}",
+            resource.logical_id,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let child_stack_id = format!(
+            "arn:aws:cloudformation:{}:{}:stack/{}/{}",
+            self.region,
+            self.account_id,
+            child_stack_name,
+            Uuid::new_v4()
+        );
+
+        let child_provisioner = ResourceProvisioner {
+            sqs_state: self.sqs_state.clone(),
+            sns_state: self.sns_state.clone(),
+            ssm_state: self.ssm_state.clone(),
+            iam_state: self.iam_state.clone(),
+            s3_state: self.s3_state.clone(),
+            eventbridge_state: self.eventbridge_state.clone(),
+            dynamodb_state: self.dynamodb_state.clone(),
+            logs_state: self.logs_state.clone(),
+            lambda_state: self.lambda_state.clone(),
+            secretsmanager_state: self.secretsmanager_state.clone(),
+            kinesis_state: self.kinesis_state.clone(),
+            kms_state: self.kms_state.clone(),
+            ecr_state: self.ecr_state.clone(),
+            cloudwatch_state: self.cloudwatch_state.clone(),
+            elbv2_state: self.elbv2_state.clone(),
+            organizations_state: self.organizations_state.clone(),
+            cognito_state: self.cognito_state.clone(),
+            rds_state: self.rds_state.clone(),
+            ecs_state: self.ecs_state.clone(),
+            acm_state: self.acm_state.clone(),
+            elasticache_state: self.elasticache_state.clone(),
+            route53_state: self.route53_state.clone(),
+            cloudfront_state: self.cloudfront_state.clone(),
+            stepfunctions_state: self.stepfunctions_state.clone(),
+            wafv2_state: self.wafv2_state.clone(),
+            apigateway_state: self.apigateway_state.clone(),
+            apigatewayv2_state: self.apigatewayv2_state.clone(),
+            ses_state: self.ses_state.clone(),
+            app_autoscaling_state: self.app_autoscaling_state.clone(),
+            athena_state: self.athena_state.clone(),
+            firehose_state: self.firehose_state.clone(),
+            glue_state: self.glue_state.clone(),
+            cloudformation_state: self.cloudformation_state.clone(),
+            delivery: self.delivery.clone(),
+            account_id: self.account_id.clone(),
+            region: self.region.clone(),
+            stack_id: child_stack_id.clone(),
+        };
+
+        let child_resources = crate::service::provision_stack_resources(
+            &child_provisioner,
+            &parsed.resources,
+            &template_body,
+            &child_parameters,
+        )
+        .map_err(|e| format!("Failed to provision nested stack: {e}"))?;
+
+        let child_outputs = parsed.outputs;
+
+        let stack = crate::state::Stack {
+            name: child_stack_name.clone(),
+            stack_id: child_stack_id.clone(),
+            template: template_body.clone(),
+            status: "CREATE_COMPLETE".to_string(),
+            resources: child_resources.clone(),
+            parameters: child_parameters,
+            tags: child_tags,
+            created_at: Utc::now(),
+            updated_at: None,
+            description: parsed.description,
+            notification_arns: Vec::new(),
+            outputs: child_outputs
+                .iter()
+                .map(|o| crate::state::StackOutput {
+                    key: o.logical_id.clone(),
+                    value: o.value.clone(),
+                    description: o.description.clone(),
+                    export_name: o.export_name.clone(),
+                })
+                .collect(),
+        };
+
+        {
+            let mut accounts = self.cloudformation_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            state.stacks.insert(child_stack_name.clone(), stack);
+
+            crate::service::record_stack_status_event(
+                state,
+                &child_stack_id,
+                &child_stack_name,
+                "AWS::CloudFormation::Stack",
+                "CREATE_IN_PROGRESS",
+            );
+            let changes: Vec<crate::service::ResourceChange> = child_resources
+                .iter()
+                .map(|r| crate::service::ResourceChange {
+                    action: crate::service::ResourceChangeAction::Create,
+                    logical_id: r.logical_id.clone(),
+                    physical_id: r.physical_id.clone(),
+                    resource_type: r.resource_type.clone(),
+                })
+                .collect();
+            crate::service::record_stack_events(
+                state,
+                &child_stack_id,
+                &child_stack_name,
+                &changes,
+            );
+            crate::service::record_stack_status_event(
+                state,
+                &child_stack_id,
+                &child_stack_name,
+                "AWS::CloudFormation::Stack",
+                "CREATE_COMPLETE",
+            );
+        }
+
+        let mut result = ProvisionResult::new(child_stack_id.clone());
+        for output in &child_outputs {
+            result.attributes.insert(
+                format!("Outputs.{}", output.logical_id),
+                output.value.clone(),
+            );
+        }
+        Ok(result)
+    }
+
+    fn delete_cloudformation_stack(&self, physical_id: &str) -> Result<(), String> {
+        let stack = {
+            let accounts = self.cloudformation_state.read();
+            let state = accounts.get(&self.account_id);
+            state.and_then(|s| {
+                s.stacks
+                    .values()
+                    .find(|st| st.stack_id == physical_id)
+                    .cloned()
+            })
+        };
+
+        if let Some(stack) = stack {
+            let stack_name = stack.name.clone();
+            let stack_id = stack.stack_id.clone();
+
+            for resource in stack.resources.iter().rev() {
+                let _ = self.delete_resource(resource);
+            }
+
+            {
+                let mut accounts = self.cloudformation_state.write();
+                let state = accounts.get_or_create(&self.account_id);
+                state.stacks.remove(&stack_name);
+
+                crate::service::record_stack_status_event(
+                    state,
+                    &stack_id,
+                    &stack_name,
+                    "AWS::CloudFormation::Stack",
+                    "DELETE_IN_PROGRESS",
+                );
+                crate::service::record_stack_status_event(
+                    state,
+                    &stack_id,
+                    &stack_name,
+                    "AWS::CloudFormation::Stack",
+                    "DELETE_COMPLETE",
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_att_cloudformation_stack(&self, physical_id: &str, attribute: &str) -> Option<String> {
+        let accounts = self.cloudformation_state.read();
+        let state = accounts.get(&self.account_id)?;
+        let stack = state.stacks.values().find(|s| s.stack_id == physical_id)?;
+
+        if let Some(output_key) = attribute.strip_prefix("Outputs.") {
+            return stack
+                .outputs
+                .iter()
+                .find(|o| o.key == output_key)
+                .map(|o| o.value.clone());
+        }
+
+        match attribute {
+            "Outputs" => Some(
+                serde_json::to_string(
+                    &stack
+                        .outputs
+                        .iter()
+                        .map(|o| (o.key.clone(), o.value.clone()))
+                        .collect::<std::collections::BTreeMap<String, String>>(),
+                )
+                .unwrap_or_default(),
+            ),
+            _ => None,
+        }
+    }
+
+    fn fetch_template_from_url(&self, url: &str) -> Result<String, String> {
+        if let Some(rest) = url.strip_prefix("s3://") {
+            let parts: Vec<&str> = rest.splitn(2, '/').collect();
+            if parts.len() != 2 {
+                return Err("Invalid s3:// URL".to_string());
+            }
+            return self.fetch_s3_template(parts[0], parts[1]);
+        }
+
+        if let Some(rest) = url.strip_prefix("https://s3.amazonaws.com/") {
+            let parts: Vec<&str> = rest.splitn(2, '/').collect();
+            if parts.len() != 2 {
+                return Err("Invalid S3 HTTPS URL".to_string());
+            }
+            return self.fetch_s3_template(parts[0], parts[1]);
+        }
+
+        if let Some(host_rest) = url.strip_prefix("https://") {
+            if let Some(slash_pos) = host_rest.find('/') {
+                let host = &host_rest[..slash_pos];
+                let key = &host_rest[slash_pos + 1..];
+                if let Some(bucket) = host.strip_suffix(".s3.amazonaws.com") {
+                    return self.fetch_s3_template(bucket, key);
+                }
+                if host.contains(".s3.") && host.ends_with(".amazonaws.com") {
+                    let bucket = host.split(".s3.").next().unwrap_or("");
+                    if !bucket.is_empty() {
+                        return self.fetch_s3_template(bucket, key);
+                    }
+                }
+            }
+        }
+
+        Err(format!("Unsupported TemplateURL: {url}"))
+    }
+
+    fn fetch_s3_template(&self, bucket: &str, key: &str) -> Result<String, String> {
+        let mut s3_accounts = self.s3_state.write();
+        let s3_state = s3_accounts.get_or_create(&self.account_id);
+        let bucket_obj = s3_state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| format!("S3 bucket not found: {bucket}"))?;
+        let obj = bucket_obj
+            .objects
+            .get(key)
+            .ok_or_else(|| format!("S3 object not found: {bucket}/{key}"))?;
+        let bytes = s3_state
+            .read_body(&obj.body)
+            .map_err(|e| format!("Failed to read S3 object body: {e}"))?;
+        String::from_utf8(bytes.to_vec()).map_err(|e| format!("S3 object is not valid UTF-8: {e}"))
+    }
 }
 
 /// Implements the CloudFormation `GenerateSecretString` shape on
@@ -18329,6 +18645,9 @@ mod tests {
             route53_state: Arc::new(RwLock::new(fakecloud_route53::Route53Accounts::new())),
             cloudfront_state: Arc::new(RwLock::new(
                 fakecloud_cloudfront::CloudFrontAccounts::new(),
+            )),
+            cloudformation_state: Arc::new(RwLock::new(
+                fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
             )),
             stepfunctions_state: Arc::new(RwLock::new(
                 fakecloud_core::multi_account::MultiAccountState::new(

--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -59,7 +59,7 @@ fn well_known_attributes_for(resource_type: &str) -> &'static [&'static str] {
 /// any resource whose `Ref` targets are still unknown just stays pending
 /// for the next pass. When no pass makes progress we report the first
 /// pending failure and rollback.
-fn provision_stack_resources(
+pub(crate) fn provision_stack_resources(
     provisioner: &ResourceProvisioner,
     resource_defs: &[template::ResourceDefinition],
     template_body: &str,
@@ -188,7 +188,7 @@ pub struct CloudFormationDeps {
 
 pub struct CloudFormationService {
     pub(crate) state: SharedCloudFormationState,
-    deps: CloudFormationDeps,
+    pub(crate) deps: CloudFormationDeps,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
 }
@@ -270,6 +270,7 @@ impl CloudFormationService {
             athena_state: self.deps.athena.clone(),
             firehose_state: self.deps.firehose.clone(),
             glue_state: self.deps.glue.clone(),
+            cloudformation_state: self.state.clone(),
             delivery: self.deps.delivery.clone(),
             account_id: account_id.to_string(),
             region: region.to_string(),
@@ -668,7 +669,7 @@ impl CloudFormationService {
             stack_id: stack_id.clone(),
             template: template_body.clone(),
             status: "CREATE_COMPLETE".to_string(),
-            resources,
+            resources: resources.clone(),
             parameters,
             tags,
             created_at: Utc::now(),
@@ -683,6 +684,32 @@ impl CloudFormationService {
             let state = accounts.get_or_create(&req.account_id);
             state.stacks.insert(stack_name.clone(), stack);
             Self::sync_exports_imports(state, &stack_id, stack_name, &outputs, &imported_names);
+
+            // Emit lifecycle events for CreateStack
+            record_stack_status_event(
+                state,
+                &stack_id,
+                stack_name,
+                "AWS::CloudFormation::Stack",
+                "CREATE_IN_PROGRESS",
+            );
+            let changes: Vec<ResourceChange> = resources
+                .iter()
+                .map(|r| ResourceChange {
+                    action: ResourceChangeAction::Create,
+                    logical_id: r.logical_id.clone(),
+                    physical_id: r.physical_id.clone(),
+                    resource_type: r.resource_type.clone(),
+                })
+                .collect();
+            record_stack_events(state, &stack_id, stack_name, &changes);
+            record_stack_status_event(
+                state,
+                &stack_id,
+                stack_name,
+                "AWS::CloudFormation::Stack",
+                "CREATE_COMPLETE",
+            );
         }
 
         Self::send_stack_notification(

--- a/crates/fakecloud-cloudformation/src/template.rs
+++ b/crates/fakecloud-cloudformation/src/template.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Internal sentinel emitted whenever a CFN value resolves to
@@ -92,6 +92,7 @@ pub fn parse_template_with_resolution(
     // hand-authored one. Parameters flow in so the items list can be a
     // `Ref` to a CommaDelimitedList parameter.
     let value = expand_for_each(&value, &BTreeMap::new(), parameters)?;
+    let value = expand_sam(&value);
 
     let description = value
         .get("Description")
@@ -567,6 +568,201 @@ fn expand_for_each(
         }
         other => Ok(other.clone()),
     }
+}
+
+/// Expand AWS::Serverless-2016-10-31 SAM resources into native
+/// CloudFormation resources so the provisioner can handle them.
+fn expand_sam(value: &Value) -> Value {
+    let transform = value.get("Transform");
+    let has_sam = match transform {
+        Some(Value::String(s)) => s == "AWS::Serverless-2016-10-31",
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .any(|v| v.as_str() == Some("AWS::Serverless-2016-10-31")),
+        _ => false,
+    };
+    if !has_sam {
+        return value.clone();
+    }
+
+    let mut value = value.clone();
+    let Some(resources) = value.get_mut("Resources") else {
+        return value;
+    };
+    let Some(resources_map) = resources.as_object_mut() else {
+        return value;
+    };
+
+    let mut new_resources = serde_json::Map::new();
+    for (logical_id, resource) in resources_map.iter() {
+        let Some(resource_obj) = resource.as_object() else {
+            new_resources.insert(logical_id.clone(), resource.clone());
+            continue;
+        };
+        let Some(ty) = resource_obj.get("Type").and_then(|v| v.as_str()) else {
+            new_resources.insert(logical_id.clone(), resource.clone());
+            continue;
+        };
+        let properties = resource_obj
+            .get("Properties")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+
+        match ty {
+            "AWS::Serverless::Function" => {
+                let mut lambda_props = if let Some(p) = properties.as_object() {
+                    p.clone()
+                } else {
+                    serde_json::Map::new()
+                };
+                // Map CodeUri / InlineCode to Code
+                if let Some(code_uri) = lambda_props.get("CodeUri").cloned() {
+                    lambda_props.remove("CodeUri");
+                    let code = if let Some(s) = code_uri.as_str() {
+                        if let Some(stripped) = s.strip_prefix("s3://") {
+                            let parts: Vec<&str> = stripped.splitn(2, '/').collect();
+                            if parts.len() == 2 {
+                                json!({"S3Bucket": parts[0], "S3Key": parts[1]})
+                            } else {
+                                json!({"S3Bucket": "sam", "S3Key": s})
+                            }
+                        } else {
+                            json!({"S3Bucket": "sam", "S3Key": s})
+                        }
+                    } else {
+                        code_uri
+                    };
+                    lambda_props.insert("Code".to_string(), code);
+                } else if let Some(inline) = lambda_props.get("InlineCode").cloned() {
+                    lambda_props.remove("InlineCode");
+                    lambda_props.insert("Code".to_string(), json!({"ZipFile": inline}));
+                }
+                let mut lambda_resource = serde_json::Map::new();
+                lambda_resource.insert("Type".to_string(), json!("AWS::Lambda::Function"));
+                lambda_resource.insert("Properties".to_string(), Value::Object(lambda_props));
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        lambda_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(lambda_resource));
+            }
+            "AWS::Serverless::Api" => {
+                let mut api_props = if let Some(p) = properties.as_object() {
+                    p.clone()
+                } else {
+                    serde_json::Map::new()
+                };
+                if let Some(def) = api_props.get("DefinitionBody").cloned() {
+                    api_props.remove("DefinitionBody");
+                    api_props.insert("Body".to_string(), def);
+                }
+                let mut api_resource = serde_json::Map::new();
+                api_resource.insert("Type".to_string(), json!("AWS::ApiGateway::RestApi"));
+                api_resource.insert("Properties".to_string(), Value::Object(api_props));
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        api_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(api_resource));
+            }
+            "AWS::Serverless::HttpApi" => {
+                let mut httpapi_resource = serde_json::Map::new();
+                httpapi_resource.insert("Type".to_string(), json!("AWS::ApiGatewayV2::Api"));
+                httpapi_resource.insert("Properties".to_string(), properties);
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        httpapi_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(httpapi_resource));
+            }
+            "AWS::Serverless::SimpleTable" => {
+                let mut table_props = if let Some(p) = properties.as_object() {
+                    p.clone()
+                } else {
+                    serde_json::Map::new()
+                };
+                if let Some(pk) = table_props.get("PrimaryKey") {
+                    if let Some(pk_obj) = pk.as_object() {
+                        let name = pk_obj.get("Name").cloned().unwrap_or_else(|| json!("id"));
+                        let ty = match pk_obj.get("Type").and_then(|v| v.as_str()) {
+                            Some("String") => json!("S"),
+                            Some("Number") => json!("N"),
+                            Some("Binary") => json!("B"),
+                            Some(other) => json!(other),
+                            None => json!("S"),
+                        };
+                        table_props.remove("PrimaryKey");
+                        table_props.insert(
+                            "KeySchema".to_string(),
+                            json!([{"AttributeName": name.clone(), "KeyType": "HASH"}]),
+                        );
+                        table_props.insert(
+                            "AttributeDefinitions".to_string(),
+                            json!([{"AttributeName": name, "AttributeType": ty}]),
+                        );
+                    }
+                }
+                if !table_props.contains_key("BillingMode") {
+                    table_props.insert("BillingMode".to_string(), json!("PAY_PER_REQUEST"));
+                }
+                let mut table_resource = serde_json::Map::new();
+                table_resource.insert("Type".to_string(), json!("AWS::DynamoDB::Table"));
+                table_resource.insert("Properties".to_string(), Value::Object(table_props));
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        table_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(table_resource));
+            }
+            "AWS::Serverless::LayerVersion" => {
+                let mut layer_props = if let Some(p) = properties.as_object() {
+                    p.clone()
+                } else {
+                    serde_json::Map::new()
+                };
+                if let Some(uri) = layer_props.get("ContentUri").cloned() {
+                    layer_props.remove("ContentUri");
+                    let content = if let Some(s) = uri.as_str() {
+                        if let Some(stripped) = s.strip_prefix("s3://") {
+                            let parts: Vec<&str> = stripped.splitn(2, '/').collect();
+                            if parts.len() == 2 {
+                                json!({"S3Bucket": parts[0], "S3Key": parts[1]})
+                            } else {
+                                json!({"S3Bucket": "sam", "S3Key": s})
+                            }
+                        } else {
+                            json!({"S3Bucket": "sam", "S3Key": s})
+                        }
+                    } else {
+                        uri
+                    };
+                    layer_props.insert("Content".to_string(), content);
+                }
+                let mut layer_resource = serde_json::Map::new();
+                layer_resource.insert("Type".to_string(), json!("AWS::Lambda::LayerVersion"));
+                layer_resource.insert("Properties".to_string(), Value::Object(layer_props));
+                for (k, v) in resource_obj {
+                    if k != "Type" && k != "Properties" {
+                        layer_resource.insert(k.clone(), v.clone());
+                    }
+                }
+                new_resources.insert(logical_id.clone(), Value::Object(layer_resource));
+            }
+            _ => {
+                new_resources.insert(logical_id.clone(), resource.clone());
+            }
+        }
+    }
+
+    resources_map.clear();
+    for (k, v) in new_resources {
+        resources_map.insert(k, v);
+    }
+    value
 }
 
 /// Resolve the `items` argument of an `Fn::ForEach` macro. Accepts:


### PR DESCRIPTION
## Summary

- AWS::CloudFormation::Stack provisioner with recursive resource provisioning
- Fn::GetAtt support for Outputs.*, Outputs, StackId, StackName, TemplateURL
- TemplateURL fetching from S3 and HTTPS
- SAM transform (AWS::Serverless-2016-10-31) expansion to native CFN resources
- DescribeStackResourceDrifts closure scope fix
- DetectStackDrift read-then-write deadlock fix
- Stack event recording on CreateStack lifecycle
- CloudFormationState wired into ResourceProvisioner for nested stacks

## Test plan

- [x] cargo test -p fakecloud-cloudformation (193 tests pass)
- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nested CloudFormation stacks, SAM transform, drift detection, and stack lifecycle events to improve feature coverage and parity. Also supports fetching `TemplateURL` from S3/HTTPS and wires CloudFormation state into the provisioner (Linear BB38).

- **New Features**
  - Provision nested `AWS::CloudFormation::Stack` recursively, with delete support and `Fn::GetAtt` for `Outputs.*` and `Outputs`.
  - Fetch templates via `TemplateURL` from `s3://`, `https://s3.amazonaws.com/<bucket>/<key>`, and `<bucket>.s3.amazonaws.com` (also regional hostnames).
  - Expand SAM (`AWS::Serverless-2016-10-31`) to native CFN: `Function`, `Api`, `HttpApi`, `SimpleTable`, `LayerVersion`.
  - Implement drift APIs with stored detection records and resource-level results: `DetectStackDrift`, `DetectStackResourceDrift`, `DescribeStackDriftDetectionStatus`, `DescribeStackResourceDrifts`.
  - Record `CreateStack` lifecycle events and per-resource events for both top-level and nested stacks; wire `CloudFormationState` into the provisioner for nested stacks.

- **Bug Fixes**
  - Fix closure scope in `DescribeStackResourceDrifts`.
  - Fix read-then-write deadlock in `DetectStackDrift`.

<sup>Written for commit b7c801fb48f00aa8680c35b487a826a0c29dbbe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

