### PR TITLE
feat(cognito): GetSigningCertificate returns real X.509 (PKI-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,6 +3228,7 @@ dependencies = [
  "http 1.4.0",
  "parking_lot",
  "rand 0.8.5",
+ "rcgen",
  "rsa",
  "serde",
  "serde_json",

--- a/crates/fakecloud-cognito/Cargo.toml
+++ b/crates/fakecloud-cognito/Cargo.toml
@@ -27,3 +27,4 @@ sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 ciborium = "0.2"
+rcgen = { workspace = true }

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7017,3 +7017,27 @@ fn pretoken_v1_claims_override_details_shape() {
     assert!(id_payload.get("aud").is_none());
     assert_eq!(id_payload["cognito:groups"], serde_json::json!(["g1"]));
 }
+
+#[test]
+fn get_signing_certificate_returns_real_x509_matching_pool_jwt_key() {
+    use base64::Engine;
+    let (svc, pool_id) = setup_svc_with_pool();
+
+    let req = make_req(
+        "GetSigningCertificate",
+        &format!(r#"{{"UserPoolId":"{pool_id}"}}"#),
+    );
+    let resp = svc.get_signing_certificate(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let cert_b64 = body["Certificate"].as_str().unwrap();
+    let der = base64::engine::general_purpose::STANDARD
+        .decode(cert_b64)
+        .unwrap();
+
+    assert!(!der.is_empty(), "cert DER should be non-empty");
+    assert_eq!(&der[0..2], &[0x30, 0x82], "DER must start with SEQUENCE");
+    assert!(
+        der.windows(8).any(|w| w == b"fakeclou"),
+        "subject should mention fakecloud"
+    );
+}

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -989,9 +989,55 @@ impl CognitoService {
 
         ensure_user_pool_exists(state, pool_id)?;
 
-        // Return a placeholder self-signed certificate (base64-encoded DER)
+        // Issue a real self-signed X.509 cert bound to the pool's RSA
+        // signing key. Verifying the cert's public key against pool-issued
+        // JWTs roundtrips: the JWT was signed by the same private key
+        // whose SubjectPublicKeyInfo lives in this cert.
+        let pem = state
+            .user_pools
+            .get(pool_id)
+            .and_then(|p| p.signing_key_pem.clone())
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalErrorException",
+                    "user pool has no signing key",
+                )
+            })?;
+        drop(accounts);
+
+        let der = build_signing_cert_der(pool_id, &pem).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalErrorException",
+                "failed to build signing certificate",
+            )
+        })?;
+        let cert_b64 = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(&der)
+        };
+
         Ok(AwsResponse::ok_json(json!({
-            "Certificate": "MIICpTCCAY0CFDfakecloud000000000000000000000MA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMMCmZha2VjbG91ZDAeFw0yNjAxMDEwMDAwMDBaFw0yNzAxMDEwMDAwMDBaMBUxEzARBgNVBAMMCmZha2VjbG91ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALfakecloud00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002DAQABo1MwUTAdBgNVHQ4EFgQUfakecloud0000000000000000wHwYDVR0jBBgwFoAUfakecloud0000000000000000wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAfakecloud0000000000000000000000000000000000000"
+            "Certificate": cert_b64
         })))
     }
+}
+
+/// Build a self-signed X.509 cert whose subject is `CN=<pool_id>` and
+/// whose key is the pool's existing RSA signing key. Returns DER bytes.
+/// Returns `None` if `signing_key_pem` is not a parseable RSA PKCS#8 PEM
+/// or rcgen rejects the params.
+fn build_signing_cert_der(pool_id: &str, signing_key_pem: &str) -> Option<Vec<u8>> {
+    use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
+
+    let key_pair = KeyPair::from_pem(signing_key_pem).ok()?;
+    let mut params = CertificateParams::new(vec![pool_id.to_string()]).ok()?;
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, pool_id);
+    dn.push(DnType::OrganizationName, "fakecloud Cognito");
+    params.distinguished_name = dn;
+
+    let cert = params.self_signed(&key_pair).ok()?;
+    Some(cert.der().to_vec())
 }


### PR DESCRIPTION
## Summary
Replace hardcoded placeholder DER (literal \`fakecloud\` bytes) in \`GetSigningCertificate\` with a real self-signed X.509 cert built via \`rcgen\`, bound to the pool's existing RSA signing key.

## Test plan
- [x] \`cargo test -p fakecloud-cognito --lib get_signing_certificate\` — passes; DER parses as ASN.1 SEQUENCE; subject contains pool/fakecloud.
- [x] \`cargo clippy -p fakecloud-cognito --all-targets -- -D warnings\` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GetSigningCertificate now returns a real self‑signed X.509 certificate generated with `rcgen`, bound to the pool’s existing RSA signing key. This replaces the placeholder and lets clients verify pool-issued JWTs against the cert’s public key.

- **New Features**
  - Returns base64-encoded DER; subject is CN=<pool_id>, O=fakecloud Cognito.
  - Fails with InternalError if the pool has no signing key or cert creation fails.
  - Added a unit test that checks DER shape and subject.

- **Dependencies**
  - Added `rcgen` for X.509 certificate generation.

<sup>Written for commit fa80e0998301a9535e6c3f6ef8c9310712892368. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

