### PR TITLE
feat(s3): S3 access points control plane + data plane routing (GG4)

### DIFF
--- a/crates/fakecloud-aws/src/arn.rs
+++ b/crates/fakecloud-aws/src/arn.rs
@@ -40,6 +40,18 @@ impl Arn {
         }
     }
 
+    /// Create an S3 Access Point ARN.
+    /// Format: `arn:aws:s3:<region>:<account-id>:accesspoint/<name>`.
+    pub fn s3_access_point(region: &str, account_id: &str, name: &str) -> Self {
+        Self {
+            partition: partition_for(region).to_string(),
+            service: "s3".to_string(),
+            region: region.to_string(),
+            account_id: account_id.to_string(),
+            resource: format!("accesspoint/{name}"),
+        }
+    }
+
     /// Override the partition (default `aws`). Use for `aws-cn` / `aws-us-gov`.
     pub fn with_partition(mut self, partition: &str) -> Self {
         self.partition = partition.to_string();

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -279,6 +279,19 @@ fn parse_localstack_prefix(prefix: &str) -> Option<RoutingHost> {
                 bucket: Some(bucket),
             })
         }
+        n if n >= 3 && labels[n - 2] == "s3-accesspoint" => {
+            let bucket = labels[..n - 2].join(".");
+            Some(RoutingHost {
+                service: "s3".to_string(),
+                region: labels[n - 1].to_string(),
+                bucket: Some(bucket),
+            })
+        }
+        n if n >= 3 && labels[n - 2] == "s3-control" => Some(RoutingHost {
+            service: "s3".to_string(),
+            region: labels[n - 1].to_string(),
+            bucket: None,
+        }),
         _ => None,
     }
 }
@@ -336,6 +349,34 @@ fn parse_aws_prefix(prefix: &str) -> Option<RoutingHost> {
             service: "s3".to_string(),
             region: "us-east-1".to_string(),
             bucket: Some(labels[..labels.len() - 1].join(".")),
+        });
+    }
+
+    // `s3-accesspoint.<region>` — path-style access point endpoint.
+    // `{alias}-{account-id}.s3-accesspoint.<region>` — virtual-hosted access point.
+    if last == "s3-accesspoint" {
+        if labels.len() == 2 {
+            return Some(RoutingHost {
+                service: "s3".to_string(),
+                region: labels[0].to_string(),
+                bucket: None,
+            });
+        }
+        let bucket = labels[..labels.len() - 2].join(".");
+        return Some(RoutingHost {
+            service: "s3".to_string(),
+            region: labels[labels.len() - 1].to_string(),
+            bucket: Some(bucket),
+        });
+    }
+
+    // `s3-control.<region>` or `{account-id}.s3-control.<region>` — S3
+    // Control endpoint (access point management).
+    if labels.len() >= 2 && labels[labels.len() - 2] == "s3-control" {
+        return Some(RoutingHost {
+            service: "s3".to_string(),
+            region: last.to_string(),
+            bucket: None,
         });
     }
 

