### PR TITLE
feat(elasticache): ACL SETUSER, CONFIG SET, Memcached ConfigurationEndpoint

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2798,17 +2798,18 @@ async fn redis_acls_supported(addr: &str) -> bool {
 
 /// Probe a Redis/Valkey container to check whether it supports CONFIG
 /// commands including CONFIG SET.  Stripped-down builds may lack CONFIG
-/// support, and some hardened images allow GET but not SET.
+/// support, and some hardened images allow GET but not SET.  The probe uses
+/// `tcp-keepalive` (default 300) rather than `maxmemory-policy` so it does
+/// not mutate the value the test later asserts.
 async fn redis_config_supported(addr: &str) -> bool {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Step 1: CONFIG SET tcp-keepalive 301 (value different from default 300).
     let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
         return false;
     };
-    // Try CONFIG SET with a harmless parameter to verify full support.
     if stream
-        .write_all(
-            b"*4\r\n$6\r\nCONFIG\r\n$3\r\nSET\r\n$14\r\nmaxmemory-policy\r\n$10\r\nnoeviction\r\n",
-        )
+        .write_all(b"*4\r\n$6\r\nCONFIG\r\n$3\r\nSET\r\n$14\r\ntcp-keepalive\r\n$3\r\n301\r\n")
         .await
         .is_err()
     {
@@ -2822,12 +2823,13 @@ async fn redis_config_supported(addr: &str) -> bool {
     if response.contains("unknown command") || response.contains("ERR") {
         return false;
     }
-    // Verify the change stuck.
+
+    // Step 2: CONFIG GET tcp-keepalive — verify the value actually changed.
     let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
         return false;
     };
     if stream
-        .write_all(b"*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$14\r\nmaxmemory-policy\r\n")
+        .write_all(b"*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$14\r\ntcp-keepalive\r\n")
         .await
         .is_err()
     {
@@ -2838,7 +2840,19 @@ async fn redis_config_supported(addr: &str) -> bool {
         return false;
     };
     let response = String::from_utf8_lossy(&buf[..n]);
-    response.contains("noeviction")
+    let works = response.contains("301");
+
+    // Step 3: restore default so the probe is non-destructive.
+    if works {
+        if let Ok(mut s) = tokio::net::TcpStream::connect(addr).await {
+            let _ = s
+                .write_all(
+                    b"*4\r\n$6\r\nCONFIG\r\n$3\r\nSET\r\n$14\r\ntcp-keepalive\r\n$3\r\n300\r\n",
+                )
+                .await;
+        }
+    }
+    works
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2780,7 +2780,12 @@ async fn redis_acls_supported(addr: &str) -> bool {
     let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
         return false;
     };
-    if stream.write_all(b"*1\r\n$8\r\nACL LIST\r\n").await.is_err() {
+    // Correct RESP array: ACL LIST is two elements, not one.
+    if stream
+        .write_all(b"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n")
+        .await
+        .is_err()
+    {
         return false;
     }
     let mut buf = vec![0u8; 1024];
@@ -2792,9 +2797,32 @@ async fn redis_acls_supported(addr: &str) -> bool {
 }
 
 /// Probe a Redis/Valkey container to check whether it supports CONFIG
-/// commands.  Stripped-down builds may lack CONFIG support.
+/// commands including CONFIG SET.  Stripped-down builds may lack CONFIG
+/// support, and some hardened images allow GET but not SET.
 async fn redis_config_supported(addr: &str) -> bool {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
+        return false;
+    };
+    // Try CONFIG SET with a harmless parameter to verify full support.
+    if stream
+        .write_all(
+            b"*4\r\n$6\r\nCONFIG\r\n$3\r\nSET\r\n$14\r\nmaxmemory-policy\r\n$10\r\nnoeviction\r\n",
+        )
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let mut buf = vec![0u8; 1024];
+    let Ok(n) = stream.read(&mut buf).await else {
+        return false;
+    };
+    let response = String::from_utf8_lossy(&buf[..n]);
+    if response.contains("unknown command") || response.contains("ERR") {
+        return false;
+    }
+    // Verify the change stuck.
     let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
         return false;
     };
@@ -2810,7 +2838,7 @@ async fn redis_config_supported(addr: &str) -> bool {
         return false;
     };
     let response = String::from_utf8_lossy(&buf[..n]);
-    !response.contains("unknown command")
+    response.contains("noeviction")
 }
 
 #[tokio::test]
@@ -2880,7 +2908,10 @@ async fn elasticache_modify_user_applies_acl_to_running_redis() {
     }
 
     let mut stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
-    stream.write_all(b"*1\r\n$8\r\nACL LIST\r\n").await.unwrap();
+    stream
+        .write_all(b"*2\r\n$3\r\nACL\r\n$4\r\nLIST\r\n")
+        .await
+        .unwrap();
     let mut buf = vec![0u8; 1024];
     let n = stream.read(&mut buf).await.unwrap();
     let response = String::from_utf8_lossy(&buf[..n]);
@@ -2944,10 +2975,11 @@ async fn elasticache_modify_cache_parameter_group_applies_config_set() {
 
     let addr = format!("127.0.0.1:{port}");
     if !redis_config_supported(&addr).await {
-        // Container runtime lacks CONFIG support — skip wire-level check.
+        // Container runtime lacks full CONFIG support — skip wire-level check.
         return;
     }
 
+    let mut last_response = String::new();
     let mut found = false;
     for _ in 0..10 {
         let mut stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
@@ -2958,11 +2990,15 @@ async fn elasticache_modify_cache_parameter_group_applies_config_set() {
         let mut buf = vec![0u8; 1024];
         let n = stream.read(&mut buf).await.unwrap();
         let response = String::from_utf8_lossy(&buf[..n]);
+        last_response = response.to_string();
         if response.contains("allkeys-lru") {
             found = true;
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
-    assert!(found, "CONFIG SET not applied after retries");
+    assert!(
+        found,
+        "CONFIG SET not applied after retries. Last response: {last_response}"
+    );
 }

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2930,7 +2930,9 @@ async fn elasticache_modify_user_applies_acl_to_running_redis() {
     let n = stream.read(&mut buf).await.unwrap();
     let response = String::from_utf8_lossy(&buf[..n]);
     assert!(
-        response.contains("user acluser on ~key* +get"),
+        response.contains("user acluser")
+            && response.contains("~key*")
+            && response.contains("+get"),
         "ACL not applied: {response}"
     );
 }

--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -2744,3 +2744,225 @@ async fn elasticache_decrease_replica_count_per_shard() {
     // 2 shards × (1 primary + 1 replica) = 4 member clusters.
     assert_eq!(group.member_clusters().len(), 4);
 }
+
+#[tokio::test]
+async fn elasticache_memcached_cluster_emits_configuration_endpoint() {
+    if !docker_available() {
+        return;
+    }
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    let create_resp = client
+        .create_cache_cluster()
+        .cache_cluster_id("memc-config")
+        .engine("memcached")
+        .cache_node_type("cache.t3.micro")
+        .send()
+        .await
+        .unwrap();
+
+    let cluster = create_resp.cache_cluster().expect("cache cluster");
+    assert_eq!(cluster.engine(), Some("memcached"));
+    let ep = cluster
+        .configuration_endpoint()
+        .expect("memcached cluster must emit ConfigurationEndpoint");
+    assert!(!ep.address().unwrap_or("").is_empty());
+    assert!(ep.port().unwrap_or(0) > 0);
+}
+
+/// Probe a Redis/Valkey container to check whether it supports the ACL
+/// command set.  Some CI environments ship stripped-down builds that
+/// lack ACL support, so we skip the wire-level assertion rather than
+/// hard-failing.
+async fn redis_acls_supported(addr: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
+        return false;
+    };
+    if stream.write_all(b"*1\r\n$8\r\nACL LIST\r\n").await.is_err() {
+        return false;
+    }
+    let mut buf = vec![0u8; 1024];
+    let Ok(n) = stream.read(&mut buf).await else {
+        return false;
+    };
+    let response = String::from_utf8_lossy(&buf[..n]);
+    !response.contains("unknown command")
+}
+
+/// Probe a Redis/Valkey container to check whether it supports CONFIG
+/// commands.  Stripped-down builds may lack CONFIG support.
+async fn redis_config_supported(addr: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await else {
+        return false;
+    };
+    if stream
+        .write_all(b"*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$14\r\nmaxmemory-policy\r\n")
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let mut buf = vec![0u8; 1024];
+    let Ok(n) = stream.read(&mut buf).await else {
+        return false;
+    };
+    let response = String::from_utf8_lossy(&buf[..n]);
+    !response.contains("unknown command")
+}
+
+#[tokio::test]
+async fn elasticache_modify_user_applies_acl_to_running_redis() {
+    if !docker_available() {
+        return;
+    }
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_user()
+        .user_id("acluser")
+        .user_name("acluser")
+        .engine("redis")
+        .access_string("on ~* +@all")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .create_user_group()
+        .user_group_id("aclgroup")
+        .engine("redis")
+        .user_ids("acluser")
+        .send()
+        .await
+        .unwrap();
+
+    let rg = client
+        .create_replication_group()
+        .replication_group_id("acl-rg")
+        .replication_group_description("acl test")
+        .user_group_ids("aclgroup")
+        .send()
+        .await
+        .unwrap()
+        .replication_group()
+        .expect("replication group")
+        .clone();
+
+    let port = rg
+        .node_groups()
+        .first()
+        .expect("node group")
+        .primary_endpoint()
+        .expect("primary endpoint")
+        .port()
+        .unwrap_or(0) as u16;
+
+    client
+        .modify_user()
+        .user_id("acluser")
+        .access_string("on ~key* +get")
+        .send()
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let addr = format!("127.0.0.1:{port}");
+    if !redis_acls_supported(&addr).await {
+        // Container runtime lacks ACL support — skip wire-level check.
+        return;
+    }
+
+    let mut stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
+    stream.write_all(b"*1\r\n$8\r\nACL LIST\r\n").await.unwrap();
+    let mut buf = vec![0u8; 1024];
+    let n = stream.read(&mut buf).await.unwrap();
+    let response = String::from_utf8_lossy(&buf[..n]);
+    assert!(
+        response.contains("user acluser on ~key* +get"),
+        "ACL not applied: {response}"
+    );
+}
+
+#[tokio::test]
+async fn elasticache_modify_cache_parameter_group_applies_config_set() {
+    if !docker_available() {
+        return;
+    }
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let server = TestServer::start().await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_parameter_group()
+        .cache_parameter_group_family("redis7")
+        .cache_parameter_group_name("param-test")
+        .description("test params")
+        .send()
+        .await
+        .unwrap();
+
+    let cluster = client
+        .create_cache_cluster()
+        .cache_cluster_id("param-cluster")
+        .cache_parameter_group_name("param-test")
+        .cache_node_type("cache.t3.micro")
+        .send()
+        .await
+        .unwrap()
+        .cache_cluster()
+        .expect("cache cluster")
+        .clone();
+
+    let port = cluster.cache_nodes()[0]
+        .endpoint()
+        .expect("cache node endpoint")
+        .port()
+        .unwrap_or(0) as u16;
+
+    client
+        .modify_cache_parameter_group()
+        .cache_parameter_group_name("param-test")
+        .set_parameter_name_values(Some(vec![
+            aws_sdk_elasticache::types::ParameterNameValue::builder()
+                .parameter_name("maxmemory-policy")
+                .parameter_value("allkeys-lru")
+                .build(),
+        ]))
+        .send()
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let addr = format!("127.0.0.1:{port}");
+    if !redis_config_supported(&addr).await {
+        // Container runtime lacks CONFIG support — skip wire-level check.
+        return;
+    }
+
+    let mut found = false;
+    for _ in 0..10 {
+        let mut stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
+        stream
+            .write_all(b"*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$14\r\nmaxmemory-policy\r\n")
+            .await
+            .unwrap();
+        let mut buf = vec![0u8; 1024];
+        let n = stream.read(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf[..n]);
+        if response.contains("allkeys-lru") {
+            found = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(found, "CONFIG SET not applied after retries");
+}

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -775,16 +775,18 @@ pub(crate) fn cache_cluster_xml(cluster: &CacheCluster, show_cache_node_info: bo
             .collect();
         format!("<LogDeliveryConfigurations>{entries}</LogDeliveryConfigurations>")
     };
-    let configuration_endpoint_xml =
-        if cluster.replication_group_id.is_some() && !cluster.endpoint_address.is_empty() {
-            format!(
+    let configuration_endpoint_xml = if (cluster.replication_group_id.is_some()
+        || cluster.engine == "memcached")
+        && !cluster.endpoint_address.is_empty()
+    {
+        format!(
             "<ConfigurationEndpoint><Address>{}</Address><Port>{}</Port></ConfigurationEndpoint>",
             xml_escape(&cluster.endpoint_address),
             cluster.endpoint_port
         )
-        } else {
-            String::new()
-        };
+    } else {
+        String::new()
+    };
 
     let preferred_maintenance_window_xml = cluster
         .preferred_maintenance_window

--- a/crates/fakecloud-elasticache/src/runtime.rs
+++ b/crates/fakecloud-elasticache/src/runtime.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::RwLock;
@@ -15,9 +16,10 @@ enum CacheEngineKind {
     Memcached,
 }
 
+#[derive(Debug, Clone)]
 pub struct ElastiCacheRuntime {
     cli: String,
-    containers: RwLock<HashMap<String, RunningCacheContainer>>,
+    containers: Arc<RwLock<HashMap<String, RunningCacheContainer>>>,
     instance_id: String,
 }
 
@@ -47,7 +49,7 @@ impl ElastiCacheRuntime {
 
         Some(Self {
             cli,
-            containers: RwLock::new(HashMap::new()),
+            containers: Arc::new(RwLock::new(HashMap::new())),
             instance_id: format!("fakecloud-{}", std::process::id()),
         })
     }
@@ -196,6 +198,30 @@ impl ElastiCacheRuntime {
             ));
         }
         Ok(())
+    }
+
+    /// Execute an arbitrary `redis-cli` command inside a tracked container.
+    /// Returns the raw `std::process::Output` so the caller can decide
+    /// whether a non-zero exit is fatal.
+    pub async fn exec_redis(
+        &self,
+        resource_id: &str,
+        redis_args: &[String],
+    ) -> Result<std::process::Output, RuntimeError> {
+        let container_id = {
+            let containers = self.containers.read();
+            containers
+                .get(resource_id)
+                .map(|c| c.container_id.clone())
+                .ok_or(RuntimeError::Unavailable)?
+        };
+        let mut args = vec!["exec".to_string(), container_id, "redis-cli".to_string()];
+        args.extend_from_slice(redis_args);
+        tokio::process::Command::new(&self.cli)
+            .args(&args)
+            .output()
+            .await
+            .map_err(|e| RuntimeError::ContainerStartFailed(e.to_string()))
     }
 
     /// Trigger `SAVE` inside a running Redis container and copy the

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -292,7 +292,7 @@ impl AwsService for ElastiCacheService {
             "ListTagsForResource" => self.list_tags_for_resource(&request),
             "ModifyCacheSubnetGroup" => self.modify_cache_subnet_group(&request),
             "ModifyGlobalReplicationGroup" => self.modify_global_replication_group(&request),
-            "ModifyReplicationGroup" => self.modify_replication_group(&request),
+            "ModifyReplicationGroup" => self.modify_replication_group(&request).await,
             "ModifyServerlessCache" => self.modify_serverless_cache(&request),
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
             "TestFailover" => self.test_failover(&request),
@@ -305,7 +305,7 @@ impl AwsService for ElastiCacheService {
             "DescribeCacheSecurityGroups" => self.describe_cache_security_groups(&request),
             "CreateCacheParameterGroup" => self.create_cache_parameter_group(&request),
             "DeleteCacheParameterGroup" => self.delete_cache_parameter_group(&request),
-            "ModifyCacheParameterGroup" => self.modify_cache_parameter_group(&request),
+            "ModifyCacheParameterGroup" => self.modify_cache_parameter_group(&request).await,
             "ResetCacheParameterGroup" => self.reset_cache_parameter_group(&request),
             "DescribeCacheParameters" => self.describe_cache_parameters(&request),
             "ModifyCacheCluster" => self.modify_cache_cluster(&request),
@@ -325,8 +325,8 @@ impl AwsService for ElastiCacheService {
             "RebalanceSlotsInGlobalReplicationGroup" => {
                 self.rebalance_slots_in_global_replication_group(&request)
             }
-            "ModifyUser" => self.modify_user(&request),
-            "ModifyUserGroup" => self.modify_user_group(&request),
+            "ModifyUser" => self.modify_user(&request).await,
+            "ModifyUserGroup" => self.modify_user_group(&request).await,
             "PurchaseReservedCacheNodesOffering" => {
                 self.purchase_reserved_cache_nodes_offering(&request)
             }
@@ -1034,7 +1034,7 @@ impl ElastiCacheService {
             container_id: running.container_id,
             host_port: running.host_port,
             replication_group_id,
-            cache_parameter_group_name,
+            cache_parameter_group_name: cache_parameter_group_name.clone(),
             security_group_ids,
             log_delivery_configurations,
             transit_encryption_enabled,
@@ -1078,6 +1078,10 @@ impl ElastiCacheService {
             if let Some(ref group_id) = cluster.replication_group_id {
                 add_cluster_to_replication_group(state, group_id, &cluster.cache_cluster_id);
             }
+        }
+        if let Some(ref param_group) = cache_parameter_group_name {
+            self.apply_parameters_for_group(&request.account_id, param_group)
+                .await;
         }
 
         Ok(AwsResponse::xml(
@@ -1420,7 +1424,7 @@ impl ElastiCacheService {
             cluster_enabled,
             kms_key_id,
             auth_token_enabled,
-            user_group_ids,
+            user_group_ids: user_group_ids.clone(),
             multi_az_enabled,
             log_delivery_configurations,
             data_tiering,
@@ -1445,7 +1449,7 @@ impl ElastiCacheService {
             cluster_mode,
             data_tiering_enabled,
             notification_topic_status: None,
-            cache_parameter_group_name,
+            cache_parameter_group_name: cache_parameter_group_name.clone(),
             cache_subnet_group_name,
             security_group_ids,
             preferred_maintenance_window,
@@ -1462,6 +1466,14 @@ impl ElastiCacheService {
             if !tags.is_empty() {
                 merge_tags(state.tags.entry(arn).or_default(), &tags);
             }
+        }
+        if !user_group_ids.is_empty() {
+            self.apply_acls_for_replication_group(&request.account_id, &replication_group_id)
+                .await;
+        }
+        if let Some(ref param_group) = cache_parameter_group_name {
+            self.apply_parameters_for_group(&request.account_id, param_group)
+                .await;
         }
 
         Ok(AwsResponse::xml(
@@ -2507,7 +2519,7 @@ impl ElastiCacheService {
         ))
     }
 
-    fn modify_replication_group(
+    async fn modify_replication_group(
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -2622,151 +2634,161 @@ impl ElastiCacheService {
         let new_notification_topic_status =
             optional_query_param(request, "NotificationTopicStatus");
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
+        let (group, region, rg_id, had_user_group_changes) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
 
-        let group = state
-            .replication_groups
-            .get_mut(&replication_group_id)
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "ReplicationGroupNotFoundFault",
-                    format!("ReplicationGroup {replication_group_id} not found."),
-                )
-            })?;
+            let group = state
+                .replication_groups
+                .get_mut(&replication_group_id)
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "ReplicationGroupNotFoundFault",
+                        format!("ReplicationGroup {replication_group_id} not found."),
+                    )
+                })?;
 
-        if let Some(desc) = new_description {
-            group.description = desc;
-        }
-        if let Some(node_type) = new_cache_node_type {
-            group.cache_node_type = node_type;
-        }
-        if let Some(version) = new_engine_version {
-            group.engine_version = version;
-        }
-        if let Some(af) = new_automatic_failover {
-            group.automatic_failover_enabled = af;
-        }
-        if let Some(limit) = new_snapshot_retention_limit {
-            group.snapshot_retention_limit = limit;
-        }
-        if let Some(window) = new_snapshot_window {
-            group.snapshot_window = window;
-        }
-        if let Some(transit) = new_transit_encryption_enabled {
-            group.transit_encryption_enabled = transit;
-        }
-        if let Some(mode) = new_transit_encryption_mode {
-            group.transit_encryption_mode = Some(mode);
-        }
-        if let Some(at_rest) = new_at_rest_encryption_enabled {
-            group.at_rest_encryption_enabled = at_rest;
-        }
-        if let Some(kms) = new_kms_key_id {
-            group.kms_key_id = Some(kms);
-        }
-        if let Some(multi_az) = new_multi_az_enabled {
-            group.multi_az_enabled = multi_az;
-        }
-        if let Some(ip_discovery) = new_ip_discovery {
-            group.ip_discovery = Some(ip_discovery);
-        }
-        if let Some(network_type) = new_network_type {
-            group.network_type = Some(network_type);
-        }
-        if let Some(cluster_mode) = new_cluster_mode {
-            // ClusterMode "enabled"/"compatible" both flip cluster_enabled true;
-            // "disabled" turns it off. Mirrors create_replication_group semantics.
-            let enabled = cluster_mode == "enabled" || cluster_mode == "compatible";
-            group.cluster_enabled = enabled;
-            group.cluster_mode = Some(cluster_mode);
-        }
-        if let Some(window) = new_preferred_maintenance_window {
-            group.preferred_maintenance_window = Some(window);
-        }
-        if let Some(name) = new_cache_parameter_group_name {
-            group.cache_parameter_group_name = Some(name);
-        }
-        if let Some(amvu) = new_auto_minor_version_upgrade {
-            group.auto_minor_version_upgrade = amvu;
-        }
-        if let Some(arn) = new_notification_topic_arn {
-            group.notification_topic_arn = Some(arn);
-        }
-        if let Some(status) = new_notification_topic_status {
-            group.notification_topic_status = Some(status);
-        }
-        if has_log_delivery_input {
-            // AWS replaces the full log-delivery configuration set per call;
-            // disabled entries (Enabled=false) are dropped from state.
-            group.log_delivery_configurations = new_log_delivery_configurations;
-        }
-        if remove_user_groups == Some(true) {
-            group.user_group_ids.clear();
-        }
-        // Add / remove user-group ids on the replication group itself.
-        // Skipped when RemoveUserGroups already cleared the list above only
-        // for removes; adds still apply because AWS lets a single call clear
-        // and then re-attach. Dedup on add to match AWS idempotency.
-        for ug_id in &user_group_ids_to_add {
-            if !group.user_group_ids.contains(ug_id) {
-                group.user_group_ids.push(ug_id.clone());
+            if let Some(desc) = new_description {
+                group.description = desc;
             }
-        }
-        for ug_id in &user_group_ids_to_remove {
-            group.user_group_ids.retain(|id| id != ug_id);
-        }
-        // AuthToken rotation: SET / ROTATE store the new token, DELETE clears
-        // it. Default strategy is SET when AuthToken is supplied without one.
-        match new_auth_token_strategy.as_deref() {
-            Some("DELETE") => {
-                group.auth_token = None;
-                group.auth_token_enabled = false;
+            if let Some(node_type) = new_cache_node_type {
+                group.cache_node_type = node_type;
             }
-            Some("SET") | Some("ROTATE") => {
-                if let Some(token) = new_auth_token {
-                    group.auth_token = Some(token);
-                    group.auth_token_enabled = true;
+            if let Some(version) = new_engine_version {
+                group.engine_version = version;
+            }
+            if let Some(af) = new_automatic_failover {
+                group.automatic_failover_enabled = af;
+            }
+            if let Some(limit) = new_snapshot_retention_limit {
+                group.snapshot_retention_limit = limit;
+            }
+            if let Some(window) = new_snapshot_window {
+                group.snapshot_window = window;
+            }
+            if let Some(transit) = new_transit_encryption_enabled {
+                group.transit_encryption_enabled = transit;
+            }
+            if let Some(mode) = new_transit_encryption_mode {
+                group.transit_encryption_mode = Some(mode);
+            }
+            if let Some(at_rest) = new_at_rest_encryption_enabled {
+                group.at_rest_encryption_enabled = at_rest;
+            }
+            if let Some(kms) = new_kms_key_id {
+                group.kms_key_id = Some(kms);
+            }
+            if let Some(multi_az) = new_multi_az_enabled {
+                group.multi_az_enabled = multi_az;
+            }
+            if let Some(ip_discovery) = new_ip_discovery {
+                group.ip_discovery = Some(ip_discovery);
+            }
+            if let Some(network_type) = new_network_type {
+                group.network_type = Some(network_type);
+            }
+            if let Some(cluster_mode) = new_cluster_mode {
+                // ClusterMode "enabled"/"compatible" both flip cluster_enabled true;
+                // "disabled" turns it off. Mirrors create_replication_group semantics.
+                let enabled = cluster_mode == "enabled" || cluster_mode == "compatible";
+                group.cluster_enabled = enabled;
+                group.cluster_mode = Some(cluster_mode);
+            }
+            if let Some(window) = new_preferred_maintenance_window {
+                group.preferred_maintenance_window = Some(window);
+            }
+            if let Some(name) = new_cache_parameter_group_name {
+                group.cache_parameter_group_name = Some(name);
+            }
+            if let Some(amvu) = new_auto_minor_version_upgrade {
+                group.auto_minor_version_upgrade = amvu;
+            }
+            if let Some(arn) = new_notification_topic_arn {
+                group.notification_topic_arn = Some(arn);
+            }
+            if let Some(status) = new_notification_topic_status {
+                group.notification_topic_status = Some(status);
+            }
+            if has_log_delivery_input {
+                // AWS replaces the full log-delivery configuration set per call;
+                // disabled entries (Enabled=false) are dropped from state.
+                group.log_delivery_configurations = new_log_delivery_configurations;
+            }
+            if remove_user_groups == Some(true) {
+                group.user_group_ids.clear();
+            }
+            // Add / remove user-group ids on the replication group itself.
+            // Skipped when RemoveUserGroups already cleared the list above only
+            // for removes; adds still apply because AWS lets a single call clear
+            // and then re-attach. Dedup on add to match AWS idempotency.
+            for ug_id in &user_group_ids_to_add {
+                if !group.user_group_ids.contains(ug_id) {
+                    group.user_group_ids.push(ug_id.clone());
                 }
             }
-            Some(other) => {
-                return Err(AwsServiceError::aws_error(
+            for ug_id in &user_group_ids_to_remove {
+                group.user_group_ids.retain(|id| id != ug_id);
+            }
+            // AuthToken rotation: SET / ROTATE store the new token, DELETE clears
+            // it. Default strategy is SET when AuthToken is supplied without one.
+            match new_auth_token_strategy.as_deref() {
+                Some("DELETE") => {
+                    group.auth_token = None;
+                    group.auth_token_enabled = false;
+                }
+                Some("SET") | Some("ROTATE") => {
+                    if let Some(token) = new_auth_token {
+                        group.auth_token = Some(token);
+                        group.auth_token_enabled = true;
+                    }
+                }
+                Some(other) => {
+                    return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "InvalidParameterValue",
                     format!(
                         "Invalid value for AuthTokenUpdateStrategy: '{other}'. Valid values: SET, ROTATE, DELETE."
                     ),
                 ));
-            }
-            None => {
-                if let Some(token) = new_auth_token {
-                    group.auth_token = Some(token);
-                    group.auth_token_enabled = true;
+                }
+                None => {
+                    if let Some(token) = new_auth_token {
+                        group.auth_token = Some(token);
+                        group.auth_token_enabled = true;
+                    }
                 }
             }
-        }
 
-        // Mirror the membership change onto the user-group side so
-        // DescribeUserGroups reflects which RGs each group covers.
-        for ug_id in &user_group_ids_to_add {
-            if let Some(ug) = state.user_groups.get_mut(ug_id) {
-                if !ug.replication_groups.contains(&replication_group_id) {
-                    ug.replication_groups.push(replication_group_id.clone());
+            // Mirror the membership change onto the user-group side so
+            // DescribeUserGroups reflects which RGs each group covers.
+            for ug_id in &user_group_ids_to_add {
+                if let Some(ug) = state.user_groups.get_mut(ug_id) {
+                    if !ug.replication_groups.contains(&replication_group_id) {
+                        ug.replication_groups.push(replication_group_id.clone());
+                    }
                 }
             }
-        }
-        for ug_id in &user_group_ids_to_remove {
-            if let Some(ug) = state.user_groups.get_mut(ug_id) {
-                ug.replication_groups
-                    .retain(|id| id != &replication_group_id);
+            for ug_id in &user_group_ids_to_remove {
+                if let Some(ug) = state.user_groups.get_mut(ug_id) {
+                    ug.replication_groups
+                        .retain(|id| id != &replication_group_id);
+                }
             }
-        }
 
-        let group = state.replication_groups[&replication_group_id].clone();
-        let region = state.region.clone();
+            let group = state.replication_groups[&replication_group_id].clone();
+            let region = state.region.clone();
+            let rg_id = replication_group_id.clone();
+            let had_user_group_changes = !user_group_ids_to_add.is_empty()
+                || remove_user_groups == Some(true)
+                || !user_group_ids_to_remove.is_empty();
+            (group, region, rg_id, had_user_group_changes)
+        };
         let xml = replication_group_xml(&group, &region);
-
+        if had_user_group_changes {
+            self.apply_acls_for_replication_group(&request.account_id, &rg_id)
+                .await;
+        }
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
@@ -3956,7 +3978,7 @@ impl ElastiCacheService {
         ))
     }
 
-    fn modify_cache_parameter_group(
+    async fn modify_cache_parameter_group(
         &self,
         request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -3967,40 +3989,44 @@ impl ElastiCacheService {
             "ParameterName",
             "ParameterValue",
         );
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
-        if !state
-            .parameter_groups
-            .iter()
-            .any(|g| g.cache_parameter_group_name == name)
         {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "CacheParameterGroupNotFound",
-                format!("CacheParameterGroup {name} not found."),
-            ));
-        }
-        let params = state
-            .parameter_group_parameters
-            .entry(name.clone())
-            .or_default();
-        for (param_name, value) in updates {
-            if let Some(existing) = params.iter_mut().find(|p| p.parameter_name == param_name) {
-                existing.parameter_value = value;
-                existing.source = "user".to_string();
-            } else {
-                params.push(crate::state::CacheParameter {
-                    parameter_name: param_name,
-                    parameter_value: value,
-                    description: String::new(),
-                    source: "user".to_string(),
-                    data_type: "string".to_string(),
-                    allowed_values: String::new(),
-                    is_modifiable: true,
-                    minimum_engine_version: String::new(),
-                });
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            if !state
+                .parameter_groups
+                .iter()
+                .any(|g| g.cache_parameter_group_name == name)
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "CacheParameterGroupNotFound",
+                    format!("CacheParameterGroup {name} not found."),
+                ));
+            }
+            let params = state
+                .parameter_group_parameters
+                .entry(name.clone())
+                .or_default();
+            for (param_name, value) in updates {
+                if let Some(existing) = params.iter_mut().find(|p| p.parameter_name == param_name) {
+                    existing.parameter_value = value;
+                    existing.source = "user".to_string();
+                } else {
+                    params.push(crate::state::CacheParameter {
+                        parameter_name: param_name,
+                        parameter_value: value,
+                        description: String::new(),
+                        source: "user".to_string(),
+                        data_type: "string".to_string(),
+                        allowed_values: String::new(),
+                        is_modifiable: true,
+                        minimum_engine_version: String::new(),
+                    });
+                }
             }
         }
+        self.apply_parameters_for_group(&request.account_id, &name)
+            .await;
         let body = format!(
             "<CacheParameterGroupName>{}</CacheParameterGroupName>",
             xml_escape(&name)
@@ -4405,50 +4431,81 @@ impl ElastiCacheService {
 
     // ── Users / User groups (modify) ──
 
-    fn modify_user(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn modify_user(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "UserId")?;
         let access_string = optional_query_param(request, "AccessString");
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
-        let user = state.users.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "UserNotFound",
-                format!("User {id} not found."),
-            )
-        })?;
-        if let Some(a) = access_string {
-            user.access_string = a;
+        let (xml, affected_rg_ids) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let user = state.users.get_mut(&id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "UserNotFound",
+                    format!("User {id} not found."),
+                )
+            })?;
+            if let Some(a) = access_string {
+                user.access_string = a;
+            }
+            user.status = "modifying".to_string();
+            let rg_ids: Vec<String> = state
+                .replication_groups
+                .values()
+                .filter(|rg| {
+                    rg.user_group_ids
+                        .iter()
+                        .any(|ug| user.user_group_ids.contains(ug))
+                })
+                .map(|rg| rg.replication_group_id.clone())
+                .collect();
+            (user_xml(user), rg_ids)
+        };
+        for rg_id in affected_rg_ids {
+            self.apply_acls_for_replication_group(&request.account_id, &rg_id)
+                .await;
         }
-        user.status = "modifying".to_string();
-        let xml = user_xml(user);
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml("ModifyUser", ELASTICACHE_NS, &xml, &request.request_id),
         ))
     }
 
-    fn modify_user_group(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn modify_user_group(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let id = required_query_param(request, "UserGroupId")?;
         let to_add = collect_indexed_strings(request, "UserIdsToAdd.member");
         let to_remove = collect_indexed_strings(request, "UserIdsToRemove.member");
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&request.account_id);
-        let group = state.user_groups.get_mut(&id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "UserGroupNotFoundFault",
-                format!("UserGroup {id} not found."),
-            )
-        })?;
-        for u in to_add {
-            if !group.user_ids.contains(&u) {
-                group.user_ids.push(u);
+        let (xml, affected_rg_ids) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let group = state.user_groups.get_mut(&id).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::NOT_FOUND,
+                    "UserGroupNotFoundFault",
+                    format!("UserGroup {id} not found."),
+                )
+            })?;
+            for u in to_add {
+                if !group.user_ids.contains(&u) {
+                    group.user_ids.push(u);
+                }
             }
+            group.user_ids.retain(|u| !to_remove.contains(u));
+            group.status = "modifying".to_string();
+            let rg_ids: Vec<String> = state
+                .replication_groups
+                .values()
+                .filter(|rg| rg.user_group_ids.contains(&id))
+                .map(|rg| rg.replication_group_id.clone())
+                .collect();
+            (user_group_xml(group), rg_ids)
+        };
+        for rg_id in affected_rg_ids {
+            self.apply_acls_for_replication_group(&request.account_id, &rg_id)
+                .await;
         }
-        group.user_ids.retain(|u| !to_remove.contains(u));
-        group.status = "modifying".to_string();
-        let xml = user_group_xml(group);
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml("ModifyUserGroup", ELASTICACHE_NS, &xml, &request.request_id),
@@ -4841,6 +4898,128 @@ impl ElastiCacheService {
                 &request.request_id,
             ),
         ))
+    }
+
+    /// Best-effort ACL application: push every user from every user group
+    /// attached to the replication group into the running Redis container
+    /// via `ACL SETUSER`.
+    async fn apply_acls_for_replication_group(&self, account_id: &str, rg_id: &str) {
+        let Some(runtime) = self.runtime.as_ref() else {
+            return;
+        };
+        let users = {
+            let accounts = self.state.read();
+            let state = accounts.get(account_id);
+            let Some(state) = state else { return };
+            let Some(rg) = state.replication_groups.get(rg_id) else {
+                return;
+            };
+            let mut users = Vec::new();
+            for ug_id in &rg.user_group_ids {
+                if let Some(ug) = state.user_groups.get(ug_id) {
+                    for uid in &ug.user_ids {
+                        if let Some(u) = state.users.get(uid) {
+                            users.push(u.clone());
+                        }
+                    }
+                }
+            }
+            users
+        };
+        for user in &users {
+            let mut args = vec![
+                "ACL".to_string(),
+                "SETUSER".to_string(),
+                user.user_id.clone(),
+            ];
+            args.extend(user.access_string.split_whitespace().map(|s| s.to_string()));
+            match runtime.exec_redis(rg_id, &args).await {
+                Ok(output) if !output.status.success() => {
+                    tracing::warn!(
+                        rg_id = %rg_id,
+                        user_id = %user.user_id,
+                        stderr = %String::from_utf8_lossy(&output.stderr),
+                        "ACL SETUSER failed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        rg_id = %rg_id,
+                        user_id = %user.user_id,
+                        %e,
+                        "ACL SETUSER exec failed"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Best-effort parameter application: run `CONFIG SET` for every
+    /// user-modified parameter on every Redis/Valkey cluster and
+    /// replication group that uses the given parameter group.
+    async fn apply_parameters_for_group(&self, account_id: &str, param_group_name: &str) {
+        let Some(runtime) = self.runtime.as_ref() else {
+            return;
+        };
+        let (target_ids, params) = {
+            let accounts = self.state.read();
+            let state = accounts.get(account_id);
+            let Some(state) = state else { return };
+            let mut target_ids = Vec::new();
+            for c in state.cache_clusters.values() {
+                if c.cache_parameter_group_name.as_deref() == Some(param_group_name)
+                    && (c.engine == ENGINE_REDIS || c.engine == ENGINE_VALKEY)
+                {
+                    target_ids.push(c.cache_cluster_id.clone());
+                }
+            }
+            for g in state.replication_groups.values() {
+                if g.cache_parameter_group_name.as_deref() == Some(param_group_name)
+                    && (g.engine == ENGINE_REDIS || g.engine == ENGINE_VALKEY)
+                {
+                    target_ids.push(g.replication_group_id.clone());
+                }
+            }
+            let params = state
+                .parameter_group_parameters
+                .get(param_group_name)
+                .cloned()
+                .unwrap_or_default();
+            (target_ids, params)
+        };
+        for id in target_ids {
+            for param in &params {
+                if !param.is_modifiable {
+                    continue;
+                }
+                let args = vec![
+                    "CONFIG".to_string(),
+                    "SET".to_string(),
+                    param.parameter_name.clone(),
+                    param.parameter_value.clone(),
+                ];
+                match runtime.exec_redis(&id, &args).await {
+                    Ok(output) if !output.status.success() => {
+                        tracing::warn!(
+                            resource_id = %id,
+                            param = %param.parameter_name,
+                            stderr = %String::from_utf8_lossy(&output.stderr),
+                            "CONFIG SET failed"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            resource_id = %id,
+                            param = %param.parameter_name,
+                            %e,
+                            "CONFIG SET exec failed"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
 }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -5006,6 +5006,7 @@ impl ElastiCacheService {
                 "ACL".to_string(),
                 "SETUSER".to_string(),
                 user.user_id.clone(),
+                "reset".to_string(),
             ];
             args.extend(user.access_string.split_whitespace().map(|s| s.to_string()));
             match runtime.exec_redis(rg_id, &args).await {

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -4487,13 +4487,27 @@ impl ElastiCacheService {
                     format!("UserGroup {id} not found."),
                 )
             })?;
-            for u in to_add {
-                if !group.user_ids.contains(&u) {
-                    group.user_ids.push(u);
+            for u in &to_add {
+                if !group.user_ids.contains(u) {
+                    group.user_ids.push(u.clone());
                 }
             }
             group.user_ids.retain(|u| !to_remove.contains(u));
             group.status = "modifying".to_string();
+            // Keep the reverse mapping on each User in sync so that
+            // ModifyUser can resolve the correct replication groups.
+            for u in &to_add {
+                if let Some(user) = state.users.get_mut(u) {
+                    if !user.user_group_ids.contains(&id) {
+                        user.user_group_ids.push(id.clone());
+                    }
+                }
+            }
+            for u in &to_remove {
+                if let Some(user) = state.users.get_mut(u) {
+                    user.user_group_ids.retain(|ug| ug != &id);
+                }
+            }
             let rg_ids: Vec<String> = state
                 .replication_groups
                 .values()
@@ -4902,12 +4916,12 @@ impl ElastiCacheService {
 
     /// Best-effort ACL application: push every user from every user group
     /// attached to the replication group into the running Redis container
-    /// via `ACL SETUSER`.
+    /// via `ACL SETUSER`, and remove any users that are no longer attached.
     async fn apply_acls_for_replication_group(&self, account_id: &str, rg_id: &str) {
         let Some(runtime) = self.runtime.as_ref() else {
             return;
         };
-        let users = {
+        let (users, all_known_user_ids) = {
             let accounts = self.state.read();
             let state = accounts.get(account_id);
             let Some(state) = state else { return };
@@ -4915,6 +4929,11 @@ impl ElastiCacheService {
                 return;
             };
             let mut users = Vec::new();
+            let mut all_known_user_ids: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for u in state.users.values() {
+                all_known_user_ids.insert(u.user_id.clone());
+            }
             for ug_id in &rg.user_group_ids {
                 if let Some(ug) = state.user_groups.get(ug_id) {
                     for uid in &ug.user_ids {
@@ -4924,8 +4943,64 @@ impl ElastiCacheService {
                     }
                 }
             }
-            users
+            (users, all_known_user_ids)
         };
+
+        // Remove users that are no longer attached to this replication group.
+        // We query the current ACL list from Redis and delete any custom user
+        // (other than "default") that is not in the desired set.
+        let desired: std::collections::HashSet<String> =
+            users.iter().map(|u| u.user_id.clone()).collect();
+        match runtime
+            .exec_redis(rg_id, &["ACL".to_string(), "USERS".to_string()])
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    let username = line.trim().trim_matches('"');
+                    if username == "default" || username.is_empty() {
+                        continue;
+                    }
+                    // Only delete users that exist in our fakecloud state but
+                    // are no longer attached to this RG.  This avoids
+                    // accidentally deleting users that belong to another
+                    // service sharing the same Redis container.
+                    if all_known_user_ids.contains(username) && !desired.contains(username) {
+                        let del_args = vec![
+                            "ACL".to_string(),
+                            "DELUSER".to_string(),
+                            username.to_string(),
+                        ];
+                        if let Ok(del_out) = runtime.exec_redis(rg_id, &del_args).await {
+                            if !del_out.status.success() {
+                                tracing::warn!(
+                                    rg_id = %rg_id,
+                                    user_id = %username,
+                                    stderr = %String::from_utf8_lossy(&del_out.stderr),
+                                    "ACL DELUSER failed"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(output) => {
+                tracing::warn!(
+                    rg_id = %rg_id,
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    "ACL USERS failed"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    rg_id = %rg_id,
+                    %e,
+                    "ACL USERS exec failed"
+                );
+            }
+        }
+
         for user in &users {
             let mut args = vec![
                 "ACL".to_string(),

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -1484,8 +1484,8 @@ fn disassociate_global_replication_group_accepts_current_primary_as_noop() {
     assert!(body.contains("<DisassociateGlobalReplicationGroupResponse"));
 }
 
-#[test]
-fn modify_replication_group_updates_description() {
+#[tokio::test]
+async fn modify_replication_group_updates_description() {
     let service = service_with_replication_group("my-rg", 1);
     let req = request(
         "ModifyReplicationGroup",
@@ -1494,14 +1494,14 @@ fn modify_replication_group_updates_description() {
             ("ReplicationGroupDescription", "Updated description"),
         ],
     );
-    let resp = service.modify_replication_group(&req).unwrap();
+    let resp = service.modify_replication_group(&req).await.unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<Description>Updated description</Description>"));
     assert!(body.contains("<ModifyReplicationGroupResponse"));
 }
 
-#[test]
-fn modify_replication_group_updates_multiple_fields() {
+#[tokio::test]
+async fn modify_replication_group_updates_multiple_fields() {
     let service = service_with_replication_group("my-rg", 1);
     let req = request(
         "ModifyReplicationGroup",
@@ -1513,7 +1513,7 @@ fn modify_replication_group_updates_multiple_fields() {
             ("SnapshotWindow", "02:00-06:00"),
         ],
     );
-    let resp = service.modify_replication_group(&req).unwrap();
+    let resp = service.modify_replication_group(&req).await.unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<CacheNodeType>cache.m5.large</CacheNodeType>"));
     assert!(body.contains("<AutomaticFailover>enabled</AutomaticFailover>"));
@@ -1521,8 +1521,8 @@ fn modify_replication_group_updates_multiple_fields() {
     assert!(body.contains("<SnapshotWindow>02:00-06:00</SnapshotWindow>"));
 }
 
-#[test]
-fn modify_replication_group_not_found() {
+#[tokio::test]
+async fn modify_replication_group_not_found() {
     let shared = std::sync::Arc::new(parking_lot::RwLock::new(
         fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
     ));
@@ -1531,11 +1531,11 @@ fn modify_replication_group_not_found() {
         "ModifyReplicationGroup",
         &[("ReplicationGroupId", "nonexistent")],
     );
-    assert!(service.modify_replication_group(&req).is_err());
+    assert!(service.modify_replication_group(&req).await.is_err());
 }
 
-#[test]
-fn modify_replication_group_updates_auth_token_with_set() {
+#[tokio::test]
+async fn modify_replication_group_updates_auth_token_with_set() {
     let service = service_with_replication_group("rg-auth", 1);
     {
         let mut a = service.state.write();
@@ -1555,7 +1555,7 @@ fn modify_replication_group_updates_auth_token_with_set() {
             ("AuthTokenUpdateStrategy", "SET"),
         ],
     );
-    let resp = service.modify_replication_group(&req).unwrap();
+    let resp = service.modify_replication_group(&req).await.unwrap();
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     // Token is never echoed back in the XML payload.
     assert!(!body.contains("<AuthToken>"));
@@ -1567,8 +1567,8 @@ fn modify_replication_group_updates_auth_token_with_set() {
     assert!(g.auth_token_enabled);
 }
 
-#[test]
-fn modify_replication_group_delete_auth_token_strategy_clears_token() {
+#[tokio::test]
+async fn modify_replication_group_delete_auth_token_strategy_clears_token() {
     let service = service_with_replication_group("rg-del", 1);
     {
         let mut a = service.state.write();
@@ -1587,7 +1587,7 @@ fn modify_replication_group_delete_auth_token_strategy_clears_token() {
             ("AuthTokenUpdateStrategy", "DELETE"),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let a = service.state.read();
     let g = a.default_ref().replication_groups.get("rg-del").unwrap();
@@ -1595,8 +1595,8 @@ fn modify_replication_group_delete_auth_token_strategy_clears_token() {
     assert!(!g.auth_token_enabled);
 }
 
-#[test]
-fn modify_replication_group_remove_user_groups_clears_list() {
+#[tokio::test]
+async fn modify_replication_group_remove_user_groups_clears_list() {
     let service = service_with_replication_group("rg-ug", 1);
     {
         let mut a = service.state.write();
@@ -1610,15 +1610,15 @@ fn modify_replication_group_remove_user_groups_clears_list() {
             ("RemoveUserGroups", "true"),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let a = service.state.read();
     let g = a.default_ref().replication_groups.get("rg-ug").unwrap();
     assert!(g.user_group_ids.is_empty());
 }
 
-#[test]
-fn modify_replication_group_persists_log_delivery_changes() {
+#[tokio::test]
+async fn modify_replication_group_persists_log_delivery_changes() {
     let service = service_with_replication_group("rg-log", 1);
     {
         let mut a = service.state.write();
@@ -1673,7 +1673,7 @@ fn modify_replication_group_persists_log_delivery_changes() {
             ),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let describe = request(
         "DescribeReplicationGroups",
@@ -1690,8 +1690,8 @@ fn modify_replication_group_persists_log_delivery_changes() {
     assert_eq!(g.log_delivery_configurations.len(), 2);
 }
 
-#[test]
-fn modify_replication_group_persists_multi_az_and_network_fields() {
+#[tokio::test]
+async fn modify_replication_group_persists_multi_az_and_network_fields() {
     let service = service_with_replication_group("rg-net", 1);
     let req = request(
         "ModifyReplicationGroup",
@@ -1702,7 +1702,7 @@ fn modify_replication_group_persists_multi_az_and_network_fields() {
             ("NetworkType", "dual_stack"),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let describe = request(
         "DescribeReplicationGroups",
@@ -1715,8 +1715,8 @@ fn modify_replication_group_persists_multi_az_and_network_fields() {
     assert!(body.contains("<NetworkType>dual_stack</NetworkType>"));
 }
 
-#[test]
-fn modify_replication_group_persists_snapshot_retention_and_window() {
+#[tokio::test]
+async fn modify_replication_group_persists_snapshot_retention_and_window() {
     let service = service_with_replication_group("rg-snap", 1);
     let req = request(
         "ModifyReplicationGroup",
@@ -1726,7 +1726,7 @@ fn modify_replication_group_persists_snapshot_retention_and_window() {
             ("SnapshotWindow", "01:00-03:00"),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let describe = request(
         "DescribeReplicationGroups",
@@ -1738,8 +1738,8 @@ fn modify_replication_group_persists_snapshot_retention_and_window() {
     assert!(body.contains("<SnapshotWindow>01:00-03:00</SnapshotWindow>"));
 }
 
-#[test]
-fn modify_replication_group_persists_notification_topic_attrs() {
+#[tokio::test]
+async fn modify_replication_group_persists_notification_topic_attrs() {
     let service = service_with_replication_group("rg-notif", 1);
     let topic_arn = "arn:aws:sns:us-east-1:123456789012:elasticache-events";
     let req = request(
@@ -1750,7 +1750,7 @@ fn modify_replication_group_persists_notification_topic_attrs() {
             ("NotificationTopicStatus", "inactive"),
         ],
     );
-    service.modify_replication_group(&req).unwrap();
+    service.modify_replication_group(&req).await.unwrap();
 
     let describe = request(
         "DescribeReplicationGroups",
@@ -3629,8 +3629,8 @@ fn delete_unknown_security_group_errors() {
     assert_eq!(err.code(), "CacheSecurityGroupNotFound");
 }
 
-#[test]
-fn cache_parameter_group_full_lifecycle_unit() {
+#[tokio::test]
+async fn cache_parameter_group_full_lifecycle_unit() {
     let svc = fresh_service();
     let create = request(
         "CreateCacheParameterGroup",
@@ -3653,7 +3653,7 @@ fn cache_parameter_group_full_lifecycle_unit() {
             ("ParameterNameValues.member.1.ParameterValue", "allkeys-lru"),
         ],
     );
-    svc.modify_cache_parameter_group(&modify).unwrap();
+    svc.modify_cache_parameter_group(&modify).await.unwrap();
 
     let describe = request(
         "DescribeCacheParameters",
@@ -3832,22 +3832,22 @@ async fn reboot_cache_cluster_marks_rebooting_when_no_runtime() {
     );
 }
 
-#[test]
-fn modify_unknown_user_errors() {
+#[tokio::test]
+async fn modify_unknown_user_errors() {
     let svc = fresh_service();
     let req = request("ModifyUser", &[("UserId", "ghost")]);
-    let err = match svc.modify_user(&req) {
+    let err = match svc.modify_user(&req).await {
         Err(e) => e,
         Ok(_) => panic!("expected error"),
     };
     assert_eq!(err.code(), "UserNotFound");
 }
 
-#[test]
-fn modify_unknown_user_group_errors() {
+#[tokio::test]
+async fn modify_unknown_user_group_errors() {
     let svc = fresh_service();
     let req = request("ModifyUserGroup", &[("UserGroupId", "ghost")]);
-    let err = match svc.modify_user_group(&req) {
+    let err = match svc.modify_user_group(&req).await {
         Err(e) => e,
         Ok(_) => panic!("expected error"),
     };


### PR DESCRIPTION
## Summary
- Apply Redis ACLs (`ACL SETUSER`) to running containers when users/user groups/replication groups are modified
- Apply parameter group changes (`CONFIG SET`) to running Redis/Valkey containers when parameter groups are modified or clusters are created
- Emit `ConfigurationEndpoint` for standalone Memcached clusters in `DescribeCacheClusters` XML
- Add `exec_redis` to `ElastiCacheRuntime` for arbitrary redis-cli commands
- Migrate service tests to `#[tokio::test]` for async runtime calls
- Add E2E tests for ACL application, CONFIG SET, and Memcached endpoint emission

## Test plan
- [x] `cargo test -p fakecloud-elasticache` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] E2E tests pass (Docker tests skip gracefully when unavailable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pushes Redis ACLs and parameter updates live to running clusters, and emits the Memcached ConfigurationEndpoint. Adds `exec_redis`, makes modify paths async, and expands E2E coverage.

- **New Features**
  - Apply ACLs to running Redis on user/user group/replication group changes (ACL SETUSER).
  - Apply parameter group updates to Redis/Valkey on modify and on create for clusters and replication groups (CONFIG SET).
  - Emit ConfigurationEndpoint for standalone Memcached clusters in DescribeCacheClusters.
  - Add `exec_redis` on `ElastiCacheRuntime` for arbitrary `redis-cli` commands.

- **Refactors & Fixes**
  - Convert modify handlers to async: ModifyReplicationGroup, ModifyUser, ModifyUserGroup, ModifyCacheParameterGroup.
  - Migrate service tests to `#[tokio::test]` and add E2E tests for ACLs, CONFIG SET, and the Memcached endpoint.
  - Remove detached users via ACL DELUSER and keep reverse `user.user_group_ids` mapping in sync.
  - Stabilize ACL/CONFIG E2E probes: correct RESP for ACL LIST, verify CONFIG SET, make CONFIG probe non-destructive (tcp-keepalive, restore default), clearer diagnostics.
  - Prepend reset to ACL SETUSER and tolerate Redis 7 ACL LIST output.

<sup>Written for commit 9d6925d791f4a1373996e3668c0c1421ccbc1847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

