### PR TITLE
feat(cognito): PreTokenGeneration trigger claim merge (Y8a)

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -530,7 +530,7 @@ impl CognitoService {
             }
         }
 
-        let tokens = {
+        let pretoken_setup = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
 
@@ -600,11 +600,53 @@ impl CognitoService {
                     .zip(pool.signing_kid.as_ref())
                     .map(|(p, k)| (p.clone(), k.clone()))
             });
-            let signing = pool_signing_owned
-                .as_ref()
-                .map(|(p, k)| (p.as_str(), k.as_str()));
-            let tokens = generate_tokens(pool_id, client_id, &sub, username, &region, signing);
+            (sub, pool_signing_owned)
+        };
+        let (sub, pool_signing_owned) = pretoken_setup;
 
+        let pretoken_overrides = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    pool_id,
+                    Some(client_id),
+                    username,
+                    &user_attrs,
+                    &region,
+                    &account_id,
+                );
+                triggers::invoke_trigger(ctx, &function_arn, &event)
+                    .await
+                    .and_then(|resp| resp.get("response").cloned())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let signing = pool_signing_owned
+            .as_ref()
+            .map(|(p, k)| (p.as_str(), k.as_str()));
+        let tokens = super::generate_tokens_with_overrides(
+            pool_id,
+            client_id,
+            &sub,
+            username,
+            &region,
+            signing,
+            None,
+            None,
+            pretoken_overrides.as_ref(),
+        );
+
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
             state.refresh_tokens.insert(
                 tokens.refresh_token.clone(),
                 RefreshTokenData {
@@ -635,9 +677,7 @@ impl CognitoService {
                 success: true,
                 feedback_value: None,
             });
-
-            tokens
-        };
+        }
 
         if let Some(ctx) = self.delivery_ctx.as_ref() {
             if let Some(function_arn) = triggers::get_trigger_arn(

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1560,6 +1560,31 @@ fn generate_tokens_with_scope(
     scope: Option<&str>,
     nonce: Option<&str>,
 ) -> TokenSet {
+    generate_tokens_with_overrides(
+        pool_id, client_id, sub, username, region, signing, scope, nonce, None,
+    )
+}
+
+/// Like [`generate_tokens_with_scope`] but accepts a
+/// `claimsAndScopeOverrideDetails`-shaped JSON value from a
+/// PreTokenGeneration trigger response.
+///
+/// - `idTokenGeneration.claimsToAddOrOverride` -> merged into id token
+/// - `idTokenGeneration.claimsToSuppress` -> removed from id token
+/// - `accessTokenGeneration.claimsToAddOrOverride` -> merged into access token
+/// - `groupOverrideDetails.groupsToOverride` -> set as `cognito:groups`
+#[allow(clippy::too_many_arguments)]
+fn generate_tokens_with_overrides(
+    pool_id: &str,
+    client_id: &str,
+    sub: &str,
+    username: &str,
+    region: &str,
+    signing: Option<(&str, &str)>,
+    scope: Option<&str>,
+    nonce: Option<&str>,
+    overrides: Option<&Value>,
+) -> TokenSet {
     let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
@@ -1592,14 +1617,13 @@ fn generate_tokens_with_scope(
             .expect("id_payload is always a JSON object")
             .insert("nonce".to_string(), Value::String(n.to_string()));
     }
-    let id_token = sign_jwt(&id_header, &id_payload, pem);
 
     let access_jti = Uuid::new_v4().to_string();
     let access_header = json!({"kid": kid, "alg": "RS256", "typ": "JWT"});
     let access_scope = scope
         .filter(|s| !s.is_empty())
         .unwrap_or("aws.cognito.signin.user.admin");
-    let access_payload = json!({
+    let mut access_payload = json!({
         "sub": sub,
         "iss": iss,
         "client_id": client_id,
@@ -1609,6 +1633,54 @@ fn generate_tokens_with_scope(
         "exp": now + 3600,
         "iat": now,
     });
+
+    // PreTokenGeneration trigger merge. Schema (v2):
+    //   claimsAndScopeOverrideDetails: {
+    //     idTokenGeneration:    { claimsToAddOrOverride, claimsToSuppress },
+    //     accessTokenGeneration:{ claimsToAddOrOverride, claimsToSuppress, scopesToAdd, scopesToSuppress },
+    //     groupOverrideDetails: { groupsToOverride, preferredRole, iamRolesToOverride },
+    //   }
+    // Real Cognito also accepts the v1 flat `claimsOverrideDetails` shape.
+    if let Some(ov) = overrides {
+        let v2 = &ov["claimsAndScopeOverrideDetails"];
+        let v1 = &ov["claimsOverrideDetails"];
+        let id_block = if !v2.is_null() {
+            &v2["idTokenGeneration"]
+        } else {
+            v1
+        };
+        let access_block = if !v2.is_null() {
+            &v2["accessTokenGeneration"]
+        } else {
+            v1
+        };
+        let group_block = if !v2.is_null() {
+            &v2["groupOverrideDetails"]
+        } else {
+            &v1["groupOverrideDetails"]
+        };
+        apply_claim_overrides(id_payload.as_object_mut().unwrap(), id_block);
+        apply_claim_overrides(access_payload.as_object_mut().unwrap(), access_block);
+        if let Some(arr) = group_block["groupsToOverride"].as_array() {
+            let groups: Vec<Value> = arr.iter().filter(|v| v.is_string()).cloned().collect();
+            if !groups.is_empty() {
+                id_payload["cognito:groups"] = Value::Array(groups.clone());
+                access_payload["cognito:groups"] = Value::Array(groups);
+            }
+        }
+        if let Some(arr) = access_block["scopesToAdd"].as_array() {
+            let extra: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            if !extra.is_empty() {
+                let merged = format!("{} {}", access_scope, extra.join(" "));
+                access_payload["scope"] = Value::String(merged);
+            }
+        }
+    }
+
+    let id_token = sign_jwt(&id_header, &id_payload, pem);
     let access_token = sign_jwt(&access_header, &access_payload, pem);
 
     let mut refresh_bytes = Vec::with_capacity(72);
@@ -1621,6 +1693,24 @@ fn generate_tokens_with_scope(
         id_token,
         access_token,
         refresh_token,
+    }
+}
+
+/// Merge a PreTokenGeneration claim block into a token payload.
+/// `claimsToAddOrOverride`: object whose entries are inserted (overwriting).
+/// `claimsToSuppress`: array of claim names to delete after the merge.
+fn apply_claim_overrides(map: &mut serde_json::Map<String, Value>, block: &Value) {
+    if let Some(adds) = block["claimsToAddOrOverride"].as_object() {
+        for (k, v) in adds {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    if let Some(suppress) = block["claimsToSuppress"].as_array() {
+        for v in suppress {
+            if let Some(k) = v.as_str() {
+                map.remove(k);
+            }
+        }
     }
 }
 

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -6925,3 +6925,95 @@ fn id_token_verifies_against_jwks_public_key() {
         .verify(signing_input.as_bytes(), &signature)
         .expect("ID token must verify against the JWKS-published public key");
 }
+
+#[test]
+fn pretoken_overrides_merge_into_id_and_access_tokens() {
+    use crate::service::generate_tokens_with_overrides;
+    use base64::Engine;
+
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let overrides = serde_json::json!({
+        "claimsAndScopeOverrideDetails": {
+            "idTokenGeneration": {
+                "claimsToAddOrOverride": {"custom:tier": "gold", "email": "x@y.z"},
+                "claimsToSuppress": ["jti"],
+            },
+            "accessTokenGeneration": {
+                "claimsToAddOrOverride": {"custom:tier": "gold"},
+                "scopesToAdd": ["openid", "email"],
+            },
+            "groupOverrideDetails": {
+                "groupsToOverride": ["admins", "beta"],
+            },
+        }
+    });
+
+    let tokens = generate_tokens_with_overrides(
+        "us-east-1_abc",
+        "client1",
+        "sub-1",
+        "alice",
+        "us-east-1",
+        None,
+        None,
+        None,
+        Some(&overrides),
+    );
+
+    let parts: Vec<&str> = tokens.id_token.split('.').collect();
+    let id_payload: serde_json::Value =
+        serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
+    assert_eq!(id_payload["custom:tier"], "gold");
+    assert_eq!(id_payload["email"], "x@y.z");
+    assert!(id_payload.get("jti").is_none(), "jti should be suppressed");
+    assert_eq!(
+        id_payload["cognito:groups"],
+        serde_json::json!(["admins", "beta"])
+    );
+
+    let parts: Vec<&str> = tokens.access_token.split('.').collect();
+    let access_payload: serde_json::Value =
+        serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
+    assert_eq!(access_payload["custom:tier"], "gold");
+    let scope = access_payload["scope"].as_str().unwrap();
+    assert!(scope.contains("openid"));
+    assert!(scope.contains("email"));
+    assert_eq!(
+        access_payload["cognito:groups"],
+        serde_json::json!(["admins", "beta"])
+    );
+}
+
+#[test]
+fn pretoken_v1_claims_override_details_shape() {
+    use crate::service::generate_tokens_with_overrides;
+    use base64::Engine;
+
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let overrides = serde_json::json!({
+        "claimsOverrideDetails": {
+            "claimsToAddOrOverride": {"custom:plan": "pro"},
+            "claimsToSuppress": ["aud"],
+            "groupOverrideDetails": {"groupsToOverride": ["g1"]},
+        }
+    });
+
+    let tokens = generate_tokens_with_overrides(
+        "us-east-1_abc",
+        "client1",
+        "sub-1",
+        "alice",
+        "us-east-1",
+        None,
+        None,
+        None,
+        Some(&overrides),
+    );
+
+    let parts: Vec<&str> = tokens.id_token.split('.').collect();
+    let id_payload: serde_json::Value =
+        serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
+    assert_eq!(id_payload["custom:plan"], "pro");
+    assert!(id_payload.get("aud").is_none());
+    assert_eq!(id_payload["cognito:groups"], serde_json::json!(["g1"]));
+}


### PR DESCRIPTION
## Summary
- Wire PreTokenGeneration Lambda trigger into InitiateAuth (USER_PASSWORD_AUTH).
- Merge \`claimsAndScopeOverrideDetails\` (v2) and \`claimsOverrideDetails\` (v1) into ID and access tokens.
- Honor \`claimsToAddOrOverride\`, \`claimsToSuppress\`, \`scopesToAdd\`, and \`groupsToOverride\` (-> \`cognito:groups\`).

## Test plan
- [x] \`cargo test -p fakecloud-cognito --lib pretoken\` — 2 unit tests pass.
- [x] \`cargo clippy -p fakecloud-cognito --all-targets -- -D warnings\` clean.
- [ ] CI workspace build + e2e + conformance.

Closes Y8a from parity-gaps-execution-plan-2026-05-10.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the PreTokenGeneration trigger into `InitiateAuth` (USER_PASSWORD_AUTH) and merges returned claim/scope overrides into ID and access tokens. Addresses Linear Y8a by bringing `fakecloud-cognito` closer to Cognito parity for token customization.

- **New Features**
  - Invokes the configured PreTokenGeneration Lambda before token issuance in `InitiateAuth`.
  - Adds `generate_tokens_with_overrides` and wires it into issuance.
  - Supports both `claimsAndScopeOverrideDetails` (v2) and `claimsOverrideDetails` (v1).
  - Applies `claimsToAddOrOverride` and `claimsToSuppress` to ID and access tokens.
  - Applies `scopesToAdd` to the access token `scope`.
  - Maps `groupsToOverride` to `cognito:groups` in both tokens.
  - Adds unit tests covering v1 and v2 shapes.

<sup>Written for commit fe10f8475fa979544534ec9d2976a39c8b90cae9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

