### PR TITLE
feat(logs): anomaly state + injection admin endpoint (L1)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -2,149 +2,149 @@
   "variants_passed": 46000,
   "total_variants": 86666,
   "per_service": {
-    "elasticloadbalancing": {
-      "passed": 162,
-      "total": 1587
-    },
-    "wafv2": {
-      "passed": 1970,
-      "total": 2141
-    },
-    "application-autoscaling": {
-      "passed": 792,
-      "total": 951
-    },
-    "logs": {
-      "passed": 3844,
-      "total": 3914
-    },
-    "athena": {
-      "passed": 2183,
-      "total": 2320
-    },
-    "ecs": {
-      "passed": 2127,
-      "total": 2401
-    },
-    "bedrock-agent": {
-      "passed": 371,
-      "total": 2532
-    },
-    "bedrock-runtime": {
-      "passed": 52,
-      "total": 447
-    },
-    "cognito-identity": {
-      "passed": 670,
-      "total": 779
-    },
-    "ssm": {
-      "passed": 5024,
-      "total": 5309
-    },
-    "sqs": {
-      "passed": 36,
-      "total": 549
-    },
-    "cognito-idp": {
-      "passed": 4400,
-      "total": 4484
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "rds": {
-      "passed": 772,
-      "total": 5497
-    },
-    "kms": {
-      "passed": 2000,
-      "total": 2231
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
     "scheduler": {
       "passed": 111,
       "total": 508
     },
-    "elasticache": {
-      "passed": 177,
-      "total": 2258
-    },
-    "route53": {
-      "passed": 336,
-      "total": 2400
-    },
-    "events": {
-      "passed": 1970,
-      "total": 2119
-    },
-    "apigatewayv1": {
-      "passed": 3135,
-      "total": 3375
-    },
-    "sts": {
-      "passed": 359,
-      "total": 448
-    },
-    "bedrock": {
-      "passed": 556,
-      "total": 3841
-    },
-    "bedrock-agent-runtime": {
-      "passed": 156,
-      "total": 1173
-    },
-    "s3": {
-      "passed": 2916,
-      "total": 3669
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "cloudfront": {
-      "passed": 265,
-      "total": 4115
-    },
-    "lambda": {
-      "passed": 406,
-      "total": 3176
-    },
-    "apigatewayv2": {
-      "passed": 228,
-      "total": 2794
-    },
-    "dynamodb": {
-      "passed": 1864,
-      "total": 2134
-    },
-    "cloudformation": {
-      "passed": 1212,
-      "total": 3433
-    },
-    "iam": {
-      "passed": 1122,
-      "total": 6000
-    },
-    "ses": {
-      "passed": 231,
-      "total": 2867
+    "sns": {
+      "passed": 530,
+      "total": 1027
     },
     "states": {
       "passed": 1253,
       "total": 1295
     },
+    "lambda": {
+      "passed": 406,
+      "total": 3176
+    },
+    "ses": {
+      "passed": 231,
+      "total": 2867
+    },
+    "wafv2": {
+      "passed": 1970,
+      "total": 2141
+    },
+    "cognito-idp": {
+      "passed": 4400,
+      "total": 4484
+    },
     "ecr": {
       "passed": 1764,
       "total": 1805
     },
-    "sns": {
-      "passed": 530,
-      "total": 1027
+    "sts": {
+      "passed": 359,
+      "total": 448
+    },
+    "iam": {
+      "passed": 1122,
+      "total": 6000
+    },
+    "elasticache": {
+      "passed": 177,
+      "total": 2258
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
+    },
+    "cloudfront": {
+      "passed": 265,
+      "total": 4115
+    },
+    "kms": {
+      "passed": 2000,
+      "total": 2231
+    },
+    "cognito-identity": {
+      "passed": 670,
+      "total": 779
+    },
+    "elasticloadbalancing": {
+      "passed": 162,
+      "total": 1587
+    },
+    "events": {
+      "passed": 1970,
+      "total": 2119
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "dynamodb": {
+      "passed": 1864,
+      "total": 2134
+    },
+    "s3": {
+      "passed": 2916,
+      "total": 3669
+    },
+    "bedrock-agent": {
+      "passed": 371,
+      "total": 2532
+    },
+    "apigatewayv2": {
+      "passed": 228,
+      "total": 2794
+    },
+    "ssm": {
+      "passed": 5024,
+      "total": 5309
+    },
+    "rds": {
+      "passed": 772,
+      "total": 5497
+    },
+    "athena": {
+      "passed": 2183,
+      "total": 2320
+    },
+    "bedrock-agent-runtime": {
+      "passed": 156,
+      "total": 1173
+    },
+    "bedrock-runtime": {
+      "passed": 52,
+      "total": 447
+    },
+    "sqs": {
+      "passed": 36,
+      "total": 549
+    },
+    "bedrock": {
+      "passed": 556,
+      "total": 3841
+    },
+    "cloudformation": {
+      "passed": 1212,
+      "total": 3433
     },
     "kinesis": {
       "passed": 1599,
       "total": 1611
+    },
+    "application-autoscaling": {
+      "passed": 792,
+      "total": 951
+    },
+    "route53": {
+      "passed": 336,
+      "total": 2400
+    },
+    "ecs": {
+      "passed": 2127,
+      "total": 2401
+    },
+    "apigatewayv1": {
+      "passed": 3139,
+      "total": 3375
     }
   }
 }

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -7,7 +7,7 @@ pub mod transformer;
 
 pub use service::LogsService;
 pub use state::{
-    Delivery, DeliveryDestination, DeliverySource, Destination, LogEvent, LogGroup, LogStream,
-    LogsSnapshot, LogsState, MetricFilter, MetricTransformation, QueryDefinition, ResourcePolicy,
-    SharedLogsState, SubscriptionFilter, LOGS_SNAPSHOT_SCHEMA_VERSION,
+    Delivery, DeliveryDestination, DeliverySource, Destination, LogAnomaly, LogEvent, LogGroup,
+    LogStream, LogsSnapshot, LogsState, MetricFilter, MetricTransformation, QueryDefinition,
+    ResourcePolicy, SharedLogsState, SubscriptionFilter, LOGS_SNAPSHOT_SCHEMA_VERSION,
 };

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -7,7 +7,7 @@ use fakecloud_core::validation::*;
 use super::LogsService;
 use chrono::Utc;
 
-use crate::state::AnomalyDetector;
+use crate::state::{AnomalyDetector, LogAnomaly};
 
 impl LogsService {
     // ---- Anomaly Detectors ----
@@ -287,10 +287,43 @@ impl LogsService {
             &body["suppressionState"],
             &["SUPPRESSED", "UNSUPPRESSED"],
         )?;
-        // Stub: return empty anomalies list
+        let detector_filter = body["anomalyDetectorArn"].as_str();
+        let suppression = body["suppressionState"].as_str();
+
+        let accounts = self.state.read();
+        let empty = crate::state::LogsState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let anomalies: Vec<Value> = state
+            .anomalies
+            .values()
+            .filter(|a| {
+                detector_filter.is_none_or(|d| a.anomaly_detector_arn == d)
+                    && suppression.is_none_or(|s| match s {
+                        "SUPPRESSED" => a.suppressed,
+                        "UNSUPPRESSED" => !a.suppressed,
+                        _ => true,
+                    })
+            })
+            .map(|a| {
+                json!({
+                    "anomalyId": a.anomaly_id,
+                    "anomalyDetectorArn": a.anomaly_detector_arn,
+                    "logGroupArnList": a.log_group_arn_list,
+                    "patternId": a.pattern_id,
+                    "patternString": a.pattern_string,
+                    "firstSeen": a.first_seen,
+                    "lastSeen": a.last_seen,
+                    "priority": a.priority,
+                    "state": a.state,
+                    "active": !a.suppressed,
+                    "suppressed": a.suppressed,
+                })
+            })
+            .collect();
+
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "anomalies": [] })).unwrap(),
+            serde_json::to_string(&json!({ "anomalies": anomalies })).unwrap(),
         ))
     }
 
