### PR TITLE
fix(ecs): keep desired_status=RUNNING in no-runtime RunTask path

### DIFF
--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -319,7 +319,11 @@ impl EcsService {
                 for id in &spawned_tasks {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
-                        t.desired_status = "STOPPED".into();
+                        // desired_status stays RUNNING: the task was requested
+                        // to run but failed to start. AWS keeps desired_status
+                        // as RUNNING for failed standalone RunTask until the
+                        // caller explicitly stops it. This also ensures
+                        // list_tasks (default filter=RUNNING) finds it.
                         t.stop_code = Some("TaskFailedToStart".into());
                         t.stopped_reason = Some(
                             "No container runtime available (docker/podman not installed)".into(),


### PR DESCRIPTION
## Summary

Standalone `RunTask` tasks that fail to start (no Docker available) should keep `desired_status=RUNNING` — AWS does not flip it to STOPPED until the caller explicitly calls `StopTask`.

This fixes the `ecs_list_tasks` conformance test which asserts tasks are visible under the default `desiredStatus=RUNNING` filter.

## Test plan

- [x] `cargo test -p fakecloud-ecs` — 79/79 pass
- [x] `cargo test -p fakecloud-conformance --test ecs ecs_list_tasks` — pass
- [x] `cargo clippy -p fakecloud-ecs --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep desired_status=RUNNING for standalone RunTask that fails to start when no container runtime is available. Matches AWS behavior so the task still appears under the default RUNNING filter, fixing the `ecs_list_tasks` conformance test.

<sup>Written for commit 527fa51c745750e3fd3e0f8c67a370b8852fd4ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

