### PR TITLE
feat(ecs): O12 - ECS_CONTAINER_METADATA_URI_V4 endpoint + env injection

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_metadata_endpoint.rs
+++ b/crates/fakecloud-e2e/tests/ecs_metadata_endpoint.rs
@@ -1,0 +1,112 @@
+//! ECS container metadata endpoint (O12).
+//!
+//! Verifies that `/_fakecloud/ecs/v4/{task_id}` and `/_fakecloud/ecs/v3/{task_id}`
+//! return the expected metadata JSON after a task is created.
+
+mod helpers;
+
+use aws_sdk_ecs::types::ContainerDefinition;
+use helpers::TestServer;
+
+#[tokio::test]
+async fn ecs_metadata_endpoint_v3_v4() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("meta-cluster")
+        .send()
+        .await
+        .expect("create_cluster");
+
+    ecs.register_task_definition()
+        .family("meta-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("alpine")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("register_task_definition");
+
+    let run = ecs
+        .run_task()
+        .cluster("meta-cluster")
+        .task_definition("meta-family")
+        .send()
+        .await
+        .expect("run_task");
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+    let task_id = arn.rsplit('/').next().unwrap();
+
+    let v4: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/ecs/v4/{}",
+        server.endpoint(),
+        task_id
+    ))
+    .await
+    .expect("v4 request")
+    .json()
+    .await
+    .expect("v4 json");
+
+    assert_eq!(
+        v4.get("Cluster").and_then(|v| v.as_str()),
+        Some("meta-cluster")
+    );
+    assert_eq!(
+        v4.get("TaskARN").and_then(|v| v.as_str()),
+        Some(arn.as_str())
+    );
+    assert_eq!(
+        v4.get("Family").and_then(|v| v.as_str()),
+        Some("meta-family")
+    );
+    assert!(
+        v4.get("DesiredStatus").and_then(|v| v.as_str()).is_some(),
+        "v4 should include DesiredStatus"
+    );
+    assert!(
+        v4.get("Containers").and_then(|v| v.as_array()).is_some(),
+        "v4 should include Containers array"
+    );
+
+    let v3: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/ecs/v3/{}",
+        server.endpoint(),
+        task_id
+    ))
+    .await
+    .expect("v3 request")
+    .json()
+    .await
+    .expect("v3 json");
+
+    assert_eq!(
+        v3.get("Cluster").and_then(|v| v.as_str()),
+        Some("meta-cluster")
+    );
+    assert_eq!(
+        v3.get("TaskARN").and_then(|v| v.as_str()),
+        Some(arn.as_str())
+    );
+    assert_eq!(
+        v3.get("Family").and_then(|v| v.as_str()),
+        Some("meta-family")
+    );
+    assert!(
+        v3.get("Containers").and_then(|v| v.as_array()).is_some(),
+        "v3 should include Containers array"
+    );
+
+    let not_found = reqwest::get(format!(
+        "{}/_fakecloud/ecs/v4/nonexistent-task-id",
+        server.endpoint()
+    ))
+    .await
+    .expect("not_found request");
+    assert_eq!(not_found.status(), 404);
+}

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -223,6 +223,20 @@ impl EcsRuntime {
                     ),
                 ));
             }
+            env.push((
+                "ECS_CONTAINER_METADATA_URI".into(),
+                format!(
+                    "http://host.docker.internal:{}/_fakecloud/ecs/v3/{}",
+                    self.server_port, task_id
+                ),
+            ));
+            env.push((
+                "ECS_CONTAINER_METADATA_URI_V4".into(),
+                format!(
+                    "http://host.docker.internal:{}/_fakecloud/ecs/v4/{}",
+                    self.server_port, task_id
+                ),
+            ));
             resolved_plans.push(ResolvedContainerPlan { plan, env });
         }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -5012,6 +5012,101 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/ecs/v4/{task_id}",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            if let Some(t) = state.tasks.get(&task_id) {
