### PR TITLE
feat(s3): GetObject enforces PublicAccessBlock.IgnorePublicAcls (R1)

### DIFF
--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -36,7 +36,7 @@ pub(crate) struct PublicAccessBlockFlags {
 }
 
 impl PublicAccessBlockFlags {
-    fn parse(xml: &str) -> Self {
+    pub(crate) fn parse(xml: &str) -> Self {
         fn flag(xml: &str, name: &str) -> bool {
             let open = format!("<{name}>");
             let close = format!("</{name}>");

--- a/crates/fakecloud-s3/src/service/objects.rs
+++ b/crates/fakecloud-s3/src/service/objects.rs
@@ -1222,6 +1222,29 @@ impl S3Service {
             .ok_or_else(|| no_such_bucket(bucket))?;
         let obj = resolve_object(b, key, req.query_params.get("versionId"))?;
 
+        // PublicAccessBlock.IgnorePublicAcls: anonymous callers cannot
+        // ride a public-read ACL when the bucket has IgnorePublicAcls
+        // set. Authenticated callers always pass this gate; the ACL
+        // check itself is unchanged for authed paths.
+        if req.access_key_id.is_none() {
+            if let Some(xml) = b.public_access_block.as_ref() {
+                let flags = crate::service::config::PublicAccessBlockFlags::parse(xml);
+                let acl_is_public = obj.acl_grants.iter().chain(b.acl_grants.iter()).any(|g| {
+                    g.grantee_type == "Group"
+                        && g.grantee_uri
+                            .as_deref()
+                            .is_some_and(|u| u.contains("acs.amazonaws.com/groups/global/AllUsers"))
+                });
+                if acl_is_public && flags.ignore_public_acls {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::FORBIDDEN,
+                        "AccessDenied",
+                        "Access Denied: PublicAccessBlock IgnorePublicAcls is enabled",
+                    ));
+                }
+            }
+        }
+
         if obj.is_delete_marker {
             return Err(AwsServiceError::aws_error_with_fields(
                 StatusCode::NOT_FOUND,

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -1368,6 +1368,42 @@ fn get_object_nonexistent_bucket() {
     );
 }
 
+#[tokio::test]
+async fn get_object_blocked_by_pab_ignore_public_acls() {
+    let svc = make_service();
+    seed_bucket(&svc, "b");
+
+    let mut put_req = make_request(Method::PUT, "/b/k", &[], b"hello");
+    put_req
+        .headers
+        .insert("x-amz-acl", "public-read".parse().unwrap());
+    svc.put_object("123456789012", &put_req, "b", "k")
+        .await
+        .unwrap();
+
+    // Anonymous GET works before PAB is enabled.
+    let get_req = make_request(Method::GET, "/b/k", &[], b"");
+    svc.get_object("123456789012", &get_req, "b", "k").unwrap();
+
+    // Enable PAB with IgnorePublicAcls=true.
+    let pab_xml = br#"<PublicAccessBlockConfiguration><IgnorePublicAcls>true</IgnorePublicAcls></PublicAccessBlockConfiguration>"#;
+    let pab_req = make_request(Method::PUT, "/b", &[("publicAccessBlock", "")], pab_xml);
+    svc.put_public_access_block("123456789012", &pab_req, "b")
+        .unwrap();
+
+    // Anonymous GET now rejected.
+    let get_req = make_request(Method::GET, "/b/k", &[], b"");
+    assert_aws_err(
+        svc.get_object("123456789012", &get_req, "b", "k"),
+        "AccessDenied",
+    );
+
+    // Authenticated GET still allowed.
+    let mut authed = make_request(Method::GET, "/b/k", &[], b"");
+    authed.access_key_id = Some("AKIA-TEST".to_string());
+    svc.get_object("123456789012", &authed, "b", "k").unwrap();
+}
+
 #[test]
 fn get_object_nonexistent_key() {
     let svc = make_service();


### PR DESCRIPTION
## Summary
- Anonymous GetObject now rejected with AccessDenied when bucket has `IgnorePublicAcls=true` AND the object/bucket ACL grants READ to AllUsers.
- Authenticated callers unaffected.

## Test plan
- [x] Unit test: anonymous GET works before PAB; rejected after enabling IgnorePublicAcls; authed GET still works.
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces S3 PublicAccessBlock IgnorePublicAcls for anonymous GetObject requests in `fakecloud-s3`, matching real S3 behavior.

- **New Features**
  - Anonymous GET is blocked when `IgnorePublicAcls=true` and the object or bucket ACL grants READ to AllUsers; returns 403 AccessDenied.
  - Authenticated callers are unaffected.

<sup>Written for commit 6aa6ca26ab53668ca96a04b5b96e5ea40fbe8ca8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

