### PR TITLE
feat(apigateway): request validator + model validation in data plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "fakecloud-wafv2",
  "http 1.4.0",
  "parking_lot",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/fakecloud-apigateway/Cargo.toml
+++ b/crates/fakecloud-apigateway/Cargo.toml
@@ -17,6 +17,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -1327,11 +1327,21 @@ fn enforce_request_validator(
             }
             let present = if let Some(name) = param_key.strip_prefix("method.request.querystring.")
             {
-                req.query_params.contains_key(name)
+                req.query_params
+                    .get(name)
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false)
             } else if let Some(name) = param_key.strip_prefix("method.request.path.") {
-                path_params.contains_key(name)
+                path_params
+                    .get(name)
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false)
             } else if let Some(name) = param_key.strip_prefix("method.request.header.") {
-                req.headers.contains_key(name)
+                req.headers
+                    .get(name)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false)
             } else {
                 // Unknown parameter source — skip.
                 true
@@ -1360,12 +1370,13 @@ fn enforce_request_validator(
 
         let model_name = match request_models.get(normalized) {
             Some(name) => name,
-            None => {
-                return Err(bad_request(format!(
-                    "Request body does not match model schema for content type {}",
-                    normalized
-                )));
-            }
+            None => match request_models.get("$default") {
+                Some(name) => name,
+                None => {
+                    // No model for this content type and no $default — skip body validation.
+                    return Ok(());
+                }
+            },
         };
 
         let model = state
@@ -2777,7 +2788,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_model_for_content_type_returns_400() {
+    async fn missing_model_for_content_type_skips_validation() {
         let state = build_state("NONE", None);
         {
             let mut accounts = state.write();
@@ -2790,17 +2801,100 @@ mod tests {
         }
         install_validator_and_model(&state, "val1", false, true);
         let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
         let service = build_service(state, lambda.clone(), None);
         let mut req = make_request(HeaderMap::new());
         req.body = bytes::Bytes::from(r#"{}"#);
+        let resp = handle(&service, &req)
+            .await
+            .expect("missing model skips validation");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
+    }
+
+    #[tokio::test]
+    async fn blank_required_query_parameter_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_parameters
+                    .insert("method.request.querystring.name".to_string(), true);
+            }
+        }
+        install_validator_and_model(&state, "val1", true, false);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.query_params.insert("name".to_string(), "".to_string());
         let err = match handle(&service, &req).await {
             Err(e) => e,
-            Ok(_) => panic!("missing model must 400"),
+            Ok(_) => panic!("blank query param must 400"),
         };
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
-        assert!(err
-            .message()
-            .contains("Request body does not match model schema for content type"));
+        assert!(err.message().contains("Missing required request parameter"));
         assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn blank_required_header_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_parameters
+                    .insert("method.request.header.X-Required".to_string(), true);
+            }
+        }
+        install_validator_and_model(&state, "val1", true, false);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Required", "".parse().unwrap());
+        let err = match handle(&service, &make_request(headers)).await {
+            Err(e) => e,
+            Ok(_) => panic!("blank header must 400"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err.message().contains("Missing required request parameter"));
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn default_model_used_when_no_exact_match() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_models
+                    .insert("$default".to_string(), "ItemModel".to_string());
+            }
+        }
+        install_validator_and_model(&state, "val1", false, true);
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.body = bytes::Bytes::from(r#"{"name": "hello", "count": 42}"#);
+        let resp = handle(&service, &req)
+            .await
+            .expect("$default model should validate");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
     }
 }

