### PR TITLE
O7: ECS awsvpc network mode with synthetic ENI attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "fakecloud-ssm",
  "http 1.4.0",
  "parking_lot",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/fakecloud-e2e/tests/ecs_awsvpc.rs
+++ b/crates/fakecloud-e2e/tests/ecs_awsvpc.rs
@@ -1,0 +1,111 @@
+//! ECS awsvpc network mode (O7).
+//!
+//! Verifies that tasks with `networkMode=awsvpc` get a synthetic ENI
+//! attachment and use a per-task docker network.
+
+mod helpers;
+
+use aws_sdk_ecs::types::{ContainerDefinition, NetworkMode};
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("skipping {test}: docker is not available");
+    false
+}
+
+#[tokio::test]
+async fn ecs_awsvpc_task_gets_eni_attachment() {
+    if !require_docker_or_skip("ecs_awsvpc_task_gets_eni_attachment") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("awsvpc-cluster")
+        .send()
+        .await
+        .expect("create_cluster");
+
+    ecs.register_task_definition()
+        .family("awsvpc-family")
+        .network_mode(NetworkMode::Awsvpc)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("sh")
+                .command("-c")
+                .command("sleep 1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("register_task_definition");
+
+    let run = ecs
+        .run_task()
+        .cluster("awsvpc-cluster")
+        .task_definition("awsvpc-family")
+        .send()
+        .await
+        .expect("run_task");
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+
+    // Poll until STOPPED so the runtime has had time to create the ENI.
+    for _ in 0..60 {
+        let desc = ecs
+            .describe_tasks()
+            .cluster("awsvpc-cluster")
+            .tasks(arn.clone())
+            .send()
+            .await
+            .expect("describe_tasks");
+        let t = &desc.tasks()[0];
+        if t.last_status() == Some("STOPPED") {
+            let attachments = t.attachments();
+            assert!(
+                attachments.iter().any(|a| a.r#type() == Some("eni")),
+                "expected ENI attachment for awsvpc task; got {attachments:?}"
+            );
+            let eni = attachments
+                .iter()
+                .find(|a| a.r#type() == Some("eni"))
+                .unwrap();
+            assert_eq!(eni.status(), Some("ATTACHED"));
+            let details: std::collections::HashMap<&str, &str> = eni
+                .details()
+                .iter()
+                .filter_map(|d| Some((d.name()?, d.value()?)))
+                .collect();
+            assert!(
+                details.contains_key("privateIPv4Address"),
+                "expected privateIPv4Address in ENI details: {details:?}"
+            );
+            assert!(
+                details.contains_key("macAddress"),
+                "expected macAddress in ENI details: {details:?}"
+            );
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!("task never reached STOPPED");
+}

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -20,6 +20,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -474,7 +474,35 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
     // Always-present fields AWS returns. SDKs deserialize these
     // unconditionally; without them, terraform/cdk plan diffs and
     // observability hooks see missing keys.
-    map.insert("attachments".into(), json!([]));
+    map.insert(
+        "attachments".into(),
+        Value::Array(
+            task.attachments
+                .iter()
+                .map(|a| {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert("id".into(), json!(a.id));
+                    obj.insert("type".into(), json!(a.attachment_type));
+                    obj.insert("status".into(), json!(a.status));
+                    obj.insert(
+                        "details".into(),
+                        Value::Array(
+                            a.details
+                                .iter()
+                                .map(|d| {
+                                    serde_json::json!({
+                                        "name": d.name,
+                                        "value": d.value,
+                                    })
+                                })
+                                .collect(),
+                        ),
+                    );
+                    Value::Object(obj)
+                })
+                .collect(),
+        ),
+    );
     map.insert("attributes".into(), json!([]));
     map.insert("availabilityZone".into(), json!("us-east-1a"));
     map.insert(
@@ -776,6 +804,7 @@ pub(crate) fn spawn_service_tasks(
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: service_exec,
+            attachments: Vec::new(),
         };
         state.tasks.insert(task_id.clone(), task);
         if let Some(cluster) = state.clusters.get_mut(&cluster_name) {

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -287,6 +287,110 @@ impl EcsRuntime {
         }
         mark_pull_stopped(state, account_id, task_id);
 
+        // For awsvpc network mode, create a per-task docker network so
+        // containers share an isolated bridge. Clean it up when the task
+        // stops. Network creation is best-effort: on failure we fall back
+        // to the default bridge and continue.
+        let awsvpc_network = resolved_plans
+            .iter()
+            .any(|rp| rp.plan.network_mode.as_deref() == Some("awsvpc"));
+        let network_name = format!("fakecloud-ecs-{}", task_id);
+        let network_created = if awsvpc_network {
+            let create = Command::new(&self.cli)
+                .args([
+                    "network",
+                    "create",
+                    "--driver",
+                    "bridge",
+                    "--label",
+                    &format!("fakecloud-ecs-task={}", task_id),
+                    &network_name,
+                ])
+                .output()
+                .await;
+            match create {
+                Ok(out) if out.status.success() => {
+                    tracing::info!(
+                        task = %task_id,
+                        network = %network_name,
+                        "created awsvpc docker network"
+                    );
+                    true
+                }
+                Ok(out) => {
+                    let err = String::from_utf8_lossy(&out.stderr);
+                    tracing::warn!(
+                        task = %task_id,
+                        network = %network_name,
+                        error = %err,
+                        "awsvpc network creation failed; falling back to default bridge"
+                    );
+                    false
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task = %task_id,
+                        network = %network_name,
+                        error = %e,
+                        "awsvpc network creation failed; falling back to default bridge"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
+        if network_created {
+            let eni_id = format!(
+                "eni-{}",
+                uuid::Uuid::new_v4()
+                    .to_string()
+                    .replace('-', "")
+                    .get(..17)
+                    .unwrap_or("")
+            );
+            let mac = format!(
+                "02:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>()
+            );
+            let ip = format!("10.0.{}.{}", rand::random::<u8>(), rand::random::<u8>());
+            let mut accounts = state.write();
+            if let Some(st) = accounts.get_mut(account_id) {
+                if let Some(task) = st.tasks.get_mut(task_id) {
+                    task.attachments.push(crate::state::TaskAttachment {
+                        id: eni_id.clone(),
+                        attachment_type: "eni".into(),
+                        status: "ATTACHED".into(),
+                        details: vec![
+                            crate::state::AttachmentDetail {
+                                name: "subnetId".into(),
+                                value: "subnet-fakecloud".into(),
+                            },
+                            crate::state::AttachmentDetail {
+                                name: "privateIPv4Address".into(),
+                                value: ip.clone(),
+                            },
+                            crate::state::AttachmentDetail {
+                                name: "macAddress".into(),
+                                value: mac.clone(),
+                            },
+                        ],
+                    });
+                }
+            }
+            tracing::info!(
+                task = %task_id,
+                eni = %eni_id,
+                ip = %ip,
+                "populated awsvpc ENI attachment"
+            );
+        }
+
         // Launch every container detached, in topological order. Before
         // each `docker run` we honour the dependent's `dependsOn[]` by
         // polling docker until each upstream container reaches the
@@ -445,6 +549,13 @@ impl EcsRuntime {
         for rc in &started {
             let _ = Command::new(&self.cli)
                 .args(["rm", "-f", &rc.container_id])
+                .output()
+                .await;
+        }
+        // Clean up the per-task docker network for awsvpc.
+        if network_created {
+            let _ = Command::new(&self.cli)
+                .args(["network", "rm", &network_name])
                 .output()
                 .await;
         }
@@ -1942,6 +2053,10 @@ pub(crate) fn build_run_argv(
     argv.push(format!("fakecloud-ecs-container={}", plan.container_name));
     argv.push("--add-host".into());
     argv.push(format!("host.docker.internal:{}", host_ip));
+    if plan.network_mode.as_deref() == Some("awsvpc") {
+        argv.push("--network".into());
+        argv.push(format!("fakecloud-ecs-{}", task_id));
+    }
     // `awsvpc` puts the container on a per-task ENI; emulating that on a
     // local docker host means *not* publishing to the host port table.
     // Bridge / host / default network modes still get `--publish`.
@@ -2415,6 +2530,7 @@ mod tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -268,6 +268,7 @@ impl EcsService {
                 captured_logs: String::new(),
                 protection: None,
                 enable_execute_command,
+                attachments: Vec::new(),
             };
             state.tasks.insert(task_id.clone(), task.clone());
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -653,6 +654,7 @@ mod multi_container_tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         };
         for name in ["app", "sidecar"] {
             task.containers.push(Container {
@@ -825,6 +827,24 @@ mod port_mapping_tests {
     }
 
     #[test]
+    fn awsvpc_network_mode_includes_network_flag() {
+        let plan = plan_with_ports(Vec::new(), Some("awsvpc"));
+        let argv = argv_string(&plan);
+        let network_idx = argv.iter().position(|s| s == "--network");
+        assert!(
+            network_idx.is_some(),
+            "awsvpc must emit --network: {argv:?}"
+        );
+        let network_name = argv.get(network_idx.unwrap() + 1);
+        assert!(
+            network_name
+                .map(|n| n.starts_with("fakecloud-ecs-"))
+                .unwrap_or(false),
+            "awsvpc must reference fakecloud-ecs network: {argv:?}"
+        );
+    }
+
+    #[test]
     fn network_bindings_populated_on_task() {
         // Build a task in state, run mark_running_multi with a started
         // container that has network_bindings populated, and verify
@@ -891,6 +911,7 @@ mod port_mapping_tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         };
         task.last_status = "PENDING".into();
         acct.tasks.insert("abc".into(), task);

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -430,6 +430,26 @@ pub struct Task {
     /// directly on RunTask). Gated when `ExecuteCommand` is invoked.
     #[serde(default)]
     pub enable_execute_command: bool,
+    /// Network attachments (ENI, elastic-inference, etc.) populated when
+    /// the task uses `awsvpc` network mode. Synthetic for fakecloud.
+    #[serde(default)]
+    pub attachments: Vec<TaskAttachment>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskAttachment {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub attachment_type: String,
+    pub status: String,
+    #[serde(default)]
+    pub details: Vec<AttachmentDetail>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AttachmentDetail {
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Implements ECS awsvpc network mode (Phase O7):

- Creates a per-task Docker bridge network when `networkMode=awsvpc`
- Populates `task.attachments` with a synthetic ENI attachment containing `privateIPv4Address` and `macAddress` details
- Injects `--network fakecloud-ecs-<task_id>` into `docker run` argv for awsvpc tasks
- Adds `TaskAttachment` / `AttachmentDetail` structs to ECS state
- Extends `task_to_json` to emit real attachment data
- Adds E2E test verifying ENI attachment appears after task reaches STOPPED

## Test plan

- [x] `cargo test -p fakecloud-ecs` passes (76 unit tests)
- [x] `cargo test -p fakecloud-e2e --test ecs_awsvpc` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ECS `awsvpc` network mode with synthetic ENI attachments. Tasks now run on a per‑task Docker network and return ENI details in `DescribeTasks`.

- **New Features**
  - Create per-task Docker bridge network `fakecloud-ecs-<task_id>` for `awsvpc`; inject `--network` into `docker run`; clean up on stop.
  - Populate `task.attachments` with a synthetic ENI (`id`, `type=eni`, `status=ATTACHED`, details: `privateIPv4Address`, `macAddress`, `subnetId`).
  - Add `TaskAttachment` and `AttachmentDetail` to ECS state; `task_to_json` emits real attachment data.
  - Add E2E test ensuring the ENI attachment appears after the task reaches STOPPED.

- **Dependencies**
  - Add `rand` to `fakecloud-ecs`.

<sup>Written for commit b333d7c558a0cd2ab9a756fc1caf8c2a16ea27b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

