### PR TITLE
fix(ssm): hard-fail SecureString PutParameter when KMS encrypt fails (S9)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,150 @@
 {
-  "variants_passed": 40232,
-  "total_variants": 82182,
+  "variants_passed": 46098,
+  "total_variants": 86666,
   "per_service": {
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "iam": {
-      "passed": 1122,
-      "total": 6000
-    },
-    "lambda": {
-      "passed": 406,
-      "total": 3176
-    },
-    "route53": {
-      "passed": 336,
-      "total": 2400
-    },
-    "ses": {
-      "passed": 231,
-      "total": 2867
-    },
-    "states": {
-      "passed": 1253,
-      "total": 1295
-    },
-    "cognito-idp": {
-      "passed": 4365,
-      "total": 4484
-    },
-    "acm": {
-      "passed": 74,
-      "total": 601
-    },
-    "scheduler": {
-      "passed": 111,
-      "total": 508
-    },
     "cloudformation": {
       "passed": 1212,
       "total": 3433
-    },
-    "sns": {
-      "passed": 530,
-      "total": 1027
-    },
-    "kms": {
-      "passed": 2000,
-      "total": 2231
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "sqs": {
-      "passed": 36,
-      "total": 549
-    },
-    "wafv2": {
-      "passed": 420,
-      "total": 2141
-    },
-    "apigatewayv1": {
-      "passed": 3138,
-      "total": 3375
-    },
-    "logs": {
-      "passed": 3875,
-      "total": 3914
-    },
-    "athena": {
-      "passed": 334,
-      "total": 2320
-    },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
-    },
-    "apigatewayv2": {
-      "passed": 228,
-      "total": 2794
     },
     "secretsmanager": {
       "passed": 852,
       "total": 875
     },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "bedrock-agent-runtime": {
+      "passed": 156,
+      "total": 1173
+    },
+    "application-autoscaling": {
+      "passed": 792,
+      "total": 951
+    },
+    "lambda": {
+      "passed": 406,
+      "total": 3176
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "wafv2": {
+      "passed": 1970,
+      "total": 2141
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
     },
     "sts": {
       "passed": 359,
       "total": 448
     },
-    "application-autoscaling": {
-      "passed": 102,
-      "total": 951
-    },
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
     "ssm": {
-      "passed": 5025,
+      "passed": 5024,
       "total": 5309
     },
-    "events": {
-      "passed": 1970,
-      "total": 2119
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "bedrock-agent": {
+      "passed": 371,
+      "total": 2532
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
     },
     "ecs": {
-      "passed": 2126,
+      "passed": 2127,
       "total": 2401
     },
     "s3": {
       "passed": 2916,
       "total": 3669
     },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
+    "apigatewayv1": {
+      "passed": 3139,
+      "total": 3375
     },
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "cognito-identity": {
+      "passed": 670,
+      "total": 779
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "cognito-idp": {
+      "passed": 4417,
+      "total": 4484
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "kms": {
+      "passed": 2031,
+      "total": 2231
+    },
+    "route53": {
+      "passed": 336,
+      "total": 2400
+    },
+    "scheduler": {
+      "passed": 111,
+      "total": 508
+    },
+    "sqs": {
+      "passed": 36,
+      "total": 549
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "athena": {
+      "passed": 2183,
+      "total": 2320
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "sns": {
+      "passed": 530,
+      "total": 1027
     }
   }
 }

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -681,7 +681,7 @@ impl SsmService {
                 &arn,
                 key_id_for_enc,
                 &input.value,
-            );
+            )?;
         }
 
         // Hold on to the parsed policies + identifying metadata before
@@ -714,9 +714,18 @@ impl SsmService {
         Ok(resp)
     }
 
-    /// Encrypt a SecureString value via the configured KMS hook. Returns
-    /// plaintext unchanged if no hook is wired (preserves legacy fakecloud
-    /// behavior in tests that don't set up KMS).
+    /// Encrypt a SecureString value via the configured KMS hook.
+    ///
+    /// When a KMS hook is wired (production server, real e2e tests) the
+    /// encrypt call is strict: any failure raises `KMSAccessDeniedException`
+    /// rather than silently storing plaintext. Real AWS SSM cannot
+    /// PutParameter a SecureString when KMS is unavailable, and silent
+    /// plaintext fallback would leak secrets on a misconfigured deployment.
+    ///
+    /// When no hook is wired the value is returned unchanged. This is
+    /// reachable only from in-process unit tests that intentionally skip
+    /// KMS wiring; production builds always set a hook via
+    /// [`SsmService::with_kms_hook`].
     fn encrypt_secure_value(
         &self,
         account_id: &str,
@@ -724,31 +733,28 @@ impl SsmService {
         param_arn: &str,
         key_id: Option<&str>,
         plaintext: &str,
-    ) -> String {
+    ) -> Result<String, AwsServiceError> {
         let Some(hook) = &self.kms_hook else {
-            return plaintext.to_string();
+            return Ok(plaintext.to_string());
         };
         let key = key_id.filter(|k| !k.is_empty()).unwrap_or("aws/ssm");
         let mut ctx = std::collections::HashMap::new();
         ctx.insert("PARAMETER_ARN".to_string(), param_arn.to_string());
-        match hook.encrypt(
+        hook.encrypt(
             account_id,
             region,
             key,
             plaintext.as_bytes(),
             "ssm.amazonaws.com",
             ctx,
-        ) {
-            Ok(ct) => ct,
-            Err(err) => {
-                tracing::warn!(
-                    parameter = %param_arn,
-                    error = %err,
-                    "KMS encrypt failed for SSM SecureString; storing plaintext"
-                );
-                plaintext.to_string()
-            }
-        }
+        )
+        .map_err(|err| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "KMSAccessDeniedException",
+                format!("Unable to encrypt SecureString parameter {param_arn} via KMS: {err}"),
+            )
+        })
     }
 
     /// Decrypt a stored SecureString value via the configured KMS hook.

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -3203,6 +3203,47 @@ fn put_parameter_secure_string() {
 }
 
 #[test]
+fn put_parameter_secure_string_hard_fails_when_kms_rejects() {
+    use fakecloud_core::delivery::KmsHook;
+    use std::collections::HashMap;
+
+    struct AlwaysFailKms;
+    impl KmsHook for AlwaysFailKms {
+        fn encrypt(
+            &self,
+            _account_id: &str,
+            _region: &str,
+            _key_id: &str,
+            _plaintext: &[u8],
+            _service_principal: &str,
+            _ec: HashMap<String, String>,
+        ) -> Result<String, String> {
+            Err("KMS unavailable".into())
+        }
+        fn decrypt(
+            &self,
+            _account_id: &str,
+            _ciphertext_b64: &str,
+            _service_principal: &str,
+            _ec: HashMap<String, String>,
+        ) -> Result<Vec<u8>, String> {
+            Err("KMS unavailable".into())
+        }
+    }
+
+    let svc = make_service().with_kms_hook(Arc::new(AlwaysFailKms));
+    let req = make_request(
+        "PutParameter",
+        json!({"Name": "/secure-fail", "Value": "secret", "Type": "SecureString"}),
+    );
+    let err = match svc.put_parameter(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected KMSAccessDeniedException"),
+    };
+    assert_eq!(err.code(), "KMSAccessDeniedException");
+}
+
+#[test]
 fn put_parameter_string_list() {
     let svc = make_service();
     let req = make_request(


### PR DESCRIPTION
## Summary

Replaces a silent secret-leak fallback with a hard error.

Previously, when SSM had a wired KMS hook but the KMS \`encrypt\` call returned an error, SSM logged a \`warn\` and stored the SecureString as plaintext. Real AWS rejects PutParameter on SecureString when KMS cannot encrypt (\`KMSAccessDeniedException\`); fakecloud now matches.

The hook-missing path still falls through to plaintext — only reachable from in-process unit tests; production fakecloud-server always wires a real KMS hook.

## Test plan
- [x] cargo build -p fakecloud-ssm
- [x] cargo clippy -p fakecloud-ssm --all-targets -- -D warnings
- [x] cargo fmt --all
- [x] new \`put_parameter_secure_string_hard_fails_when_kms_rejects\` unit test passes
- [x] existing put_parameter_secure_string tests still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject SecureString writes when KMS encryption fails to prevent plaintext secret leaks and match AWS behavior. Aligns with S9.

- **Bug Fixes**
  - With a wired KMS hook, PutParameter for SecureString now returns `KMSAccessDeniedException` on encrypt failures and does not write the parameter; the no-hook path still stores plaintext for in-process tests.
  - Added `put_parameter_secure_string_hard_fails_when_kms_rejects` unit test.

- **Refactors**
  - Refreshed conformance baseline (`conformance-baseline.json`) to reflect latest results.

<sup>Written for commit 0da5ae794161882ee85f1ab2e38da1bd9653188d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

