### PR TITLE
docs(s3): sync docs + SDK helpers (B6)

### DIFF
--- a/website/content/docs/services/s3.md
+++ b/website/content/docs/services/s3.md
@@ -9,7 +9,7 @@ fakecloud implements **107 of 107** S3 operations at 100% Smithy conformance.
 ## Supported features
 
 - **Objects** — GET/PUT/DELETE/HEAD, versioning, delete markers, metadata, tags, ACLs
-- **Multipart uploads** — full lifecycle; resumable across restarts in persistent mode
+- **Multipart uploads** — full lifecycle; resumable across restarts in persistent mode. `CompleteMultipartUpload` emits `s3:ObjectCreated:CompleteMultipartUpload` with the full-object checksum.
 - **Lifecycle** — expiration and storage class transitions via `/_fakecloud/s3/lifecycle-processor/tick`
 - **Notifications** — delivery to SNS, SQS, Lambda, and EventBridge on object create/delete
 - **Versioning** — enable/suspend, list object versions, delete specific versions
@@ -17,6 +17,11 @@ fakecloud implements **107 of 107** S3 operations at 100% Smithy conformance.
 - **Bucket subresources** — policy, CORS, lifecycle, logging, website, public access block, object lock, replication, ownership, inventory, encryption, accelerate, request payment, tagging
 - **Object Lock** — legal hold, retention modes
 - **Website hosting** — index/error documents, redirect rules
+- **Access Points** — full control plane (`CreateAccessPoint`, `GetAccessPoint`, `DeleteAccessPoint`, `ListAccessPoints`) via the `s3-control` host prefix; data plane traffic to `s3-accesspoint.<region>` resolves the alias to its underlying bucket so standard S3 operations work unchanged.
+- **S3 Select** — real `SelectObjectContent` over CSV/JSON via EventStream framing (`Records`, `Stats`, `End` messages).
+- **Object Lambda** — `WriteGetObjectResponse` actually stores the transformed body + metadata against the original request token; the next `GetObject` on the access point returns the transformed payload.
+- **Public Access Block** — `IgnorePublicAcls` is enforced on `GetObject`; public-read ACL grants are ignored when the bucket-level block is set.
+- **ACL ownership modes** — `BucketOwnerEnforced` disables ACLs entirely (all ACL writes rejected, reads return owner-only).
 
 ## Protocol
 

--- a/website/content/local-s3-for-tests.md
+++ b/website/content/local-s3-for-tests.md
@@ -15,7 +15,7 @@ Point your AWS SDK at `http://localhost:4566`.
 
 ## Why fakecloud for S3
 
-- **107 S3 operations** at 100% conformance — buckets, objects, multipart uploads, versioning, lifecycle, CORS, notifications, object lock, replication, website hosting.
+- **107 S3 operations** at 100% conformance — buckets, objects, multipart uploads, versioning, lifecycle, CORS, notifications, object lock, replication, website hosting, access points, S3 Select, Object Lambda.
 - **Real cross-service triggers.** S3 notifications fire SNS, SQS, and Lambda for real. `PutObject` -> Lambda invocation happens end-to-end.
 - **Any AWS SDK in any language.** Real HTTP server on port 4566 — Python boto3, Node aws-sdk, Go aws-sdk-go-v2, Java, Kotlin, Rust, PHP, AWS CLI all work.
 - **No Docker required** for S3 itself (binary runs the storage engine in-process).
@@ -121,7 +121,15 @@ aws --endpoint-url http://localhost:4566 s3api put-bucket-notification-configura
   }'
 ```
 
-Now `PutObject` fires the Lambda for real — not a stub. fakecloud runs Lambda code in real runtime containers across 23 runtimes.
+Now `PutObject` fires the Lambda for real — not a stub. fakecloud runs Lambda code in real runtime containers across 23 runtimes. `CompleteMultipartUpload` fires its own `s3:ObjectCreated:CompleteMultipartUpload` event with the full-object checksum attached.
+
+## Access Points, S3 Select, Object Lambda
+
+- **Access Points.** Create via `s3-control.<region>` host, then read/write via `s3-accesspoint.<region>` — fakecloud resolves the alias to the underlying bucket so any AWS SDK that targets access point endpoints works unchanged.
+- **S3 Select.** `SelectObjectContent` over CSV/JSON returns a real EventStream (`Records`/`Stats`/`End` frames), not a stubbed full-object download.
+- **Object Lambda.** `WriteGetObjectResponse` stores the transformed body and metadata against the request token; the next `GetObject` on the access point serves the transformed payload.
+- **Public Access Block.** `IgnorePublicAcls` is enforced on `GetObject` so misconfigured public ACLs stop being readable the moment you set the bucket-level block.
+- **BucketOwnerEnforced.** ACLs can be turned off entirely; ACL writes are rejected and reads return owner-only, matching real S3.
 
 ## How it differs from alternatives
 


### PR DESCRIPTION
## Summary

Batch B6 of the sync-audit: bring S3 docs in line with recent shipped features.

- `website/content/docs/services/s3.md`: add Access Points (control + data plane, #1275), real SelectObjectContent EventStream (#1244), real WriteGetObjectResponse (#1245), PublicAccessBlock IgnorePublicAcls enforcement on GetObject (#1294), BucketOwnerEnforced ACL mode (#907/#908), CompleteMultipartUpload event + checksum (#910).
- `website/content/local-s3-for-tests.md`: mirror the same surface for the SEO landing page.
- No SDK helpers added: PR #1275 did not ship an access-points introspection endpoint under `/_fakecloud/s3/*`, so there's nothing for the SDKs to wrap. The only S3 introspection endpoints remain `/_fakecloud/s3/notifications` and `/_fakecloud/s3/lifecycle-processor/tick`, which already have SDK coverage.

## Test plan

- [x] docs render (markdown only, no build needed)
- [x] no `crates/` or `parity.md` touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs S3 docs and the local S3 testing page with the latest shipped features. No SDK helpers were added because S3 introspection endpoints did not change.

- **New Features**
  - Access Points: control plane via `s3-control`; data plane via `s3-accesspoint.<region>` resolving to the bucket.
  - S3 Select: real `SelectObjectContent` EventStream with `Records`, `Stats`, and `End`.
  - Object Lambda: `WriteGetObjectResponse` persists transformed body/metadata; next `GetObject` returns it.
  - Public Access Block: `IgnorePublicAcls` enforced on `GetObject`.
  - ACL mode: `BucketOwnerEnforced` disables ACLs; writes rejected; reads owner-only.
  - Multipart: `CompleteMultipartUpload` emits `s3:ObjectCreated:CompleteMultipartUpload` with full-object checksum.
  - Local S3 page updated to mirror these features; S3 introspection endpoints unchanged (`/_fakecloud/s3/notifications`, `/_fakecloud/s3/lifecycle-processor/tick`).

<sup>Written for commit 9007ccb18f439d47fabd9453545f8bc0a9909796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

