### PR TITLE
feat(sns): email subscriptions deliver via SMTP relay (D2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,6 +3910,7 @@ dependencies = [
  "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
+ "fakecloud-ses",
  "http 1.4.0",
  "parking_lot",
  "rand 0.8.5",

--- a/crates/fakecloud-sns/Cargo.toml
+++ b/crates/fakecloud-sns/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
+fakecloud-ses = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }

--- a/crates/fakecloud-sns/src/delivery.rs
+++ b/crates/fakecloud-sns/src/delivery.rs
@@ -224,6 +224,75 @@ mod tests {
     }
 
     #[test]
+    fn publish_email_invokes_smtp_relay_when_env_set() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut log = Vec::new();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            stream.write_all(b"220 stub\r\n").unwrap();
+            let mut in_data = false;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                let trimmed = line.trim_end().to_string();
+                log.push(trimmed.clone());
+                if in_data {
+                    if trimmed == "." {
+                        stream.write_all(b"250 ok\r\n").unwrap();
+                        in_data = false;
+                    }
+                    continue;
+                }
+                let up = trimmed.to_uppercase();
+                if up.starts_with("HELO") || up.starts_with("EHLO") {
+                    stream.write_all(b"250 hello\r\n").unwrap();
+                } else if up.starts_with("MAIL FROM") || up.starts_with("RCPT TO") {
+                    stream.write_all(b"250 ok\r\n").unwrap();
+                } else if up == "DATA" {
+                    stream.write_all(b"354 send data\r\n").unwrap();
+                    in_data = true;
+                } else if up == "QUIT" {
+                    stream.write_all(b"221 bye\r\n").unwrap();
+                    break;
+                } else {
+                    stream.write_all(b"250 ok\r\n").unwrap();
+                }
+            }
+            tx.send(log).ok();
+        });
+        // SAFETY: tests in the same process share env; setting and
+        // unsetting around the call is OK because the publish path is
+        // synchronous.
+        std::env::set_var(
+            "FAKECLOUD_SES_SMTP_RELAY",
+            format!("smtp://127.0.0.1:{port}"),
+        );
+        let (topic, arn) = make_topic("t1");
+        let sub = make_subscription(&arn, "email", "user@example.com", true);
+        let state = make_state(vec![topic], vec![sub]);
+        let bus = Arc::new(DeliveryBus::new());
+        let delivery = SnsDeliveryImpl::new(state.clone(), bus);
+        delivery.publish_to_topic(&arn, "greetings", Some("subj"));
+        std::env::remove_var("FAKECLOUD_SES_SMTP_RELAY");
+        let log = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("smtp stub did not receive mail");
+        assert!(log
+            .iter()
+            .any(|l| l.starts_with("RCPT TO:<user@example.com>")));
+        assert!(log.iter().any(|l| l == "Subject: subj"));
+        assert!(log.iter().any(|l| l == "greetings"));
+    }
+
+    #[test]
     fn publish_records_sms_delivery() {
         let (topic, arn) = make_topic("t1");
         let sub = make_subscription(&arn, "sms", "+14155550199", true);

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -800,23 +800,67 @@ pub(crate) fn deliver_to_email_subscribers(
     }
     let now = Utc::now();
     let subject_owned = ctx.subject.map(|s| s.to_string());
+    let topic_arn = ctx.topic_arn.to_string();
+    let body = ctx.default_message.to_string();
     let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
-    let mut accounts = state.write();
-    let state = accounts.get_or_create(acct);
-    for email_address in subs {
-        tracing::info!(
-            email = %email_address,
-            topic_arn = %ctx.topic_arn,
-            "SNS delivering to email (stub)"
-        );
-        state.sent_emails.push(crate::state::SentEmail {
-            email_address: email_address.clone(),
-            message: ctx.default_message.to_string(),
-            subject: subject_owned.clone(),
-            topic_arn: ctx.topic_arn.to_string(),
-            timestamp: now,
-        });
+    {
+        let mut accounts = state.write();
+        let state = accounts.get_or_create(acct);
+        for email_address in subs {
+            tracing::info!(
+                email = %email_address,
+                topic_arn = %topic_arn,
+                "SNS delivering to email"
+            );
+            state.sent_emails.push(crate::state::SentEmail {
+                email_address: email_address.clone(),
+                message: body.clone(),
+                subject: subject_owned.clone(),
+                topic_arn: topic_arn.clone(),
+                timestamp: now,
+            });
+        }
     }
+
+    // Opt-in SMTP relay: when FAKECLOUD_SES_SMTP_RELAY is set, fire the
+    // notification via plain SMTP so dev setups receive real mail in
+    // their MTA (Mailpit / MailHog). Reuses the SES helper so the
+    // behavior matches SES SendEmail.
+    if let Ok(relay_url) = std::env::var("FAKECLOUD_SES_SMTP_RELAY") {
+        let subject = subject_owned
+            .clone()
+            .unwrap_or_else(|| format!("AWS Notification - {topic_arn}"));
+        let from = format!("no-reply@sns.{}.amazonaws.com", default_region(&topic_arn));
+        for email_address in subs {
+            let to = [email_address.clone()];
+            let mail = fakecloud_ses::smtp_relay::OutboundMail {
+                from: &from,
+                to: &to,
+                cc: &[],
+                bcc: &[],
+                subject: Some(&subject),
+                text_body: Some(&body),
+                html_body: None,
+            };
+            if let Err(err) = fakecloud_ses::smtp_relay::relay(&relay_url, &mail) {
+                tracing::warn!(
+                    relay = %relay_url,
+                    email = %email_address,
+                    error = %err,
+                    "SNS email SMTP relay failed"
+                );
+            }
+        }
+    }
+}
+
+fn default_region(topic_arn: &str) -> String {
+    topic_arn
+        .split(':')
+        .nth(3)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("us-east-1")
+        .to_string()
 }
 
 pub(crate) fn deliver_to_sms_subscribers(


### PR DESCRIPTION
## Summary
- SNS email-protocol fanout now invokes `fakecloud_ses::smtp_relay` when `FAKECLOUD_SES_SMTP_RELAY` is set.
- In-memory `sent_emails` store unchanged.
- From-address: `no-reply@sns.<region>.amazonaws.com`; subject falls back to `AWS Notification - <topic-arn>`.

## Test plan
- [x] Unit test spawns a stub SMTP server, publishes to SNS email subscription, asserts RCPT/Subject/body land on the wire.
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in SMTP relay for SNS email subscriptions when FAKECLOUD_SES_SMTP_RELAY is set, so local MTAs can receive real mail. The in-memory `sent_emails` log remains the source of truth.

- **New Features**
  - From address: no-reply@sns.<region>.amazonaws.com.
  - Subject: published Subject, or "AWS Notification - <topic-arn>" if missing.

<sup>Written for commit a44697d8ebc7cae8b1c57458c3dcee58c4fa16fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

