### PR TITLE
feat(cognito): CompromisedCredentialsRiskConfiguration BLOCK enforcement (S11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,6 +2877,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha2 0.10.9",
  "tokio",
  "tower-http",
  "tracing",

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -100,6 +100,52 @@ enum AdminAuthOutcome {
 }
 
 impl CognitoService {
+    /// CompromisedCredentialsRiskConfiguration enforcement.
+    /// Returns `Err(NotAuthorizedException)` when the pool's risk
+    /// config has `Actions.EventAction = BLOCK` and the password
+    /// matches a known compromised hash.
+    pub(super) fn evaluate_compromised_credentials(
+        &self,
+        account_id: &str,
+        pool_id: &str,
+        client_id: &str,
+        password: &str,
+    ) -> Result<(), AwsServiceError> {
+        use sha2::{Digest, Sha256};
+        let accounts = self.state.read();
+        let Some(state) = accounts.get(account_id) else {
+            return Ok(());
+        };
+        // Risk config keyed by (pool, client) with a fallback to (pool, "").
+        let pool_key = format!("{pool_id}:{client_id}");
+        let pool_default = format!("{pool_id}:");
+        let cfg = state
+            .risk_configurations
+            .get(&pool_key)
+            .or_else(|| state.risk_configurations.get(&pool_default));
+        let Some(cfg) = cfg else {
+            return Ok(());
+        };
+        let action = cfg["CompromisedCredentialsRiskConfiguration"]["Actions"]["EventAction"]
+            .as_str()
+            .unwrap_or("");
+        if !action.eq_ignore_ascii_case("BLOCK") {
+            return Ok(());
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(password.as_bytes());
+        let hash = format!("{:x}", hasher.finalize());
+        if state.compromised_password_hashes.contains(&hash) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "NotAuthorizedException",
+                "Password has been found in a previous data breach. \
+                 This password cannot be used. Please use a different password.",
+            ));
+        }
+        Ok(())
+    }
+
     pub(super) async fn admin_initiate_auth(
         &self,
         req: &AwsRequest,
@@ -261,6 +307,13 @@ impl CognitoService {
         region: &str,
         req: &AwsRequest,
     ) -> Result<AdminAuthOutcome, AwsServiceError> {
+        self.evaluate_compromised_credentials(
+            &req.account_id,
+            &input.pool_id,
+            &input.client_id,
+            &input.password,
+        )?;
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -469,6 +522,14 @@ impl CognitoService {
                     "PASSWORD is required in AuthParameters",
                 )
             })?;