@@ -310,11 +343,54 @@ impl LogsService {
             &body["suppressionType"],
             &["LIMITED", "INFINITE"],
         )?;
-        // No-op stub
+        let anomaly_id = body["anomalyId"].as_str();
+        let suppress = !body["suppressionType"].is_null();
+        if let Some(id) = anomaly_id {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            if let Some(a) = state.anomalies.get_mut(id) {
+                a.suppressed = suppress;
+            }
+        }
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
 
     // -- Import tasks --
+
+    /// Admin: inject a synthetic anomaly so tests can exercise
+    /// ListAnomalies / UpdateAnomaly without running real detection.
+    /// Called from the `/_fakecloud/logs/anomalies/inject` endpoint.
+    pub fn inject_anomaly(
+        &self,
+        account_id: &str,
+        _region: &str,
+        anomaly_detector_arn: String,
+        log_group_arns: Vec<String>,
+        pattern_string: String,
+        priority: Option<String>,
+    ) -> String {
+        let now = Utc::now().timestamp_millis();
+        let anomaly_id = uuid::Uuid::new_v4().to_string();
+        let pattern_id = format!("{:032x}", uuid::Uuid::new_v4().as_u128());
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(account_id);
+        state.anomalies.insert(
+            anomaly_id.clone(),
+            LogAnomaly {
+                anomaly_id: anomaly_id.clone(),
+                anomaly_detector_arn,
+                log_group_arn_list: log_group_arns,
+                pattern_id,
+                pattern_string,
+                first_seen: now,
+                last_seen: now,
+                priority: priority.unwrap_or_else(|| "MEDIUM".to_string()),
+                state: "ACTIVE".to_string(),
+                suppressed: false,
+            },
+        );
+        anomaly_id
+    }
 }
 
 #[cfg(test)]
