### PR TITLE
docs(ses): sync docs + SDK helpers with shipped features (B1)

### DIFF
--- a/sdks/go/ses.go
+++ b/sdks/go/ses.go
@@ -24,3 +24,43 @@ func (c *SESClient) SimulateInbound(ctx context.Context, req *InboundEmailReques
 	}
 	return &out, nil
 }
+
+// GetMetrics returns SES emulator counters (e.g. suppressed drops).
+func (c *SESClient) GetMetrics(ctx context.Context) (*SESMetrics, error) {
+	var out SESMetrics
+	if err := c.fc.doGet(ctx, "/_fakecloud/ses/metrics", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetMailFromStatus overrides the MAIL FROM domain verification status for
+// an identity. Status must be one of NotStarted/Pending/Success/Failed.
+func (c *SESClient) SetMailFromStatus(ctx context.Context, identity, status string) (*SESMailFromStatusResponse, error) {
+	var out SESMailFromStatusResponse
+	path := "/_fakecloud/ses/identities/" + identity + "/mail-from-status"
+	if err := c.fc.doPost(ctx, path, &SESMailFromStatusRequest{Status: status}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetDkimPublicKey returns the DKIM selector + public key for an identity.
+func (c *SESClient) GetDkimPublicKey(ctx context.Context, identity string) (*SESDkimPublicKey, error) {
+	var out SESDkimPublicKey
+	path := "/_fakecloud/ses/identities/" + identity + "/dkim-public-key"
+	if err := c.fc.doGet(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetSandbox toggles the SES sandbox state for the account.
+// sandbox=true disables production access; sandbox=false re-enables it.
+func (c *SESClient) SetSandbox(ctx context.Context, sandbox bool) (*SESSandboxResponse, error) {
+	var out SESSandboxResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/ses/account/sandbox", &SESSandboxRequest{Sandbox: sandbox}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -180,6 +180,41 @@ type InboundEmailResponse struct {
 	ActionsExecuted []InboundActionExecuted `json:"actionsExecuted"`
 }
 
+// SESMetrics exposes counters tracked by the SES emulator.
+type SESMetrics struct {
+	SuppressedDropsTotal uint64 `json:"suppressedDropsTotal"`
+}
+
+// SESMailFromStatusRequest sets the MAIL FROM domain verification status.
+type SESMailFromStatusRequest struct {
+	Status string `json:"status"`
+}
+
+// SESMailFromStatusResponse is returned after updating MAIL FROM status.
+type SESMailFromStatusResponse struct {
+	Identity             string `json:"identity"`
+	MailFromDomainStatus string `json:"mailFromDomainStatus"`
+}
+
+// SESDkimPublicKey describes the DKIM signing material for an identity.
+type SESDkimPublicKey struct {
+	Identity       string `json:"identity"`
+	Selector       string `json:"selector"`
+	PublicKeyBase64 string `json:"publicKeyBase64"`
+	SigningEnabled bool   `json:"signingEnabled"`
+}
+
+// SESSandboxRequest toggles sandbox / production access for the account.
+type SESSandboxRequest struct {
+	Sandbox bool `json:"sandbox"`
+}
+
+// SESSandboxResponse echoes the new sandbox state.
+type SESSandboxResponse struct {
+	Sandbox                  bool `json:"sandbox"`
+	ProductionAccessEnabled  bool `json:"productionAccessEnabled"`
+}
+
 // ── SNS ────────────────────────────────────────────────────────────
 
 // SNSMessage represents a published SNS message.

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -62,7 +62,13 @@ import dev.fakecloud.Types.ResetResponse;
 import dev.fakecloud.Types.ResetServiceResponse;
 import dev.fakecloud.Types.RotationTickResponse;
 import dev.fakecloud.Types.S3NotificationsResponse;
+import dev.fakecloud.Types.SesDkimPublicKey;
 import dev.fakecloud.Types.SesEmailsResponse;
+import dev.fakecloud.Types.SesMailFromStatusRequest;
+import dev.fakecloud.Types.SesMailFromStatusResponse;
+import dev.fakecloud.Types.SesMetrics;
+import dev.fakecloud.Types.SesSandboxRequest;
+import dev.fakecloud.Types.SesSandboxResponse;
 import dev.fakecloud.Types.SetCertificateStatusRequest;
 import dev.fakecloud.Types.SetHealthCheckStatusRequest;
 import dev.fakecloud.Types.SnsMessagesResponse;
@@ -308,6 +314,30 @@ public final class FakeCloud {
 
         public InboundEmailResponse simulateInbound(InboundEmailRequest req) {
             return http.postJson("/_fakecloud/ses/inbound", req, InboundEmailResponse.class);
+        }
+
+        public SesMetrics getMetrics() {
+            return http.get("/_fakecloud/ses/metrics", SesMetrics.class);
+        }
+
+        public SesMailFromStatusResponse setMailFromStatus(String identity, String status) {
+            return http.postJson(
+                    "/_fakecloud/ses/identities/" + identity + "/mail-from-status",
+                    new SesMailFromStatusRequest(status),
+                    SesMailFromStatusResponse.class);
+        }
+
+        public SesDkimPublicKey getDkimPublicKey(String identity) {
+            return http.get(
+                    "/_fakecloud/ses/identities/" + identity + "/dkim-public-key",
+                    SesDkimPublicKey.class);
+        }
+
+        public SesSandboxResponse setSandbox(boolean sandbox) {
+            return http.postJson(
+                    "/_fakecloud/ses/account/sandbox",
+                    new SesSandboxRequest(sandbox),
+                    SesSandboxResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -153,6 +153,28 @@ public final class Types {
             List<String> matchedRules,
             List<InboundActionExecuted> actionsExecuted) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SesMetrics(long suppressedDropsTotal) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SesMailFromStatusRequest(String status) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SesMailFromStatusResponse(String identity, String mailFromDomainStatus) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SesDkimPublicKey(
+            String identity,
+            String selector,
+            String publicKeyBase64,
+            boolean signingEnabled) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SesSandboxRequest(boolean sandbox) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SesSandboxResponse(boolean sandbox, boolean productionAccessEnabled) {}
+
     // ── SNS ────────────────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record SnsMessage(

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -260,6 +260,39 @@ final class SesClient
             $this->http->postJson('/_fakecloud/ses/inbound', $req->toArray())
         );
     }
+
+    public function getMetrics(): SesMetrics
+    {
+        return SesMetrics::fromArray(
+            $this->http->get('/_fakecloud/ses/metrics')
+        );
+    }
+
+    public function setMailFromStatus(string $identity, string $status): SesMailFromStatusResponse
+    {
+        return SesMailFromStatusResponse::fromArray(
+            $this->http->postJson(
+                '/_fakecloud/ses/identities/' . rawurlencode($identity) . '/mail-from-status',
+                ['status' => $status],
+            )
+        );
+    }
+
+    public function getDkimPublicKey(string $identity): SesDkimPublicKey
+    {
+        return SesDkimPublicKey::fromArray(
+            $this->http->get(
+                '/_fakecloud/ses/identities/' . rawurlencode($identity) . '/dkim-public-key'
+            )
+        );
+    }
+
+    public function setSandbox(bool $sandbox): SesSandboxResponse
+    {
+        return SesSandboxResponse::fromArray(
+            $this->http->postJson('/_fakecloud/ses/account/sandbox', ['sandbox' => $sandbox])
+        );
+    }
 }
 
 final class SnsClient

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -433,6 +433,67 @@ final class InboundEmailResponse
     }
 }
 
+final class SesMetrics
+{
+    public function __construct(
+        public readonly int $suppressedDropsTotal,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self((int) ($data['suppressedDropsTotal'] ?? 0));
+    }
+}
+
+final class SesMailFromStatusResponse
+{
+    public function __construct(
+        public readonly string $identity,
+        public readonly string $mailFromDomainStatus,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['identity'], $data['mailFromDomainStatus']);
+    }
+}
+
+final class SesDkimPublicKey
+{
+    public function __construct(
+        public readonly string $identity,
+        public readonly ?string $selector,
+        public readonly ?string $publicKeyBase64,
+        public readonly bool $signingEnabled,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['identity'],
+            $data['selector'] ?? null,
+            $data['publicKeyBase64'] ?? null,
+            (bool) ($data['signingEnabled'] ?? false),
+        );
+    }
+}
+
+final class SesSandboxResponse
+{
+    public function __construct(
+        public readonly bool $sandbox,
+        public readonly bool $productionAccessEnabled,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (bool) $data['sandbox'],
+            (bool) $data['productionAccessEnabled'],
+        );
+    }
+}
+
 // ── SNS ────────────────────────────────────────────────────────
 
 final class SnsMessage

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -66,7 +66,11 @@ from fakecloud.types import (
     RotationTickResponse,
     S3NotificationsResponse,
     SchedulerSchedulesResponse,
+    SesDkimPublicKey,
     SesEmailsResponse,
+    SesMailFromStatusResponse,
+    SesMetrics,
+    SesSandboxResponse,
     SfnEnqueueActivityTaskRequest,
     SfnEnqueueActivityTaskResponse,
     SnsMessagesResponse,
@@ -561,6 +565,36 @@ class SesClient:
         _check(resp)
         return InboundEmailResponse.from_dict(resp.json())
 
+    async def get_metrics(self) -> SesMetrics:
+        resp = await self._client.get(f"{self._base}/_fakecloud/ses/metrics")
+        _check(resp)
+        return SesMetrics.from_dict(resp.json())
+
+    async def set_mail_from_status(
+        self, identity: str, status: str
+    ) -> SesMailFromStatusResponse:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/ses/identities/{identity}/mail-from-status",
+            json={"status": status},
+        )
+        _check(resp)
+        return SesMailFromStatusResponse.from_dict(resp.json())
+
+    async def get_dkim_public_key(self, identity: str) -> SesDkimPublicKey:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/ses/identities/{identity}/dkim-public-key"
+        )
+        _check(resp)
+        return SesDkimPublicKey.from_dict(resp.json())
+
+    async def set_sandbox(self, sandbox: bool) -> SesSandboxResponse:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/ses/account/sandbox",
+            json={"sandbox": sandbox},
+        )
+        _check(resp)
+        return SesSandboxResponse.from_dict(resp.json())
+
 
 class SnsClient:
     """Async SNS introspection client."""
