### PR TITLE
feat(apigatewayv2): access log delivery to CloudWatch Logs

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/lib.rs
+++ b/crates/fakecloud-apigatewayv2/src/lib.rs
@@ -12,7 +12,8 @@ pub mod websocket_dispatch;
 
 pub use service::ApiGatewayV2Service;
 pub use state::{
-    ApiGatewayV2Snapshot, ApiGatewayV2State, Authorizer, ConnectionInfo, CorsConfiguration,
-    Deployment, HttpApi, Integration, JwtConfiguration, Route, SharedApiGatewayV2State,
-    SharedWebSocketRegistry, Stage, WebSocketRegistry, APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
+    AccessLogSettings, ApiGatewayV2Snapshot, ApiGatewayV2State, Authorizer, ConnectionInfo,
+    CorsConfiguration, Deployment, HttpApi, Integration, JwtConfiguration, Route,
+    SharedApiGatewayV2State, SharedWebSocketRegistry, Stage, WebSocketRegistry,
+    APIGATEWAYV2_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -1481,15 +1481,15 @@ impl ApiGatewayV2Service {
         if let Some(settings) = body.get("accessLogSettings") {
             if settings.is_null() {
                 stage.access_log_settings = None;
-            } else {
-                let destination_arn = settings["destinationArn"].as_str().map(String::from);
+            } else if let Some(arn) = settings["destinationArn"].as_str() {
                 let format = settings["format"].as_str().map(String::from);
-                stage.access_log_settings =
-                    destination_arn.map(|arn| crate::state::AccessLogSettings {
-                        destination_arn: arn,
-                        format,
-                    });
+                stage.access_log_settings = Some(crate::state::AccessLogSettings {
+                    destination_arn: arn.to_string(),
+                    format,
+                });
             }
+            // If accessLogSettings is present but destinationArn is missing,
+            // preserve the existing settings (Cubic finding).
         }
 
         stage.last_updated_date = Some(chrono::Utc::now());
@@ -1998,6 +1998,7 @@ impl ApiGatewayV2Service {
         let mut api_id = String::new();
         let mut stage_name = String::new();
         let mut resource_path = String::new();
+        let mut matched_route_key = String::new();
 
         let result: Result<AwsResponse, AwsServiceError> = async {
             // Try custom domain resolution first.
@@ -2109,6 +2110,8 @@ impl ApiGatewayV2Service {
                         format!("No route matches: {} {}", req.method, resource_path),
                     )
                 })?;
+
+            matched_route_key = route_match.route.route_key.clone();
 
             // Authorizer enforcement
             let authorizer_info = self
@@ -2233,7 +2236,7 @@ impl ApiGatewayV2Service {
 
         self.record_request(&req, &api_id, &stage_name, &resource_path, status_code);
 
-        self.emit_access_log(&req, &api_id, &stage_name, &resource_path, status_code);
+        self.emit_access_log(&req, &api_id, &stage_name, &matched_route_key, status_code);
 
         result
     }
@@ -2653,7 +2656,7 @@ impl ApiGatewayV2Service {
         req: &AwsRequest,
         api_id: &str,
         stage: &str,
-        path: &str,
+        route_key: &str,
         status_code: u16,
     ) {
         let Some(delivery) = self.delivery.as_ref() else {
@@ -2706,17 +2709,38 @@ impl ApiGatewayV2Service {
             r#"{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}"#,
         );
 
-        let log_line = format
-            .replace("$context.requestId", &req.request_id)
-            .replace("$context.apiId", api_id)
-            .replace("$context.stage", stage)
-            .replace("$context.identity.sourceIp", &source_ip)
-            .replace("$context.requestTime", &request_time)
-            .replace("$context.httpMethod", req.method.as_str())
-            .replace("$context.routeKey", path)
-            .replace("$context.status", &status_code.to_string())
-            .replace("$context.protocol", "HTTP/1.1")
-            .replace("$context.responseLength", "0");
+        // Token-aware single-pass substitution to avoid overlapping corruption.
+        let mut log_line = String::new();
+        let mut rest = format;
+        while let Some(pos) = rest.find("$context.") {
+            log_line.push_str(&rest[..pos]);
+            rest = &rest[pos..];
+            let end = rest[9..]
+                .find(|c: char| !c.is_alphanumeric() && c != '.' && c != '_')
+                .map(|i| i + 9)
+                .unwrap_or(rest.len());
+            let token = &rest[..end];
+            let value = match token {
+                "$context.requestId" => req.request_id.as_str(),
+                "$context.apiId" => api_id,
+                "$context.stage" => stage,
+                "$context.identity.sourceIp" => &source_ip,
+                "$context.requestTime" => &request_time,
+                "$context.httpMethod" => req.method.as_str(),
+                "$context.routeKey" => route_key,
+                "$context.status" => {
+                    log_line.push_str(&status_code.to_string());
+                    rest = &rest[end..];
+                    continue;
+                }
+                "$context.protocol" => "HTTP/1.1",
+                "$context.responseLength" => "0",
+                _ => token,
+            };
+            log_line.push_str(value);
+            rest = &rest[end..];
+        }
+        log_line.push_str(rest);
 
         let timestamp = chrono::Utc::now().timestamp_millis();
         let log_stream_name = format!("{}/{}", api_id, stage);

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -1272,6 +1272,18 @@ impl ApiGatewayV2Service {
                 .collect::<BTreeMap<String, String>>()
         });
 
+        let access_log_settings = body.get("accessLogSettings").and_then(|v| {
+            if v.is_null() {
+                return None;
+            }
+            let destination_arn = v.get("destinationArn")?.as_str()?.to_string();
+            let format = v.get("format").and_then(|f| f.as_str().map(String::from));
+            Some(crate::state::AccessLogSettings {
+                destination_arn,
+                format,
+            })
+        });
+
         let created_date = chrono::Utc::now();
 
         let stage = Stage {
@@ -1283,6 +1295,7 @@ impl ApiGatewayV2Service {
             last_updated_date: None,
             web_acl_arn: None,
             stage_variables,
+            access_log_settings,
         };
 
         let mut accounts = self.state.write();
@@ -1463,6 +1476,20 @@ impl ApiGatewayV2Service {
                 }
             }
             stage.stage_variables = Some(map);
+        }
+
+        if let Some(settings) = body.get("accessLogSettings") {
+            if settings.is_null() {
+                stage.access_log_settings = None;
+            } else {
+                let destination_arn = settings["destinationArn"].as_str().map(String::from);
+                let format = settings["format"].as_str().map(String::from);
+                stage.access_log_settings =
+                    destination_arn.map(|arn| crate::state::AccessLogSettings {
+                        destination_arn: arn,
+                        format,
+                    });
+            }
         }
 
         stage.last_updated_date = Some(chrono::Utc::now());
@@ -1968,244 +1995,247 @@ impl ApiGatewayV2Service {
         &self,
         mut req: AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // Try custom domain resolution first.
-        let (api_id, stage_name, stage_vars) = {
-            let accounts = self.state.read();
-            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
-            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let mut api_id = String::new();
+        let mut stage_name = String::new();
+        let mut resource_path = String::new();
 
-            if let Some((api_id, stage_name, new_segs, new_raw_path)) =
-                resolve_custom_domain(&req, state)
-            {
-                req.path_segments = new_segs;
-                req.raw_path = new_raw_path;
-                let stage_vars = state
-                    .stages
-                    .get(&api_id)
-                    .and_then(|stages| stages.get(&stage_name))
-                    .and_then(|s| s.stage_variables.clone())
-                    .unwrap_or_default();
-                (api_id, stage_name, stage_vars)
-            } else {
-                // Execute API format: /{stage}/{path...}
-                if req.path_segments.is_empty() {
-                    return Err(AwsServiceError::aws_error(
-                        StatusCode::NOT_FOUND,
-                        "NotFoundException",
-                        "Stage not specified",
-                    ));
+        let result: Result<AwsResponse, AwsServiceError> = async {
+            // Try custom domain resolution first.
+            let (a, s, stage_vars) = {
+                let accounts = self.state.read();
+                let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+                let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+                if let Some((a, s, new_segs, new_raw_path)) = resolve_custom_domain(&req, state) {
+                    req.path_segments = new_segs;
+                    req.raw_path = new_raw_path;
+                    let stage_vars = state
+                        .stages
+                        .get(&a)
+                        .and_then(|stages| stages.get(&s))
+                        .and_then(|st| st.stage_variables.clone())
+                        .unwrap_or_default();
+                    (a, s, stage_vars)
+                } else {
+                    // Execute API format: /{stage}/{path...}
+                    if req.path_segments.is_empty() {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "NotFoundException",
+                            "Stage not specified",
+                        ));
+                    }
+                    let s = req.path_segments[0].clone();
+                    // Strip the stage segment so route matching uses the resource path.
+                    req.path_segments.remove(0);
+                    let stage_vars = state
+                        .stages
+                        .iter()
+                        .find_map(|(_, stages)| stages.get(&s))
+                        .and_then(|st| st.stage_variables.clone())
+                        .unwrap_or_default();
+                    // Find which API has this stage (sort by API ID for deterministic resolution)
+                    let mut stage_entries: Vec<_> = state
+                        .stages
+                        .iter()
+                        .filter_map(|(api_id, stages)| {
+                            stages.get(&s).map(|stage| (api_id.clone(), stage.clone()))
+                        })
+                        .collect();
+                    stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
+                    let (a, _) = stage_entries.into_iter().next().ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "NotFoundException",
+                            format!("Stage not found: {}", s),
+                        )
+                    })?;
+                    (a, s, stage_vars)
                 }
-                let stage_name = req.path_segments[0].clone();
-                // Strip the stage segment so route matching uses the resource path.
-                req.path_segments.remove(0);
-                let stage_vars = state
-                    .stages
-                    .iter()
-                    .find_map(|(_, stages)| stages.get(&stage_name))
-                    .and_then(|s| s.stage_variables.clone())
+            };
+
+            api_id = a;
+            stage_name = s;
+
+            resource_path = if req.path_segments.is_empty() {
+                "/".to_string()
+            } else {
+                format!("/{}", req.path_segments.join("/"))
+            };
+
+            let (routes, cors_config) = {
+                let accounts = self.state.read();
+                let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+                let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+                let routes = state
+                    .routes
+                    .get(&api_id)
+                    .map(|r| r.values().cloned().collect())
                     .unwrap_or_default();
-                // Find which API has this stage (sort by API ID for deterministic resolution)
-                let mut stage_entries: Vec<_> = state
-                    .stages
-                    .iter()
-                    .filter_map(|(api_id, stages)| {
-                        stages
-                            .get(&stage_name)
-                            .map(|stage| (api_id.clone(), stage.clone()))
-                    })
-                    .collect();
-                stage_entries.sort_by(|a, b| a.0.cmp(&b.0));
-                let (api_id, _) = stage_entries.into_iter().next().ok_or_else(|| {
+
+                let cors_config = state
+                    .apis
+                    .get(&api_id)
+                    .and_then(|api| api.cors_configuration.clone());
+
+                (routes, cors_config)
+            };
+
+            // Handle CORS preflight requests
+            if let Some(ref cors_cfg) = cors_config {
+                if cors::is_preflight_request(&req) {
+                    return Ok(cors::handle_preflight(cors_cfg, &req));
+                }
+            }
+
+            // WAFv2 inspection: when the matched stage's ARN is associated
+            // with a WebACL and the service was wired with WAF state,
+            // evaluate the request before route match / authorizer /
+            // integration. Block / Captcha / Challenge short-circuit;
+            // Count is recorded but lets the request continue.
+            if let Some(resp) = self.evaluate_waf(&req, &api_id, &stage_name) {
+                return Ok(resp);
+            }
+
+            // Match the request against routes
+            let router = Router::new(routes);
+            let route_match = router
+                .match_route(req.method.as_str(), &resource_path)
+                .ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::NOT_FOUND,
                         "NotFoundException",
-                        format!("Stage not found: {}", stage_name),
+                        format!("No route matches: {} {}", req.method, resource_path),
                     )
                 })?;
-                (api_id, stage_name, stage_vars)
-            }
-        };
 
