### PR TITLE
feat(logs): persist delivery configuration + standard templates (L2)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,25 +2,133 @@
   "variants_passed": 46000,
   "total_variants": 86666,
   "per_service": {
-    "acm": {
-      "passed": 601,
-      "total": 601
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "cognito-identity": {
+      "passed": 670,
+      "total": 779
+    },
+    "ecs": {
+      "passed": 2127,
+      "total": 2401
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "s3": {
+      "passed": 2916,
+      "total": 3669
     },
     "scheduler": {
       "passed": 111,
       "total": 508
     },
-    "sns": {
-      "passed": 530,
-      "total": 1027
+    "bedrock-agent-runtime": {
+      "passed": 156,
+      "total": 1173
     },
-    "states": {
-      "passed": 1253,
-      "total": 1295
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
     },
     "lambda": {
       "passed": 406,
       "total": 3176
+    },
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "cognito-idp": {
+      "passed": 4400,
+      "total": 4484
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "cloudformation": {
+      "passed": 1212,
+      "total": 3433
+    },
+    "application-autoscaling": {
+      "passed": 792,
+      "total": 951
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "sqs": {
+      "passed": 36,
+      "total": 549
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
+    },
+    "sns": {
+      "passed": 530,
+      "total": 1027
+    },
+    "ssm": {
+      "passed": 5024,
+      "total": 5309
+    },
+    "kms": {
+      "passed": 2000,
+      "total": 2231
+    },
+    "apigatewayv1": {
+      "passed": 3138,
+      "total": 3375
+    },
+    "athena": {
+      "passed": 2183,
+      "total": 2320
+    },
+    "sts": {
+      "passed": 359,
+      "total": 448
     },
     "ses": {
       "passed": 231,
@@ -30,121 +138,13 @@
       "passed": 1970,
       "total": 2141
     },
-    "cognito-idp": {
-      "passed": 4400,
-      "total": 4484
-    },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
-    },
-    "sts": {
-      "passed": 359,
-      "total": 448
-    },
-    "iam": {
-      "passed": 1122,
-      "total": 6000
-    },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
-    },
-    "kms": {
-      "passed": 2000,
-      "total": 2231
-    },
-    "cognito-identity": {
-      "passed": 670,
-      "total": 779
-    },
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
-    },
-    "events": {
-      "passed": 1970,
-      "total": 2119
-    },
-    "logs": {
-      "passed": 3844,
-      "total": 3914
-    },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
-    },
-    "s3": {
-      "passed": 2916,
-      "total": 3669
-    },
-    "bedrock-agent": {
-      "passed": 371,
-      "total": 2532
-    },
-    "apigatewayv2": {
-      "passed": 228,
-      "total": 2794
-    },
-    "ssm": {
-      "passed": 5024,
-      "total": 5309
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "athena": {
-      "passed": 2183,
-      "total": 2320
-    },
-    "bedrock-agent-runtime": {
-      "passed": 156,
-      "total": 1173
-    },
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
-    "sqs": {
-      "passed": 36,
-      "total": 549
-    },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "cloudformation": {
-      "passed": 1212,
-      "total": 3433
-    },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "application-autoscaling": {
-      "passed": 792,
-      "total": 951
-    },
     "route53": {
       "passed": 336,
       "total": 2400
     },
-    "ecs": {
-      "passed": 2127,
-      "total": 2401
-    },
-    "apigatewayv1": {
-      "passed": 3139,
-      "total": 3375
+    "bedrock-agent": {
+      "passed": 371,
+      "total": 2532
     }
   }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8233,6 +8233,9 @@ impl ResourceProvisioner {
             delivery_destination_type,
             arn: arn.clone(),
             tags: BTreeMap::new(),
+            field_delimiter: None,
+            record_fields: Vec::new(),
+            s3_delivery_configuration: None,
         };
 
         let mut logs_accounts = self.logs_state.write();

--- a/crates/fakecloud-conformance/tests/logs.rs
+++ b/crates/fakecloud-conformance/tests/logs.rs
@@ -1628,5 +1628,5 @@ async fn logs_describe_configuration_templates() {
         .send()
         .await
         .unwrap();
-    assert!(resp.configuration_templates().is_empty());
+    assert!(!resp.configuration_templates().is_empty());
 }

--- a/crates/fakecloud-e2e/tests/logs.rs
+++ b/crates/fakecloud-e2e/tests/logs.rs
@@ -1174,7 +1174,7 @@ async fn logs_misc_stubs() {
         .send()
         .await
         .unwrap();
-    assert!(resp.configuration_templates().is_empty());
+    assert!(!resp.configuration_templates().is_empty());
 
     // PutBearerTokenAuthentication
     client

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -721,6 +721,13 @@ impl LogsService {
             delivery_destination_type: dest_type.to_string(),
             arn: arn.clone(),
             tags: tags.clone(),
+            field_delimiter: field_delimiter.clone(),
+            record_fields: record_fields.clone(),
+            s3_delivery_configuration: if s3_delivery_config.is_null() {
+                None
+            } else {
+                Some(s3_delivery_config.clone())
+            },
         };
 
         state.deliveries.insert(delivery_id.clone(), delivery);
@@ -775,19 +782,26 @@ impl LogsService {
             )
         })?;
 
+        let mut delivery_json = json!({
+            "id": d.id,
+            "deliverySourceName": d.delivery_source_name,
+            "deliveryDestinationArn": d.delivery_destination_arn,
+            "deliveryDestinationType": d.delivery_destination_type,
+            "arn": d.arn,
+            "tags": d.tags,
+        });
+        if !d.record_fields.is_empty() {
+            delivery_json["recordFields"] = json!(d.record_fields);
+        }
+        if let Some(ref delim) = d.field_delimiter {
+            delivery_json["fieldDelimiter"] = json!(delim);
+        }
+        if let Some(ref s3) = d.s3_delivery_configuration {
+            delivery_json["s3DeliveryConfiguration"] = s3.clone();
+        }
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({
-                "delivery": {
-                    "id": d.id,
-                    "deliverySourceName": d.delivery_source_name,
-                    "deliveryDestinationArn": d.delivery_destination_arn,
-                    "deliveryDestinationType": d.delivery_destination_type,
-                    "arn": d.arn,
-                    "tags": d.tags,
-                }
-            }))
-            .unwrap(),
+            serde_json::to_string(&json!({ "delivery": delivery_json })).unwrap(),
         ))
     }
 