--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -40,6 +40,15 @@ struct DataPlaneMatch {
     stage_vars: BTreeMap<String, String>,
     authorization_type: String,
     authorizer: Option<Authorizer>,
+    /// Method-level request parameter declarations (`method.request.*`).
+    /// `true` = required, `false` = optional.
+    request_parameters: BTreeMap<String, bool>,
+    /// Content-type → model name mapping for request body validation.
+    request_models: BTreeMap<String, String>,
+    /// Optional validator ID. When set, the data plane validates request
+    /// parameters and/or body per the validator's configuration before
+    /// invoking the integration.
+    request_validator_id: Option<String>,
     /// Whether the matched method has `apiKeyRequired = true`. When set,
     /// the data plane enforces the `x-api-key` header + the associated
     /// usage plan's throttle/quota before invoking the integration.
@@ -81,6 +90,9 @@ pub async fn handle(
         stage_vars,
         authorization_type,
         authorizer,
+        request_parameters,
+        request_models,
+        request_validator_id,
         api_key_required,
         stage_web_acl_arn,
     } = {
@@ -151,6 +163,17 @@ pub async fn handle(
                             .as_ref()
                             .map(|m| m.api_key_required)
                             .unwrap_or(false);
+                        let request_parameters = method_record
+                            .as_ref()
+                            .map(|m| m.request_parameters.clone())
+                            .unwrap_or_default();
+                        let request_models = method_record
+                            .as_ref()
+                            .map(|m| m.request_models.clone())
+                            .unwrap_or_default();
+                        let request_validator_id = method_record
+                            .as_ref()
+                            .and_then(|m| m.request_validator_id.clone());
                         let stage_web_acl_arn = api_stages
                             .get(&stage_name)
                             .and_then(|s| s.web_acl_arn.clone());
@@ -162,6 +185,9 @@ pub async fn handle(
                             stage_vars,
                             authorization_type,
                             authorizer,
+                            request_parameters,
+                            request_models,
+                            request_validator_id,
                             api_key_required,
                             stage_web_acl_arn,
                         });
@@ -271,6 +297,25 @@ pub async fn handle(
         // `<resource_path>/<HTTP_METHOD>` (e.g. `/items/GET`).
         let method_path = format!("{}/{}", resource_path, req.method.as_str().to_uppercase());
         if let Err(err) = enforce_usage_plan(service, req, &api_id, &stage_name, &method_path) {
+            service.record_request(&req.account_id, &api_id, &stage_name, req, err.status());
+            return Err(err);
+        }
+    }
+
+    // Request validator enforcement: when the matched method references a
+    // validator, check required parameters and/or validate the request body
+    // against the declared model before invoking the integration.
+    if let Some(validator_id) = &request_validator_id {
+        if let Err(err) = enforce_request_validator(
+            service,
+            req,
+            &api_id,
+            &stage_name,
+            validator_id,
+            &request_parameters,
+            &request_models,
+            &path_params,
+        ) {
             service.record_request(&req.account_id, &api_id, &stage_name, req, err.status());
             return Err(err);
         }
@@ -1244,6 +1289,118 @@ fn parse_throttle(t: &serde_json::Value) -> Option<(f64, f64)> {
 /// quota counters at the start of the period (UTC midnight for DAY,
 /// Sunday for WEEK, first-of-month for MONTH); `offset` shifts the
 /// boundary by N days. The returned string is purely a counter key.
+#[allow(clippy::too_many_arguments)]
+fn enforce_request_validator(
+    service: &ApiGatewayService,
+    req: &AwsRequest,
+    api_id: &str,
+    _stage_name: &str,
+    validator_id: &str,
+    request_parameters: &BTreeMap<String, bool>,
+    request_models: &BTreeMap<String, String>,
+    path_params: &BTreeMap<String, String>,
+) -> Result<(), AwsServiceError> {
+    let accounts = service.state_handle().read();
+    let state = accounts
+        .get(&req.account_id)
+        .ok_or_else(|| bad_request("Request validation failed"))?;
+
+    let validator = state
+        .request_validators
+        .get(api_id)
+        .and_then(|m| m.get(validator_id))
+        .ok_or_else(|| bad_request("Request validation failed"))?;
+
+    let validate_body = validator
+        .get("validateRequestBody")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let validate_params = validator
+        .get("validateRequestParameters")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if validate_params {
+        for (param_key, required) in request_parameters {
+            if !*required {
+                continue;
+            }
+            let present = if let Some(name) = param_key.strip_prefix("method.request.querystring.")
+            {
+                req.query_params.contains_key(name)
+            } else if let Some(name) = param_key.strip_prefix("method.request.path.") {
+                path_params.contains_key(name)
+            } else if let Some(name) = param_key.strip_prefix("method.request.header.") {
+                req.headers.contains_key(name)
+            } else {
+                // Unknown parameter source — skip.
+                true
+            };
+            if !present {
+                return Err(bad_request(format!(
+                    "Missing required request parameter: {}",
+                    param_key
+                )));
+            }
+        }
+    }
+
+    if validate_body {
+        let content_type = req
+            .headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/json");
+        // Normalize content-type by stripping charset suffix.
+        let normalized = content_type
+            .split(';')
+            .next()
+            .unwrap_or(content_type)
+            .trim();
+
+        let model_name = match request_models.get(normalized) {
+            Some(name) => name,
+            None => {
+                return Err(bad_request(format!(
+                    "Request body does not match model schema for content type {}",
+                    normalized
+                )));
+            }
+        };
+
+        let model = state
+            .models
+            .get(api_id)
+            .and_then(|m| m.get(model_name))
+            .ok_or_else(|| bad_request("Request body does not match model schema"))?;
+
+        let schema_str = model
+            .schema
+            .as_deref()
+            .ok_or_else(|| bad_request("Request body does not match model schema"))?;
+        let schema: serde_json::Value = serde_json::from_str(schema_str)
+            .map_err(|_| bad_request("Request body does not match model schema"))?;
+
+        let body_json: serde_json::Value = serde_json::from_slice(&req.body)
+            .map_err(|_| bad_request("Request body does not match model schema"))?;
+
+        drop(accounts);
+
+        if let Err(e) = crate::model_validation::validate(&schema, &body_json) {
+            return Err(bad_request(format!(
+                "Request body does not match model schema for content type {}: {}",
+                normalized, e
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn bad_request(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "BadRequestException", msg.into())
+}
+
 fn current_quota_window(
     now: chrono::DateTime<chrono::Utc>,
     period: QuotaPeriod,
@@ -2434,5 +2591,216 @@ mod tests {
         assert_eq!(payload["headers"]["x-custom"], "secret");
         assert_eq!(payload["httpMethod"], "GET");
         assert!(payload["methodArn"].as_str().unwrap().contains("/items"));
+    }
+
+    // ── Request validator tests ──
+
+    fn install_validator_and_model(
+        state: &SharedApiGatewayState,
+        validator_id: &str,
+        validate_params: bool,
+        validate_body: bool,
+    ) {
+        use crate::state::Model;
+        let mut accounts = state.write();
+        let st = accounts.get_or_create(TEST_ACCOUNT);
+        // Register validator
+        let mut validators = std::collections::BTreeMap::new();
+        validators.insert(
+            validator_id.to_string(),
+            serde_json::json!({
+                "id": validator_id,
+                "name": "test-validator",
+                "validateRequestParameters": validate_params,
+                "validateRequestBody": validate_body,
+            }),
+        );
+        st.request_validators
+            .insert(TEST_API_ID.to_string(), validators);
+        // Register model
+        let mut models = std::collections::BTreeMap::new();
+        models.insert(
+            "ItemModel".to_string(),
+            Model {
+                id: "model1".to_string(),
+                name: "ItemModel".to_string(),
+                description: None,
+                schema: Some(r#"{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"count":{"type":"integer"}}}"#.to_string()),
+                content_type: "application/json".to_string(),
+            },
+        );
+        st.models.insert(TEST_API_ID.to_string(), models);
+    }
+
+    #[tokio::test]
+    async fn missing_required_query_parameter_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_parameters
+                    .insert("method.request.querystring.name".to_string(), true);
+            }
+        }
+        install_validator_and_model(&state, "val1", true, false);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let err = match handle(
+            &service,
+            &AwsRequest {
+                query_params: std::collections::HashMap::new(),
+                ..make_request(HeaderMap::new())
+            },
+        )
+        .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("missing query param must 400"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err.message().contains("Missing required request parameter"));
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_required_header_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_parameters
+                    .insert("method.request.header.X-Required".to_string(), true);
+            }
+        }
+        install_validator_and_model(&state, "val1", true, false);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let err = match handle(&service, &make_request(HeaderMap::new())).await {
+            Err(e) => e,
+            Ok(_) => panic!("missing header must 400"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err.message().contains("Missing required request parameter"));
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn present_required_parameters_passes_validation() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_parameters
+                    .insert("method.request.querystring.name".to_string(), true);
+            }
+        }
+        install_validator_and_model(&state, "val1", true, false);
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.query_params
+            .insert("name".to_string(), "test".to_string());
+        let resp = handle(&service, &req)
+            .await
+            .expect("present params must pass");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_body_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_models
+                    .insert("application/json".to_string(), "ItemModel".to_string());
+            }
+        }
+        install_validator_and_model(&state, "val1", false, true);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.body = bytes::Bytes::from(r#"{"count": 42}"#);
+        let err = match handle(&service, &req).await {
+            Err(e) => e,
+            Ok(_) => panic!("invalid body must 400"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err
+            .message()
+            .contains("Request body does not match model schema"));
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
+    }
+
+    #[tokio::test]
+    async fn valid_body_passes_validation() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                m.request_models
+                    .insert("application/json".to_string(), "ItemModel".to_string());
+            }
+        }
+        install_validator_and_model(&state, "val1", false, true);
+        let lambda = Arc::new(StubLambda::new());
+        lambda.set(
+            BACKEND_ARN,
+            serde_json::json!({"statusCode": 200, "body": "ok"}),
+        );
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.body = bytes::Bytes::from(r#"{"name": "hello", "count": 42}"#);
+        let resp = handle(&service, &req).await.expect("valid body must pass");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
+    }
+
+    #[tokio::test]
+    async fn missing_model_for_content_type_returns_400() {
+        let state = build_state("NONE", None);
+        {
+            let mut accounts = state.write();
+            let st = accounts.get_or_create(TEST_ACCOUNT);
+            let mkey = format!("{TEST_API_ID}/{RES_ID}/GET");
+            if let Some(m) = st.methods.get_mut(&mkey) {
+                m.request_validator_id = Some("val1".to_string());
+                // No requestModels registered
+            }
+        }
+        install_validator_and_model(&state, "val1", false, true);
+        let lambda = Arc::new(StubLambda::new());
+        let service = build_service(state, lambda.clone(), None);
+        let mut req = make_request(HeaderMap::new());
+        req.body = bytes::Bytes::from(r#"{}"#);
+        let err = match handle(&service, &req).await {
+            Err(e) => e,
+            Ok(_) => panic!("missing model must 400"),
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(err
+            .message()
+            .contains("Request body does not match model schema for content type"));
+        assert_eq!(lambda.invocation_count(BACKEND_ARN), 0);
     }
 }

--- a/crates/fakecloud-apigateway/src/lib.rs
+++ b/crates/fakecloud-apigateway/src/lib.rs
@@ -14,6 +14,7 @@ pub mod data_plane;
 pub mod dispatch;
 pub mod facade;
 pub mod lambda_proxy;
+pub mod model_validation;
 pub(crate) mod service;
 pub mod state;
 

--- a/crates/fakecloud-apigateway/src/model_validation.rs
+++ b/crates/fakecloud-apigateway/src/model_validation.rs
@@ -245,6 +245,71 @@ fn json_type_str(types: &Value) -> String {
     }
 }
 
+fn is_ipv6(s: &str) -> bool {
+    // Pure IPv6
+    let pure_re = Regex::new(
+        r"^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$",
+    )
+    .unwrap();
+    if pure_re.is_match(s) {
+        return true;
+    }
+
+    // Mixed notation (embedded IPv4)
+    if !s.contains('.') {
+        return false;
+    }
+
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+
+    // Last part must be valid IPv4
+    let last = parts.last().unwrap();
+    let ipv4_re = Regex::new(
+        r"^(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+    )
+    .unwrap();
+    if !ipv4_re.is_match(last) {
+        return false;
+    }
+
+    // Count valid prefix groups
+    let prefix = &parts[..parts.len() - 1];
+    let mut non_empty = 0;
+    let mut empty = 0;
+    for p in prefix {
+        if p.is_empty() {
+            empty += 1;
+        } else if p.len() <= 4 && p.chars().all(|c| c.is_ascii_hexdigit()) {
+            non_empty += 1;
+        } else {
+            return false;
+        }
+    }
+
+    if s == "::" {
+        return true;
+    }
+
+    if empty == 0 {
+        non_empty + 2 == 8
+    } else if empty == 1 {
+        non_empty + 2 < 8
+    } else if empty == 2 {
+        let at_start = prefix.iter().take(2).all(|p| p.is_empty());
+        let at_end = prefix.iter().rev().take(2).all(|p| p.is_empty());
+        if at_start || at_end {
+            non_empty + 2 <= 8
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
 fn check_format(fmt: &str, s: &str) -> bool {
     match fmt {
         "email" => {
@@ -274,11 +339,7 @@ fn check_format(fmt: &str, s: &str) -> bool {
         )
         .map(|re| re.is_match(s))
         .unwrap_or(true),
-        "ipv6" => Regex::new(
-            r"^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$",
-        )
-        .map(|re| re.is_match(s))
-        .unwrap_or(true),
+        "ipv6" => is_ipv6(s),
         _ => true,
     }
 }
@@ -404,5 +465,22 @@ mod tests {
         assert!(validate(&schema, &json!("not-an-ip")).is_err());
         assert!(validate(&schema, &json!("192.168.1.1")).is_err());
         assert!(validate(&schema, &json!(":::")).is_err());
+    }
+
+    #[test]
+    fn format_ipv6_mixed_notation_accepts_valid() {
+        let schema = json!({"type": "string", "format": "ipv6"});
+        assert!(validate(&schema, &json!("::ffff:192.168.1.1")).is_ok());
+        assert!(validate(&schema, &json!("::192.168.1.1")).is_ok());
+        assert!(validate(&schema, &json!("2001:db8::192.168.1.1")).is_ok());
+    }
+
+    #[test]
+    fn format_ipv6_mixed_notation_rejects_invalid() {
+        let schema = json!({"type": "string", "format": "ipv6"});
+        // Too many groups before IPv4
+        assert!(validate(&schema, &json!("2001:db8:1:2:3:4:5:192.168.1.1")).is_err());
+        // Not an IPv4 address
+        assert!(validate(&schema, &json!("::ffff:999.999.999.999")).is_err());
     }
 }

--- a/crates/fakecloud-apigateway/src/model_validation.rs
+++ b/crates/fakecloud-apigateway/src/model_validation.rs
@@ -1,0 +1,369 @@
+//! Minimal JSON Schema Draft 4 validator for API Gateway model validation.
+//!
+//! Supports the subset of JSON Schema that API Gateway commonly uses:
+//! `type`, `required`, `properties`, `items`, `enum`, `minLength`, `maxLength`,
+//! `minimum`, `maximum`, `pattern`, `additionalProperties`, and `format`.
+
+use regex::Regex;
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError {
+    pub path: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Validate `value` against a JSON Schema (Draft 4 subset).
+/// Returns `Ok(())` when valid, or the first validation error encountered.
+pub fn validate(schema: &Value, value: &Value) -> Result<(), ValidationError> {
+    validate_at(schema, value, "")
+}
+
+fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), ValidationError> {
+    if let Some(o) = schema.as_object() {
+        if let Some(ref_val) = o.get("$ref").and_then(|v| v.as_str()) {
+            // We don't support remote $ref resolution. Inline refs only.
+            return Err(ValidationError {
+                path: path.to_string(),
+                message: format!("Remote $ref resolution not supported: {ref_val}"),
+            });
+        }
+
+        if let Some(types) = o.get("type") {
+            if !type_matches(types, value) {
+                return Err(ValidationError {
+                    path: path.to_string(),
+                    message: format!(
+                        "Expected type {}, got {}",
+                        json_type_str(types),
+                        value_type_str(value)
+                    ),
+                });
+            }
+        }
+
+        if let Some(enum_vals) = o.get("enum").and_then(|v| v.as_array()) {
+            if !enum_vals.contains(value) {
+                return Err(ValidationError {
+                    path: path.to_string(),
+                    message: format!(
+                        "Value not in enum: {:?}",
+                        enum_vals.iter().map(|v| v.to_string()).collect::<Vec<_>>()
+                    ),
+                });
+            }
+        }
+
+        match value {
+            Value::String(s) => {
+                if let Some(min) = o.get("minLength").and_then(|v| v.as_u64()) {
+                    if s.chars().count() < min as usize {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("String length {} < minLength {}", s.len(), min),
+                        });
+                    }
+                }
+                if let Some(max) = o.get("maxLength").and_then(|v| v.as_u64()) {
+                    if s.chars().count() > max as usize {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("String length {} > maxLength {}", s.len(), max),
+                        });
+                    }
+                }
+                if let Some(pattern) = o.get("pattern").and_then(|v| v.as_str()) {
+                    let re = Regex::new(pattern).map_err(|e| ValidationError {
+                        path: path.to_string(),
+                        message: format!("Invalid pattern: {e}"),
+                    })?;
+                    if !re.is_match(s) {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("String does not match pattern: {pattern}"),
+                        });
+                    }
+                }
+                if let Some(fmt) = o.get("format").and_then(|v| v.as_str()) {
+                    if !check_format(fmt, s) {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("String does not match format: {fmt}"),
+                        });
+                    }
+                }
+            }
+            Value::Number(n) => {
+                if let Some(min) = o.get("minimum").and_then(|v| v.as_f64()) {
+                    if n.as_f64().unwrap_or(f64::NAN) < min {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("Number {} < minimum {}", n, min),
+                        });
+                    }
+                }
+                if let Some(max) = o.get("maximum").and_then(|v| v.as_f64()) {
+                    if n.as_f64().unwrap_or(f64::NAN) > max {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("Number {} > maximum {}", n, max),
+                        });
+                    }
+                }
+            }
+            Value::Array(arr) => {
+                if let Some(items_schema) = o.get("items") {
+                    for (i, item) in arr.iter().enumerate() {
+                        let item_path = format!("{}[{}]", path, i);
+                        validate_at(items_schema, item, &item_path)?;
+                    }
+                }
+                if let Some(min_items) = o.get("minItems").and_then(|v| v.as_u64()) {
+                    if arr.len() < min_items as usize {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("Array length {} < minItems {}", arr.len(), min_items),
+                        });
+                    }
+                }
+                if let Some(max_items) = o.get("maxItems").and_then(|v| v.as_u64()) {
+                    if arr.len() > max_items as usize {
+                        return Err(ValidationError {
+                            path: path.to_string(),
+                            message: format!("Array length {} > maxItems {}", arr.len(), max_items),
+                        });
+                    }
+                }
+            }
+            Value::Object(obj) => {
+                if let Some(required) = o.get("required").and_then(|v| v.as_array()) {
+                    let keys: BTreeSet<&str> = obj.keys().map(|s| s.as_str()).collect();
+                    for req in required {
+                        if let Some(r) = req.as_str() {
+                            if !keys.contains(r) {
+                                return Err(ValidationError {
+                                    path: path.to_string(),
+                                    message: format!("Missing required property: {r}"),
+                                });
+                            }
+                        }
+                    }
+                }
+                if let Some(props) = o.get("properties").and_then(|v| v.as_object()) {
+                    for (key, prop_schema) in props {
+                        if let Some(prop_value) = obj.get(key) {
+                            let prop_path = if path.is_empty() {
+                                key.clone()
+                            } else {
+                                format!("{}.{}", path, key)
+                            };
+                            validate_at(prop_schema, prop_value, &prop_path)?;
+                        }
+                    }
+                }
+                if let Some(additional) = o.get("additionalProperties") {
+                    if additional == &Value::Bool(false) {
+                        let known: BTreeSet<&str> = o
+                            .get("properties")
+                            .and_then(|v| v.as_object())
+                            .map(|p| p.keys().map(|s| s.as_str()).collect())
+                            .unwrap_or_default();
+                        for key in obj.keys() {
+                            if !known.contains(key.as_str()) {
+                                return Err(ValidationError {
+                                    path: path.to_string(),
+                                    message: format!("Additional property not allowed: {key}"),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn type_matches(types: &Value, value: &Value) -> bool {
+    let expected = match types {
+        Value::String(s) => vec![s.as_str()],
+        Value::Array(arr) => arr.iter().filter_map(|v| v.as_str()).collect(),
+        _ => return true,
+    };
+    if expected.is_empty() {
+        return true;
+    }
+    let actual = value_type_str(value);
+    expected.contains(&actual.as_str())
+        || (expected.contains(&"number") && actual == "integer")
+        || (expected.contains(&"integer") && actual == "number" && is_integer(value))
+}
+
+fn is_integer(value: &Value) -> bool {
+    value
+        .as_f64()
+        .map(|f| f.fract() == 0.0 && !f.is_nan() && !f.is_infinite())
+        .unwrap_or(false)
+}
+
+fn value_type_str(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(_) => "boolean".to_string(),
+        Value::Number(n) => {
+            if n.is_i64() || n.is_u64() || (n.as_f64().map(|f| f.fract() == 0.0).unwrap_or(false)) {
+                "integer".to_string()
+            } else {
+                "number".to_string()
+            }
+        }
+        Value::String(_) => "string".to_string(),
+        Value::Array(_) => "array".to_string(),
+        Value::Object(_) => "object".to_string(),
+    }
+}
+
+fn json_type_str(types: &Value) -> String {
+    match types {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect::<Vec<_>>()
+            .join(" | "),
+        _ => "any".to_string(),
+    }
+}
+
+fn check_format(fmt: &str, s: &str) -> bool {
+    match fmt {
+        "email" => {
+            // Basic email check
+            s.contains('@') && s.contains('.')
+        }
+        "uri" | "uri-reference" => {
+            // Basic URI check
+            s.contains("://") || s.starts_with('/') || s.starts_with("#")
+        }
+        "date-time" => {
+            // ISO 8601 basic check
+            Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+                .map(|re| re.is_match(s))
+                .unwrap_or(true)
+        }
+        "date" => Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+            .map(|re| re.is_match(s))
+            .unwrap_or(true),
+        "uuid" => Regex::new(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        )
+        .map(|re| re.is_match(s))
+        .unwrap_or(true),
+        "ipv4" => Regex::new(r"^(\d{1,3}\.){3}\d{1,3}$")
+            .map(|re| re.is_match(s))
+            .unwrap_or(true),
+        "ipv6" => s.contains(':'),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn valid_string() {
+        let schema = json!({"type": "string"});
+        assert!(validate(&schema, &json!("hello")).is_ok());
+    }
+
+    #[test]
+    fn invalid_string_type() {
+        let schema = json!({"type": "string"});
+        let err = validate(&schema, &json!(42)).unwrap_err();
+        assert!(err.message.contains("Expected type string"));
+    }
+
+    #[test]
+    fn required_property_missing() {
+        let schema = json!({
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"}
+            }
+        });
+        let err = validate(&schema, &json!({})).unwrap_err();
+        assert!(err.message.contains("Missing required property: name"));
+    }
+
+    #[test]
+    fn nested_property_validation() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "age": {"type": "integer", "minimum": 0}
+                    }
+                }
+            }
+        });
+        assert!(validate(&schema, &json!({"user": {"age": 25}})).is_ok());
+        let err = validate(&schema, &json!({"user": {"age": -1}})).unwrap_err();
+        assert!(err.message.contains("minimum"));
+    }
+
+    #[test]
+    fn array_items_validation() {
+        let schema = json!({
+            "type": "array",
+            "items": {"type": "integer"}
+        });
+        assert!(validate(&schema, &json!([1, 2, 3])).is_ok());
+        let err = validate(&schema, &json!([1, "two", 3])).unwrap_err();
+        assert!(err.message.contains("Expected type integer"));
+    }
+
+    #[test]
+    fn enum_validation() {
+        let schema = json!({"enum": ["red", "green", "blue"]});
+        assert!(validate(&schema, &json!("red")).is_ok());
+        let err = validate(&schema, &json!("yellow")).unwrap_err();
+        assert!(err.message.contains("enum"));
+    }
+
+    #[test]
+    fn pattern_validation() {
+        let schema = json!({"type": "string", "pattern": "^[a-z]+$"});
+        assert!(validate(&schema, &json!("hello")).is_ok());
+        let err = validate(&schema, &json!("Hello123")).unwrap_err();
+        assert!(err.message.contains("pattern"));
+    }
+
+    #[test]
+    fn additional_properties_false() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "additionalProperties": false
+        });
+        assert!(validate(&schema, &json!({"name": "test"})).is_ok());
+        let err = validate(&schema, &json!({"name": "test", "extra": 1})).unwrap_err();
+        assert!(err.message.contains("Additional property not allowed"));
+    }
+}