--- a/crates/fakecloud-e2e/tests/s3_access_points.rs
+++ b/crates/fakecloud-e2e/tests/s3_access_points.rs
@@ -1,0 +1,172 @@
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn s3_access_point_control_plane_crud() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    // Pre-create bucket.
+    s3.create_bucket().bucket("ap-bucket").send().await.unwrap();
+
+    let endpoint = server.endpoint();
+    let http = reqwest::Client::new();
+    let port = server.port();
+    let control_host = format!(
+        "000000000000.s3-control.us-east-1.localhost.localstack.cloud:{}",
+        port
+    );
+
+    // Create access point.
+    let create_resp = http
+        .put(format!("{}/v20180820/accesspoint/my-ap", endpoint))
+        .header("Host", &control_host)
+        .header("Content-Type", "application/xml")
+        .body(
+            "<CreateAccessPointConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Bucket>ap-bucket</Bucket>\
+             </CreateAccessPointConfiguration>",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        create_resp.status().is_success(),
+        "create-access-point failed: {}",
+        create_resp.text().await.unwrap_or_default()
+    );
+
+    // Get access point.
+    let get_resp = http
+        .get(format!("{}/v20180820/accesspoint/my-ap", endpoint))
+        .header("Host", &control_host)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        get_resp.status().is_success(),
+        "get-access-point failed: {}",
+        get_resp.text().await.unwrap_or_default()
+    );
+    let body = get_resp.text().await.unwrap();
+    assert!(body.contains("my-ap"));
+    assert!(body.contains("ap-bucket"));
+
+    // List access points.
+    let list_resp = http
+        .get(format!("{}/v20180820/accesspoint", endpoint))
+        .header("Host", &control_host)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        list_resp.status().is_success(),
+        "list-access-points failed: {}",
+        list_resp.text().await.unwrap_or_default()
+    );
+    let body = list_resp.text().await.unwrap();
+    assert!(body.contains("my-ap"));
+
+    // Delete access point.
+    let del_resp = http
+        .delete(format!("{}/v20180820/accesspoint/my-ap", endpoint))
+        .header("Host", &control_host)
+        .send()
+        .await
+        .unwrap();
+    assert!(del_resp.status().is_success());
+
+    // Verify deleted.
+    let list_resp = http
+        .get(format!("{}/v20180820/accesspoint", endpoint))
+        .header("Host", &control_host)
+        .send()
+        .await
+        .unwrap();
+    assert!(list_resp.status().is_success());
+    let body = list_resp.text().await.unwrap();
+    assert!(!body.contains("my-ap"));
+}
+
+#[tokio::test]
+async fn s3_access_point_data_plane_put_get() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("ap-data-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let endpoint = server.endpoint();
+    let http = reqwest::Client::new();
+    let port = server.port();
+    let control_host = format!(
+        "000000000000.s3-control.us-east-1.localhost.localstack.cloud:{}",
+        port
+    );
+    let ap_host = format!(
+        "data-ap-123456789012.s3-accesspoint.us-east-1.localhost.localstack.cloud:{}",
+        port
+    );
+
+    // Create access point.
+    let create_resp = http
+        .put(format!("{}/v20180820/accesspoint/data-ap", endpoint))
+        .header("Host", &control_host)
+        .header("Content-Type", "application/xml")
+        .body(
+            "<CreateAccessPointConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Bucket>ap-data-bucket</Bucket>\
+             </CreateAccessPointConfiguration>",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        create_resp.status().is_success(),
+        "create-access-point failed: {}",
+        create_resp.text().await.unwrap_or_default()
+    );
+
+    // Put object via access point endpoint (raw HTTP).
+    // Fake SigV4 auth header so the streaming dispatch path recognizes
+    // this as an S3 PUT and wires body_stream.
+    let put_resp = http
+        .put(format!("{}/hello.txt", endpoint))
+        .header("Host", &ap_host)
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc",
+        )
+        .body("world")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        put_resp.status().is_success(),
+        "put-object via AP failed: {}",
+        put_resp.text().await.unwrap_or_default()
+    );
+
+    // Get object via access point endpoint.
+    let get_resp = http
+        .get(format!("{}/hello.txt", endpoint))
+        .header("Host", &ap_host)
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        get_resp.status().is_success(),
+        "get-object via AP failed: {}",
+        get_resp.text().await.unwrap_or_default()
+    );
+    let body = get_resp.text().await.unwrap();
+    assert_eq!(body, "world");
+}

--- a/crates/fakecloud-s3/src/lib.rs
+++ b/crates/fakecloud-s3/src/lib.rs
@@ -13,4 +13,4 @@ mod xml_util;
 
 pub use delivery::S3DeliveryImpl;
 pub use service::S3Service;
-pub use state::{memory_body, S3Bucket, S3Object, S3State, SharedS3State};
+pub use state::{memory_body, S3AccessPoint, S3Bucket, S3Object, S3State, SharedS3State};

