### PR TITLE
feat(ses): X9 — SendBounce + deliverability simulator addresses

### DIFF
--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -25,6 +25,10 @@ const COMPLAINT_ADDR: &str = "complaint@simulator.amazonses.com";
 #[cfg(test)]
 const SUCCESS_ADDR: &str = "success@simulator.amazonses.com";
 const SUPPRESSION_ADDR: &str = "suppressionlist@simulator.amazonses.com";
+const OOTO_ADDR: &str = "ooto@simulator.amazonses.com";
+const SOFTBOUNCE_ADDR: &str = "softbounce@simulator.amazonses.com";
+const FORWARDING_ADDR: &str = "forwarding@simulator.amazonses.com";
+const TRANSIENT_BOUNCE_ADDR: &str = "transient-bounce@simulator.amazonses.com";
 
 /// The event types we generate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +131,10 @@ pub fn classify_recipients(recipients: &[String]) -> (Vec<SesEventType>, bool) {
     let has_bounce = recipients.iter().any(|r| r == BOUNCE_ADDR);
     let has_complaint = recipients.iter().any(|r| r == COMPLAINT_ADDR);
     let has_suppression = recipients.iter().any(|r| r == SUPPRESSION_ADDR);
+    let has_ooto = recipients.iter().any(|r| r == OOTO_ADDR);
+    let has_softbounce = recipients.iter().any(|r| r == SOFTBOUNCE_ADDR);
+    let has_forwarding = recipients.iter().any(|r| r == FORWARDING_ADDR);
+    let has_transient_bounce = recipients.iter().any(|r| r == TRANSIENT_BOUNCE_ADDR);
     // success@simulator is the default behavior, no special handling needed
 
     if has_bounce {
@@ -140,6 +148,19 @@ pub fn classify_recipients(recipients: &[String]) -> (Vec<SesEventType>, bool) {
         events.push(SesEventType::Send);
         events.push(SesEventType::Bounce);
         suppress = true;
+    } else if has_ooto {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Delivery);
+        events.push(SesEventType::Complaint);
+    } else if has_softbounce {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Bounce);
+    } else if has_forwarding {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Delivery);
+    } else if has_transient_bounce {
+        events.push(SesEventType::Send);
+        events.push(SesEventType::Bounce);
     } else {
         // Normal send or success@simulator
         events.push(SesEventType::Send);

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -105,6 +105,15 @@ pub struct SentEmail {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentBounce {
+    pub bounce_message_id: String,
+    pub original_message_id: String,
+    pub bounce_sender: String,
+    pub bounced_recipients: Vec<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContactList {
     pub contact_list_name: String,
     pub description: Option<String>,
@@ -350,6 +359,8 @@ pub struct SesState {
     pub templates: BTreeMap<String, EmailTemplate>,
     #[serde(default, skip_serializing)]
     pub sent_emails: Vec<SentEmail>,
+    #[serde(default, skip_serializing)]
+    pub bounces: Vec<SentBounce>,
     pub contact_lists: BTreeMap<String, ContactList>,
     pub contacts: BTreeMap<String, BTreeMap<String, Contact>>,
     /// Tags keyed by resource ARN, value is key→value tag map.
@@ -464,6 +475,7 @@ impl SesState {
             configuration_sets: BTreeMap::new(),
             templates: BTreeMap::new(),
             sent_emails: Vec::new(),
+            bounces: Vec::new(),
             contact_lists: BTreeMap::new(),
             contacts: BTreeMap::new(),
             tags: BTreeMap::new(),

--- a/crates/fakecloud-ses/src/v1.rs
+++ b/crates/fakecloud-ses/src/v1.rs
@@ -44,6 +44,7 @@ pub const V1_ACTIONS: &[&str] = &[
     "SendRawEmail",
     "SendTemplatedEmail",
     "SendBulkTemplatedEmail",
+    "SendBounce",
     // Templates
     "CreateTemplate",
     "GetTemplate",

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -39,6 +39,7 @@ pub fn handle_v1_action(
         "SendRawEmail" => send_raw_email(state, req),
         "SendTemplatedEmail" => send_templated_email(state, req),
         "SendBulkTemplatedEmail" => send_bulk_templated_email(state, req),
+        "SendBounce" => send_bounce(state, req),
         // Templates
         "CreateTemplate" => create_template(state, req),
         "GetTemplate" => get_template(state, req),
@@ -1627,6 +1628,91 @@ pub(crate) fn send_bulk_destination(
         .sent_emails
         .push(sent);
     message_id
+}
+
+pub(crate) fn send_bounce(
+    state: &SharedSesState,
+    req: &AwsRequest,
+) -> Result<AwsResponse, AwsServiceError> {
+    let bounce_sender = required_param(&req.query_params, "BounceSender")?;
+    let original_message_id = required_param(&req.query_params, "OriginalMessageId")?;
+
+    let mut recipients: Vec<String> = Vec::new();
+    let mut recipient_xml = String::new();
+    for i in 1.. {
+        let prefix = format!("BouncedRecipientInfoList.member.{i}");
+        let recipient = match req.query_params.get(&format!("{prefix}.Recipient")) {
+            Some(r) => r.clone(),
+            None => break,
+        };
+        recipients.push(recipient.clone());
+        let bounce_type = req
+            .query_params
+            .get(&format!("{prefix}.BounceType"))
+            .map(|s| s.as_str())
+            .unwrap_or("ContentRejected");
+        let action = req
+            .query_params
+            .get(&format!("{prefix}.RecipientDsnFields.Action"))
+            .cloned()
+            .unwrap_or_else(|| "failed".to_string());
+        let status = req
+            .query_params
+            .get(&format!("{prefix}.RecipientDsnFields.Status"))
+            .cloned()
+            .unwrap_or_else(|| "5.1.1".to_string());
+        let diagnostic = req
+            .query_params
+            .get(&format!("{prefix}.RecipientDsnFields.DiagnosticCode"))
+            .cloned()
+            .unwrap_or_else(|| "smtp; 550 5.1.1 user unknown".to_string());
+        recipient_xml.push_str(&format!(
+            "<member>\
+             <Recipient>{recipient}</Recipient>\
+             <StatusCode>{status}</StatusCode>\
+             <Action>{action}</Action>\
+             <DiagnosticCode>{diagnostic}</DiagnosticCode>\
+             <BounceType>{bounce_type}</BounceType>\
+             </member>"
+        ));
+    }
+    if recipients.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "MissingParameter",
+            "BouncedRecipientInfoList is required",
+        ));
+    }
+
+    let bounce_message_id = format!(
+        "{:016x}{:016x}-{:08x}-{:04x}",
+        rand_u64(),
+        rand_u64(),
+        rand_u32(),
+        rand_u16(),
+    );
+
+    let bounce = crate::state::SentBounce {
+        bounce_message_id: bounce_message_id.clone(),
+        original_message_id: original_message_id.to_string(),
+        bounce_sender: bounce_sender.to_string(),
+        bounced_recipients: recipients,
+        timestamp: Utc::now(),
+    };
+    state
+        .write()
+        .get_or_create(&req.account_id)
+        .bounces
+        .push(bounce);
+
+    let inner = format!(
+        "<MessageId>{bounce_message_id}</MessageId>\
+         <BouncedRecipientInfoList>{recipient_xml}</BouncedRecipientInfoList>"
+    );
+    Ok(AwsResponse::xml(
+        StatusCode::OK,
+        query_response_xml("SendBounce", SES_NS, &inner, &req.request_id),
+    ))
 }
 
 pub(crate) fn create_template(

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1711,3 +1711,92 @@ fn send_email_v1_skips_suppressed_recipient() {
         Ok(_) => panic!("expected MessageRejected"),
     }
 }
+
+// ── X9: SendBounce + simulator addresses ──
+
+#[test]
+fn test_send_bounce_v1() {
+    let state = make_state();
+    let req = make_v1_request(
+        "SendBounce",
+        vec![
+            ("BounceSender", "bounce@example.com"),
+            ("OriginalMessageId", "msg-123"),
+            (
+                "BouncedRecipientInfoList.member.1.Recipient",
+                "bad@example.com",
+            ),
+            (
+                "BouncedRecipientInfoList.member.2.Recipient",
+                "unknown@example.com",
+            ),
+        ],
+    );
+    let resp = handle_v1_action(&state, &req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<MessageId>"));
+    assert!(body.contains("<BouncedRecipientInfoList>"));
+    assert!(body.contains("<Recipient>bad@example.com</Recipient>"));
+    assert!(body.contains("<Recipient>unknown@example.com</Recipient>"));
+    assert!(body.contains("<BounceType>ContentRejected</BounceType>"));
+
+    let accounts = state.read();
+    let st = accounts.get("123456789012").unwrap();
+    assert_eq!(st.bounces.len(), 1);
+    assert_eq!(st.bounces[0].original_message_id, "msg-123");
+    assert_eq!(st.bounces[0].bounce_sender, "bounce@example.com");
+    assert_eq!(st.bounces[0].bounced_recipients.len(), 2);
+}
+
+#[test]
+fn test_send_bounce_v1_custom_dsn_fields() {
+    let state = make_state();
+    let req = make_v1_request(
+        "SendBounce",
+        vec![
+            ("BounceSender", "postmaster@example.com"),
+            ("OriginalMessageId", "abc-def"),
+            (
+                "BouncedRecipientInfoList.member.1.Recipient",
+                "user@example.com",
+            ),
+            (
+                "BouncedRecipientInfoList.member.1.BounceType",
+                "DoesNotExist",
+            ),
+            (
+                "BouncedRecipientInfoList.member.1.RecipientDsnFields.Action",
+                "failed",
+            ),
+            (
+                "BouncedRecipientInfoList.member.1.RecipientDsnFields.Status",
+                "5.1.1",
+            ),
+            (
+                "BouncedRecipientInfoList.member.1.RecipientDsnFields.DiagnosticCode",
+                "No such user",
+            ),
+        ],
+    );
+    let resp = handle_v1_action(&state, &req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(body.contains("<BounceType>DoesNotExist</BounceType>"));
+    assert!(body.contains("<StatusCode>5.1.1</StatusCode>"));
+    assert!(body.contains("<DiagnosticCode>No such user</DiagnosticCode>"));
+}
+
+#[test]
+fn test_send_bounce_v1_missing_recipient() {
+    let state = make_state();
+    let req = make_v1_request(
+        "SendBounce",
+        vec![
+            ("BounceSender", "bounce@example.com"),
+            ("OriginalMessageId", "msg-123"),
+        ],
+    );
+    match handle_v1_action(&state, &req) {
+        Err(e) => assert_eq!(e.code(), "MissingParameter"),
+        Ok(_) => panic!("expected MissingParameter"),
+    }
+}


### PR DESCRIPTION
## Summary
- Implement v1 `SendBounce` action with full query param parsing
  (BounceSender, OriginalMessageId, BouncedRecipientInfoList with
  Recipient/BounceType/RecipientDsnFields).
- Store bounce in `SesState.bounces` and return `MessageId` +
  `BouncedRecipientInfoList` XML.
- Add 4 deliverability simulator addresses to `fanout.rs`
  (`ooto`, `softbounce`, `forwarding`, `transient-bounce`) so tests
  can exercise those event paths.
- Unit tests for happy path, custom DSN fields, and missing-recipient
  rejection.

## Test plan
- [x] `cargo test -p fakecloud-ses` passes (238 tests)
- [x] `cargo clippy -p fakecloud-ses --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `SendBounce` in `fakecloud-ses` and adds SES deliverability simulator addresses to mirror real SES behavior. Completes Linear X9 and enables testing for bounce, complaint, and delivery flows.

- New Features
  - Implemented `SendBounce` (parses `BounceSender`, `OriginalMessageId`, and `BouncedRecipientInfoList.*` incl. DSN fields), stores in `SesState.bounces`, and returns SES-compatible XML with `MessageId` and `BouncedRecipientInfoList`.
  - Added simulator addresses to fanout: ooto, softbounce, forwarding, transient-bounce; routes to the expected Send/Delivery/Bounce/Complaint events.
  - Added unit tests for happy path, custom DSN fields, and missing-recipient rejection.

<sup>Written for commit b171ffaf9454d774fcbf78face4dd9ebfa168a33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