--- a/crates/fakecloud-apigateway/src/model_validation.rs
+++ b/crates/fakecloud-apigateway/src/model_validation.rs
@@ -269,10 +269,16 @@ fn check_format(fmt: &str, s: &str) -> bool {
         )
         .map(|re| re.is_match(s))
         .unwrap_or(true),
-        "ipv4" => Regex::new(r"^(\d{1,3}\.){3}\d{1,3}$")
-            .map(|re| re.is_match(s))
-            .unwrap_or(true),
-        "ipv6" => s.contains(':'),
+        "ipv4" => Regex::new(
+            r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+        )
+        .map(|re| re.is_match(s))
+        .unwrap_or(true),
+        "ipv6" => Regex::new(
+            r"^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$",
+        )
+        .map(|re| re.is_match(s))
+        .unwrap_or(true),
         _ => true,
     }
 }
@@ -365,5 +371,38 @@ mod tests {
         assert!(validate(&schema, &json!({"name": "test"})).is_ok());
         let err = validate(&schema, &json!({"name": "test", "extra": 1})).unwrap_err();
         assert!(err.message.contains("Additional property not allowed"));
+    }
+
+    #[test]
+    fn format_ipv4_accepts_valid() {
+        let schema = json!({"type": "string", "format": "ipv4"});
+        assert!(validate(&schema, &json!("192.168.1.1")).is_ok());
+        assert!(validate(&schema, &json!("0.0.0.0")).is_ok());
+        assert!(validate(&schema, &json!("255.255.255.255")).is_ok());
+    }
+
+    #[test]
+    fn format_ipv4_rejects_invalid() {
+        let schema = json!({"type": "string", "format": "ipv4"});
+        assert!(validate(&schema, &json!("999.999.999.999")).is_err());
+        assert!(validate(&schema, &json!("256.1.1.1")).is_err());
+        assert!(validate(&schema, &json!("192.168.1")).is_err());
+        assert!(validate(&schema, &json!("not-an-ip")).is_err());
+    }
+
+    #[test]
+    fn format_ipv6_accepts_valid() {
+        let schema = json!({"type": "string", "format": "ipv6"});
+        assert!(validate(&schema, &json!("2001:0db8:85a3:0000:0000:8a2e:0370:7334")).is_ok());
+        assert!(validate(&schema, &json!("::1")).is_ok());
+        assert!(validate(&schema, &json!("fe80::1")).is_ok());
+    }
+
+    #[test]
+    fn format_ipv6_rejects_invalid() {
+        let schema = json!({"type": "string", "format": "ipv6"});
+        assert!(validate(&schema, &json!("not-an-ip")).is_err());
+        assert!(validate(&schema, &json!("192.168.1.1")).is_err());
+        assert!(validate(&schema, &json!(":::")).is_err());
     }
 }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -730,3 +730,106 @@ async fn data_plane_throttle_returns_429_when_burst_exhausted() {
         .expect("send");
     assert_eq!(second.status(), 429);
 }
