### PR TITLE
feat(apigatewayv2): Lambda authorizer enforcement in HTTP data plane (S4)

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -7,6 +7,15 @@ use std::collections::HashMap;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
+/// Authorizer result to inject into the v2.0 request context.
+pub enum AuthorizerInfo {
+    /// JWT claims returned by a Cognito/JWT authorizer.
+    Jwt { claims: serde_json::Value },
+    /// Lambda authorizer context (already shaped as the `authorizer`
+    /// object that should appear under `requestContext`).
+    Lambda { context: serde_json::Value },
+}
+
 /// Constructs a Lambda proxy integration event in v2.0 format.
 /// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
 pub fn construct_event(
@@ -14,7 +23,7 @@ pub fn construct_event(
     route_key: &str,
     stage: &str,
     path_parameters: HashMap<String, String>,
-    authorizer_claims: Option<serde_json::Value>,
+    authorizer: Option<AuthorizerInfo>,
 ) -> serde_json::Value {
     let (is_base64_encoded, body) = encode_body(req);
 
@@ -63,15 +72,22 @@ pub fn construct_event(
         json!(chrono::Utc::now().timestamp_millis()),
     );
 
-    if let Some(claims) = authorizer_claims {
-        let mut jwt = serde_json::Map::new();
-        jwt.insert("claims".to_string(), claims);
-        let mut authorizer = serde_json::Map::new();
-        authorizer.insert("jwt".to_string(), serde_json::Value::Object(jwt));
-        request_context.insert(
-            "authorizer".to_string(),
-            serde_json::Value::Object(authorizer),
-        );
+    if let Some(auth) = authorizer {
+        match auth {
+            AuthorizerInfo::Jwt { claims } => {
+                let mut jwt = serde_json::Map::new();
+                jwt.insert("claims".to_string(), claims);
+                let mut authorizer = serde_json::Map::new();
+                authorizer.insert("jwt".to_string(), serde_json::Value::Object(jwt));
+                request_context.insert(
+                    "authorizer".to_string(),
+                    serde_json::Value::Object(authorizer),
+                );
+            }
+            AuthorizerInfo::Lambda { context } => {
+                request_context.insert("authorizer".to_string(), context);
+            }
+        }
     }
 
     json!({
@@ -295,12 +311,41 @@ mod tests {
             "POST /pets",
             "prod",
             path_params,
-            Some(claims.clone()),
+            Some(AuthorizerInfo::Jwt {
+                claims: claims.clone(),
+            }),
         );
 
         assert_eq!(
             event["requestContext"]["authorizer"]["jwt"]["claims"],
             claims
+        );
+    }
+
+    #[test]
+    fn test_construct_event_with_lambda_authorizer_context() {
+        let req = create_test_request();
+        let path_params = HashMap::new();
+        let ctx = json!({"principalId": "lambda-user", "role": "admin"});
+
+        let event = construct_event(
+            &req,
+            "POST /pets",
+            "prod",
+            path_params,
+            Some(AuthorizerInfo::Lambda {
+                context: ctx.clone(),
+            }),
+        );
+
+        assert_eq!(
+            event["requestContext"]["authorizer"]["principalId"],
+            "lambda-user"
+        );
+        assert_eq!(event["requestContext"]["authorizer"]["role"], "admin");
+        assert!(
+            event["requestContext"]["authorizer"]["jwt"].is_null(),
+            "jwt should be absent for Lambda authorizer"
         );
     }
 

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2320,7 +2320,10 @@ impl ApiGatewayV2Service {
         // When configured, every listed source must be present.
         if let Some(sources) = &authorizer.identity_source {
             for source in sources {
-                if extract_identity_source_value(req, source).is_none() {
+                if extract_identity_source_value(req, source)
+                    .map(|v| v.is_empty())
+                    .unwrap_or(true)
+                {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::UNAUTHORIZED,
                         "UnauthorizedException",

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2316,27 +2316,18 @@ impl ApiGatewayV2Service {
         api_id: &str,
         authorizer: &Authorizer,
     ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
-        let identity_sources = authorizer.identity_source.as_ref().ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::UNAUTHORIZED,
-                "UnauthorizedException",
-                "Authorizer has no identity source",
-            )
-        })?;
-
-        // Collect all configured identity-source values (headers, query strings).
-        let mut identity_values = Vec::new();
-        for source in identity_sources {
-            if let Some(val) = extract_identity_source_value(req, source) {
-                identity_values.push(val);
+        // Identity sources are optional for REQUEST authorizers.
+        // When configured, every listed source must be present.
+        if let Some(sources) = &authorizer.identity_source {
+            for source in sources {
+                if extract_identity_source_value(req, source).is_none() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::UNAUTHORIZED,
+                        "UnauthorizedException",
+                        "Missing required identity source",
+                    ));
+                }
             }
-        }
-        if identity_values.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::UNAUTHORIZED,
-                "UnauthorizedException",
-                "Missing required identity source",
-            ));
         }
 
         let auth_uri = authorizer.authorizer_uri.as_deref().ok_or_else(|| {
@@ -2647,15 +2638,28 @@ fn extract_lambda_arn(uri: &str) -> Option<String> {
 }
 
 /// Build the method ARN used in Lambda-authorizer policy documents.
+/// AWS format: `arn:aws:execute-api:<region>:<account-id>:<api-id>/<stage>/<method>/<path>`.
 fn build_method_arn(req: &AwsRequest, api_id: &str) -> String {
     let stage = req
         .path_segments
         .first()
         .map(|s| s.as_str())
         .unwrap_or("$default");
+    let path = req
+        .path_segments
+        .iter()
+        .skip(1)
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join("/");
     format!(
-        "arn:aws:execute-api:{}:{}:{}/{}/{}",
-        req.region, req.account_id, api_id, stage, req.raw_path
+        "arn:aws:execute-api:{}:{}:{}/{}/{}/{}",
+        req.region,
+        req.account_id,
+        api_id,
+        stage,
+        req.method.as_str(),
+        path
     )
 }
 
@@ -2679,7 +2683,7 @@ fn parse_policy_effect(response: &serde_json::Value, method_arn: &str) -> crate:
                 .iter()
                 .filter_map(|v| v.as_str())
                 .any(|s| arn_matches(s, method_arn)),
-            _ => true,
+            _ => false,
         };
         if !matches {
             continue;

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -14,6 +14,7 @@ use crate::state::{
     Integration, Route, SharedApiGatewayV2State, Stage, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
 };
 use crate::{cors, http_proxy, lambda_proxy, mock, router::Router};
+use lambda_proxy::AuthorizerInfo;
 
 const SUPPORTED: &[&str] = &[
     "CreateApi",
@@ -2036,7 +2037,7 @@ impl ApiGatewayV2Service {
             })?;
 
         // Authorizer enforcement
-        let authorizer_claims = self
+        let authorizer_info = self
             .enforce_authorizer(&req, &api_id, &route_match.route)
             .await?;
 
@@ -2097,7 +2098,7 @@ impl ApiGatewayV2Service {
                     &route_match.route.route_key,
                     stage_name,
                     route_match.path_parameters,
-                    authorizer_claims.clone(),
+                    authorizer_info,
                 );
 
                 lambda_proxy::invoke_lambda(delivery, function_arn, event).await?
@@ -2147,15 +2148,15 @@ impl ApiGatewayV2Service {
         Ok(response)
     }
 
-    /// Enforce the authorizer configured on a route. Returns the decoded
-    /// JWT claims when a JWT authorizer succeeds, or `None` when the route
+    /// Enforce the authorizer configured on a route. Returns an
+    /// `AuthorizerInfo` when validation succeeds, or `None` when the route
     /// has no authorizer. Propagates `401 Unauthorized` on failure.
     async fn enforce_authorizer(
         &self,
         req: &AwsRequest,
         api_id: &str,
         route: &Route,
-    ) -> Result<Option<serde_json::Value>, AwsServiceError> {
+    ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
         let authorizer_id = match &route.authorizer_id {
             Some(id) => id,
             None => return Ok(None),
@@ -2182,6 +2183,10 @@ impl ApiGatewayV2Service {
 
         match authorizer.authorizer_type.as_str() {
             "JWT" => self.enforce_jwt_authorizer(req, &authorizer).await,
+            "REQUEST" => {
+                self.enforce_lambda_authorizer(req, api_id, &authorizer)
+                    .await
+            }
             _ => Err(AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "InternalError",
@@ -2198,7 +2203,7 @@ impl ApiGatewayV2Service {
         &self,
         req: &AwsRequest,
         authorizer: &Authorizer,
-    ) -> Result<Option<serde_json::Value>, AwsServiceError> {
+    ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
         let identity_sources = authorizer.identity_source.as_ref().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::UNAUTHORIZED,
@@ -2300,7 +2305,176 @@ impl ApiGatewayV2Service {
             }
         }
 
-        Ok(Some(claims))
+        Ok(Some(AuthorizerInfo::Jwt { claims }))
+    }
+
+    /// Invoke a Lambda authorizer (REQUEST type) and interpret the
+    /// response. Supports both IAM-policy and simple-response formats.
+    async fn enforce_lambda_authorizer(
+        &self,
+        req: &AwsRequest,
+        api_id: &str,
+        authorizer: &Authorizer,
+    ) -> Result<Option<AuthorizerInfo>, AwsServiceError> {
+        let identity_sources = authorizer.identity_source.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::UNAUTHORIZED,
+                "UnauthorizedException",
+                "Authorizer has no identity source",
+            )
+        })?;
+
+        // Collect all configured identity-source values (headers, query strings).
+        let mut identity_values = Vec::new();
+        for source in identity_sources {
+            if let Some(val) = extract_identity_source_value(req, source) {
+                identity_values.push(val);
+            }
+        }
+        if identity_values.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::UNAUTHORIZED,
+                "UnauthorizedException",
+                "Missing required identity source",
+            ));
+        }
+
+        let auth_uri = authorizer.authorizer_uri.as_deref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "Authorizer is missing authorizerUri; cannot invoke Lambda",
+            )
+        })?;
+        let function_arn = extract_lambda_arn(auth_uri).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "authorizerUri must reference a Lambda function ARN",
+            )
+        })?;
+
+        let method_arn = build_method_arn(req, api_id);
+
+        let mut headers = serde_json::Map::new();
+        for (k, v) in req.headers.iter() {
+            if let Ok(s) = v.to_str() {
+                headers.insert(
+                    k.as_str().to_string(),
+                    serde_json::Value::String(s.to_string()),
+                );
+            }
+        }
+        let mut query = serde_json::Map::new();
+        for (k, v) in &req.query_params {
+            query.insert(k.clone(), serde_json::Value::String(v.clone()));
+        }
+
+        let event = json!({
+            "type": "REQUEST",
+            "methodArn": method_arn,
+            "resource": req.raw_path,
+            "path": req.raw_path,
+            "httpMethod": req.method.as_str(),
+            "headers": headers,
+            "queryStringParameters": query,
+            "requestContext": {
+                "apiId": api_id,
+                "stage": req.path_segments.first().map(|s| s.as_str()).unwrap_or("$default"),
+                "path": req.raw_path,
+                "httpMethod": req.method.as_str(),
+            },
+        });
+
+        let delivery = self.delivery.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "Lambda delivery not configured",
+            )
+        })?;
+        let response_bytes = delivery
+            .invoke_lambda(&function_arn, &event.to_string())
+            .await
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    "Lambda delivery not configured",
+                )
+            })?
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "ForbiddenException",
+                    format!("Authorizer Lambda failed: {e}"),
+                )
+            })?;
+        let response: serde_json::Value = serde_json::from_slice(&response_bytes).map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::FORBIDDEN,
+                "ForbiddenException",
+                format!("Authorizer returned invalid JSON: {e}"),
+            )
+        })?;
+
+        // v2 simple response: { "isAuthorized": true/false, "context": {...} }
+        if let Some(is_authorized) = response.get("isAuthorized").and_then(|v| v.as_bool()) {
+            if !is_authorized {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::FORBIDDEN,
+                    "ForbiddenException",
+                    "User is not authorized to access this resource",
+                ));
+            }
+            let mut ctx = response
+                .get("context")
+                .cloned()
+                .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()))
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+            ctx.insert(
+                "principalId".to_string(),
+                response
+                    .get("principalId")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::Value::String("user".to_string())),
+            );
+            return Ok(Some(AuthorizerInfo::Lambda {
+                context: serde_json::Value::Object(ctx),
+            }));
+        }
+
+        // IAM-policy format (same as v1 TOKEN/REQUEST)
+        let effect = parse_policy_effect(&response, &method_arn);
+        let principal_id = response
+            .get("principalId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("user")
+            .to_string();
+        let context = response
+            .get("context")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+
+        match effect {
+            crate::state::AuthEffect::Allow => {
+                let mut ctx = context.as_object().cloned().unwrap_or_default();
+                ctx.insert(
+                    "principalId".to_string(),
+                    serde_json::Value::String(principal_id),
+                );
+                Ok(Some(AuthorizerInfo::Lambda {
+                    context: serde_json::Value::Object(ctx),
+                }))
+            }
+            crate::state::AuthEffect::Deny => Err(AwsServiceError::aws_error(
+                StatusCode::FORBIDDEN,
+                "ForbiddenException",
+                "User is not authorized to access this resource",
+            )),
+        }
     }
 
     /// Build the resource ARN that callers use when associating a