@@ -853,21 +867,31 @@ impl LogsService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let id = require_str(&body, "id")?;
+        let id = require_str(&body, "id")?.to_string();
 
-        let accounts = self.state.read();
-        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        if !state.deliveries.contains_key(id) {
-            return Err(AwsServiceError::aws_error(
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let delivery = state.deliveries.get_mut(&id).ok_or_else(|| {
+            AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
                 format!("Delivery not found: {id}"),
-            ));
-        }
-        drop(accounts);
+            )
+        })?;
 
-        // No-op: delivery configuration update is accepted but not stored
+        if let Some(delim) = body["fieldDelimiter"].as_str() {
+            delivery.field_delimiter = Some(delim.to_string());
+        }
+        if let Some(arr) = body["recordFields"].as_array() {
+            delivery.record_fields = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if !body["s3DeliveryConfiguration"].is_null() {
+            delivery.s3_delivery_configuration = Some(body["s3DeliveryConfiguration"].clone());
+        }
+
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
 
@@ -879,12 +903,60 @@ impl LogsService {
         validate_optional_string_length("service", body["service"].as_str(), 1, 255)?;
         validate_optional_string_length("nextToken", body["nextToken"].as_str(), 1, 4096)?;
         validate_optional_range_i64("limit", body["limit"].as_i64(), 1, 50)?;
-        // Stub: return empty configuration templates
+        let service_filter = body["service"].as_str();
+        let log_type_filter = body["logTypes"].as_array();
+        let dest_type_filter = body["resourceType"].as_str();
+
+        let templates = standard_delivery_templates();
+        let filtered: Vec<Value> = templates
+            .into_iter()
+            .filter(|t| {
+                service_filter.is_none_or(|s| t["service"].as_str() == Some(s))
+                    && dest_type_filter
+                        .is_none_or(|d| t["deliveryDestinationType"].as_str() == Some(d))
+                    && log_type_filter.is_none_or(|types| {
+                        types.iter().any(|v| v.as_str() == t["logType"].as_str())
+                    })
+            })
+            .collect();
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "configurationTemplates": [] })).unwrap(),
+            serde_json::to_string(&json!({ "configurationTemplates": filtered })).unwrap(),
         ))
     }
