### PR TITLE
feat(apigateway): VPC_LINK integration (R6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fakecloud-core",
+ "fakecloud-elbv2",
  "fakecloud-persistence",
  "fakecloud-wafv2",
  "http 1.4.0",

--- a/crates/fakecloud-apigateway/Cargo.toml
+++ b/crates/fakecloud-apigateway/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
+fakecloud-elbv2 = { workspace = true }
 fakecloud-wafv2 = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/fakecloud-apigateway/src/data_plane.rs
+++ b/crates/fakecloud-apigateway/src/data_plane.rs
@@ -347,7 +347,13 @@ pub async fn handle(
                 .ok_or_else(|| bad_gateway("Lambda delivery not configured"))?;
             lambda_proxy::invoke_lambda(delivery, &function_arn, event).await
         }
-        "HTTP_PROXY" | "HTTP" => http_proxy(req, &integration).await,
+        "HTTP_PROXY" | "HTTP" => {
+            if integration.connection_type.as_deref() == Some("VPC_LINK") {
+                vpc_link_proxy(req, &integration, service).await
+            } else {
+                http_proxy(req, &integration).await
+            }
+        }
         "MOCK" => Ok(AwsResponse::ok_json(json!({}))),
         other => Err(bad_gateway(format!(
             "Integration type '{other}' not supported in fakecloud's data plane",
@@ -1021,6 +1027,78 @@ async fn http_proxy(
         headers,
         body: bytes::Bytes::from(body.to_vec()).into(),
     })
+}
+
+/// Resolve a VPC_LINK integration by looking up the VpcLink's
+/// `targetArns`, finding the first NLB/ALB that has a bound port in
+/// the ELBv2 dataplane, and forwarding the request there.
+async fn vpc_link_proxy(
+    req: &AwsRequest,
+    integration: &Integration,
+    service: &ApiGatewayService,
+) -> Result<AwsResponse, AwsServiceError> {
+    let connection_id = integration
+        .connection_id
+        .as_deref()
+        .ok_or_else(|| bad_gateway("VPC_LINK integration missing connectionId"))?;
+
+    let target_arns: Vec<String> = {
+        let accounts = service.state_handle().read();
+        let state = accounts
+            .get(&req.account_id)
+            .ok_or_else(|| bad_gateway("VPC_LINK: account not found in API Gateway state"))?;
+        let vpc_link = state
+            .vpc_links
+            .get(connection_id)
+            .ok_or_else(|| bad_gateway(format!("VPC_LINK not found: {connection_id}")))?;
+        let target_arns = vpc_link
+            .get("targetArns")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| bad_gateway("VPC_LINK missing targetArns"))?;
+        if target_arns.is_empty() {
+            return Err(bad_gateway("VPC_LINK targetArns is empty"));
+        }
+        target_arns
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect()
+    };
+
+    let elbv2 = service
+        .elbv2_state
+        .as_ref()
+        .ok_or_else(|| bad_gateway("VPC_LINK not available: ELBv2 state not wired"))?;
+    let port = {
+        let elbv2_read = elbv2.read();
+        let elbv2_account = elbv2_read
+            .get(&req.account_id)
+            .ok_or_else(|| bad_gateway("VPC_LINK: account not found in ELBv2 state"))?;
+        let mut bound_port = None;
+        for arn in &target_arns {
+            if let Some(lb) = elbv2_account.load_balancers.get(arn) {
+                if let Some(port) = lb.bound_port {
+                    bound_port = Some(port);
+                    break;
+                }
+            }
+        }
+        bound_port.ok_or_else(|| {
+            bad_gateway("VPC_LINK: none of the target NLBs/ALBs have an active dataplane port")
+        })?
+    };
+
+    // Build the backend URL from the integration URI, replacing the
+    // host with the local ELBv2 dataplane endpoint.
+    let original_url = integration.uri.as_deref().unwrap_or("http://localhost/");
+    let path_and_query = http::Uri::try_from(original_url)
+        .ok()
+        .and_then(|u| u.path_and_query().map(|p| p.as_str().to_string()))
+        .unwrap_or_else(|| req.raw_path.clone());
+    let backend_url = format!("http://127.0.0.1:{port}{path_and_query}");
+
+    let mut proxy_integration = integration.clone();
+    proxy_integration.uri = Some(backend_url);
+    http_proxy(req, &proxy_integration).await
 }
 
 // ── Usage plan throttle + quota ──
@@ -2896,5 +2974,90 @@ mod tests {
             .expect("$default model should validate");
         assert_eq!(resp.status, StatusCode::OK);
         assert_eq!(lambda.invocation_count(BACKEND_ARN), 1);
+    }
+
+    #[tokio::test]
+    async fn vpc_link_proxy_resolves_target_nlb_and_attempts_connection() {
+        // Seed API Gateway state with a VpcLink pointing at an NLB ARN.
+        let mut state = ApiGatewayState::new(TEST_ACCOUNT, TEST_REGION);
+        let vpc_link_id = "vpclink001";
+        state.vpc_links.insert(
+            vpc_link_id.to_string(),
+            serde_json::json!({
+                "id": vpc_link_id,
+                "name": "link",
+                "targetArns": ["arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-nlb/50dc6c495c0c9188"],
+                "status": "AVAILABLE"
+            }),
+        );
+        let apigw_state: SharedApiGatewayState = {
+            let mut mas =
+                MultiAccountState::new(TEST_ACCOUNT, TEST_REGION, "http://localhost:4566");
+            *mas.get_or_create(TEST_ACCOUNT) = state;
+            Arc::new(parking_lot::RwLock::new(mas))
+        };
+
+        // Seed ELBv2 state with a load balancer that has a bound port.
+        let mut elbv2_accounts = fakecloud_elbv2::state::Elbv2Accounts::new();
+        let elbv2_state = elbv2_accounts.get_or_create(TEST_ACCOUNT);
+        let lb_arn = "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-nlb/50dc6c495c0c9188";
+        let mut lb: fakecloud_elbv2::state::LoadBalancer =
+            serde_json::from_value(serde_json::json!({
+                "arn": lb_arn,
+                "name": "my-nlb",
+                "dns_name": "my-nlb-123.elb.us-east-1.amazonaws.com",
+                "canonical_hosted_zone_id": "Z35SXDOTRQ7X7K",
+                "created_time": "2024-01-01T00:00:00Z",
+                "scheme": "internal",
+                "vpc_id": "vpc-123",
+                "state_code": "active",
+                "lb_type": "application",
+                "availability_zones": [],
+                "security_groups": [],
+                "ip_address_type": "ipv4",
+                "tags": [],
+                "attributes": {}
+            }))
+            .unwrap();
+        lb.bound_port = Some(54321);
+        elbv2_state.load_balancers.insert(lb_arn.to_string(), lb);
+        let shared_elbv2 = Arc::new(parking_lot::RwLock::new(elbv2_accounts));
+
+        let service = ApiGatewayService::new(apigw_state).with_elbv2(shared_elbv2);
+
+        let integration = Integration {
+            rest_api_id: "api1".to_string(),
+            resource_id: "res1".to_string(),
+            http_method: "GET".to_string(),
+            integration_type: "HTTP".to_string(),
+            integration_http_method: Some("GET".to_string()),
+            uri: Some("http://backend.internal/items".to_string()),
+            credentials: None,
+            request_parameters: BTreeMap::new(),
+            request_templates: BTreeMap::new(),
+            passthrough_behavior: "WHEN_NO_MATCH".to_string(),
+            timeout_in_millis: None,
+            cache_namespace: None,
+            cache_key_parameters: vec![],
+            content_handling: None,
+            connection_type: Some("VPC_LINK".to_string()),
+            connection_id: Some(vpc_link_id.to_string()),
+            tls_config: None,
+        };
+
+        let req = make_request(HeaderMap::new());
+        let result = vpc_link_proxy(&req, &integration, &service).await;
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("VPC_LINK to port 54321 with no server must fail"),
+        };
+        // No actual HTTP server is listening on port 54321, so the
+        // proxy step must fail with a backend HTTP error.
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        let msg = err.message();
+        assert!(
+            msg.contains("backend HTTP failure") || msg.contains("connection refused"),
+            "expected backend connection error, got: {msg}"
+        );
     }
 }