@@ -2461,6 +2635,107 @@ fn issuer_to_pool_arn(account_id: &str, region: &str, issuer: &str) -> Option<St
         "arn:aws:cognito-idp:{}:{}:userpool/{}",
         region, account_id, pool_id
     ))
+}
+
+/// Pull a Lambda function ARN out of an `authorizerUri` value.
+fn extract_lambda_arn(uri: &str) -> Option<String> {
+    // Expected: arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<arn>/invocations
+    let suffix = uri.strip_prefix("arn:aws:apigateway:")?;
+    let rest = suffix.split_once("lambda:path/2015-03-31/functions/")?.1;
+    let arn = rest.strip_suffix("/invocations")?;
+    Some(arn.to_string())
+}
+
+/// Build the method ARN used in Lambda-authorizer policy documents.
+fn build_method_arn(req: &AwsRequest, api_id: &str) -> String {
+    let stage = req
+        .path_segments
+        .first()
+        .map(|s| s.as_str())
+        .unwrap_or("$default");
+    format!(
+        "arn:aws:execute-api:{}:{}:{}/{}/{}",
+        req.region, req.account_id, api_id, stage, req.raw_path
+    )
+}
+
+/// Walk `policyDocument.Statement` and resolve to a single Allow/Deny
+/// effect. Multiple matching Allow statements collapse to Allow; any
+/// Deny short-circuits to Deny.
+fn parse_policy_effect(response: &serde_json::Value, method_arn: &str) -> crate::state::AuthEffect {
+    let Some(stmts) = response
+        .get("policyDocument")
+        .and_then(|p| p.get("Statement"))
+        .and_then(|s| s.as_array())
+    else {
+        return crate::state::AuthEffect::Deny;
+    };
+    let mut allow = false;
+    for stmt in stmts {
+        let effect = stmt.get("Effect").and_then(|v| v.as_str()).unwrap_or("");
+        let matches = match stmt.get("Resource") {
+            Some(serde_json::Value::String(s)) => arn_matches(s, method_arn),
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .any(|s| arn_matches(s, method_arn)),
+            _ => true,
+        };
+        if !matches {
+            continue;
+        }
+        match effect {
+            "Deny" => return crate::state::AuthEffect::Deny,
+            "Allow" => allow = true,
+            _ => {}
+        }
+    }
+    if allow {
+        crate::state::AuthEffect::Allow
+    } else {
+        crate::state::AuthEffect::Deny
+    }
+}
+
+/// Glob-match a policy resource expression (`arn:...:*` etc) against a
+/// concrete method ARN. `*` matches any sequence inside a single
+/// segment; `?` matches a single character.
+fn arn_matches(pattern: &str, target: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    let mut p_chars = pattern.chars().peekable();
+    let mut t_chars = target.chars().peekable();
+    loop {
+        match (p_chars.peek().copied(), t_chars.peek().copied()) {
+            (None, None) => return true,
+            (Some('*'), _) => {
+                p_chars.next();
+                // Try matching * against 0, 1, 2, ... chars in target.
+                // Simple recursive backtracking (patterns are tiny).
+                let rest_p: String = p_chars.collect();
+                let mut rest_t: String = t_chars.collect();
+                loop {
+                    if arn_matches(&rest_p, &rest_t) {
+                        return true;
+                    }
+                    if rest_t.is_empty() {
+                        return false;
+                    }
+                    rest_t.remove(0);
+                }
+            }
+            (Some('?'), Some(_)) => {
+                p_chars.next();
+                t_chars.next();
+            }
+            (Some(pc), Some(tc)) if pc == tc => {
+                p_chars.next();
+                t_chars.next();
+            }
+            _ => return false,
+        }
+    }
 }
 
 #[path = "service_helpers.rs"]

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1849,6 +1849,70 @@ async fn execute_api_lambda_authorizer_partial_identity_source_returns_401() {
 }
 
 #[tokio::test]