--- a/crates/fakecloud-s3/src/service/access_points.rs
+++ b/crates/fakecloud-s3/src/service/access_points.rs
@@ -1,0 +1,272 @@
+use bytes::Bytes;
+use chrono::Utc;
+use http::{HeaderMap, StatusCode};
+
+use fakecloud_aws::arn::Arn;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::service::{s3_xml, xml_escape, S3Service};
+use crate::state::S3AccessPoint;
+
+/// Detect whether the request arrived via an S3 access point endpoint
+/// (`s3-accesspoint.*` Host header). If so, resolve the alias to the
+/// underlying bucket name and rewrite `req.path_segments` so the rest
+/// of the dispatch logic sees a normal bucket-key request.
+pub(crate) fn resolve_access_point(
+    service: &S3Service,
+    req: &mut AwsRequest,
+) -> Result<(), AwsServiceError> {
+    let host = req
+        .headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let is_access_point = host.to_ascii_lowercase().contains("s3-accesspoint");
+    if !is_access_point {
+        return Ok(());
+    }
+
+    // The alias is the first path segment (prepended by dispatch from the
+    // Host header). It may be `{name}-{account_id}`.
+    let alias = req.path_segments.first().cloned().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidRequest",
+            "Access point alias missing from request path",
+        )
+    })?;
+
+    let accts = service.state.read();
+    let _empty = crate::state::S3State::new(&req.account_id, &req.region);
+    let state = accts.get(&req.account_id).unwrap_or(&_empty);
+
+    // Try exact alias match first, then strip account-id suffix.
+    let ap = state
+        .access_points
+        .get(&alias)
+        .or_else(|| {
+            let suffix = format!("-{}", req.account_id);
+            let name = alias.strip_suffix(&suffix)?;
+            state.access_points.get(name)
+        })
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchAccessPoint",
+                format!("The specified accesspoint does not exist: {alias}"),
+            )
+        })?;
+
+    let bucket = ap.bucket.clone();
+    drop(accts);
+
+    // Rewrite the first path segment from alias -> bucket.
+    if !req.path_segments.is_empty() {
+        req.path_segments[0] = bucket.clone();
+    }
+    // Rewrite raw_path prefix too so key extraction stays consistent.
+    let old_prefix = format!("/{alias}/");
+    let new_prefix = format!("/{bucket}/");
+    if req.raw_path.starts_with(&old_prefix) {
+        req.raw_path = format!("{}{}", new_prefix, &req.raw_path[old_prefix.len()..]);
+    } else if req.raw_path == format!("/{alias}") || req.raw_path == format!("/{alias}/") {
+        req.raw_path = format!("/{bucket}");
+    }
+
+    Ok(())
+}
+
+impl S3Service {
+    pub(super) fn create_access_point(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        name: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body_str = std::str::from_utf8(&req.body).unwrap_or("");
+        let bucket = crate::xml_util::extract_tag(body_str, "Bucket").ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MalformedXML",
+                "Bucket is required in CreateAccessPointConfiguration",
+            )
+        })?;
+
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
+
+        // Bucket must exist in this account.
+        if !state.buckets.contains_key(&bucket) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidBucket",
+                format!("The specified bucket does not exist: {bucket}"),
+            ));
+        }
+
+        if state.access_points.contains_key(name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::CONFLICT,
+                "AccessPointAlreadyExists",
+                format!("Access point already exists: {name}"),
+            ));
+        }
+
+        let vpc_config = crate::xml_util::extract_tag(body_str, "VPCConfiguration");
+        let public_access_block =
+            crate::xml_util::extract_tag(body_str, "PublicAccessBlockConfiguration");
+
+        let ap = S3AccessPoint {
+            name: name.to_string(),
+            bucket,
+            account_id: account_id.to_string(),
+            network_origin: if vpc_config.is_some() {
+                "VPC".to_string()
+            } else {
+                "Internet".to_string()
+            },
+            vpc_configuration: vpc_config,
+            creation_date: Utc::now(),
+            public_access_block,
+            bucket_account_id: Some(account_id.to_string()),
+        };
+
+        let arn = Arn::s3_access_point(&req.region, account_id, name);
+        let alias = format!("{name}-{account_id}");
+
+        state.access_points.insert(name.to_string(), ap);
+
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <CreateAccessPointResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <AccessPointArn>{arn}</AccessPointArn>\
+             <Alias>{alias}</Alias>\
+             </CreateAccessPointResult>"
+        );
+        Ok(s3_xml(StatusCode::OK, body))
+    }
+
+    pub(super) fn get_access_point(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        name: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let _empty = crate::state::S3State::new(account_id, &req.region);
+        let state = accts.get(account_id).unwrap_or(&_empty);
+
+        let ap = state.access_points.get(name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchAccessPoint",
+                format!("The specified accesspoint does not exist: {name}"),
+            )
+        })?;
+
+        let arn = Arn::s3_access_point(&req.region, account_id, name);
+        let alias = format!("{}-{}", ap.name, ap.account_id);
+
+        let mut vpc_xml = String::new();
+        if let Some(ref vpc) = ap.vpc_configuration {
+            vpc_xml.push_str(&format!("<VpcConfiguration>{vpc}</VpcConfiguration>"));
+        }
+
+        let mut pab_xml = String::new();
+        if let Some(ref pab) = ap.public_access_block {
+            pab_xml.push_str(&format!(
+                "<PublicAccessBlockConfiguration>{pab}</PublicAccessBlockConfiguration>"
+            ));
+        }
+
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <GetAccessPointResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Name>{name}</Name>\
+             <Bucket>{bucket}</Bucket>\
+             <NetworkOrigin>{origin}</NetworkOrigin>\
+             <AccessPointArn>{arn}</AccessPointArn>\
+             <Alias>{alias}</Alias>\
+             {vpc_xml}\
+             {pab_xml}\
+             </GetAccessPointResult>",
+            bucket = xml_escape(&ap.bucket),
+            origin = xml_escape(&ap.network_origin),
+        );
+        Ok(s3_xml(StatusCode::OK, body))
+    }
+
+    pub(super) fn delete_access_point(
+        &self,
+        account_id: &str,
+        _req: &AwsRequest,
+        name: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
+        let removed = state.access_points.remove(name).is_some();
+        if !removed {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "NoSuchAccessPoint",
+                format!("The specified accesspoint does not exist: {name}"),
+            ));
+        }
+        Ok(AwsResponse {
+            status: StatusCode::NO_CONTENT,
+            content_type: "application/xml".to_string(),
+            body: Bytes::new().into(),
+            headers: HeaderMap::new(),
+        })
+    }
+
+    pub(super) fn list_access_points(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accts = self.state.read();
+        let _empty = crate::state::S3State::new(account_id, &req.region);
+        let state = accts.get(account_id).unwrap_or(&_empty);
+
+        let bucket_filter = req.query_params.get("bucket").cloned();
+        let mut entries: Vec<&S3AccessPoint> = state
+            .access_points
+            .values()
+            .filter(|ap| {
+                if let Some(ref b) = bucket_filter {
+                    &ap.bucket == b
+                } else {
+                    true
+                }
+            })
+            .collect();
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let mut ap_xml = String::new();
+        for ap in entries {
+            let arn = Arn::s3_access_point(&req.region, account_id, &ap.name);
+            let alias = format!("{}-{}", ap.name, ap.account_id);
+            ap_xml.push_str(&format!(
+                "<AccessPoint>\
+                 <Name>{name}</Name>\
+                 <Bucket>{bucket}</Bucket>\
+                 <NetworkOrigin>{origin}</NetworkOrigin>\
+                 <AccessPointArn>{arn}</AccessPointArn>\
+                 <Alias>{alias}</Alias>\
+                 </AccessPoint>",
+                name = xml_escape(&ap.name),
+                bucket = xml_escape(&ap.bucket),
+                origin = xml_escape(&ap.network_origin),
+            ));
+        }
+
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <ListAccessPointsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             {ap_xml}\
+             </ListAccessPointsResult>"
+        );
+        Ok(s3_xml(StatusCode::OK, body))
+    }
+}

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -18,6 +18,7 @@ use base64::Engine as _;
 use crate::logging;
 use crate::state::{AclGrant, S3Bucket, S3Object, SharedS3State};
 
