### PR TITLE
docs(lambda): sync docs with shipped features (B7)

### DIFF
--- a/website/content/docs/services/lambda.md
+++ b/website/content/docs/services/lambda.md
@@ -1,6 +1,6 @@
 +++
 title = "Lambda"
-description = "Real code execution in Docker containers across 23 runtimes. Event source mappings, warm container reuse."
+description = "Real code execution in Docker containers across 27 runtimes. Event source mappings, warm container reuse."
 weight = 5
 +++
 
@@ -10,12 +10,15 @@ fakecloud implements **85 of 85** Lambda operations at 100% Smithy conformance. 
 
 - **Function CRUD** — create, update, delete, list, get
 - **Real code execution** — functions run in Docker containers with the official AWS Lambda runtime images
-- **23 runtimes** — Node.js (16/18/20/22/24), Python (3.8/3.9/3.10/3.11/3.12/3.13/3.14), Java (11/17/21/25), Go (1.x), Ruby (3.3/3.4), .NET (8/10), `provided.al2`, `provided.al2023`
+- **27 runtimes** — Node.js (16/18/20/22/24), Python (3.8/3.9/3.10/3.11/3.12/3.13/3.14), Java (11/17/21/25), Go (1.x), Ruby (3.2/3.3/3.4), .NET (6/8/10), `provided.al2`, `provided.al2023`
 - **Event source mappings** — SQS, Kinesis, DynamoDB Streams polling loops with **`FilterCriteria`** (EventBridge-style JSON pattern, exists/prefix/suffix/equals-ignore-case/anything-but/numeric operators, SQS body decode), **`StartingPosition`** (`TRIM_HORIZON` / `LATEST` / `AT_TIMESTAMP` for Kinesis, `TRIM_HORIZON` / `LATEST` for DDB Streams), **`MaximumBatchingWindowInSeconds`** (SQS), and **`FunctionResponseTypes=[ReportBatchItemFailures]`** for SQS partial-batch failure semantics
 - **Layers** — create, publish, attach to functions; layer ZIP content is extracted into `/opt` of the runtime container at invoke time, so Python `import`, Node `require`, and `LD_LIBRARY_PATH` lookups resolve against attached layers exactly as on real AWS
 - **Environment variables** — passed to the container
-- **Aliases and versions** — publish, point aliases at versions
-- **Concurrency controls** — reserved concurrency (recorded, not enforced)
+- **Aliases and versions** — publish, point aliases at versions; alias-based weighted routing (`RoutingConfig`) is enforced at invoke time so traffic splits between versions exactly as on AWS
+- **Concurrency controls** — reserved concurrency enforced at invocation time: per-function reservation caps in-flight invocations and excess requests are rejected with `TooManyRequestsException` (HTTP 429) and `Reason=ReservedFunctionConcurrentInvocationLimitExceeded`
+- **`UpdateFunctionCode` from S3** — `S3Bucket`/`S3Key`/`S3ObjectVersion` fetches the ZIP from the fakecloud S3 implementation; the stored `CodeSha256` is the real SHA-256 of the fetched bytes
+- **CloudWatch metrics** — every invoke publishes `Invocations`, `Errors`, `Duration`, `Throttles`, and `ConcurrentExecutions` to the `AWS/Lambda` namespace, queryable via `GetMetricStatistics` / `GetMetricData`
+- **`GetAccountSettings`** — returns real `AccountUsage` counters (`FunctionCount`, `TotalCodeSize`) and `AccountLimit` so SDKs that pre-flight account quotas see live values
 - **Warm container reuse** — subsequent invocations of the same function reuse the container
 - **Async invoke destinations** — `OnSuccess` / `OnFailure` routes the invocation result to SQS, SNS, EventBridge, or another Lambda by ARN scheme; record matches the AWS destinations schema (`requestContext`, `requestPayload`, `responseContext`, `responsePayload`)
 - **`InvocationType` honored** — `Event` returns 202 and runs in the background, `RequestResponse` blocks for the result, `DryRun` validates without executing

--- a/website/content/test-lambda-locally.md
+++ b/website/content/test-lambda-locally.md
@@ -1,6 +1,6 @@
 +++
 title = "Test Lambda locally"
-description = "Run AWS Lambda locally with real runtimes and real event triggers. 23 Lambda runtimes, real S3/SQS/SNS/EventBridge triggers, no account required."
+description = "Run AWS Lambda locally with real runtimes and real event triggers. 27 Lambda runtimes, real S3/SQS/SNS/EventBridge triggers, no account required."
 template = "page.html"
 +++
 
