### PR TITLE
docs(kms): sync docs with shipped features (B8)

### DIFF
--- a/website/content/docs/services/kms.md
+++ b/website/content/docs/services/kms.md
@@ -8,10 +8,12 @@ fakecloud implements **53 of 53** KMS operations at 100% Smithy conformance.
 
 ## Supported features
 
-- **Symmetric keys** — CreateKey, Encrypt, Decrypt, GenerateDataKey, ReEncrypt
-- **Asymmetric keys** — Sign, Verify, GetPublicKey
+- **Symmetric keys** — CreateKey, Encrypt, Decrypt, GenerateDataKey, ReEncrypt. Real AES-256-GCM envelope encryption with AWS-shaped ciphertext blobs (key id header + IV + ciphertext + tag).
+- **Asymmetric keys** — Sign, Verify, GetPublicKey across:
+  - **RSA** — RSA_2048, RSA_3072, RSA_4096 with real RSA Sign/Verify/GetPublicKey
+  - **ECC** — ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, and ECC_SECG_P256K1 with real ECDSA Sign/Verify/GetPublicKey
 - **Key management** — DescribeKey, EnableKey, DisableKey, ScheduleKeyDeletion, CancelKeyDeletion
-- **Aliases** — CRUD with `alias/` prefix validation
+- **Aliases** — CRUD with `alias/` prefix validation. Accepted anywhere a key id/ARN is accepted (Encrypt, Decrypt, Sign, Verify, GenerateDataKey, ReEncrypt, grants, key policies, cross-service KmsKeyId).
 - **Grants** — CreateGrant, RetireGrant, RevokeGrant, ListGrants
 - **Key rotation** — automatic rotation flag (tracked), on-demand rotation
 - **Key policies** — PutKeyPolicy, GetKeyPolicy, ListKeyPolicies
@@ -20,7 +22,7 @@ fakecloud implements **53 of 53** KMS operations at 100% Smithy conformance.
 - **Key import** — GetParametersForImport, ImportKeyMaterial with real key material handling
 - **Custom key stores** — CRUD (records only)
 - **Key replica** — ReplicateKey
-- **Cross-service KMS hook** — services that accept a `KmsKeyId` (Secrets Manager today, SSM SecureString / S3 SSE-KMS / SQS / SNS / DynamoDB rolling out in follow-up PRs) call into KMS for real encrypt/decrypt and the calls are recorded at `/_fakecloud/kms/usage` so test code can assert which service principal triggered which operation on which key with which encryption context. AWS-managed aliases (`aws/secretsmanager`, etc.) auto-provision on first use.
+- **Cross-service KMS hook** — S3 (SSE-KMS), SQS, SNS, DynamoDB, Secrets Manager, and SSM SecureString call into KMS for real encrypt/decrypt under the hood. Every call is recorded at `/_fakecloud/kms/usage` so test code can assert which service principal triggered which operation on which key with which encryption context. AWS-managed aliases (`aws/s3`, `aws/sqs`, `aws/sns`, `aws/dynamodb`, `aws/secretsmanager`, `aws/ssm`, ...) auto-provision on first use.
 
 ## Introspection
 
@@ -32,7 +34,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
 ## Gotchas
 
-- **Encryption is real but deterministic.** fakecloud uses a stable in-memory key derivation so encrypted values round-trip correctly across Encrypt/Decrypt calls in the same process, but the ciphertext is not compatible with real AWS KMS.
+- **Real AES-256-GCM, AWS-shaped ciphertext.** Encrypt/Decrypt round-trip across process restarts as long as the same key material is available. Ciphertext layout mimics AWS (key id header, IV, ciphertext, GCM tag) so length and shape match what real callers expect, but blobs are not interchangeable with real AWS KMS.
 
 ## Source
 

--- a/website/content/kms-emulator.md
+++ b/website/content/kms-emulator.md
@@ -16,7 +16,9 @@ Point your AWS SDK at `http://localhost:4566`.
 ## Why fakecloud for KMS
 
 - **53 KMS operations** at 100% conformance — symmetric and asymmetric keys, encrypt/decrypt, aliases, grants, data key generation, real ECDH, key import, multi-region keys, key policies.
