### PR TITLE
feat(s3): real SelectObjectContent with EventStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,8 +3783,11 @@ name = "fakecloud-s3"
 version = "0.13.3"
 dependencies = [
  "async-trait",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
  "base64 0.22.1",
  "bytes",
+ "bytes-utils",
  "chrono",
  "crc32c",
  "crc32fast",
@@ -3797,6 +3800,7 @@ dependencies = [
  "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
  "serde",
  "serde_json",
  "sha1",

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -1997,19 +1997,23 @@ async fn s3_select_object_content() {
     let mut stream = resp.payload;
     let mut records = Vec::new();
     let mut got_end = false;
-    while let Ok(Some(event)) = stream.recv().await {
-        match event {
-            aws_sdk_s3::types::SelectObjectContentEventStream::Records(rec) => {
-                if let Some(payload) = rec.payload() {
-                    records.extend_from_slice(payload.as_ref());
+    loop {
+        match stream.recv().await {
+            Ok(Some(event)) => match event {
+                aws_sdk_s3::types::SelectObjectContentEventStream::Records(rec) => {
+                    if let Some(payload) = rec.payload() {
+                        records.extend_from_slice(payload.as_ref());
+                    }
                 }
-            }
-            aws_sdk_s3::types::SelectObjectContentEventStream::Stats(_) => {}
-            aws_sdk_s3::types::SelectObjectContentEventStream::End(_) => {
-                got_end = true;
-                break;
-            }
-            other => panic!("unexpected SelectObjectContent event: {other:?}"),
+                aws_sdk_s3::types::SelectObjectContentEventStream::Stats(_) => {}
+                aws_sdk_s3::types::SelectObjectContentEventStream::End(_) => {
+                    got_end = true;
+                    break;
+                }
+                other => panic!("unexpected SelectObjectContent event: {other:?}"),
+            },
+            Ok(None) => break,
+            Err(e) => panic!("SelectObjectContent stream error: {e:?}"),
         }
     }
     assert!(got_end, "expected End event in SelectObjectContent stream");

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -1978,7 +1978,11 @@ async fn s3_select_object_content() {
         .expression_type(aws_sdk_s3::types::ExpressionType::Sql)
         .input_serialization(
             aws_sdk_s3::types::InputSerialization::builder()
-                .csv(aws_sdk_s3::types::CsvInput::builder().build())
+                .csv(
+                    aws_sdk_s3::types::CsvInput::builder()
+                        .file_header_info(aws_sdk_s3::types::FileHeaderInfo::Use)
+                        .build(),
+                )
                 .build(),
         )
         .output_serialization(
@@ -1993,18 +1997,19 @@ async fn s3_select_object_content() {
     let mut stream = resp.payload;
     let mut records = Vec::new();
     let mut got_end = false;
-    while let Some(event) = stream.recv().await {
+    while let Ok(Some(event)) = stream.recv().await {
         match event {
-            Ok(aws_sdk_s3::types::SelectObjectContentEventStream::Records(rec)) => {
+            aws_sdk_s3::types::SelectObjectContentEventStream::Records(rec) => {
                 if let Some(payload) = rec.payload() {
                     records.extend_from_slice(payload.as_ref());
                 }
             }
-            Ok(aws_sdk_s3::types::SelectObjectContentEventStream::End(_)) => {
+            aws_sdk_s3::types::SelectObjectContentEventStream::Stats(_) => {}
+            aws_sdk_s3::types::SelectObjectContentEventStream::End(_) => {
                 got_end = true;
                 break;
             }
-            _ => {}
+            other => panic!("unexpected SelectObjectContent event: {other:?}"),
         }
     }
     assert!(got_end, "expected End event in SelectObjectContent stream");

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -1970,7 +1970,7 @@ async fn s3_select_object_content() {
         .send()
         .await
         .unwrap();
-    client
+    let resp = client
         .select_object_content()
         .bucket("select-bkt")
         .key("data.csv")
@@ -1989,6 +1989,30 @@ async fn s3_select_object_content() {
         .send()
         .await
         .unwrap();
+
+    let mut stream = resp.payload;
+    let mut records = Vec::new();
+    let mut got_end = false;
+    while let Some(event) = stream.recv().await {
+        match event {
+            Ok(aws_sdk_s3::types::SelectObjectContentEventStream::Records(rec)) => {
+                if let Some(payload) = rec.payload() {
+                    records.extend_from_slice(payload.as_ref());
+                }
+            }
+            Ok(aws_sdk_s3::types::SelectObjectContentEventStream::End(_)) => {
+                got_end = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_end, "expected End event in SelectObjectContent stream");
+    assert!(
+        !records.is_empty(),
+        "expected records in SelectObjectContent response"
+    );
+    assert_eq!(String::from_utf8_lossy(&records), "1,2\n");
 }
 
 #[test_action("s3", "UpdateObjectEncryption", checksum = "6cdb3788")]

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -35,3 +35,7 @@ toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+aws-smithy-eventstream = "0.60"
+aws-smithy-http = "0.63"
+bytes = { workspace = true }
+bytes-utils = "0.1"

--- a/crates/fakecloud-s3/Cargo.toml
+++ b/crates/fakecloud-s3/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = { workspace = true }
 crc32c = { workspace = true }
 crc32fast = { workspace = true }
 crc64fast-nvme = { workspace = true }
+quick-xml = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fakecloud-s3/src/eventstream.rs
+++ b/crates/fakecloud-s3/src/eventstream.rs
@@ -1,0 +1,89 @@
+//! Minimal `application/vnd.amazon.eventstream` frame encoder for S3 Select.
+//!
+//! Reuses the same wire format as Lambda's eventstream (prelude + headers +
+//! payload + CRCs) but defines S3-specific event types.
+
+const HEADER_TYPE_STRING: u8 = 7;
+
+/// Encode a single eventstream frame.
+pub fn encode_frame(headers: &[(&str, &str)], payload: &[u8]) -> Vec<u8> {
+    let headers_bytes = encode_headers(headers);
+    let headers_len = headers_bytes.len() as u32;
+    let total_len = 12u32 + headers_len + payload.len() as u32 + 4;
+
+    let mut out = Vec::with_capacity(total_len as usize);
+    out.extend_from_slice(&total_len.to_be_bytes());
+    out.extend_from_slice(&headers_len.to_be_bytes());
+
+    let prelude_crc = crc32fast::hash(&out[..8]);
+    out.extend_from_slice(&prelude_crc.to_be_bytes());
+
+    out.extend_from_slice(&headers_bytes);
+    out.extend_from_slice(payload);
+
+    let msg_crc = crc32fast::hash(&out);
+    out.extend_from_slice(&msg_crc.to_be_bytes());
+
+    out
+}
+
+fn encode_headers(headers: &[(&str, &str)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (name, value) in headers {
+        let name_bytes = name.as_bytes();
+        let value_bytes = value.as_bytes();
+        debug_assert!(name_bytes.len() <= u8::MAX as usize, "header name too long");
+        debug_assert!(
+            value_bytes.len() <= u16::MAX as usize,
+            "header value too long"
+        );
+        buf.push(name_bytes.len() as u8);
+        buf.extend_from_slice(name_bytes);
+        buf.push(HEADER_TYPE_STRING);
+        buf.extend_from_slice(&(value_bytes.len() as u16).to_be_bytes());
+        buf.extend_from_slice(value_bytes);
+    }
+    buf
+}
+
+/// `Records` event carrying the query result payload.
+pub fn records_event_frame(payload: &[u8]) -> Vec<u8> {
+    encode_frame(
+        &[
+            (":event-type", "Records"),
+            (":content-type", "application/octet-stream"),
+            (":message-type", "event"),
+        ],
+        payload,
+    )
+}
+
+/// `Stats` event with byte counters.
+pub fn stats_event_frame(bytes_scanned: u64, bytes_processed: u64, bytes_returned: u64) -> Vec<u8> {
+    let payload = serde_json::json!({
+        "BytesScanned": bytes_scanned,
+        "BytesProcessed": bytes_processed,
+        "BytesReturned": bytes_returned,
+    });
+    let body = serde_json::to_vec(&payload).expect("static JSON shape never fails to serialize");
+    encode_frame(
+        &[
+            (":event-type", "Stats"),
+            (":content-type", "application/json"),
+            (":message-type", "event"),
+        ],
+        &body,
+    )
+}
+
+/// `End` event signalling the stream is complete.
+pub fn end_event_frame() -> Vec<u8> {
+    encode_frame(
+        &[
+            (":event-type", "End"),
+            (":content-type", "application/xml"),
+            (":message-type", "event"),
+        ],
+        b"",
+    )
+}

--- a/crates/fakecloud-s3/src/eventstream.rs
+++ b/crates/fakecloud-s3/src/eventstream.rs
@@ -5,7 +5,6 @@
 
 const HEADER_TYPE_STRING: u8 = 7;
 
-/// Encode a single eventstream frame.
 pub fn encode_frame(headers: &[(&str, &str)], payload: &[u8]) -> Vec<u8> {
     let headers_bytes = encode_headers(headers);
     let headers_len = headers_bytes.len() as u32;
@@ -46,7 +45,6 @@ fn encode_headers(headers: &[(&str, &str)]) -> Vec<u8> {
     buf
 }
 
-/// `Records` event carrying the query result payload.
 pub fn records_event_frame(payload: &[u8]) -> Vec<u8> {
     encode_frame(
         &[
@@ -58,25 +56,21 @@ pub fn records_event_frame(payload: &[u8]) -> Vec<u8> {
     )
 }
 
-/// `Stats` event with byte counters.
 pub fn stats_event_frame(bytes_scanned: u64, bytes_processed: u64, bytes_returned: u64) -> Vec<u8> {
-    let payload = serde_json::json!({
-        "BytesScanned": bytes_scanned,
-        "BytesProcessed": bytes_processed,
-        "BytesReturned": bytes_returned,
-    });
-    let body = serde_json::to_vec(&payload).expect("static JSON shape never fails to serialize");
+    let payload = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Stats>\n  <BytesScanned>{}</BytesScanned>\n  <BytesProcessed>{}</BytesProcessed>\n  <BytesReturned>{}</BytesReturned>\n</Stats>\n",
+        bytes_scanned, bytes_processed, bytes_returned
+    );
     encode_frame(
         &[
             (":event-type", "Stats"),
-            (":content-type", "application/json"),
+            (":content-type", "application/xml"),
             (":message-type", "event"),
         ],
-        &body,
+        payload.as_bytes(),
     )
 }
 
-/// `End` event signalling the stream is complete.
 pub fn end_event_frame() -> Vec<u8> {
     encode_frame(
         &[
@@ -86,4 +80,87 @@ pub fn end_event_frame() -> Vec<u8> {
         ],
         b"",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_smithy_eventstream::frame::read_message_from;
+    use bytes::Bytes;
+
+    #[test]
+    fn records_frame_decodes_with_sdk() {
+        let frame = records_event_frame(b"hello");
+        let msg = read_message_from(&mut Bytes::from(frame)).unwrap();
+        assert_eq!(msg.payload().as_ref(), b"hello");
+        let headers: Vec<_> = msg
+            .headers()
+            .iter()
+            .map(|h| {
+                (
+                    h.name().as_str().to_string(),
+                    h.value().as_string().unwrap().as_str().to_string(),
+                )
+            })
+            .collect();
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":event-type" && v == "Records"));
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":message-type" && v == "event"));
+    }
+
+    #[test]
+    fn stats_frame_decodes_with_sdk() {
+        let frame = stats_event_frame(100, 50, 25);
+        let msg = read_message_from(&mut Bytes::from(frame)).unwrap();
+        let payload = std::str::from_utf8(msg.payload().as_ref()).unwrap();
+        assert!(payload.contains("BytesScanned"));
+        assert!(payload.contains("100"));
+    }
+
+    #[test]
+    fn end_frame_decodes_with_sdk() {
+        let frame = end_event_frame();
+        let msg = read_message_from(&mut Bytes::from(frame)).unwrap();
+        assert!(msg.payload().is_empty());
+        let headers: Vec<_> = msg
+            .headers()
+            .iter()
+            .map(|h| {
+                (
+                    h.name().as_str().to_string(),
+                    h.value().as_string().unwrap().as_str().to_string(),
+                )
+            })
+            .collect();
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == ":event-type" && v == "End"));
+    }
+
+    #[test]
+    fn concatenated_frames_decode_with_sdk_decoder() {
+        let records = records_event_frame(b"hello");
+        let stats = stats_event_frame(100, 50, 25);
+        let end = end_event_frame();
+
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&records);
+        combined.extend_from_slice(&stats);
+        combined.extend_from_slice(&end);
+
+        let mut decoder = aws_smithy_eventstream::frame::MessageFrameDecoder::new();
+        let mut buf = bytes_utils::SegmentedBuf::new();
+        buf.push(Bytes::from(combined));
+
+        let mut count = 0;
+        while let aws_smithy_eventstream::frame::DecodedFrame::Complete(_) =
+            decoder.decode_frame(&mut buf).unwrap()
+        {
+            count += 1;
+        }
+        assert_eq!(count, 3, "Expected 3 decoded frames");
+    }
 }

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod delivery;
+pub mod eventstream;
 pub mod inventory;
 pub mod lifecycle;
 pub mod logging;
 pub mod persistence;
 pub mod resource_policy;
+pub(crate) mod select;
 pub(crate) mod service;
 pub mod simulation;
 pub(crate) mod state;

--- a/crates/fakecloud-s3/src/select.rs
+++ b/crates/fakecloud-s3/src/select.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 // ── XML request shapes ──────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
 #[serde(rename = "SelectObjectContentRequest")]
 pub struct SelectRequest {
     pub Expression: String,
@@ -21,6 +22,7 @@ pub struct SelectRequest {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct InputSerialization {
     pub CSV: Option<CsvInput>,
     pub JSON: Option<JsonInput>,
@@ -29,6 +31,7 @@ pub struct InputSerialization {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct CsvInput {
     #[serde(rename = "FileHeaderInfo")]
     pub file_header_info: Option<String>,
@@ -45,18 +48,21 @@ pub struct CsvInput {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct JsonInput {
     #[serde(rename = "Type")]
     pub json_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct OutputSerialization {
     pub CSV: Option<CsvOutput>,
     pub JSON: Option<JsonOutput>,
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct CsvOutput {
     #[serde(rename = "QuoteFields")]
     pub quote_fields: Option<String>,
@@ -71,6 +77,7 @@ pub struct CsvOutput {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(non_snake_case, dead_code)]
 pub struct JsonOutput {
     #[serde(rename = "RecordDelimiter")]
     pub record_delimiter: Option<String>,
@@ -113,19 +120,22 @@ pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
         return Err("expected SELECT");
     }
 
-    let from_pos = upper.find(" FROM ").ok_or("expected FROM")?;
-    let select_part = sql[7..from_pos].trim();
+    let from_keyword = upper.find(" FROM ").ok_or("expected FROM")?;
+    let from_offset = " FROM ".len();
+    let select_part = sql[7..from_keyword].trim();
 
-    let rest = &sql[from_pos + 6..];
-    let where_pos = rest.to_uppercase().find(" WHERE ");
+    let after_from = &sql[from_keyword + from_offset..];
+    let upper_after = after_from.to_uppercase();
+    let where_keyword = upper_after.find(" WHERE ");
 
-    let (from, where_clause) = match where_pos {
+    let (from, where_clause) = match where_keyword {
         Some(wp) => {
-            let from = rest[..wp].trim().to_string();
-            let where_str = rest[wp + 7..].trim();
+            let from = after_from[..wp].trim().to_string();
+            let after_where = &after_from[wp + 7..];
+            let where_str = after_where.trim();
             (from, Some(parse_where(where_str)?))
         }
-        None => (rest.trim().to_string(), None),
+        None => (after_from.trim().to_string(), None),
     };
 
     let select = if select_part.eq_ignore_ascii_case("*") {
@@ -147,14 +157,12 @@ pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
 
 fn parse_where(s: &str) -> Result<WhereClause, &'static str> {
     let upper = s.to_uppercase();
-    // LIKE
     if let Some(pos) = upper.find(" LIKE ") {
         let col = s[..pos].trim().to_string();
         let pattern = s[pos + 6..].trim();
         let pat = strip_quotes(pattern).unwrap_or(pattern).to_string();
         return Ok(WhereClause::Like(col, pat));
     }
-    // =
     if let Some(pos) = s.find('=') {
         let col = s[..pos].trim().to_string();
         let val_str = s[pos + 1..].trim();
@@ -178,7 +186,6 @@ fn strip_quotes(s: &str) -> Option<&str> {
 
 // ── CSV parser ──────────────────────────────────────────────────────
 
-/// Parse CSV bytes into an optional header row and data rows.
 pub fn parse_csv(
     input: &[u8],
     has_header: bool,
@@ -206,8 +213,6 @@ pub fn parse_csv(
 
 // ── JSON parser (newline-delimited) ─────────────────────────────────
 
-/// Parse newline-delimited JSON into rows.
-/// Each line must be a JSON object; keys become headers on the first row.
 pub fn parse_json_lines(input: &[u8]) -> (Option<Vec<String>>, Vec<Vec<String>>) {
     let text = String::from_utf8_lossy(input);
     let mut headers: Option<Vec<String>> = None;
@@ -248,13 +253,13 @@ pub fn parse_json_lines(input: &[u8]) -> (Option<Vec<String>>, Vec<Vec<String>>)
 
 // ── Query evaluation ────────────────────────────────────────────────
 
-/// Evaluate a parsed query against parsed rows.
 pub fn evaluate_query(
     query: &Query,
     headers: &Option<Vec<String>>,
     rows: &[Vec<String>],
-) -> Vec<Vec<String>> {
+) -> (Vec<Vec<String>>, Option<Vec<String>>) {
     let mut result = Vec::new();
+    let mut out_headers: Option<Vec<String>> = None;
 
     for row in rows {
         if !matches_where(query.where_clause.as_ref(), headers, row) {
@@ -263,6 +268,9 @@ pub fn evaluate_query(
         let out_row = match &query.select {
             SqlSelect::All => row.clone(),
             SqlSelect::Columns(cols) => {
+                if out_headers.is_none() {
+                    out_headers = Some(cols.clone());
+                }
                 let mut out = Vec::with_capacity(cols.len());
                 for col in cols {
                     if let Some(idx) = header_index(headers, col) {
@@ -277,7 +285,7 @@ pub fn evaluate_query(
         result.push(out_row);
     }
 
-    result
+    (result, out_headers)
 }
 
 fn header_index(headers: &Option<Vec<String>>, col: &str) -> Option<usize> {
@@ -324,7 +332,6 @@ fn col_name(clause: &WhereClause) -> &str {
 
 // ── Output formatters ───────────────────────────────────────────────
 
-/// Format rows as CSV bytes.
 pub fn format_csv(rows: &[Vec<String>], field_delimiter: &str, record_delimiter: &str) -> Vec<u8> {
     let mut out = String::new();
     for row in rows {
@@ -339,7 +346,6 @@ pub fn format_csv(rows: &[Vec<String>], field_delimiter: &str, record_delimiter:
     out.into_bytes()
 }
 
-/// Format rows as newline-delimited JSON bytes.
 pub fn format_json_lines(rows: &[Vec<String>], headers: &Option<Vec<String>>) -> Vec<u8> {
     let mut out = String::new();
     let hdrs = headers.as_ref().cloned().unwrap_or_default();
@@ -411,8 +417,9 @@ mod tests {
         let q = parse_sql("SELECT * FROM s3object").unwrap();
         let hdrs = Some(vec!["a".to_string(), "b".to_string()]);
         let rows = vec![vec!["1".to_string(), "2".to_string()]];
-        let out = evaluate_query(&q, &hdrs, &rows);
+        let (out, out_hdrs) = evaluate_query(&q, &hdrs, &rows);
         assert_eq!(out, vec![vec!["1", "2"]]);
+        assert!(out_hdrs.is_none());
     }
 
     #[test]
@@ -423,7 +430,7 @@ mod tests {
             vec!["1".to_string(), "2".to_string()],
             vec!["3".to_string(), "4".to_string()],
         ];
-        let out = evaluate_query(&q, &hdrs, &rows);
+        let (out, _) = evaluate_query(&q, &hdrs, &rows);
         assert_eq!(out, vec![vec!["1", "2"]]);
     }
 
@@ -432,8 +439,9 @@ mod tests {
         let q = parse_sql("SELECT b FROM s3object").unwrap();
         let hdrs = Some(vec!["a".to_string(), "b".to_string()]);
         let rows = vec![vec!["1".to_string(), "2".to_string()]];
-        let out = evaluate_query(&q, &hdrs, &rows);
+        let (out, out_hdrs) = evaluate_query(&q, &hdrs, &rows);
         assert_eq!(out, vec![vec!["2"]]);
+        assert_eq!(out_hdrs, Some(vec!["b".to_string()]));
     }
 
     #[test]

--- a/crates/fakecloud-s3/src/select.rs
+++ b/crates/fakecloud-s3/src/select.rs
@@ -122,16 +122,25 @@ pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
 
     let from_keyword = upper.find(" FROM ").ok_or("expected FROM")?;
     let from_offset = " FROM ".len();
-    let select_part = sql[7..from_keyword].trim();
+    let select_part = sql
+        .get(7..from_keyword)
+        .ok_or("invalid SQL encoding")?
+        .trim();
 
-    let after_from = &sql[from_keyword + from_offset..];
+    let after_from = sql
+        .get(from_keyword + from_offset..)
+        .ok_or("invalid SQL encoding")?;
     let upper_after = after_from.to_uppercase();
     let where_keyword = upper_after.find(" WHERE ");
 
     let (from, where_clause) = match where_keyword {
         Some(wp) => {
-            let from = after_from[..wp].trim().to_string();
-            let after_where = &after_from[wp + 7..];
+            let from = after_from
+                .get(..wp)
+                .ok_or("invalid SQL encoding")?
+                .trim()
+                .to_string();
+            let after_where = after_from.get(wp + 7..).ok_or("invalid SQL encoding")?;
             let where_str = after_where.trim();
             (from, Some(parse_where(where_str)?))
         }

--- a/crates/fakecloud-s3/src/select.rs
+++ b/crates/fakecloud-s3/src/select.rs
@@ -1,0 +1,445 @@
+//! S3 SelectObjectContent query engine (basic).
+//!
+//! Supports CSV input/output and a minimal SQL dialect:
+//!   SELECT * FROM s3object
+//!   SELECT col1, col2 FROM s3object
+//!   SELECT * FROM s3object WHERE col = 'val'
+//!   SELECT * FROM s3object WHERE col = 123
+//!   SELECT * FROM s3object WHERE col LIKE 'prefix%'
+
+use serde::Deserialize;
+
+// ── XML request shapes ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "SelectObjectContentRequest")]
+pub struct SelectRequest {
+    pub Expression: String,
+    pub ExpressionType: String,
+    pub InputSerialization: InputSerialization,
+    pub OutputSerialization: OutputSerialization,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct InputSerialization {
+    pub CSV: Option<CsvInput>,
+    pub JSON: Option<JsonInput>,
+    #[serde(rename = "CompressionType")]
+    pub compression_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct CsvInput {
+    #[serde(rename = "FileHeaderInfo")]
+    pub file_header_info: Option<String>,
+    #[serde(rename = "RecordDelimiter")]
+    pub record_delimiter: Option<String>,
+    #[serde(rename = "FieldDelimiter")]
+    pub field_delimiter: Option<String>,
+    #[serde(rename = "QuoteCharacter")]
+    pub quote_character: Option<String>,
+    #[serde(rename = "QuoteEscapeCharacter")]
+    pub quote_escape_character: Option<String>,
+    #[serde(rename = "Comments")]
+    pub comments: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct JsonInput {
+    #[serde(rename = "Type")]
+    pub json_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct OutputSerialization {
+    pub CSV: Option<CsvOutput>,
+    pub JSON: Option<JsonOutput>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct CsvOutput {
+    #[serde(rename = "QuoteFields")]
+    pub quote_fields: Option<String>,
+    #[serde(rename = "RecordDelimiter")]
+    pub record_delimiter: Option<String>,
+    #[serde(rename = "FieldDelimiter")]
+    pub field_delimiter: Option<String>,
+    #[serde(rename = "QuoteCharacter")]
+    pub quote_character: Option<String>,
+    #[serde(rename = "QuoteEscapeCharacter")]
+    pub quote_escape_character: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct JsonOutput {
+    #[serde(rename = "RecordDelimiter")]
+    pub record_delimiter: Option<String>,
+}
+
+// ── SQL evaluator ─────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum SqlSelect {
+    All,
+    Columns(Vec<String>),
+}
+
+#[derive(Debug)]
+pub enum WhereClause {
+    Eq(String, LiteralValue),
+    Like(String, String),
+}
+
+#[derive(Debug, Clone)]
+pub enum LiteralValue {
+    String(String),
+    Number(f64),
+}
+
+#[derive(Debug)]
+pub struct Query {
+    pub select: SqlSelect,
+    pub from: String,
+    pub where_clause: Option<WhereClause>,
+}
+
+/// Parse a minimal SELECT statement. Errors are static strings for
+/// simplicity — callers map them to AWS error codes.
+pub fn parse_sql(sql: &str) -> Result<Query, &'static str> {
+    let sql = sql.trim();
+    let upper = sql.to_uppercase();
+
+    if !upper.starts_with("SELECT ") {
+        return Err("expected SELECT");
+    }
+
+    let from_pos = upper.find(" FROM ").ok_or("expected FROM")?;
+    let select_part = sql[7..from_pos].trim();
+
+    let rest = &sql[from_pos + 6..];
+    let where_pos = rest.to_uppercase().find(" WHERE ");
+
+    let (from, where_clause) = match where_pos {
+        Some(wp) => {
+            let from = rest[..wp].trim().to_string();
+            let where_str = rest[wp + 7..].trim();
+            (from, Some(parse_where(where_str)?))
+        }
+        None => (rest.trim().to_string(), None),
+    };
+
+    let select = if select_part.eq_ignore_ascii_case("*") {
+        SqlSelect::All
+    } else {
+        let cols: Vec<String> = select_part
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect();
+        SqlSelect::Columns(cols)
+    };
+
+    Ok(Query {
+        select,
+        from,
+        where_clause,
+    })
+}
+
+fn parse_where(s: &str) -> Result<WhereClause, &'static str> {
+    let upper = s.to_uppercase();
+    // LIKE
+    if let Some(pos) = upper.find(" LIKE ") {
+        let col = s[..pos].trim().to_string();
+        let pattern = s[pos + 6..].trim();
+        let pat = strip_quotes(pattern).unwrap_or(pattern).to_string();
+        return Ok(WhereClause::Like(col, pat));
+    }
+    // =
+    if let Some(pos) = s.find('=') {
+        let col = s[..pos].trim().to_string();
+        let val_str = s[pos + 1..].trim();
+        let val = if val_str.starts_with('\'') && val_str.ends_with('\'') {
+            LiteralValue::String(strip_quotes(val_str).unwrap_or(val_str).to_string())
+        } else {
+            LiteralValue::Number(val_str.parse().map_err(|_| "invalid number")?)
+        };
+        return Ok(WhereClause::Eq(col, val));
+    }
+    Err("unsupported WHERE clause")
+}
+
+fn strip_quotes(s: &str) -> Option<&str> {
+    if s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'') {
+        Some(&s[1..s.len() - 1])
+    } else {
+        None
+    }
+}
+
+// ── CSV parser ──────────────────────────────────────────────────────
+
+/// Parse CSV bytes into an optional header row and data rows.
+pub fn parse_csv(
+    input: &[u8],
+    has_header: bool,
+    field_delimiter: char,
+    record_delimiter: char,
+) -> (Option<Vec<String>>, Vec<Vec<String>>) {
+    let text = String::from_utf8_lossy(input);
+    let mut headers = None;
+    let mut rows = Vec::new();
+
+    for line in text.split(record_delimiter) {
+        if line.is_empty() {
+            continue;
+        }
+        let fields: Vec<String> = line.split(field_delimiter).map(|s| s.to_string()).collect();
+        if headers.is_none() && has_header {
+            headers = Some(fields);
+        } else {
+            rows.push(fields);
+        }
+    }
+
+    (headers, rows)
+}
+
+// ── JSON parser (newline-delimited) ─────────────────────────────────
+
+/// Parse newline-delimited JSON into rows.
+/// Each line must be a JSON object; keys become headers on the first row.
+pub fn parse_json_lines(input: &[u8]) -> (Option<Vec<String>>, Vec<Vec<String>>) {
+    let text = String::from_utf8_lossy(input);
+    let mut headers: Option<Vec<String>> = None;
+    let mut rows = Vec::new();
+
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let serde_json::Value::Object(map) = val else {
+            continue;
+        };
+        if headers.is_none() {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            headers = Some(keys.clone());
+        }
+        let row: Vec<String> = headers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|k| {
+                map.get(k)
+                    .map(|v| match v {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    })
+                    .unwrap_or_default()
+            })
+            .collect();
+        rows.push(row);
+    }
+
+    (headers, rows)
+}
+
+// ── Query evaluation ────────────────────────────────────────────────
+
+/// Evaluate a parsed query against parsed rows.
+pub fn evaluate_query(
+    query: &Query,
+    headers: &Option<Vec<String>>,
+    rows: &[Vec<String>],
+) -> Vec<Vec<String>> {
+    let mut result = Vec::new();
+
+    for row in rows {
+        if !matches_where(query.where_clause.as_ref(), headers, row) {
+            continue;
+        }
+        let out_row = match &query.select {
+            SqlSelect::All => row.clone(),
+            SqlSelect::Columns(cols) => {
+                let mut out = Vec::with_capacity(cols.len());
+                for col in cols {
+                    if let Some(idx) = header_index(headers, col) {
+                        out.push(row.get(idx).cloned().unwrap_or_default());
+                    } else {
+                        out.push(String::new());
+                    }
+                }
+                out
+            }
+        };
+        result.push(out_row);
+    }
+
+    result
+}
+
+fn header_index(headers: &Option<Vec<String>>, col: &str) -> Option<usize> {
+    headers
+        .as_ref()?
+        .iter()
+        .position(|h| h.eq_ignore_ascii_case(col))
+}
+
+fn matches_where(
+    clause: Option<&WhereClause>,
+    headers: &Option<Vec<String>>,
+    row: &[String],
+) -> bool {
+    let Some(clause) = clause else {
+        return true;
+    };
+    let idx = match header_index(headers, col_name(clause)) {
+        Some(i) => i,
+        None => return false,
+    };
+    let cell = row.get(idx).cloned().unwrap_or_default();
+    match clause {
+        WhereClause::Eq(_, val) => match val {
+            LiteralValue::String(s) => cell == *s,
+            LiteralValue::Number(n) => cell.parse::<f64>().map(|c| c == *n).unwrap_or(false),
+        },
+        WhereClause::Like(_, pat) => {
+            if pat.ends_with('%') {
+                let prefix = &pat[..pat.len() - 1];
+                cell.starts_with(prefix)
+            } else {
+                cell == *pat
+            }
+        }
+    }
+}
+
+fn col_name(clause: &WhereClause) -> &str {
+    match clause {
+        WhereClause::Eq(col, _) | WhereClause::Like(col, _) => col.as_str(),
+    }
+}
+
+// ── Output formatters ───────────────────────────────────────────────
+
+/// Format rows as CSV bytes.
+pub fn format_csv(rows: &[Vec<String>], field_delimiter: &str, record_delimiter: &str) -> Vec<u8> {
+    let mut out = String::new();
+    for row in rows {
+        for (i, field) in row.iter().enumerate() {
+            if i > 0 {
+                out.push_str(field_delimiter);
+            }
+            out.push_str(field);
+        }
+        out.push_str(record_delimiter);
+    }
+    out.into_bytes()
+}
+
+/// Format rows as newline-delimited JSON bytes.
+pub fn format_json_lines(rows: &[Vec<String>], headers: &Option<Vec<String>>) -> Vec<u8> {
+    let mut out = String::new();
+    let hdrs = headers.as_ref().cloned().unwrap_or_default();
+    for row in rows {
+        let mut map = serde_json::Map::new();
+        for (i, field) in row.iter().enumerate() {
+            let key = hdrs.get(i).cloned().unwrap_or_else(|| format!("_{i}"));
+            map.insert(key, serde_json::Value::String(field.clone()));
+        }
+        out.push_str(&serde_json::to_string(&serde_json::Value::Object(map)).unwrap());
+        out.push('\n');
+    }
+    out.into_bytes()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_select_star() {
+        let q = parse_sql("SELECT * FROM s3object").unwrap();
+        assert!(matches!(q.select, SqlSelect::All));
+        assert_eq!(q.from, "s3object");
+        assert!(q.where_clause.is_none());
+    }
+
+    #[test]
+    fn parse_select_columns() {
+        let q = parse_sql("SELECT a, b FROM s3object").unwrap();
+        assert!(matches!(q.select, SqlSelect::Columns(cols) if cols == vec!["a", "b"]));
+    }
+
+    #[test]
+    fn parse_where_eq_string() {
+        let q = parse_sql("SELECT * FROM s3object WHERE name = 'alice'").unwrap();
+        assert!(
+            matches!(q.where_clause, Some(WhereClause::Eq(_, LiteralValue::String(ref s))) if s == "alice")
+        );
+    }
+
+    #[test]
+    fn parse_where_eq_number() {
+        let q = parse_sql("SELECT * FROM s3object WHERE age = 30").unwrap();
+        assert!(
+            matches!(q.where_clause, Some(WhereClause::Eq(_, LiteralValue::Number(n))) if n == 30.0)
+        );
+    }
+
+    #[test]
+    fn parse_where_like() {
+        let q = parse_sql("SELECT * FROM s3object WHERE name LIKE 'a%'").unwrap();
+        assert!(
+            matches!(q.where_clause, Some(WhereClause::Like(ref col, ref pat)) if col == "name" && pat == "a%")
+        );
+    }
+
+    #[test]
+    fn csv_parse_with_header() {
+        let (hdrs, rows) = parse_csv(b"a,b\n1,2\n3,4", true, ',', '\n');
+        assert_eq!(hdrs, Some(vec!["a".to_string(), "b".to_string()]));
+        assert_eq!(rows, vec![vec!["1", "2"], vec!["3", "4"]]);
+    }
+
+    #[test]
+    fn evaluate_select_all() {
+        let q = parse_sql("SELECT * FROM s3object").unwrap();
+        let hdrs = Some(vec!["a".to_string(), "b".to_string()]);
+        let rows = vec![vec!["1".to_string(), "2".to_string()]];
+        let out = evaluate_query(&q, &hdrs, &rows);
+        assert_eq!(out, vec![vec!["1", "2"]]);
+    }
+
+    #[test]
+    fn evaluate_where_eq() {
+        let q = parse_sql("SELECT * FROM s3object WHERE a = '1'").unwrap();
+        let hdrs = Some(vec!["a".to_string(), "b".to_string()]);
+        let rows = vec![
+            vec!["1".to_string(), "2".to_string()],
+            vec!["3".to_string(), "4".to_string()],
+        ];
+        let out = evaluate_query(&q, &hdrs, &rows);
+        assert_eq!(out, vec![vec!["1", "2"]]);
+    }
+
+    #[test]
+    fn evaluate_select_columns() {
+        let q = parse_sql("SELECT b FROM s3object").unwrap();
+        let hdrs = Some(vec!["a".to_string(), "b".to_string()]);
+        let rows = vec![vec!["1".to_string(), "2".to_string()]];
+        let out = evaluate_query(&q, &hdrs, &rows);
+        assert_eq!(out, vec![vec!["2"]]);
+    }
+
+    #[test]
+    fn format_csv_round_trip() {
+        let rows = vec![vec!["1".to_string(), "2".to_string()]];
+        let bytes = format_csv(&rows, ",", "\n");
+        assert_eq!(bytes, b"1,2\n");
+    }
+}

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -2035,15 +2035,28 @@ impl S3Service {
     pub(super) fn select_object_content(
         &self,
         account_id: &str,
-        _req: &AwsRequest,
+        req: &AwsRequest,
         bucket: &str,
         key: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // SelectObjectContent normally returns an EventStream of
-        // RecordsEvent / EndEvent frames. We can't easily produce real
-        // EventStream binary frames here, but the SDK only requires a 200
-        // with the right content-type; the parser will then receive an
-        // empty event stream which is decoded as zero records.
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
+        let request: crate::select::SelectRequest =
+            quick_xml::de::from_str(body_str).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "MalformedXML",
+                    format!("Invalid SelectObjectContent request: {e}"),
+                )
+            })?;
+
+        if request.ExpressionType != "SQL" {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidExpressionType",
+                "Only SQL expressions are supported",
+            ));
+        }
+
         let accts = self.state.read();
         let empty = crate::state::S3State::new(account_id, "us-east-1");
         let state = accts.get(account_id).unwrap_or(&empty);
@@ -2051,14 +2064,93 @@ impl S3Service {
             .buckets
             .get(bucket)
             .ok_or_else(|| no_such_bucket(bucket))?;
-        if !b.objects.contains_key(key) {
-            return Err(AwsServiceError::aws_error(
+        let obj = b.objects.get(key).ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchKey",
                 format!("Key {key} does not exist."),
+            )
+        })?;
+
+        let object_bytes = state.read_body(&obj.body).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "ServiceException",
+                format!("Failed to read object body: {e}"),
+            )
+        })?;
+
+        let query = crate::select::parse_sql(&request.Expression).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidExpression",
+                format!("Failed to parse SQL expression: {e}"),
+            )
+        })?;
+
+        if !query.from.eq_ignore_ascii_case("s3object") {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidExpression",
+                "Only FROM s3object is supported",
             ));
         }
-        let body = Bytes::new();
+
+        // Parse input
+        let (headers, rows) = if let Some(csv_input) = request.InputSerialization.CSV {
+            let has_header = csv_input.file_header_info.as_deref() == Some("USE");
+            let field_delimiter = csv_input
+                .field_delimiter
+                .as_deref()
+                .and_then(|s| s.chars().next())
+                .unwrap_or(',');
+            let record_delimiter = csv_input
+                .record_delimiter
+                .as_deref()
+                .and_then(|s| s.chars().next())
+                .unwrap_or('\n');
+            crate::select::parse_csv(&object_bytes, has_header, field_delimiter, record_delimiter)
+        } else if request.InputSerialization.JSON.is_some() {
+            crate::select::parse_json_lines(&object_bytes)
+        } else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+                "Only CSV and JSON input are supported",
+            ));
+        };
+
+        // Evaluate query
+        let result_rows = crate::select::evaluate_query(&query, &headers, &rows);
+
+        // Format output
+        let output_bytes = if let Some(csv_output) = request.OutputSerialization.CSV {
+            let fd = csv_output.field_delimiter.as_deref().unwrap_or(",");
+            let rd = csv_output.record_delimiter.as_deref().unwrap_or("\n");
+            crate::select::format_csv(&result_rows, fd, rd)
+        } else if request.OutputSerialization.JSON.is_some() {
+            crate::select::format_json_lines(&result_rows, &headers)
+        } else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+                "Only CSV and JSON output are supported",
+            ));
+        };
+
+        // Build eventstream response
+        let mut body = Vec::new();
+        body.extend(crate::eventstream::records_event_frame(&output_bytes));
+        let bytes_scanned = object_bytes.len() as u64;
+        let bytes_processed = output_bytes.len() as u64;
+        let bytes_returned = output_bytes.len() as u64;
+        body.extend(crate::eventstream::stats_event_frame(
+            bytes_scanned,
+            bytes_processed,
+            bytes_returned,
+        ));
+        body.extend(crate::eventstream::end_event_frame());
+
         Ok(AwsResponse {
             status: StatusCode::OK,
             content_type: "application/octet-stream".to_string(),

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -2121,7 +2121,7 @@ impl S3Service {
         };
 
         // Evaluate query
-        let result_rows = crate::select::evaluate_query(&query, &headers, &rows);
+        let (result_rows, out_headers) = crate::select::evaluate_query(&query, &headers, &rows);
 
         // Format output
         let output_bytes = if let Some(csv_output) = request.OutputSerialization.CSV {
@@ -2129,7 +2129,7 @@ impl S3Service {
             let rd = csv_output.record_delimiter.as_deref().unwrap_or("\n");
             crate::select::format_csv(&result_rows, fd, rd)
         } else if request.OutputSerialization.JSON.is_some() {
-            crate::select::format_json_lines(&result_rows, &headers)
+            crate::select::format_json_lines(&result_rows, &out_headers)
         } else {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -2153,7 +2153,7 @@ impl S3Service {
 
         Ok(AwsResponse {
             status: StatusCode::OK,
-            content_type: "application/octet-stream".to_string(),
+            content_type: "application/vnd.amazon.eventstream".to_string(),
             body: body.into(),
             headers: HeaderMap::new(),
         })

--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -2129,7 +2129,8 @@ impl S3Service {
             let rd = csv_output.record_delimiter.as_deref().unwrap_or("\n");
             crate::select::format_csv(&result_rows, fd, rd)
         } else if request.OutputSerialization.JSON.is_some() {
-            crate::select::format_json_lines(&result_rows, &out_headers)
+            let json_headers = out_headers.or(headers);
+            crate::select::format_json_lines(&result_rows, &json_headers)
         } else {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Summary
- Implement S3 SelectObjectContent end-to-end
- Parse XML request (Expression, Input/OutputSerialization)
- Evaluate simple SQL (SELECT *, SELECT cols, basic WHERE with = and LIKE)
- Parse CSV and newline-delimited JSON input
- Format CSV and JSON output
- Encode response as vnd.amazon.eventstream frames (Records, Stats, End)
- Update conformance test to assert real records

## Test plan
- [x] `cargo test -p fakecloud-s3` passes (302 tests)
- [x] `cargo test -p fakecloud-conformance --test s3` passes (50 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real S3 SelectObjectContent with Amazon EventStream frames and a basic SQL engine for CSV/NDJSON, with correct content-type and XML Stats for SDK compatibility. Also hardens SQL parsing and JSON output to avoid panics and preserve headers.

- **New Features**
  - Parse SelectObjectContent XML via `quick-xml`; validate `ExpressionType=SQL` and `FROM s3object`.
  - SQL: SELECT *, column lists, and WHERE with = and LIKE (prefix).
  - Input: CSV (headers via `FileHeaderInfo=USE`, custom delimiters) and NDJSON; infers JSON headers from the first object.
  - Output: CSV or JSON lines; EventStream response with CRCs: Records (data), Stats (XML), End.

- **Bug Fixes**
  - Prevent panic on non-ASCII/malformed SQL with safe string slicing.
  - Preserve original CSV headers in JSON output when `SELECT *` produces no explicit headers.
  - Tests: set `FileHeaderInfo=USE`, handle Stats, and explicitly panic on stream errors.

<sup>Written for commit ed35d1e449751ed513a103abcfda6abfdf846f62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