@@ -1046,6 +1080,36 @@ class _SyncSesClient:
         )
         _check(resp)
         return InboundEmailResponse.from_dict(resp.json())
+
+    def get_metrics(self) -> SesMetrics:
+        resp = self._client.get(f"{self._base}/_fakecloud/ses/metrics")
+        _check(resp)
+        return SesMetrics.from_dict(resp.json())
+
+    def set_mail_from_status(
+        self, identity: str, status: str
+    ) -> SesMailFromStatusResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/ses/identities/{identity}/mail-from-status",
+            json={"status": status},
+        )
+        _check(resp)
+        return SesMailFromStatusResponse.from_dict(resp.json())
+
+    def get_dkim_public_key(self, identity: str) -> SesDkimPublicKey:
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/ses/identities/{identity}/dkim-public-key"
+        )
+        _check(resp)
+        return SesDkimPublicKey.from_dict(resp.json())
+
+    def set_sandbox(self, sandbox: bool) -> SesSandboxResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/ses/account/sandbox",
+            json={"sandbox": sandbox},
+        )
+        _check(resp)
+        return SesSandboxResponse.from_dict(resp.json())
 
 
 class _SyncSnsClient:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -373,6 +373,62 @@ class InboundEmailResponse:
         )
 
 
+@dataclass
+class SesMetrics:
+    suppressed_drops_total: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SesMetrics:
+        d = _convert_keys(data)
+        return cls(suppressed_drops_total=int(d.get("suppressed_drops_total", 0)))
+
+
+@dataclass
+class SesMailFromStatusResponse:
+    identity: str
+    mail_from_domain_status: str
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SesMailFromStatusResponse:
+        d = _convert_keys(data)
+        return cls(
+            identity=d["identity"],
+            mail_from_domain_status=d["mail_from_domain_status"],
+        )
+
+
+@dataclass
+class SesDkimPublicKey:
+    identity: str
+    selector: Optional[str]
+    public_key_base64: Optional[str]
+    signing_enabled: bool
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SesDkimPublicKey:
+        d = _convert_keys(data)
+        return cls(
+            identity=d["identity"],
+            selector=d.get("selector"),
+            public_key_base64=d.get("public_key_base64"),
+            signing_enabled=bool(d.get("signing_enabled", False)),
+        )
+
+
+@dataclass
+class SesSandboxResponse:
+    sandbox: bool
+    production_access_enabled: bool
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SesSandboxResponse:
+        d = _convert_keys(data)
+        return cls(
+            sandbox=bool(d["sandbox"]),
+            production_access_enabled=bool(d["production_access_enabled"]),
+        )
+
+
 # ── SNS ─────────────────────────────────────────────────────────────
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -223,14 +223,11 @@ export class SesClient {
   }
 
   async setSandbox(sandbox: boolean): Promise<SesSandboxResponse> {
-    const resp = await fetch(
-      `${this.baseUrl}/_fakecloud/ses/account/sandbox`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sandbox }),
-      },
-    );
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/ses/account/sandbox`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sandbox }),
+    });
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -25,6 +25,11 @@ import type {
   SesEmailsResponse,
   InboundEmailRequest,
   InboundEmailResponse,
+  SesMetrics,
+  SesMailFromStatus,
+  SesMailFromStatusResponse,
+  SesDkimPublicKey,
+  SesSandboxResponse,
   SnsMessagesResponse,
   PendingConfirmationsResponse,
   ConfirmSubscriptionRequest,
@@ -187,6 +192,45 @@ export class SesClient {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(req),
     });
+    return parse(resp);
+  }
+
+  async getMetrics(): Promise<SesMetrics> {
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/ses/metrics`);
+    return parse(resp);
+  }
+
+  async setMailFromStatus(
+    identity: string,
+    status: SesMailFromStatus,
+  ): Promise<SesMailFromStatusResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ses/identities/${encodeURIComponent(identity)}/mail-from-status`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      },
+    );
+    return parse(resp);
+  }
+
+  async getDkimPublicKey(identity: string): Promise<SesDkimPublicKey> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ses/identities/${encodeURIComponent(identity)}/dkim-public-key`,
+    );
+    return parse(resp);
+  }
+
+  async setSandbox(sandbox: boolean): Promise<SesSandboxResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ses/account/sandbox`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sandbox }),
+      },
+    );
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -169,11 +169,7 @@ export interface SesMetrics {
   suppressedDropsTotal: number;
 }
 
-export type SesMailFromStatus =
-  | "NotStarted"
-  | "Pending"
-  | "Success"
-  | "Failed";
+export type SesMailFromStatus = "NotStarted" | "Pending" | "Success" | "Failed";
 
 export interface SesMailFromStatusResponse {
   identity: string;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -165,6 +165,33 @@ export interface InboundEmailResponse {
   actionsExecuted: InboundActionExecuted[];
 }
 
+export interface SesMetrics {
+  suppressedDropsTotal: number;
+}
+
+export type SesMailFromStatus =
+  | "NotStarted"
+  | "Pending"
+  | "Success"
+  | "Failed";
+
+export interface SesMailFromStatusResponse {
+  identity: string;
+  mailFromDomainStatus: SesMailFromStatus;
+}
+
+export interface SesDkimPublicKey {
+  identity: string;
+  selector: string;
+  publicKeyBase64: string;
+  signingEnabled: boolean;
+}
+
+export interface SesSandboxResponse {
+  sandbox: boolean;
+  productionAccessEnabled: boolean;
+}
+
 // ── SNS ────────────────────────────────────────────────────────────
 
 export interface SnsMessage {

--- a/website/content/docs/services/ses.md
+++ b/website/content/docs/services/ses.md
@@ -11,17 +11,31 @@ fakecloud implements **110 of 110** SES v2 operations at 100% Smithy conformance
 ### Sending (SES v2)
 
 - **SendEmail, SendBulkEmail** — recorded at `/_fakecloud/ses/emails`, including the stamped `DKIM-Signature` header when signing is enabled
-- **Identities** — email identity and domain identity CRUD, DKIM (real RSA-SHA256 signing with relaxed/relaxed canonicalization), mail-from, feedback attributes, signing attributes
+- **SendBounce (v1)** — synthesise an inbound bounce message; the bounce record lands in `/_fakecloud/ses/emails` and triggers configured event destinations
+- **Identities** — email identity and domain identity CRUD, real DKIM RSA-SHA256 signing with relaxed/relaxed canonicalization (public key served at `/_fakecloud/ses/identities/{name}/dkim-public-key`), mail-from, feedback attributes, signing attributes
 - **Configuration sets** — CRUD, event destinations, reputation options, sending options, tracking, suppression, VDM, archiving
-- **Templates** — email templates, custom verification templates, test rendering
+- **Templates** — email templates, custom verification templates, and `TestRenderEmailTemplate` which produces a full RFC 5322 / MIME message (Subject, From, To, CC, BCC, Reply-To, Date, Message-ID, multipart bodies, attachments) from the stored template + JSON template data
 - **Contact lists** — CRUD, contacts, subscription topics
 - **Dedicated IPs** — pools, warmup, scaling
 - **Suppression list** — CRUD, account-level suppression
-- **Event destinations** — fan out to SNS and EventBridge on send/delivery/bounce/complaint
+- **Event destinations** — fan out to **SNS, EventBridge, Kinesis Data Streams, Kinesis Data Firehose, and CloudWatch** on send/delivery/bounce/complaint/click/open/reject/rendering-failure
+- **GetMessageInsights** — per-message delivery / engagement timeline (send + delivery + bounce + complaint + open + click events) keyed by `MessageId`
 - **Import and export jobs** — CRUD
 - **Multi-region endpoints** — CRUD
 - **Tenants** — multi-tenant isolation
 - **Reputation** — entity management, policy
+
+### Deliverability simulator addresses
+
+fakecloud honours the standard [AWS mailbox simulator](https://docs.aws.amazon.com/ses/latest/dg/send-email-simulator.html) recipients on `SendEmail` / `SendRawEmail` / `SendBulkEmail`:
+
+- `bounce@simulator.amazonses.com` -> synthetic hard bounce + `Bounce` event
+- `complaint@simulator.amazonses.com` -> synthetic complaint event
+- `suppressionlist@simulator.amazonses.com` -> account suppression hit
+- `success@simulator.amazonses.com` -> normal `Delivery` event
+- `ooto@simulator.amazonses.com` -> out-of-office auto-reply
+
+Events fan out through the configuration set's event destinations exactly like a real send.
 
 ### Inbound (SES v1)
 
@@ -49,16 +63,28 @@ fakecloud also exposes a minimal SMTP submission listener that mirrors `email-sm
 - After `MAIL FROM` / `RCPT TO` / `DATA`, the message is recorded in the SES `sent_emails` ledger as a `SentEmail` with `raw_data` populated, mirroring `SendRawEmail`. It then surfaces on `GET /_fakecloud/ses/emails` like any other accepted message.
 - STARTTLS is not implemented — keep the listener bound to localhost in tests.
 
