### PR TITLE
feat(apigatewayv2): JWT authorizer enforcement in HTTP data plane (S3)

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -14,6 +14,7 @@ pub fn construct_event(
     route_key: &str,
     stage: &str,
     path_parameters: HashMap<String, String>,
+    authorizer_claims: Option<serde_json::Value>,
 ) -> serde_json::Value {
     let (is_base64_encoded, body) = encode_body(req);
 
@@ -42,26 +43,44 @@ pub fn construct_event(
         })
         .collect();
 
+    let mut request_context = serde_json::Map::new();
+    request_context.insert(
+        "http".to_string(),
+        json!({
+            "method": req.method.as_str(),
+            "path": req.raw_path,
+            "sourceIp": "127.0.0.1"
+        }),
+    );
+    request_context.insert("routeKey".to_string(), json!(route_key));
+    request_context.insert("stage".to_string(), json!(stage));
+    request_context.insert("requestId".to_string(), json!(&req.request_id));
+    request_context.insert("accountId".to_string(), json!(&req.account_id));
+    request_context.insert("domainName".to_string(), json!("localhost"));
+    request_context.insert("time".to_string(), json!(chrono::Utc::now().to_rfc3339()));
+    request_context.insert(
+        "timeEpoch".to_string(),
+        json!(chrono::Utc::now().timestamp_millis()),
+    );
+
+    if let Some(claims) = authorizer_claims {
+        let mut jwt = serde_json::Map::new();
+        jwt.insert("claims".to_string(), claims);
+        let mut authorizer = serde_json::Map::new();
+        authorizer.insert("jwt".to_string(), serde_json::Value::Object(jwt));
+        request_context.insert(
+            "authorizer".to_string(),
+            serde_json::Value::Object(authorizer),
+        );
+    }
+
     json!({
         "version": "2.0",
         "routeKey": route_key,
         "rawPath": req.raw_path,
         "rawQueryString": raw_query_string,
         "headers": headers,
-        "requestContext": {
-            "http": {
-                "method": req.method.as_str(),
-                "path": req.raw_path,
-                "sourceIp": "127.0.0.1"
-            },
-            "routeKey": route_key,
-            "stage": stage,
-            "requestId": &req.request_id,
-            "accountId": &req.account_id,
-            "domainName": "localhost",
-            "time": chrono::Utc::now().to_rfc3339(),
-            "timeEpoch": chrono::Utc::now().timestamp_millis()
-        },
+        "requestContext": serde_json::Value::Object(request_context),
         "pathParameters": path_parameters,
         "queryStringParameters": query_string_parameters,
         "body": body,
@@ -252,7 +271,7 @@ mod tests {
         let req = create_test_request();
         let path_params = HashMap::from([("id".to_string(), "123".to_string())]);
 
-        let event = construct_event(&req, "POST /pets/{id}", "prod", path_params);
+        let event = construct_event(&req, "POST /pets/{id}", "prod", path_params, None);
 
         assert_eq!(event["version"], "2.0");
         assert_eq!(event["routeKey"], "POST /pets/{id}");
@@ -263,6 +282,36 @@ mod tests {
         assert_eq!(event["queryStringParameters"]["filter"], "available");
         assert_eq!(event["body"], r#"{"name":"Fluffy"}"#);
         assert_eq!(event["isBase64Encoded"], false);
+    }
+
+    #[test]
+    fn test_construct_event_with_authorizer_claims() {
+        let req = create_test_request();
+        let path_params = HashMap::new();
+        let claims = json!({"sub": "user-123", "aud": "my-client"});
+
+        let event = construct_event(
+            &req,
+            "POST /pets",
+            "prod",
+            path_params,
+            Some(claims.clone()),
+        );
+
+        assert_eq!(
+            event["requestContext"]["authorizer"]["jwt"]["claims"],
+            claims
+        );
+    }
+
+    #[test]
+    fn test_construct_event_without_authorizer_omits_field() {
+        let req = create_test_request();
+        let event = construct_event(&req, "POST /pets", "prod", HashMap::new(), None);
+        assert!(
+            event["requestContext"]["authorizer"].is_null(),
+            "authorizer should be absent when None"
+        );
     }
 
     #[test]
@@ -347,7 +396,7 @@ mod tests {
             access_key_id: None,
             principal: None,
         };
-        let event = construct_event(&req, "POST /img", "prod", HashMap::new());
+        let event = construct_event(&req, "POST /img", "prod", HashMap::new(), None);
         assert_eq!(event["isBase64Encoded"], true);
     }
 
@@ -371,7 +420,7 @@ mod tests {
             access_key_id: None,
             principal: None,
         };
-        let event = construct_event(&req, "GET /noop", "prod", HashMap::new());
+        let event = construct_event(&req, "GET /noop", "prod", HashMap::new(), None);
         assert_eq!(event["isBase64Encoded"], false);
         assert!(event["body"].is_null());
     }

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2173,12 +2173,23 @@ impl ApiGatewayV2Service {
         };
 
         let Some(authorizer) = authorizer else {
-            return Ok(None);
+            return Err(AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                format!("Authorizer not found: {}", authorizer_id),
+            ));
         };
 
         match authorizer.authorizer_type.as_str() {
             "JWT" => self.enforce_jwt_authorizer(req, &authorizer).await,
-            _ => Ok(None),
+            _ => Err(AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                format!(
+                    "Unsupported authorizer type: {}",
+                    authorizer.authorizer_type
+                ),
+            )),
         }
     }
 

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2035,6 +2035,11 @@ impl ApiGatewayV2Service {
                 )
             })?;
 