-        let resource_path = if req.path_segments.is_empty() {
-            "/".to_string()
-        } else {
-            format!("/{}", req.path_segments.join("/"))
-        };
+            // Authorizer enforcement
+            let authorizer_info = self
+                .enforce_authorizer(&req, &api_id, &route_match.route)
+                .await?;
 
-        let (routes, cors_config) = {
-            let accounts = self.state.read();
-            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
-            let state = accounts.get(&req.account_id).unwrap_or(&empty);
-
-            let routes = state
-                .routes
-                .get(&api_id)
-                .map(|r| r.values().cloned().collect())
-                .unwrap_or_default();
-
-            let cors_config = state
-                .apis
-                .get(&api_id)
-                .and_then(|api| api.cors_configuration.clone());
-
-            (routes, cors_config)
-        };
-
-        // Handle CORS preflight requests
-        if let Some(ref cors_cfg) = cors_config {
-            if cors::is_preflight_request(&req) {
-                return Ok(cors::handle_preflight(cors_cfg, &req));
-            }
-        }
-
-        // WAFv2 inspection: when the matched stage's ARN is associated
-        // with a WebACL and the service was wired with WAF state,
-        // evaluate the request before route match / authorizer /
-        // integration. Block / Captcha / Challenge short-circuit;
-        // Count is recorded but lets the request continue.
-        if let Some(resp) = self.evaluate_waf(&req, &api_id, &stage_name) {
-            self.record_request(
-                &req,
-                &api_id,
-                &stage_name,
-                &resource_path,
-                resp.status.as_u16(),
-            );
-            return Ok(resp);
-        }
-
-        // Match the request against routes
-        let router = Router::new(routes);
-        let route_match = router
-            .match_route(req.method.as_str(), &resource_path)
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "NotFoundException",
-                    format!("No route matches: {} {}", req.method, resource_path),
-                )
-            })?;
-
-        // Authorizer enforcement
-        let authorizer_info = self
-            .enforce_authorizer(&req, &api_id, &route_match.route)
-            .await?;
-
-        // Get the integration for this route
-        let integration_id = route_match
-            .route
-            .target
-            .as_ref()
-            .and_then(|target| target.strip_prefix("integrations/"))
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "InternalError",
-                    "Route has no integration",
-                )
-            })?;
-
-        let mut integration = {
-            let accounts = self.state.read();
-            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
-            let state = accounts.get(&req.account_id).unwrap_or(&empty);
-            state
-                .integrations
-                .get(&api_id)
-                .and_then(|integrations| integrations.get(integration_id))
+            // Get the integration for this route
+            let integration_id = route_match
+                .route
+                .target
+                .as_ref()
+                .and_then(|target| target.strip_prefix("integrations/"))
                 .ok_or_else(|| {
                     AwsServiceError::aws_error(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "InternalError",
-                        format!("Integration not found: {}", integration_id),
-                    )
-                })?
-                .clone()
-        };
-
-        // Substitute stage variables into the integration URI before dispatch.
-        if let Some(ref uri) = integration.integration_uri {
-            let substituted = substitute_stage_variables(uri, &stage_vars);
-            if substituted != *uri {
-                integration.integration_uri = Some(substituted);
-            }
-        }
-
-        // Handle based on integration type
-        let mut response = match integration.integration_type.as_str() {
-            "AWS_PROXY" => {
-                let delivery = self.delivery.as_ref().ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "InternalError",
-                        "Lambda delivery not configured",
+                        "Route has no integration",
                     )
                 })?;
 