+                                let body = serde_json::json!({
+                                    "Cluster": t.cluster_name,
+                                    "TaskARN": t.task_arn,
+                                    "Family": t.family,
+                                    "Revision": t.revision,
+                                    "DesiredStatus": t.desired_status,
+                                    "KnownStatus": t.last_status,
+                                    "Limits": {
+                                        "CPU": t.cpu.as_ref().and_then(|c| c.parse::<f64>().ok()),
+                                        "Memory": t.memory.as_ref().and_then(|m| m.parse::<i64>().ok()),
+                                    },
+                                    "PullStartedAt": t.pull_started_at.map(|d| d.to_rfc3339()),
+                                    "PullStoppedAt": t.pull_stopped_at.map(|d| d.to_rfc3339()),
+                                    "CreatedAt": t.created_at.to_rfc3339(),
+                                    "StartedAt": t.started_at.map(|d| d.to_rfc3339()),
+                                    "StoppedAt": t.stopped_at.map(|d| d.to_rfc3339()),
+                                    "AvailabilityZone": "us-east-1a",
+                                    "Containers": t.containers.iter().map(|c| serde_json::json!({
+                                        "DockerId": c.runtime_id,
+                                        "Name": c.name,
+                                        "DockerName": c.runtime_id.as_ref().map(|id| format!("ecs-{}", id)),
+                                        "Image": c.image,
+                                        "ImageID": c.image_digest,
+                                        "Ports": c.network_bindings,
+                                        "Labels": {},
+                                        "DesiredStatus": c.last_status,
+                                        "KnownStatus": c.last_status,
+                                        "ExitCode": c.exit_code,
+                                        "Health": {
+                                            "status": c.health_status.as_deref().unwrap_or("UNKNOWN"),
+                                        },
+                                    })).collect::<Vec<_>>(),
+                                });
+                                return (axum::http::StatusCode::OK, axum::Json(body));
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/ecs/v3/{task_id}",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_id): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            if let Some(t) = state.tasks.get(&task_id) {
+                                let body = serde_json::json!({
+                                    "Cluster": t.cluster_name,
+                                    "TaskARN": t.task_arn,
+                                    "Family": t.family,
+                                    "Revision": t.revision,
+                                    "DesiredStatus": t.desired_status,
+                                    "KnownStatus": t.last_status,
+                                    "Containers": t.containers.iter().map(|c| serde_json::json!({
+                                        "DockerId": c.runtime_id,
+                                        "Name": c.name,
+                                        "DockerName": c.runtime_id.as_ref().map(|id| format!("ecs-{}", id)),
+                                        "Image": c.image,
+                                        "ImageID": c.image_digest,
+                                        "Ports": c.network_bindings,
+                                        "Labels": {},
+                                        "DesiredStatus": c.last_status,
+                                        "KnownStatus": c.last_status,
+                                        "ExitCode": c.exit_code,
+                                    })).collect::<Vec<_>>(),
+                                });
+                                return (axum::http::StatusCode::OK, axum::Json(body));
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/ecs/tasks/{task_id}/force-stop",
             axum::routing::post({
                 let ec = ecs_introspection_state.clone();


### PR DESCRIPTION
## Summary
- Inject `ECS_CONTAINER_METADATA_URI` and `ECS_CONTAINER_METADATA_URI_V4` env vars into every ECS container at launch time, pointing at the fakecloud server's metadata endpoints.
- Add `GET /_fakecloud/ecs/v4/{task_id}` endpoint returning task metadata in the ECS metadata V4 format.
- Add `GET /_fakecloud/ecs/v3/{task_id}` endpoint for v3 compatibility.
- E2E test verifying both endpoints return correct metadata.

## Test plan
- [x] `cargo test -p fakecloud-e2e --test ecs_metadata_endpoint` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ECS metadata endpoints (v4 and v3) and inject `ECS_CONTAINER_METADATA_URI`/`ECS_CONTAINER_METADATA_URI_V4` into every ECS container so apps can read task metadata. This enables standard ECS metadata usage inside fakecloud.

- New Features
  - Inject env vars in ECS containers pointing to `/_fakecloud/ecs/v3/{task_id}` and `/_fakecloud/ecs/v4/{task_id}` on `host.docker.internal:{port}`.
  - Add `GET /_fakecloud/ecs/v4/{task_id}` returning v4 task metadata (Cluster, TaskARN, Family, DesiredStatus, KnownStatus, Limits, Containers, timestamps).
  - Add `GET /_fakecloud/ecs/v3/{task_id}` for v3-compatible metadata.
  - Return 404 for unknown task IDs.
  - E2E test covers both endpoints.

<sup>Written for commit 5fd671426330f569d3bf5750acb43ff1f5b0fa45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

