### PR TITLE
fix(protocol): route bedrock-runtime credential scope to the bedrock handler

### DIFF
--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -71,7 +71,7 @@ pub fn detect_service_headers_only(
     if let Some(credential) = query_params.get("X-Amz-Credential") {
         let parts: Vec<&str> = credential.split('/').collect();
         if parts.len() >= 4 {
-            let service = parts[3].to_string();
+            let service = normalize_service_name(parts[3]).to_string();
             if let Some(protocol) = rest_protocol_for(&service) {
                 return Some(DetectedRequest {
                     service,
@@ -162,7 +162,7 @@ pub fn detect_service(
         // Format: AKID/date/region/service/aws4_request
         let parts: Vec<&str> = credential.split('/').collect();
         if parts.len() >= 4 {
-            let service = parts[3].to_string();
+            let service = normalize_service_name(parts[3]).to_string();
             if let Some(protocol) = rest_protocol_for(&service) {
                 return Some(DetectedRequest {
                     service,
@@ -475,7 +475,25 @@ fn infer_service_from_action(action: &str) -> Option<String> {
 fn extract_service_from_auth(headers: &HeaderMap) -> Option<String> {
     let auth = headers.get("authorization")?.to_str().ok()?;
     let info = fakecloud_aws::sigv4::parse_sigv4(auth)?;
-    Some(info.service)
+    Some(normalize_service_name(&info.service).to_string())
+}
+
+/// Map AWS service-name aliases that share path namespace and handlers
+/// to the canonical form used by fakecloud's service registry.
+///
+/// AWS uses `bedrock-runtime` in the SigV4 credential scope of runtime
+/// API calls (`InvokeModel`, `ApplyGuardrail`, etc.) but the REST paths
+/// (e.g. `POST /guardrail/{id}/version/{ver}/apply`) live under the same
+/// `BedrockService` handler that owns the control-plane `bedrock` paths.
+/// Without normalization, `detect_service` returns `None` for
+/// `bedrock-runtime` (not in `REST_JSON_SERVICES`), the central
+/// dispatcher falls back to API Gateway, and `/guardrail/...` 404s with
+/// `NotFoundException: Stage not found: guardrail`. See issue #1232.
+fn normalize_service_name(service: &str) -> &str {
+    match service {
+        "bedrock-runtime" => "bedrock",
+        other => other,
+    }
 }
 
 /// Parse form-encoded body into key-value pairs.
@@ -790,6 +808,69 @@ mod tests {
         let query = HashMap::new();
         let body = Bytes::new();
         assert!(detect_service(&headers, &query, &body).is_none());
+    }
+
+    #[test]
+    fn normalize_service_name_aliases_bedrock_runtime_to_bedrock() {
+        // The bedrock-runtime credential scope shares path namespace with
+        // the bedrock control plane (`POST /guardrail/{id}/version/{ver}/apply`
+        // is implemented under BedrockService). Routing must resolve to
+        // the bedrock service so the existing handlers run. See #1232.
+        assert_eq!(normalize_service_name("bedrock-runtime"), "bedrock");
+    }
+
+    #[test]
+    fn normalize_service_name_passes_through_unaliased_services() {
+        // Every service that isn't on the alias list must round-trip
+        // unchanged — including the canonical bedrock name itself, so a
+        // plain bedrock request takes the same code path it always has.
+        assert_eq!(normalize_service_name("bedrock"), "bedrock");
+        assert_eq!(normalize_service_name("s3"), "s3");
+        assert_eq!(normalize_service_name("lambda"), "lambda");
+        assert_eq!(normalize_service_name(""), "");
+        assert_eq!(
+            normalize_service_name("unknown-future-service"),
+            "unknown-future-service"
+        );
+    }
+
+    #[test]
+    fn detect_service_via_authorization_header_normalizes_bedrock_runtime() {
+        // SigV4 auth header carries `bedrock-runtime` in the credential
+        // scope; dispatcher must route to the bedrock service handler so
+        // `/guardrail/...` lands on `BedrockService` instead of falling
+        // through to API Gateway.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            "AWS4-HMAC-SHA256 \
+             Credential=AKID/20240101/us-east-1/bedrock-runtime/aws4_request, \
+             SignedHeaders=host, Signature=abc"
+                .parse()
+                .unwrap(),
+        );
+        let query = HashMap::new();
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "bedrock");
+        assert_eq!(detected.protocol, AwsProtocol::RestJson);
+    }
+
+    #[test]
+    fn detect_service_via_sigv4_presigned_credential_normalizes_bedrock_runtime() {
+        // Same alias normalization on the presigned-URL path: a request
+        // signed with bedrock-runtime in the X-Amz-Credential query param
+        // must still resolve to the bedrock service handler.
+        let headers = HeaderMap::new();
+        let mut query = HashMap::new();
+        query.insert(
+            "X-Amz-Credential".to_string(),
+            "AKID/20240101/us-east-1/bedrock-runtime/aws4_request".to_string(),
+        );
+        let body = Bytes::new();
+        let detected = detect_service(&headers, &query, &body).unwrap();
+        assert_eq!(detected.service, "bedrock");
+        assert_eq!(detected.protocol, AwsProtocol::RestJson);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1232.

Implements the fix described in the issue — a private
`normalize_service_name()` helper in `crates/fakecloud-core/src/protocol.rs` that maps
`bedrock-runtime` → `bedrock`, wired into the two service-name extraction
sites the dispatcher consults:

  - `extract_service_from_auth` — SigV4 Authorization header path.
  - Both `X-Amz-Credential` parsers (in `detect_service_headers_only`
    and `detect_service`) — presigned-URL path.

Other services round-trip unchanged.

### Tests added

`cargo test -p fakecloud-core --lib`: **192 passed / 0 failed** (4 new + 188 pre-existing).

- `normalize_service_name_aliases_bedrock_runtime_to_bedrock` — pins the alias itself.
- `normalize_service_name_passes_through_unaliased_services` — pins that `bedrock`, `s3`, `lambda`, the empty string, and unknown future service names all round-trip unchanged.
- `detect_service_via_authorization_header_normalizes_bedrock_runtime` — exercises the full dispatch via a SigV4 Authorization header with the `bedrock-runtime` scope; asserts the resulting `DetectedRequest` has `service = "bedrock"` and `protocol = RestJson`, which is exactly what routes the request to `BedrockService` instead of falling through to API Gateway.
- `detect_service_via_sigv4_presigned_credential_normalizes_bedrock_runtime` — same dispatch via the `X-Amz-Credential` query param (presigned-URL path).

### Local CI checks

- `cargo fmt --check`: clean
- `cargo clippy -p fakecloud-core --all-targets -- -D warnings`: clean
- `cargo test -p fakecloud-core --lib`: 192 passed / 0 failed

(Workspace-wide `cargo clippy --all-targets --workspace -- -D warnings` surfaced one pre-existing warning in `crates/fakecloud-dynamodb/src/service/helpers.rs:3067` — `clippy::search_is_some` — that is unrelated to this change and predates the branch.)

### What this enables

Any consumer using an AWS SDK that signs runtime API calls with the documented `bedrock-runtime` credential scope can now run `ApplyGuardrail` against fakecloud: the request reaches the bedrock service handler with the existing path match (`POST /guardrail/{id}/version/{guardrailVersion}/apply`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes routing for Bedrock runtime requests by normalizing the `bedrock-runtime` credential scope to `bedrock`, so runtime APIs hit the Bedrock handler instead of falling back to API Gateway. This enables calls like ApplyGuardrail to succeed and closes #1232.

- **Bug Fixes**
  - Added `normalize_service_name()` to map `bedrock-runtime` → `bedrock`.
  - Applied normalization in `extract_service_from_auth` and both `X-Amz-Credential` parsing paths (`detect_service_headers_only`, `detect_service`).
  - Added unit tests for the alias and both dispatch paths; other services are unchanged.

<sup>Written for commit 8a22916e2c82973540ce7115d5309eca7bba4b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

