### PR TITLE
feat(stepfunctions): CC10 Map distributed mode

### DIFF
--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -1006,7 +1006,7 @@ async fn write_map_results_to_s3(
 
 /// Apply ItemBatcher configuration to group items into batches.
 fn apply_item_batcher(items: &[Value], batcher: &Value, _effective_input: &Value) -> Vec<Value> {
-    let max_per_batch = batcher["MaxItemsPerBatch"].as_u64().unwrap_or(1) as usize;
+    let max_per_batch = batcher["MaxItemsPerBatch"].as_u64().unwrap_or(u64::MAX) as usize;
     let max_bytes = batcher["MaxInputBytesPerBatch"].as_u64().unwrap_or(0) as usize;
     let batch_input = batcher.get("BatchInput").cloned();
 

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -681,6 +681,9 @@ async fn execute_parallel_state(
 }
 
 /// Execute a Map state: iterate over an array and run a sub-state machine per item.
+/// Supports distributed mode: ItemReader (S3), ItemBatcher, ResultWriter (S3),
+/// ToleratedFailurePercentage, and MaxConcurrencyPath.
+#[allow(clippy::too_many_arguments)]
 async fn execute_map_state(
     state_def: &Value,
     input: &Value,
@@ -700,10 +703,36 @@ async fn execute_map_state(
         apply_input_path(input, input_path)
     };
 
-    // Get the items to iterate over
-    let items_path = state_def["ItemsPath"].as_str().unwrap_or("$");
-    let items_value = crate::io_processing::resolve_path(&effective_input, items_path);
-    let items = items_value.as_array().cloned().unwrap_or_default();
+    // Resolve MaxConcurrencyPath if present
+    let max_concurrency = if let Some(path) = state_def["MaxConcurrencyPath"].as_str() {
+        crate::io_processing::resolve_path(&effective_input, path)
+            .as_u64()
+            .unwrap_or(0)
+    } else {
+        state_def["MaxConcurrency"].as_u64().unwrap_or(0)
+    };
+    let effective_concurrency = if max_concurrency == 0 {
+        40
+    } else {
+        max_concurrency as usize
+    };
+
+    // Read items from ItemReader (S3) or ItemsPath
+    let items = if let Some(item_reader) = state_def.get("ItemReader") {
+        read_items_from_s3(item_reader, registry, execution_arn).await?
+    } else {
+        let items_path = state_def["ItemsPath"].as_str().unwrap_or("$");
+        let items_value = crate::io_processing::resolve_path(&effective_input, items_path);
+        items_value.as_array().cloned().unwrap_or_default()
+    };
+
+    // Apply ItemBatcher if present
+    let batch_config = state_def.get("ItemBatcher").cloned();
+    let batched_items = if let Some(ref batcher) = batch_config {
+        apply_item_batcher(&items, batcher, &effective_input)
+    } else {
+        items
+    };
 
     // Get the iterator definition (ItemProcessor or Iterator for backwards compat)
     let iterator_def = state_def
@@ -717,18 +746,17 @@ async fn execute_map_state(
             )
         })?;
 
-    let max_concurrency = state_def["MaxConcurrency"].as_u64().unwrap_or(0);
-    let effective_concurrency = if max_concurrency == 0 {
-        40
-    } else {
-        max_concurrency as usize
-    };
+    let tolerated_failure_percentage = state_def["ToleratedFailurePercentage"]
+        .as_f64()
+        .unwrap_or(0.0);
+    let total_items = batched_items.len() as f64;
+    let mut failure_count = 0usize;
 
     let semaphore = Arc::new(tokio::sync::Semaphore::new(effective_concurrency));
 
     // Process all items
     let mut handles = Vec::new();
-    for (index, item) in items.into_iter().enumerate() {
+    for (index, batch_item) in batched_items.into_iter().enumerate() {
         let iter_def = iterator_def.clone();
         let delivery = delivery.clone();
         let ddb = dynamodb_state.clone();
@@ -740,11 +768,11 @@ async fn execute_map_state(
         // Apply ItemSelector if present
         let item_input = if let Some(selector) = state_def.get("ItemSelector") {
             let mut ctx = serde_json::Map::new();
-            ctx.insert("value".to_string(), item.clone());
+            ctx.insert("value".to_string(), batch_item.clone());
             ctx.insert("index".to_string(), json!(index));
             apply_parameters(selector, &Value::Object(ctx), None)
         } else {
-            item
+            batch_item
         };
 
         add_event(
@@ -795,7 +823,11 @@ async fn execute_map_state(
                     0,
                     json!({ "index": index, "error": error }),
                 );
-                return Err((error, cause));
+                failure_count += 1;
+                let failure_percentage = (failure_count as f64 / total_items) * 100.0;
+                if failure_percentage > tolerated_failure_percentage {
+                    return Err((error, cause));
+                }
             }
         }
     }
@@ -803,6 +835,11 @@ async fn execute_map_state(
     // Sort by index to maintain order
     results.sort_by_key(|(i, _)| *i);
     let map_output = Value::Array(results.into_iter().map(|(_, v)| v).collect());
+
+    // Write results to S3 if ResultWriter is configured
+    if let Some(result_writer) = state_def.get("ResultWriter") {
+        write_map_results_to_s3(result_writer, registry, execution_arn, &map_output).await?;
+    }
 
     // Apply ResultSelector if present
     let selected = if let Some(selector) = state_def.get("ResultSelector") {
@@ -826,6 +863,189 @@ async fn execute_map_state(
     };
 
     Ok(output)
+}
+
+/// Read items from S3 for distributed Map mode ItemReader.
+async fn read_items_from_s3(
+    item_reader: &Value,
+    registry: &Option<SharedServiceRegistry>,
+    execution_arn: &str,
+) -> Result<Vec<Value>, (String, String)> {
+    let resource = item_reader["Resource"]
+        .as_str()
+        .unwrap_or("arn:aws:states:::s3:getObject");
+    if !resource.contains("s3:getObject") {
+        return Err((
+            "States.Runtime".to_string(),
+            format!("ItemReader unsupported resource: {resource}"),
+        ));
+    }
+
+    let params = item_reader
+        .get("Parameters")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let bucket = params["Bucket"].as_str().ok_or_else(|| {
+        (
+            "States.Runtime".to_string(),
+            "ItemReader missing Bucket".to_string(),
+        )
+    })?;
+    let key = params["Key"].as_str().ok_or_else(|| {
+        (
+            "States.Runtime".to_string(),
+            "ItemReader missing Key".to_string(),
+        )
+    })?;
+
+    let registry_arc = resolve_registry(registry)?;
+    let account_id = account_from_execution_arn(execution_arn);
+
+    let body = call_sdk_action_raw_bytes(
+        &registry_arc,
+        "s3",
+        "GetObject",
+        &json!({ "Bucket": bucket, "Key": key }),
+        &account_id,
+    )
+    .await?;
+
+    // Parse JSON array from the S3 object body
+    let parsed: Value = serde_json::from_slice(&body).map_err(|e| {
+        (
+            "States.Runtime".to_string(),
+            format!("ItemReader failed to parse S3 object as JSON: {e}"),
+        )
+    })?;
+
+    parsed.as_array().cloned().ok_or_else(|| {
+        (
+            "States.Runtime".to_string(),
+            "ItemReader S3 object is not a JSON array".to_string(),
+        )
+    })
+}
+
+/// Write Map results to S3 for distributed Map mode ResultWriter.
+async fn write_map_results_to_s3(
+    result_writer: &Value,
+    registry: &Option<SharedServiceRegistry>,
+    execution_arn: &str,
+    results: &Value,
+) -> Result<(), (String, String)> {
+    let resource = result_writer["Resource"]
+        .as_str()
+        .unwrap_or("arn:aws:states:::s3:putObject");
+    if !resource.contains("s3:putObject") {
+        return Err((
+            "States.Runtime".to_string(),
+            format!("ResultWriter unsupported resource: {resource}"),
+        ));
+    }
+
+    let params = result_writer
+        .get("Parameters")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let bucket = params["Bucket"].as_str().ok_or_else(|| {
+        (
+            "States.Runtime".to_string(),
+            "ResultWriter missing Bucket".to_string(),
+        )
+    })?;
+    let prefix = params["Prefix"].as_str().unwrap_or("map-results/");
+
+    let registry_arc = resolve_registry(registry)?;
+    let account_id = account_from_execution_arn(execution_arn);
+
+    use bytes::Bytes;
+    let body = Bytes::from(
+        serde_json::to_vec(results).expect("serde_json::Value serialization is infallible"),
+    );
+
+    // Build a raw S3 PutObject request with the JSON body
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    let service = registry_arc.get("s3").ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            "S3 service not available for ResultWriter".to_string(),
+        )
+    })?;
+
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: "PutObject".to_string(),
+        region: "us-east-1".to_string(),
+        account_id: account_id.to_string(),
+        request_id: uuid::Uuid::new_v4().to_string(),
+        headers: HeaderMap::new(),
+        query_params: std::collections::HashMap::new(),
+        body,
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec![bucket.to_string(), format!("{prefix}result.json")],
+        raw_path: format!("/{bucket}/{prefix}result.json"),
+        raw_query: String::new(),
+        method: Method::PUT,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+
+    service.handle(req).await.map_err(|err| {
+        let code = err.code().to_string();
+        let msg = err.message();
+        (
+            format!("S3.{code}"),
+            format!("ResultWriter PutObject failed: {msg}"),
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Apply ItemBatcher configuration to group items into batches.
+fn apply_item_batcher(items: &[Value], batcher: &Value, _effective_input: &Value) -> Vec<Value> {
+    let max_per_batch = batcher["MaxItemsPerBatch"].as_u64().unwrap_or(1) as usize;
+    let max_bytes = batcher["MaxInputBytesPerBatch"].as_u64().unwrap_or(0) as usize;
+    let batch_input = batcher.get("BatchInput").cloned();
+
+    let mut batches: Vec<Vec<Value>> = Vec::new();
+    let mut current_batch: Vec<Value> = Vec::new();
+    let mut current_bytes = 0usize;
+
+    for item in items.iter().cloned() {
+        let item_bytes = serde_json::to_vec(&item).unwrap_or_default().len();
+        if !current_batch.is_empty()
+            && (current_batch.len() >= max_per_batch
+                || (max_bytes > 0 && current_bytes + item_bytes > max_bytes))
+        {
+            batches.push(current_batch);
+            current_batch = Vec::new();
+            current_bytes = 0;
+        }
+        current_bytes += item_bytes;
+        current_batch.push(item);
+    }
+    if !current_batch.is_empty() {
+        batches.push(current_batch);
+    }
+
+    batches
+        .into_iter()
+        .enumerate()
+        .map(|(index, batch)| {
+            let mut map = serde_json::Map::new();
+            map.insert("index".to_string(), json!(index));
+            map.insert("items".to_string(), Value::Array(batch));
+            if let Some(Value::Object(ref obj)) = batch_input {
+                for (k, v) in obj {
+                    map.insert(k.clone(), v.clone());
+                }
+            }
+            Value::Object(map)
+        })
+        .collect()
 }
 
 /// Invoke a resource (Lambda function or SDK integration).
@@ -1175,6 +1395,72 @@ async fn call_sdk_action(
             format!("aws-sdk integration: failed to parse response JSON: {e}"),
         )
     })
+}
+
+/// Call an SDK action and return raw bytes without JSON parsing.
+/// Used by distributed Map mode to read/write S3 objects.
+async fn call_sdk_action_raw_bytes(
+    registry: &Arc<fakecloud_core::registry::ServiceRegistry>,
+    service_name: &str,
+    action_pascal: &str,
+    input: &Value,
+    account_id: &str,
+) -> Result<bytes::Bytes, (String, String)> {
+    use bytes::Bytes;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+
+    let service = registry.get(service_name).ok_or_else(|| {
+        (
+            "States.TaskFailed".to_string(),
+            format!("Unknown aws-sdk service '{service_name}'"),
+        )
+    })?;
+
+    let body_bytes = Bytes::from(
+        serde_json::to_vec(input).expect("serde_json::Value serialization is infallible"),
+    );
+
+    let req = AwsRequest {
+        service: service_name.to_string(),
+        action: action_pascal.to_string(),
+        region: "us-east-1".to_string(),
+        account_id: account_id.to_string(),
+        request_id: uuid::Uuid::new_v4().to_string(),
+        headers: HeaderMap::new(),
+        query_params: std::collections::HashMap::new(),
+        body: body_bytes,
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec![],
+        raw_path: "/".to_string(),
+        raw_query: String::new(),
+        method: Method::POST,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+
+    let response = service.handle(req).await.map_err(|err| {
+        let code = err.code().to_string();
+        let msg = err.message();
+        let prefix_service = match service_name {
+            "dynamodb" => "DynamoDb".to_string(),
+            "states" => "Sfn".to_string(),
+            other => camel_to_pascal(other),
+        };
+        (
+            format!("{prefix_service}.{code}"),
+            format!("{action_pascal} failed: {msg}"),
+        )
+    })?;
+
+    match response.body {
+        fakecloud_core::service::ResponseBody::Bytes(b) => Ok(b),
+        fakecloud_core::service::ResponseBody::File { .. } => Err((
+            "States.TaskFailed".to_string(),
+            "aws-sdk integration: file-backed response not supported".to_string(),
+        )),
+    }
 }
 
 /// Cap on `.sync` polling so a stuck downstream task can't hang an

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -540,9 +540,9 @@ fn map_iterates_pass_state_over_items_path() {
 }
 
 #[test]
-fn map_tolerated_failure_percentage_allows_some_failures() {
+fn map_tolerated_failure_percentage_allows_at_threshold() {
     let state = make_state();
-    let arn = arn_for("map-tolerated");
+    let arn = arn_for("map-tolerated-ok");
     let def = json!({
         "StartAt": "M",
         "States": {
@@ -553,14 +553,58 @@ fn map_tolerated_failure_percentage_allows_some_failures() {
                     "StartAt": "Item",
                     "States": {
                         "Item": {
+                            "Type": "Choice",
+                            "Choices": [
+                                { "Variable": "$", "NumericEquals": 2, "Next": "FailItem" }
+                            ],
+                            "Default": "Ok"
+                        },
+                        "FailItem": {
                             "Type": "Task",
                             "Resource": "arn:aws:states:::nothing:here",
-                            "Catch": [
-                                { "ErrorEquals": ["States.ALL"], "Next": "Ignore" }
-                            ],
                             "End": true
                         },
-                        "Ignore": { "Type": "Pass", "End": true }
+                        "Ok": { "Type": "Pass", "End": true }
+                    }
+                },
+                "ToleratedFailurePercentage": 50,
+                "End": true
+            }
+        }
+    });
+    drive(&state, &arn, def, Some(r#"{"items":[1,2]}"#));
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    });
+}
+
+#[test]
+fn map_tolerated_failure_percentage_fails_when_exceeded() {
+    let state = make_state();
+    let arn = arn_for("map-tolerated-fail");
+    let def = json!({
+        "StartAt": "M",
+        "States": {
+            "M": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "Iterator": {
+                    "StartAt": "Item",
+                    "States": {
+                        "Item": {
+                            "Type": "Choice",
+                            "Choices": [
+                                { "Variable": "$", "NumericGreaterThan": 1, "Next": "FailItem" }
+                            ],
+                            "Default": "Ok"
+                        },
+                        "FailItem": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::nothing:here",
+                            "End": true
+                        },
+                        "Ok": { "Type": "Pass", "End": true }
                     }
                 },
                 "ToleratedFailurePercentage": 50,
@@ -571,7 +615,7 @@ fn map_tolerated_failure_percentage_allows_some_failures() {
     drive(&state, &arn, def, Some(r#"{"items":[1,2,3]}"#));
 
     read_exec(&state, &arn, |exec| {
-        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        assert_eq!(exec.status, ExecutionStatus::Failed);
     });
 }
 
@@ -594,7 +638,12 @@ fn map_max_concurrency_path_reads_from_input() {
             }
         }
     });
-    drive(&state, &arn, def, Some(r#"{"items":[1,2,3],"maxConcurrency":2}"#));
+    drive(
+        &state,
+        &arn,
+        def,
+        Some(r#"{"items":[1,2,3],"maxConcurrency":2}"#),
+    );
 
     read_exec(&state, &arn, |exec| {
         assert_eq!(exec.status, ExecutionStatus::Succeeded);

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -539,6 +539,102 @@ fn map_iterates_pass_state_over_items_path() {
     });
 }
 
+#[test]
+fn map_tolerated_failure_percentage_allows_some_failures() {
+    let state = make_state();
+    let arn = arn_for("map-tolerated");
+    let def = json!({
+        "StartAt": "M",
+        "States": {
+            "M": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "Iterator": {
+                    "StartAt": "Item",
+                    "States": {
+                        "Item": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::nothing:here",
+                            "Catch": [
+                                { "ErrorEquals": ["States.ALL"], "Next": "Ignore" }
+                            ],
+                            "End": true
+                        },
+                        "Ignore": { "Type": "Pass", "End": true }
+                    }
+                },
+                "ToleratedFailurePercentage": 50,
+                "End": true
+            }
+        }
+    });
+    drive(&state, &arn, def, Some(r#"{"items":[1,2,3]}"#));
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    });
+}
+
+#[test]
+fn map_max_concurrency_path_reads_from_input() {
+    let state = make_state();
+    let arn = arn_for("map-concurrency");
+    let def = json!({
+        "StartAt": "M",
+        "States": {
+            "M": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "MaxConcurrencyPath": "$.maxConcurrency",
+                "Iterator": {
+                    "StartAt": "Item",
+                    "States": { "Item": { "Type": "Pass", "End": true } }
+                },
+                "End": true
+            }
+        }
+    });
+    drive(&state, &arn, def, Some(r#"{"items":[1,2,3],"maxConcurrency":2}"#));
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        assert_eq!(output, json!([1, 2, 3]));
+    });
+}
+
+#[test]
+fn map_item_batcher_groups_items() {
+    let state = make_state();
+    let arn = arn_for("map-batcher");
+    let def = json!({
+        "StartAt": "M",
+        "States": {
+            "M": {
+                "Type": "Map",
+                "ItemsPath": "$.items",
+                "ItemBatcher": {
+                    "MaxItemsPerBatch": 2,
+                    "BatchInput": { "extra": "data" }
+                },
+                "Iterator": {
+                    "StartAt": "Item",
+                    "States": { "Item": { "Type": "Pass", "End": true } }
+                },
+                "End": true
+            }
+        }
+    });
+    drive(&state, &arn, def, Some(r#"{"items":[1,2,3,4]}"#));
+
+    read_exec(&state, &arn, |exec| {
+        assert_eq!(exec.status, ExecutionStatus::Succeeded);
+        let output: Value = serde_json::from_str(exec.output.as_ref().unwrap()).unwrap();
+        // Batched into 2 groups of 2 items each
+        assert_eq!(output.as_array().unwrap().len(), 2);
+    });
+}
+
 // ── Task: unsupported resources / delivery == None ───────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Add ItemReader support: read JSON arrays from S3 for distributed Map input
- Add ItemBatcher support: group items into batches with MaxItemsPerBatch, MaxInputBytesPerBatch, and BatchInput
- Add ResultWriter support: write Map results to S3 as JSON
- Add ToleratedFailurePercentage: allow configurable % of iteration failures before failing the whole Map state
- Add MaxConcurrencyPath: read max concurrency from input JSONPath
- Add call_sdk_action_raw_bytes helper for non-JSON SDK responses (S3 objects)
- Update existing Map test to work with new batching structure
- Add unit tests for tolerated failures, concurrency path, and item batcher

## Test plan
- [x] cargo test -p fakecloud-stepfunctions passes (159 tests)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements distributed Map support in Step Functions. Adds S3-backed input/output, item batching, tolerated failure thresholds, and input-driven concurrency.

- **New Features**
  - S3 ItemReader and ResultWriter to read/write JSON arrays for distributed Map.
  - ItemBatcher to group items by `MaxItemsPerBatch`, `MaxInputBytesPerBatch`, with optional `BatchInput`.
  - `ToleratedFailurePercentage` to allow partial failures before failing the Map.
  - `MaxConcurrencyPath` to set concurrency from input; falls back to `MaxConcurrency` or 40.
  - Added `call_sdk_action_raw_bytes` for non-JSON SDK payloads (e.g., S3 objects).

<sup>Written for commit 980e23bf7815247a07f0b0ca1181fcc45385784e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

