### PR TITLE
feat(kms): real ECDSA P-521 + drop fake-bytes Sign/Verify (PKI-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,6 +3652,7 @@ dependencies = [
  "k256",
  "p256 0.13.2",
  "p384",
+ "p521",
  "parking_lot",
  "rand 0.8.5",
  "rsa",
@@ -5690,6 +5691,20 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
 

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -32,3 +32,4 @@ signature = "2"
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 p384 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 k256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
+p521 = { version = "0.13", features = ["ecdsa", "pkcs8"] }

--- a/crates/fakecloud-kms/src/asym_ecdsa.rs
+++ b/crates/fakecloud-kms/src/asym_ecdsa.rs
@@ -1,10 +1,10 @@
 //! Real ECDSA Sign/Verify for KMS asymmetric specs.
 //!
 //! AWS KMS supports four ECDSA curves: NIST P-256, P-384, P-521, and
-//! SECG (Bitcoin's secp256k1). We implement P-256, P-384, and P-256K1
-//! against the `p256` / `p384` / `k256` crates. P-521 has no widely
-//! used pure-Rust ECDSA crate at this version, so it falls through to
-//! the legacy fake-bytes path documented in `service_crypto.rs`.
+//! SECG (Bitcoin's secp256k1). All four are implemented end-to-end here
+//! against the `p256` / `p384` / `p521` / `k256` crates — there is no
+//! legacy fake-bytes path. SM2 is not currently supported and is
+//! refused at CreateKey.
 
 use rsa::sha2::{Sha256, Sha384};
 use signature::{Signer, Verifier};
@@ -59,6 +59,23 @@ pub fn generate_keypair(key_spec: &str) -> Result<Option<KeyPair>, EcdsaError> {
             let pub_der = vk
                 .to_public_key_der()
                 .map_err(|e| EcdsaError::CryptoFailure(format!("p384 spki encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            Ok(Some((priv_der, pub_der)))
+        }
+        "ECC_NIST_P521" => {
+            use p521::pkcs8::{EncodePrivateKey as _, EncodePublicKey as _};
+            let mut rng = rand::thread_rng();
+            let secret = p521::SecretKey::random(&mut rng);
+            let priv_der = secret
+                .to_pkcs8_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("p521 pkcs8 encode: {e}")))?
+                .as_bytes()
+                .to_vec();
+            let pub_der = secret
+                .public_key()
+                .to_public_key_der()
+                .map_err(|e| EcdsaError::CryptoFailure(format!("p521 spki encode: {e}")))?
                 .as_bytes()
                 .to_vec();
             Ok(Some((priv_der, pub_der)))
@@ -142,6 +159,25 @@ pub fn sign(
                 Ok(sig.to_der().as_bytes().to_vec())
             }
         }
+        ("ECC_NIST_P521", "ECDSA_SHA_512") => {
+            use p521::pkcs8::DecodePrivateKey as _;
+            let secret = p521::SecretKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p521 decode: {e}")))?;
+            let sk = p521::ecdsa::SigningKey::from_slice(&secret.to_bytes())
+                .map_err(|e| EcdsaError::CorruptKey(format!("p521 SigningKey: {e}")))?;
+            let sig: p521::ecdsa::Signature = if message_is_digest {
+                // KMS MessageType=DIGEST passes the pre-hashed message.
+                // p521 ECDSA in this crate version hashes internally,
+                // so signing a digest here would double-hash. We only
+                // support the hash-the-message path end-to-end.
+                return Err(EcdsaError::UnsupportedAlgorithm(
+                    "ECC_NIST_P521 MessageType=DIGEST not supported in this fakecloud build".into(),
+                ));
+            } else {
+                sk.sign(message)
+            };
+            Ok(sig.to_der().as_bytes().to_vec())
+        }
         _ => Err(EcdsaError::UnsupportedAlgorithm(format!(
             "{key_spec}/{signing_algorithm}"
         ))),
@@ -216,6 +252,24 @@ pub fn verify(
             } else {
                 Ok(vk.verify(message, &sig).is_ok())
             }
+        }
+        ("ECC_NIST_P521", "ECDSA_SHA_512") => {
+            use p521::pkcs8::DecodePrivateKey as _;
+            let secret = p521::SecretKey::from_pkcs8_der(priv_der)
+                .map_err(|e| EcdsaError::CorruptKey(format!("p521 decode: {e}")))?;
+            let sk = p521::ecdsa::SigningKey::from_slice(&secret.to_bytes())
+                .map_err(|e| EcdsaError::CorruptKey(format!("p521 SigningKey: {e}")))?;
+            let vk: p521::ecdsa::VerifyingKey = (&sk).into();
+            let sig = match p521::ecdsa::Signature::from_der(signature) {
+                Ok(s) => s,
+                Err(_) => return Ok(false),
+            };
+            if message_is_digest {
+                return Err(EcdsaError::UnsupportedAlgorithm(
+                    "ECC_NIST_P521 MessageType=DIGEST not supported in this fakecloud build".into(),
+                ));
+            }
+            Ok(vk.verify(message, &sig).is_ok())
         }
         _ => Err(EcdsaError::UnsupportedAlgorithm(format!(
             "{key_spec}/{signing_algorithm}"
@@ -309,9 +363,26 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_curve_returns_none_for_keypair() {
-        // P-521 is currently out of scope here.
-        assert!(generate_keypair("ECC_NIST_P521").unwrap().is_none());
+    fn p521_sign_verify_roundtrip_with_message() {
+        let (priv_der, _) = generate_keypair("ECC_NIST_P521").unwrap().unwrap();
+        let msg = b"hello p521";
+        let sig = sign("ECC_NIST_P521", &priv_der, "ECDSA_SHA_512", msg, false).unwrap();
+        assert!(verify(
+            "ECC_NIST_P521",
+            &priv_der,
+            "ECDSA_SHA_512",
+            msg,
+            &sig,
+            false
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn sm2_keypair_returns_none() {
+        // SM2 is the Chinese GM standard; we refuse it at CreateKey
+        // rather than fake the signing path.
+        assert!(generate_keypair("SM2").unwrap().is_none());
     }
 
     #[test]

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -521,6 +521,25 @@ impl KmsService {
             asym_pub = Some(k);
         }
 
+        // Refuse asymmetric specs we cannot really generate keys for
+        // rather than store a no-DER key that would later fall through
+        // to a fake-bytes Sign/Verify path. SM2 currently has no
+        // pure-Rust impl wired in.
+        let is_asymmetric = input.key_spec.starts_with("ECC_")
+            || input.key_spec.starts_with("RSA_")
+            || input.key_spec == "SM2";
+        if is_asymmetric && asym_priv.is_none() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UnsupportedOperationException",
+                format!(
+                    "KeySpec '{}' is not supported by this fakecloud build; \
+                     no fake-signature fallback is provided",
+                    input.key_spec
+                ),
+            ));
+        }
+
         let key = KmsKey {
             key_id: key_id.clone(),
             arn: arn.clone(),

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -382,47 +382,45 @@ impl KmsService {
 
         let message_is_digest = body["MessageType"].as_str() == Some("DIGEST");
 
-        let signature_bytes = if let Some(priv_der) = &key.asymmetric_private_key_der {
-            if signing_algorithm.starts_with("ECDSA") {
-                super::asym_ecdsa::sign(
-                    &key.key_spec,
-                    priv_der,
-                    signing_algorithm,
-                    &message_bytes,
-                    message_is_digest,
+        let priv_der = key.asymmetric_private_key_der.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UnsupportedOperationException",
+                format!(
+                    "KeySpec '{}' has no signing key material in this fakecloud build",
+                    key.key_spec
+                ),
+            )
+        })?;
+        let signature_bytes = if signing_algorithm.starts_with("ECDSA") {
+            super::asym_ecdsa::sign(
+                &key.key_spec,
+                priv_der,
+                signing_algorithm,
+                &message_bytes,
+                message_is_digest,
+            )
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("Sign failed: {e}"),
                 )
-                .map_err(|e| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "ValidationException",
-                        format!("Sign failed: {e}"),
-                    )
-                })?
-            } else {
-                super::asym::rsa_sign(
-                    priv_der,
-                    signing_algorithm,
-                    &message_bytes,
-                    message_is_digest,
-                )
-                .map_err(|e| {
-                    AwsServiceError::aws_error(
-                        StatusCode::BAD_REQUEST,
-                        "ValidationException",
-                        format!("Sign failed: {e}"),
-                    )
-                })?
-            }
+            })?
         } else {
-            // Legacy fake-bytes path for specs whose real-crypto branch
-            // hasn't landed yet (P-521, SM2). Keeps the rest of the
-            // surface working until later G batches replace this with
-            // real-crypto paths.
-            let sig_data = format!(
-                "fakecloud-sig:{}:{}:{}",
-                key.key_id, signing_algorithm, message_b64
-            );
-            sig_data.into_bytes()
+            super::asym::rsa_sign(
+                priv_der,
+                signing_algorithm,
+                &message_bytes,
+                message_is_digest,
+            )
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("Sign failed: {e}"),
+                )
+            })?
         };
 
         let signature_b64 = base64::engine::general_purpose::STANDARD.encode(&signature_bytes);
