### PR TITLE
feat(ses): X7 — event destinations for Kinesis, Firehose, and CloudWatch

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -619,6 +619,14 @@ impl DeliveryBus {
         self
     }
 
+    /// Put a record to a Kinesis Data Stream identified by ARN.
+    /// Silently no-ops when no Kinesis sender is wired.
+    pub fn put_record_to_kinesis(&self, stream_arn: &str, data: &str, partition_key: &str) {
+        if let Some(ref sender) = self.kinesis_sender {
+            sender.put_record(stream_arn, data, partition_key);
+        }
+    }
+
     pub fn with_stepfunctions(mut self, starter: Arc<dyn StepFunctionsDelivery>) -> Self {
         self.stepfunctions_starter = Some(starter);
         self

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -499,7 +499,7 @@ async fn main() {
         DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
             .with_sns(sns_delivery.clone())
-            .with_kinesis(kinesis_delivery_for_eb)
+            .with_kinesis(kinesis_delivery_for_eb.clone())
             .with_stepfunctions(sfn_delivery_for_eb),
     );
 
@@ -563,8 +563,8 @@ async fn main() {
         .with_sqs(sqs_delivery.clone())
         .with_kinesis(kinesis_delivery)
         .with_s3(s3_delivery_for_logs)
-        .with_firehose(firehose_delivery_for_logs)
-        .with_cloudwatch_metrics(cloudwatch_delivery_for_logs);
+        .with_firehose(firehose_delivery_for_logs.clone())
+        .with_cloudwatch_metrics(cloudwatch_delivery_for_logs.clone());
     if let Some(ref ld) = lambda_delivery {
         delivery_for_logs = delivery_for_logs.with_lambda(ld.clone());
     }
@@ -1616,11 +1616,16 @@ async fn main() {
     let delivery_for_ses = Arc::new(
         DeliveryBus::new()
             .with_sns(sns_delivery_for_ses)
-            .with_eventbridge(eb_delivery_for_ses),
+            .with_eventbridge(eb_delivery_for_ses)
+            .with_kinesis(kinesis_delivery_for_eb.clone())
+            .with_firehose(firehose_delivery_for_logs.clone())
+            .with_cloudwatch_metrics(cloudwatch_delivery_for_logs.clone()),
     );
     let ses_delivery_ctx = fakecloud_ses::fanout::SesDeliveryContext {
         ses_state: ses_state.clone(),
         delivery_bus: delivery_for_ses,
+        account_id: cli.account_id.clone(),
+        region: cli.region.clone(),
     };
     let ses_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -1,6 +1,7 @@
 //! SES event fanout: publishes send/delivery/bounce/complaint events
 //! to configured event destinations (SNS topics, EventBridge buses).
 
+use base64::Engine;
 use chrono::Utc;
 use serde_json::json;
 use std::sync::Arc;
@@ -14,6 +15,8 @@ use crate::state::{EventDestination, SentEmail, SharedSesState, SuppressedDestin
 pub struct SesDeliveryContext {
     pub ses_state: SharedSesState,
     pub delivery_bus: Arc<DeliveryBus>,
+    pub account_id: String,
+    pub region: String,
 }
 
 /// Mailbox simulator addresses.
@@ -255,6 +258,60 @@ fn deliver_event(
                 &detail,
                 "default",
             );
+        }
+
+        // Kinesis / Firehose destination
+        if let Some(ref kf) = dest.kinesis_firehose_destination {
+            let event_json = event.to_string();
+            if let Some(ds_arn) = kf.get("DeliveryStreamARN").and_then(|v| v.as_str()) {
+                tracing::info!(
+                    delivery_stream_arn = %ds_arn,
+                    event_type = ?event_type,
+                    "SES event fanout -> Firehose"
+                );
+                ctx.delivery_bus
+                    .put_record_to_firehose(ds_arn, event_json.as_bytes());
+            }
+            if let Some(stream_arn) = kf.get("StreamARN").and_then(|v| v.as_str()) {
+                tracing::info!(
+                    stream_arn = %stream_arn,
+                    event_type = ?event_type,
+                    "SES event fanout -> Kinesis"
+                );
+                let data_b64 = base64::engine::general_purpose::STANDARD.encode(&event_json);
+                let partition_key = event["mail"]["messageId"].as_str().unwrap_or("default");
+                ctx.delivery_bus
+                    .put_record_to_kinesis(stream_arn, &data_b64, partition_key);
+            }
+        }
+
+        // CloudWatch destination
+        if let Some(ref cw) = dest.cloud_watch_destination {
+            if let Some(dims) = cw.get("DimensionConfigurations").and_then(|v| v.as_array()) {
+                for dim_cfg in dims {
+                    let dim_name = dim_cfg["DimensionName"].as_str().unwrap_or("EventType");
+                    let dim_value = dim_cfg["DefaultDimensionValue"]
+                        .as_str()
+                        .unwrap_or(event_type.as_str());
+                    let mut dimensions = std::collections::BTreeMap::new();
+                    dimensions.insert(dim_name.to_string(), dim_value.to_string());
+                    tracing::info!(
+                        dimension = %dim_name,
+                        event_type = ?event_type,
+                        "SES event fanout -> CloudWatch"
+                    );
+                    ctx.delivery_bus.put_cloudwatch_metric(
+                        &ctx.account_id,
+                        &ctx.region,
+                        "AWS/SES2",
+                        event_type.as_str(),
+                        1.0,
+                        Some("Count"),
+                        dimensions,
+                        Utc::now().timestamp_millis(),
+                    );
+                }
+            }
         }
     }
 }
@@ -720,5 +777,61 @@ mod tests {
         assert!(none.is_empty());
         let missing = get_matching_destinations(&state, "unknown", SesEventType::Send);
         assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn deliver_event_kinesis_firehose_cloudwatch_no_panic() {
+        let state = shared_state();
+        state.write().default_mut().event_destinations.insert(
+            "cs".to_string(),
+            vec![EventDestination {
+                name: "multi-dest".to_string(),
+                enabled: true,
+                matching_event_types: vec!["SEND".to_string()],
+                kinesis_firehose_destination: Some(serde_json::json!({
+                    "DeliveryStreamARN": "arn:aws:firehose:us-east-1:123456789012:deliverystream/my-stream",
+                    "StreamARN": "arn:aws:kinesis:us-east-1:123456789012:stream/my-kinesis"
+                })),
+                cloud_watch_destination: Some(serde_json::json!({
+                    "DimensionConfigurations": [
+                        {
+                            "DimensionName": "EventType",
+                            "DimensionValueSource": "MESSAGE_TAG",
+                            "DefaultDimensionValue": "Send"
+                        }
+                    ]
+                })),
+                sns_destination: None,
+                event_bridge_destination: None,
+                pinpoint_destination: None,
+            }],
+        );
+        let ctx = SesDeliveryContext {
+            ses_state: state,
+            delivery_bus: Arc::new(DeliveryBus::new()),
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+        };
+        let event = build_ses_event(
+            SesEventType::Send,
+            &SentEmail {
+                message_id: "msg-1".to_string(),
+                from: "sender@example.com".to_string(),
+                to: vec!["recipient@example.com".to_string()],
+                cc: vec![],
+                bcc: vec![],
+                subject: None,
+                html_body: None,
+                text_body: None,
+                raw_data: None,
+                template_name: None,
+                template_data: None,
+                dkim_signature: None,
+                headers: Vec::new(),
+                timestamp: Utc::now(),
+            },
+        );
+        // No senders wired — must not panic.
+        deliver_event(&ctx, &event, SesEventType::Send, "cs");
     }
 }

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -4326,3 +4326,70 @@ async fn send_email_v2_skips_suppressed_recipient() {
     assert_eq!(results[1]["Status"], "MESSAGE_REJECTED");
     assert_eq!(results[1]["Error"], "Address is on the suppression list");
 }
+
+#[tokio::test]
+async fn test_event_destination_kinesis_firehose_cloudwatch() {
+    let state = make_state();
+    let svc = SesV2Service::new(state);
+
+    // Create config set first
+    let req = make_request(
+        Method::POST,
+        "/v2/email/configuration-sets",
+        r#"{"ConfigurationSetName": "my-config"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    // Create event destination with Kinesis, Firehose, and CloudWatch
+    let req = make_request(
+        Method::POST,
+        "/v2/email/configuration-sets/my-config/event-destinations",
+        r#"{
+            "EventDestinationName": "multi-dest",
+            "EventDestination": {
+                "Enabled": true,
+                "MatchingEventTypes": ["SEND", "DELIVERY"],
+                "KinesisFirehoseDestination": {
+                    "DeliveryStreamARN": "arn:aws:firehose:us-east-1:123456789012:deliverystream/my-stream",
+                    "StreamARN": "arn:aws:kinesis:us-east-1:123456789012:stream/my-kinesis"
+                },
+                "CloudWatchDestination": {
+                    "DimensionConfigurations": [
+                        {
+                            "DimensionName": "EventType",
+                            "DimensionValueSource": "MESSAGE_TAG",
+                            "DefaultDimensionValue": "Send"
+                        }
+                    ]
+                }
+            }
+        }"#,
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    // Get event destinations and verify all fields round-trip
+    let req = make_request(
+        Method::GET,
+        "/v2/email/configuration-sets/my-config/event-destinations",
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let dests = body["EventDestinations"].as_array().unwrap();
+    assert_eq!(dests.len(), 1);
+    assert_eq!(dests[0]["Name"], "multi-dest");
+    assert_eq!(
+        dests[0]["KinesisFirehoseDestination"]["DeliveryStreamARN"],
+        "arn:aws:firehose:us-east-1:123456789012:deliverystream/my-stream"
+    );
+    assert_eq!(
+        dests[0]["KinesisFirehoseDestination"]["StreamARN"],
+        "arn:aws:kinesis:us-east-1:123456789012:stream/my-kinesis"
+    );
+    assert_eq!(
+        dests[0]["CloudWatchDestination"]["DimensionConfigurations"][0]["DimensionName"],
+        "EventType"
+    );
+}


### PR DESCRIPTION
## Summary

Wire SES v2 event fanout to Kinesis Data Streams, Firehose Delivery Streams, and CloudWatch Metrics destinations.

- `fakecloud-core/delivery.rs`: expose `put_record_to_kinesis` on `DeliveryBus`
- `fakecloud-ses/fanout.rs`: extend `deliver_event` with Kinesis/Firehose/CloudWatch branches
- `fakecloud-server/main.rs`: wire Kinesis, Firehose, and CloudWatch senders into the SES delivery context
- `fakecloud-ses/service/tests.rs`: round-trip test for event destination config

## Test plan

- [x] `cargo test -p fakecloud-ses --lib` — 233 tests pass
- [x] `cargo check -p fakecloud-ses` — clean build, no deprecation warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SES v2 event destinations for Kinesis Data Streams, Firehose Delivery Streams, and CloudWatch Metrics. Implements X7 by wiring these senders into the SES fanout and emitting CloudWatch metrics with the correct account and region.

- New Features
  - `fakecloud-ses`: Fanout sends to Kinesis (base64 JSON; partition key = messageId), Firehose (raw JSON bytes), and CloudWatch (`AWS/SES2`, Count, optional dimensions).
  - `fakecloud-core`: Added `DeliveryBus::put_record_to_kinesis` (no-op if no sender).
  - `fakecloud-server`: Wires Kinesis/Firehose/CloudWatch into SES; passes `account_id` and `region`.
  - Tests cover event destination round-trip and no-op behavior when senders are not wired.

<sup>Written for commit b1a60674ebabb0815d6d74b63a87a588a04d44f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

