### PR TITLE
docs(bedrock-agent): new pages + SDK sub-clients (B11)

### DIFF
--- a/sdks/go/bedrockagent.go
+++ b/sdks/go/bedrockagent.go
@@ -1,0 +1,18 @@
+package fakecloud
+
+// BedrockAgentClient is the Bedrock Agent (control plane) sub-client.
+//
+// The fakecloud Bedrock Agent service has no admin/introspection endpoints
+// today; this client exists so callers can hold a typed handle alongside the
+// other Bedrock sub-clients and so future helpers can land here without an
+// API break.
+type BedrockAgentClient struct {
+	fc *FakeCloud
+}
+
+// BedrockAgentRuntimeClient is the Bedrock Agent Runtime (data plane)
+// sub-client. Placeholder for future introspection helpers around
+// InvokeAgent, Retrieve, and RetrieveAndGenerate.
+type BedrockAgentRuntimeClient struct {
+	fc *FakeCloud
+}

--- a/sdks/go/fakecloud.go
+++ b/sdks/go/fakecloud.go
@@ -112,6 +112,16 @@ func (fc *FakeCloud) StepFunctions() *StepFunctionsClient { return &StepFunction
 // Bedrock returns the Bedrock sub-client.
 func (fc *FakeCloud) Bedrock() *BedrockClient { return &BedrockClient{fc: fc} }
 
+// BedrockAgent returns the Bedrock Agent (control plane) sub-client.
+func (fc *FakeCloud) BedrockAgent() *BedrockAgentClient {
+	return &BedrockAgentClient{fc: fc}
+}
+
+// BedrockAgentRuntime returns the Bedrock Agent Runtime (data plane) sub-client.
+func (fc *FakeCloud) BedrockAgentRuntime() *BedrockAgentRuntimeClient {
+	return &BedrockAgentRuntimeClient{fc: fc}
+}
+
 // ECS returns the ECS sub-client.
 func (fc *FakeCloud) ECS() *ECSClient { return &ECSClient{fc: fc} }
 

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -98,6 +98,8 @@ public final class FakeCloud {
     private final ApiGatewayV2Client apigatewayv2;
     private final StepFunctionsClient stepfunctions;
     private final BedrockClient bedrock;
+    private final BedrockAgentClient bedrockAgent;
+    private final BedrockAgentRuntimeClient bedrockAgentRuntime;
     private final EcsClient ecs;
     private final Elbv2Client elbv2;
     private final Route53Client route53;
@@ -126,6 +128,8 @@ public final class FakeCloud {
         this.apigatewayv2 = new ApiGatewayV2Client(http);
         this.stepfunctions = new StepFunctionsClient(http);
         this.bedrock = new BedrockClient(http);
+        this.bedrockAgent = new BedrockAgentClient(http);
+        this.bedrockAgentRuntime = new BedrockAgentRuntimeClient(http);
         this.ecs = new EcsClient(http);
         this.elbv2 = new Elbv2Client(http);
         this.route53 = new Route53Client(http);
@@ -186,6 +190,8 @@ public final class FakeCloud {
     public ApiGatewayV2Client apigatewayv2() { return apigatewayv2; }
     public StepFunctionsClient stepfunctions() { return stepfunctions; }
     public BedrockClient bedrock() { return bedrock; }
+    public BedrockAgentClient bedrockAgent() { return bedrockAgent; }
+    public BedrockAgentRuntimeClient bedrockAgentRuntime() { return bedrockAgentRuntime; }
     public EcsClient ecs() { return ecs; }
     public Elbv2Client elbv2() { return elbv2; }
     public Route53Client route53() { return route53; }
@@ -541,6 +547,31 @@ public final class FakeCloud {
         public BedrockStatusResponse clearFaults() {
             return http.delete("/_fakecloud/bedrock/faults", BedrockStatusResponse.class);
         }
+    }
+
+    /**
+     * Bedrock Agent (control plane) sub-client.
+     *
+     * The fakecloud Bedrock Agent service has no admin/introspection
+     * endpoints today; this client exists so callers can hold a typed handle
+     * alongside the other Bedrock sub-clients and so future helpers can land
+     * here without an API break.
+     */
+    public static final class BedrockAgentClient {
+        @SuppressWarnings("unused")
+        private final HttpTransport http;
+        BedrockAgentClient(HttpTransport http) { this.http = http; }
+    }
+
+    /**
+     * Bedrock Agent Runtime (data plane) sub-client. Placeholder for future
+     * introspection helpers around InvokeAgent, Retrieve, and
+     * RetrieveAndGenerate.
+     */
+    public static final class BedrockAgentRuntimeClient {
+        @SuppressWarnings("unused")
+        private final HttpTransport http;
+        BedrockAgentRuntimeClient(HttpTransport http) { this.http = http; }
     }
 
     public static final class EcsClient {

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -34,6 +34,8 @@ final class FakeCloud
     private ApiGatewayV2Client $apigatewayv2;
     private StepFunctionsClient $stepfunctions;
     private BedrockClient $bedrock;
+    private BedrockAgentClient $bedrockAgent;
+    private BedrockAgentRuntimeClient $bedrockAgentRuntime;
     private EcsClient $ecs;
     private Elbv2Client $elbv2;
     private Route53Client $route53;
@@ -59,6 +61,8 @@ final class FakeCloud
         $this->apigatewayv2 = new ApiGatewayV2Client($this->http);
         $this->stepfunctions = new StepFunctionsClient($this->http);
         $this->bedrock = new BedrockClient($this->http);
+        $this->bedrockAgent = new BedrockAgentClient($this->http);
+        $this->bedrockAgentRuntime = new BedrockAgentRuntimeClient($this->http);
         $this->ecs = new EcsClient($this->http);
         $this->elbv2 = new Elbv2Client($this->http);
         $this->route53 = new Route53Client($this->http);
@@ -121,6 +125,8 @@ final class FakeCloud
     public function apigatewayv2(): ApiGatewayV2Client { return $this->apigatewayv2; }
     public function stepfunctions(): StepFunctionsClient { return $this->stepfunctions; }
     public function bedrock(): BedrockClient { return $this->bedrock; }
+    public function bedrockAgent(): BedrockAgentClient { return $this->bedrockAgent; }
+    public function bedrockAgentRuntime(): BedrockAgentRuntimeClient { return $this->bedrockAgentRuntime; }
     public function ecs(): EcsClient { return $this->ecs; }
     public function elbv2(): Elbv2Client { return $this->elbv2; }
     public function route53(): Route53Client { return $this->route53; }
@@ -556,6 +562,28 @@ final class BedrockClient
             $this->http->delete('/_fakecloud/bedrock/faults')
         );
     }
+}
+
+/**
+ * Bedrock Agent (control plane) sub-client.
+ *
+ * The fakecloud Bedrock Agent service has no admin/introspection endpoints
+ * today; this client exists so callers can hold a typed handle alongside the
+ * other Bedrock sub-clients and so future helpers can land here without an
+ * API break.
+ */
+final class BedrockAgentClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+}
+
+/**
+ * Bedrock Agent Runtime (data plane) sub-client. Placeholder for future
+ * introspection helpers around InvokeAgent, Retrieve, and RetrieveAndGenerate.
+ */
+final class BedrockAgentRuntimeClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
 }
 
 final class EcsClient