+async fn execute_api_lambda_authorizer_empty_identity_source_returns_401() {
+    // Identity source header present but empty -> 401.
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({"isAuthorized": true})
+        .to_string()
+        .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Authorization header present but empty -> 401.
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers.insert("Authorization", "".parse().unwrap());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn execute_api_lambda_authorizer_malformed_policy_no_resource() {
     // Policy statement missing Resource field should default to Deny.
     let svc = make_svc_with_lambda(Ok(serde_json::json!({

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1717,3 +1717,217 @@ async fn execute_api_lambda_authorizer_no_identity_source_returns_401() {
     let err = expect_err(svc.handle(req).await);
     assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
 }
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_optional_identity_source() {
+    // REQUEST authorizer with no identitySource configured still invokes Lambda.
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({
+        "isAuthorized": true,
+        "context": {"role": "admin"}
+    })
+    .to_string()
+    .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // No identity sources configured -> request proceeds to Lambda and is allowed.
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_partial_identity_source_returns_401() {
+    // Two identity sources configured, only one present -> 401.
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({"isAuthorized": true})
+        .to_string()
+        .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization", "$request.header.X-Custom"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Only Authorization header present, missing X-Custom -> 401.
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_malformed_policy_no_resource() {
+    // Policy statement missing Resource field should default to Deny.
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({
+        "principalId": "user-1",
+        "policyDocument": {
+            "Statement": [{"Effect": "Allow"}]
+        }
+    })
+    .to_string()
+    .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn build_method_arn_includes_method_and_no_double_slash() {
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let arn = build_method_arn(&req, "abc123");
+    assert_eq!(
+        arn,
+        "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/GET/pets"
+    );
+
+    // Empty path after stage should not produce trailing slash.
+    let req2 = make_request(Method::GET, "/prod", "");
+    let arn2 = build_method_arn(&req2, "abc123");
+    assert_eq!(
+        arn2,
+        "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/GET/"
+    );
+}

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1359,3 +1359,361 @@ async fn execute_api_jwt_authorizer_no_delivery_returns_500() {
     let err = expect_err(svc.handle(req).await);
     assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
+
+// ─── Lambda authorizer tests ───────────────────────────────────────
+
+struct MockLambdaInvoker {
+    response: Result<Vec<u8>, String>,
+}
+
+impl fakecloud_core::delivery::LambdaDelivery for MockLambdaInvoker {
+    fn invoke_lambda(
+        &self,
+        _function_arn: &str,
+        _payload: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>> {
+        let res = self.response.clone();
+        Box::pin(async move { res })
+    }
+}
+
+fn make_svc_with_lambda(response: Result<Vec<u8>, String>) -> ApiGatewayV2Service {
+    let state = make_state();
+    let delivery = Arc::new(
+        fakecloud_core::delivery::DeliveryBus::new()
+            .with_lambda(Arc::new(MockLambdaInvoker { response })),
+    );
+    ApiGatewayV2Service::new(state).with_delivery(delivery)
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_simple_response_allow() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({
+        "isAuthorized": true,
+        "context": {"role": "admin"}
+    })
+    .to_string()
+    .into_bytes()));
+    let api_id = create_api(&svc);
+
+    // Create REQUEST authorizer
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create MOCK integration
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route with authorizer
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute with token -> 200 (authorizer allows)
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_simple_response_deny() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({"isAuthorized": false})
+        .to_string()
+        .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_policy_allow() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({
+        "principalId": "user-1",
+        "policyDocument": {
+            "Statement": [{"Effect": "Allow", "Resource": "*"}]
+        },
+        "context": {"role": "admin"}
+    })
+    .to_string()
+    .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_policy_deny() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({
+        "principalId": "user-1",
+        "policyDocument": {
+            "Statement": [{"Effect": "Deny", "Resource": "*"}]
+        }
+    })
+    .to_string()
+    .into_bytes()));
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let mut req = make_request(Method::GET, "/prod/pets", "");
+    req.headers
+        .insert("Authorization", "Bearer tok".parse().unwrap());
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn execute_api_lambda_authorizer_no_identity_source_returns_401() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "name": "lambda-auth",
+        "authorizerType": "REQUEST",
+        "identitySource": ["$request.header.Authorization"],
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:authorizer/invocations"
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/authorizers"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let auth_id = body_json(&resp)["authorizerId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+        "authorizerId": auth_id
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // No Authorization header -> 401
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let err = expect_err(svc.handle(req).await);
+    assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -360,6 +360,13 @@ pub struct ApiRequest {
     pub status_code: u16,
 }
 
+/// Result of evaluating a Lambda-authorizer policy document.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthEffect {
+    Allow,
+    Deny,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implement Lambda authorizer (REQUEST type) enforcement for API Gateway v2 HTTP APIs.

- `enforce_authorizer` now dispatches `"REQUEST"` type to `enforce_lambda_authorizer`
- Collect identity source values from headers/query strings
- Build Lambda REQUEST event and invoke via delivery bus
- Support simple response (`isAuthorized` + `context`) and IAM policy document response
- Parse policy effect with ARN glob matching (`*`, `?`)
- `AuthorizerInfo::Lambda` injects authorizer context into v2.0 request context
- Add unit tests for simple allow/deny and policy allow/deny
- Fix fail-open holes: unsupported authorizer type and missing authorizer now return 500 instead of silently bypassing auth

## Test plan

- [x] `cargo test --package fakecloud-apigatewayv2 --all-targets` passes (126 tests)
- [x] `cargo clippy --package fakecloud-apigatewayv2 --all-targets -- -D warnings` clean
- [x] New tests:
  - `execute_api_lambda_authorizer_simple_response_allow`
  - `execute_api_lambda_authorizer_simple_response_deny`
  - `execute_api_lambda_authorizer_policy_allow`
  - `execute_api_lambda_authorizer_policy_deny`
  - `execute_api_lambda_authorizer_no_identity_source_returns_401`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Lambda (REQUEST) authorizers for API Gateway v2 HTTP APIs. Requests now call the configured Lambda, inject authorizer context into `requestContext.authorizer`, and return the correct 401/403; identity source validation (incl. empty values), `methodArn`, and policy parsing are tightened.

- New Features
  - Routes with "REQUEST" authorizers invoke `enforce_lambda_authorizer` to collect identity sources, build the Lambda REQUEST event (incl. `methodArn`), and invoke via the delivery bus.
  - Supports simple responses (`isAuthorized` + optional `context`) and IAM policy documents with ARN glob matching; injects context into v2.0 `requestContext.authorizer` via `AuthorizerInfo`.
  - Tests cover simple/policy allow/deny, missing/optional/partial identity sources, empty identity source (401), and Lambda context in events.

- Bug Fixes
  - Unsupported authorizer type and missing authorizer now return 500 instead of bypassing auth.
  - Identity sources are optional for REQUEST; when configured, all listed sources must be present and non-empty (401 on missing/empty).
  - `methodArn` now includes the HTTP method and a normalized path (no double slashes).
  - Malformed policy statements (e.g., missing `Resource`) default to Deny.

<sup>Written for commit cee73d702a2edeb385875d90d900ab567d3825a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