+## SMTP outbound relay (opt-in)
+
+For tests that want fakecloud to forward accepted messages out to a real SMTP server (for example [MailHog](https://github.com/mailhog/MailHog) or your own integration mailbox), set `FAKECLOUD_SES_SMTP_RELAY=smtp://host:port` before starting the server. When set, fakecloud will dispatch every accepted `SendEmail` / `SendRawEmail` / `SendBulkEmail` / SMTP-submitted message to the configured relay in addition to recording it locally.
+
+- **Opt-in only.** With the variable unset, no outbound network traffic is generated — messages are recorded in memory like before.
+- Failures from the relay are logged but do not fail the send (the message is still recorded), matching SES's "accepted for delivery" semantics.
+
 ## Introspection
 
 - `GET /_fakecloud/ses/emails` — list all sent emails with full body, synthesized headers (DKIM-Signature first when signing was active), attachments
+- `GET /_fakecloud/ses/metrics` — counters (e.g. `suppressedDropsTotal`) for the SES emulator
 - `GET /_fakecloud/ses/identities/{name}/dkim-public-key` — pull the published Easy DKIM public key (SPKI DER, base64) so tests can verify signatures end-to-end
+- `POST /_fakecloud/ses/identities/{name}/mail-from-status` — override an identity's MAIL FROM domain verification status (`NotStarted` / `Pending` / `Success` / `Failed`)
+- `POST /_fakecloud/ses/account/sandbox` — toggle account-level sandbox / production access state for sending checks
 - `POST /_fakecloud/ses/inbound` — simulate receiving an inbound email, trigger receipt rule evaluation
+
+The introspection SDKs (Go/TypeScript/Python/Java/PHP) wrap each of these as a one-line helper, e.g. `fc.ses().getDkimPublicKey("example.com")`, `fc.ses().setSandbox(false)`.
 
 ## Cross-service delivery
 
-- **SES -> SNS / EventBridge** — Send/delivery/bounce/complaint events fan out via configured event destinations
-- **SES Inbound -> S3 / SNS / Lambda / Bounce / AddHeader / Stop** — Receipt rules evaluate and execute every supported action type
+- **SES -> SNS / EventBridge / Kinesis Data Streams / Kinesis Data Firehose / CloudWatch** — Send/delivery/bounce/complaint/click/open/reject/rendering-failure events fan out via configured event destinations
+- **SES Inbound -> S3 / SNS / Lambda / Bounce / AddHeader / Stop / Workmail** — Receipt rules evaluate and execute every supported action type
 
 ## Why this matters
 

--- a/website/content/ses-emulator.md
+++ b/website/content/ses-emulator.md
@@ -20,6 +20,8 @@ Point your AWS SDK at `http://localhost:4566`.
 - **Test-assertion SDK.** `fc.ses.getEmails()` returns the sent-email log so tests can assert recipients, subject, body, destinations, bounces.
 - **Real DKIM signing.** Configure a domain identity, fakecloud signs outbound mail with the computed DKIM-Signature header.
 - **Configuration sets + event destinations.** Sending, delivery, bounce, complaint, click, open events published to SNS / Kinesis / CloudWatch destinations.
+- **Optional SMTP submission listener.** Set `FAKECLOUD_SES_SMTP_PORT=2525` and fakecloud accepts mail from your existing SMTP libraries on the standard SES `AUTH PLAIN` / `AUTH LOGIN` flow, with the same `ServiceUserName` / `ServicePassword` produced by IAM `CreateServiceSpecificCredential`. Off by default.
+- **Optional outbound SMTP relay.** Set `FAKECLOUD_SES_SMTP_RELAY=smtp://host:port` and accepted messages are forwarded to that relay (for example a local [MailHog](https://github.com/mailhog/MailHog) instance) in addition to being recorded. Off by default — no network traffic without an explicit opt-in.
 - **No account, no auth token, no paid tier.** AGPL-3.0.
 
 ## Send an email


### PR DESCRIPTION
## Summary

- Add SDK helpers for the 4 SES introspection endpoints that already exist on the server but weren't yet wrapped: `GET /_fakecloud/ses/metrics`, `POST /_fakecloud/ses/identities/{name}/mail-from-status`, `GET /_fakecloud/ses/identities/{name}/dkim-public-key`, `POST /_fakecloud/ses/account/sandbox`. Mirrored 1:1 across Go, TypeScript, Python (async + sync), Java, and PHP.
- Bring `website/content/docs/services/ses.md` in sync with merged backend behavior: `SendBounce`, deliverability simulator addresses, `TestRenderEmailTemplate` MIME builder, `GetMessageInsights`, event destinations to Kinesis Data Streams + Kinesis Data Firehose + CloudWatch (in addition to SNS / EventBridge), DKIM signing, SMTP outbound relay (env-flagged opt-in via `FAKECLOUD_SES_SMTP_RELAY`), plus the newly-wrapped introspection endpoints.
- Polish `website/content/ses-emulator.md` to mention the opt-in SMTP submission listener and the opt-in outbound relay without exaggerating either as "on by default".
- No `crates/*` changes; no `parity.md` changes (B15 handles that).

## Test plan

- [x] `go build ./...` in `sdks/go`
- [x] `npm run build` (`tsc`) in `sdks/typescript`
- [x] `pip install -e .` + `python -c "from fakecloud import types; assert hasattr(types, 'SesMetrics')"` in `sdks/python`
- [x] `./gradlew build -x test` in `sdks/java`
- [ ] PHP build skipped — no `php`/`composer` on this host; reviewed syntax manually (same-namespace types, no new imports needed)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SES introspection helpers across Go/TypeScript/Python/Java/PHP and updates SES docs to match current behavior. Enables metrics, DKIM key retrieval, MAIL FROM status overrides, and sandbox toggles; docs now cover new events, simulator mailboxes, full template rendering, SMTP submission, and optional outbound relay.

- **New Features**
  - SDKs (Go/TypeScript/Python/Java/PHP): wrap 4 SES introspection endpoints — `GET /_fakecloud/ses/metrics`, `POST /_fakecloud/ses/identities/{name}/mail-from-status`, `GET /_fakecloud/ses/identities/{name}/dkim-public-key`, `POST /_fakecloud/ses/account/sandbox`.
  - Docs: aligned with backend support — SendBounce, deliverability simulator addresses, `TestRenderEmailTemplate` (full MIME), GetMessageInsights, event destinations expanded to Kinesis Data Streams/Firehose/CloudWatch (in addition to SNS/EventBridge), DKIM signing, optional SMTP submission listener (`FAKECLOUD_SES_SMTP_PORT`), opt-in outbound relay via `FAKECLOUD_SES_SMTP_RELAY`, and the newly wrapped introspection endpoints.

<sup>Written for commit b55422d4d310bb7b5dfbaa1e771e083ff38c7c43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