-                let integration_uri = integration.integration_uri.as_ref().ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "InternalError",
-                        "Integration has no URI",
-                    )
-                })?;
+            let mut integration = {
+                let accounts = self.state.read();
+                let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+                let state = accounts.get(&req.account_id).unwrap_or(&empty);
+                state
+                    .integrations
+                    .get(&api_id)
+                    .and_then(|integrations| integrations.get(integration_id))
+                    .ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "InternalError",
+                            format!("Integration not found: {}", integration_id),
+                        )
+                    })?
+                    .clone()
+            };
 
-                if is_lambda_arn(integration_uri) {
-                    let event = lambda_proxy::construct_event(
-                        &req,
-                        &route_match.route.route_key,
-                        &stage_name,
-                        route_match.path_parameters,
-                        authorizer_info,
-                    );
-                    lambda_proxy::invoke_lambda(delivery, integration_uri, event).await?
-                } else {
-                    dispatch_aws_service_integration(delivery, integration_uri, &req)?
+            // Substitute stage variables into the integration URI before dispatch.
+            if let Some(ref uri) = integration.integration_uri {
+                let substituted = substitute_stage_variables(uri, &stage_vars);
+                if substituted != *uri {
+                    integration.integration_uri = Some(substituted);
                 }
             }
-            "HTTP_PROXY" => {
-                // HTTP proxy integration
-                let target_url = integration.integration_uri.as_ref().ok_or_else(|| {
-                    AwsServiceError::aws_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "InternalError",
-                        "Integration has no URI",
-                    )
-                })?;
 
-                http_proxy::forward_request(target_url, &req, integration.timeout_in_millis).await?
+            // Handle based on integration type
+            let mut response = match integration.integration_type.as_str() {
+                "AWS_PROXY" => {
+                    let delivery = self.delivery.as_ref().ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "InternalError",
+                            "Lambda delivery not configured",
+                        )
+                    })?;
+
+                    let integration_uri =
+                        integration.integration_uri.as_ref().ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "InternalError",
+                                "Integration has no URI",
+                            )
+                        })?;
+
+                    if is_lambda_arn(integration_uri) {
+                        let event = lambda_proxy::construct_event(
+                            &req,
+                            &route_match.route.route_key,
+                            &stage_name,
+                            route_match.path_parameters,
+                            authorizer_info,
+                        );
+                        lambda_proxy::invoke_lambda(delivery, integration_uri, event).await?
+                    } else {
+                        dispatch_aws_service_integration(delivery, integration_uri, &req)?
+                    }
+                }
+                "HTTP_PROXY" => {
+                    // HTTP proxy integration
+                    let target_url = integration.integration_uri.as_ref().ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "InternalError",
+                            "Integration has no URI",
+                        )
+                    })?;
+
+                    http_proxy::forward_request(target_url, &req, integration.timeout_in_millis)
+                        .await?
+                }
+                "MOCK" => {
+                    // Mock integration
+                    mock::create_mock_response()
+                }
+                _ => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::NOT_IMPLEMENTED,
+                        "NotImplemented",
+                        format!(
+                            "Integration type not supported: {}",
+                            integration.integration_type
+                        ),
+                    ));
+                }
+            };
+
+            // Add CORS headers if CORS is configured
+            if let Some(ref cors_cfg) = cors_config {
+                response = cors::add_cors_headers(response, cors_cfg);
             }
