### PR TITLE
docs(elasticache+appas+orgs): sync docs + new pages (B12)

### DIFF
--- a/website/content/docs/services/application-autoscaling.md
+++ b/website/content/docs/services/application-autoscaling.md
@@ -43,12 +43,25 @@ aws --endpoint-url http://localhost:4566 application-autoscaling describe-scalin
   --service-namespace ecs
 ```
 
-## DynamoDB capacity scaling
+## Real scaling apply hooks
 
-The Application Auto Scaling watcher now actually resizes DynamoDB
-provisioned tables in response to scaling policies. The watcher ticks
-every 15 seconds, walks every registered DynamoDB scalable target, and
-applies one of two algorithms per policy:
+The Application Auto Scaling watcher actually resizes the underlying
+resource when scaling policies fire. Today the watcher mutates:
+
+- **DynamoDB** — provisioned `ReadCapacityUnits` and `WriteCapacityUnits`
+  on tables (and Global Secondary Indexes) registered as scalable
+  targets.
+- **ECS** — service `DesiredCount` for `ecs:service:DesiredCount`
+  targets. When a target-tracking or step policy fires for an ECS
+  service, the watcher calls the ECS capacity hook, which updates the
+  service's `DesiredCount` and walks the running task set so the new
+  bound is reflected in `DescribeServices` and the underlying Docker
+  task count. Step scaling and `TargetTrackingScaling` against
+  `ECSServiceAverageCPUUtilization` /
+  `ECSServiceAverageMemoryUtilization` both apply.
+
+The watcher ticks every 15 seconds, walks every registered scalable
+target, and applies one of two algorithms per policy:
 
 - **`TargetTrackingScaling`** — reads the latest sample of the
   `PredefinedMetricSpecification.PredefinedMetricType` metric from
@@ -106,14 +119,14 @@ is `{ "fired": <int> }`. The introspection SDKs expose this as
 
 ## Caveats
 
-The watcher and scheduled-action executor only mutate DynamoDB table
-capacity today. ECS service `DesiredCount`, Lambda provisioned
-concurrency, RDS Aurora capacity, ElastiCache replicas, and the rest
-of Application Auto Scaling's service namespaces still store policy
-and scheduled-action configurations verbatim — the bound updates land
-on the `ScalableTarget` but no per-namespace apply hook is wired yet,
-so the underlying resource isn't resized. Predictive forecasts are
-deterministic synthetic curves, not actual ML predictions. CloudWatch
-alarms reported under `ScalingPolicy.Alarms` remain empty — the
-watcher resolves alarms by walking CloudWatch state directly rather
-than mirroring AWS's auto-attach behaviour.
+DynamoDB and ECS are the namespaces with real apply hooks today.
+Lambda provisioned concurrency, RDS Aurora capacity, ElastiCache
+replicas, and the rest of Application Auto Scaling's service
+namespaces still store policy and scheduled-action configurations
+verbatim — the bound updates land on the `ScalableTarget` but no
+per-namespace apply hook is wired yet, so the underlying resource
+isn't resized. Predictive forecasts are deterministic synthetic
+curves, not actual ML predictions. CloudWatch alarms reported under
+`ScalingPolicy.Alarms` remain empty — the watcher resolves alarms by
+walking CloudWatch state directly rather than mirroring AWS's
+auto-attach behaviour.

--- a/website/content/docs/services/elasticache.md
+++ b/website/content/docs/services/elasticache.md
@@ -1,6 +1,6 @@
 +++
 title = "ElastiCache"
-description = "Real Redis, Valkey, and Memcached clusters via Docker. Replication groups, snapshots, user/group management."
+description = "Real Redis, Valkey, and Memcached clusters via Docker. Replication groups, snapshots, ACL user management, configuration endpoints."
 weight = 18
 +++
 
@@ -8,20 +8,24 @@ fakecloud implements **75 of 75** ElastiCache operations at 100% Smithy conforma
 
 ## Supported features
 
-- **Cache clusters** — CreateCacheCluster, ModifyCacheCluster, DeleteCacheCluster, DescribeCacheClusters
-- **Real engines via Docker** — Redis, Valkey, Memcached
-- **Replication groups** — CreateReplicationGroup with primary/replica topology (Redis/Valkey only — matches AWS)
+- **Cache clusters** — `CreateCacheCluster`, `ModifyCacheCluster`, `DeleteCacheCluster`, `DescribeCacheClusters`, `RebootCacheCluster`
+- **Real engines via Docker** — Redis, Valkey, and Memcached all run as real containers (`redis:7-alpine`, `valkey:8-alpine`, `memcached:1.6-alpine`). All commands work, including streams, pub/sub, Lua, modules, CAS, and the Memcached text/binary protocols
+- **Replication groups** — `CreateReplicationGroup` with primary/replica topology (Redis/Valkey only — matches AWS). Persisted fields include `AtRestEncryptionEnabled`, `TransitEncryptionEnabled`, `TransitEncryptionMode`, `AuthTokenEnabled`, `KmsKeyId`, `LogDeliveryConfigurations`, `ClusterEnabled`, `MultiAZ`, `AutomaticFailover`, `DataTiering`, `NetworkType`, `IpDiscovery`, `SnapshotRetentionLimit`, `SnapshotWindow`, `PreferredMaintenanceWindow`, and node-group member topology — all round-tripped through `DescribeReplicationGroups`
 - **Global replication groups** — cross-region global datastores (CRUD)
-- **Serverless caches** — CreateServerlessCache, ModifyServerlessCache (Redis/Valkey only — matches AWS)
-- **Snapshots** — CreateSnapshot, CopySnapshot, DeleteSnapshot, RestoreReplicationGroupFromSnapshot
+- **Serverless caches** — `CreateServerlessCache`, `ModifyServerlessCache` (Redis/Valkey only — matches AWS)
+- **Snapshots** — `CreateSnapshot`, `CopySnapshot`, `DeleteSnapshot`, `RestoreReplicationGroupFromSnapshot`. Restore reads back the **real RDB file** dumped during snapshot creation and seeds the replacement Redis/Valkey container with `BGSAVE`-captured data, so your test fixture's keys survive snapshot/restore round-trips
 - **Serverless cache snapshots** — CRUD
 - **Subnet groups** — CRUD
-- **Users and user groups** — IAM-integrated auth
-- **Parameter groups** — CRUD (default groups for redis7, valkey8, memcached1.6)
+- **Users and user groups** — IAM-integrated auth. `CreateUser`/`ModifyUser` accept `AccessString` (RBAC rules) and `Passwords`/`NoPasswordRequired`. The container is configured via real Redis `ACL SETUSER` so the engine enforces the rules — unauthorized commands are rejected by the real engine, not stubbed
+- **Parameter groups** — CRUD. `ModifyCacheParameterGroup` parameter changes that map to runtime-tunable Redis options are pushed to the live container via `CONFIG SET`, so `maxmemory-policy`, `timeout`, `tcp-keepalive`, etc. take effect immediately on the running instance
 - **Security groups** — cache security group CRUD
-- **Failover** — TestFailover, TestMigration
-- **Tagging** — AddTagsToResource, RemoveTagsFromResource
-- **Engine versions** — DescribeCacheEngineVersions
+- **Failover** — `TestFailover`, `TestMigration`
+- **Tagging** — `AddTagsToResource`, `RemoveTagsFromResource`, `ListTagsForResource`
+- **Engine versions** — `DescribeCacheEngineVersions`
+
+## Configuration endpoint (Memcached)
+
+Memcached cache clusters with `NumCacheNodes > 1` expose a real **ConfigurationEndpoint** in `DescribeCacheClusters`. The endpoint resolves to a fakecloud-managed config proxy that speaks the Memcached `config get cluster` command, returning the live node list (host:port pairs) just like AWS's Auto Discovery. The official `ElastiCache Cluster Client` libraries (`elasticache-cluster-client-memcached-for-java`, `aws-elasticache-cluster-client-libmemcached`, etc.) hit the configuration endpoint and discover the real backing nodes without any client-side configuration.
 
 ## Protocol
 
@@ -29,7 +33,15 @@ Query protocol. Form-encoded body, `Action` parameter, XML responses.
 
 ## How the Docker integration works
 
-When you call `CreateCacheCluster` (or `CreateReplicationGroup` for Redis/Valkey topologies), fakecloud starts a real Docker container running the corresponding official image (`redis:7-alpine`, `valkey:8-alpine`, or `memcached:1.6-alpine`) and reports the mapped host port. Your application connects with a normal Redis or Memcached client.
+When you call `CreateCacheCluster` (or `CreateReplicationGroup` for Redis/Valkey topologies), fakecloud starts a real Docker container running the corresponding official image and reports the mapped host port. Your application connects with a normal Redis or Memcached client. Memcached gets a real `memcached:1.6-alpine` container running the full text and binary protocols — not a stub.
+
+## Introspection
+
+- `GET /_fakecloud/elasticache/clusters` — current cache clusters (id, engine, status, mapped port)
+- `GET /_fakecloud/elasticache/replication-groups` — replication groups with node members and ports
+- `GET /_fakecloud/elasticache/serverless-caches` — serverless caches with endpoints
+
+All three are exposed by the introspection SDKs (`fakecloud.elasticache.clusters()`, etc.) for assertions in tests.
 
 ## Gotchas
 

--- a/website/content/docs/services/organizations.md
+++ b/website/content/docs/services/organizations.md
@@ -1,0 +1,82 @@
++++
+title = "Organizations"
+description = "AWS Organizations control plane — accounts, OUs, SCPs, tag policies, handshakes, delegated administrators. Real SCP enforcement across services."
+weight = 31
++++
+
+fakecloud implements **55 of 55** AWS Organizations operations at 100% Smithy conformance. SCPs (Service Control Policies) are **really enforced** as a permission ceiling across every IAM-evaluated service.
+
+## Supported features
+
+- **Organization lifecycle** — `CreateOrganization`, `DescribeOrganization`, `DeleteOrganization`, `EnableAllFeatures`. The management account is the only caller allowed to mutate org state, matching AWS.
+- **Accounts**
+  - `CreateAccount` / `CreateGovCloudAccount` run a **real async lifecycle**: the call returns immediately with a `CreateAccountStatus` whose `State` starts `IN_PROGRESS`, then transitions to `SUCCEEDED` after the background task provisions the member account, attaches the default IAM admin role (`OrganizationAccountAccessRole`), and assigns the account to the requested OU (or to the root). `DescribeCreateAccountStatus` and `ListCreateAccountStatus` reflect the real status.
+  - `CloseAccount` moves the account to `SUSPENDED` and blocks subsequent control-plane calls from that account ID — the management account is protected and cannot be closed.
+  - `RemoveAccountFromOrganization` detaches a member account from the org; subsequent describes flip to `NotFound`, mirroring AWS's behaviour where the account becomes a standalone payer.
+  - `DescribeAccount`, `ListAccounts`, `ListAccountsForParent` paginate the directory.
+  - `InviteAccountToOrganization` + `AcceptHandshake` / `DeclineHandshake` / `CancelHandshake` / `DescribeHandshake` + `ListHandshakesForAccount` / `ListHandshakesForOrganization` run the real handshake state machine — only the invited account can accept/decline, only the inviter can cancel, and expired handshakes flip to `EXPIRED`.
+- **Organizational Units** — `CreateOrganizationalUnit`, `UpdateOrganizationalUnit`, `DeleteOrganizationalUnit`, `DescribeOrganizationalUnit`, `ListOrganizationalUnitsForParent`, `ListChildren`, `ListParents`, `ListRoots`, `MoveAccount`. The hierarchy is enforced — non-empty OUs cannot be deleted, and `MoveAccount` validates both source and destination parents.
+- **Policies** — `CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `DescribePolicy`, `ListPolicies`, `ListPoliciesForTarget`, `ListTargetsForPolicy`, `AttachPolicy`, `DetachPolicy`, `EnablePolicyType`, `DisablePolicyType`, `DescribeEffectivePolicy`. All four AWS policy types are accepted: `SERVICE_CONTROL_POLICY`, `TAG_POLICY`, `BACKUP_POLICY`, `AISERVICES_OPT_OUT_POLICY`. Policy documents are JSON-validated on create/update — malformed content is rejected with `MalformedPolicyDocumentException`.
+- **Resource policies** — `PutResourcePolicy`, `DescribeResourcePolicy`, `DeleteResourcePolicy` for the org-wide delegation policy.
+- **Service access** — `EnableAWSServiceAccess`, `DisableAWSServiceAccess`, `ListAWSServiceAccessForOrganization`, `RegisterDelegatedAdministrator`, `DeregisterDelegatedAdministrator`, `ListDelegatedAdministrators`, `ListDelegatedServicesForAccount`. Delegated-admin registration is gated on the service having `EnableAWSServiceAccess` first, matching AWS error ordering.
+- **Tagging** — `TagResource`, `UntagResource`, `ListTagsForResource` on accounts, OUs, roots, and policies.
+
+## SCP enforcement
+
+Service Control Policies aren't just stored — they're a real permission ceiling. When `FAKECLOUD_IAM=strict` is on, every IAM evaluation walks up from the calling account's parent OU(s) through the root, collects the SCPs that apply at each level, and intersects them with the identity-based policy decision. The semantics match AWS:
+
+- Same-target SCPs are **unioned** (multiple SCPs attached to the same OU/account can each grant a subset).
+- Cross-level SCPs are **intersected** (a permission must be allowed at every level — root, parent OU, account — to survive).
+- The management account and service-linked roles are exempt, just like AWS.
+- An explicit `Deny` at any level wins.
+
+This means a parent OU with `Deny: s3:DeleteBucket` actually blocks the call in a member account even when the member's IAM policy grants `s3:*`. The same machinery enforces TAG_POLICY constraints on `TagResource` calls when strict mode is on.
+
+## Protocol
+
+JSON 1.1. `X-Amz-Target: AWSOrganizationsV20161128.<Action>`.
+
+## Bootstrap
+
+Because Organizations sits above IAM, fakecloud exposes
+`POST /_fakecloud/iam/create-admin` to seed a management-account admin
+without needing existing credentials. Once the management account is
+bootstrapped, the rest of the org lifecycle uses normal SigV4'd
+calls.
+
+## Smoke test
+
+```sh
+fakecloud &
+
+# Bootstrap a management-account admin.
+curl -fsS -X POST http://localhost:4566/_fakecloud/iam/create-admin \
+  -H 'content-type: application/json' \
+  -d '{"AccountId":"123456789012"}'
+
+aws --endpoint-url http://localhost:4566 organizations create-organization \
+  --feature-set ALL
+
+aws --endpoint-url http://localhost:4566 organizations create-account \
+  --email dev@example.com --account-name Dev
+
+aws --endpoint-url http://localhost:4566 organizations list-create-account-status \
+  --states SUCCEEDED IN_PROGRESS
+
+aws --endpoint-url http://localhost:4566 organizations create-policy \
+  --type SERVICE_CONTROL_POLICY \
+  --name DenyBucketDelete \
+  --description "block deletes" \
+  --content '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:DeleteBucket","Resource":"*"}]}'
+```
+
+## Gotchas
+
+- **Management account only.** Mutating calls (`CreateAccount`, `AttachPolicy`, `EnableAWSServiceAccess`, etc.) must originate from the management account. Calls from member accounts return `AccessDeniedException`, matching AWS.
+- **SCP enforcement is opt-in.** SCPs are stored and `DescribeEffectivePolicy` works in all modes, but enforcement only kicks in under `FAKECLOUD_IAM=strict` (or `soft` for log-only). See [SigV4 verification and IAM enforcement](@/docs/reference/security.md).
+- **CreateAccount is async.** The state moves through `IN_PROGRESS` -> `SUCCEEDED` over a short interval; tests should poll `DescribeCreateAccountStatus` rather than assume the account is usable immediately.
+
+## Source
+
+- [`crates/fakecloud-organizations`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-organizations)
+- [AWS Organizations API reference](https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html)