+
+        // CompromisedCredentialsRiskConfiguration: when the pool has a
+        // risk config with `EventAction = BLOCK` for sign-in events and
+        // the password is in the compromised-password hash set, reject
+        // with NotAuthorizedException. The hash set is populated via
+        // `/_fakecloud/cognito/compromised-passwords` for deterministic
+        // tests.
+        self.evaluate_compromised_credentials(&req.account_id, pool_id, client_id, password)?;
 
         let (user_attrs, region, account_id) = {
             let accounts = self.state.read();
@@ -2304,5 +2365,108 @@ impl CognitoService {
             .retain(|_, v| !(v.user_pool_id == pool_id && v.username == username));
 
         Ok(AwsResponse::ok_json(json!({})))
+    }
+}
+
+#[cfg(test)]
+mod risk_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_service() -> CognitoService {
+        let state = std::sync::Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+        ));
+        CognitoService::new(state)
+    }
+
+    fn seed_compromised(svc: &CognitoService, password: &str) {
+        use sha2::{Digest, Sha256};
+        let mut accounts = svc.state.write();
+        let s = accounts.get_or_create("123456789012");
+        let mut hasher = Sha256::new();
+        hasher.update(password.as_bytes());
+        let hash = format!("{:x}", hasher.finalize());
+        s.compromised_password_hashes.insert(hash);
+    }
+
+    fn seed_risk_block(svc: &CognitoService, pool_id: &str, client_id: &str) {
+        let mut accounts = svc.state.write();
+        let s = accounts.get_or_create("123456789012");
+        let key = format!("{pool_id}:{client_id}");
+        s.risk_configurations.insert(
+            key,
+            json!({
+                "CompromisedCredentialsRiskConfiguration": {
+                    "Actions": {"EventAction": "BLOCK"}
+                }
+            }),
+        );
+    }
+
+    #[test]
+    fn no_risk_config_passes() {
+        let svc = make_service();
+        seed_compromised(&svc, "Password123!");
+        let res = svc.evaluate_compromised_credentials(
+            "123456789012",
+            "pool-x",
+            "client-x",
+            "Password123!",
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn block_rejects_compromised_password() {
+        let svc = make_service();
+        seed_compromised(&svc, "Password123!");
+        seed_risk_block(&svc, "pool-x", "client-x");
+        let err = svc
+            .evaluate_compromised_credentials("123456789012", "pool-x", "client-x", "Password123!")
+            .unwrap_err();
+        match err {
+            AwsServiceError::AwsError { code, .. } => assert_eq!(code, "NotAuthorizedException"),
+            other => panic!("expected AwsError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_accepts_clean_password() {
+        let svc = make_service();
+        seed_compromised(&svc, "Password123!");
+        seed_risk_block(&svc, "pool-x", "client-x");
+        let res = svc.evaluate_compromised_credentials(
+            "123456789012",
+            "pool-x",
+            "client-x",
+            "DifferentPassword!",
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn audit_only_does_not_block() {
+        let svc = make_service();
+        seed_compromised(&svc, "Password123!");
+        {
+            let mut accounts = svc.state.write();
+            let s = accounts.get_or_create("123456789012");
+            s.risk_configurations.insert(
+                "pool-x:client-x".to_string(),
+                json!({
+                    "CompromisedCredentialsRiskConfiguration": {
+                        "Actions": {"EventAction": "NO_ACTION"}
+                    }
+                }),
+            );
+        }
+        let res = svc.evaluate_compromised_credentials(
+            "123456789012",
+            "pool-x",
+            "client-x",
+            "Password123!",
+        );
+        assert!(res.is_ok());
     }
 }

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -37,7 +37,7 @@ use crate::state::{
 use crate::triggers::CognitoDeliveryContext;
 
 pub struct CognitoService {
-    state: SharedCognitoState,
+    pub(crate) state: SharedCognitoState,
     delivery_ctx: Option<CognitoDeliveryContext>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -104,6 +104,13 @@ pub struct CognitoState {
     /// have to walk every pool.
     #[serde(default)]
     pub federated_identities: BTreeMap<String, FederatedIdentity>,
+    /// Set of compromised-password hashes (sha256 hex of plaintext).
+    /// Populated via the `/_fakecloud/cognito/compromised-passwords`
+    /// admin endpoint and consulted on `InitiateAuth`/`AdminInitiateAuth`
+    /// when a pool has CompromisedCredentialsRiskConfiguration with
+    /// `EventAction = BLOCK`.
+    #[serde(default)]
+    pub compromised_password_hashes: std::collections::BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -165,6 +172,7 @@ impl CognitoState {
             identity_pools: BTreeMap::new(),
             identity_pool_role_attachments: BTreeMap::new(),
             federated_identities: BTreeMap::new(),
+            compromised_password_hashes: std::collections::BTreeSet::new(),
         }
     }
 

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -174,6 +174,18 @@ pub struct LogsAnomalyInjectResponse {
     pub anomaly_id: String,
 }
 
+/// Admin payload for `/_fakecloud/cognito/compromised-passwords`.
+/// Plaintext passwords are hashed (sha256) and added to the
+/// compromised-credentials set consulted by `InitiateAuth` /
+/// `AdminInitiateAuth` when the pool's
+/// `CompromisedCredentialsRiskConfiguration.Actions.EventAction` is
+/// `BLOCK`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoCompromisedPasswordsRequest {
+    pub passwords: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboundEmailRequest {

--- a/crates/fakecloud-server/Cargo.toml
+++ b/crates/fakecloud-server/Cargo.toml
@@ -62,6 +62,7 @@ chrono = { workspace = true }
 md-5 = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
+sha2 = { workspace = true }
 uuid = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -4089,6 +4089,30 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/cognito/compromised-passwords",
+            axum::routing::post({
+                let cs = cognito_state.clone();
+                move |axum::Json(body): axum::Json<types::CognitoCompromisedPasswordsRequest>| {
+                    let cs = cs.clone();
+                    async move {
+                        use sha2::{Digest, Sha256};
+                        let mut mas = cs.write();
+                        let state = mas.default_mut();
+                        let mut added = 0usize;
+                        for p in body.passwords {
+                            let mut hasher = Sha256::new();
+                            hasher.update(p.as_bytes());
+                            let hash = format!("{:x}", hasher.finalize());
+                            if state.compromised_password_hashes.insert(hash) {
+                                added += 1;
+                            }
+                        }
+                        axum::Json(serde_json::json!({ "added": added }))
+                    }
+                }
+            }),
+        )
+        .route(
             "/{pool_id}/.well-known/openid-configuration",
             axum::routing::get({
                 let cs = cognito_oidc_state;


### PR DESCRIPTION
## Summary
- New per-account `compromised_password_hashes` set in CognitoState.
- `evaluate_compromised_credentials` helper consulted at the top of `initiate_user_password_auth` and `admin_auth_verify`.
- When the pool's risk config has `EventAction = BLOCK` and the password's sha256 is in the set, returns `NotAuthorizedException`.
- Admin endpoint `POST /_fakecloud/cognito/compromised-passwords` (`{passwords: [...]}`) seeds the set.

## Test plan
- [x] Unit tests: no config (passes), BLOCK+match (rejects), BLOCK+clean (passes), NO_ACTION+match (passes).
- [x] cargo clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements BLOCK enforcement for compromised credentials in Cognito auth flows (S11) and adds an admin endpoint to seed compromised password hashes.

- **New Features**
  - Per-account `compromised_password_hashes` set and `evaluate_compromised_credentials` used in `InitiateAuth` (USER_PASSWORD_AUTH) and `AdminInitiateAuth`.
  - When `EventAction = BLOCK` and the sha256 of the supplied password is in the set, return NotAuthorizedException.
  - New admin route `POST /_fakecloud/cognito/compromised-passwords` (body: `CognitoCompromisedPasswordsRequest`) hashes plaintexts and adds them to the set.

- **Dependencies**
  - Added `sha2`.

<sup>Written for commit 81f554a858b5ea5a7607198419a053c0c6727884. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