+mod access_points;
 mod acl;
 mod buckets;
 mod config;
@@ -227,6 +228,36 @@ impl AwsService for S3Service {
             }
         }
 
+        // Access point data plane: resolve alias -> bucket before routing.
+        access_points::resolve_access_point(self, &mut req)?;
+
+        let account_id = req.account_id.as_str();
+
+        // S3 Control endpoint (access point management).
+        let host = req
+            .headers
+            .get("host")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let is_control = host.to_ascii_lowercase().contains("s3-control");
+        if is_control {
+            let v1 = req.path_segments.first().map(|s| s.as_str());
+            let v2 = req.path_segments.get(1).map(|s| s.as_str());
+            let v3 = req.path_segments.get(2).map(|s| s.as_str());
+            if v1 == Some("v20180820") && v2 == Some("accesspoint") {
+                if let Some(name) = v3 {
+                    match req.method {
+                        Method::PUT => return self.create_access_point(account_id, &req, name),
+                        Method::GET => return self.get_access_point(account_id, &req, name),
+                        Method::DELETE => return self.delete_access_point(account_id, &req, name),
+                        _ => {}
+                    }
+                } else if req.method == Method::GET {
+                    return self.list_access_points(account_id, &req);
+                }
+            }
+        }
+
         // S3 REST routing: method + path segments + query params
         let bucket = req.path_segments.first().map(|s| s.as_str());
         // Extract key from the raw path to preserve leading slashes and empty segments.
