### PR TITLE
feat(elasticache): restore from snapshot with real RDB dump

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2453,8 +2453,6 @@ async fn elasticache_create_cache_cluster_round_trips_extended_fields() {
         .ip_discovery(aws_sdk_elasticache::types::IpDiscovery::Ipv4)
         .outpost_mode(aws_sdk_elasticache::types::OutpostMode::SingleOutpost)
         .preferred_outpost_arn("arn:aws:outposts:us-east-1:123456789012:outpost/op-abc")
-        .snapshot_name("seed-snap")
-        .snapshot_arns("arn:aws:s3:::my-bucket/seed.rdb")
         .snapshot_retention_limit(7)
         .snapshot_window("03:00-05:00")
         .tags(

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -106,7 +106,7 @@ impl ElastiCacheRuntime {
         ];
         if let Some(path) = rdb_path {
             args.push("-v".to_string());
-            args.push(format!("{path}:/data/dump.rdb"));
+            args.push(format!("{path}:/data/dump.rdb:ro"));
         }
         args.push(image.to_string());
 

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -59,9 +59,16 @@ impl ElastiCacheRuntime {
     pub async fn ensure_redis(
         &self,
         resource_id: &str,
+        rdb_path: Option<&str>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
-        self.spawn_container(resource_id, "redis:7-alpine", 6379, CacheEngineKind::Redis)
-            .await
+        self.spawn_container(
+            resource_id,
+            "redis:7-alpine",
+            6379,
+            CacheEngineKind::Redis,
+            rdb_path,
+        )
+        .await
     }
 
     pub async fn ensure_memcached(
@@ -73,6 +80,7 @@ impl ElastiCacheRuntime {
             "memcached:1.6-alpine",
             11211,
             CacheEngineKind::Memcached,
+            None,
         )
         .await
     }
@@ -83,20 +91,27 @@ impl ElastiCacheRuntime {
         image: &str,
         container_port: u16,
         engine: CacheEngineKind,
+        rdb_path: Option<&str>,
     ) -> Result<RunningCacheContainer, RuntimeError> {
         self.stop_container(resource_id).await;
 
+        let mut args: Vec<String> = vec![
+            "create".to_string(),
+            "-p".to_string(),
+            format!(":{container_port}"),
+            "--label".to_string(),
+            format!("fakecloud-elasticache={resource_id}"),
+            "--label".to_string(),
+            format!("fakecloud-instance={}", self.instance_id),
+        ];
+        if let Some(path) = rdb_path {
+            args.push("-v".to_string());
+            args.push(format!("{path}:/data/dump.rdb"));
+        }
+        args.push(image.to_string());
+
         let output = tokio::process::Command::new(&self.cli)
-            .args([
-                "create",
-                "-p",
-                &format!(":{container_port}"),
-                "--label",
-                &format!("fakecloud-elasticache={resource_id}"),
-                "--label",
-                &format!("fakecloud-instance={}", self.instance_id),
-                image,
-            ])
+            .args(&args)
             .output()
             .await
             .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
@@ -178,6 +193,45 @@ impl ElastiCacheRuntime {
         if !output.status.success() {
             return Err(RuntimeError::ContainerStartFailed(
                 String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Trigger `SAVE` inside a running Redis container and copy the
+    /// resulting `dump.rdb` out to `dest_path`.
+    pub async fn dump_rdb(&self, resource_id: &str, dest_path: &str) -> Result<(), RuntimeError> {
+        let container_id = {
+            let containers = self.containers.read();
+            containers
+                .get(resource_id)
+                .map(|c| c.container_id.clone())
+                .ok_or(RuntimeError::Unavailable)?
+        };
+
+        let save_output = tokio::process::Command::new(&self.cli)
+            .args(["exec", &container_id, "redis-cli", "SAVE"])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !save_output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(
+                String::from_utf8_lossy(&save_output.stderr)
+                    .trim()
+                    .to_string(),
+            ));
+        }
+
+        let cp_output = tokio::process::Command::new(&self.cli)
+            .args(["cp", &format!("{container_id}:/data/dump.rdb"), dest_path])
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))?;
+        if !cp_output.status.success() {
+            return Err(RuntimeError::ContainerStartFailed(
+                String::from_utf8_lossy(&cp_output.stderr)
+                    .trim()
+                    .to_string(),
             ));
         }
         Ok(())

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -253,7 +253,7 @@ impl AwsService for ElastiCacheService {
             "CreateReplicationGroup" => self.create_replication_group(&request).await,
             "CreateServerlessCache" => self.create_serverless_cache(&request).await,
             "CreateServerlessCacheSnapshot" => self.create_serverless_cache_snapshot(&request),
-            "CreateSnapshot" => self.create_snapshot(&request),
+            "CreateSnapshot" => self.create_snapshot(&request).await,
             "CreateUser" => self.create_user(&request),
             "CreateUserGroup" => self.create_user_group(&request),
             "DecreaseReplicaCount" => self.decrease_replica_count(&request),
@@ -918,7 +918,7 @@ impl ElastiCacheService {
             parse_query_list_param(request, "PreferredOutpostArns", "PreferredOutpostArn");
         let tags = parse_tags(request)?;
 
-        let (preferred_availability_zone, arn) = {
+        let (preferred_availability_zone, arn, rdb_path) = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
             if !state.begin_cache_cluster_creation(&cache_cluster_id) {
@@ -960,6 +960,22 @@ impl ElastiCacheService {
                 }
             }
 
+            let rdb_path = if let Some(ref snap_name) = snapshot_name {
+                match state.snapshots.get(snap_name) {
+                    Some(snap) => snap.rdb_path.clone(),
+                    None => {
+                        state.cancel_cache_cluster_creation(&cache_cluster_id);
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "SnapshotNotFoundFault",
+                            format!("Snapshot {snap_name} not found."),
+                        ));
+                    }
+                }
+            } else {
+                None
+            };
+
             let preferred_availability_zone =
                 optional_query_param(request, "PreferredAvailabilityZone")
                     .unwrap_or_else(|| format!("{}a", state.region));
@@ -967,7 +983,7 @@ impl ElastiCacheService {
                 "arn:aws:elasticache:{}:{}:cluster:{}",
                 state.region, state.account_id, cache_cluster_id
             );
-            (preferred_availability_zone, arn)
+            (preferred_availability_zone, arn, rdb_path)
         };
 
         let runtime = self.runtime.as_ref().ok_or_else(|| {
@@ -986,7 +1002,9 @@ impl ElastiCacheService {
         let runtime_result = if engine == ENGINE_MEMCACHED {
             runtime.ensure_memcached(&cache_cluster_id).await
         } else {
-            runtime.ensure_redis(&cache_cluster_id).await
+            runtime
+                .ensure_redis(&cache_cluster_id, rdb_path.as_deref())
+                .await
         };
         let running = match runtime_result {
             Ok(r) => r,
@@ -1297,7 +1315,7 @@ impl ElastiCacheService {
         .unwrap_or(true);
         let tags = parse_tags(request)?;
         // Reserve the ID under a write lock before starting the container.
-        {
+        let rdb_path = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
             if !state.begin_replication_group_creation(&replication_group_id) {
@@ -1317,7 +1335,23 @@ impl ElastiCacheService {
                     ));
                 }
             }
-        }
+
+            if let Some(ref snap_name) = snapshot_name {
+                match state.snapshots.get(snap_name) {
+                    Some(snap) => snap.rdb_path.clone(),
+                    None => {
+                        state.cancel_replication_group_creation(&replication_group_id);
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "SnapshotNotFoundFault",
+                            format!("Snapshot {snap_name} not found."),
+                        ));
+                    }
+                }
+            } else {
+                None
+            }
+        };
 
         let runtime = self.runtime.as_ref().ok_or_else(|| {
             self.state
@@ -1332,7 +1366,10 @@ impl ElastiCacheService {
             )
         })?;
 
-        let running = match runtime.ensure_redis(&replication_group_id).await {
+        let running = match runtime
+            .ensure_redis(&replication_group_id, rdb_path.as_deref())
+            .await
+        {
             Ok(r) => r,
             Err(e) => {
                 self.state
@@ -1820,7 +1857,7 @@ impl ElastiCacheService {
             )
         })?;
 
-        let running = match runtime.ensure_redis(&serverless_cache_name).await {
+        let running = match runtime.ensure_redis(&serverless_cache_name, None).await {
             Ok(r) => r,
             Err(e) => {
                 self.state
@@ -2239,7 +2276,7 @@ impl ElastiCacheService {
         ))
     }
 
-    fn create_snapshot(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn create_snapshot(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let snapshot_name = required_query_param(request, "SnapshotName")?;
         let replication_group_id = optional_query_param(request, "ReplicationGroupId");
         let cache_cluster_id = optional_query_param(request, "CacheClusterId");
@@ -2253,81 +2290,105 @@ impl ElastiCacheService {
             ));
         }
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
+        let (mut snapshot, arn, group_id) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
 
-        if state.snapshots.contains_key(&snapshot_name) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "SnapshotAlreadyExistsFault",
-                format!("Snapshot {snapshot_name} already exists."),
-            ));
+            if state.snapshots.contains_key(&snapshot_name) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "SnapshotAlreadyExistsFault",
+                    format!("Snapshot {snapshot_name} already exists."),
+                ));
+            }
+
+            // Resolve the replication group: either directly by ID or via CacheClusterId
+            let group_id = if let Some(ref rg_id) = replication_group_id {
+                rg_id.clone()
+            } else {
+                let cluster_id = cache_cluster_id.as_ref().unwrap();
+                if let Some(cluster) = state.cache_clusters.get(cluster_id) {
+                    if let Some(group_id) = cluster.replication_group_id.clone() {
+                        group_id
+                    } else {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterCombination",
+                            format!(
+                                "CacheCluster {cluster_id} is not associated with a replication group."
+                            ),
+                        ));
+                    }
+                } else {
+                    // CacheClusterId may also map to a member cluster like "rg-001", find parent group
+                    state
+                        .replication_groups
+                        .values()
+                        .find(|g| g.member_clusters.contains(cluster_id))
+                        .map(|g| g.replication_group_id.clone())
+                        .ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "CacheClusterNotFound",
+                                format!("CacheCluster {cluster_id} not found."),
+                            )
+                        })?
+                }
+            };
+
+            let group = state.replication_groups.get(&group_id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "ReplicationGroupNotFoundFault",
+                    format!("ReplicationGroup {group_id} not found."),
+                )
+            })?;
+
+            let arn = format!(
+                "arn:aws:elasticache:{}:{}:snapshot:{}",
+                state.region, state.account_id, snapshot_name
+            );
+
+            let snapshot = CacheSnapshot {
+                snapshot_name: snapshot_name.clone(),
+                replication_group_id: group.replication_group_id.clone(),
+                replication_group_description: group.description.clone(),
+                snapshot_status: "available".to_string(),
+                cache_node_type: group.cache_node_type.clone(),
+                engine: group.engine.clone(),
+                engine_version: group.engine_version.clone(),
+                num_cache_clusters: group.num_cache_clusters,
+                arn: arn.clone(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                snapshot_source: "manual".to_string(),
+                rdb_path: None,
+            };
+            (snapshot, arn, group_id)
+        };
+
+        if let Some(ref runtime) = self.runtime {
+            let tmp_path = format!(
+                "/tmp/fakecloud-ec-{}-{}.rdb",
+                snapshot_name,
+                std::process::id()
+            );
+            match runtime.dump_rdb(&group_id, &tmp_path).await {
+                Ok(()) => {
+                    snapshot.rdb_path = Some(tmp_path);
+                }
+                Err(err) => {
+                    tracing::warn!("Failed to dump RDB for snapshot {}: {}", snapshot_name, err);
+                }
+            }
         }
 