+
+// ── Request validator enforcement (Phase R3) ──
+
+#[tokio::test]
+async fn data_plane_request_validator_rejects_missing_body_field() {
+    let server = TestServer::start().await;
+    let client = server.apigateway_client().await;
+
+    let api = client
+        .create_rest_api()
+        .name("validator-test")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+
+    let resource = client
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("items")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+
+    // Create a model with required "name" field.
+    client
+        .create_model()
+        .rest_api_id(&api_id)
+        .name("ItemModel")
+        .content_type("application/json")
+        .schema(r#"{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}"#)
+        .send()
+        .await
+        .expect("create_model");
+
+    // Create a validator that validates the request body.
+    let validator = client
+        .create_request_validator()
+        .rest_api_id(&api_id)
+        .name("body-validator")
+        .validate_request_body(true)
+        .send()
+        .await
+        .expect("create_request_validator");
+    let validator_id = validator.id().unwrap().to_string();
+
+    client
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("POST")
+        .authorization_type("NONE")
+        .request_validator_id(&validator_id)
+        .request_models("application/json", "ItemModel")
+        .send()
+        .await
+        .expect("put_method");
+
+    client
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("POST")
+        .r#type(aws_sdk_apigateway::types::IntegrationType::Mock)
+        .send()
+        .await
+        .expect("put_integration");
+
+    client
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+
+    let http = reqwest::Client::new();
+
+    // Missing required "name" field must return 400.
+    let bad = http
+        .post(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("content-type", "application/json")
+        .body(r#"{"count": 42}"#)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(bad.status(), 400);
+
+    // Valid body with required "name" field must pass.
+    let good = http
+        .post(format!("{}/prod/items", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .header("content-type", "application/json")
+        .body(r#"{"name": "hello"}"#)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(good.status(), 200);
+}


### PR DESCRIPTION
## Summary
- Add minimal JSON Schema Draft 4 validator (`model_validation.rs`) supporting `type`, `required`, `properties`, `items`, `enum`, `minLength`, `maxLength`, `minimum`, `maximum`, `pattern`, `additionalProperties`, `format`.
- Wire request validator enforcement into `data_plane::handle` after API key / usage plan checks and before integration invocation.
- `validateRequestParameters`: check required query/path/header params.
- `validateRequestBody`: resolve model by content-type, validate body JSON against stored schema.
- Unit tests for validator engine + data plane enforcement.
- E2E test driving full SDK lifecycle: create model, validator, method with validator + model, deploy, then assert 400 on bad body and 200 on valid body.

## Test plan
- [x] `cargo test -p fakecloud-apigateway` passes (43 tests)
- [x] `cargo test -p fakecloud-e2e --test apigateway data_plane_request_validator` passes
- [x] `cargo clippy -p fakecloud-apigateway --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request validation to the API Gateway data plane: enforce required params and validate JSON bodies against models. Invalid requests return 400 and do not hit the backend.

- **New Features**
  - Enforce required query/path/header parameters when a method has a request validator.
  - Validate request body JSON via method requestModels by content type using a minimal JSON Schema Draft 4 validator (type, required, properties, items, enum, min/max length/number, pattern, additionalProperties, format); uses `regex` for pattern/format checks.
  - Run validation after API key/usage plan checks and before invoking the integration.

- **Bug Fixes**
  - Treat blank required query parameters and headers as missing.
  - Resolve body model by content type with $default fallback; skip validation when no model matches.
  - Tighten IP format checks and support IPv6 mixed notation (e.g., ::ffff:192.168.1.1).

<sup>Written for commit b6ca3070ef9274e33670c6d7623a7132f99dde6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