-- **Real cryptography.** Encrypt/decrypt operations use real AES-GCM / RSA / ECDSA / ECDH primitives. Output ciphertexts are cryptographically meaningful, not opaque stubs.
+- **Real cryptography.** Symmetric Encrypt/Decrypt/GenerateDataKey use real AES-256-GCM envelope encryption with AWS-shaped ciphertext blobs. Asymmetric Sign/Verify/GetPublicKey use real RSA (RSA_2048/3072/4096) and real ECDSA (ECC_NIST_P256/P384/P521, ECC_SECG_P256K1). DeriveSharedSecret performs real ECDH. Output ciphertexts and signatures are cryptographically meaningful, not opaque stubs.
+- **Aliases everywhere.** `alias/...` works anywhere a key id is accepted — Encrypt, Decrypt, Sign, Verify, GenerateDataKey, ReEncrypt, grants, key policies, and cross-service `KmsKeyId` parameters.
+- **Cross-service KMS hook.** S3 (SSE-KMS), SQS, SNS, DynamoDB, Secrets Manager, and SSM SecureString call into KMS for real encrypt/decrypt. Every call is recorded at `/_fakecloud/kms/usage` so tests can assert which service triggered which KMS operation on which key.
 - **Any AWS SDK in any language.** Real HTTP server on port 4566.
 - **KMS key policies enforced.** Opt-in `--iam strict` mode validates key-policy Principal/Condition semantics with AWS's cross-account combining rules.
 - **No account, no auth token, no paid tier.** AGPL-3.0.
@@ -72,8 +74,14 @@ Used in envelope-encryption flows. Real AES-GCM throughout.
 ## Asymmetric + ECDH
 
 ```python
+# Real RSA Sign/Verify (RSA_2048 / RSA_3072 / RSA_4096)
+rsa = kms.create_key(KeySpec='RSA_2048', KeyUsage='SIGN_VERIFY')
+
+# Real ECDSA Sign/Verify (P-256, P-384, P-521, secp256k1)
+ec = kms.create_key(KeySpec='ECC_NIST_P521', KeyUsage='SIGN_VERIFY')
+
+# Real ECDH key agreement
 asym = kms.create_key(KeySpec='ECC_NIST_P256', KeyUsage='KEY_AGREEMENT')
-# Real ECDH key agreement for end-to-end tests
 ```
 
 ## SSE-KMS on S3


### PR DESCRIPTION
## Summary

Batch B8 of sync-audit. KMS docs-only updates to reflect already-shipped features.

- **services/kms.md**: itemize asymmetric key support — RSA_2048/3072/4096 (real Sign/Verify/GetPublicKey, #917) and ECC_NIST_P256/P384/P521 + SECG_P256K1 (real ECDSA, #919 + #1303). Note aliases accepted anywhere keys are (#901). Document AWS-shaped ciphertext + real AES-256-GCM envelope encryption (#766). Expand cross-service KMS hook to list S3/SQS/SNS/DynamoDB (#742-743) alongside Secrets Manager / SSM.
- **kms-emulator.md**: mirror the same key-type itemization and aliases-everywhere note; add RSA + P-521 examples.

## Test plan

- [ ] Verify rendered website pages reflect the new key-type list
- [ ] Confirm no parity.md / crates / SDK files were touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync KMS and emulator docs with shipped features to remove drift and clarify capabilities.
Adds explicit asymmetric key specs (RSA_2048/3072/4096; ECC P-256/P-384/P-521; secp256k1), documents real AES-256-GCM envelope encryption with AWS-shaped ciphertext, clarifies that aliases work anywhere a key id/ARN is accepted, expands the cross-service KMS hook list (S3 SSE-KMS, SQS, SNS, DynamoDB, Secrets Manager, SSM) with usage recorded at `/_fakecloud/kms/usage`, and adds RSA and P-521 examples to the emulator page.

<sup>Written for commit 72271a59153ca93bbac82e3f83fd722fd1926fef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

