### PR TITLE
feat(apigatewayv2): stage variables, custom domain routing, AWS service integrations

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use http::{Method, StatusCode};
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -1265,6 +1266,11 @@ impl ApiGatewayV2Service {
         let description = body["description"].as_str().map(|s| s.to_string());
         let auto_deploy = body["autoDeploy"].as_bool().unwrap_or(false);
         let deployment_id = body["deploymentId"].as_str().map(|s| s.to_string());
+        let stage_variables = body["stageVariables"].as_object().map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect::<BTreeMap<String, String>>()
+        });
 
         let created_date = chrono::Utc::now();
 
@@ -1276,6 +1282,7 @@ impl ApiGatewayV2Service {
             created_date,
             last_updated_date: None,
             web_acl_arn: None,
+            stage_variables,
         };
 
         let mut accounts = self.state.write();
@@ -1446,6 +1453,16 @@ impl ApiGatewayV2Service {
 
         if let Some(deployment_id) = body["deploymentId"].as_str() {
             stage.deployment_id = Some(deployment_id.to_string());
+        }
+
+        if let Some(vars) = body["stageVariables"].as_object() {
+            let mut map = BTreeMap::new();
+            for (k, v) in vars.iter() {
+                if let Some(s) = v.as_str() {
+                    map.insert(k.clone(), s.to_string());
+                }
+            }
+            stage.stage_variables = Some(map);
         }
 
         stage.last_updated_date = Some(chrono::Utc::now());
@@ -1947,59 +1964,92 @@ impl ApiGatewayV2Service {
 
     // ─── EXECUTE API ────────────────────────────────────────────────────
 
-    async fn handle_execute_api(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // Execute API format: /{stage}/{path...}
-        if req.path_segments.is_empty() {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "NotFoundException",
-                "Stage not specified",
-            ));
-        }
-
-        let stage_name = &req.path_segments[0];
-        let resource_path = format!("/{}", req.path_segments[1..].join("/"));
-
-        // Find the API for this stage and get CORS configuration
-        let (api_id, routes, cors_config) = {
+    async fn handle_execute_api(
+        &self,
+        mut req: AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        // Try custom domain resolution first.
+        let (api_id, stage_name, stage_vars) = {
             let accounts = self.state.read();
             let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
             let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-            // Find which API has this stage (sort by API ID for deterministic resolution)
-            let mut stage_entries: Vec<_> = state
-                .stages
-                .iter()
-                .filter_map(|(api_id, stages)| {
-                    stages
-                        .get(stage_name)
-                        .map(|stage| (api_id.clone(), stage.clone()))
-                })
-                .collect();
-            stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
-            let (api_id, _stage) = stage_entries.into_iter().next().ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "NotFoundException",
-                    format!("Stage not found: {}", stage_name),
-                )
-            })?;
+            if let Some((api_id, stage_name, new_segs, new_raw_path)) =
+                resolve_custom_domain(&req, state)
+            {
+                req.path_segments = new_segs;
+                req.raw_path = new_raw_path;
+                let stage_vars = state
+                    .stages
+                    .get(&api_id)
+                    .and_then(|stages| stages.get(&stage_name))
+                    .and_then(|s| s.stage_variables.clone())
+                    .unwrap_or_default();
+                (api_id, stage_name, stage_vars)
+            } else {
+                // Execute API format: /{stage}/{path...}
+                if req.path_segments.is_empty() {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "NotFoundException",
+                        "Stage not specified",
+                    ));
+                }
+                let stage_name = req.path_segments[0].clone();
+                // Strip the stage segment so route matching uses the resource path.
+                req.path_segments.remove(0);
+                let stage_vars = state
+                    .stages
+                    .iter()
+                    .find_map(|(_, stages)| stages.get(&stage_name))
+                    .and_then(|s| s.stage_variables.clone())
+                    .unwrap_or_default();
+                // Find which API has this stage (sort by API ID for deterministic resolution)
+                let mut stage_entries: Vec<_> = state
+                    .stages
+                    .iter()
+                    .filter_map(|(api_id, stages)| {
+                        stages
+                            .get(&stage_name)
+                            .map(|stage| (api_id.clone(), stage.clone()))
+                    })
+                    .collect();
+                stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
+                let (api_id, _) = stage_entries.into_iter().next().ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::NOT_FOUND,
+                        "NotFoundException",
+                        format!("Stage not found: {}", stage_name),
+                    )
+                })?;
+                (api_id, stage_name, stage_vars)
+            }
+        };
 
