### PR TITLE
feat(ecs): O8 - loadBalancers → ELBv2 RegisterTargets cross-service hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "fakecloud-ssm",
  "http 1.4.0",
  "parking_lot",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -27,6 +27,8 @@ pub struct DeliveryBus {
     ses_dispatcher: Option<Arc<dyn SesSendEmailDispatcher>>,
     /// Run an ECS task on a cluster (cross-service universal target).
     ecs_task_runner: Option<Arc<dyn EcsTaskRunner>>,
+    /// Register/deregister ELBv2 targets from ECS runtime.
+    elbv2_target_registration: Option<Arc<dyn Elbv2TargetRegistration>>,
     /// Publish CloudWatch metric data points (CloudWatch Logs metric
     /// filters extract these on PutLogEvents).
     cloudwatch_metrics: Option<Arc<dyn CloudwatchDelivery>>,
@@ -258,6 +260,24 @@ pub trait EcsTaskRunner: Send + Sync {
     ) -> Result<(), String>;
 }
 
+/// Register/deregister targets with ELBv2 target groups from outside
+/// the elbv2 crate. Used by ECS runtime when tasks with load balancers
+/// reach RUNNING or STOPPED.
+pub trait Elbv2TargetRegistration: Send + Sync {
+    fn register_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    );
+    fn deregister_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    );
+}
+
 /// Publish CloudWatch metric data points from outside the cloudwatch
 /// crate. Used by CloudWatch Logs metric filters when an incoming log
 /// event matches their pattern.
@@ -369,6 +389,7 @@ impl DeliveryBus {
             firehose_sender: None,
             ses_dispatcher: None,
             ecs_task_runner: None,
+            elbv2_target_registration: None,
             cloudwatch_metrics: None,
             cloudwatch_logs: None,
             cognito_jwt_verifier: None,
@@ -505,6 +526,37 @@ impl DeliveryBus {
     pub fn with_ecs_task_runner(mut self, runner: Arc<dyn EcsTaskRunner>) -> Self {
         self.ecs_task_runner = Some(runner);
         self
+    }
+
+    pub fn with_elbv2_target_registration(mut self, reg: Arc<dyn Elbv2TargetRegistration>) -> Self {
+        self.elbv2_target_registration = Some(reg);
+        self
+    }
+
+    /// Register targets with an ELBv2 target group. Silently no-ops when
+    /// no ELBv2 target registration hook is wired.
+    pub fn register_elbv2_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    ) {
+        if let Some(ref reg) = self.elbv2_target_registration {
+            reg.register_targets(account_id, target_group_arn, targets);
+        }
+    }
+
+    /// Deregister targets from an ELBv2 target group. Silently no-ops
+    /// when no ELBv2 target registration hook is wired.
+    pub fn deregister_elbv2_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    ) {
+        if let Some(ref reg) = self.elbv2_target_registration {
+            reg.deregister_targets(account_id, target_group_arn, targets);
+        }
     }
 
     /// Send an email via SES. Returns `Err` when no SES dispatcher is