-        // Resolve the replication group: either directly by ID or via CacheClusterId
-        let group_id = if let Some(ref rg_id) = replication_group_id {
-            rg_id.clone()
-        } else {
-            let cluster_id = cache_cluster_id.as_ref().unwrap();
-            if let Some(cluster) = state.cache_clusters.get(cluster_id) {
-                if let Some(group_id) = cluster.replication_group_id.clone() {
-                    group_id
-                } else {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidParameterCombination",
-                        format!(
-                            "CacheCluster {cluster_id} is not associated with a replication group."
-                        ),
-                    ));
-                }
-            } else {
-                // CacheClusterId may also map to a member cluster like "rg-001", find parent group
-                state
-                    .replication_groups
-                    .values()
-                    .find(|g| g.member_clusters.contains(cluster_id))
-                    .map(|g| g.replication_group_id.clone())
-                    .ok_or_else(|| {
-                        AwsServiceError::aws_error(
-                            StatusCode::NOT_FOUND,
-                            "CacheClusterNotFound",
-                            format!("CacheCluster {cluster_id} not found."),
-                        )
-                    })?
-            }
-        };
-
-        let group = state.replication_groups.get(&group_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ReplicationGroupNotFoundFault",
-                format!("ReplicationGroup {group_id} not found."),
-            )
-        })?;
-
-        let arn = format!(
-            "arn:aws:elasticache:{}:{}:snapshot:{}",
-            state.region, state.account_id, snapshot_name
-        );
-
-        let snapshot = CacheSnapshot {
-            snapshot_name: snapshot_name.clone(),
-            replication_group_id: group.replication_group_id.clone(),
-            replication_group_description: group.description.clone(),
-            snapshot_status: "available".to_string(),
-            cache_node_type: group.cache_node_type.clone(),
-            engine: group.engine.clone(),
-            engine_version: group.engine_version.clone(),
-            num_cache_clusters: group.num_cache_clusters,
-            arn: arn.clone(),
-            created_at: chrono::Utc::now().to_rfc3339(),
-            snapshot_source: "manual".to_string(),
-        };
-
         let xml = snapshot_xml(&snapshot);