-            "MOCK" => {
-                // Mock integration
-                mock::create_mock_response()
-            }
-            _ => {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_IMPLEMENTED,
-                    "NotImplemented",
-                    format!(
-                        "Integration type not supported: {}",
-                        integration.integration_type
-                    ),
-                ));
-            }
+
+            Ok(response)
+        }
+        .await;
+
+        let status_code = match &result {
+            Ok(resp) => resp.status.as_u16(),
+            Err(err) => err.status().as_u16(),
         };
 
-        // Add CORS headers if CORS is configured
-        if let Some(ref cors_cfg) = cors_config {
-            response = cors::add_cors_headers(response, cors_cfg);
-        }
+        self.record_request(&req, &api_id, &stage_name, &resource_path, status_code);
 
-        // Record this request to history
-        self.record_request(
-            &req,
-            &api_id,
-            &stage_name,
-            &resource_path,
-            response.status.as_u16(),
-        );
+        self.emit_access_log(&req, &api_id, &stage_name, &resource_path, status_code);
 
-        Ok(response)
+        result
     }
 
     /// Enforce the authorizer configured on a route. Returns an
@@ -2616,6 +2646,87 @@ impl ApiGatewayV2Service {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         state.request_history.push(request_record);
+    }
+
+    fn emit_access_log(
+        &self,
+        req: &AwsRequest,
+        api_id: &str,
+        stage: &str,
+        path: &str,
+        status_code: u16,
+    ) {
+        let Some(delivery) = self.delivery.as_ref() else {
+            return;
+        };
+
+        let access_log_settings = {
+            let accounts = self.state.read();
+            let empty = ApiGatewayV2State::new(&req.account_id, &req.region);
+            let state = accounts.get(&req.account_id).unwrap_or(&empty);
+            state
+                .stages
+                .get(api_id)
+                .and_then(|stages| stages.get(stage))
+                .and_then(|s| s.access_log_settings.clone())
+        };
+
+        let Some(settings) = access_log_settings else {
+            return;
+        };
+
+        let log_group_name = settings
+            .destination_arn
+            .split(":log-group:")
+            .nth(1)
+            .map(|s| {
+                if let Some(prefix) = s.strip_suffix(":*") {
+                    prefix.to_string()
+                } else {
+                    s.to_string()
+                }
+            });
+
+        let Some(log_group_name) = log_group_name else {
+            return;
+        };
+
+        let request_time = chrono::Utc::now()
+            .format("%d/%b/%Y:%H:%M:%S %z")
+            .to_string();
+        let source_ip = req
+            .headers
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.split(',').next().map(str::trim))
+            .unwrap_or("-")
+            .to_string();
+
+        let format = settings.format.as_deref().unwrap_or(
+            r#"{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}"#,
+        );
+
+        let log_line = format
+            .replace("$context.requestId", &req.request_id)
+            .replace("$context.apiId", api_id)
+            .replace("$context.stage", stage)
+            .replace("$context.identity.sourceIp", &source_ip)
+            .replace("$context.requestTime", &request_time)
+            .replace("$context.httpMethod", req.method.as_str())
+            .replace("$context.routeKey", path)
+            .replace("$context.status", &status_code.to_string())
+            .replace("$context.protocol", "HTTP/1.1")
+            .replace("$context.responseLength", "0");
+
+        let timestamp = chrono::Utc::now().timestamp_millis();
+        let log_stream_name = format!("{}/{}", api_id, stage);
+
+        delivery.put_log_events(
+            &req.account_id,
+            &log_group_name,
+            &log_stream_name,
+            &[(timestamp, log_line)],
+        );
     }
 }
 

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -2234,7 +2234,9 @@ impl ApiGatewayV2Service {
             Err(err) => err.status().as_u16(),
         };
 