+        // Authorizer enforcement
+        let authorizer_claims = self
+            .enforce_authorizer(&req, &api_id, &route_match.route)
+            .await?;
+
         // Get the integration for this route
         let integration_id = route_match
             .route
@@ -2092,6 +2097,7 @@ impl ApiGatewayV2Service {
                     &route_match.route.route_key,
                     stage_name,
                     route_match.path_parameters,
+                    authorizer_claims.clone(),
                 );
 
                 lambda_proxy::invoke_lambda(delivery, function_arn, event).await?
@@ -2139,6 +2145,151 @@ impl ApiGatewayV2Service {
         );
 
         Ok(response)
+    }
+
+    /// Enforce the authorizer configured on a route. Returns the decoded
+    /// JWT claims when a JWT authorizer succeeds, or `None` when the route
+    /// has no authorizer. Propagates `401 Unauthorized` on failure.
+    async fn enforce_authorizer(
+        &self,
+        req: &AwsRequest,
+        api_id: &str,
+        route: &Route,
+    ) -> Result<Option<serde_json::Value>, AwsServiceError> {
+        let authorizer_id = match &route.authorizer_id {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        let authorizer = {
+            let accounts = self.state.read();
+            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            state
+                .authorizers
+                .get(api_id)
+                .and_then(|a| a.get(authorizer_id))
+                .cloned()
+        };
+
+        let Some(authorizer) = authorizer else {
+            return Ok(None);
+        };
+
+        match authorizer.authorizer_type.as_str() {
+            "JWT" => self.enforce_jwt_authorizer(req, &authorizer).await,
+            _ => Ok(None),
+        }
+    }
+
+    /// Validate a JWT token against the configured issuer and audience.
+    async fn enforce_jwt_authorizer(
+        &self,
+        req: &AwsRequest,
+        authorizer: &Authorizer,
+    ) -> Result<Option<serde_json::Value>, AwsServiceError> {
+        let identity_sources = authorizer.identity_source.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::UNAUTHORIZED,
+                "UnauthorizedException",
+                "Authorizer has no identity source",
+            )
+        })?;
+
+        let token_value = identity_sources
+            .iter()
+            .find_map(|source| extract_identity_source_value(req, source))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::UNAUTHORIZED,
+                    "UnauthorizedException",
+                    "Missing required JWT",
+                )
+            })?;
+
+        let token = token_value
+            .strip_prefix("Bearer ")
+            .or_else(|| token_value.strip_prefix("bearer "))
+            .unwrap_or(&token_value)
+            .trim();
+
+        if token.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::UNAUTHORIZED,
+                "UnauthorizedException",
+                "Empty Authorization header",
+            ));
+        }
+
+        let jwt_config = authorizer.jwt_configuration.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "JWT authorizer has no configuration",
+            )
+        })?;
+
+        let issuer = jwt_config.issuer.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "JWT authorizer has no issuer",
+            )
+        })?;
+
+        let delivery = self.delivery.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "JWT verifier not configured",
+            )
+        })?;
+
+        let pool_arn =
+            issuer_to_pool_arn(&req.account_id, &req.region, issuer).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    "Invalid JWT issuer format",
+                )
+            })?;
+
+        let claims = delivery
+            .verify_cognito_jwt(&req.account_id, &pool_arn, token)
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::UNAUTHORIZED,
+                    "UnauthorizedException",
+                    format!("Invalid JWT: {e}"),
+                )
+            })?;
+
+        // Validate audience
+        if let Some(audiences) = &jwt_config.audience {
+            let token_aud = claims.get("aud").and_then(|v| v.as_str());
+            let token_aud_array = claims.get("aud").and_then(|v| v.as_array());
+            let matches = token_aud
+                .map(|a| audiences.contains(&a.to_string()))
+                .unwrap_or(false)
+                || token_aud_array
+                    .map(|arr| {
+                        arr.iter().any(|v| {
+                            v.as_str()
+                                .map(|s| audiences.contains(&s.to_string()))
+                                .unwrap_or(false)
+                        })
+                    })
+                    .unwrap_or(false);
+            if !matches {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::UNAUTHORIZED,
+                    "UnauthorizedException",
+                    "Invalid audience",
+                ));
+            }
+        }
+
+        Ok(Some(claims))
     }
 
     /// Build the resource ARN that callers use when associating a