@@ -363,5 +439,42 @@ mod tests {
             json!({ "anomalyDetectorArn": &arn }),
         );
         svc.delete_log_anomaly_detector(&req).unwrap();
+    }
+
+    #[test]
+    fn list_anomalies_returns_injected_entries() {
+        let svc = make_service();
+        let id = svc.inject_anomaly(
+            "123456789012",
+            "us-east-1",
+            "arn:aws:logs:us-east-1:123456789012:anomaly-detector:abc".to_string(),
+            vec!["arn:aws:logs:us-east-1:123456789012:log-group:test".to_string()],
+            "ERROR pattern".to_string(),
+            None,
+        );
+
+        let req = make_request("ListAnomalies", json!({}));
+        let resp = svc.list_anomalies(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let arr = body["anomalies"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["anomalyId"], id);
+        assert_eq!(arr[0]["patternString"], "ERROR pattern");
+        assert_eq!(arr[0]["suppressed"], false);
+
+        let req = make_request(
+            "UpdateAnomaly",
+            json!({
+                "anomalyDetectorArn": "arn:aws:logs:us-east-1:123456789012:anomaly-detector:abc",
+                "anomalyId": id,
+                "suppressionType": "INFINITE",
+            }),
+        );
+        svc.update_anomaly(&req).unwrap();
+
+        let req = make_request("ListAnomalies", json!({"suppressionState": "SUPPRESSED"}));
+        let resp = svc.list_anomalies(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["anomalies"].as_array().unwrap().len(), 1);
     }
 }

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -75,6 +75,25 @@ pub struct LogsState {
     /// Internal export storage: keyed by "bucket/prefix/..." path, value is exported data.
     /// Used by CreateExportTask and delivery pipeline when direct S3 access is unavailable.
     pub export_storage: BTreeMap<String, Vec<u8>>,
+    /// Detected log anomalies keyed by anomaly id. Populated via the
+    /// `/_fakecloud/logs/anomalies/inject` admin endpoint and surfaced
+    /// through ListAnomalies / UpdateAnomaly.
+    #[serde(default)]
+    pub anomalies: BTreeMap<String, LogAnomaly>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogAnomaly {
+    pub anomaly_id: String,
+    pub anomaly_detector_arn: String,
+    pub log_group_arn_list: Vec<String>,
+    pub pattern_id: String,
+    pub pattern_string: String,
+    pub first_seen: i64,
+    pub last_seen: i64,
+    pub priority: String,
+    pub state: String,
+    pub suppressed: bool,
 }
 
 impl LogsState {
@@ -101,6 +120,7 @@ impl LogsState {
             s3_table_sources: BTreeMap::new(),
             bearer_token_auth: BTreeMap::new(),
             export_storage: BTreeMap::new(),
+            anomalies: BTreeMap::new(),
         }
     }
 
@@ -124,6 +144,7 @@ impl LogsState {
         self.s3_table_sources.clear();
         self.bearer_token_auth.clear();
         self.export_storage.clear();
+        self.anomalies.clear();
     }
 }
 

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -154,6 +154,26 @@ pub struct SesSandboxRequest {
     pub sandbox: bool,
 }
 