-        self.record_request(&req, &api_id, &stage_name, &resource_path, status_code);
+        if !api_id.is_empty() {
+            self.record_request(&req, &api_id, &stage_name, &resource_path, status_code);
+        }
 
         self.emit_access_log(&req, &api_id, &stage_name, &matched_route_key, status_code);
 

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -2439,3 +2439,226 @@ async fn execute_api_aws_proxy_unsupported_arn_returns_not_implemented() {
         msg
     );
 }
+
+// ─── Access log tests ────────────────────────────────────────────────
+
+#[derive(Default)]
+#[allow(clippy::type_complexity)]
+struct MockCloudwatchLogsDelivery {
+    events: parking_lot::Mutex<Vec<(String, String, String, Vec<(i64, String)>)>>,
+}
+
+impl fakecloud_core::delivery::CloudwatchLogsDelivery for MockCloudwatchLogsDelivery {
+    fn put_log_events(
+        &self,
+        account_id: &str,
+        log_group_name: &str,
+        log_stream_name: &str,
+        events: &[(i64, String)],
+    ) {
+        self.events.lock().push((
+            account_id.to_string(),
+            log_group_name.to_string(),
+            log_stream_name.to_string(),
+            events.to_vec(),
+        ));
+    }
+}
+
+fn make_svc_with_access_logs(mock: Arc<MockCloudwatchLogsDelivery>) -> ApiGatewayV2Service {
+    let state = make_state();
+    let delivery =
+        Arc::new(fakecloud_core::delivery::DeliveryBus::new().with_cloudwatch_logs(mock));
+    ApiGatewayV2Service::new(state).with_delivery(delivery)
+}
+
+#[tokio::test]
+async fn execute_api_emits_access_log_when_configured() {
+    let mock = Arc::new(MockCloudwatchLogsDelivery::default());
+    let svc = make_svc_with_access_logs(mock.clone());
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "accessLogSettings": {
+            "destinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/apigateway/access-logs",
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let events = mock.events.lock();
+    assert_eq!(events.len(), 1, "expected exactly one access log event");
+    let (account_id, log_group, log_stream, log_events) = &events[0];
+    assert_eq!(account_id, "123456789012");
+    assert_eq!(log_group, "/aws/apigateway/access-logs");
+    assert_eq!(log_stream, &format!("{api_id}/prod"));
+    assert_eq!(log_events.len(), 1);
+    let log_line = &log_events[0].1;
+    assert!(log_line.contains("\"requestId\":\"test-id\""));
+    assert!(log_line.contains("\"httpMethod\":\"GET\""));
+    assert!(log_line.contains("\"status\":\"200\""));
+}
+
+#[tokio::test]
+async fn execute_api_no_access_log_when_not_configured() {
+    let mock = Arc::new(MockCloudwatchLogsDelivery::default());
+    let svc = make_svc_with_access_logs(mock.clone());
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let body = serde_json::json!({"stageName": "prod"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/prod/pets", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let events = mock.events.lock();
+    assert!(events.is_empty(), "expected no access log events");
+}
+
+#[tokio::test]
+async fn execute_api_access_log_honors_custom_format() {
+    let mock = Arc::new(MockCloudwatchLogsDelivery::default());
+    let svc = make_svc_with_access_logs(mock.clone());
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({"integrationType": "MOCK"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/integrations"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let integration_id = body_json(&resp)["integrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "target": format!("integrations/{integration_id}"),
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let custom_format = "$context.apiId $context.stage $context.status";
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "accessLogSettings": {
+            "destinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:my-logs:*",
+            "format": custom_format,
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, "/prod/pets", "");
+    svc.handle(req).await.unwrap();
+
+    let events = mock.events.lock();
+    assert_eq!(events.len(), 1);
+    let log_line = &events[0].3[0].1;
+    let expected = format!("{api_id} prod 200");
+    assert_eq!(log_line, &expected);
+}
+
+#[tokio::test]
+async fn execute_api_access_log_emitted_on_error_paths() {
+    let mock = Arc::new(MockCloudwatchLogsDelivery::default());
+    let svc = make_svc_with_access_logs(mock.clone());
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "accessLogSettings": {
+            "destinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:err-logs",
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // No route configured - should 404 and still log
+    let req = make_request(Method::GET, "/prod/unknown", "");
+    let err = match svc.handle(req).await {
+        Ok(_) => panic!("expected error"),
+        Err(e) => e,
+    };
+    assert_eq!(err.status(), StatusCode::NOT_FOUND);
+
+    let events = mock.events.lock();
+    assert_eq!(events.len(), 1);
+    let log_line = &events[0].3[0].1;
+    assert!(log_line.contains("\"status\":\"404\""));
+}

--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -313,6 +313,17 @@ pub struct Stage {
     /// time via `${stageVariables.<name>}`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub stage_variables: Option<BTreeMap<String, String>>,
+    /// Access log destination + format for this stage.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub access_log_settings: Option<AccessLogSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessLogSettings {
+    pub destination_arn: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -15479,6 +15479,15 @@ impl ResourceProvisioner {
                     .collect()
             });
 
+        let access_log_settings = props.get("AccessLogSettings").and_then(|v| {
+            let destination_arn = v.get("DestinationArn")?.as_str()?.to_string();
+            let format = v.get("Format").and_then(|f| f.as_str().map(String::from));
+            Some(fakecloud_apigatewayv2::AccessLogSettings {
+                destination_arn,
+                format,
+            })
+        });
+
         let stage = ApiGwV2Stage {
             stage_name: stage_name.clone(),
             description: props
@@ -15491,6 +15500,7 @@ impl ResourceProvisioner {
             last_updated_date: None,
             web_acl_arn: None,
             stage_variables,
+            access_log_settings,
         };
 
         let mut accounts = self.apigatewayv2_state.write();


### PR DESCRIPTION
## Summary
- Add AccessLogSettings struct to state with destination_arn + format
- Wire accessLogSettings parsing into CreateStage and UpdateStage
- Emit access logs on every request (success and error paths) via DeliveryBus
- Support \$context. variable substitution in custom formats
- Export AccessLogSettings from crate root for CloudFormation provisioner
- Add CloudFormation AccessLogSettings parsing for AWS::ApiGatewayV2::Stage
- Add unit tests for configured, unconfigured, custom format, and error paths

## Test plan
- [x] `cargo test -p fakecloud-apigatewayv2 --lib` passes (133 tests)
- [x] `cargo test --workspace --lib` passes (all crates)
- [x] `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds access log delivery for API Gateway v2 stages to CloudWatch Logs. Supports destination ARN, custom formats with `$context` variables, and logs on both success and error requests.

- **New Features**
  - Added `AccessLogSettings` to `fakecloud-apigatewayv2` and exported from crate root.
  - Parse/persist `accessLogSettings` in CreateStage/UpdateStage and in `fakecloud-cloudformation` for `AWS::ApiGatewayV2::Stage`.
  - Emit CloudWatch access logs for every request with `$context` substitution; tests cover configured, unconfigured, custom format, and error paths.

- **Bug Fixes**
  - Populate `$context.routeKey` using the matched route key.
  - Use a single-pass token scanner to prevent overlapping `$context` substitutions.
  - Preserve existing settings on UpdateStage when `accessLogSettings` lacks `destinationArn`, and skip recording health check requests.

<sup>Written for commit 38089a8ed70a6ac349093a36f192ff0844180e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