@@ -2274,6 +2425,31 @@ fn decision_to_response(decision: fakecloud_wafv2::Decision) -> Option<AwsRespon
     let mut resp = AwsResponse::json_value(status, body);
     resp.content_type = "application/json".to_string();
     Some(resp)
+}
+
+/// Parse an API Gateway v2 identity-source expression and extract
+/// the corresponding value from the request.
+fn extract_identity_source_value(req: &AwsRequest, source: &str) -> Option<String> {
+    if let Some(header_name) = source.strip_prefix("$request.header.") {
+        req.headers
+            .get(header_name)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    } else if let Some(param_name) = source.strip_prefix("$request.querystring.") {
+        req.query_params.get(param_name).cloned()
+    } else {
+        None
+    }
+}
+
+/// Map a Cognito issuer URL (`https://cognito-idp.<region>.amazonaws.com/<pool-id>`)
+/// to the corresponding user-pool ARN.
+fn issuer_to_pool_arn(account_id: &str, region: &str, issuer: &str) -> Option<String> {
+    let pool_id = issuer.rsplit_once('/')?.1;
+    Some(format!(
+        "arn:aws:cognito-idp:{}:{}:userpool/{}",
+        region, account_id, pool_id
+    ))
 }
 
 #[path = "service_helpers.rs"]

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1167,3 +1167,195 @@ async fn get_route_not_found() {
     let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/routes/ghost"), "");
     assert!(svc.handle(req).await.is_err());
 }
