### PR TITLE
feat(bedrock-agent-runtime): real eventstream framing for Invoke* (F6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "crc32fast",
  "fakecloud-bedrock-agent",
  "fakecloud-core",
  "fakecloud-testkit",

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,150 @@
 {
-  "variants_passed": 40232,
-  "total_variants": 82182,
+  "variants_passed": 46098,
+  "total_variants": 86666,
   "per_service": {
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "iam": {
-      "passed": 1122,
-      "total": 6000
-    },
-    "lambda": {
-      "passed": 406,
-      "total": 3176
-    },
-    "route53": {
-      "passed": 336,
-      "total": 2400
-    },
-    "ses": {
-      "passed": 231,
-      "total": 2867
-    },
-    "states": {
-      "passed": 1253,
-      "total": 1295
-    },
-    "cognito-idp": {
-      "passed": 4365,
-      "total": 4484
-    },
-    "acm": {
-      "passed": 74,
-      "total": 601
-    },
-    "scheduler": {
-      "passed": 111,
-      "total": 508
-    },
     "cloudformation": {
       "passed": 1212,
       "total": 3433
-    },
-    "sns": {
-      "passed": 530,
-      "total": 1027
-    },
-    "kms": {
-      "passed": 2000,
-      "total": 2231
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "sqs": {
-      "passed": 36,
-      "total": 549
-    },
-    "wafv2": {
-      "passed": 420,
-      "total": 2141
-    },
-    "apigatewayv1": {
-      "passed": 3138,
-      "total": 3375
-    },
-    "logs": {
-      "passed": 3875,
-      "total": 3914
-    },
-    "athena": {
-      "passed": 334,
-      "total": 2320
-    },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
-    },
-    "apigatewayv2": {
-      "passed": 228,
-      "total": 2794
     },
     "secretsmanager": {
       "passed": 852,
       "total": 875
     },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "bedrock-agent-runtime": {
+      "passed": 156,
+      "total": 1173
+    },
+    "application-autoscaling": {
+      "passed": 792,
+      "total": 951
+    },
+    "lambda": {
+      "passed": 406,
+      "total": 3176
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "wafv2": {
+      "passed": 1970,
+      "total": 2141
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
     },
     "sts": {
       "passed": 359,
       "total": 448
     },
-    "application-autoscaling": {
-      "passed": 102,
-      "total": 951
-    },
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
     "ssm": {
-      "passed": 5025,
+      "passed": 5024,
       "total": 5309
     },
-    "events": {
-      "passed": 1970,
-      "total": 2119
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "bedrock-agent": {
+      "passed": 371,
+      "total": 2532
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
     },
     "ecs": {
-      "passed": 2126,
+      "passed": 2127,
       "total": 2401
     },
     "s3": {
       "passed": 2916,
       "total": 3669
     },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
+    "apigatewayv1": {
+      "passed": 3139,
+      "total": 3375
     },
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "cognito-identity": {
+      "passed": 670,
+      "total": 779
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "cognito-idp": {
+      "passed": 4417,
+      "total": 4484
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "kms": {
+      "passed": 2031,
+      "total": 2231
+    },
+    "route53": {
+      "passed": 336,
+      "total": 2400
+    },
+    "scheduler": {
+      "passed": 111,
+      "total": 508
+    },
+    "sqs": {
+      "passed": 36,
+      "total": 549
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "athena": {
+      "passed": 2183,
+      "total": 2320
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "sns": {
+      "passed": 530,
+      "total": 1027
     }
   }
 }

--- a/crates/fakecloud-bedrock-agent-runtime/Cargo.toml
+++ b/crates/fakecloud-bedrock-agent-runtime/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
+crc32fast = { workspace = true }
 http = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/fakecloud-bedrock-agent-runtime/src/eventstream.rs
+++ b/crates/fakecloud-bedrock-agent-runtime/src/eventstream.rs
@@ -1,0 +1,163 @@
+//! Minimal `application/vnd.amazon.eventstream` frame encoder used by
+//! `InvokeAgent` and `InvokeFlow` to ship streamed responses to AWS SDK
+//! clients.
+//!
+//! Frame layout (network byte order):
+//!
+//! ```text
+//! +-----------------------------------+
+//! | total length        (u32 BE)      |
+//! | headers length      (u32 BE)      |
+//! | prelude CRC32       (u32 BE)      |  CRC of the two preceding u32s
+//! | headers bytes       (raw)         |
+//! | payload bytes       (raw)         |
+//! | message CRC32       (u32 BE)      |  CRC of the whole frame so far
+//! +-----------------------------------+
+//! ```
+//!
+//! Each header: `name_len (u8) | name | type (u8 = 7) | value_len (u16
+//! BE) | value`. Only the string header type (7) is needed for Bedrock
+//! Agent — `:event-type`, `:content-type`, `:message-type` are all
+//! short ASCII strings.
+
+const HEADER_TYPE_STRING: u8 = 7;
+
+pub fn encode_frame(headers: &[(&str, &str)], payload: &[u8]) -> Vec<u8> {
+    let headers_bytes = encode_headers(headers);
+    let headers_len = headers_bytes.len() as u32;
+    let total_len = 12u32 + headers_len + payload.len() as u32 + 4;
+
+    let mut out = Vec::with_capacity(total_len as usize);
+    out.extend_from_slice(&total_len.to_be_bytes());
+    out.extend_from_slice(&headers_len.to_be_bytes());
+
+    let prelude_crc = crc32fast::hash(&out[..8]);
+    out.extend_from_slice(&prelude_crc.to_be_bytes());
+
+    out.extend_from_slice(&headers_bytes);
+    out.extend_from_slice(payload);
+
+    let msg_crc = crc32fast::hash(&out);
+    out.extend_from_slice(&msg_crc.to_be_bytes());
+
+    out
+}
+
+fn encode_headers(headers: &[(&str, &str)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (name, value) in headers {
+        let name_bytes = name.as_bytes();
+        let value_bytes = value.as_bytes();
+        debug_assert!(name_bytes.len() <= u8::MAX as usize, "header name too long");
+        debug_assert!(
+            value_bytes.len() <= u16::MAX as usize,
+            "header value too long"
+        );
+        buf.push(name_bytes.len() as u8);
+        buf.extend_from_slice(name_bytes);
+        buf.push(HEADER_TYPE_STRING);
+        buf.extend_from_slice(&(value_bytes.len() as u16).to_be_bytes());
+        buf.extend_from_slice(value_bytes);
+    }
+    buf
+}
+
+/// Build a `chunk` event frame for `InvokeAgent`. Carries a JSON
+/// payload `{"bytes": "<base64 of model output>"}`.
+pub fn chunk_frame(text: &str) -> Vec<u8> {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let body = serde_json::to_vec(&serde_json::json!({ "bytes": b64 }))
+        .expect("static JSON shape never fails");
+    encode_frame(
+        &[
+            (":event-type", "chunk"),
+            (":content-type", "application/json"),
+            (":message-type", "event"),
+        ],
+        &body,
+    )
+}
+
+/// Build a `flowOutputEvent` frame for `InvokeFlow`. Carries the same
+/// JSON shape AWS does — `nodeName` + `content.document` envelope.
+pub fn flow_output_frame(node_name: &str, document: &str) -> Vec<u8> {
+    let body = serde_json::to_vec(&serde_json::json!({
+        "nodeName": node_name,
+        "content": { "document": document },
+    }))
+    .expect("static JSON shape never fails");
+    encode_frame(
+        &[
+            (":event-type", "flowOutputEvent"),
+            (":content-type", "application/json"),
+            (":message-type", "event"),
+        ],
+        &body,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decode_frame(buf: &[u8]) -> (Vec<(String, String)>, Vec<u8>) {
+        assert!(buf.len() >= 16);
+        let total_len = u32::from_be_bytes(buf[0..4].try_into().unwrap()) as usize;
+        assert_eq!(total_len, buf.len());
+        let headers_len = u32::from_be_bytes(buf[4..8].try_into().unwrap()) as usize;
+        assert_eq!(
+            u32::from_be_bytes(buf[8..12].try_into().unwrap()),
+            crc32fast::hash(&buf[0..8])
+        );
+        let headers_start = 12;
+        let headers_end = headers_start + headers_len;
+        let payload_end = total_len - 4;
+        assert_eq!(
+            u32::from_be_bytes(buf[payload_end..total_len].try_into().unwrap()),
+            crc32fast::hash(&buf[..payload_end])
+        );
+        let mut headers = Vec::new();
+        let hbuf = &buf[headers_start..headers_end];
+        let mut i = 0;
+        while i < hbuf.len() {
+            let nl = hbuf[i] as usize;
+            let name = String::from_utf8(hbuf[i + 1..i + 1 + nl].to_vec()).unwrap();
+            i += 1 + nl;
+            assert_eq!(hbuf[i], HEADER_TYPE_STRING);
+            i += 1;
+            let vl = u16::from_be_bytes(hbuf[i..i + 2].try_into().unwrap()) as usize;
+            i += 2;
+            let value = String::from_utf8(hbuf[i..i + vl].to_vec()).unwrap();
+            i += vl;
+            headers.push((name, value));
+        }
+        (headers, buf[headers_end..payload_end].to_vec())
+    }
+
+    #[test]
+    fn chunk_frame_roundtrips() {
+        let frame = chunk_frame("hello agent");
+        let (headers, payload) = decode_frame(&frame);
+        let event_type = headers.iter().find(|(k, _)| k == ":event-type").unwrap();
+        assert_eq!(event_type.1, "chunk");
+        let body: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        let b64 = body["bytes"].as_str().unwrap();
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .unwrap();
+        assert_eq!(decoded, b"hello agent");
+    }
+
+    #[test]
+    fn flow_output_frame_roundtrips() {
+        let frame = flow_output_frame("StartNode", "document text");
+        let (headers, payload) = decode_frame(&frame);
+        let event_type = headers.iter().find(|(k, _)| k == ":event-type").unwrap();
+        assert_eq!(event_type.1, "flowOutputEvent");
+        let body: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(body["nodeName"], "StartNode");
+        assert_eq!(body["content"]["document"], "document text");
+    }
+}

--- a/crates/fakecloud-bedrock-agent-runtime/src/lib.rs
+++ b/crates/fakecloud-bedrock-agent-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod eventstream;
 pub mod service;
 pub mod state;
 

--- a/crates/fakecloud-bedrock-agent-runtime/src/service.rs
+++ b/crates/fakecloud-bedrock-agent-runtime/src/service.rs
@@ -410,18 +410,23 @@ async fn handle_invoke_agent(
         });
     }
 
-    // InvokeAgent returns an event stream. For stub, return a single-event JSON body.
-    let response = json!({
-        "completion": {
-            "chunk": {
-                "bytes": base64_encode(&output)
-            }
-        },
-        "contentType": "application/json",
-        "sessionId": session_id,
-    });
-
-    Ok(AwsResponse::ok_json(response))
+    // InvokeAgent returns `application/vnd.amazon.eventstream`-framed
+    // bytes. We emit a single `chunk` event carrying the canned
+    // response. AWS SDK clients deserialize this exactly the same way
+    // they do real Bedrock — base64-decoding the `bytes` field of each
+    // chunk event back into model output.
+    let frame = crate::eventstream::chunk_frame(&output);
+    let mut headers = http::HeaderMap::new();
+    if let Ok(value) = http::HeaderValue::from_str(&session_id) {
+        headers.insert("x-amz-bedrock-agent-session-id", value);
+    }
+    let _ = json!(null); // keep the macro import alive for other handlers in this module
+    Ok(fakecloud_core::service::AwsResponse {
+        status: StatusCode::OK,
+        content_type: "application/vnd.amazon.eventstream".to_string(),
+        body: fakecloud_core::service::ResponseBody::Bytes(frame.into()),
+        headers,
+    })
 }
 
 async fn handle_invoke_flow(
@@ -458,19 +463,18 @@ async fn handle_invoke_flow(
         );
     }
 
-    let response = json!({
-        "responseStream": {
-            "flowOutputEvent": {
-                "content": {
-                    "document": format!("Flow output for input: {}", input)
-                },
-                "nodeName": "StartNode"
-            }
-        },
-        "executionId": execution_id,
-    });
-
-    Ok(AwsResponse::ok_json(response))
+    let document = format!("Flow output for input: {}", input);
+    let frame = crate::eventstream::flow_output_frame("StartNode", &document);
+    let mut headers = http::HeaderMap::new();
+    if let Ok(value) = http::HeaderValue::from_str(&execution_id) {
+        headers.insert("x-amz-bedrock-flow-execution-id", value);
+    }
+    Ok(fakecloud_core::service::AwsResponse {
+        status: StatusCode::OK,
+        content_type: "application/vnd.amazon.eventstream".to_string(),
+        body: fakecloud_core::service::ResponseBody::Bytes(frame.into()),
+        headers,
+    })
 }
 
 async fn handle_invoke_inline_agent(
@@ -480,18 +484,17 @@ async fn handle_invoke_inline_agent(
 ) -> Result<AwsResponse, AwsServiceError> {
     let session_id = req_str(body, "sessionId").unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let input_text = req_str(body, "inputText").unwrap_or_default();
-
-    let response = json!({
-        "completion": {
-            "chunk": {
-                "bytes": base64_encode(format!("Inline agent says: {}", input_text))
-            }
-        },
-        "contentType": "application/json",
-        "sessionId": session_id,
-    });
-
-    Ok(AwsResponse::ok_json(response))
+    let frame = crate::eventstream::chunk_frame(&format!("Inline agent says: {}", input_text));
+    let mut headers = http::HeaderMap::new();
+    if let Ok(value) = http::HeaderValue::from_str(&session_id) {
+        headers.insert("x-amz-bedrock-agent-session-id", value);
+    }
+    Ok(fakecloud_core::service::AwsResponse {
+        status: StatusCode::OK,
+        content_type: "application/vnd.amazon.eventstream".to_string(),
+        body: fakecloud_core::service::ResponseBody::Bytes(frame.into()),
+        headers,
+    })
 }
 
 async fn handle_optimize_prompt(
@@ -1194,10 +1197,4 @@ async fn handle_list_tags_for_resource(
 
     let response = json!({ "tags": {} });
     Ok(AwsResponse::ok_json(response))
-}
-
-// base64 helper using workspace base64 crate
-fn base64_encode(input: impl AsRef<[u8]>) -> String {
-    use base64::{engine::general_purpose::STANDARD, Engine};
-    STANDARD.encode(input.as_ref())
 }


### PR DESCRIPTION
## Summary

InvokeAgent / InvokeFlow / InvokeInlineAgent now return real \`application/vnd.amazon.eventstream\` framed bytes instead of a single-event JSON envelope. AWS SDK clients (Rust / Python / Java aws-sdk-bedrockagentruntime) drive eventstream parsers and cannot deserialize the previous JSON-shape stub.

- New \`crates/fakecloud-bedrock-agent-runtime/src/eventstream.rs\` with a minimal vnd.amazon.eventstream encoder (network-byte-order, header table + payload + dual CRC32) following the same pattern used by \`fakecloud-lambda::eventstream\` and \`fakecloud-s3::eventstream\`
- \`chunk_frame\` builds an InvokeAgent / InvokeInlineAgent event (\`:event-type=chunk\`, body \`{"bytes": "<b64>"}\`)
- \`flow_output_frame\` builds an InvokeFlow event (\`:event-type=flowOutputEvent\`, body \`{nodeName, content.document}\`)
- Wires framed bytes into all three handlers; surfaces session/execution id in response headers
- Adds \`crc32fast\` workspace dep

## Test plan
- [x] cargo build -p fakecloud-bedrock-agent-runtime
- [x] cargo clippy -p fakecloud-bedrock-agent-runtime --all-targets -- -D warnings
- [x] cargo fmt --all
- [x] cargo test -p fakecloud-bedrock-agent-runtime (2 frame round-trip tests pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `InvokeAgent`, `InvokeFlow`, and `InvokeInlineAgent` to real `application/vnd.amazon.eventstream` frames so SDKs can parse streamed responses. Restores compatibility with `aws-sdk-bedrockagentruntime` (Rust/Python/Java) and refreshes the conformance baseline.

- **New Features**
  - Minimal eventstream encoder in `fakecloud-bedrock-agent-runtime/src/eventstream.rs` (BE lengths, header table, dual CRC32).
  - Helpers: `chunk_frame` (agents) and `flow_output_frame` (flows).
  - Handlers return framed bytes with content type `application/vnd.amazon.eventstream` and set `x-amz-bedrock-agent-session-id` / `x-amz-bedrock-flow-execution-id`.
  - Added round-trip tests for both frame types.

- **Dependencies**
  - Added `crc32fast` to `fakecloud-bedrock-agent-runtime`.

<sup>Written for commit 97ed744e1a1b945920f22a591cfde8a1d121c1e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

