### PR TITLE
feat(introspection): PKI stub introspection endpoints (PKI-1)

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -99,6 +99,42 @@ impl AcmService {
         self.set_certificate_status(arn_or_id, "ISSUED", None)
     }
 
+    /// Return parsed-on-best-effort structural info about an imported
+    /// certificate + chain, surfaced via
+    /// `/_fakecloud/acm/certificates/{arn-or-id}/chain-info` so tests can
+    /// assert what fakecloud actually accepted at ImportCertificate.
+    ///
+    /// We deliberately do **not** anchor the chain to a real root —
+    /// fakecloud is not a PKI. The returned JSON exposes the PEM block
+    /// counts and byte lengths so callers can confirm we received the
+    /// chain they expected, plus an `external_ca_validated: false`
+    /// marker that documents the emulator gap.
+    pub fn chain_info(&self, arn_or_id: &str) -> Option<serde_json::Value> {
+        let state = self.state.read();
+        for account in state.accounts.values() {
+            let key = account
+                .certificates
+                .keys()
+                .find(|k| k.as_str() == arn_or_id || cert_id_from_arn(k) == arn_or_id)
+                .cloned()?;
+            if let Some(cert) = account.certificates.get(&key) {
+                let pem = cert.certificate_pem.as_deref().unwrap_or("");
+                let chain = cert.certificate_chain_pem.as_deref().unwrap_or("");
+                return Some(serde_json::json!({
+                    "certificate_arn": key,
+                    "certificate_pem_bytes": pem.len(),
+                    "certificate_pem_blocks": pem.matches("-----BEGIN CERTIFICATE-----").count(),
+                    "chain_pem_bytes": chain.len(),
+                    "chain_pem_blocks": chain.matches("-----BEGIN CERTIFICATE-----").count(),
+                    "external_ca_validated": false,
+                    "status": cert.status,
+                    "cert_type": cert.cert_type,
+                }));
+            }
+        }
+        None
+    }
+
     /// Flip a stored certificate's status (and optionally a failure
     /// reason). Returns `false` if no certificate matches `arn_or_id`
     /// across any account. The admin endpoint `POST

--- a/crates/fakecloud-apigatewayv2/src/service.rs
+++ b/crates/fakecloud-apigatewayv2/src/service.rs
@@ -177,6 +177,29 @@ impl ApiGatewayV2Service {
         self
     }
 
+    /// Return the stored `MutualTlsAuthentication` block for a custom
+    /// domain name, plus a marker that fakecloud accepted the trust
+    /// store URI structurally without anchoring it to a real CA.
+    ///
+    /// Surfaced via
+    /// `/_fakecloud/apigatewayv2/domain-names/{name}/mtls-info` so tests
+    /// can assert what trust store URI we received and confirm the
+    /// expected emulator gap (no external PKI validation).
+    pub fn mtls_info(&self, domain_name: &str) -> Option<serde_json::Value> {
+        let accounts = self.state.read();
+        for (_, state) in accounts.iter() {
+            if let Some(domain) = state.domain_names.get(domain_name) {
+                let mtls = domain.get("MutualTlsAuthentication").cloned();
+                return Some(serde_json::json!({
+                    "domain_name": domain_name,
+                    "mutual_tls_authentication": mtls,
+                    "external_ca_validated": false,
+                }));
+            }
+        }
+        None
+    }
+
     /// Snapshot of the WAF Count-action metrics. Keyed by
     /// `"<webacl-arn>|<rule-name>"`. Returns an empty map when WAF
     /// inspection is disabled.

--- a/crates/fakecloud-cognito/src/service/branding.rs
+++ b/crates/fakecloud-cognito/src/service/branding.rs
@@ -499,26 +499,39 @@ impl CognitoService {
             ));
         }
 