+/// Admin payload for `/_fakecloud/logs/anomalies/inject`. Lets tests
+/// seed synthetic CloudWatch Logs anomalies so they can exercise
+/// `ListAnomalies` / `UpdateAnomaly` deterministically.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsAnomalyInjectRequest {
+    pub anomaly_detector_arn: String,
+    #[serde(default)]
+    pub log_group_arns: Vec<String>,
+    pub pattern_string: String,
+    #[serde(default)]
+    pub priority: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsAnomalyInjectResponse {
+    pub anomaly_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboundEmailRequest {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1393,6 +1393,7 @@ async fn main() {
         } else {
             None
         };
+    let logs_anomalies_state = logs_state.clone();
     let mut logs_service = LogsService::new(logs_state.clone(), delivery_for_logs);
     if let Some(store) = logs_snapshot_store {
         logs_service = logs_service.with_snapshot_store(store);
@@ -3461,6 +3462,38 @@ async fn main() {
                         })
                         .collect();
                     axum::Json(types::SnsSmsResponse { messages })
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/logs/anomalies/inject",
+            axum::routing::post({
+                let ls = logs_anomalies_state.clone();
+                move |axum::Json(body): axum::Json<types::LogsAnomalyInjectRequest>| async move {
+                    let now = chrono::Utc::now().timestamp_millis();
+                    let anomaly_id = uuid::Uuid::new_v4().to_string();
+                    let pattern_id = format!("{:032x}", uuid::Uuid::new_v4().as_u128());
+                    let mut accounts = ls.write();
+                    let state = accounts.default_mut();
+                    state.anomalies.insert(
+                        anomaly_id.clone(),
+                        fakecloud_logs::LogAnomaly {
+                            anomaly_id: anomaly_id.clone(),
+                            anomaly_detector_arn: body.anomaly_detector_arn,
+                            log_group_arn_list: body.log_group_arns,
+                            pattern_id,
+                            pattern_string: body.pattern_string,
+                            first_seen: now,
+                            last_seen: now,
+                            priority: body.priority.unwrap_or_else(|| "MEDIUM".to_string()),
+                            state: "ACTIVE".to_string(),
+                            suppressed: false,
+                        },
+                    );
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(types::LogsAnomalyInjectResponse { anomaly_id }),
+                    )
                 }
             }),
         )


### PR DESCRIPTION
## Summary
- ListAnomalies now reads from a per-account anomalies map populated via POST /_fakecloud/logs/anomalies/inject.
- UpdateAnomaly flips the suppressed flag on the matching entry.
- Suppression filter (SUPPRESSED / UNSUPPRESSED) honored on ListAnomalies.

## Test plan
- [x] Unit test: inject -> ListAnomalies returns entry; UpdateAnomaly suppresses; ListAnomalies(SUPPRESSED) sees it.
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-account anomaly store and an admin injection endpoint so tests can seed anomalies and exercise Logs anomaly APIs. `ListAnomalies` now returns stored entries with filters; `UpdateAnomaly` toggles suppression.

- **New Features**
  - `ListAnomalies` reads per-account anomalies and filters by `anomalyDetectorArn` and `suppressionState` (`SUPPRESSED`/`UNSUPPRESSED`); returns `active` and `suppressed` flags.
  - New POST `/_fakecloud/logs/anomalies/inject` to seed synthetic anomalies for tests; returns `anomalyId`. Added request/response types in `fakecloud-sdk`.
  - `UpdateAnomaly` sets `suppressed` when `suppressionType` is `LIMITED`/`INFINITE`, or clears it when omitted.
  - Added `LogAnomaly` storage to `LogsState` and re-exported from `fakecloud-logs`; refreshed conformance baseline.

<sup>Written for commit a091a6e7ce980d63330437968553c72ff0338c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

