### PR TITLE
fix(kinesis): use opaque 56-digit decimal sequence numbers everywhere

### DIFF
--- a/crates/fakecloud-kinesis/src/delivery.rs
+++ b/crates/fakecloud-kinesis/src/delivery.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use chrono::Utc;
 use fakecloud_core::delivery::KinesisDelivery;
 
-use crate::state::{KinesisRecord, SharedKinesisState};
+use crate::service::append_record;
+use crate::state::SharedKinesisState;
 
 /// Kinesis delivery implementation for cross-service integrations.
 pub struct KinesisDeliveryImpl {
@@ -48,21 +48,10 @@ impl KinesisDelivery for KinesisDeliveryImpl {
             };
 
             if let Some(shard) = stream.shards.get_mut(shard_idx as usize) {
-                let now = Utc::now();
-                let sequence_number = now.timestamp_nanos_opt().unwrap_or(0).to_string();
-
-                // Data is base64-encoded; decode to raw bytes for storage.
-                // GetRecords will base64-encode when returning, matching AWS behavior.
                 let data_bytes = base64::engine::general_purpose::STANDARD
                     .decode(data)
                     .unwrap_or_else(|_| data.as_bytes().to_vec());
-
-                shard.records.push(KinesisRecord {
-                    sequence_number: sequence_number.clone(),
-                    partition_key: partition_key.to_string(),
-                    data: data_bytes,
-                    approximate_arrival_timestamp: now,
-                });
+                let sequence_number = append_record(shard, partition_key, data_bytes);
 
                 tracing::debug!(
                     stream_name = %stream_name,
@@ -85,6 +74,7 @@ impl KinesisDelivery for KinesisDeliveryImpl {
 mod tests {
     use super::*;
     use crate::state::{KinesisShard, KinesisState, KinesisStream, SharedKinesisState};
+    use chrono::Utc;
     use fakecloud_aws::arn::Arn;
     use parking_lot::RwLock;
     use std::collections::BTreeMap;

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -1508,13 +1508,13 @@ fn get_records_skips_records_past_retention() {
         let shard = &mut stream.shards[0];
         let stale_ts = chrono::Utc::now() - chrono::Duration::hours(48);
         shard.records.push(KinesisRecord {
-            sequence_number: "1".to_string(),
+            sequence_number: format!("{:056}", 1),
             partition_key: "p".to_string(),
             data: b"stale".to_vec(),
             approximate_arrival_timestamp: stale_ts,
         });
         shard.records.push(KinesisRecord {
-            sequence_number: "2".to_string(),
+            sequence_number: format!("{:056}", 2),
             partition_key: "p".to_string(),
             data: b"fresh".to_vec(),
             approximate_arrival_timestamp: chrono::Utc::now(),


### PR DESCRIPTION
## Summary

Replace timestamp-nanos sequence numbers in `delivery.rs` with the same `append_record` helper used by the control plane, so cross-service puts produce the same padded format as `PutRecord`/`PutRecords`.

## Test plan

- [x] `cargo clippy -p fakecloud-kinesis --all-targets -- -D warnings` clean
- [x] `cargo fmt --all`
- [x] Existing unit tests in `delivery.rs` pass
- [x] Existing `service_tests.rs` updated to use padded sequence numbers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use opaque 56-digit, zero-padded decimal sequence numbers for Kinesis delivery by reusing the shared `append_record` helper. Cross-service puts now match the control plane and `PutRecord`/`PutRecords` formats; tests updated to expect padded numbers.

<sup>Written for commit c0e120a55950e8b663b8c63b5912e5a97c748933. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