--- a/crates/fakecloud-e2e/tests/ecs_awsvpc.rs
+++ b/crates/fakecloud-e2e/tests/ecs_awsvpc.rs
@@ -1,0 +1,111 @@
+//! ECS awsvpc network mode (O7).
+//!
+//! Verifies that tasks with `networkMode=awsvpc` get a synthetic ENI
+//! attachment and use a per-task docker network.
+
+mod helpers;
+
+use aws_sdk_ecs::types::{ContainerDefinition, NetworkMode};
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("skipping {test}: docker is not available");
+    false
+}
+
+#[tokio::test]
+async fn ecs_awsvpc_task_gets_eni_attachment() {
+    if !require_docker_or_skip("ecs_awsvpc_task_gets_eni_attachment") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("awsvpc-cluster")
+        .send()
+        .await
+        .expect("create_cluster");
+
+    ecs.register_task_definition()
+        .family("awsvpc-family")
+        .network_mode(NetworkMode::Awsvpc)
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/docker/library/alpine:3.20")
+                .essential(true)
+                .command("sh")
+                .command("-c")
+                .command("sleep 1")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("register_task_definition");
+
+    let run = ecs
+        .run_task()
+        .cluster("awsvpc-cluster")
+        .task_definition("awsvpc-family")
+        .send()
+        .await
+        .expect("run_task");
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+
+    // Poll until STOPPED so the runtime has had time to create the ENI.
+    for _ in 0..60 {
+        let desc = ecs
+            .describe_tasks()
+            .cluster("awsvpc-cluster")
+            .tasks(arn.clone())
+            .send()
+            .await
+            .expect("describe_tasks");
+        let t = &desc.tasks()[0];
+        if t.last_status() == Some("STOPPED") {
+            let attachments = t.attachments();
+            assert!(
+                attachments.iter().any(|a| a.r#type() == Some("eni")),
+                "expected ENI attachment for awsvpc task; got {attachments:?}"
+            );
+            let eni = attachments
+                .iter()
+                .find(|a| a.r#type() == Some("eni"))
+                .unwrap();
+            assert_eq!(eni.status(), Some("ATTACHED"));
+            let details: std::collections::HashMap<&str, &str> = eni
+                .details()
+                .iter()
+                .filter_map(|d| Some((d.name()?, d.value()?)))
+                .collect();
+            assert!(
+                details.contains_key("privateIPv4Address"),
+                "expected privateIPv4Address in ENI details: {details:?}"
+            );
+            assert!(
+                details.contains_key("macAddress"),
+                "expected macAddress in ENI details: {details:?}"
+            );
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!("task never reached STOPPED");
+}

--- a/crates/fakecloud-ecs/Cargo.toml
+++ b/crates/fakecloud-ecs/Cargo.toml
@@ -20,6 +20,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -474,7 +474,35 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
     // Always-present fields AWS returns. SDKs deserialize these
     // unconditionally; without them, terraform/cdk plan diffs and
     // observability hooks see missing keys.
-    map.insert("attachments".into(), json!([]));
+    map.insert(
+        "attachments".into(),
+        Value::Array(
+            task.attachments
+                .iter()
+                .map(|a| {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert("id".into(), json!(a.id));
+                    obj.insert("type".into(), json!(a.attachment_type));
+                    obj.insert("status".into(), json!(a.status));
+                    obj.insert(
+                        "details".into(),
+                        Value::Array(
+                            a.details
+                                .iter()
+                                .map(|d| {
+                                    serde_json::json!({
+                                        "name": d.name,
+                                        "value": d.value,
+                                    })
+                                })
+                                .collect(),
+                        ),
+                    );
+                    Value::Object(obj)
+                })
+                .collect(),
+        ),
+    );
     map.insert("attributes".into(), json!([]));
     map.insert("availabilityZone".into(), json!("us-east-1a"));
     map.insert(
@@ -776,6 +804,7 @@ pub(crate) fn spawn_service_tasks(
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: service_exec,
+            attachments: Vec::new(),
         };
         state.tasks.insert(task_id.clone(), task);
         if let Some(cluster) = state.clusters.get_mut(&cluster_name) {

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -137,6 +137,42 @@ impl EcsRuntime {
         self
     }
 
+    fn register_lb_targets(&self, state: &SharedEcsState, account_id: &str, task_id: &str) {
+        let Some(ref bus) = self.delivery_bus else {
+            return;
+        };
+        let accounts = state.read();
+        let Some(s) = accounts.get(account_id) else {
+            return;
+        };
+        let Some(task) = s.tasks.get(task_id) else {
+            return;
+        };
+        let targets = compute_elbv2_targets(s, task);
+        drop(accounts);
+        for (tg_arn, tg_targets) in targets {
+            bus.register_elbv2_targets(account_id, &tg_arn, tg_targets);
+        }
+    }
+
+    fn deregister_lb_targets(&self, state: &SharedEcsState, account_id: &str, task_id: &str) {
+        let Some(ref bus) = self.delivery_bus else {
+            return;
+        };
+        let accounts = state.read();
+        let Some(s) = accounts.get(account_id) else {
+            return;
+        };
+        let Some(task) = s.tasks.get(task_id) else {
+            return;
+        };
+        let targets = compute_elbv2_targets(s, task);
+        drop(accounts);
+        for (tg_arn, tg_targets) in targets {
+            bus.deregister_elbv2_targets(account_id, &tg_arn, tg_targets);
+        }
+    }
+
     /// Wire CloudWatch Logs state so tasks using the `awslogs` driver
     /// get their captured stdout/stderr forwarded.
     pub fn with_logs(mut self, logs: SharedLogsState) -> Self {
@@ -464,6 +500,7 @@ impl EcsRuntime {
             );
         }
         mark_running_multi(state, account_id, task_id, &started);
+        self.register_lb_targets(state, account_id, task_id);
         self.emit_state_change(state, account_id, task_id, "RUNNING", None);
 
         // Wait for the first essential container (or, if none are
@@ -577,6 +614,7 @@ impl EcsRuntime {
             wait_outcome.stop_code,
             None,
         );
+        self.deregister_lb_targets(state, account_id, task_id);
         self.emit_state_change(
             state,
             account_id,
@@ -2189,6 +2227,80 @@ pub(crate) fn network_bindings_for(plan: &ContainerPlan) -> Vec<serde_json::Valu
         .collect()
 }
 
+/// Compute ELBv2 target registrations for a task based on its service's
+/// loadBalancers configuration. Returns (target_group_arn, [(target_id, port)])
+/// for each target group that should receive this task.
+#[allow(clippy::type_complexity)]
+pub(crate) fn compute_elbv2_targets(
+    ecs_state: &crate::state::EcsState,
+    task: &crate::state::Task,
+) -> Vec<(String, Vec<(String, Option<i64>)>)> {
+    let mut result = Vec::new();
+    let Some(group) = task.group.as_deref() else {
+        return result;
+    };
+    let service_name = group.strip_prefix("service:").unwrap_or(group);
+    let key = crate::state::EcsState::service_key(&task.cluster_name, service_name);
+    let Some(service) = ecs_state.services.get(&key) else {
+        return result;
+    };
+
+    let network_mode = ecs_state
+        .task_definitions
+        .get(&task.family)
+        .and_then(|revs| revs.get(&task.revision))
+        .and_then(|td| td.network_mode.as_deref());
+
+    for lb in &service.load_balancers {
+        let tg_arn = lb.get("targetGroupArn").and_then(|v| v.as_str());
+        let container_name = lb.get("containerName").and_then(|v| v.as_str());
+        let container_port = lb.get("containerPort").and_then(|v| v.as_i64());
+        let Some(tg_arn) = tg_arn else { continue };
+        let Some(container_name) = container_name else {
+            continue;
+        };
+
+        let target_id = if network_mode == Some("awsvpc") {
+            task.attachments
+                .iter()
+                .find(|a| a.attachment_type == "eni")
+                .and_then(|eni| {
+                    eni.details
+                        .iter()
+                        .find(|d| d.name == "privateIPv4Address")
+                        .map(|d| d.value.clone())
+                })
+        } else {
+            Some("127.0.0.1".to_string())
+        };
+
+        let port = if network_mode == Some("awsvpc") {
+            container_port
+        } else {
+            task.containers
+                .iter()
+                .find(|c| c.name == container_name)
+                .and_then(|c| {
+                    c.network_bindings
+                        .iter()
+                        .find(|nb| {
+                            nb.get("containerPort").and_then(|v| v.as_i64()) == container_port
+                        })
+                        .and_then(|nb| nb.get("hostPort").and_then(|v| v.as_i64()))
+                })
+        };
+
+        if let Some(id) = target_id {
+            if let Some(entry) = result.iter_mut().find(|(arn, _)| arn == tg_arn) {
+                entry.1.push((id, port));
+            } else {
+                result.push((tg_arn.to_string(), vec![(id, port)]));
+            }
+        }
+    }
+    result
+}
+
 struct TaskSnapshot {
     task_arn: String,
     cluster_arn: String,
@@ -3382,5 +3494,261 @@ mod tests {
         let raw = serde_json::json!({"hostPath": "/dev/null", "containerPath": "/dev/null"});
         let dev = parse_device(&raw).expect("parses");
         assert_eq!(dev.permissions, "rwm");
+    }
+
+    #[test]
+    fn compute_elbv2_targets_empty_when_no_group() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create("000000000000");
+        let mut task = make_task("t1");
+        task.group = None;
+        acct.tasks.insert("t1".into(), task);
+        let state = acct.clone();
+        let targets = compute_elbv2_targets(&state, state.tasks.get("t1").unwrap());
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn compute_elbv2_targets_bridge_mode_uses_localhost_and_host_port() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create("000000000000");
+
+        let td = crate::state::TaskDefinition {
+            family: "app".into(),
+            revision: 1,
+            task_definition_arn: "arn:aws:ecs:us-east-1:000000000000:task-definition/app:1".into(),
+            container_definitions: Vec::new(),
+            network_mode: Some("bridge".into()),
+            status: "ACTIVE".into(),
+            task_role_arn: None,
+            execution_role_arn: None,
+            requires_compatibilities: Vec::new(),
+            compatibilities: Vec::new(),
+            cpu: None,
+            memory: None,
+            pid_mode: None,
+            ipc_mode: None,
+            volumes: Vec::new(),
+            placement_constraints: Vec::new(),
+            proxy_configuration: None,
+            inference_accelerators: Vec::new(),
+            ephemeral_storage: None,
+            runtime_platform: None,
+            requires_attributes: Vec::new(),
+            registered_at: Utc::now(),
+            registered_by: None,
+            deregistered_at: None,
+            tags: Vec::new(),
+            enable_fault_injection: None,
+        };
+        acct.task_definitions.insert("app".into(), {
+            let mut m = std::collections::BTreeMap::new();
+            m.insert(1, td);
+            m
+        });
+
+        let service = crate::state::Service {
+            service_name: "svc".into(),
+            service_arn: "arn:aws:ecs:us-east-1:000000000000:service/default/svc".into(),
+            cluster_name: "default".into(),
+            cluster_arn: "arn:aws:ecs:us-east-1:000000000000:cluster/default".into(),
+            task_definition_arn: "arn:aws:ecs:us-east-1:000000000000:task-definition/app:1".into(),
+            family: "app".into(),
+            revision: 1,
+            desired_count: 1,
+            running_count: 0,
+            pending_count: 0,
+            launch_type: "FARGATE".into(),
+            status: "ACTIVE".into(),
+            scheduling_strategy: "REPLICA".into(),
+            deployment_controller: "ECS".into(),
+            minimum_healthy_percent: Some(0),
+            maximum_percent: Some(200),
+            circuit_breaker: None,
+            deployments: Vec::new(),
+            load_balancers: vec![serde_json::json!({
+                "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg/abc",
+                "containerName": "app",
+                "containerPort": 80,
+            })],
+            service_registries: Vec::new(),
+            placement_constraints: Vec::new(),
+            placement_strategy: Vec::new(),
+            network_configuration: None,
+            tags: Vec::new(),
+            created_at: Utc::now(),
+            created_by: None,
+            role_arn: None,
+            platform_version: None,
+            health_check_grace_period_seconds: None,
+            enable_execute_command: false,
+            enable_ecs_managed_tags: false,
+            propagate_tags: None,
+            capacity_provider_strategy: Vec::new(),
+            availability_zone_rebalancing: None,
+        };
+        acct.services.insert(
+            crate::state::EcsState::service_key("default", "svc"),
+            service,
+        );
+
+        let mut task = make_task("t1");
+        task.group = Some("service:svc".into());
+        task.containers = vec![crate::state::Container {
+            container_arn: "arn:aws:ecs:us-east-1:000000000000:container/default/abc/app".into(),
+            name: "app".into(),
+            image: "alpine".into(),
+            task_arn: task.task_arn.clone(),
+            last_status: "RUNNING".into(),
+            exit_code: None,
+            reason: None,
+            runtime_id: Some("dockerid-app".into()),
+            essential: true,
+            cpu: None,
+            memory: None,
+            memory_reservation: None,
+            network_bindings: vec![serde_json::json!({
+                "bindIP": "0.0.0.0",
+                "containerPort": 80,
+                "hostPort": 32768,
+                "protocol": "tcp",
+            })],
+            network_interfaces: Vec::new(),
+            health_status: None,
+            managed_agents: None,
+            image_digest: None,
+        }];
+        acct.tasks.insert("t1".into(), task);
+
+        let state = acct.clone();
+        let targets = compute_elbv2_targets(&state, state.tasks.get("t1").unwrap());
+        assert_eq!(targets.len(), 1);
+        let (arn, tg_targets) = &targets[0];
+        assert_eq!(
+            arn,
+            "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg/abc"
+        );
+        assert_eq!(tg_targets.len(), 1);
+        assert_eq!(tg_targets[0].0, "127.0.0.1");
+        assert_eq!(tg_targets[0].1, Some(32768));
+    }
+
+    #[test]
+    fn compute_elbv2_targets_awsvpc_uses_eni_ip() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create("000000000000");
+
+        let td = crate::state::TaskDefinition {
+            family: "app".into(),
+            revision: 1,
+            task_definition_arn: "arn:aws:ecs:us-east-1:000000000000:task-definition/app:1".into(),
+            container_definitions: Vec::new(),
+            network_mode: Some("awsvpc".into()),
+            status: "ACTIVE".into(),
+            task_role_arn: None,
+            execution_role_arn: None,
+            requires_compatibilities: Vec::new(),
+            compatibilities: Vec::new(),
+            cpu: None,
+            memory: None,
+            pid_mode: None,
+            ipc_mode: None,
+            volumes: Vec::new(),
+            placement_constraints: Vec::new(),
+            proxy_configuration: None,
+            inference_accelerators: Vec::new(),
+            ephemeral_storage: None,
+            runtime_platform: None,
+            requires_attributes: Vec::new(),
+            registered_at: Utc::now(),
+            registered_by: None,
+            deregistered_at: None,
+            tags: Vec::new(),
+            enable_fault_injection: None,
+        };
+        acct.task_definitions.insert("app".into(), {
+            let mut m = std::collections::BTreeMap::new();
+            m.insert(1, td);
+            m
+        });
+
+        let service = crate::state::Service {
+            service_name: "svc".into(),
+            service_arn: "arn:aws:ecs:us-east-1:000000000000:service/default/svc".into(),
+            cluster_name: "default".into(),
+            cluster_arn: "arn:aws:ecs:us-east-1:000000000000:cluster/default".into(),
+            task_definition_arn: "arn:aws:ecs:us-east-1:000000000000:task-definition/app:1".into(),
+            family: "app".into(),
+            revision: 1,
+            desired_count: 1,
+            running_count: 0,
+            pending_count: 0,
+            launch_type: "FARGATE".into(),
+            status: "ACTIVE".into(),
+            scheduling_strategy: "REPLICA".into(),
+            deployment_controller: "ECS".into(),
+            minimum_healthy_percent: Some(0),
+            maximum_percent: Some(200),
+            circuit_breaker: None,
+            deployments: Vec::new(),
+            load_balancers: vec![serde_json::json!({
+                "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg/abc",
+                "containerName": "app",
+                "containerPort": 80,
+            })],
+            service_registries: Vec::new(),
+            placement_constraints: Vec::new(),
+            placement_strategy: Vec::new(),
+            network_configuration: None,
+            tags: Vec::new(),
+            created_at: Utc::now(),
+            created_by: None,
+            role_arn: None,
+            platform_version: None,
+            health_check_grace_period_seconds: None,
+            enable_execute_command: false,
+            enable_ecs_managed_tags: false,
+            propagate_tags: None,
+            capacity_provider_strategy: Vec::new(),
+            availability_zone_rebalancing: None,
+        };
+        acct.services.insert(
+            crate::state::EcsState::service_key("default", "svc"),
+            service,
+        );
+
+        let mut task = make_task("t1");
+        task.group = Some("service:svc".into());
+        task.attachments = vec![crate::state::TaskAttachment {
+            id: "eni-123".into(),
+            attachment_type: "eni".into(),
+            status: "ATTACHED".into(),
+            details: vec![
+                crate::state::AttachmentDetail {
+                    name: "privateIPv4Address".into(),
+                    value: "172.18.0.2".into(),
+                },
+                crate::state::AttachmentDetail {
+                    name: "macAddress".into(),
+                    value: "02:42:ac:12:00:02".into(),
+                },
+            ],
+        }];
+        acct.tasks.insert("t1".into(), task);
+
+        let state = acct.clone();
+        let targets = compute_elbv2_targets(&state, state.tasks.get("t1").unwrap());
+        assert_eq!(targets.len(), 1);
+        let (arn, tg_targets) = &targets[0];
+        assert_eq!(
+            arn,
+            "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg/abc"
+        );
+        assert_eq!(tg_targets.len(), 1);
+        assert_eq!(tg_targets[0].0, "172.18.0.2");
+        assert_eq!(tg_targets[0].1, Some(80));
     }
 }

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -287,6 +287,110 @@ impl EcsRuntime {
         }
         mark_pull_stopped(state, account_id, task_id);
 
+        // For awsvpc network mode, create a per-task docker network so
+        // containers share an isolated bridge. Clean it up when the task
+        // stops. Network creation is best-effort: on failure we fall back
+        // to the default bridge and continue.
+        let awsvpc_network = resolved_plans
+            .iter()
+            .any(|rp| rp.plan.network_mode.as_deref() == Some("awsvpc"));
+        let network_name = format!("fakecloud-ecs-{}", task_id);
+        let network_created = if awsvpc_network {
+            let create = Command::new(&self.cli)
+                .args([
+                    "network",
+                    "create",
+                    "--driver",
+                    "bridge",
+                    "--label",
+                    &format!("fakecloud-ecs-task={}", task_id),
+                    &network_name,
+                ])
+                .output()
+                .await;
+            match create {
+                Ok(out) if out.status.success() => {
+                    tracing::info!(
+                        task = %task_id,
+                        network = %network_name,
+                        "created awsvpc docker network"
+                    );
+                    true
+                }
+                Ok(out) => {
+                    let err = String::from_utf8_lossy(&out.stderr);
+                    tracing::warn!(
+                        task = %task_id,
+                        network = %network_name,
+                        error = %err,
+                        "awsvpc network creation failed; falling back to default bridge"
+                    );
+                    false
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task = %task_id,
+                        network = %network_name,
+                        error = %e,
+                        "awsvpc network creation failed; falling back to default bridge"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
+        if network_created {
+            let eni_id = format!(
+                "eni-{}",
+                uuid::Uuid::new_v4()
+                    .to_string()
+                    .replace('-', "")
+                    .get(..17)
+                    .unwrap_or("")
+            );
+            let mac = format!(
+                "02:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>(),
+                rand::random::<u8>()
+            );
+            let ip = format!("10.0.{}.{}", rand::random::<u8>(), rand::random::<u8>());
+            let mut accounts = state.write();
+            if let Some(st) = accounts.get_mut(account_id) {
+                if let Some(task) = st.tasks.get_mut(task_id) {
+                    task.attachments.push(crate::state::TaskAttachment {
+                        id: eni_id.clone(),
+                        attachment_type: "eni".into(),
+                        status: "ATTACHED".into(),
+                        details: vec![
+                            crate::state::AttachmentDetail {
+                                name: "subnetId".into(),
+                                value: "subnet-fakecloud".into(),
+                            },
+                            crate::state::AttachmentDetail {
+                                name: "privateIPv4Address".into(),
+                                value: ip.clone(),
+                            },
+                            crate::state::AttachmentDetail {
+                                name: "macAddress".into(),
+                                value: mac.clone(),
+                            },
+                        ],
+                    });
+                }
+            }
+            tracing::info!(
+                task = %task_id,
+                eni = %eni_id,
+                ip = %ip,
+                "populated awsvpc ENI attachment"
+            );
+        }
+
         // Launch every container detached, in topological order. Before
         // each `docker run` we honour the dependent's `dependsOn[]` by
         // polling docker until each upstream container reaches the
@@ -445,6 +549,13 @@ impl EcsRuntime {
         for rc in &started {
             let _ = Command::new(&self.cli)
                 .args(["rm", "-f", &rc.container_id])
+                .output()
+                .await;
+        }
+        // Clean up the per-task docker network for awsvpc.
+        if network_created {
+            let _ = Command::new(&self.cli)
+                .args(["network", "rm", &network_name])
                 .output()
                 .await;
         }
@@ -1942,6 +2053,10 @@ pub(crate) fn build_run_argv(
     argv.push(format!("fakecloud-ecs-container={}", plan.container_name));
     argv.push("--add-host".into());
     argv.push(format!("host.docker.internal:{}", host_ip));
+    if plan.network_mode.as_deref() == Some("awsvpc") {
+        argv.push("--network".into());
+        argv.push(format!("fakecloud-ecs-{}", task_id));
+    }
     // `awsvpc` puts the container on a per-task ENI; emulating that on a
     // local docker host means *not* publishing to the host port table.
     // Bridge / host / default network modes still get `--publish`.
@@ -2415,6 +2530,7 @@ mod tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -268,6 +268,7 @@ impl EcsService {
                 captured_logs: String::new(),
                 protection: None,
                 enable_execute_command,
+                attachments: Vec::new(),
             };
             state.tasks.insert(task_id.clone(), task.clone());
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -653,6 +654,7 @@ mod multi_container_tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         };
         for name in ["app", "sidecar"] {
             task.containers.push(Container {
@@ -825,6 +827,24 @@ mod port_mapping_tests {
     }
 
     #[test]
+    fn awsvpc_network_mode_includes_network_flag() {
+        let plan = plan_with_ports(Vec::new(), Some("awsvpc"));
+        let argv = argv_string(&plan);
+        let network_idx = argv.iter().position(|s| s == "--network");
+        assert!(
+            network_idx.is_some(),
+            "awsvpc must emit --network: {argv:?}"
+        );
+        let network_name = argv.get(network_idx.unwrap() + 1);
+        assert!(
+            network_name
+                .map(|n| n.starts_with("fakecloud-ecs-"))
+                .unwrap_or(false),
+            "awsvpc must reference fakecloud-ecs network: {argv:?}"
+        );
+    }
+
+    #[test]
     fn network_bindings_populated_on_task() {
         // Build a task in state, run mark_running_multi with a started
         // container that has network_bindings populated, and verify
@@ -891,6 +911,7 @@ mod port_mapping_tests {
             captured_logs: String::new(),
             protection: None,
             enable_execute_command: false,
+            attachments: Vec::new(),
         };
         task.last_status = "PENDING".into();
         acct.tasks.insert("abc".into(), task);

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -430,6 +430,26 @@ pub struct Task {
     /// directly on RunTask). Gated when `ExecuteCommand` is invoked.
     #[serde(default)]
     pub enable_execute_command: bool,
+    /// Network attachments (ENI, elastic-inference, etc.) populated when
+    /// the task uses `awsvpc` network mode. Synthetic for fakecloud.
+    #[serde(default)]
+    pub attachments: Vec<TaskAttachment>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskAttachment {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub attachment_type: String,
+    pub status: String,
+    #[serde(default)]
+    pub details: Vec<AttachmentDetail>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AttachmentDetail {
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -584,7 +584,16 @@ async fn main() {
             Arc::new(DeliveryBus::new().with_sqs(sqs_delivery.clone())),
         ),
     );
-    let ecs_delivery_bus = Arc::new(DeliveryBus::new().with_eventbridge(eb_delivery_for_ecs));
+    let elbv2_state: fakecloud_elbv2::SharedElbv2State = Arc::new(parking_lot::RwLock::new(
+        fakecloud_elbv2::Elbv2Accounts::new(),
+    ));
+    let ecs_delivery_bus = Arc::new(
+        DeliveryBus::new()
+            .with_eventbridge(eb_delivery_for_ecs)
+            .with_elbv2_target_registration(Arc::new(Elbv2TargetRegistrationImpl {
+                state: elbv2_state.clone(),
+            })),
+    );
     ecs_runtime = fakecloud_ecs::runtime::EcsRuntime::new(bound_addr.port())
         .map(|rt| {
             rt.with_delivery_bus(ecs_delivery_bus.clone())
@@ -650,10 +659,6 @@ async fn main() {
 
     let glue_state: fakecloud_glue::SharedGlueState =
         Arc::new(parking_lot::RwLock::new(fakecloud_glue::GlueAccounts::new()));
-
-    let elbv2_state: fakecloud_elbv2::SharedElbv2State = Arc::new(parking_lot::RwLock::new(
-        fakecloud_elbv2::Elbv2Accounts::new(),
-    ));
 
     // Clone state for reset endpoint before moving into services
     let reset_state = ResetState {
@@ -6678,6 +6683,58 @@ impl fakecloud_core::delivery::SesSendEmailDispatcher for SesSendEmailDispatcher
             timestamp: chrono::Utc::now(),
         });
         Ok(())
+    }
+}
+
+/// ELBv2 target registration/deregistration from ECS runtime.
+struct Elbv2TargetRegistrationImpl {
+    state: fakecloud_elbv2::SharedElbv2State,
+}
+
+impl fakecloud_core::delivery::Elbv2TargetRegistration for Elbv2TargetRegistrationImpl {
+    fn register_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    ) {
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(account_id);
+        let Some(tg) = st.target_groups.get_mut(target_group_arn) else {
+            return;
+        };
+        for (id, port) in targets {
+            tg.targets.retain(|t| t.id != id);
+            tg.targets.push(fakecloud_elbv2::state::TargetDescription {
+                id,
+                port: port.map(|p| p as i32),
+                availability_zone: None,
+                health: fakecloud_elbv2::state::TargetHealth {
+                    state: "initial".into(),
+                    reason: None,
+                    description: None,
+                },
+                consecutive_success: 0,
+                consecutive_failure: 0,
+                last_probe_at: None,
+            });
+        }
+    }
+
+    fn deregister_targets(
+        &self,
+        account_id: &str,
+        target_group_arn: &str,
+        targets: Vec<(String, Option<i64>)>,
+    ) {
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(account_id);
+        let Some(tg) = st.target_groups.get_mut(target_group_arn) else {
+            return;
+        };
+        for (id, _port) in targets {
+            tg.targets.retain(|t| t.id != id);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `Elbv2TargetRegistration` trait to `fakecloud-core` `DeliveryBus`
- `compute_elbv2_targets` helper resolves targets from service `loadBalancers`
  + task `portMappings` (bridge mode) or ENI private IP (awsvpc mode)
- Register targets on task start, deregister on stop via ECS runtime
- Implement `Elbv2TargetRegistrationImpl` in `fakecloud-server` wiring ELBv2 state
- Unit tests for bridge + awsvpc target computation

## Test plan
- [x] `cargo test -p fakecloud-ecs` passes (79 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Unit tests for `compute_elbv2_targets` in bridge and awsvpc modes
- [ ] CI green
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-register ELBv2 targets for ECS services from service `loadBalancers` when tasks start, and remove them on stop. Adds `awsvpc` support with a per-task Docker network and synthetic ENI attachments used to resolve target IPs.

- **New Features**
  - `fakecloud-core`: adds `Elbv2TargetRegistration` hook on `DeliveryBus`; `fakecloud-server` implements it and updates ELBv2 target group state.
  - `fakecloud-ecs`: `compute_elbv2_targets` resolves targets per service; bridge uses host `portMappings`, `awsvpc` uses ENI private IP; runtime registers on RUNNING and deregisters on STOPPED.
  - `awsvpc` runtime: creates `fakecloud-ecs-<task_id>` network, injects `--network`, and includes ENI `attachments` in task JSON.

- **Dependencies**
  - Add `rand` to `fakecloud-ecs` (for synthetic ENI data).

<sup>Written for commit 07bef283b5c511ba0a30def7e988b587dd09cacd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

