### PR TITLE
fix(ecs): keep desired_status=RUNNING in no-runtime service spawn paths

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_enforce.rs
+++ b/crates/fakecloud-e2e/tests/ecs_enforce.rs
@@ -14,6 +14,27 @@ mod helpers;
 use aws_sdk_ecs::types::{ContainerDefinition, PropagateTags, Tag, TaskField};
 use helpers::TestServer;
 
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("skipping {test}: docker is not available");
+    false
+}
+
 async fn bootstrap(client: &aws_sdk_ecs::Client, cluster: &str, family: &str, tags: Vec<Tag>) {
     client
         .create_cluster()
@@ -240,6 +261,9 @@ async fn propagate_tags_service_copies_service_tags_onto_tasks() {
 
 #[tokio::test]
 async fn update_service_scale_in_skips_protected_tasks() {
+    if !require_docker_or_skip("update_service_scale_in_skips_protected_tasks") {
+        return;
+    }
     let server = TestServer::start().await;
     let client = server.ecs_client().await;
     bootstrap(&client, "prot-cluster", "prot-td", vec![]).await;

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -222,7 +222,6 @@ impl EcsService {
                 for id in &spawn_task_ids {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
-                        t.desired_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
                         t.stopped_reason = Some(
                             "No container runtime available (docker/podman not installed)".into(),
@@ -526,7 +525,6 @@ impl EcsService {
                 for id in &spawn_ids {
                     if let Some(t) = state.tasks.get_mut(id) {
                         t.last_status = "STOPPED".into();
-                        t.desired_status = "STOPPED".into();
                         t.stop_code = Some("TaskFailedToStart".into());
                         t.stopped_reason = Some(
                             "No container runtime available (docker/podman not installed)".into(),


### PR DESCRIPTION
## Summary

- Remove `desired_status = "STOPPED"` from `create_service` and `update_service` no-runtime fallback blocks. Tasks still show `last_status=STOPPED` and `stopped_reason` pointing to missing runtime, but `desired_status` stays `RUNNING` so `list_tasks` default filter finds them.
- Skip `update_service_scale_in_skips_protected_tasks` e2e test when Docker is unavailable; the test requires tasks to actually run.

## Test plan

- [x] `cargo test -p fakecloud-conformance --test ecs` → 76/76 pass
- [x] `cargo test -p fakecloud-e2e --test ecs_enforce` → 5/5 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep ECS tasks spawned without a container runtime in desired_status=RUNNING so they appear in list_tasks. Skip the scale-in e2e test when Docker isn’t available to avoid false failures.

- **Bug Fixes**
  - `fakecloud-ecs`: In no-runtime create/update-service paths, stop setting desired_status=STOPPED. Keep RUNNING; last_status stays STOPPED with a missing-runtime reason.
  - `fakecloud-e2e`: Detect Docker and skip the scale-in protection test when unavailable; fail in CI if Docker is missing.

<sup>Written for commit 504bb5eb3a5934816d262f2f82992d7471a38025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