--- a/crates/fakecloud-apigateway/src/service.rs
+++ b/crates/fakecloud-apigateway/src/service.rs
@@ -166,6 +166,8 @@ pub struct ApiGatewayService {
     /// by `"<acl-arn>|<rule-name>"`; exposed via the admin endpoint
     /// for tests and future metrics scraping.
     pub(crate) waf_count_metrics: Arc<parking_lot::Mutex<BTreeMap<String, u64>>>,
+    /// ELBv2 state for resolving VPC_LINK target NLB/ALB bound ports.
+    pub(crate) elbv2_state: Option<fakecloud_elbv2::SharedElbv2State>,
 }
 
 impl ApiGatewayService {
@@ -181,6 +183,7 @@ impl ApiGatewayService {
             waf_state: None,
             waf_rate_limiter: None,
             waf_count_metrics: Arc::new(parking_lot::Mutex::new(BTreeMap::new())),
+            elbv2_state: None,
         }
     }
 
@@ -214,6 +217,11 @@ impl ApiGatewayService {
     /// inspection is disabled or no Count rules have fired.
     pub fn waf_count_metrics_snapshot(&self) -> BTreeMap<String, u64> {
         self.waf_count_metrics.lock().clone()
+    }
+
+    pub fn with_elbv2(mut self, state: fakecloud_elbv2::SharedElbv2State) -> Self {
+        self.elbv2_state = Some(state);
+        self
     }
 
     pub(crate) fn delivery(&self) -> Option<&Arc<DeliveryBus>> {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2411,7 +2411,8 @@ async fn main() {
             None
         };
     let mut apigw_v1_service = ApiGatewayService::new(apigatewayv1_state.clone())
-        .with_waf(wafv2_state.clone(), wafv2_rate_limiter.clone());
+        .with_waf(wafv2_state.clone(), wafv2_rate_limiter.clone())
+        .with_elbv2(elbv2_state.clone());
     {
         let cognito_jwt_verifier: Arc<dyn fakecloud_core::delivery::CognitoJwtVerifier> = Arc::new(
             fakecloud_cognito::StateBackedJwtVerifier::new(cognito_state.clone()),


### PR DESCRIPTION
## Summary
- Add `elbv2_state` to `ApiGatewayService` for resolving VPC_LINK targets.
- Implement `vpc_link_proxy` in data plane:
  - Look up VpcLink by `connectionId`
  - Extract `targetArns`
  - Find first NLB/ALB with a `bound_port` in ELBv2 state
  - Rewrite integration URI to local dataplane endpoint (`http://127.0.0.1:{port}`)
  - Forward via existing `http_proxy`
- Wire ELBv2 state in `fakecloud-server/src/main.rs`.
- Unit test verifies VPC_LINK resolves target NLB and attempts HTTP connection.

## Test plan
- [x] `cargo test -p fakecloud-apigateway --lib` — 53 passed
- [x] `cargo clippy -p fakecloud-apigateway --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] `cargo check -p fakecloud` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VPC_LINK support to API Gateway’s data plane for HTTP integrations. VpcLink targets are resolved via ELBv2 and traffic is proxied through the local dataplane.

- New Features
  - Implemented vpc_link_proxy: resolves VpcLink by connectionId, reads targetArns, picks the first NLB/ALB with a bound_port, rewrites the URI to http://127.0.0.1:{port}, and forwards via existing http_proxy.
  - Added elbv2_state to ApiGatewayService and wired it in `fakecloud-server` to enable target resolution.

- Dependencies
  - Added `fakecloud-elbv2` to `fakecloud-apigateway`.

<sup>Written for commit 3a6d0c61aeb3a8a8daa9e7b87862ef0b62412961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