@@ -13,11 +13,12 @@ fakecloud
 
 ## What you get
 
-- **All 23 AWS Lambda runtimes** — Node 16/18/20/22/24, Python 3.8/3.9/3.10/3.11/3.12/3.13/3.14, Java 11/17/21/25, .NET 8/10, Ruby 3.3/3.4, Go 1.x, custom (`provided.al2`, `provided.al2023`).
+- **All 27 AWS Lambda runtimes** — Node 16/18/20/22/24, Python 3.8/3.9/3.10/3.11/3.12/3.13/3.14, Java 11/17/21/25, .NET 6/8/10, Ruby 3.2/3.3/3.4, Go 1.x, custom (`provided.al2`, `provided.al2023`).
 - **Real code execution.** fakecloud pulls the AWS Lambda runtime container and runs your handler. Not a stub, not a simulated response.
 - **Real event triggers.** S3 -> Lambda, SQS -> Lambda, SNS -> Lambda, EventBridge -> Lambda, DynamoDB Streams -> Lambda, API Gateway v2 -> Lambda. All wired end-to-end.
 - **Real event source mappings.** fakecloud polls SQS/Kinesis, batches events, invokes your Lambda, handles success/failure/DLQ the way AWS does.
 - **CloudWatch Logs.** Your function's stdout captured and queryable via `aws logs tail`.
+- **CloudWatch metrics.** Every invoke publishes `Invocations`, `Errors`, `Duration`, `Throttles`, and `ConcurrentExecutions` to the `AWS/Lambda` namespace, so dashboards and `GetMetricStatistics` work the same as on AWS.
 - **No account, no auth token, no paid tier.**
 
 ## Quick deploy + invoke
@@ -53,7 +54,7 @@ cat out.json
 
 | Tool | Runs function code | Multi-runtime | Cross-service triggers | Language | Free |
 |---|---|---|---|---|---|
-| fakecloud | Yes (Docker) | 23 runtimes | Yes (S3, SQS, SNS, EventBridge, DynamoDB Streams, API GW v2) | Any | Yes |
+| fakecloud | Yes (Docker) | 27 runtimes | Yes (S3, SQS, SNS, EventBridge, DynamoDB Streams, API GW v2) | Any | Yes |
 | SAM Local | Yes (Docker) | All AWS runtimes | Partial (synthetic events only) | Any | Yes |
 | LocalStack Community (post-Mar 2026) | Yes (Docker, auth required) | All | Yes | Any | No (auth token required) |
 | serverless-offline | Yes (in-process) | Node only | API Gateway only | Node | Yes |


### PR DESCRIPTION
Batch B7 of sync-audit: docs-only refresh for Lambda.

## Changes

### services/lambda.md
- Bump runtime count 23 -> 27 (PR #781 + #787 added nodejs24.x, python3.14, java25, dotnet10; legacy nodejs16/18/20/22, python3.8-3.13, java11/17/21, dotnet6/8, ruby3.2 included).
- Reserved concurrency: was "recorded, not enforced", now enforced at invocation time with TooManyRequestsException + ReservedFunctionConcurrentInvocationLimitExceeded (PR #905).
- Add: UpdateFunctionCode S3 fetch with real CodeSha256 (PR #902 + #1293).
- Add: Invoke publishes Invocations/Errors/Duration/Throttles/ConcurrentExecutions to AWS/Lambda namespace (PR #1295).
- Reword layers bullet to note extraction into /opt at invoke (PR #862).
- Add: alias-based weighted routing enforced at invoke time (PR #905).
- Add: GetAccountSettings returns real AccountUsage/AccountLimit (PRs #892-893).
- ESM FilterCriteria + partial-batch failure + StartingPosition already documented in the example block (PR #740).

### test-lambda-locally.md
- Mirror runtime count 23 -> 27 in description, feature list, and comparison table.
- Add CloudWatch metrics bullet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync Lambda docs to match shipped features and ensure “Test Lambda locally” mirrors them.

Bumped runtimes to 27 and documented enforced reserved concurrency (429 TooManyRequests), alias-weighted routing, S3-based UpdateFunctionCode with real CodeSha256, CloudWatch metrics on invoke, GetAccountSettings with live usage/limits, and layer extraction to /opt; mirrored runtime and metrics updates in “Test Lambda locally” and its comparison table.

<sup>Written for commit a8da96a410bba6b93083f612882bf61b5bb5c1a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