-            // Get routes for this API
+        let resource_path = if req.path_segments.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", req.path_segments.join("/"))
+        };
+
+        let (routes, cors_config) = {
+            let accounts = self.state.read();
+            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
             let routes = state
                 .routes
                 .get(&api_id)
                 .map(|r| r.values().cloned().collect())
                 .unwrap_or_default();
 
-            // Get CORS configuration from API
             let cors_config = state
                 .apis
                 .get(&api_id)
                 .and_then(|api| api.cors_configuration.clone());
 
-            Ok::<_, AwsServiceError>((api_id, routes, cors_config))
-        }?;
+            (routes, cors_config)
+        };
 
         // Handle CORS preflight requests
         if let Some(ref cors_cfg) = cors_config {
@@ -2013,11 +2063,11 @@ impl ApiGatewayV2Service {
         // evaluate the request before route match / authorizer /
         // integration. Block / Captcha / Challenge short-circuit;
         // Count is recorded but lets the request continue.
-        if let Some(resp) = self.evaluate_waf(&req, &api_id, stage_name) {
+        if let Some(resp) = self.evaluate_waf(&req, &api_id, &stage_name) {
             self.record_request(
                 &req,
                 &api_id,
-                stage_name,
+                &stage_name,
                 &resource_path,
                 resp.status.as_u16(),
             );
@@ -2055,7 +2105,7 @@ impl ApiGatewayV2Service {
                 )
             })?;
 
-        let integration = {
+        let mut integration = {
             let accounts = self.state.read();
             let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
             let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -2073,10 +2123,17 @@ impl ApiGatewayV2Service {
                 .clone()
         };
 
+        // Substitute stage variables into the integration URI before dispatch.
+        if let Some(ref uri) = integration.integration_uri {
+            let substituted = substitute_stage_variables(uri, &stage_vars);
+            if substituted != *uri {
+                integration.integration_uri = Some(substituted);
+            }
+        }
+
         // Handle based on integration type
         let mut response = match integration.integration_type.as_str() {
             "AWS_PROXY" => {
-                // Lambda proxy integration
                 let delivery = self.delivery.as_ref().ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -2085,7 +2142,7 @@ impl ApiGatewayV2Service {
                     )
                 })?;
 
-                let function_arn = integration.integration_uri.as_ref().ok_or_else(|| {
+                let integration_uri = integration.integration_uri.as_ref().ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "InternalError",
@@ -2093,15 +2150,18 @@ impl ApiGatewayV2Service {
                     )
                 })?;
 
-                let event = lambda_proxy::construct_event(
-                    &req,
-                    &route_match.route.route_key,
-                    stage_name,
-                    route_match.path_parameters,
-                    authorizer_info,
-                );
-
-                lambda_proxy::invoke_lambda(delivery, function_arn, event).await?
+                if is_lambda_arn(integration_uri) {
+                    let event = lambda_proxy::construct_event(
+                        &req,
+                        &route_match.route.route_key,
+                        &stage_name,
+                        route_match.path_parameters,
+                        authorizer_info,
+                    );
+                    lambda_proxy::invoke_lambda(delivery, integration_uri, event).await?
+                } else {
+                    dispatch_aws_service_integration(delivery, integration_uri, &req)?
+                }
             }
             "HTTP_PROXY" => {
                 // HTTP proxy integration
@@ -2140,7 +2200,7 @@ impl ApiGatewayV2Service {
         self.record_request(
             &req,
             &api_id,
-            stage_name,
+            &stage_name,
             &resource_path,
             response.status.as_u16(),
         );
@@ -2743,6 +2803,147 @@ fn arn_matches(pattern: &str, target: &str) -> bool {
             _ => return false,
         }
     }
+}
+
+/// Replace `${stageVariables.<name>}` placeholders in `uri` with values
+/// from `stage_variables`. Unknown names are left as-is.
+fn substitute_stage_variables(uri: &str, stage_variables: &BTreeMap<String, String>) -> String {
+    let mut result = uri.to_string();
+    for (k, v) in stage_variables {
+        let placeholder = format!("${{stageVariables.{}}}", k);
+        result = result.replace(&placeholder, v);
+    }
+    result
+}
+
+/// When the request Host header matches a custom domain name, look up
+/// the ApiMapping for the base path and return `(api_id, stage_name,
+/// remaining_path_segments, resource_path)`.
+///
+/// The returned `remaining_path_segments` is what should be used for
+/// route matching (the base path prefix is stripped). `resource_path`
+/// is the display path recorded in request history.
+fn resolve_custom_domain(
+    req: &AwsRequest,
+    state: &ApiGatewayV2State,
+) -> Option<(String, String, Vec<String>, String)> {
+    let host = req.headers.get("host").and_then(|v| v.to_str().ok())?;
+
+    // Only consider hosts that don't look like the default execute-api endpoint.
+    if host.contains(".execute-api.") {
+        return None;
+    }
+
+    let domain = state.domain_names.get(host)?;
+    let domain_name = domain["DomainName"].as_str()?;
+
+    let mappings = state.api_mappings.get(domain_name)?;
+    if mappings.is_empty() {
+        return None;
+    }
+
+    // Find the mapping whose ApiMappingKey matches the longest prefix of the path.
+    let raw_path = &req.raw_path;
+    let mut best: Option<(&str, &str, Vec<String>, String)> = None;
+
+    for mapping in mappings.values() {
+        let key = mapping["ApiMappingKey"].as_str().unwrap_or("");
+        let api_id = mapping["ApiId"].as_str()?;
+        let stage = mapping["Stage"].as_str()?;
+
+        let (stripped_path, remaining) = if key.is_empty() {
+            (raw_path.to_string(), raw_path.to_string())
+        } else {
+            let prefix = format!("/{}/", key);
+            let prefix_root = format!("/{}", key);
+            if *raw_path == *prefix_root || raw_path.starts_with(&prefix) {
+                let rest = &raw_path[prefix_root.len()..];
+                (rest.to_string(), rest.to_string())
+            } else {
+                continue;
+            }
+        };
+
+        let segs: Vec<String> = if stripped_path.is_empty() || stripped_path == "/" {
+            vec![]
+        } else {
+            stripped_path
+                .split('/')
+                .skip(1)
+                .map(|s| s.to_string())
+                .collect()
+        };
+
+        let best_key_len = best.as_ref().map(|(k, _, _, _)| k.len()).unwrap_or(0);
+        if key.len() >= best_key_len {
+            best = Some((api_id, stage, segs, remaining));
+        }
+    }
+
+    best.map(|(api_id, stage, segs, resource_path)| {
+        (api_id.to_string(), stage.to_string(), segs, resource_path)
+    })
+}
+
+/// Returns true when `uri` is a Lambda function ARN.
+fn is_lambda_arn(uri: &str) -> bool {
+    uri.starts_with("arn:aws:lambda:") && uri.contains(":function:")
+}
+
+/// Dispatch a non-Lambda AWS_PROXY integration to the appropriate
+/// AWS service via the delivery bus. Supported targets:
+///   - SQS queue ARN
+///   - SNS topic ARN
+///   - StepFunctions state-machine ARN
+fn dispatch_aws_service_integration(
+    delivery: &DeliveryBus,
+    integration_uri: &str,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    if integration_uri.starts_with("arn:aws:sqs:") {
+        let message = String::from_utf8_lossy(&req.body);
+        delivery.send_to_sqs(integration_uri, &message, &std::collections::HashMap::new());
+        return Ok(AwsResponse::ok_json(json!({
+            "statusCode": 200,
+            "body": json!({"MessageId": uuid::Uuid::new_v4().to_string()}).to_string()
+        })));
+    }
+
+    if integration_uri.starts_with("arn:aws:sns:") {
+        let message = String::from_utf8_lossy(&req.body);
+        let subject = req
+            .headers
+            .get("x-amz-sns-subject")
+            .and_then(|v| v.to_str().ok());
+        delivery.publish_to_sns(integration_uri, &message, subject);
+        return Ok(AwsResponse::ok_json(json!({
+            "statusCode": 200,
+            "body": json!({"MessageId": uuid::Uuid::new_v4().to_string()}).to_string()
+        })));
+    }
+
+    if integration_uri.starts_with("arn:aws:states:") && integration_uri.contains(":stateMachine:")
+    {
+        let input = String::from_utf8_lossy(&req.body);
+        let execution_name = format!("apigw-{}-{}", req.request_id, uuid::Uuid::new_v4().simple());
+        delivery.start_stepfunctions_execution(integration_uri, &input);
+        return Ok(AwsResponse::ok_json(json!({
+            "statusCode": 200,
+            "body": json!({
+                "executionArn": format!("{}/execution/{}", integration_uri, execution_name),
+                "startDate": chrono::Utc::now().to_rfc3339()
+            }).to_string()
+        })));
+    }
+
+    Err(AwsServiceError::aws_error(
+        StatusCode::NOT_IMPLEMENTED,
+        "NotImplemented",
+        format!(
+            "AWS_PROXY integration target not supported: {}",
+            integration_uri
+        ),
+    ))
 }
 
 #[path = "service_helpers.rs"]

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -1995,3 +1995,447 @@ fn build_method_arn_includes_method_and_no_double_slash() {
         "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/GET/"
     );
 }
+
+// ── stage variables ──
+
+#[tokio::test]
+async fn execute_api_stage_variable_substitution_in_lambda_arn() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({"statusCode": 200})
+        .to_string()
+        .into_bytes()));
+    let api_id = create_api(&svc);
+
+    // Create integration with stage variable placeholder
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:lambda:us-east-1:123456789012:function:my-fn:${stageVariables.env}",
+        "payloadFormatVersion": "2.0",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage with stage variable
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "stageVariables": {"env": "prod"},
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute - should succeed because stage variable substitutes to a valid Lambda ARN
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_stage_variable_passthrough_when_key_missing() {
+    let svc = make_svc_with_lambda(Ok(serde_json::json!({"statusCode": 200})
+        .to_string()
+        .into_bytes()));
+    let api_id = create_api(&svc);
+
+    // Create integration with stage variable placeholder but no matching stage variable
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:lambda:us-east-1:123456789012:function:my-fn:${stageVariables.env}",
+        "payloadFormatVersion": "2.0",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Stage without the required stage variable
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute - placeholder remains in URI but Lambda ARN check still matches,
+    // so mock lambda is invoked and request succeeds.
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+// ── custom domain + api mapping ──
+
+#[tokio::test]
+async fn execute_api_custom_domain_base_path_mapping() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    // Create MOCK integration
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route GET /pets
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create custom domain
+    let body = serde_json::json!({"domainName": "example.com"});
+    let req = make_request(Method::POST, "/v2/domainnames", &body.to_string());
+    svc.handle(req).await.unwrap();
+
+    // Create api mapping with base path "v1"
+    let body = serde_json::json!({"apiId": api_id, "stage": "prod", "apiMappingKey": "v1"});
+    let req = make_request(
+        Method::POST,
+        "/v2/domainnames/example.com/apimappings",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute with custom domain host and base path - should strip "/v1" and match route
+    let mut req = make_request(Method::GET, "/v1/pets", "");
+    req.headers.insert("host", "example.com".parse().unwrap());
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn execute_api_custom_domain_empty_base_path() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    // Create MOCK integration
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create route GET /pets
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create stage
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create custom domain
+    let body = serde_json::json!({"domainName": "example.com"});
+    let req = make_request(Method::POST, "/v2/domainnames", &body.to_string());
+    svc.handle(req).await.unwrap();
+
+    // Create api mapping with empty base path
+    let body = serde_json::json!({"apiId": api_id, "stage": "prod"});
+    let req = make_request(
+        Method::POST,
+        "/v2/domainnames/example.com/apimappings",
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Execute with custom domain host - full path used for route matching
+    let mut req = make_request(Method::GET, "/pets", "");
+    req.headers.insert("host", "example.com".parse().unwrap());
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+// ── AWS service integrations ──
+
+#[tokio::test]
+async fn execute_api_aws_proxy_sqs_integration() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:sqs:us-east-1:123456789012:my-queue",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "POST /messages",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::POST, "/prod/messages", "hello sqs");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let b = body_json(&resp);
+    assert_eq!(b["statusCode"], 200);
+    // MessageId is present in the inner JSON body string
+    let inner: serde_json::Value = serde_json::from_str(b["body"].as_str().unwrap()).unwrap();
+    assert!(!inner["MessageId"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn execute_api_aws_proxy_sns_integration() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:sns:us-east-1:123456789012:my-topic",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "POST /notify",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::POST, "/prod/notify", "hello sns");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let b = body_json(&resp);
+    assert_eq!(b["statusCode"], 200);
+    let inner: serde_json::Value = serde_json::from_str(b["body"].as_str().unwrap()).unwrap();
+    assert!(!inner["MessageId"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn execute_api_aws_proxy_stepfunctions_integration() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:states:us-east-1:123456789012:stateMachine:my-sm",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "POST /workflow",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::POST, "/prod/workflow", "{\"name\":\"test\"}");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let b = body_json(&resp);
+    assert_eq!(b["statusCode"], 200);
+    let inner: serde_json::Value = serde_json::from_str(b["body"].as_str().unwrap()).unwrap();
+    assert!(inner["executionArn"]
+        .as_str()
+        .unwrap()
+        .contains("stateMachine:my-sm"));
+    assert!(inner["startDate"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn execute_api_aws_proxy_unsupported_arn_returns_not_implemented() {
+    let state = make_state();
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let svc = ApiGatewayV2Service::new(state).with_delivery(delivery);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "integrationType": "AWS_PROXY",
+        "integrationUri": "arn:aws:dynamodb:us-east-1:123456789012:table/my-table",
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /items",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/prod/items", "");
+    let err = match svc.handle(req).await {
+        Ok(_) => panic!("expected error"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("NotImplemented"),
+        "expected NotImplemented but got: {}",
+        msg
+    );
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -309,6 +309,10 @@ pub struct Stage {
     /// is attached, which is the common case.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub web_acl_arn: Option<String>,
+    /// Stage variables substituted into integration URIs at request
+    /// time via `${stageVariables.<name>}`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub stage_variables: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -15470,6 +15470,15 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
+        let stage_variables = props
+            .get("StageVariables")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            });
+
         let stage = ApiGwV2Stage {
             stage_name: stage_name.clone(),
             description: props
@@ -15481,6 +15490,7 @@ impl ResourceProvisioner {
             created_date: Utc::now(),
             last_updated_date: None,
             web_acl_arn: None,
+            stage_variables,
         };
 
         let mut accounts = self.apigatewayv2_state.write();


### PR DESCRIPTION
## Summary

- Add `stage_variables` field to `Stage` struct and parse in `CreateStage`/`UpdateStage`
- Implement custom domain resolution via `Host` header + `ApiMapping` base-path stripping
- Substitute `${stageVariables.<name>}` placeholders in integration URIs at request time
- Dispatch non-Lambda `AWS_PROXY` integrations to SQS, SNS, StepFunctions via `DeliveryBus`
- Add unit tests covering stage variable substitution, custom domain routing, and AWS service integration dispatch paths

## Test plan

- [x] `cargo test -p fakecloud-apigatewayv2 --lib` passes (129 tests)
- [x] `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings` clean
- [x] `cargo fmt -p fakecloud-apigatewayv2` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stage variables, custom domain routing, and AWS service integrations to `fakecloud-apigatewayv2`, plus CloudFormation support for stage variables in `fakecloud-cloudformation`. Supports `${stageVariables.*}` substitution and custom domain base-path mappings.

- **New Features**
  - Stage variables (`stageVariables`) on stages; parsed in Create/Update and stored on `Stage`.
  - Substitute `${stageVariables.<name>}` in integration URIs at request time.
  - Custom domain resolution via `Host` header and `ApiMapping` base-path stripping.
  - Non-Lambda `AWS_PROXY` integrations dispatch to SQS, SNS, and StepFunctions via `DeliveryBus`.
  - CloudFormation: accept `StageVariables` on `AWS::ApiGatewayV2::Stage` and persist to stage.

<sup>Written for commit 2875b67926f4114c330bbe1bb7cfc559b7832d41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