+        let mut attestation_info: Option<crate::state::WebAuthnAttestationInfo> = None;
         if let Some(att_b64) = credential["response"]["attestationObject"].as_str() {
             use base64::Engine;
             match crate::webauthn::parse_packed_attestation(att_b64) {
                 Ok(parsed) => {
+                    let mut self_attest_verified = false;
                     if let Some(cd_b64) = credential["response"]["clientDataJSON"].as_str() {
                         let cd_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
                             .decode(cd_b64.trim_end_matches('='))
                             .or_else(|_| base64::engine::general_purpose::STANDARD.decode(cd_b64));
                         if let Ok(cd_bytes) = cd_bytes {
-                            if let Err(e) =
-                                crate::webauthn::verify_packed_attestation(&parsed, &cd_bytes)
-                            {
-                                return Err(AwsServiceError::aws_error(
-                                    StatusCode::BAD_REQUEST,
-                                    "InvalidParameterException",
-                                    format!("WebAuthn attestation invalid: {e}").as_str(),
-                                ));
+                            match crate::webauthn::verify_packed_attestation(&parsed, &cd_bytes) {
+                                Ok(()) => {
+                                    self_attest_verified = parsed.x5c.is_empty();
+                                }
+                                Err(e) => {
+                                    return Err(AwsServiceError::aws_error(
+                                        StatusCode::BAD_REQUEST,
+                                        "InvalidParameterException",
+                                        format!("WebAuthn attestation invalid: {e}").as_str(),
+                                    ));
+                                }
                             }
                         }
                     }
+                    attestation_info = Some(crate::state::WebAuthnAttestationInfo {
+                        fmt: "packed".to_string(),
+                        alg: parsed.alg,
+                        signature_len: parsed.sig.len(),
+                        x5c_chain_len: parsed.x5c.len(),
+                        cose_public_key_present: parsed.cose_public_key.is_some(),
+                        self_attest_verified,
+                    });
                 }
                 Err(crate::webauthn::AttestationError::UnsupportedFormat(fmt)) => {
                     return Err(AwsServiceError::aws_error(
@@ -595,6 +608,7 @@ impl CognitoService {
             authenticator_attachment,
             authenticator_transport,
             created_at: now,
+            attestation_info,
         };
 
         let key = format!("{pool_id}:{username}");

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -133,6 +133,27 @@ pub struct WebAuthnCredential {
     pub authenticator_attachment: Option<String>,
     pub authenticator_transport: Vec<String>,
     pub created_at: DateTime<Utc>,
+    /// Parsed attestation introspection. `None` when the client did not
+    /// send `attestationObject` (some flows ship only the credential id).
+    #[serde(default)]
+    pub attestation_info: Option<WebAuthnAttestationInfo>,
+}
+
+/// What fakecloud saw when it parsed the WebAuthn `attestationObject`.
+/// Surfaced via `/_fakecloud/cognito/webauthn-credentials` so tests can
+/// assert what we accepted — including the deliberate emulator gap that
+/// `x5c` chains are taken structurally without anchoring to a real root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebAuthnAttestationInfo {
+    pub fmt: String,
+    pub alg: i64,
+    pub signature_len: usize,
+    pub x5c_chain_len: usize,
+    pub cose_public_key_present: bool,
+    /// `true` when we ran real RS256/ES256 verification against the
+    /// COSE public key; `false` when x5c was present (structurally
+    /// accepted, no PKI anchoring).
+    pub self_attest_verified: bool,
 }
 
 /// Linked external provider for a user

--- a/crates/fakecloud-e2e/tests/pki_introspection.rs
+++ b/crates/fakecloud-e2e/tests/pki_introspection.rs
@@ -1,0 +1,88 @@
+//! PKI-stub introspection endpoints. Tests assert that fakecloud exposes
+//! what it accepted from clients without claiming to validate external
+//! CA chains.
+
+mod helpers;
+
+use aws_sdk_acm::primitives::Blob;
+use helpers::TestServer;
+
+const SELF_SIGNED_PEM: &str =
+    "-----BEGIN CERTIFICATE-----\nMIIBnzCCAQgCCQ==\n-----END CERTIFICATE-----\n";
+const SELF_SIGNED_KEY: &str =
+    "-----BEGIN PRIVATE KEY-----\nMIIBnzCCAQgCCQ==\n-----END PRIVATE KEY-----\n";
+
+#[tokio::test]
+async fn acm_chain_info_exposes_block_counts_and_no_external_validation() {
+    let server = TestServer::start().await;
+    let acm = server.acm_client().await;
+
+    let chain_pem = format!("{SELF_SIGNED_PEM}{SELF_SIGNED_PEM}");
+    let imported = acm
+        .import_certificate()
+        .certificate(Blob::new(SELF_SIGNED_PEM.as_bytes()))
+        .private_key(Blob::new(SELF_SIGNED_KEY.as_bytes()))
+        .certificate_chain(Blob::new(chain_pem.as_bytes()))
+        .send()
+        .await
+        .unwrap();
+
+    let arn = imported.certificate_arn.unwrap();
+    let id = arn.rsplit('/').next().unwrap();
+
+    let info: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/acm/certificates/{}/chain-info",
+        server.endpoint(),
+        id
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    assert_eq!(info["certificate_pem_blocks"], 1);
+    assert_eq!(info["chain_pem_blocks"], 2);
+    assert_eq!(info["external_ca_validated"], false);
+    assert_eq!(info["certificate_arn"], arn);
+}
+
+#[tokio::test]
+async fn apigatewayv2_mtls_info_reports_trust_store_without_validation() {
+    let server = TestServer::start().await;
+    let api = server.apigatewayv2_client().await;
+
+    api.create_domain_name()
+        .domain_name("api.example.com")
+        .mutual_tls_authentication(
+            aws_sdk_apigatewayv2::types::MutualTlsAuthenticationInput::builder()
+                .truststore_uri("s3://my-bucket/truststore.pem")
+                .truststore_version("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let info: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/apigatewayv2/domain-names/api.example.com/mtls-info",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    assert_eq!(info["domain_name"], "api.example.com");
+    let mtls = &info["mutual_tls_authentication"];
+    let uri = mtls
+        .get("TruststoreUri")
+        .or_else(|| mtls.get("truststoreUri"));
+    assert_eq!(
+        uri.and_then(|v| v.as_str()),
+        Some("s3://my-bucket/truststore.pem"),
+        "mtls block = {mtls:?}"
+    );
+    assert_eq!(info["external_ca_validated"], false);
+}

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2379,7 +2379,8 @@ async fn main() {
     if let Some(store) = apigw_snapshot_store {
         apigw_service = apigw_service.with_snapshot_store(store);
     }
-    let v2_arc: Arc<dyn fakecloud_core::service::AwsService> = Arc::new(apigw_service);
+    let apigatewayv2_service = Arc::new(apigw_service);
+    let v2_arc: Arc<dyn fakecloud_core::service::AwsService> = apigatewayv2_service.clone();
 
     // v1 (REST APIs) shares the SigV4 service identifier `apigateway`
     // with v2; the registry is keyed by that identifier so we wrap
@@ -6202,6 +6203,63 @@ async fn main() {
                         } else {
                             axum::http::StatusCode::NOT_FOUND
                         }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/acm/certificates/{arn_or_id}/chain-info",
+            axum::routing::get({
+                let svc = acm_service.clone();
+                move |axum::extract::Path(arn_or_id): axum::extract::Path<String>| {
+                    let svc = svc.clone();
+                    async move {
+                        match svc.chain_info(&arn_or_id) {
+                            Some(v) => (axum::http::StatusCode::OK, axum::Json(v)).into_response(),
+                            None => axum::http::StatusCode::NOT_FOUND.into_response(),
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/apigatewayv2/domain-names/{name}/mtls-info",
+            axum::routing::get({
+                let svc = apigatewayv2_service.clone();
+                move |axum::extract::Path(name): axum::extract::Path<String>| {
+                    let svc = svc.clone();
+                    async move {
+                        match svc.mtls_info(&name) {
+                            Some(v) => (axum::http::StatusCode::OK, axum::Json(v)).into_response(),
+                            None => axum::http::StatusCode::NOT_FOUND.into_response(),
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/cognito/webauthn-credentials",
+            axum::routing::get({
+                let cs = cognito_state.clone();
+                move || {
+                    let cs = cs.clone();
+                    async move {
+                        let accounts = cs.read();
+                        let mut out = Vec::new();
+                        for (account_id, state) in accounts.iter() {
+                            for (pool_user_key, creds) in &state.webauthn_credentials {
+                                for c in creds {
+                                    out.push(serde_json::json!({
+                                        "account_id": account_id,
+                                        "pool_user": pool_user_key,
+                                        "credential_id": c.credential_id,
+                                        "relying_party_id": c.relying_party_id,
+                                        "attestation_info": c.attestation_info,
+                                    }));
+                                }
+                            }
+                        }
+                        axum::Json(serde_json::json!({ "credentials": out }))
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
Expose what fakecloud accepted for stubbed external-CA paths, marked \`external_ca_validated: false\`.

- \`GET /_fakecloud/acm/certificates/{arn-or-id}/chain-info\`
- \`GET /_fakecloud/apigatewayv2/domain-names/{name}/mtls-info\`
- \`GET /_fakecloud/cognito/webauthn-credentials\` — includes parsed \`attestation_info\` (fmt, alg, x5c length, cose key presence, self-attest verified flag)

Codifies emulator policy: real-verify self-signed paths, accept external-CA chains structurally + expose introspection.

## Test plan
- [x] \`cargo test -p fakecloud-e2e --test pki_introspection\` — 2 tests pass.
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [ ] Full CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PKI introspection endpoints so tests can see what fakecloud accepted for external-CA paths without real CA validation. Satisfies PKI-1 by verifying self-signed/self-attest paths and marking external CA chains as not validated.

- **New Features**
  - GET /_fakecloud/acm/certificates/{arn-or-id}/chain-info — returns PEM block counts/bytes, status, cert_type, and external_ca_validated: false.
  - GET /_fakecloud/apigatewayv2/domain-names/{name}/mtls-info — returns stored MutualTlsAuthentication and external_ca_validated: false.
  - GET /_fakecloud/cognito/webauthn-credentials — returns registered credentials with parsed attestation_info (fmt, alg, signature_len, x5c_chain_len, cose_public_key_present, self_attest_verified).

<sup>Written for commit fd613c3f41f2323ca6b0598d4e3b492d4348a1bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

