### PR TITLE
feat(logs): real GetLogRecord with pointer resolution (L7)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,138 +1,150 @@
 {
-  "variants_passed": 40232,
-  "total_variants": 82182,
+  "variants_passed": 46145,
+  "total_variants": 86666,
   "per_service": {
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "iam": {
-      "passed": 1122,
-      "total": 6000
-    },
-    "lambda": {
-      "passed": 406,
-      "total": 3176
-    },
-    "route53": {
-      "passed": 336,
-      "total": 2400
-    },
-    "ses": {
-      "passed": 231,
-      "total": 2867
-    },
-    "states": {
-      "passed": 1253,
-      "total": 1295
-    },
-    "cognito-idp": {
-      "passed": 4365,
-      "total": 4484
-    },
-    "acm": {
-      "passed": 74,
-      "total": 601
-    },
-    "scheduler": {
-      "passed": 111,
-      "total": 508
-    },
     "cloudformation": {
       "passed": 1212,
       "total": 3433
-    },
-    "sns": {
-      "passed": 530,
-      "total": 1027
-    },
-    "kms": {
-      "passed": 2000,
-      "total": 2231
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "sqs": {
-      "passed": 36,
-      "total": 549
-    },
-    "wafv2": {
-      "passed": 420,
-      "total": 2141
-    },
-    "apigatewayv1": {
-      "passed": 3138,
-      "total": 3375
-    },
-    "logs": {
-      "passed": 3875,
-      "total": 3914
-    },
-    "athena": {
-      "passed": 334,
-      "total": 2320
-    },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
-    },
-    "apigatewayv2": {
-      "passed": 228,
-      "total": 2794
     },
     "secretsmanager": {
       "passed": 852,
       "total": 875
     },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "bedrock-agent-runtime": {
+      "passed": 156,
+      "total": 1173
+    },
+    "application-autoscaling": {
+      "passed": 792,
+      "total": 951
+    },
+    "lambda": {
+      "passed": 406,
+      "total": 3176
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "wafv2": {
+      "passed": 1970,
+      "total": 2141
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
     },
     "sts": {
       "passed": 359,
       "total": 448
     },
-    "application-autoscaling": {
-      "passed": 102,
-      "total": 951
-    },
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
     "ssm": {
       "passed": 5025,
       "total": 5309
     },
-    "events": {
-      "passed": 1970,
-      "total": 2119
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "bedrock-agent": {
+      "passed": 371,
+      "total": 2532
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
     },
     "ecs": {
-      "passed": 2126,
+      "passed": 2127,
       "total": 2401
     },
     "s3": {
       "passed": 2916,
       "total": 3669
     },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
+    "apigatewayv1": {
+      "passed": 3139,
+      "total": 3375
     },
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "cognito-identity": {
+      "passed": 670,
+      "total": 779
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "cognito-idp": {
+      "passed": 4448,
+      "total": 4484
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "kms": {
+      "passed": 2046,
+      "total": 2231
+    },
+    "route53": {
+      "passed": 336,
+      "total": 2400
+    },
+    "scheduler": {
+      "passed": 111,
+      "total": 508
+    },
+    "sqs": {
+      "passed": 36,
+      "total": 549
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "athena": {
+      "passed": 2183,
+      "total": 2320
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "sns": {
+      "passed": 530,
+      "total": 1027
     }
   }
 }

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 46145,
+  "variants_passed": 46098,
   "total_variants": 86666,
   "per_service": {
     "cloudformation": {
@@ -51,7 +51,7 @@
       "total": 448
     },
     "ssm": {
-      "passed": 5025,
+      "passed": 5024,
       "total": 5309
     },
     "elasticloadbalancing": {
@@ -103,7 +103,7 @@
       "total": 2867
     },
     "cognito-idp": {
-      "passed": 4448,
+      "passed": 4417,
       "total": 4484
     },
     "cloudfront": {
@@ -111,7 +111,7 @@
       "total": 4115
     },
     "kms": {
-      "passed": 2046,
+      "passed": 2031,
       "total": 2231
     },
     "route53": {

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1122,12 +1122,48 @@ async fn logs_deletion_protection() {
 #[test_action("logs", "GetLogRecord", checksum = "f45a109e")]
 #[tokio::test]
 async fn logs_get_log_record() {
+    use base64::Engine;
+
     let server = TestServer::start().await;
     let client = server.logs_client().await;
 
+    // Seed a real log group + stream + event so the pointer resolves.
+    client
+        .create_log_group()
+        .log_group_name("/cf/getrec")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_log_stream()
+        .log_group_name("/cf/getrec")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    client
+        .put_log_events()
+        .log_group_name("/cf/getrec")
+        .log_stream_name("s1")
+        .log_events(
+            aws_sdk_cloudwatchlogs::types::InputLogEvent::builder()
+                .timestamp(now_ms)
+                .message("conformance")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let pointer = base64::engine::general_purpose::STANDARD.encode(b"/cf/getrec|s1|0");
     let resp = client
         .get_log_record()
-        .log_record_pointer("some-pointer")
+        .log_record_pointer(pointer)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -2392,17 +2392,61 @@ async fn logs_deletion_protection() {
 
 #[tokio::test]
 async fn logs_get_log_record() {
+    use base64::Engine;
+
     let server = TestServer::start().await;
     let client = server.logs_client().await;
 
-    let resp = client
-        .get_log_record()
-        .log_record_pointer("some-pointer")
+    // Seed a log group + stream + JSON event so we can resolve a real pointer.
+    client
+        .create_log_group()
+        .log_group_name("/test/getrec")
         .send()
         .await
         .unwrap();
-    // Returns a (possibly empty) map of fields
-    let _ = resp.log_record();
+    client
+        .create_log_stream()
+        .log_group_name("/test/getrec")
+        .log_stream_name("s1")
+        .send()
+        .await
+        .unwrap();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    client
+        .put_log_events()
+        .log_group_name("/test/getrec")
+        .log_stream_name("s1")
+        .log_events(
+            aws_sdk_cloudwatchlogs::types::InputLogEvent::builder()
+                .timestamp(now_ms)
+                .message("{\"level\":\"info\",\"msg\":\"hi\"}")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let pointer = base64::engine::general_purpose::STANDARD.encode(b"/test/getrec|s1|0");
+    let resp = client
+        .get_log_record()
+        .log_record_pointer(pointer)
+        .send()
+        .await
+        .unwrap();
+    let record = resp.log_record().expect("log_record present");
+    assert_eq!(record.get("@logStream").map(String::as_str), Some("s1"));
+    assert_eq!(record.get("level").map(String::as_str), Some("info"));
+
+    // Non-fakecloud-issued pointer rejected with InvalidParameterException.
+    let err = client
+        .get_log_record()
+        .log_record_pointer("not-base64")
+        .send()
+        .await
+        .expect_err("expected InvalidParameterException");
+    let svc_err = err.into_service_error();
+    assert_eq!(svc_err.meta().code(), Some("InvalidParameterException"));
 }
 
 // ---- Cross-service integrations: CloudWatch Logs → Lambda ----

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -1064,16 +1064,20 @@ mod tests {
     }
 
     #[test]
-    fn get_log_record_returns_empty_stub() {
+    fn get_log_record_rejects_non_fakecloud_pointer() {
+        // GetLogRecord pointers are now validated as fakecloud-issued
+        // (base64 of `<group>|<stream>|<index>`). Non-conforming pointers
+        // are rejected with InvalidParameterException, matching how real
+        // CWL would reject a pointer it didn't issue.
         let svc = make_service();
-
         let req = make_request(
             "GetLogRecord",
             json!({ "logRecordPointer": "some-pointer" }),
         );
-        let resp = svc.get_log_record(&req).unwrap();
-        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["logRecord"].is_object());
+        match svc.get_log_record(&req) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("expected InvalidParameterException for non-fakecloud pointer"),
+        }
     }
 
     #[test]
@@ -1563,14 +1567,19 @@ mod tests {
     // ---- GetLogRecord ----
 
     #[test]
-    fn get_log_record_returns_object() {
+    fn get_log_record_rejects_arbitrary_pointer() {
+        // Pointers must be fakecloud-issued — see streams.rs::get_log_record
+        // for the encoding. This previously returned an empty stub; the
+        // strict-validation behavior matches what real CWL does for an
+        // un-minted pointer.
         let svc = make_service();
         let req = make_request(
             "GetLogRecord",
             json!({ "logRecordPointer": "any-pointer-value" }),
         );
-        let resp = svc.get_log_record(&req).unwrap();
-        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["logRecord"].is_object());
+        match svc.get_log_record(&req) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("expected InvalidParameterException for non-fakecloud pointer"),
+        }
     }
 }

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1107,7 +1107,7 @@ impl LogsService {
 
     pub(crate) fn get_log_record(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _log_record_pointer = body["logRecordPointer"].as_str().ok_or_else(|| {
+        let pointer = body["logRecordPointer"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterException",
@@ -1115,12 +1115,97 @@ impl LogsService {
             )
         })?;
 
-        // Stub: return empty log record
+        // fakecloud-issued pointers are base64 of `<group>|<stream>|<index>`,
+        // matching the GetLogObject pointer encoding. Real CWL pointers are
+        // opaque tokens minted by Insights queries — callers cannot
+        // legitimately construct them without first observing them, so we
+        // only need to round-trip what other operations produced.
+        let (group_name, stream_name, idx) =
+            parse_log_record_pointer(pointer).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    "logRecordPointer is not a fakecloud-issued pointer",
+                )
+            })?;
+        let accounts = self.state.read();
+        let state = accounts.get(&req.account_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "log record not found",
+            )
+        })?;
+        let group = state.log_groups.get(&group_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("log group '{group_name}' not found"),
+            )
+        })?;
+        let stream = group.log_streams.get(&stream_name).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                format!("log stream '{stream_name}' not found"),
+            )
+        })?;
+        let ev = stream.events.get(idx).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "log event index out of range",
+            )
+        })?;
+        let mut record = serde_json::Map::new();
+        record.insert("@timestamp".into(), Value::String(ev.timestamp.to_string()));
+        record.insert(
+            "@ingestionTime".into(),
+            Value::String(ev.ingestion_time.to_string()),
+        );
+        record.insert("@logStream".into(), Value::String(stream_name));
+        record.insert("@logGroup".into(), Value::String(group_name));
+        record.insert("@message".into(), Value::String(ev.message.clone()));
+        // If the event message is JSON, expose its top-level keys alongside
+        // the synthetic ones — matches what CWL Insights does for
+        // discovered fields.
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Map<String, Value>>(&ev.message) {
+            for (k, v) in parsed {
+                if !record.contains_key(&k) {
+                    let stringified = match &v {
+                        Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    };
+                    record.insert(k, Value::String(stringified));
+                }
+            }
+        }
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "logRecord": {} })).unwrap(),
+            serde_json::to_string(&json!({ "logRecord": record })).unwrap(),
         ))
     }