@@ -481,38 +479,35 @@ impl KmsService {
             .unwrap_or_default();
         let message_is_digest = body["MessageType"].as_str() == Some("DIGEST");
 
-        let signature_valid = if let Some(priv_der) = &key.asymmetric_private_key_der {
-            if signing_algorithm.starts_with("ECDSA") {
-                super::asym_ecdsa::verify(
-                    &key.key_spec,
-                    priv_der,
-                    signing_algorithm,
-                    &message_bytes,
-                    &signature_bytes,
-                    message_is_digest,
-                )
-                .unwrap_or(false)
-            } else {
-                super::asym::rsa_verify(
-                    priv_der,
-                    signing_algorithm,
-                    &message_bytes,
-                    &signature_bytes,
-                    message_is_digest,
-                )
-                .unwrap_or(false)
-            }
+        let priv_der = key.asymmetric_private_key_der.as_ref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "UnsupportedOperationException",
+                format!(
+                    "KeySpec '{}' has no signing key material in this fakecloud build",
+                    key.key_spec
+                ),
+            )
+        })?;
+        let signature_valid = if signing_algorithm.starts_with("ECDSA") {
+            super::asym_ecdsa::verify(
+                &key.key_spec,
+                priv_der,
+                signing_algorithm,
+                &message_bytes,
+                &signature_bytes,
+                message_is_digest,
+            )
+            .unwrap_or(false)
         } else {
-            // Legacy fake-bytes verify (paired with the legacy Sign
-            // path above). Replaced spec-by-spec as later G batches
-            // ship real crypto for ECDSA / ECDH-derived specs.
-            let expected_sig_data = format!(
-                "fakecloud-sig:{}:{}:{}",
-                key.key_id, signing_algorithm, message_b64
-            );
-            let expected_signature_b64 =
-                base64::engine::general_purpose::STANDARD.encode(expected_sig_data.as_bytes());
-            signature_b64 == expected_signature_b64
+            super::asym::rsa_verify(
+                priv_der,
+                signing_algorithm,
+                &message_bytes,
+                &signature_bytes,
+                message_is_digest,
+            )
+            .unwrap_or(false)
         };
 
         if !signature_valid {


### PR DESCRIPTION
## Summary
- Implement real ECDSA P-521 via \`p521\` crate (SecretKey pkcs8 ser/deser + ECDSA sign/verify).
- Refuse SM2 at CreateKey with \`UnsupportedOperationException\`.
- Drop legacy \`fakecloud-sig:<keyid>:<alg>:<msg>\` fake-bytes path in Sign / Verify.
- Any asymmetric SIGN_VERIFY spec without backing DER now errors at CreateKey rather than falling through to a fake roundtrip.

## Behavior change
\`ECC_NIST_P521\` keys now produce real ECDSA signatures verifiable externally against GetPublicKey output. P-521 with MessageType=DIGEST is not yet supported (the p521 crate's ECDSA wrapper hashes internally) — callers must send the raw message.

## Test plan
- [x] \`cargo test -p fakecloud-kms\` — 175 tests pass including new \`p521_sign_verify_roundtrip\` + \`sm2_keypair_returns_none\`.
- [x] \`cargo clippy -p fakecloud-kms --all-targets -- -D warnings\` clean.
- [x] Workspace builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements real ECDSA P‑521 sign/verify using the `p521` crate and removes the fake‑bytes fallback (PKI‑3). P‑521 signatures are now externally verifiable; unsupported asymmetric specs are rejected instead of faked.

- **New Features**
  - Real P‑521 key generation and ECDSA sign/verify via `p521` with PKCS#8/SPKI DER.
  - External verification of `GetPublicKey` + P‑521 signatures now works.

- **Migration**
  - Use MessageType=RAW for P‑521; DIGEST is not supported.
  - Do not use SM2; CreateKey returns UnsupportedOperationException.
  - Remove reliance on the old "fakecloud-sig:<...>" behavior; specs without real key material now error at CreateKey/Sign/Verify.

<sup>Written for commit 2c54782ddea08edc6f77fee1a1df290d3a6faac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