+}
+
+fn standard_delivery_templates() -> Vec<Value> {
+    let services = [
+        "AWS/APIGateway",
+        "AWS/Bedrock",
+        "AWS/Lambda",
+        "AWS/CloudFront",
+    ];
+    let dest_types = ["S3", "CWL", "FH"];
+    let mut out = Vec::new();
+    for svc in services {
+        for dt in dest_types {
+            out.push(json!({
+                "service": svc,
+                "logType": "ACCESS_LOGS",
+                "resourceType": "AWS::Logs::DeliverySource",
+                "deliveryDestinationType": dt,
+                "defaultDeliveryConfigValues": {
+                    "fieldDelimiter": " ",
+                    "recordFields": ["timestamp", "message"],
+                },
+                "allowedFields": [
+                    {"name": "timestamp", "mandatory": true},
+                    {"name": "message", "mandatory": false},
+                ],
+                "allowedOutputFormats": ["json", "plain", "w3c", "raw", "parquet"],
+                "allowedActionForAllowVendedLogsDeliveryForResource": "logs:CreateDelivery",
+            }));
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -1220,5 +1292,73 @@ mod tests {
         let resp = svc.describe_deliveries(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["deliveries"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn update_delivery_configuration_persists_fields() {
+        let svc = make_service();
+
+        let req = make_request(
+            "PutDeliverySource",
+            json!({
+                "name": "my-source",
+                "resourceArn": "arn:aws:logs:us-east-1:123456789012:log-group:test",
+                "logType": "ACCESS_LOGS"
+            }),
+        );
+        svc.put_delivery_source(&req).unwrap();
+        let req = make_request(
+            "PutDeliveryDestination",
+            json!({"name": "my-dest", "deliveryDestinationConfiguration": {"destinationResourceArn": "arn:aws:s3:::my-bucket"}}),
+        );
+        let resp = svc.put_delivery_destination(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let dest_arn = body["deliveryDestination"]["arn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let req = make_request(
+            "CreateDelivery",
+            json!({"deliverySourceName": "my-source", "deliveryDestinationArn": dest_arn}),
+        );
+        let resp = svc.create_delivery(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let id = body["delivery"]["id"].as_str().unwrap().to_string();
+
+        let req = make_request(
+            "UpdateDeliveryConfiguration",
+            json!({
+                "id": id,
+                "fieldDelimiter": "|",
+                "recordFields": ["@timestamp", "@message"],
+            }),
+        );
+        svc.update_delivery_configuration(&req).unwrap();
+
+        let req = make_request("GetDelivery", json!({ "id": id }));
+        let resp = svc.get_delivery(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["delivery"]["fieldDelimiter"], "|");
+        assert_eq!(body["delivery"]["recordFields"][0], "@timestamp");
+    }
+
+    #[test]
+    fn describe_configuration_templates_returns_standard_set() {
+        let svc = make_service();
+        let req = make_request("DescribeConfigurationTemplates", json!({}));
+        let resp = svc.describe_configuration_templates(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let arr = body["configurationTemplates"].as_array().unwrap();
+        assert!(!arr.is_empty(), "expected non-empty templates");
+
+        let req = make_request(
+            "DescribeConfigurationTemplates",
+            json!({"service": "AWS/Lambda"}),
+        );
+        let resp = svc.describe_configuration_templates(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let filtered = body["configurationTemplates"].as_array().unwrap();
+        assert!(filtered.iter().all(|t| t["service"] == "AWS/Lambda"));
     }
 }

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -1503,12 +1503,12 @@ mod tests {
     }
 
     #[test]
-    fn describe_configuration_templates_returns_empty() {
+    fn describe_configuration_templates_returns_standard_set() {
         let svc = make_service();
         let req = make_request("DescribeConfigurationTemplates", json!({}));
         let resp = svc.describe_configuration_templates(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-        assert!(body["configurationTemplates"]
+        assert!(!body["configurationTemplates"]
             .as_array()
             .unwrap()
             .is_empty());

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -297,6 +297,12 @@ pub struct Delivery {
     pub delivery_destination_type: String,
     pub arn: String,
     pub tags: BTreeMap<String, String>,
+    #[serde(default)]
+    pub field_delimiter: Option<String>,
+    #[serde(default)]
+    pub record_fields: Vec<String>,
+    #[serde(default)]
+    pub s3_delivery_configuration: Option<serde_json::Value>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary
- UpdateDeliveryConfiguration persists fieldDelimiter/recordFields/s3DeliveryConfiguration on the Delivery (was no-op).
- GetDelivery/CreateDelivery responses surface persisted fields.
- DescribeConfigurationTemplates returns standard vended-logs templates with service/resourceType/logTypes filtering.

## Test plan
- [x] Unit test: UpdateDeliveryConfiguration -> GetDelivery round-trips fieldDelimiter + recordFields
- [x] Unit test: DescribeConfigurationTemplates returns non-empty set, filterable by service
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist delivery configuration on `Delivery` and return it from `CreateDelivery`/`GetDelivery`. Add standard vended-logs configuration templates with filtering.

- **New Features**
  - `UpdateDeliveryConfiguration` now saves `fieldDelimiter`, `recordFields`, and `s3DeliveryConfiguration`.
  - `CreateDelivery`/`GetDelivery` include these fields when present.
  - `DescribeConfigurationTemplates` returns standard templates (APIGateway, Bedrock, Lambda, CloudFront × S3/CWL/FH) with `service`, `resourceType`, and `logTypes` filters, plus defaults, allowed fields, and output formats.

- **Bug Fixes**
  - CloudFormation provisioner initializes the new `Delivery` fields with defaults.
  - Updated tests (unit, conformance, and e2e) to expect non-empty configuration templates.

<sup>Written for commit d51a5219267c13e35b39236f0d021d3df9b55727. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