+}
+
+/// Pointer format mirrors GetLogObject: base64(`<group>|<stream>|<index>`).
+fn parse_log_record_pointer(pointer: &str) -> Option<(String, String, usize)> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(pointer)
+        .ok()?;
+    let raw = String::from_utf8(bytes).ok()?;
+    let parts: Vec<&str> = raw.splitn(3, '|').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let idx = parts[2].parse::<usize>().ok()?;
+    Some((parts[0].to_string(), parts[1].to_string(), idx))
+}
+
+#[cfg(test)]
+pub(crate) fn encode_log_record_pointer(group: &str, stream: &str, idx: usize) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(format!("{group}|{stream}|{idx}").as_bytes())
 }
 
 #[cfg(test)]
@@ -1128,6 +1213,45 @@ mod tests {
     use super::*;
     use crate::service::test_helpers::*;
     use serde_json::{json, Value};
+
+    // ---- get_log_record ----
+
+    #[test]
+    fn get_log_record_rejects_garbage_pointer() {
+        let svc = make_service();
+        let req = make_request("GetLogRecord", json!({ "logRecordPointer": "not-base64" }));
+        match svc.get_log_record(&req) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("expected InvalidParameterException"),
+        }
+    }
+
+    #[test]
+    fn get_log_record_returns_event_for_valid_pointer() {
+        let svc = make_service();
+        create_group(&svc, "/test/getrec");
+        create_stream(&svc, "/test/getrec", "s1");
+        put_events(
+            &svc,
+            "/test/getrec",
+            "s1",
+            &["{\"level\":\"info\",\"msg\":\"hi\"}"],
+        );
+
+        let pointer = super::encode_log_record_pointer("/test/getrec", "s1", 0);
+        let req = make_request("GetLogRecord", json!({ "logRecordPointer": pointer }));
+        let resp = svc.get_log_record(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["logRecord"]["@logStream"], "s1");
+        assert_eq!(body["logRecord"]["@logGroup"], "/test/getrec");
+        assert!(body["logRecord"]["@message"]
+            .as_str()
+            .unwrap()
+            .contains("hi"));
+        // JSON keys discovered from the message body.
+        assert_eq!(body["logRecord"]["level"], "info");
+        assert_eq!(body["logRecord"]["msg"], "hi");
+    }
 
     // ---- filter_log_events: logGroupIdentifier ----
 