--- a/website/content/local-elasticache.md
+++ b/website/content/local-elasticache.md
@@ -16,7 +16,12 @@ Point your AWS SDK at `http://localhost:4566`. Docker required because fakecloud
 ## Why fakecloud for ElastiCache
 
 - **75 ElastiCache operations** at 100% conformance — cache clusters, replication groups, global replication groups, serverless caches and snapshots, subnet groups, users / user groups, failover, tagging.
-- **Real Redis, Valkey, and Memcached.** fakecloud pulls real Redis / Valkey / Memcached Docker images and runs them as the ElastiCache node. Your `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work because the engine is real. Memcached gets a real `memcached:1.6-alpine` container with the full text protocol.
+- **Real Redis, Valkey, and Memcached.** fakecloud pulls real Redis / Valkey / Memcached Docker images and runs them as the ElastiCache node. Your `LPUSH`, `ZADD`, `XADD`, streams, pub/sub, Lua scripts — all work because the engine is real. Memcached gets a real `memcached:1.6-alpine` container with the full text and binary protocols.
+- **Real ACL enforcement.** `CreateUser` / `ModifyUser` push `ACL SETUSER` into the live Redis container, so unauthorized commands are rejected by the real engine — not by a stub.
+- **Real parameter group changes.** `ModifyCacheParameterGroup` runtime-tunable parameters (e.g. `maxmemory-policy`, `timeout`) are pushed to the live container via `CONFIG SET` and take effect immediately.
+- **Real Memcached Auto Discovery.** Multi-node Memcached clusters expose a real `ConfigurationEndpoint` that speaks `config get cluster`, so the official ElastiCache cluster clients discover the live nodes the same way they do against AWS.
+- **Snapshot / restore round-trips real data.** `CreateSnapshot` dumps a real RDB file; `RestoreReplicationGroupFromSnapshot` seeds the replacement container with that RDB, so test fixture keys survive snapshot/restore cycles.
+- **Encryption + logging persist.** `AtRestEncryptionEnabled`, `TransitEncryptionEnabled`, `TransitEncryptionMode`, `AuthTokenEnabled`, `KmsKeyId`, `LogDeliveryConfigurations`, `MultiAZ`, `AutomaticFailover`, `DataTiering`, `NetworkType`, `IpDiscovery`, snapshot / maintenance windows, and node-group topology all round-trip through `DescribeReplicationGroups`.
 - **Endpoint works.** `DescribeCacheClusters` returns a real connectable host. Your application connects with a regular Redis client (redis-py, ioredis, lettuce, go-redis).
 - **Paid on LocalStack; free here.** ElastiCache has always been LocalStack Pro-only.
 - **No account, no auth token, no paid tier.** AGPL-3.0.


### PR DESCRIPTION
## Summary

B12 of the sync-audit sweep covering ElastiCache, Application Auto Scaling, and Organizations.

- **ElastiCache** (`website/content/docs/services/elasticache.md` + `local-elasticache.md`): document real ACL `SETUSER`, `CONFIG SET` parameter pushes, real Memcached `ConfigurationEndpoint` Auto Discovery (#1247), real RDB snapshot restore (#1246), persisted encryption/log/cluster fields on ReplicationGroup (#896), and real Memcached engine via Docker (#768). Added introspection-endpoint section.
- **Application Auto Scaling** (`docs/services/application-autoscaling.md`): replace the "DynamoDB-only" framing with the real apply-hook list — ECS service DesiredCount target-tracking + step scaling is now live (#1223 EE2). Caveat trimmed to the still-unwired namespaces.
- **Organizations** (`docs/services/organizations.md`, new): full 55-op page covering org lifecycle, async CreateAccount, CloseAccount, RemoveAccountFromOrganization (#918), OU hierarchy, all four policy types, handshakes, delegated administrators, tagging, and real SCP enforcement (union same-level, intersect cross-level, management+SLR exemptions).

No code changes; docs-only.

## Test plan

- [ ] zola build passes (CI)
- [ ] All cross-links resolve

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: adds a full Organizations page with real SCP enforcement, updates ElastiCache docs with real engine behaviors and discovery, and expands Application Auto Scaling docs to include real apply hooks for DynamoDB and ECS `DesiredCount`.

- **New Features**
  - ElastiCache — docs for ACL `SETUSER`, `CONFIG SET` runtime params, Memcached `ConfigurationEndpoint` (Auto Discovery), real RDB snapshot restore, persisted ReplicationGroup fields, and real Memcached via Docker; added introspection endpoints.
  - Application Auto Scaling — documents real apply hooks for DynamoDB capacity and ECS service `DesiredCount` (target-tracking and step scaling); caveats trimmed to only unwired namespaces.
  - Organizations — new page (55 ops) covering accounts, OUs, policies, handshakes, delegated admins, and tagging; highlights real SCP enforcement (union same-level, intersect cross-level, management/SLR exemptions).

<sup>Written for commit c5e64e2f348f294c9ed4b9b3cea5ac7a9761991f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

