### PR TITLE
feat(lambda): UpdateFunctionCode fetches real bytes from S3 (R4)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -578,7 +578,11 @@ async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
     let lambda = server.lambda_client().await;
     let s3 = server.s3_client().await;
 
-    s3.create_bucket().bucket("deploy-bucket").send().await.unwrap();
+    s3.create_bucket()
+        .bucket("deploy-bucket")
+        .send()
+        .await
+        .unwrap();
     let v1 = make_python_zip();
     s3.put_object()
         .bucket("deploy-bucket")

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -571,13 +571,24 @@ async fn lambda_update_function_code_replaces_zip_and_recomputes_hash() {
 
 #[tokio::test]
 async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
-    // S3Bucket+S3Key swap fingerprints the descriptor; a different
-    // descriptor must rotate CodeSha256 / RevisionId, identical
-    // descriptor must not.
+    // After R4 wired real S3 fetches, UpdateFunctionCode with S3Bucket+Key
+    // pulls the object bytes. The hash now reflects the actual ZIP, so
+    // seed the S3 bucket with the artifact before pointing Lambda at it.
     let server = TestServer::start().await;
-    let client = server.lambda_client().await;
+    let lambda = server.lambda_client().await;
+    let s3 = server.s3_client().await;
 
-    client
+    s3.create_bucket().bucket("deploy-bucket").send().await.unwrap();
+    let v1 = make_python_zip();
+    s3.put_object()
+        .bucket("deploy-bucket")
+        .key("lambdas/v2.zip")
+        .body(aws_sdk_s3::primitives::ByteStream::from(v1.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    lambda
         .create_function()
         .function_name("upd-s3")
         .runtime(aws_sdk_lambda::types::Runtime::Python312)
@@ -585,14 +596,25 @@ async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
         .handler("index.handler")
         .code(
             aws_sdk_lambda::types::FunctionCode::builder()
-                .zip_file(Blob::new(make_python_zip()))
+                .zip_file(Blob::new(v1.clone()))
                 .build(),
         )
         .send()
         .await
         .unwrap();
 
-    let pre_sha = client
+    // Seed a second, different artifact for the S3-source update.
+    let mut v2 = make_python_zip();
+    v2.extend_from_slice(b"-v2-tail");
+    s3.put_object()
+        .bucket("deploy-bucket")
+        .key("lambdas/v2.zip")
+        .body(aws_sdk_s3::primitives::ByteStream::from(v2.clone()))
+        .send()
+        .await
+        .unwrap();
+
+    let pre_sha = lambda
         .get_function_configuration()
         .function_name("upd-s3")
         .send()
@@ -602,7 +624,7 @@ async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
         .unwrap()
         .to_string();
 
-    let updated = client
+    let updated = lambda
         .update_function_code()
         .function_name("upd-s3")
         .s3_bucket("deploy-bucket")
@@ -612,18 +634,6 @@ async fn lambda_update_function_code_with_s3_descriptor_rotates_hash() {
         .unwrap();
     let post_sha = updated.code_sha256().unwrap().to_string();
     assert_ne!(post_sha, pre_sha);
-
-    // Adding S3ObjectVersion changes the descriptor, so the hash rotates.
-    let versioned = client
-        .update_function_code()
-        .function_name("upd-s3")
-        .s3_bucket("deploy-bucket")
-        .s3_key("lambdas/v2.zip")
-        .s3_object_version("ver-abc123")
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(versioned.code_sha256().unwrap(), post_sha);
 }
 
 #[tokio::test]

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -456,9 +456,38 @@ impl LambdaService {
         // and size still rotate when the descriptor differs, so
         // optimistic-concurrency callers see RevisionId bump on real
         // changes.
+        // S3-sourced code: if an S3Delivery hook is wired, fetch the
+        // actual object bytes and treat them as a ZIP upload. This
+        // matches real Lambda's S3-pull semantics. Fall back to the
+        // descriptor-hash shortcut when no hook is available.
+        let s3_fetched_zip: Option<Vec<u8>> = match (
+            body["S3Bucket"].as_str(),
+            body["S3Key"].as_str(),
+        ) {
+            (Some(bucket), Some(key)) if new_zip.is_none() && new_image_uri.is_none() => {
+                if let Some(s3) = &self.s3_delivery {
+                    match s3.get_object(&req.account_id, bucket, key) {
+                        Ok(bytes) => Some(bytes),
+                        Err(e) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "InvalidParameterValueException",
+                                format!("Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: {e}"),
+                            ));
+                        }
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
         let new_s3_descriptor: Option<Vec<u8>> =
             match (body["S3Bucket"].as_str(), body["S3Key"].as_str()) {
-                (Some(bucket), Some(key)) if new_zip.is_none() && new_image_uri.is_none() => {
+                (Some(bucket), Some(key))
+                    if new_zip.is_none() && new_image_uri.is_none() && s3_fetched_zip.is_none() =>
+                {
                     let mut descriptor = serde_json::Map::new();
                     descriptor.insert("S3Bucket".to_string(), Value::String(bucket.to_string()));
                     descriptor.insert("S3Key".to_string(), Value::String(key.to_string()));
@@ -472,6 +501,7 @@ impl LambdaService {
                 }
                 _ => None,
             };
+        let new_zip = new_zip.or(s3_fetched_zip);
         let supplied_signing_profile = body["SigningProfileVersionArn"].as_str().map(String::from);
         let supplied_revision_id = body["RevisionId"].as_str().map(String::from);
         let new_architectures: Option<Vec<String>> = body["Architectures"].as_array().map(|arr| {

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -595,6 +595,7 @@ pub struct LambdaService {
     snapshot_lock: Arc<AsyncMutex<()>>,
     pub(crate) delivery_bus: Option<Arc<fakecloud_core::delivery::DeliveryBus>>,
     pub(crate) role_trust_validator: Option<Arc<dyn fakecloud_core::auth::RoleTrustValidator>>,
+    pub(crate) s3_delivery: Option<Arc<dyn fakecloud_core::delivery::S3Delivery>>,
     /// Per-account-per-function in-flight invocation count, used to
     /// gate `Invoke` against `PutFunctionConcurrency`'s
     /// `ReservedConcurrentExecutions` ceiling. Keyed by
@@ -613,8 +614,14 @@ impl LambdaService {
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             delivery_bus: None,
             role_trust_validator: None,
+            s3_delivery: None,
             inflight_invocations: Arc::new(parking_lot::RwLock::new(BTreeMap::new())),
         }
+    }
+
+    pub fn with_s3_delivery(mut self, s3: Arc<dyn fakecloud_core::delivery::S3Delivery>) -> Self {
+        self.s3_delivery = Some(s3);
+        self
     }
 
     pub fn with_runtime(mut self, runtime: Arc<ContainerRuntime>) -> Self {

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1353,6 +1353,75 @@ async fn create_event_source_mapping_round_trips_advanced_fields() {
     assert_eq!(v["Topics"][0], "t1");
 }
 
+struct StubS3 {
+    object: std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>>,
+}
+impl fakecloud_core::delivery::S3Delivery for StubS3 {
+    fn put_object(
+        &self,
+        _account_id: &str,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+        _content_type: Option<&str>,
+    ) -> Result<(), String> {
+        self.object
+            .lock()
+            .unwrap()
+            .insert(format!("{bucket}/{key}"), body);
+        Ok(())
+    }
+    fn get_object(&self, _account_id: &str, bucket: &str, key: &str) -> Result<Vec<u8>, String> {
+        self.object
+            .lock()
+            .unwrap()
+            .get(&format!("{bucket}/{key}"))
+            .cloned()
+            .ok_or_else(|| "missing".to_string())
+    }
+}
+
+#[tokio::test]
+async fn update_function_code_fetches_real_bytes_from_s3() {
+    let stub = std::sync::Arc::new(StubS3 {
+        object: std::sync::Mutex::new(std::collections::HashMap::new()),
+    });
+    let payload = b"real-zip-bytes-from-s3-bucket";
+    stub.object
+        .lock()
+        .unwrap()
+        .insert("my-bucket/lambda.zip".to_string(), payload.to_vec());
+
+    let svc = LambdaService::new(make_state()).with_s3_delivery(stub);
+    let body = json!({
+        "FunctionName": "fromzip",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/r",
+        "Handler": "index.handler",
+        "Code": {"ZipFile": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"seed")},
+    });
+    let req = make_request(Method::POST, "/2015-03-31/functions", &body.to_string());
+    svc.handle(req).await.unwrap();
+
+    let body = json!({"S3Bucket": "my-bucket", "S3Key": "lambda.zip"});
+    let req = make_request(
+        Method::PUT,
+        "/2015-03-31/functions/fromzip/code",
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let post: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(payload);
+    let expected = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        hasher.finalize(),
+    );
+    assert_eq!(post["CodeSha256"].as_str().unwrap(), expected);
+    assert_eq!(post["CodeSize"].as_i64().unwrap(), payload.len() as i64);
+}
+
 // ── UpdateFunctionCode behavior tests (D1) ──
 
 #[tokio::test]

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -563,7 +563,7 @@ async fn main() {
     let mut delivery_for_logs = DeliveryBus::new()
         .with_sqs(sqs_delivery.clone())
         .with_kinesis(kinesis_delivery)
-        .with_s3(s3_delivery_for_logs)
+        .with_s3(s3_delivery_for_logs.clone())
         .with_firehose(firehose_delivery_for_logs.clone())
         .with_cloudwatch_metrics(cloudwatch_delivery_for_logs.clone());
     if let Some(ref ld) = lambda_delivery {
@@ -1175,6 +1175,7 @@ async fn main() {
     lambda_service = lambda_service.with_role_trust_validator(
         fakecloud_iam::pass_role::IamRoleTrustValidator::shared(iam_state.clone()),
     );
+    lambda_service = lambda_service.with_s3_delivery(s3_delivery_for_logs.clone());
     if let Some(ref rt) = container_runtime {
         lambda_service = lambda_service.with_runtime(rt.clone());
     }


### PR DESCRIPTION
## Summary
- LambdaService gains an optional S3Delivery hook.
- UpdateFunctionCode with S3Bucket+S3Key pulls the object via the hook and treats the bytes as a ZIP, producing a real sha256 + CodeSize matching the artifact.
- Falls back to descriptor-hash when no hook is wired (library tests).

## Test plan
- [x] Unit test: seed S3 object, UpdateFunctionCode with S3Bucket+S3Key -> CodeSha256 matches sha256(bytes)
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UpdateFunctionCode now fetches ZIP bytes from S3 when `S3Bucket` + `S3Key` are provided, so `CodeSha256` and `CodeSize` match the real artifact. E2E tests now seed the bucket/object to reflect this behavior.

- **New Features**
  - `LambdaService` supports `s3_delivery` via `with_s3_delivery(...)`.
  - With `S3Bucket` + `S3Key` (and no inline `ZipFile`/image), bytes are fetched and processed as a ZIP.
  - Falls back to descriptor hashing when no S3 hook is wired.
  - S3 get failures return `InvalidParameterValueException` (400) with a NoSuchKey-style message.
  - `fakecloud-server` wires the shared S3 delivery into `LambdaService`.

- **Bug Fixes**
  - E2E test seeds the S3 bucket/object and verifies hash rotation by changing artifact bytes, not just the descriptor.

<sup>Written for commit bc7f34505a86a99717465e3a15dbe48c7c6346a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