--- a/sdks/python/src/fakecloud/__init__.py
+++ b/sdks/python/src/fakecloud/__init__.py
@@ -2,6 +2,8 @@
 
 from fakecloud.client import (
     ApplicationAutoScalingClient,
+    BedrockAgentClient,
+    BedrockAgentRuntimeClient,
     BedrockClient,
     CognitoClient,
     DynamoDbClient,
@@ -23,6 +25,8 @@ from fakecloud.client import (
 
 __all__ = [
     "ApplicationAutoScalingClient",
+    "BedrockAgentClient",
+    "BedrockAgentRuntimeClient",
     "BedrockClient",
     "CognitoClient",
     "DynamoDbClient",

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -858,6 +858,33 @@ class BedrockClient:
         return BedrockStatusResponse.from_dict(resp.json())
 
 
+class BedrockAgentClient:
+    """Async Bedrock Agent (control plane) sub-client.
+
+    The fakecloud Bedrock Agent service has no admin/introspection endpoints
+    today; this client exists so callers can hold a typed handle alongside
+    the other Bedrock sub-clients and so future introspection helpers can
+    land here without an API break.
+    """
+
+    def __init__(self, client: httpx.AsyncClient, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+
+class BedrockAgentRuntimeClient:
+    """Async Bedrock Agent Runtime (data plane) sub-client.
+
+    Placeholder for future introspection helpers around InvokeAgent,
+    Retrieve, and RetrieveAndGenerate. Holds the base URL for parity with
+    the other Bedrock sub-clients.
+    """
+
+    def __init__(self, client: httpx.AsyncClient, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+
 # ── Sync sub-clients ────────────────────────────────────────────────
 
 
@@ -1220,6 +1247,18 @@ class _SyncBedrockClient:
         return BedrockStatusResponse.from_dict(resp.json())
 
 
+class _SyncBedrockAgentClient:
+    def __init__(self, client: httpx.Client, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+
+class _SyncBedrockAgentRuntimeClient:
+    def __init__(self, client: httpx.Client, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+
 # ── Main clients ────────────────────────────────────────────────────
 
 
@@ -1339,6 +1378,14 @@ class FakeCloud:
     @property
     def bedrock(self) -> BedrockClient:
         return BedrockClient(self._client, self._base)
+
+    @property
+    def bedrock_agent(self) -> BedrockAgentClient:
+        return BedrockAgentClient(self._client, self._base)
+
+    @property
+    def bedrock_agent_runtime(self) -> BedrockAgentRuntimeClient:
+        return BedrockAgentRuntimeClient(self._client, self._base)
 
     @property
     def ecs(self) -> EcsClient:
@@ -1473,6 +1520,14 @@ class FakeCloudSync:
     @property
     def bedrock(self) -> _SyncBedrockClient:
         return _SyncBedrockClient(self._client, self._base)
+
+    @property
+    def bedrock_agent(self) -> _SyncBedrockAgentClient:
+        return _SyncBedrockAgentClient(self._client, self._base)
+
+    @property
+    def bedrock_agent_runtime(self) -> _SyncBedrockAgentRuntimeClient:
+        return _SyncBedrockAgentRuntimeClient(self._client, self._base)
 
     @property
     def ecs(self) -> _SyncEcsClient:

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -510,6 +510,28 @@ export class BedrockClient {
   }
 }
 
+/**
+ * Bedrock Agent (control plane) sub-client.
+ *
+ * The fakecloud Bedrock Agent service has no admin/introspection endpoints
+ * today; this client exists so callers can hold a typed handle alongside the
+ * other Bedrock sub-clients and so future helpers can land here without an
+ * API break.
+ */
+export class BedrockAgentClient {
+  constructor(private readonly baseUrl: string) {}
+}
+
+/**
+ * Bedrock Agent Runtime (data plane) sub-client.
+ *
+ * Placeholder for future introspection helpers around InvokeAgent, Retrieve,
+ * and RetrieveAndGenerate.
+ */
+export class BedrockAgentRuntimeClient {
+  constructor(private readonly baseUrl: string) {}
+}
+
 // ── Main client ────────────────────────────────────────────────────
 
 export class FakeCloud {
@@ -531,6 +553,8 @@ export class FakeCloud {
   private readonly _apigatewayv2: ApiGatewayV2Client;
   private readonly _stepfunctions: StepFunctionsClient;
   private readonly _bedrock: BedrockClient;
+  private readonly _bedrockAgent: BedrockAgentClient;
+  private readonly _bedrockAgentRuntime: BedrockAgentRuntimeClient;
   private readonly _ecs: EcsClient;
   private readonly _elbv2: Elbv2Client;
   private readonly _route53: Route53Client;
@@ -556,6 +580,8 @@ export class FakeCloud {
     this._apigatewayv2 = new ApiGatewayV2Client(this.baseUrl);
     this._stepfunctions = new StepFunctionsClient(this.baseUrl);
     this._bedrock = new BedrockClient(this.baseUrl);
+    this._bedrockAgent = new BedrockAgentClient(this.baseUrl);
+    this._bedrockAgentRuntime = new BedrockAgentRuntimeClient(this.baseUrl);
     this._ecs = new EcsClient(this.baseUrl);
     this._elbv2 = new Elbv2Client(this.baseUrl);
     this._route53 = new Route53Client(this.baseUrl);
@@ -663,6 +689,14 @@ export class FakeCloud {
 
   get bedrock(): BedrockClient {
     return this._bedrock;
+  }
+
+  get bedrockAgent(): BedrockAgentClient {
+    return this._bedrockAgent;
+  }
+
+  get bedrockAgentRuntime(): BedrockAgentRuntimeClient {
+    return this._bedrockAgentRuntime;
   }
 
   get ecs(): EcsClient {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -14,6 +14,8 @@ export {
   SecretsManagerClient,
   CognitoClient,
   BedrockClient,
+  BedrockAgentClient,
+  BedrockAgentRuntimeClient,
   EcsClient,
 } from "./client.js";
 export type * from "./types.js";

--- a/website/content/docs/services/bedrock-agent-runtime.md
+++ b/website/content/docs/services/bedrock-agent-runtime.md
@@ -1,0 +1,72 @@
++++
+title = "Bedrock Agent Runtime"
+description = "InvokeAgent, Retrieve, RetrieveAndGenerate, flow execution, sessions, memory — Bedrock Agent data plane with real eventstream framing."
+weight = 23
++++
+
+fakecloud implements the **Bedrock Agent Runtime** data plane: agent invocation, knowledge-base retrieval, retrieve-and-generate, flow execution, session and memory management, prompt optimization, and reranking. Streaming responses use **real AWS eventstream framing** (prelude, headers, payload, CRCs) so any AWS SDK can parse the response without special-casing the emulator.
+
+For the control plane (CreateAgent, knowledge bases, action groups, flows), see [Bedrock Agent](/docs/services/bedrock-agent/).
+
+## Operations
+
+### Agent invocation
+
+- **InvokeAgent** — `POST /agents/{agentId}/agentAliases/{agentAliasId}/sessions/{sessionId}/text`. Returns `application/vnd.amazon.eventstream` with real framed events: `chunk` (assistant text), `trace` (orchestration / pre-processing / post-processing / knowledge-base lookup / action-group invocation), and optional `returnControl` (when an action group is declared `RETURN_CONTROL`).
+- **InvokeInlineAgent** — pass the agent definition in the request, no `agentId` needed. Same eventstream contract as InvokeAgent.
+- **InvokeFlow** — execute a prepared flow. Eventstream of `flowOutputEvent`, `flowTraceEvent`, `flowCompletionEvent`.
+
+### Retrieval
+
+- **Retrieve** — query a knowledge base, returns `retrievalResults[]` with `content`, `location`, `score`, `metadata`.
+- **RetrieveAndGenerate** — non-streaming RAG. Combines retrieval with a model call and returns `output.text`, `citations[]`, `sessionId`, `guardrailAction`.
+- **RetrieveAndGenerateStream** — streaming variant. Eventstream of `output`, `citation`, and `guardrail` events.
+- **Rerank** — re-score a list of sources against a query using a reranker model.
+
+### Flow execution (long-running flows)
+
+- StartFlowExecution, StopFlowExecution
+- GetFlowExecution, ListFlowExecutions, ListFlowExecutionEvents
+- GetExecutionFlowSnapshot
+
+### Sessions
+
+- CreateSession, GetSession, UpdateSession, ListSessions, EndSession, DeleteSession
+- CreateInvocation, ListInvocations
+- PutInvocationStep, GetInvocationStep, ListInvocationSteps
+
+### Memory
+
+- GetAgentMemory — return persisted memory (`SESSION_SUMMARY`) for an agent
+- DeleteAgentMemory
+
+### Misc
+
+- OptimizePrompt — rewrite a prompt for a target model (eventstream)
+- GenerateQuery — generate a structured query for a knowledge base
+- TagResource, UntagResource, ListTagsForResource
+
+## Protocol
+
+REST + JSON for non-streaming ops, REST + `application/vnd.amazon.eventstream` for InvokeAgent / InvokeFlow / InvokeInlineAgent / RetrieveAndGenerateStream / OptimizePrompt.
+
+## Eventstream framing
+
+The eventstream encoder produces AWS-compliant binary frames: 12-byte prelude (total length, headers length, prelude CRC32), header block, payload, and trailing message CRC32. Both `:event-type` and `:content-type` headers are emitted per frame so SDKs decode the same shapes they decode against real AWS. This means streaming tests work end-to-end through `boto3`, `aws-sdk-js`, `aws-sdk-go-v2`, and the Java/Kotlin SDKs without mocking the body decoder.
+
+## State model
+
+- InvokeAgent canned responses default to a single-chunk echo of the input, with traces for `preProcessingTrace`, `orchestrationTrace`, and (when knowledge bases are attached) `knowledgeBaseLookupTrace`. The first call on a fresh session returns a `sessionId` matching the path segment.
+- RetrieveAndGenerate canned responses include a citation back to the first knowledge-base document returned by Retrieve, so RAG round-trip tests assert on citation plumbing.
+- Sessions persist `sessionMetadata` and `encryptionKeyArn`. Invocation steps persist the verbatim payload.
+
+## Limitations
+
+- No real model inference. Responses come from the same configurable-response / echo path documented under [Bedrock](/docs/services/bedrock/).
+- No real vector retrieval. Retrieve and RetrieveAndGenerate return synthetic results derived from the data sources attached to the knowledge base.
+- Action group Lambda executors are not invoked; the runtime emits a `RETURN_CONTROL` event so test code asserting on the agent's action-group contract receives the same shape it would receive from a real `RETURN_CONTROL` action group.
+
+## Source
+
+- [`crates/fakecloud-bedrock-agent-runtime`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-bedrock-agent-runtime)
+- [AWS Bedrock Agent Runtime API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Agents_for_Amazon_Bedrock_Runtime.html)

--- a/website/content/docs/services/bedrock-agent.md
+++ b/website/content/docs/services/bedrock-agent.md
@@ -1,0 +1,79 @@
++++
+title = "Bedrock Agent"
+description = "Agents, knowledge bases, action groups, flows, prompts, collaborators — full Bedrock Agent control plane."
+weight = 22
++++
+
+fakecloud implements the **Bedrock Agent** control plane: agents, agent aliases and versions, knowledge bases, data sources, ingestion jobs, action groups, agent collaborators, flows (with versions and aliases), prompts, and tag management.
+
+Bedrock Agent is a separate AWS service from Bedrock — it has its own endpoint (`bedrock-agent.<region>.amazonaws.com`) and its own SDK client (`boto3.client("bedrock-agent")`). For the model invocation surface, see [Bedrock](/docs/services/bedrock/). For the agent invocation surface, see [Bedrock Agent Runtime](/docs/services/bedrock-agent-runtime/).
+
+## Operations
+
+### Agents
+
+- **CRUD** — CreateAgent, GetAgent, ListAgents, UpdateAgent, DeleteAgent
+- **PrepareAgent** — transition `NOT_PREPARED` -> `PREPARING` -> `PREPARED`
+- **Versions** — GetAgentVersion, ListAgentVersions, DeleteAgentVersion
+- **Aliases** — CreateAgentAlias, GetAgentAlias, ListAgentAliases, UpdateAgentAlias, DeleteAgentAlias
+
+### Knowledge bases
+
+- **CRUD** — CreateKnowledgeBase, GetKnowledgeBase, ListKnowledgeBases, UpdateKnowledgeBase, DeleteKnowledgeBase
+- **Data sources** — CreateDataSource, GetDataSource, ListDataSources, UpdateDataSource, DeleteDataSource
+- **Ingestion jobs** — StartIngestionJob, GetIngestionJob, ListIngestionJobs, StopIngestionJob
+- **Documents** — DeleteKnowledgeBaseDocuments, GetKnowledgeBaseDocuments, ListKnowledgeBaseDocuments
+
+### Action groups
+
+- CreateAgentActionGroup, GetAgentActionGroup, ListAgentActionGroups, UpdateAgentActionGroup, DeleteAgentActionGroup
+- Supports Lambda executor, OpenAPI schema, function schema, and `RETURN_CONTROL` action groups
+- Parent action group signatures (`AMAZON.UserInput`, `AMAZON.CodeInterpreter`) accepted
+
+### Agent <-> knowledge base wiring
+
+- AssociateAgentKnowledgeBase, DisassociateAgentKnowledgeBase
+- GetAgentKnowledgeBase, ListAgentKnowledgeBases, UpdateAgentKnowledgeBase
+
+### Agent collaborators (multi-agent)
+
+- AssociateAgentCollaborator, DisassociateAgentCollaborator
+- GetAgentCollaborator, ListAgentCollaborators, UpdateAgentCollaborator
+
+### Flows
+
+- **CRUD** — CreateFlow, GetFlow, ListFlows, UpdateFlow, DeleteFlow, PrepareFlow
+- **Versions** — CreateFlowVersion, GetFlowVersion, ListFlowVersions, DeleteFlowVersion
+- **Aliases** — CreateFlowAlias, GetFlowAlias, ListFlowAliases, UpdateFlowAlias, DeleteFlowAlias
+
+### Prompts
+
+- CreatePrompt, GetPrompt, ListPrompts, UpdatePrompt, DeletePrompt
+- Variants with model overrides, inference configuration, and template variables
+
+### Tags
+
+- TagResource, UntagResource, ListTagsForResource — on agents, agent aliases, knowledge bases, data sources, flows, flow aliases, prompts
+
+## Protocol
+
+REST + JSON. Path-based routing; identifiers are URL-safe strings minted by fakecloud (no AWS-side validation enforced on caller-supplied IDs).
+
+## State model
+
+- Agents start `NOT_PREPARED`. `PrepareAgent` advances to `PREPARED` (and immediately becomes invokable from Bedrock Agent Runtime). `DRAFT` version is implicit; explicit versions are created on first alias attached to `DRAFT`.
+- Knowledge bases start `CREATING` and transition to `ACTIVE` on next describe. Ingestion jobs follow `STARTING -> IN_PROGRESS -> COMPLETE`.
+- Data sources transition the same way and persist their `vectorIngestionConfiguration` verbatim.
+
+## Limitations
+
+- Embedding pipelines are not executed; ingestion jobs report success without indexing real content.
+- Action group Lambda executors and OpenAPI schemas are stored verbatim and returned by the runtime in `RETURN_CONTROL` traces; the agent does not actually call Lambda for action group execution.
+- Prompt evaluation is not performed; prompts are stored and returned for SDK round-trip tests.
+
+For the data plane (InvokeAgent, Retrieve, RetrieveAndGenerate), see [Bedrock Agent Runtime](/docs/services/bedrock-agent-runtime/).
+
+## Source
+
+- [`crates/fakecloud-bedrock-agent`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-bedrock-agent)
+- [AWS Bedrock Agent API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Agents_for_Amazon_Bedrock.html)


### PR DESCRIPTION
## Summary

Batch B11 of the post-encapsulated-leaping-wren sync audit. Adds first-class SDK + docs surface for the two Bedrock Agent crates shipped in PRs #1242 / #1243 / #1283.

- New website pages: `bedrock-agent.md` (agents, knowledge bases, action groups, flows, prompts, collaborators) and `bedrock-agent-runtime.md` (InvokeAgent + Retrieve + RetrieveAndGenerate, real eventstream framing).
- New SDK sub-clients in all 5 languages (`bedrock_agent` / `bedrockAgent` and `bedrock_agent_runtime` / `bedrockAgentRuntime`) wired to the base URL. The fakecloud Bedrock Agent service has no `/_fakecloud/bedrock-agent/*` admin endpoints today, so the sub-clients are intentionally empty placeholders — they exist so callers can hold a typed handle alongside the other Bedrock sub-clients and so future introspection helpers can land without an API break.
- Python `__init__.py` re-exports the new classes; TS `index.ts` re-exports too.

## Test plan

- [x] TypeScript: `npm run build` clean
- [x] Go: `go build ./...` clean
- [x] Java: `./gradlew compileJava` clean
- [x] Python: smoke import + `.bedrock_agent` / `.bedrock_agent_runtime` properties resolve on both async + sync clients
- [ ] PHP: covered by CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for Bedrock Agent and Bedrock Agent Runtime, and add new SDK sub-clients across TS, Python, Go, Java, and PHP. This gives typed handles for agents and runtime now, and keeps room for future helpers without API breaks.

- **New Features**
  - Docs: new pages for Bedrock Agent (control plane) and Bedrock Agent Runtime (data plane) with real eventstream framing details.
  - SDKs: added `bedrockAgent`/`bedrock_agent` and `bedrockAgentRuntime`/`bedrock_agent_runtime` sub-clients in all 5 languages; exposed via getters/properties and wired to the base URL. TS `index.ts` and Python `__init__.py` re-export the new classes.
  - Note: these sub-clients are placeholders (no admin endpoints yet) so callers can hold typed handles alongside other Bedrock clients.

<sup>Written for commit 2b9dfcf7e5c28e8a1455a57ed175eb3d473969bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