+
+// ── JWT authorizer enforcement ──
+
+#[test]
+fn extract_identity_source_value_header() {
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    assert_eq!(
+        super::extract_identity_source_value(&req, "$request.header.Authorization"),
+        Some("Bearer tok".to_string())
+    );
+}
+
+#[test]
+fn extract_identity_source_value_querystring() {
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.query_params
+        .insert("token".to_string(), "abc".to_string());
+    assert_eq!(
+        super::extract_identity_source_value(&req, "$request.querystring.token"),
+        Some("abc".to_string())
+    );
+}
+
+#[test]
+fn extract_identity_source_value_unknown_prefix() {
+    let req = make_request(Method::GET, "/prod/pets", "");
+    assert_eq!(
+        super::extract_identity_source_value(&req, "$request.body.action"),
+        None
+    );
+}
+
+#[test]
+fn issuer_to_pool_arn_parses_cognito_url() {
+    let arn = super::issuer_to_pool_arn(
+        "123456789012",
+        "us-east-1",
+        "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123",
+    );
+    assert_eq!(
+        arn,
+        Some("arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123".to_string())
+    );
+}
+
+#[test]
+fn issuer_to_pool_arn_bad_format_returns_none() {
+    assert_eq!(
+        super::issuer_to_pool_arn("123456789012", "us-east-1", "not-a-url"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn execute_api_jwt_authorizer_no_token_returns_401() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    // Create JWT authorizer
+    let body = serde_json::json!({
+        "name": "jwt-auth",
+        "authorizerType": "JWT",
+        "identitySource": ["$request.header.Authorization"],
+        "jwtConfiguration": {
+            "audience": ["my-client-id"],
+            "issuer": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123"
+        }
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create integration
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route with authorizer
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute without token -> 401
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn execute_api_jwt_authorizer_no_delivery_returns_500() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    // Create JWT authorizer
+    let body = serde_json::json!({
+        "name": "jwt-auth",
+        "authorizerType": "JWT",
+        "identitySource": ["$request.header.Authorization"],
+        "jwtConfiguration": {
+            "audience": ["my-client-id"],
+            "issuer": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123"
+        }
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create integration
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route with authorizer
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute with token but no delivery -> 500
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer dummy".parse().unwrap());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2351,7 +2351,14 @@ async fn main() {
     let mut apigw_service = ApiGatewayV2Service::new(apigatewayv2_state.clone())
         .with_waf(wafv2_state.clone(), wafv2_rate_limiter.clone());
     if let Some(ref ld) = lambda_delivery {
-        let delivery_for_apigw = Arc::new(DeliveryBus::new().with_lambda(ld.clone()));
+        let cognito_jwt_verifier: Arc<dyn fakecloud_core::delivery::CognitoJwtVerifier> = Arc::new(
+            fakecloud_cognito::StateBackedJwtVerifier::new(cognito_state.clone()),
+        );
+        let delivery_for_apigw = Arc::new(
+            DeliveryBus::new()
+                .with_lambda(ld.clone())
+                .with_cognito_jwt_verifier(cognito_jwt_verifier),
+        );
         apigw_service = apigw_service.with_delivery(delivery_for_apigw);
     }
     if let Some(store) = apigw_snapshot_store {


### PR DESCRIPTION
## Summary
- JWT authorizer enforcement for API Gateway v2 HTTP data plane
- Token extraction from `identitySource` (`$request.header.*` / `$request.querystring.*`)
- JWT validation via existing `DeliveryBus.verify_cognito_jwt` with issuer URL to pool ARN mapping
- Audience claim validation against `jwtConfiguration.audience`
- Authorizer claims injection into Lambda proxy v2.0 event under `requestContext.authorizer.jwt.claims`
- Server wiring: cognito JWT verifier hooked into v2 service delivery bus

## Test plan
- [x] Unit tests for `extract_identity_source_value` and `issuer_to_pool_arn`
- [x] Unit test: 401 when token missing on JWT-protected route
- [x] Unit test: 500 when delivery bus has no verifier wired
- [x] Unit test: Lambda event construction with authorizer claims
- [x] `cargo test -p fakecloud-apigatewayv2` passes (110 unit + 10 e2e tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JWT authorizer enforcement to API Gateway v2 HTTP execution. Routes extract tokens from identitySource, validate Cognito JWTs and audience, and inject claims into Lambda proxy v2.0 events.

- **New Features**
  - Enforce per-route authorizers via `enforce_authorizer`; support `$request.header.*` and `$request.querystring.*`.
  - Verify tokens with `DeliveryBus.verify_cognito_jwt` (issuer URL → user pool ARN) and check `aud` against `jwtConfiguration.audience`; return 401 on missing/invalid.
  - Inject claims into `requestContext.authorizer.jwt.claims`; `lambda_proxy::construct_event` now accepts optional claims.
  - Wire Cognito JWT verifier into the API Gateway v2 `DeliveryBus` in `fakecloud-server`.

- **Bug Fixes**
  - Return 500 when a configured authorizer can’t be resolved (no fail-open).
  - Return 500 for unsupported authorizer types.

<sup>Written for commit 590a2f766eaed623bcecd3d622e6a93a351f5e3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