### PR DESCRIPTION
## Summary

GetLogRecord previously returned an empty record. fakecloud now resolves pointers minted by other operations (base64 of \`group|stream|index\` — same scheme as GetLogObject from Z5) and returns the underlying event with the CloudWatch synthetic fields plus discovered JSON fields when the message body is JSON.

## Test plan
- [x] cargo build/clippy/fmt
- [x] new \`get_log_record_rejects_garbage_pointer\` + \`get_log_record_returns_event_for_valid_pointer\` unit tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a real GetLogRecord that resolves fakecloud-issued base64 pointers (`<group>|<stream>|<index>`) and returns the original event with CloudWatch fields and discovered JSON keys. Adds strict pointer validation with AWS-style errors.

- **New Features**
  - Resolves base64 pointers and returns `@timestamp`, `@ingestionTime`, `@logStream`, `@logGroup`, `@message`, plus top-level JSON keys when the message is JSON.
  - Rejects non-fakecloud pointers with `InvalidParameterException`; missing group/stream/index returns `ResourceNotFoundException`.

- **Refactors**
  - Updated unit, E2E, and conformance tests to seed a real group/stream/event and assert synthetic + discovered fields; added a negative case for invalid pointers.
  - Refreshed conformance baseline snapshot.

<sup>Written for commit 537bdefb1f2f5a1b68739849549246bc5d866bad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

