### PR TITLE
feat(ses): real GetMessageInsights delivery tracking data

### DIFF
--- a/crates/fakecloud-e2e/tests/ses.rs
+++ b/crates/fakecloud-e2e/tests/ses.rs
@@ -5,7 +5,7 @@ use aws_sdk_sesv2::types::{
     DkimSigningAttributes, DkimSigningAttributesOrigin, EmailContent, EmailTemplateContent,
     EventBridgeDestination, EventDestinationDefinition, EventType, ExportDataSource,
     ExportDestination, ExportMetric, FeatureStatus, HttpsPolicy, ImportDataSource,
-    ImportDestination, MailType, Message, Metric, MetricDimensionName, MetricNamespace,
+    ImportDestination, MailType, Message, MessageTag, Metric, MetricDimensionName, MetricNamespace,
     MetricsDataSource, RawMessage, ReputationEntityType, RouteDetails, ScalingMode, SendingStatus,
     SnsDestination, SubscriptionStatus, SuppressionListDestination, SuppressionListImportAction,
     SuppressionListReason, Tag, Template, TlsPolicy, Topic, TopicPreference, VdmAttributes,
@@ -233,6 +233,89 @@ async fn ses_send_email_simple() {
 
     let message_id = resp.message_id().unwrap();
     assert!(!message_id.is_empty());
+}
+
+#[tokio::test]
+async fn ses_get_message_insights_real() {
+    let server = TestServer::start().await;
+    let client = server.sesv2_client().await;
+
+    client
+        .create_email_identity()
+        .email_identity("sender@example.com")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_email_identity()
+        .email_identity("recipient@gmail.com")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .send_email()
+        .from_email_address("sender@example.com")
+        .destination(
+            Destination::builder()
+                .to_addresses("recipient@gmail.com")
+                .build(),
+        )
+        .content(
+            EmailContent::builder()
+                .simple(
+                    Message::builder()
+                        .subject(Content::builder().data("Test Subject").build().unwrap())
+                        .body(
+                            Body::builder()
+                                .text(Content::builder().data("Hello world").build().unwrap())
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .email_tags(
+            MessageTag::builder()
+                .name("campaign")
+                .value("test")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let message_id = resp.message_id().unwrap();
+    let insights = client
+        .get_message_insights()
+        .message_id(message_id)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(insights.message_id().unwrap(), message_id);
+    assert_eq!(insights.from_email_address().unwrap(), "sender@example.com");
+    assert_eq!(insights.subject().unwrap(), "Test Subject");
+    assert_eq!(insights.email_tags().len(), 1);
+    assert_eq!(insights.email_tags()[0].name(), "campaign");
+    assert_eq!(insights.email_tags()[0].value(), "test");
+
+    let recipient_insights = insights.insights();
+    assert_eq!(recipient_insights.len(), 1);
+    assert_eq!(
+        recipient_insights[0].destination().unwrap(),
+        "recipient@gmail.com"
+    );
+    assert_eq!(recipient_insights[0].isp().unwrap(), "Gmail");
+
+    let events = recipient_insights[0].events();
+    assert!(!events.is_empty());
+    assert_eq!(events[0].r#type().unwrap().as_str(), "SEND");
+    assert_eq!(
+        events.last().unwrap().r#type().unwrap().as_str(),
+        "DELIVERY"
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3298,6 +3298,8 @@ async fn main() {
                                     dkim_signature: None,
                                     headers: Vec::new(),
                                     timestamp: chrono::Utc::now(),
+                                    email_tags: Vec::new(),
+                                    delivery_insights: Vec::new(),
                                 };
                                 {
                                     let mut mas = ses_state_for_inbound_actions.write();
@@ -6634,6 +6636,8 @@ impl fakecloud_core::delivery::EmailDispatcher for SesEmailDispatcher {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: chrono::Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         });
     }
 }
@@ -6681,6 +6685,8 @@ impl fakecloud_core::delivery::SesSendEmailDispatcher for SesSendEmailDispatcher
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: chrono::Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         });
         Ok(())
     }

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 
 use fakecloud_core::delivery::DeliveryBus;
 
-use crate::state::{EventDestination, SentEmail, SharedSesState, SuppressedDestination};
+use crate::state::{
+    DeliveryInsightEvent, EmailRecipientInsight, EventDestination, SentEmail, SharedSesState,
+    SuppressedDestination,
+};
 
 /// Shared references needed for cross-service event delivery.
 #[derive(Clone)]
@@ -337,6 +340,58 @@ fn deliver_event(
     }
 }
 
+/// Infer ISP name from an email address domain.
+pub fn infer_isp(email: &str) -> String {
+    let domain = email.split('@').nth(1).unwrap_or("").to_ascii_lowercase();
+    match domain.as_str() {
+        "gmail.com" => "Gmail",
+        "yahoo.com" | "ymail.com" => "Yahoo",
+        "hotmail.com" | "outlook.com" | "live.com" => "Outlook",
+        "aol.com" => "AOL",
+        "icloud.com" | "me.com" | "mac.com" => "Apple",
+        "protonmail.com" => "ProtonMail",
+        "zoho.com" => "Zoho",
+        _ => "Other",
+    }
+    .to_string()
+}
+
+/// Build per-recipient delivery insights from the generated event types.
+fn build_delivery_insights(
+    email: &SentEmail,
+    event_types: &[SesEventType],
+) -> Vec<EmailRecipientInsight> {
+    let mut insights = Vec::new();
+    for dest in &email.to {
+        let mut events = Vec::new();
+        for et in event_types {
+            let mut ev = DeliveryInsightEvent {
+                timestamp: Utc::now(),
+                event_type: et.as_str().to_string(),
+                ..Default::default()
+            };
+            match et {
+                SesEventType::Bounce => {
+                    ev.bounce_type = Some("Permanent".to_string());
+                    ev.bounce_sub_type = Some("General".to_string());
+                    ev.diagnostic_code = Some("smtp; 550 5.1.1 user unknown".to_string());
+                }
+                SesEventType::Complaint => {
+                    ev.complaint_feedback_type = Some("abuse".to_string());
+                }
+                _ => {}
+            }
+            events.push(ev);
+        }
+        insights.push(EmailRecipientInsight {
+            destination: dest.clone(),
+            isp: infer_isp(dest),
+            events,
+        });
+    }
+    insights
+}
+
 /// Process event fanout for a sent email.
 ///
 /// This is the main entry point called from SendEmail / SendBulkEmail.
@@ -345,37 +400,39 @@ fn deliver_event(
 /// 2. Classifies recipients for mailbox simulator behavior
 /// 3. Generates appropriate events
 /// 4. Fans out to configured destinations
+/// 5. Stores per-recipient delivery insights on the SentEmail
 ///
 /// Returns `true` if the email was suppressed (caller should handle accordingly).
 pub fn process_send_events(
     ctx: &SesDeliveryContext,
-    email: &SentEmail,
+    email: &mut SentEmail,
     config_set_name: Option<&str>,
 ) -> bool {
-    let config_set = match resolve_config_set(&ctx.ses_state, config_set_name, &email.from) {
-        Some(cs) => cs,
-        None => return false, // No config set, no event destinations to fan out to
-    };
+    let config_set = resolve_config_set(&ctx.ses_state, config_set_name, &email.from);
 
-    // Check suppression list with the effective reasons filter
-    if let Some(suppressed_addr) =
-        check_suppression_list(&ctx.ses_state, &email.to, Some(config_set.as_str()))
-    {
-        tracing::info!(
-            address = %suppressed_addr,
-            config_set = %config_set,
-            "SES: recipient is on suppression list, generating bounce"
-        );
-        // Increment the suppression-drop counter so introspection /
-        // /_fakecloud/ses/metrics callers can observe the gate firing.
+    // Check suppression list with the effective reasons filter when a config set exists
+    if let Some(ref cs) = config_set {
+        if let Some(suppressed_addr) =
+            check_suppression_list(&ctx.ses_state, &email.to, Some(cs.as_str()))
         {
-            let mut mas = ctx.ses_state.write();
-            let state = mas.default_mut();
-            state.suppressed_drops_total = state.suppressed_drops_total.saturating_add(1);
+            tracing::info!(
+                address = %suppressed_addr,
+                config_set = %cs,
+                "SES: recipient is on suppression list, generating bounce"
+            );
+            // Increment the suppression-drop counter so introspection /
+            // /_fakecloud/ses/metrics callers can observe the gate firing.
+            {
+                let mut mas = ctx.ses_state.write();
+                let state = mas.default_mut();
+                state.suppressed_drops_total = state.suppressed_drops_total.saturating_add(1);
+            }
+            let bounce_event = build_ses_event(SesEventType::Bounce, email);
+            deliver_event(ctx, &bounce_event, SesEventType::Bounce, cs);
+            // Store insights: one BOUNCE event per recipient
+            email.delivery_insights = build_delivery_insights(email, &[SesEventType::Bounce]);
+            return true;
         }
-        let bounce_event = build_ses_event(SesEventType::Bounce, email);
-        deliver_event(ctx, &bounce_event, SesEventType::Bounce, &config_set);
-        return true;
     }
 
     // Classify recipients for simulator behavior
@@ -399,11 +456,16 @@ pub fn process_send_events(
         }
     }
 
-    // Generate and deliver events
-    for event_type in event_types {
-        let event = build_ses_event(event_type, email);
-        deliver_event(ctx, &event, event_type, &config_set);
+    // Generate and deliver events to configured destinations
+    if let Some(ref cs) = config_set {
+        for event_type in &event_types {
+            let event = build_ses_event(*event_type, email);
+            deliver_event(ctx, &event, *event_type, cs);
+        }
     }
+
+    // Store per-recipient delivery insights regardless of config set
+    email.delivery_insights = build_delivery_insights(email, &event_types);
 
     false
 }
@@ -475,6 +537,8 @@ mod tests {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         };
         let event = build_ses_event(SesEventType::Send, &email);
         assert_eq!(event["eventType"], "Send");
@@ -500,6 +564,8 @@ mod tests {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         };
         let event = build_ses_event(SesEventType::Bounce, &email);
         assert_eq!(event["eventType"], "Bounce");
@@ -524,6 +590,8 @@ mod tests {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         };
         let event = build_ses_event(SesEventType::Delivery, &email);
         assert_eq!(event["eventType"], "Delivery");
@@ -548,6 +616,8 @@ mod tests {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         };
         let event = build_ses_event(SesEventType::Complaint, &email);
         assert_eq!(event["eventType"], "Complaint");
@@ -850,6 +920,8 @@ mod tests {
                 dkim_signature: None,
                 headers: Vec::new(),
                 timestamp: Utc::now(),
+                email_tags: Vec::new(),
+                delivery_insights: Vec::new(),
             },
         );
         // No senders wired — must not panic.

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -453,6 +453,8 @@ impl SesV2Service {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags: Vec::new(),
+            delivery_insights: Vec::new(),
         };
 
         self.state
@@ -2058,12 +2060,73 @@ impl SesV2Service {
             .iter()
             .find(|e| e.message_id == message_id);
         if let Some(email) = sent {
+            let email_tags: Vec<serde_json::Value> = email
+                .email_tags
+                .iter()
+                .map(|(name, value)| json!({"Name": name, "Value": value}))
+                .collect();
+            let insights: Vec<serde_json::Value> = email
+                .delivery_insights
+                .iter()
+                .map(|ins| {
+                    let events: Vec<serde_json::Value> = ins
+                        .events
+                        .iter()
+                        .map(|ev| {
+                            let mut detail = serde_json::Map::new();
+                            if ev.event_type == "BOUNCE" {
+                                let mut bounce = serde_json::Map::new();
+                                if let Some(ref bt) = ev.bounce_type {
+                                    bounce.insert("BounceType".to_string(), json!(bt));
+                                }
+                                if let Some(ref bs) = ev.bounce_sub_type {
+                                    bounce.insert("BounceSubType".to_string(), json!(bs));
+                                }
+                                if let Some(ref dc) = ev.diagnostic_code {
+                                    bounce.insert("DiagnosticCode".to_string(), json!(dc));
+                                }
+                                if !bounce.is_empty() {
+                                    detail.insert("Bounce".to_string(), json!(bounce));
+                                }
+                            }
+                            if ev.event_type == "COMPLAINT" {
+                                let mut complaint = serde_json::Map::new();
+                                if let Some(ref cst) = ev.complaint_sub_type {
+                                    complaint.insert("ComplaintSubType".to_string(), json!(cst));
+                                }
+                                if let Some(ref cft) = ev.complaint_feedback_type {
+                                    complaint
+                                        .insert("ComplaintFeedbackType".to_string(), json!(cft));
+                                }
+                                if !complaint.is_empty() {
+                                    detail.insert("Complaint".to_string(), json!(complaint));
+                                }
+                            }
+                            let mut event = serde_json::Map::new();
+                            event.insert(
+                                "Timestamp".to_string(),
+                                json!(ev.timestamp.timestamp() as f64),
+                            );
+                            event.insert("Type".to_string(), json!(ev.event_type));
+                            if !detail.is_empty() {
+                                event.insert("Details".to_string(), json!(detail));
+                            }
+                            json!(event)
+                        })
+                        .collect();
+                    json!({
+                        "Destination": ins.destination,
+                        "Isp": ins.isp,
+                        "Events": events,
+                    })
+                })
+                .collect();
             let body = json!({
                 "MessageId": email.message_id,
                 "FromEmailAddress": email.from,
                 "Subject": email.subject,
-                "EmailTags": [],
-                "Insights": [],
+                "EmailTags": email_tags,
+                "Insights": insights,
             });
             Ok(AwsResponse::json(StatusCode::OK, body.to_string()))
         } else {

--- a/crates/fakecloud-ses/src/service/sending.rs
+++ b/crates/fakecloud-ses/src/service/sending.rs
@@ -344,6 +344,19 @@ impl SesV2Service {
                 (None, None, None, None, None, None)
             };
 
+        let email_tags = body["EmailTags"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let name = t["Name"].as_str()?;
+                        let value = t["Value"].as_str()?;
+                        Some((name.to_string(), value.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let message_id = uuid::Uuid::new_v4().to_string();
 
         let sent = SentEmail {
@@ -361,10 +374,12 @@ impl SesV2Service {
             dkim_signature: None,
             headers: Vec::new(),
             timestamp: Utc::now(),
+            email_tags,
+            delivery_insights: Vec::new(),
         };
 
         let signed = self.compute_dkim_signature(&req.account_id, &sent);
-        let sent = match signed {
+        let mut sent = match signed {
             Some((sig, hdrs)) => SentEmail {
                 dkim_signature: Some(sig),
                 headers: hdrs,
@@ -375,7 +390,7 @@ impl SesV2Service {
 
         // Event fanout: check suppression list, generate events, deliver to destinations
         if let Some(ref ctx) = self.delivery_ctx {
-            crate::fanout::process_send_events(ctx, &sent, config_set_name.as_deref());
+            crate::fanout::process_send_events(ctx, &mut sent, config_set_name.as_deref());
         }
 
         self.state
@@ -508,9 +523,11 @@ impl SesV2Service {
                 dkim_signature: None,
                 headers: Vec::new(),
                 timestamp: Utc::now(),
+                email_tags: Vec::new(),
+                delivery_insights: Vec::new(),
             };
             let signed = self.compute_dkim_signature(&req.account_id, &sent);
-            let sent = match signed {
+            let mut sent = match signed {
                 Some((sig, hdrs)) => SentEmail {
                     dkim_signature: Some(sig),
                     headers: hdrs,
@@ -521,7 +538,7 @@ impl SesV2Service {
 
             // Event fanout for each bulk entry
             if let Some(ref ctx) = self.delivery_ctx {
-                crate::fanout::process_send_events(ctx, &sent, config_set_name.as_deref());
+                crate::fanout::process_send_events(ctx, &mut sent, config_set_name.as_deref());
             }
 
             self.state

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -4096,6 +4096,78 @@ async fn test_get_message_insights_unknown() {
 }
 
 #[tokio::test]
+async fn test_get_message_insights_real() {
+    use crate::state::{DeliveryInsightEvent, EmailRecipientInsight};
+
+    let state = make_state();
+    enable_production_access(&state);
+
+    // Seed a verified identity
+    seed_identity(&state, "sender@example.com");
+
+    // Pre-populate a sent email with insights
+    {
+        let mut accounts = state.write();
+        let st = accounts.get_or_create("123456789012");
+        st.sent_emails.push(crate::state::SentEmail {
+            message_id: "msg-123".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["recipient@gmail.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: Some("Hello".to_string()),
+            html_body: None,
+            text_body: None,
+            raw_data: None,
+            template_name: None,
+            template_data: None,
+            dkim_signature: None,
+            headers: Vec::new(),
+            timestamp: chrono::Utc::now(),
+            email_tags: vec![("campaign".to_string(), "test".to_string())],
+            delivery_insights: vec![EmailRecipientInsight {
+                destination: "recipient@gmail.com".to_string(),
+                isp: "Gmail".to_string(),
+                events: vec![
+                    DeliveryInsightEvent {
+                        timestamp: chrono::Utc::now(),
+                        event_type: "SEND".to_string(),
+                        ..Default::default()
+                    },
+                    DeliveryInsightEvent {
+                        timestamp: chrono::Utc::now(),
+                        event_type: "DELIVERY".to_string(),
+                        ..Default::default()
+                    },
+                ],
+            }],
+        });
+    }
+
+    let svc = SesV2Service::new(state);
+    let req = make_request(Method::GET, "/v2/email/insights/msg-123", "");
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["MessageId"], "msg-123");
+    assert_eq!(body["FromEmailAddress"], "sender@example.com");
+    assert_eq!(body["Subject"], "Hello");
+    let tags = body["EmailTags"].as_array().unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0]["Name"], "campaign");
+    assert_eq!(tags[0]["Value"], "test");
+    let insights = body["Insights"].as_array().unwrap();
+    assert_eq!(insights.len(), 1);
+    assert_eq!(insights[0]["Destination"], "recipient@gmail.com");
+    assert_eq!(insights[0]["Isp"], "Gmail");
+    let events = insights[0]["Events"].as_array().unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["Type"], "SEND");
+    assert!(!events[0]["Timestamp"].is_null());
+    assert_eq!(events[1]["Type"], "DELIVERY");
+}
+
+#[tokio::test]
 async fn test_list_recommendations_seeds_default() {
     let state = make_state();
     let svc = SesV2Service::new(state);

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -102,6 +102,37 @@ pub struct SentEmail {
     #[serde(default)]
     pub headers: Vec<(String, String)>,
     pub timestamp: DateTime<Utc>,
+    /// Tags applied to the email at send time (EmailTags from v2 SendEmail).
+    #[serde(default)]
+    pub email_tags: Vec<(String, String)>,
+    /// Per-destination delivery insights populated by the event fanout.
+    #[serde(default)]
+    pub delivery_insights: Vec<EmailRecipientInsight>,
+}
+
+/// Per-recipient delivery insights for MessageInsights.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailRecipientInsight {
+    pub destination: String,
+    pub isp: String,
+    pub events: Vec<DeliveryInsightEvent>,
+}
+
+/// A single event within an EmailRecipientInsight.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DeliveryInsightEvent {
+    pub timestamp: DateTime<Utc>,
+    pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounce_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounce_sub_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complaint_sub_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complaint_feedback_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1287,6 +1287,8 @@ pub(crate) fn send_email(
         dkim_signature: None,
         headers: Vec::new(),
         timestamp: Utc::now(),
+        email_tags: Vec::new(),
+        delivery_insights: Vec::new(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
 
@@ -1365,6 +1367,8 @@ pub(crate) fn send_raw_email(
         dkim_signature: None,
         headers: Vec::new(),
         timestamp: Utc::now(),
+        email_tags: Vec::new(),
+        delivery_insights: Vec::new(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
 
@@ -1456,6 +1460,8 @@ pub(crate) fn send_templated_email(
         dkim_signature: None,
         headers: Vec::new(),
         timestamp: Utc::now(),
+        email_tags: Vec::new(),
+        delivery_insights: Vec::new(),
     };
     let sent = sign_sent_email(state, &req.account_id, &req.region, sent);
 
@@ -1619,6 +1625,8 @@ pub(crate) fn send_bulk_destination(
         dkim_signature: None,
         headers: Vec::new(),
         timestamp: Utc::now(),
+        email_tags: Vec::new(),
+        delivery_insights: Vec::new(),
     };
     let sent = sign_sent_email(state, account_id, "", sent);
 


### PR DESCRIPTION
## Summary

Make `GetMessageInsights` return real delivery tracking data instead of an empty `Insights` array.

- Add `DeliveryInsightEvent` + `EmailRecipientInsight` structs to `SentEmail` state
- Parse `EmailTags` from v2 `SendEmail` request body and store on `SentEmail`
- After delivering events, build per-recipient insights with ISP inference and event history
- `get_message_insights` now returns real `EmailTags` and `Insights` arrays with `Timestamp`, `Type`, and `Details` for `BOUNCE`/`COMPLAINT`
- Fix `process_send_events` to populate insights even when no `ConfigurationSet` is configured (previously returned early with empty insights)
- Add e2e test sending email with `MessageTag` and asserting full insights response shape

GG9 parity gap closed.

## Test plan

- [x] `cargo test -p fakecloud-ses` — 239 unit tests pass
- [x] `cargo test -p fakecloud-e2e --test ses` — 53 e2e tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`get_message_insights` now returns real delivery tracking data with per-recipient events and `EmailTags`. Insights are stored on every send and returned even when no `ConfigurationSet` is set, closing the GG9 parity gap.

- New Features
  - Store `email_tags` and per-recipient `delivery_insights` on `SentEmail` using `DeliveryInsightEvent` and `EmailRecipientInsight`.
  - Parse `EmailTags` from v2 `SendEmail` and return them from `get_message_insights`.
  - Build per-recipient event history (e.g., SEND → DELIVERY, plus BOUNCE/COMPLAINT) with ISP inference (Gmail, Yahoo, Outlook, etc.).
  - Include event `Timestamp`, `Type`, and `Details` for `BOUNCE`/`COMPLAINT` in the insights response.

- Bug Fixes
  - Populate insights even without a `ConfigurationSet`; suppression bounces are still generated and counted.

<sup>Written for commit f41fa34d726e6d198dd182ee3e025fff82e74e7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

