### PR TITLE
docs(apigateway): sync v1+v2 docs with shipped features (B3)

### DIFF
--- a/website/content/docs/services/apigateway.md
+++ b/website/content/docs/services/apigateway.md
@@ -12,12 +12,13 @@ REST APIs (v1) and HTTP APIs (v2) are independent AWS services. The v2 (HTTP API
 
 - **REST APIs** — CreateRestApi, GetRestApi(s), UpdateRestApi, PutRestApi (OpenAPI overwrite/merge), ImportRestApi, DeleteRestApi
 - **Resources & methods** — full CRUD; nested paths; method requests/responses
-- **Integrations** — `MOCK`, `HTTP`/`HTTP_PROXY`, `AWS_PROXY` (Lambda); integration responses
-- **Deployments & stages** — CreateDeployment auto-creates a stage when `stageName` is set; cache flush operations
-- **Models & request validators** — schema management; validator CRUD
-- **Authorizers** — TOKEN, REQUEST, COGNITO_USER_POOLS shapes
+- **Integrations** — `MOCK`, `HTTP`/`HTTP_PROXY`, `AWS_PROXY` (Lambda), AWS direct service integrations (`AWS`), `VPC_LINK`; request + response templates with VTL evaluation; integration responses
+- **Deployments & stages** — CreateDeployment auto-creates a stage when `stageName` is set; cache flush operations; stage variables
+- **Models & request validators** — schema management; validator CRUD; body/parameter validation enforced at the data plane
+- **Authorizers** — TOKEN and REQUEST invoke real Lambda authorizer functions; COGNITO_USER_POOLS validates real RS256 JWTs against the user pool's JWKS (issuer, expiry, audience, signature)
 - **API keys & usage plans** — CRUD + association via `usage_plan_keys`; data plane enforces `apiKeyRequired`, plan-level `throttle` (token-bucket per key+plan), method-level overrides under `apiStages[].throttle["{path}/{HTTP_METHOD}"]` (including the `/*/*` wildcard), and `quota` (DAY/WEEK/MONTH counters)
-- **VPC links, domain names, base path mappings, client certificates** — full CRUD
+- **VPC links, domain names, base path mappings, client certificates** — full CRUD; custom domains route to APIs via base path mapping
+- **Binary media types** — request/response bodies for configured `binaryMediaTypes` are base64-encoded into the Lambda proxy event and decoded from the integration response
 - **Documentation parts/versions** — full CRUD
 - **Gateway responses** — full CRUD
 - **Tags** — TagResource/UntagResource/GetTags
@@ -28,9 +29,13 @@ REST APIs (v1) and HTTP APIs (v2) are independent AWS services. The v2 (HTTP API
 
 When a request arrives at a deployed stage URL (`/restapis/{api_id}/{stage}/{path...}` or via the configured stage), fakecloud walks the resource tree, picks the matching method/integration, and dispatches:
 
-- `AWS_PROXY` — invokes the target Lambda via the same `DeliveryBus` used elsewhere; builds the v1.0 Lambda proxy event envelope (`event.version = "1.0"`, `requestContext.identity`, `multiValueHeaders`, `multiValueQueryStringParameters`, `pathParameters`, `stageVariables`, base64 body when binary).
+- `AWS_PROXY` — invokes the target Lambda via the same `DeliveryBus` used elsewhere; builds the v1.0 Lambda proxy event envelope (`event.version = "1.0"`, `requestContext.identity`, `multiValueHeaders`, `multiValueQueryStringParameters`, `pathParameters`, `stageVariables`, base64 body when the request content-type matches a configured `binaryMediaType`).
 - `HTTP` / `HTTP_PROXY` — forwards via `reqwest` to the configured URI.
-- `MOCK` — returns an empty JSON body unless an integration response template overrides it.
+- `AWS` — direct AWS service integration; the URI is parsed for service/action and dispatched to the in-process service handler (no SigV4 round-trip).
+- `VPC_LINK` — connection ID resolves to the configured VPC link target URL; request is forwarded the same way `HTTP` is, with the VPC link as the backend.
+- `MOCK` — request template selects the integration response; response templates apply VTL substitution over `$input`, `$context`, and `$stageVariables` to build the body.
+
+Request validators (`validateRequestBody`, `validateRequestParameters`) run before the integration: missing required headers/query parameters and JSON bodies that fail the attached model schema short-circuit with `400 BadRequestException`. Stage variables are exposed to integration URIs (`${stageVariables.name}`) and to VTL templates. TOKEN/REQUEST authorizers invoke the configured Lambda and cache the policy by `identitySource` for `authorizerResultTtlInSeconds`; COGNITO_USER_POOLS authorizers fetch the user pool's JWKS, verify the JWT's RS256 signature, issuer, expiry, and (if configured) audience, and expose claims under `requestContext.authorizer.claims`.
 
 Before the integration runs, methods with `apiKeyRequired = true` go through the API key + usage plan gate: an `x-api-key` header is required, the value is matched against `state.api_keys` (must be enabled), and the first usage plan whose `apiStages[]` contains `(api_id, stage)` is selected. Throttle resolution prefers the matched apiStage's `throttle["{resource_path}/{HTTP_METHOD}"]` override (with `/*/*` honored as the catch-all) over the plan-level `throttle`; the chosen `(rateLimit, burstLimit)` drives a token-bucket whose meter key includes the override path so per-method buckets stay segregated. The plan's `quota` (DAY/WEEK/MONTH counter against `limit`, with `offset` shifting the period boundary) is enforced after throttle. Failures return `403 ForbiddenException` and `429 LimitExceededException` respectively, matching the AWS wire shape.
 
@@ -45,6 +50,9 @@ REST-style URL dispatch. fakecloud's facade routes `/restapis/...`, `/apikeys`, 
 ## Cross-service delivery
 
 - **API Gateway v1 -> Lambda** — REST API methods with `AWS_PROXY` integrations invoke Lambda functions with proxy event v1.0 format
+- **API Gateway v1 -> Lambda (authorizers)** — TOKEN and REQUEST authorizers invoke real Lambda functions and honor the returned IAM policy + context
+- **API Gateway v1 -> Cognito** — COGNITO_USER_POOLS authorizers fetch the configured user pool's JWKS and verify caller JWTs end-to-end
+- **API Gateway v1 -> AWS services** — `AWS` integrations dispatch to in-process service handlers (SQS, SNS, DynamoDB, S3, ...) without leaving the process
 
 ## Why this matters
 
@@ -58,7 +66,7 @@ LocalStack paywalls API Gateway v1. fakecloud implements the full REST API surfa
 
 ## Limitations
 
-- The data plane is partially implemented. `MOCK`, `HTTP`/`HTTP_PROXY`, and `AWS_PROXY` (Lambda) integrations work. AWS direct service integrations, VTL templates, VPC_LINK resolution, binary media types, and gateway response customization are either stubbed or not yet implemented.
+- Gateway response customization (per-`responseType` template overrides) renders the default response body; the AWS catalog of templated error shapes is not yet substituted.
 
 ## Source
 

--- a/website/content/docs/services/apigatewayv2.md
+++ b/website/content/docs/services/apigatewayv2.md
@@ -9,12 +9,14 @@ fakecloud implements **103 of 103** API Gateway v2 operations at 100% conformanc
 ## Supported features
 
 - **HTTP APIs** — CreateApi, UpdateApi, DeleteApi, GetApis
-- **WebSocket APIs** — CreateApi with `protocolType=WEBSOCKET`, live data plane upgrade endpoint
-- **Routes** — path parameters, wildcards, HTTP method routing
-- **Integrations** — Lambda proxy (v2.0 format), HTTP proxy, Mock integration
-- **Stages** — CRUD, deployments, default stage
-- **Authorizers** — JWT (OIDC issuers, audience validation) and Lambda authorizers
+- **WebSocket APIs** — CreateApi with `protocolType=WEBSOCKET`, live data plane upgrade endpoint, `$connect` / `$disconnect` / `$default` route dispatch to Lambda
+- **Routes** — path parameters, wildcards, HTTP method routing; stage variable substitution in integration URIs and route keys
+- **Integrations** — Lambda proxy (v2.0 format), HTTP proxy, Mock integration, AWS service integrations dispatched in-process
+- **Stages** — CRUD, deployments, default stage; stage variables exposed to integrations and access logs
+- **Authorizers** — JWT validated with real RS256 verification against the issuer's JWKS (audience, expiry, scope); REQUEST Lambda authorizers invoke real functions and cache by `identitySource`
+- **Custom domain names + API mappings** — `ApiMapping` resolves host header to the right API + stage at request time
 - **CORS** — configuration on routes and globally
+- **Access logs** — per-stage `accessLogSettings` deliver formatted log events to the configured CloudWatch Logs log group
 - **Request history** — every request served is recorded for introspection
 - **Deployments** — CreateDeployment, GetDeployments
 - **Management API** — `apigatewaymanagementapi` ops (PostToConnection, GetConnection, DeleteConnection) at `/@connections/{id}` and `/{stage}/@connections/{id}`
@@ -31,14 +33,14 @@ REST for management, path-based routing for the executed API. WebSocket APIs upg
 ## Cross-service delivery
 
 - **API Gateway v2 -> Lambda** — HTTP API routes invoke Lambda functions with proxy integration v2.0 event format
+- **API Gateway v2 -> Lambda (authorizers)** — REQUEST (Lambda) authorizers invoke real functions; policy + context returned drive the request decision
+- **API Gateway v2 -> JWT issuers** — JWT authorizers fetch the configured issuer's JWKS and verify caller tokens (RS256 signature, expiry, audience, scope)
+- **API Gateway v2 -> CloudWatch Logs** — stage access logs delivered to the configured log group with the formatted access log line
+- **API Gateway v2 -> AWS services** — AWS service integrations dispatch to in-process service handlers
 
 ## Why this matters
 
 LocalStack paywalls API Gateway v2. fakecloud implements the full HTTP API surface free, with real route matching, real Lambda proxy integration, and full request introspection. Webhook testing for event-driven applications is fully supported.
-
-## Limitations
-
-- The data plane is partially implemented. WebSocket support (`$connect`/`$disconnect`/`$default`), Lambda proxy integration, and HTTP proxy integration work. JWT authorizer enforcement, Lambda authorizer enforcement, AWS service integrations, stage-variable substitution, custom-domain `ApiMapping`, and access log delivery are either stubbed or partially implemented.
 
 ## Source
 


### PR DESCRIPTION
## Summary

Docs-only sync for API Gateway v1 and v2 — bring website docs in line with shipped features.

### v1 (`apigateway.md`)
- Drop \"stub authorizer\" language. TOKEN/REQUEST now invoke real Lambda; COGNITO_USER_POOLS validates real RS256 JWTs against the pool JWKS.
- Document VTL evaluator + MOCK/HTTP request+response templates, AWS direct service integrations, VPC_LINK, binary media types, custom domains + base path mapping, request validators.
- Remove stale \"data plane partially implemented\" limitation block; replace with a narrower gateway-response caveat.

### v2 (`apigatewayv2.md`)
- Document real JWT authorizers (RS256 JWKS verification), real Lambda authorizers, stage variables, custom domain `ApiMapping` routing, AWS service integrations, CloudWatch Logs access log delivery, and WebSocket `\$connect`/`\$disconnect`/`\$default` routing.
- Drop the \"partially implemented\" data plane limitation block — everything called out as stubbed is now real.

Op counts already current (v1: 124/124, v2: 103/103).

## Test plan

- [ ] Render the site and eyeball both pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync API Gateway v1 and v2 docs with shipped data‑plane features. Adds coverage for JWT (RS256 JWKS) and Lambda authorizers, `AWS` service integrations and `VPC_LINK`, VTL request/response templates and stage variables, request validators and binary media types (v1), custom domains + API mappings, access logs (v2), and WebSocket `$connect`/`$disconnect`/`$default`; removes the old “partially implemented” notes and narrows v1’s caveat to gateway responses.

<sup>Written for commit dafb42c10da646050f305de68bb0d2a690d733e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