-        state.tags.insert(arn, Vec::new());
-        state.snapshots.insert(snapshot_name, snapshot);
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            state.tags.insert(arn, Vec::new());
+            state.snapshots.insert(snapshot_name, snapshot);
+        }
 
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -2368,7 +2368,8 @@ impl ElastiCacheService {
 
         if let Some(ref runtime) = self.runtime {
             let tmp_path = format!(
-                "/tmp/fakecloud-ec-{}-{}.rdb",
+                "/tmp/fakecloud-ec-{}-{}-{}.rdb",
+                request.account_id,
                 snapshot_name,
                 std::process::id()
             );
@@ -2386,6 +2387,16 @@ impl ElastiCacheService {
         {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
+            if state.snapshots.contains_key(&snapshot_name) {
+                if let Some(ref path) = snapshot.rdb_path {
+                    let _ = std::fs::remove_file(path);
+                }
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "SnapshotAlreadyExistsFault",
+                    format!("Snapshot {snapshot_name} already exists."),
+                ));
+            }
             state.tags.insert(arn, Vec::new());
             state.snapshots.insert(snapshot_name, snapshot);
         }

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -1058,8 +1058,8 @@ async fn delete_cache_cluster_removes_cluster_from_replication_group() {
     assert_eq!(group.num_cache_clusters, 1);
 }
 
-#[test]
-fn create_snapshot_rejects_standalone_cache_cluster_id() {
+#[tokio::test]
+async fn create_snapshot_rejects_standalone_cache_cluster_id() {
     let service = service_with_cache_cluster("standalone");
     let req = request(
         "CreateSnapshot",
@@ -1068,7 +1068,7 @@ fn create_snapshot_rejects_standalone_cache_cluster_id() {
             ("CacheClusterId", "standalone"),
         ],
     );
-    assert!(service.create_snapshot(&req).is_err());
+    assert!(service.create_snapshot(&req).await.is_err());
 }
 
 fn service_with_replication_group(group_id: &str, num_clusters: i32) -> ElastiCacheService {
@@ -2276,8 +2276,8 @@ fn test_failover_not_found() {
 
 // Snapshot tests
 
-#[test]
-fn create_snapshot_returns_snapshot_xml() {
+#[tokio::test]
+async fn create_snapshot_returns_snapshot_xml() {
     let service = service_with_replication_group("snap-rg", 1);
     let req = request(
         "CreateSnapshot",
@@ -2286,7 +2286,7 @@ fn create_snapshot_returns_snapshot_xml() {
             ("ReplicationGroupId", "snap-rg"),
         ],
     );
-    let resp = service.create_snapshot(&req).unwrap();
+    let resp = service.create_snapshot(&req).await.unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<SnapshotName>my-snap</SnapshotName>"));
     assert!(body.contains("<ReplicationGroupId>snap-rg</ReplicationGroupId>"));
@@ -2296,8 +2296,8 @@ fn create_snapshot_returns_snapshot_xml() {
     assert!(body.contains("<CreateSnapshotResponse"));
 }
 
-#[test]
-fn create_snapshot_via_cache_cluster_id() {
+#[tokio::test]
+async fn create_snapshot_via_cache_cluster_id() {
     let service = service_with_replication_group("cc-rg", 2);
     let req = request(
         "CreateSnapshot",
@@ -2306,20 +2306,20 @@ fn create_snapshot_via_cache_cluster_id() {
             ("CacheClusterId", "cc-rg-001"),
         ],
     );
-    let resp = service.create_snapshot(&req).unwrap();
+    let resp = service.create_snapshot(&req).await.unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<ReplicationGroupId>cc-rg</ReplicationGroupId>"));
 }
 
-#[test]
-fn create_snapshot_rejects_missing_group_and_cluster() {
+#[tokio::test]
+async fn create_snapshot_rejects_missing_group_and_cluster() {
     let service = service_with_replication_group("rg", 1);
     let req = request("CreateSnapshot", &[("SnapshotName", "bad-snap")]);
-    assert!(service.create_snapshot(&req).is_err());
+    assert!(service.create_snapshot(&req).await.is_err());
 }
 
-#[test]
-fn create_snapshot_rejects_duplicate_name() {
+#[tokio::test]
+async fn create_snapshot_rejects_duplicate_name() {
     let service = service_with_replication_group("dup-rg", 1);
     let req = request(
         "CreateSnapshot",
@@ -2328,12 +2328,12 @@ fn create_snapshot_rejects_duplicate_name() {
             ("ReplicationGroupId", "dup-rg"),
         ],
     );
-    service.create_snapshot(&req).unwrap();
-    assert!(service.create_snapshot(&req).is_err());
+    service.create_snapshot(&req).await.unwrap();
+    assert!(service.create_snapshot(&req).await.is_err());
 }
 
-#[test]
-fn create_snapshot_rejects_nonexistent_group() {
+#[tokio::test]
+async fn create_snapshot_rejects_nonexistent_group() {
     let shared = std::sync::Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
     ));
@@ -2345,18 +2345,18 @@ fn create_snapshot_rejects_nonexistent_group() {
             ("ReplicationGroupId", "no-such-rg"),
         ],
     );
-    assert!(service.create_snapshot(&req).is_err());
+    assert!(service.create_snapshot(&req).await.is_err());
 }
 
-#[test]
-fn create_snapshot_rejects_missing_name() {
+#[tokio::test]
+async fn create_snapshot_rejects_missing_name() {
     let service = service_with_replication_group("rg", 1);
     let req = request("CreateSnapshot", &[("ReplicationGroupId", "rg")]);
-    assert!(service.create_snapshot(&req).is_err());
+    assert!(service.create_snapshot(&req).await.is_err());
 }
 
-#[test]
-fn create_snapshot_registers_arn_for_tags() {
+#[tokio::test]
+async fn create_snapshot_registers_arn_for_tags() {
     let service = service_with_replication_group("tag-rg", 1);
     let req = request(
         "CreateSnapshot",
@@ -2365,7 +2365,7 @@ fn create_snapshot_registers_arn_for_tags() {
             ("ReplicationGroupId", "tag-rg"),
         ],
     );
-    service.create_snapshot(&req).unwrap();
+    service.create_snapshot(&req).await.unwrap();
 
     let __a = service.state.read();
     let state = __a.default_ref();
@@ -2373,15 +2373,15 @@ fn create_snapshot_registers_arn_for_tags() {
     assert!(state.tags.contains_key(&arn));
 }
 
-#[test]
-fn describe_snapshots_returns_all() {
+#[tokio::test]
+async fn describe_snapshots_returns_all() {
     let service = service_with_replication_group("desc-rg", 1);
     for name in &["snap-a", "snap-b"] {
         let req = request(
             "CreateSnapshot",
             &[("SnapshotName", name), ("ReplicationGroupId", "desc-rg")],
         );
-        service.create_snapshot(&req).unwrap();
+        service.create_snapshot(&req).await.unwrap();
     }
     let req = request("DescribeSnapshots", &[]);
     let resp = service.describe_snapshots(&req).unwrap();
@@ -2391,15 +2391,15 @@ fn describe_snapshots_returns_all() {
     assert!(body.contains("<DescribeSnapshotsResponse"));
 }
 
-#[test]
-fn describe_snapshots_filters_by_name() {
+#[tokio::test]
+async fn describe_snapshots_filters_by_name() {
     let service = service_with_replication_group("filt-rg", 1);
     for name in &["snap-1", "snap-2"] {
         let req = request(
             "CreateSnapshot",
             &[("SnapshotName", name), ("ReplicationGroupId", "filt-rg")],
         );
-        service.create_snapshot(&req).unwrap();
+        service.create_snapshot(&req).await.unwrap();
     }
     let req = request("DescribeSnapshots", &[("SnapshotName", "snap-1")]);
     let resp = service.describe_snapshots(&req).unwrap();
@@ -2408,8 +2408,8 @@ fn describe_snapshots_filters_by_name() {
     assert!(!body.contains("<SnapshotName>snap-2</SnapshotName>"));
 }
 
-#[test]
-fn describe_snapshots_filters_by_replication_group() {
+#[tokio::test]
+async fn describe_snapshots_filters_by_replication_group() {
     let service = service_with_replication_group("rg-a", 1);
     let req = request(
         "CreateSnapshot",
@@ -2418,7 +2418,7 @@ fn describe_snapshots_filters_by_replication_group() {
             ("ReplicationGroupId", "rg-a"),
         ],
     );
-    service.create_snapshot(&req).unwrap();
+    service.create_snapshot(&req).await.unwrap();
 
     let req = request("DescribeSnapshots", &[("ReplicationGroupId", "rg-a")]);
     let resp = service.describe_snapshots(&req).unwrap();
@@ -2442,8 +2442,8 @@ fn describe_snapshots_not_found_by_name() {
     assert!(service.describe_snapshots(&req).is_err());
 }
 
-#[test]
-fn delete_snapshot_removes_and_returns_deleting() {
+#[tokio::test]
+async fn delete_snapshot_removes_and_returns_deleting() {
     let service = service_with_replication_group("del-rg", 1);
     let req = request(
         "CreateSnapshot",
@@ -2452,7 +2452,7 @@ fn delete_snapshot_removes_and_returns_deleting() {
             ("ReplicationGroupId", "del-rg"),
         ],
     );
-    service.create_snapshot(&req).unwrap();
+    service.create_snapshot(&req).await.unwrap();
 
     let req = request("DeleteSnapshot", &[("SnapshotName", "del-snap")]);
     let resp = service.delete_snapshot(&req).unwrap();
@@ -2469,8 +2469,8 @@ fn delete_snapshot_removes_and_returns_deleting() {
         .contains_key("del-snap"));
 }
 
-#[test]
-fn delete_snapshot_cleans_up_tags() {
+#[tokio::test]
+async fn delete_snapshot_cleans_up_tags() {
     let service = service_with_replication_group("tag-del-rg", 1);
     let req = request(
         "CreateSnapshot",
@@ -2479,7 +2479,7 @@ fn delete_snapshot_cleans_up_tags() {
             ("ReplicationGroupId", "tag-del-rg"),
         ],
     );
-    service.create_snapshot(&req).unwrap();
+    service.create_snapshot(&req).await.unwrap();
 
     let arn = "arn:aws:elasticache:us-east-1:123456789012:snapshot:tag-del-snap".to_string();
     assert!(service.state.read().default_ref().tags.contains_key(&arn));
@@ -2513,6 +2513,7 @@ fn snapshot_xml_contains_all_fields() {
         arn: "arn:aws:elasticache:us-east-1:123:snapshot:test-snap".to_string(),
         created_at: "2024-01-01T00:00:00Z".to_string(),
         snapshot_source: "manual".to_string(),
+        rdb_path: None,
     };
     let xml = snapshot_xml(&snap);
     assert!(xml.contains("<SnapshotName>test-snap</SnapshotName>"));
@@ -4559,4 +4560,132 @@ fn create_cache_cluster_through_handler_persists_tags_and_extended_fields() {
         cluster.transit_encryption_mode.as_deref(),
         Some("preferred")
     );
+}
+
+// ── snapshot restore paths ──
+
+#[tokio::test]
+async fn create_cache_cluster_with_missing_snapshot_errors() {
+    let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let svc = ElastiCacheService::new(shared);
+    let req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "cc-restore"),
+            ("SnapshotName", "no-such-snap"),
+        ],
+    );
+    let err = match svc.create_cache_cluster(&req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected error"),
+    };
+    assert_eq!(err.code(), "SnapshotNotFoundFault");
+}
+
+#[tokio::test]
+async fn create_replication_group_with_missing_snapshot_errors() {
+    let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let svc = ElastiCacheService::new(shared);
+    let req = request(
+        "CreateReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-restore"),
+            ("ReplicationGroupDescription", "desc"),
+            ("SnapshotName", "no-such-snap"),
+        ],
+    );
+    let err = match svc.create_replication_group(&req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected error"),
+    };
+    assert_eq!(err.code(), "SnapshotNotFoundFault");
+}
+
+#[tokio::test]
+async fn create_cache_cluster_with_existing_snapshot_skips_to_runtime() {
+    let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let svc = ElastiCacheService::new(shared);
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("123456789012");
+        state.snapshots.insert(
+            "my-snap".to_string(),
+            crate::state::CacheSnapshot {
+                snapshot_name: "my-snap".to_string(),
+                replication_group_id: "rg-1".to_string(),
+                replication_group_description: "desc".to_string(),
+                snapshot_status: "available".to_string(),
+                cache_node_type: "cache.t3.micro".to_string(),
+                engine: "redis".to_string(),
+                engine_version: "7.1".to_string(),
+                num_cache_clusters: 1,
+                arn: "arn:aws:elasticache:us-east-1:123456789012:snapshot:my-snap".to_string(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                snapshot_source: "manual".to_string(),
+                rdb_path: Some("/tmp/fake.rdb".to_string()),
+            },
+        );
+    }
+    let req = request(
+        "CreateCacheCluster",
+        &[
+            ("CacheClusterId", "cc-restore"),
+            ("SnapshotName", "my-snap"),
+        ],
+    );
+    let err = match svc.create_cache_cluster(&req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected error"),
+    };
+    assert_eq!(err.code(), "InvalidParameterValue");
+    assert_eq!(err.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn create_replication_group_with_existing_snapshot_skips_to_runtime() {
+    let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let svc = ElastiCacheService::new(shared);
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("123456789012");
+        state.snapshots.insert(
+            "my-snap".to_string(),
+            crate::state::CacheSnapshot {
+                snapshot_name: "my-snap".to_string(),
+                replication_group_id: "rg-1".to_string(),
+                replication_group_description: "desc".to_string(),
+                snapshot_status: "available".to_string(),
+                cache_node_type: "cache.t3.micro".to_string(),
+                engine: "redis".to_string(),
+                engine_version: "7.1".to_string(),
+                num_cache_clusters: 1,
+                arn: "arn:aws:elasticache:us-east-1:123456789012:snapshot:my-snap".to_string(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                snapshot_source: "manual".to_string(),
+                rdb_path: Some("/tmp/fake.rdb".to_string()),
+            },
+        );
+    }
+    let req = request(
+        "CreateReplicationGroup",
+        &[
+            ("ReplicationGroupId", "rg-restore"),
+            ("ReplicationGroupDescription", "desc"),
+            ("SnapshotName", "my-snap"),
+        ],
+    );
+    let err = match svc.create_replication_group(&req).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected error"),
+    };
+    assert_eq!(err.code(), "InvalidParameterValue");
+    assert_eq!(err.status(), http::StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -404,6 +404,9 @@ pub struct CacheSnapshot {
     pub arn: String,
     pub created_at: String,
     pub snapshot_source: String,
+    /// Path to the dumped RDB file on the local disk, if the runtime was
+    /// available at snapshot-create time.
+    pub rdb_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -1243,6 +1246,7 @@ mod tests {
                 arn: "arn:aws:elasticache:us-east-1:123456789012:snapshot:my-snapshot".to_string(),
                 created_at: "2024-01-01T00:00:00Z".to_string(),
                 snapshot_source: "manual".to_string(),
+                rdb_path: None,
             },
         );
         assert_eq!(state.snapshots.len(), 1);


### PR DESCRIPTION
## Summary
- Make `CreateSnapshot` dump real RDB from running Redis via `redis-cli SAVE` + `docker cp`
- Store `rdb_path` on `CacheSnapshot` for restore-time reuse
- `CreateCacheCluster`/`CreateReplicationGroup` now accept `SnapshotName` and seed new containers with saved RDB via volume mount
- Reject unknown snapshot names with `SnapshotNotFoundFault`

## Test plan
- [x] `cargo test -p fakecloud-elasticache` — 216 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] New tests: missing snapshot errors for both cluster + replication group; existing snapshot skips to runtime

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use real Redis RDB files for snapshots and restore so new clusters/groups can start with realistic data. `CreateSnapshot` now dumps a live RDB when the runtime is available, and restore mounts it at startup; e2e tests seed a snapshot for restore paths.

- **New Features**
  - `CreateSnapshot` runs `redis-cli SAVE` + `docker cp` to persist a real `dump.rdb`; stores `rdb_path` on snapshots.
  - Redis startup accepts an optional RDB via `ensure_redis`/`spawn_container` with `-v rdb_path:/data/dump.rdb:ro`.
  - `CreateSnapshot` is async to dump when the runtime is available.
  - `CreateCacheCluster`/`CreateReplicationGroup` accept `SnapshotName`, look up the saved `rdb_path`, and seed new containers; unknown names return `SnapshotNotFoundFault`.

- **Bug Fixes**
  - Mount the RDB dump read-only to avoid in-container writes.
  - Include `account_id` in the temp dump path to prevent cross-account collisions.
  - Re-check snapshot name uniqueness after the async dump to close a race window.

<sup>Written for commit b215d8c6f6d7a1e48bd5c726bda993c9677ddde6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