@@ -253,8 +284,6 @@ impl AwsService for S3Service {
         } else {
             None
         };
-
-        let account_id = req.account_id.as_str();
 
         // Multipart upload operations (checked before main match)
         if let Some(b) = bucket {

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3976,3 +3976,233 @@ async fn compute_checksum_streaming_supports_crc64nvme() {
     .unwrap();
     assert_eq!(decoded.len(), 8);
 }
+
+#[tokio::test]
+async fn access_point_control_plane_crud() {
+    let state: SharedS3State = Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("000000000000", "us-east-1", ""),
+    ));
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let service = crate::S3Service::new(state, delivery);
+
+    // Pre-create bucket.
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-1".to_string(),
+        headers: http::HeaderMap::new(),
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec!["ap-bucket".to_string()],
+        raw_path: "/ap-bucket".to_string(),
+        raw_query: String::new(),
+        method: http::Method::PUT,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+    service.handle(req).await.unwrap();
+
+    // Create access point.
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-2".to_string(),
+        headers: {
+            let mut h = http::HeaderMap::new();
+            h.insert("host", "000000000000.s3-control.us-east-1.localhost.localstack.cloud:4566".parse().unwrap());
+            h
+        },
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::from_static(b"<CreateAccessPointConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>ap-bucket</Bucket></CreateAccessPointConfiguration>"),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec!["v20180820".to_string(), "accesspoint".to_string(), "my-ap".to_string()],
+        raw_path: "/v20180820/accesspoint/my-ap".to_string(),
+        raw_query: String::new(),
+        method: http::Method::PUT,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+    let resp = service.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("AccessPointArn"));
+    assert!(body.contains("my-ap-000000000000"));
+
+    // Get access point.
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-3".to_string(),
+        headers: {
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                "host",
+                "000000000000.s3-control.us-east-1.localhost.localstack.cloud:4566"
+                    .parse()
+                    .unwrap(),
+            );
+            h
+        },
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec![
+            "v20180820".to_string(),
+            "accesspoint".to_string(),
+            "my-ap".to_string(),
+        ],
+        raw_path: "/v20180820/accesspoint/my-ap".to_string(),
+        raw_query: String::new(),
+        method: http::Method::GET,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+    let resp = service.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("my-ap"));
+    assert!(body.contains("ap-bucket"));
+
+    // List access points.
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-4".to_string(),
+        headers: {
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                "host",
+                "000000000000.s3-control.us-east-1.localhost.localstack.cloud:4566"
+                    .parse()
+                    .unwrap(),
+            );
+            h
+        },
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec!["v20180820".to_string(), "accesspoint".to_string()],
+        raw_path: "/v20180820/accesspoint".to_string(),
+        raw_query: String::new(),
+        method: http::Method::GET,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+    let resp = service.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+    let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+    assert!(body.contains("my-ap"));
+
+    // Delete access point.
+    let req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-5".to_string(),
+        headers: {
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                "host",
+                "000000000000.s3-control.us-east-1.localhost.localstack.cloud:4566"
+                    .parse()
+                    .unwrap(),
+            );
+            h
+        },
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec![
+            "v20180820".to_string(),
+            "accesspoint".to_string(),
+            "my-ap".to_string(),
+        ],
+        raw_path: "/v20180820/accesspoint/my-ap".to_string(),
+        raw_query: String::new(),
+        method: http::Method::DELETE,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+    let resp = service.handle(req).await.unwrap();
+    assert_eq!(resp.status, http::StatusCode::NO_CONTENT);
+}
+
+#[test]
+fn access_point_data_plane_routes_to_bucket() {
+    let state: SharedS3State = Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("000000000000", "us-east-1", ""),
+    ));
+    let delivery = Arc::new(fakecloud_core::delivery::DeliveryBus::new());
+    let service = crate::S3Service::new(state.clone(), delivery);
+
+    // Create bucket and access point directly in state.
+    {
+        let mut st = state.write();
+        let s3_st = st.get_or_create("000000000000");
+        s3_st.buckets.insert(
+            "ap-data-bucket".to_string(),
+            crate::state::S3Bucket::new("ap-data-bucket", "us-east-1", "000000000000"),
+        );
+        s3_st.access_points.insert(
+            "data-ap".to_string(),
+            crate::state::S3AccessPoint {
+                name: "data-ap".to_string(),
+                bucket: "ap-data-bucket".to_string(),
+                account_id: "000000000000".to_string(),
+                network_origin: "Internet".to_string(),
+                vpc_configuration: None,
+                creation_date: chrono::Utc::now(),
+                public_access_block: None,
+                bucket_account_id: Some("000000000000".to_string()),
+            },
+        );
+    }
+
+    let mut req = AwsRequest {
+        service: "s3".to_string(),
+        action: String::new(),
+        region: "us-east-1".to_string(),
+        account_id: "000000000000".to_string(),
+        request_id: "req-1".to_string(),
+        headers: {
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                "host",
+                "data-ap-000000000000.s3-accesspoint.us-east-1.localhost.localstack.cloud:4566"
+                    .parse()
+                    .unwrap(),
+            );
+            h
+        },
+        query_params: std::collections::HashMap::new(),
+        body: bytes::Bytes::new(),
+        body_stream: parking_lot::Mutex::new(None),
+        path_segments: vec!["data-ap-000000000000".to_string(), "key.txt".to_string()],
+        raw_path: "/data-ap-000000000000/key.txt".to_string(),
+        raw_query: String::new(),
+        method: http::Method::GET,
+        is_query_protocol: false,
+        access_key_id: None,
+        principal: None,
+    };
+
+    crate::service::access_points::resolve_access_point(&service, &mut req).unwrap();
+
+    assert_eq!(req.path_segments[0], "ap-data-bucket");
+    assert_eq!(req.raw_path, "/ap-data-bucket/key.txt");
+}

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -213,6 +213,18 @@ pub struct ObjectLambdaResponse {
     pub kms_key_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct S3AccessPoint {
+    pub name: String,
+    pub bucket: String,
+    pub account_id: String,
+    pub network_origin: String,
+    pub vpc_configuration: Option<String>,
+    pub creation_date: DateTime<Utc>,
+    pub public_access_block: Option<String>,
+    pub bucket_account_id: Option<String>,
+}
+
 pub struct S3State {
     pub account_id: String,
     pub region: String,
@@ -221,6 +233,7 @@ pub struct S3State {
     pub body_cache: Option<Arc<BodyCache>>,
     /// Object Lambda responses keyed by request token.
     pub object_lambda_responses: BTreeMap<String, ObjectLambdaResponse>,
+    pub access_points: BTreeMap<String, S3AccessPoint>,
 }
 
 impl S3State {
@@ -232,6 +245,7 @@ impl S3State {
             notification_events: Vec::new(),
             body_cache: None,
             object_lambda_responses: BTreeMap::new(),
+            access_points: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `S3AccessPoint` struct to `S3State` with full fields.
- Implement control plane ops (`CreateAccessPoint`, `GetAccessPoint`, `DeleteAccessPoint`, `ListAccessPoints`) via `s3-control` host prefix.
- Implement data plane routing: `resolve_access_point` detects `s3-accesspoint.*` Host header, resolves alias to underlying bucket, rewrites path so standard S3 dispatch works.
- Add `Arn::s3_access_point` helper and parse `s3-accesspoint` / `s3-control` hosts in `protocol.rs`.
- Unit tests for control plane CRUD and data plane alias resolution.
- E2E tests exercising full CRUD via raw HTTP and put/get through access point endpoint.

Closes parity gap GG4.

## Test plan

- [x] `cargo test -p fakecloud-s3` — 321 passed
- [x] `cargo test -p fakecloud-e2e --test s3_access_points` — 2 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full S3 Access Points support: control plane CRUD via `s3-control` and data plane routing for `s3-accesspoint` endpoints that resolve aliases to buckets. Enables creating and using access points end to end and closes the GG4 parity gap.

- **New Features**
  - Added `S3AccessPoint` to `S3State` with full metadata.
  - Control plane: `CreateAccessPoint`, `GetAccessPoint`, `DeleteAccessPoint`, `ListAccessPoints` at `/v20180820/accesspoint/{name}` when Host is `s3-control.*`.
  - Data plane: `resolve_access_point` detects `s3-accesspoint.*` Host, maps alias to bucket, and rewrites path for normal S3 routing.
  - Protocol parsing updated to recognize `s3-accesspoint.<region>` and `s3-control.<region>` hosts.
  - Added `Arn::s3_access_point` helper.
  - Unit and E2E tests cover CRUD and PUT/GET via access point endpoints.

<sup>Written for commit 2afbf8284397e0591c2f96d88ccc247eae59dacd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

