### PR TITLE
feat(ecs): CODE_DEPLOY blue/green task sets (O16)

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_enforce.rs
+++ b/crates/fakecloud-e2e/tests/ecs_enforce.rs
@@ -468,3 +468,208 @@ async fn daemon_spawns_one_task_per_capacity_provider() {
         "all daemon tasks should be STOPPED after delete_daemon; got {del_daemon_tasks:?}"
     );
 }
+
+// ── CODE_DEPLOY blue/green (O16) ────────────────────────────────────────
+
+#[tokio::test]
+async fn codedeploy_service_creates_primary_task_set() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("bg-cluster")
+        .send()
+        .await
+        .unwrap();
+    client
+        .register_task_definition()
+        .family("bg-td")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let dc = aws_sdk_ecs::types::DeploymentController::builder()
+        .r#type(aws_sdk_ecs::types::DeploymentControllerType::CodeDeploy)
+        .build()
+        .unwrap();
+    client
+        .create_service()
+        .cluster("bg-cluster")
+        .service_name("web")
+        .task_definition("bg-td")
+        .desired_count(2)
+        .deployment_controller(dc)
+        .send()
+        .await
+        .expect("create_service CODE_DEPLOY");
+
+    let described = client
+        .describe_services()
+        .cluster("bg-cluster")
+        .services("web")
+        .send()
+        .await
+        .expect("describe_services");
+    let svc = described.services().first().expect("service present");
+    let sets = svc.task_sets();
+    assert_eq!(
+        sets.len(),
+        1,
+        "CODE_DEPLOY service should have one PRIMARY task set; got {sets:?}"
+    );
+    let ts = &sets[0];
+    assert_eq!(
+        ts.status(),
+        Some("PRIMARY"),
+        "task set should be PRIMARY; got {:?}",
+        ts.status()
+    );
+    assert!(
+        ts.task_definition().unwrap_or("").contains("bg-td"),
+        "PRIMARY task set should reference bg-td; got {:?}",
+        ts.task_definition()
+    );
+    assert_eq!(
+        svc.deployments().len(),
+        0,
+        "CODE_DEPLOY service should have no deployments; got {:?}",
+        svc.deployments()
+    );
+}
+
+#[tokio::test]
+async fn codedeploy_update_service_flips_primary_task_set() {
+    let server = TestServer::start().await;
+    let client = server.ecs_client().await;
+    client
+        .create_cluster()
+        .cluster_name("bg-up-cluster")
+        .send()
+        .await
+        .unwrap();
+    client
+        .register_task_definition()
+        .family("bg-td")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    client
+        .register_task_definition()
+        .family("bg-td2")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let dc = aws_sdk_ecs::types::DeploymentController::builder()
+        .r#type(aws_sdk_ecs::types::DeploymentControllerType::CodeDeploy)
+        .build()
+        .unwrap();
+    client
+        .create_service()
+        .cluster("bg-up-cluster")
+        .service_name("web")
+        .task_definition("bg-td")
+        .desired_count(2)
+        .deployment_controller(dc)
+        .send()
+        .await
+        .expect("create_service CODE_DEPLOY");
+
+    // Update service to new task definition.
+    client
+        .update_service()
+        .cluster("bg-up-cluster")
+        .service("web")
+        .task_definition("bg-td2")
+        .send()
+        .await
+        .expect("update_service");
+
+    let described = client
+        .describe_services()
+        .cluster("bg-up-cluster")
+        .services("web")
+        .send()
+        .await
+        .expect("describe_services");
+    let svc = described.services().first().expect("service present");
+    let sets: Vec<_> = svc.task_sets().to_vec();
+    assert_eq!(
+        sets.len(),
+        2,
+        "after update there should be 2 task sets; got {sets:?}"
+    );
+    let primary = sets
+        .iter()
+        .find(|ts| ts.status() == Some("PRIMARY"))
+        .expect("one PRIMARY task set");
+    assert!(
+        primary.task_definition().unwrap_or("").contains("bg-td2"),
+        "PRIMARY should reference new TD bg-td2; got {:?}",
+        primary.task_definition()
+    );
+    let old = sets
+        .iter()
+        .find(|ts| ts.status() == Some("ACTIVE"))
+        .expect("old task set demoted to ACTIVE");
+    assert!(
+        old.task_definition().unwrap_or("").contains("bg-td"),
+        "ACTIVE should reference old TD bg-td; got {:?}",
+        old.task_definition()
+    );
+    assert_eq!(
+        old.computed_desired_count(),
+        0,
+        "old task set should have computedDesiredCount=0; got {:?}",
+        old.computed_desired_count()
+    );
+
+    // Old tasks on bg-td should be desired STOPPED.
+    let tasks = client
+        .list_tasks()
+        .cluster("bg-up-cluster")
+        .send()
+        .await
+        .expect("list_tasks");
+    //
+    for arn in tasks.task_arns() {
+        let d = client
+            .describe_tasks()
+            .cluster("bg-up-cluster")
+            .tasks(arn)
+            .send()
+            .await
+            .expect("describe_tasks");
+        let t = d.tasks().first().expect("task");
+        let td = t.task_definition_arn().unwrap_or("");
+        if td.contains("bg-td") && !td.contains("bg-td2") {
+            assert_eq!(
+                t.desired_status(),
+                Some("STOPPED"),
+                "old-TD task should be desired STOPPED; got {:?}",
+                t.desired_status()
+            );
+        }
+    }
+}

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -439,6 +439,9 @@ pub(crate) fn task_to_json(task: &Task) -> Value {
     if let Some(ref v) = task.group {
         map.insert("group".into(), json!(v));
     }
+    if let Some(ref v) = task.task_set_arn {
+        map.insert("taskSetArn".into(), json!(v));
+    }
     map.insert("connectivity".into(), json!(task.connectivity));
     if let Some(ref v) = task.stop_code {
         map.insert("stopCode".into(), json!(v));
@@ -668,6 +671,7 @@ pub(crate) fn spawn_service_tasks(
     count: i32,
     principal_arn: &str,
     launch_type: &str,
+    task_set_arn: Option<String>,
 ) -> Vec<String> {
     if count <= 0 {
         return Vec::new();
@@ -812,6 +816,7 @@ pub(crate) fn spawn_service_tasks(
             enable_execute_command: service_exec,
             attachments: Vec::new(),
             volume_configurations: Vec::new(),
+            task_set_arn: task_set_arn.clone(),
         };
         state.tasks.insert(task_id.clone(), task);
         if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -978,6 +983,7 @@ pub(crate) fn spawn_daemon_tasks(
             enable_execute_command: daemon_exec,
             attachments: Vec::new(),
             volume_configurations: Vec::new(),
+            task_set_arn: None,
         };
         state.tasks.insert(task_id.clone(), task);
         if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -1017,6 +1023,23 @@ pub(crate) fn recompute_service_counts(
     if let Some(map) = service_json.as_object_mut() {
         map.insert("runningCount".into(), json!(running));
         map.insert("pendingCount".into(), json!(pending));
+    }
+}
+
+pub(crate) fn inject_service_task_sets(
+    state: &EcsState,
+    service_name: &str,
+    cluster_name: &str,
+    service_json: &mut Value,
+) {
+    let sets: Vec<Value> = state
+        .task_sets
+        .values()
+        .filter(|ts| ts.service_name == service_name && ts.cluster_name == cluster_name)
+        .map(task_set_to_json)
+        .collect();
+    if let Some(map) = service_json.as_object_mut() {
+        map.insert("taskSets".into(), Value::Array(sets));
     }
 }
 

--- a/crates/fakecloud-ecs/src/runtime.rs
+++ b/crates/fakecloud-ecs/src/runtime.rs
@@ -2644,6 +2644,7 @@ mod tests {
             enable_execute_command: false,
             attachments: Vec::new(),
             volume_configurations: Vec::new(),
+            task_set_arn: None,
         }
     }
 

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -637,10 +637,13 @@ impl EcsService {
             .services
             .get(&service_key)
             .ok_or_else(|| service_not_found(&service_name))?;
-        if svc.deployment_controller != "EXTERNAL" {
+        if !matches!(
+            svc.deployment_controller.as_str(),
+            "EXTERNAL" | "CODE_DEPLOY"
+        ) {
             return Err(client_exception(
                 "CreateTaskSet requires the service to be created with \
-                 deploymentController.type = EXTERNAL",
+                 deploymentController.type = EXTERNAL or CODE_DEPLOY",
             ));
         }
         let ts_id = format!("ecs-svc-{}", uuid::Uuid::new_v4().simple());

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -140,22 +140,27 @@ impl EcsService {
                     return Err(service_already_exists(&service_name));
                 }
             }
-            let deployment = Deployment {
-                deployment_id: format!(
-                    "ecs-svc/{}",
-                    uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
-                ),
-                status: "PRIMARY".into(),
-                task_definition_arn: td_arn.clone(),
-                desired_count,
-                pending_count: 0,
-                running_count: 0,
-                failed_tasks: 0,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                launch_type: launch_type.clone(),
-                rollout_state: "IN_PROGRESS".into(),
-                rollout_state_reason: Some("ECS deployment in progress.".into()),
+            let is_code_deploy = deployment_controller == "CODE_DEPLOY";
+            let deployments = if is_code_deploy {
+                Vec::new()
+            } else {
+                vec![Deployment {
+                    deployment_id: format!(
+                        "ecs-svc/{}",
+                        uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
+                    ),
+                    status: "PRIMARY".into(),
+                    task_definition_arn: td_arn.clone(),
+                    desired_count,
+                    pending_count: 0,
+                    running_count: 0,
+                    failed_tasks: 0,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    launch_type: launch_type.clone(),
+                    rollout_state: "IN_PROGRESS".into(),
+                    rollout_state_reason: Some("ECS deployment in progress.".into()),
+                }]
             };
             let service = Service {
                 service_name: service_name.clone(),
@@ -171,13 +176,13 @@ impl EcsService {
                 launch_type: launch_type.clone(),
                 status: "ACTIVE".into(),
                 scheduling_strategy: scheduling,
-                deployment_controller,
+                deployment_controller: deployment_controller.clone(),
                 minimum_healthy_percent: min_healthy,
                 maximum_percent: max_percent,
                 circuit_breaker,
-                deployments: vec![deployment],
-                load_balancers,
-                service_registries,
+                deployments,
+                load_balancers: load_balancers.clone(),
+                service_registries: service_registries.clone(),
                 placement_constraints,
                 placement_strategy,
                 network_configuration,
@@ -206,9 +211,54 @@ impl EcsService {
                 last_status: Some("ACTIVE".into()),
                 detail: json!({"serviceArn": service_arn, "desiredCount": desired_count}),
             });
-            let ids =
-                spawn_service_tasks(state, &service, desired_count, &principal_arn, &launch_type);
-            (service_to_json(state.services.get(&key).unwrap()), ids)
+            let ids = spawn_service_tasks(
+                state,
+                &service,
+                desired_count,
+                &principal_arn,
+                &launch_type,
+                None,
+            );
+            if is_code_deploy {
+                let ts_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+                let ts_arn = format!(
+                    "arn:aws:ecs:{}:{}:task-set/{}/{}/{}",
+                    state.region, state.account_id, cluster_name, service_name, ts_id
+                );
+                let task_set = TaskSet {
+                    task_set_id: ts_id,
+                    task_set_arn: ts_arn.clone(),
+                    service_arn: service_arn.clone(),
+                    cluster_arn: service.cluster_arn.clone(),
+                    service_name: service_name.clone(),
+                    cluster_name: cluster_name.clone(),
+                    external_id: None,
+                    status: "PRIMARY".into(),
+                    task_definition: service.task_definition_arn.clone(),
+                    computed_desired_count: desired_count,
+                    pending_count: ids.len() as i32,
+                    running_count: 0,
+                    launch_type: Some(launch_type.clone()),
+                    platform_version: Some("1.4.0".into()),
+                    scale: None,
+                    stability_status: "STABILIZING".into(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    load_balancers: service.load_balancers.clone(),
+                    service_registries: service.service_registries.clone(),
+                    capacity_provider_strategy: service.capacity_provider_strategy.clone(),
+                    tags: Vec::new(),
+                };
+                state.task_sets.insert(
+                    format!("{}/{}/{}", cluster_name, service_name, task_set.task_set_id),
+                    task_set,
+                );
+            }
+            let mut service_json = service_to_json(state.services.get(&key).unwrap());
+            if is_code_deploy {
+                inject_service_task_sets(state, &service_name, &cluster_name, &mut service_json);
+            }
+            (service_json, ids)
         };
 
         if let Some(rt) = runtime {
@@ -315,152 +365,279 @@ impl EcsService {
                 if let Some(n) = new_desired {
                     let n = n.max(0) as i32;
                     svc.desired_count = n;
-                    if let Some(d) = svc.deployments.iter_mut().find(|d| d.status == "PRIMARY") {
-                        d.desired_count = n;
-                        d.updated_at = Utc::now();
+                    if svc.deployment_controller != "CODE_DEPLOY" {
+                        if let Some(d) = svc.deployments.iter_mut().find(|d| d.status == "PRIMARY")
+                        {
+                            d.desired_count = n;
+                            d.updated_at = Utc::now();
+                        }
                     }
                 }
 
                 if let Some(arn) = new_td_arn.clone() {
-                    // Roll a new PRIMARY deployment; mark the previous one ACTIVE
-                    // so it's eligible for drain once the new deployment ramps.
-                    for d in svc.deployments.iter_mut() {
-                        if d.status == "PRIMARY" {
-                            d.status = "ACTIVE".into();
-                            old_deployments_drained.push(d.deployment_id.clone());
-                        }
-                    }
-                    svc.deployments.insert(
-                        0,
-                        Deployment {
-                            deployment_id: format!(
-                                "ecs-svc/{}",
-                                uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
-                            ),
-                            status: "PRIMARY".into(),
-                            task_definition_arn: arn.clone(),
-                            desired_count: svc.desired_count,
-                            pending_count: 0,
-                            running_count: 0,
-                            failed_tasks: 0,
-                            created_at: Utc::now(),
-                            updated_at: Utc::now(),
-                            launch_type: svc.launch_type.clone(),
-                            rollout_state: "IN_PROGRESS".into(),
-                            rollout_state_reason: Some("ECS deployment in progress.".into()),
-                        },
-                    );
                     svc.task_definition_arn = arn;
                     svc.family = new_family;
                     svc.revision = new_revision;
                     new_deployment_triggered = true;
+                    if svc.deployment_controller != "CODE_DEPLOY" {
+                        // Roll a new PRIMARY deployment; mark the previous one ACTIVE
+                        // so it's eligible for drain once the new deployment ramps.
+                        for d in svc.deployments.iter_mut() {
+                            if d.status == "PRIMARY" {
+                                d.status = "ACTIVE".into();
+                                old_deployments_drained.push(d.deployment_id.clone());
+                            }
+                        }
+                        svc.deployments.insert(
+                            0,
+                            Deployment {
+                                deployment_id: format!(
+                                    "ecs-svc/{}",
+                                    uuid::Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff
+                                ),
+                                status: "PRIMARY".into(),
+                                task_definition_arn: svc.task_definition_arn.clone(),
+                                desired_count: svc.desired_count,
+                                pending_count: 0,
+                                running_count: 0,
+                                failed_tasks: 0,
+                                created_at: Utc::now(),
+                                updated_at: Utc::now(),
+                                launch_type: svc.launch_type.clone(),
+                                rollout_state: "IN_PROGRESS".into(),
+                                rollout_state_reason: Some("ECS deployment in progress.".into()),
+                            },
+                        );
+                    }
                 }
 
                 effective_desired = svc.desired_count;
             }
 
+            let controller = state
+                .services
+                .get(&key)
+                .unwrap()
+                .deployment_controller
+                .clone();
+            let primary_ts_arn = if controller == "CODE_DEPLOY" {
+                state
+                    .task_sets
+                    .values()
+                    .find(|ts| {
+                        ts.service_name == service_name
+                            && ts.cluster_name == cluster_name
+                            && ts.status == "PRIMARY"
+                    })
+                    .map(|ts| ts.task_set_arn.clone())
+            } else {
+                None
+            };
+
             // Compute spawn + stop plan.
             let mut spawn: Vec<String> = Vec::new();
             let mut stop: Vec<String> = Vec::new();
 
-            // Tasks belonging to this service (by startedBy convention).
-            // Track per-task protection so scale-down skips protected ones
-            // (UpdateTaskProtection). Real AWS only terminates a protected
-            // task when nothing else is eligible.
             let service_tag = format!("ecs-svc/{}", service_name);
             let now = Utc::now();
-            let current_tasks: Vec<(String, String, bool)> = state
-                .tasks
-                .iter()
-                .filter(|(_, t)| {
-                    t.started_by.as_deref() == Some(service_tag.as_str())
-                        && t.cluster_name == cluster_name
-                        && t.last_status != "STOPPED"
-                })
-                .map(|(id, t)| {
-                    let protected = t
-                        .protection
-                        .as_ref()
-                        .filter(|p| p.enabled && p.expiration.is_none_or(|exp| exp > now))
-                        .is_some();
-                    (id.clone(), t.task_definition_arn.clone(), protected)
-                })
-                .collect();
 
-            let current_count = current_tasks.len() as i32;
-            if effective_desired > current_count {
-                let add = (effective_desired - current_count) as usize;
-                let svc_snapshot = state.services.get(&key).unwrap().clone();
-                let mut new_ids = spawn_service_tasks(
-                    state,
-                    &svc_snapshot,
-                    add as i32,
-                    &principal_arn,
-                    &launch_type_clone,
-                );
-                spawn.append(&mut new_ids);
-            } else if effective_desired < current_count {
-                let mut remove = (current_count - effective_desired) as usize;
-                // First pass: drain unprotected tasks. Only fall back to
-                // protected ones when there's nothing else left to stop.
-                for (id, _, protected) in current_tasks.iter() {
-                    if remove == 0 {
-                        break;
-                    }
-                    if !*protected {
-                        stop.push(id.clone());
-                        remove -= 1;
-                    }
-                }
-                if remove > 0 {
-                    for (id, _, protected) in current_tasks.iter() {
-                        if remove == 0 {
-                            break;
-                        }
-                        if *protected && !stop.contains(id) {
-                            stop.push(id.clone());
-                            remove -= 1;
-                        }
-                    }
-                }
-            }
-
-            // If a new deployment was triggered, also stop tasks still on
-            // the old task definition so the new deployment can ramp up,
-            // then spawn replacements — but only enough to hit the
-            // effective desired count (not `stop.len()`, which conflates
-            // scale-down drain with TD-drain and would over-spawn).
-            if new_deployment_triggered {
+            if new_deployment_triggered && controller == "CODE_DEPLOY" {
                 let new_td_arn_match = state
                     .services
                     .get(&key)
                     .unwrap()
                     .task_definition_arn
                     .clone();
-                // Tasks already on the new task definition that we're NOT
-                // stopping (scale-down may have picked the first N; those
-                // are skipped here via `stop.contains(id)`).
-                let kept_on_new_td: i32 = current_tasks
-                    .iter()
-                    .filter(|(id, t_arn, _)| *t_arn == new_td_arn_match && !stop.contains(id))
-                    .count() as i32;
-                for (id, t_arn, protected) in &current_tasks {
-                    if *t_arn != new_td_arn_match && !stop.contains(id) && !*protected {
+
+                // Create new ACTIVE task set with the new TD
+                let ts_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+                let ts_arn = format!(
+                    "arn:aws:ecs:{}:{}:task-set/{}/{}/{}",
+                    state.region, state.account_id, cluster_name, service_name, ts_id
+                );
+                let svc_snapshot = state.services.get(&key).unwrap().clone();
+                let task_set = TaskSet {
+                    task_set_id: ts_id,
+                    task_set_arn: ts_arn.clone(),
+                    service_arn: svc_snapshot.service_arn.clone(),
+                    cluster_arn: svc_snapshot.cluster_arn.clone(),
+                    service_name: service_name.clone(),
+                    cluster_name: cluster_name.clone(),
+                    external_id: None,
+                    status: "ACTIVE".into(),
+                    task_definition: new_td_arn_match.clone(),
+                    computed_desired_count: 0,
+                    pending_count: 0,
+                    running_count: 0,
+                    launch_type: Some(launch_type_clone.clone()),
+                    platform_version: Some("1.4.0".into()),
+                    scale: None,
+                    stability_status: "STABILIZING".into(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    load_balancers: svc_snapshot.load_balancers.clone(),
+                    service_registries: svc_snapshot.service_registries.clone(),
+                    capacity_provider_strategy: svc_snapshot.capacity_provider_strategy.clone(),
+                    tags: Vec::new(),
+                };
+                state.task_sets.insert(
+                    format!("{}/{}/{}", cluster_name, service_name, task_set.task_set_id),
+                    task_set.clone(),
+                );
+
+                // Spawn tasks for the new task set
+                let mut new_ids = spawn_service_tasks(
+                    state,
+                    &svc_snapshot,
+                    effective_desired,
+                    &principal_arn,
+                    &launch_type_clone,
+                    Some(ts_arn.clone()),
+                );
+                spawn.append(&mut new_ids);
+
+                // Flip PRIMARY: demote old PRIMARY to ACTIVE with computed_desired_count=0
+                if let Some(old_ts) = state.task_sets.values_mut().find(|ts| {
+                    ts.service_name == service_name
+                        && ts.cluster_name == cluster_name
+                        && ts.status == "PRIMARY"
+                }) {
+                    old_ts.status = "ACTIVE".into();
+                    old_ts.computed_desired_count = 0;
+                    old_ts.updated_at = Utc::now();
+                }
+
+                // Promote new task set to PRIMARY
+                if let Some(new_ts) = state.task_sets.get_mut(&format!(
+                    "{}/{}/{}",
+                    cluster_name, service_name, task_set.task_set_id
+                )) {
+                    new_ts.status = "PRIMARY".into();
+                    new_ts.computed_desired_count = effective_desired;
+                    new_ts.updated_at = Utc::now();
+                }
+
+                // Stop ALL old tasks
+                for (id, task) in state.tasks.iter() {
+                    if task.started_by.as_deref() == Some(service_tag.as_str())
+                        && task.cluster_name == cluster_name
+                        && task.task_definition_arn != new_td_arn_match
+                        && !stop.contains(id)
+                    {
                         stop.push(id.clone());
                     }
                 }
-                let already_spawned = spawn.len() as i32;
-                let need = (effective_desired - kept_on_new_td - already_spawned).max(0);
-                if need > 0 {
+            } else {
+                // Tasks belonging to this service (by startedBy convention).
+                // Track per-task protection so scale-down skips protected ones
+                // (UpdateTaskProtection). Real AWS only terminates a protected
+                // task when nothing else is eligible.
+                let current_tasks: Vec<(String, String, bool)> = state
+                    .tasks
+                    .iter()
+                    .filter(|(_, t)| {
+                        t.started_by.as_deref() == Some(service_tag.as_str())
+                            && t.cluster_name == cluster_name
+                            && t.last_status != "STOPPED"
+                    })
+                    .map(|(id, t)| {
+                        let protected = t
+                            .protection
+                            .as_ref()
+                            .filter(|p| p.enabled && p.expiration.is_none_or(|exp| exp > now))
+                            .is_some();
+                        (id.clone(), t.task_definition_arn.clone(), protected)
+                    })
+                    .collect();
+
+                let current_count = current_tasks.len() as i32;
+                if effective_desired > current_count {
+                    let add = (effective_desired - current_count) as usize;
                     let svc_snapshot = state.services.get(&key).unwrap().clone();
-                    let mut more = spawn_service_tasks(
+                    let mut new_ids = spawn_service_tasks(
                         state,
                         &svc_snapshot,
-                        need,
+                        add as i32,
                         &principal_arn,
                         &launch_type_clone,
+                        primary_ts_arn.clone(),
                     );
-                    spawn.append(&mut more);
+                    spawn.append(&mut new_ids);
+                } else if effective_desired < current_count {
+                    let mut remove = (current_count - effective_desired) as usize;
+                    // First pass: drain unprotected tasks. Only fall back to
+                    // protected ones when there's nothing else left to stop.
+                    for (id, _, protected) in current_tasks.iter() {
+                        if remove == 0 {
+                            break;
+                        }
+                        if !*protected {
+                            stop.push(id.clone());
+                            remove -= 1;
+                        }
+                    }
+                    if remove > 0 {
+                        for (id, _, protected) in current_tasks.iter() {
+                            if remove == 0 {
+                                break;
+                            }
+                            if *protected && !stop.contains(id) {
+                                stop.push(id.clone());
+                                remove -= 1;
+                            }
+                        }
+                    }
+                }
+
+                // If a new deployment was triggered, also stop tasks still on
+                // the old task definition so the new deployment can ramp up,
+                // then spawn replacements — but only enough to hit the
+                // effective desired count (not `stop.len()`, which conflates
+                // scale-down drain with TD-drain and would over-spawn).
+                if new_deployment_triggered {
+                    let new_td_arn_match = state
+                        .services
+                        .get(&key)
+                        .unwrap()
+                        .task_definition_arn
+                        .clone();
+                    // Tasks already on the new task definition that we're NOT
+                    // stopping (scale-down may have picked the first N; those
+                    // are skipped here via `stop.contains(id)`).
+                    let kept_on_new_td: i32 = current_tasks
+                        .iter()
+                        .filter(|(id, t_arn, _)| *t_arn == new_td_arn_match && !stop.contains(id))
+                        .count() as i32;
+                    for (id, t_arn, protected) in &current_tasks {
+                        if *t_arn != new_td_arn_match && !stop.contains(id) && !*protected {
+                            stop.push(id.clone());
+                        }
+                    }
+                    let already_spawned = spawn.len() as i32;
+                    let need = (effective_desired - kept_on_new_td - already_spawned).max(0);
+                    if need > 0 {
+                        let svc_snapshot = state.services.get(&key).unwrap().clone();
+                        let mut more = spawn_service_tasks(
+                            state,
+                            &svc_snapshot,
+                            need,
+                            &principal_arn,
+                            &launch_type_clone,
+                            primary_ts_arn.clone(),
+                        );
+                        spawn.append(&mut more);
+                    }
+                }
+            }
+
+            if controller == "CODE_DEPLOY" && !new_deployment_triggered {
+                if let Some(ts) = state.task_sets.values_mut().find(|ts| {
+                    ts.service_name == service_name
+                        && ts.cluster_name == cluster_name
+                        && ts.status == "PRIMARY"
+                }) {
+                    ts.computed_desired_count = effective_desired;
+                    ts.updated_at = Utc::now();
                 }
             }
 
@@ -480,7 +657,11 @@ impl EcsService {
             });
 
             let svc = state.services.get(&key).unwrap();
-            (service_to_json(svc), spawn, stop)
+            let mut service_json = service_to_json(svc);
+            if controller == "CODE_DEPLOY" {
+                inject_service_task_sets(state, &service_name, &cluster_name, &mut service_json);
+            }
+            (service_json, spawn, stop)
         };
 
         // Always flip desired_status for tasks we plan to stop.
@@ -560,7 +741,7 @@ impl EcsService {
         let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
         let force = body.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
 
-        let (snapshot, task_ids_to_stop) = {
+        let (snapshot, task_ids_to_stop, task_sets_for_response) = {
             let mut accounts = self.state.write();
             let state = accounts
                 .get_mut(&request.account_id)
@@ -595,6 +776,18 @@ impl EcsService {
                 }
             }
             let svc_snapshot = state.services.get(&key).unwrap().clone();
+            let mut task_sets_for_response = Vec::new();
+            if svc_snapshot.deployment_controller == "CODE_DEPLOY" {
+                task_sets_for_response = state
+                    .task_sets
+                    .values()
+                    .filter(|ts| ts.service_name == service_name && ts.cluster_name == cluster_name)
+                    .map(task_set_to_json)
+                    .collect();
+                state.task_sets.retain(|_, ts| {
+                    ts.service_name != service_name || ts.cluster_name != cluster_name
+                });
+            }
             state.services.remove(&key);
             state.push_event(crate::state::LifecycleEvent {
                 at: Utc::now(),
@@ -604,7 +797,7 @@ impl EcsService {
                 last_status: Some("DRAINING".into()),
                 detail: json!({"serviceArn": svc_snapshot.service_arn}),
             });
-            (svc_snapshot, stop_ids)
+            (svc_snapshot, stop_ids, task_sets_for_response)
         };
 
         for id in &task_ids_to_stop {
@@ -635,9 +828,13 @@ impl EcsService {
             }
         }
 
-        Ok(AwsResponse::ok_json(
-            json!({ "service": service_to_json(&snapshot) }),
-        ))
+        let mut resp = json!({ "service": service_to_json(&snapshot) });
+        if !task_sets_for_response.is_empty() {
+            resp.as_object_mut()
+                .unwrap()
+                .insert("taskSets".into(), json!(task_sets_for_response));
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_services(
@@ -677,6 +874,7 @@ impl EcsService {
                     let mut v = service_to_json(svc);
                     // Update derived running/pending counts from current tasks.
                     recompute_service_counts(state, &name, &cluster_name, &mut v);
+                    inject_service_task_sets(state, &name, &cluster_name, &mut v);
                     found.push(v);
                 }
                 None => failures.push(json!({"arn": r, "reason": "MISSING"})),

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -286,6 +286,7 @@ impl EcsService {
                 enable_execute_command,
                 attachments: Vec::new(),
                 volume_configurations: volume_configurations.clone(),
+                task_set_arn: None,
             };
             state.tasks.insert(task_id.clone(), task.clone());
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
@@ -677,6 +678,7 @@ mod multi_container_tests {
             enable_execute_command: false,
             attachments: Vec::new(),
             volume_configurations: Vec::new(),
+            task_set_arn: None,
         };
         for name in ["app", "sidecar"] {
             task.containers.push(Container {
@@ -935,6 +937,7 @@ mod port_mapping_tests {
             enable_execute_command: false,
             attachments: Vec::new(),
             volume_configurations: Vec::new(),
+            task_set_arn: None,
         };
         task.last_status = "PENDING".into();
         acct.tasks.insert("abc".into(), task);

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -438,6 +438,10 @@ pub struct Task {
     /// inherited from the service. Stored as raw JSON.
     #[serde(default)]
     pub volume_configurations: Vec<Value>,
+    /// Task set this task belongs to. Populated when the task is spawned
+    /// by a service using the CODE_DEPLOY deployment controller.
+    #[serde(default)]
+    pub task_set_arn: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Implement real CODE_DEPLOY blue/green task set behavior for ECS services.

- `CreateService` with `CODE_DEPLOY` controller spawns tasks into a PRIMARY TaskSet instead of creating a Deployment record.
- `UpdateService` with `CODE_DEPLOY` + new `taskDefinition` creates a new ACTIVE TaskSet, spawns replacement tasks, flips PRIMARY, demotes the old task set to ACTIVE with `computedDesiredCount=0`, and stops old tasks.
- `UpdateService` scale-only changes update the PRIMARY TaskSet `computed_desired_count`.
- `DeleteService` cleans up TaskSets for CODE_DEPLOY services.
- `DescribeServices` injects `taskSets` into the response.
- `CreateTaskSet` gate relaxed to allow CODE_DEPLOY services.
- Tasks now carry `task_set_arn` and `task_to_json` emits it.

## Test plan

- [x] `codedeploy_service_creates_primary_task_set` e2e verifies PRIMARY TaskSet creation on CreateService
- [x] `codedeploy_update_service_flips_primary_task_set` e2e verifies blue/green flip: new ACTIVE task set, PRIMARY promotion, old task set demotion, old tasks stopped
- [x] Full `ecs_enforce` suite passes (8/8)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CODE_DEPLOY blue/green deployments for ECS services using TaskSets, matching AWS behavior. Addresses Linear O16 and updates ECS APIs to surface taskSets and manage PRIMARY/ACTIVE flips.

- **New Features**
  - CODE_DEPLOY services now create a PRIMARY TaskSet on create (no Deployment record).
  - UpdateService with a new taskDefinition creates an ACTIVE TaskSet, spawns replacements, promotes it to PRIMARY, demotes the old set to ACTIVE with computedDesiredCount=0, and stops old tasks.
  - Scale-only updates adjust the PRIMARY TaskSet computedDesiredCount.
  - DescribeServices and DeleteService include taskSets in responses.
  - Tasks carry taskSetArn and it is emitted by task_to_json.

- **Bug Fixes**
  - CreateTaskSet is allowed for services with deploymentController.type=CODE_DEPLOY.

<sup>Written for commit b66f526365c736d1877ce57c4a8a0988db3a85b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

