### PR TITLE
docs(cognito): sync docs + SDK helpers (B2)

### DIFF
--- a/sdks/go/cognito.go
+++ b/sdks/go/cognito.go
@@ -116,3 +116,28 @@ func (c *CognitoClient) MintAuthorizationCode(ctx context.Context, req *MintAuth
 	}
 	return &out, nil
 }
+
+// SetCompromisedPasswords registers plaintext passwords as compromised.
+// Each is SHA-256 hashed server-side and added to the per-account
+// compromised-password set, after which `SignUp` / `AdminInitiateAuth`
+// will fail with `InvalidPasswordException` on any pool whose
+// `CompromisedCredentialsRiskConfiguration.Actions.EventAction` is
+// `BLOCK`.
+func (c *CognitoClient) SetCompromisedPasswords(ctx context.Context, req *CompromisedPasswordsRequest) (*CompromisedPasswordsResponse, error) {
+	var out CompromisedPasswordsResponse
+	if err := c.fc.doPost(ctx, "/_fakecloud/cognito/compromised-passwords", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetWebAuthnCredentials lists every registered WebAuthn credential
+// across pools and users, including the parsed packed-attestation
+// info captured at registration time.
+func (c *CognitoClient) GetWebAuthnCredentials(ctx context.Context) (*WebAuthnCredentialsResponse, error) {
+	var out WebAuthnCredentialsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/cognito/webauthn-credentials", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1,5 +1,7 @@
 package fakecloud
 
+import "encoding/json"
+
 // ── Health & Reset ─────────────────────────────────────────────────
 
 // HealthResponse is returned by the health endpoint.
@@ -472,6 +474,40 @@ type MintAuthorizationCodeRequest struct {
 // MintAuthorizationCodeResponse is returned after minting a code.
 type MintAuthorizationCodeResponse struct {
 	Code string `json:"code"`
+}
+
+// CompromisedPasswordsRequest is the payload for the
+// /_fakecloud/cognito/compromised-passwords admin endpoint. Each
+// supplied plaintext password is SHA-256 hashed and added to the
+// compromised-password set; subsequent `SignUp` / `AdminInitiateAuth`
+// calls fail with `InvalidPasswordException` when a user pool has
+// `CompromisedCredentialsRiskConfiguration.Actions.EventAction = BLOCK`
+// and the supplied password hashes to a member of that set.
+type CompromisedPasswordsRequest struct {
+	Passwords []string `json:"passwords"`
+}
+
+// CompromisedPasswordsResponse is returned after registering passwords.
+type CompromisedPasswordsResponse struct {
+	Added uint64 `json:"added"`
+}
+
+// WebAuthnCredential describes a registered WebAuthn credential
+// surfaced by the introspection endpoint. `AttestationInfo` is the
+// parsed-attestation JSON object (packed format details, AAGUID,
+// certificate chain summary, signature counter) and is left as raw
+// JSON because its shape depends on the attestation format.
+type WebAuthnCredential struct {
+	AccountID       string          `json:"account_id"`
+	PoolUser        string          `json:"pool_user"`
+	CredentialID    string          `json:"credential_id"`
+	RelyingPartyID  string          `json:"relying_party_id"`
+	AttestationInfo json.RawMessage `json:"attestation_info"`
+}
+
+// WebAuthnCredentialsResponse contains all registered WebAuthn credentials.
+type WebAuthnCredentialsResponse struct {
+	Credentials []WebAuthnCredential `json:"credentials"`
 }
 
 // ── Step Functions ─────────────────────────────────────────────────

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -8,6 +8,9 @@ import dev.fakecloud.Types.AppAsTickResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
 import dev.fakecloud.Types.MintAuthorizationCodeRequest;
 import dev.fakecloud.Types.MintAuthorizationCodeResponse;
+import dev.fakecloud.Types.CompromisedPasswordsRequest;
+import dev.fakecloud.Types.CompromisedPasswordsResponse;
+import dev.fakecloud.Types.WebAuthnCredentialsResponse;
 import dev.fakecloud.Types.BedrockFaultRule;
 import dev.fakecloud.Types.BedrockFaultsResponse;
 import dev.fakecloud.Types.BedrockInvocationsResponse;
@@ -477,6 +480,20 @@ public final class FakeCloud {
                     "/_fakecloud/cognito/authorization-codes",
                     req,
                     MintAuthorizationCodeResponse.class);
+        }
+
+        public CompromisedPasswordsResponse setCompromisedPasswords(
+                CompromisedPasswordsRequest req) {
+            return http.postJson(
+                    "/_fakecloud/cognito/compromised-passwords",
+                    req,
+                    CompromisedPasswordsResponse.class);
+        }
+
+        public WebAuthnCredentialsResponse getWebAuthnCredentials() {
+            return http.get(
+                    "/_fakecloud/cognito/webauthn-credentials",
+                    WebAuthnCredentialsResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -355,6 +355,40 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record MintAuthorizationCodeResponse(String code) {}
 
+    /**
+     * Payload for {@code POST /_fakecloud/cognito/compromised-passwords}.
+     * Each plaintext is SHA-256 hashed server-side and added to the
+     * per-account compromised-password set; subsequent {@code SignUp}
+     * / {@code AdminInitiateAuth} fail with
+     * {@code InvalidPasswordException} on any pool whose
+     * {@code CompromisedCredentialsRiskConfiguration.Actions.EventAction}
+     * is {@code BLOCK}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CompromisedPasswordsRequest(List<String> passwords) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record CompromisedPasswordsResponse(long added) {}
+
+    /**
+     * Registered WebAuthn credential from
+     * {@code GET /_fakecloud/cognito/webauthn-credentials}. The
+     * {@code attestationInfo} field is the parsed-attestation JSON
+     * (packed format details, AAGUID, certificate chain summary,
+     * signature counter); its shape depends on the attestation format
+     * so it is surfaced as a generic {@link Object}.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record WebAuthnCredential(
+            @com.fasterxml.jackson.annotation.JsonProperty("account_id") String accountId,
+            @com.fasterxml.jackson.annotation.JsonProperty("pool_user") String poolUser,
+            @com.fasterxml.jackson.annotation.JsonProperty("credential_id") String credentialId,
+            @com.fasterxml.jackson.annotation.JsonProperty("relying_party_id") String relyingPartyId,
+            @com.fasterxml.jackson.annotation.JsonProperty("attestation_info") Object attestationInfo) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record WebAuthnCredentialsResponse(List<WebAuthnCredential> credentials) {}
+
     // ── Step Functions ─────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record StepFunctionsExecution(

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -469,6 +469,24 @@ final class CognitoClient
             )
         );
     }
+
+    public function setCompromisedPasswords(
+        CompromisedPasswordsRequest $req
+    ): CompromisedPasswordsResponse {
+        return CompromisedPasswordsResponse::fromArray(
+            $this->http->postJson(
+                '/_fakecloud/cognito/compromised-passwords',
+                $req->toArray()
+            )
+        );
+    }
+
+    public function getWebAuthnCredentials(): WebAuthnCredentialsResponse
+    {
+        return WebAuthnCredentialsResponse::fromArray(
+            $this->http->get('/_fakecloud/cognito/webauthn-credentials')
+        );
+    }
 }
 
 final class ApiGatewayV2Client

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1088,6 +1088,79 @@ final class MintAuthorizationCodeResponse
     }
 }
 
+/**
+ * Payload for `POST /_fakecloud/cognito/compromised-passwords`. Each
+ * plaintext is SHA-256 hashed server-side and added to the per-account
+ * compromised-password set; subsequent `SignUp` / `AdminInitiateAuth`
+ * fail with `InvalidPasswordException` on any pool whose
+ * `CompromisedCredentialsRiskConfiguration.Actions.EventAction` is
+ * `BLOCK`.
+ */
+final class CompromisedPasswordsRequest
+{
+    public function __construct(
+        /** @var string[] */
+        public readonly array $passwords,
+    ) {}
+
+    public function toArray(): array
+    {
+        return ['passwords' => $this->passwords];
+    }
+}
+
+final class CompromisedPasswordsResponse
+{
+    public function __construct(public readonly int $added) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self((int) $data['added']);
+    }
+}
+
+/**
+ * Registered WebAuthn credential surfaced by
+ * `GET /_fakecloud/cognito/webauthn-credentials`. `$attestationInfo`
+ * is the parsed-attestation associative array (packed format details,
+ * AAGUID, certificate chain summary, signature counter); its shape
+ * depends on the attestation format so it stays untyped.
+ */
+final class WebAuthnCredential
+{
+    public function __construct(
+        public readonly string $accountId,
+        public readonly string $poolUser,
+        public readonly string $credentialId,
+        public readonly string $relyingPartyId,
+        public readonly mixed $attestationInfo,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['account_id'],
+            $data['pool_user'],
+            $data['credential_id'],
+            $data['relying_party_id'],
+            $data['attestation_info'] ?? null,
+        );
+    }
+}
+
+final class WebAuthnCredentialsResponse
+{
+    public function __construct(
+        /** @var WebAuthnCredential[] */
+        public readonly array $credentials,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(WebAuthnCredential::fromArray(...), $data['credentials'] ?? []));
+    }
+}
+
 // ── Step Functions ─────────────────────────────────────────────
 
 final class StepFunctionsExecution

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -17,6 +17,8 @@ from fakecloud.types import (
     BedrockModelResponseConfig,
     BedrockResponseRule,
     BedrockStatusResponse,
+    CompromisedPasswordsRequest,
+    CompromisedPasswordsResponse,
     ConfirmationCodesResponse,
     ConfirmSubscriptionRequest,
     ConfirmSubscriptionResponse,
@@ -55,9 +57,6 @@ from fakecloud.types import (
     LifecycleTickResponse,
     MintAuthorizationCodeRequest,
     MintAuthorizationCodeResponse,
-    CompromisedPasswordsRequest,
-    CompromisedPasswordsResponse,
-    WebAuthnCredentialsResponse,
     PendingConfirmationsResponse,
     RdsInstancesResponse,
     ResetResponse,
@@ -73,6 +72,7 @@ from fakecloud.types import (
     TtlTickResponse,
     UserConfirmationCodes,
     WarmContainersResponse,
+    WebAuthnCredentialsResponse,
 )
 
 
@@ -1171,9 +1171,7 @@ class _SyncCognitoClient:
         return CompromisedPasswordsResponse.from_dict(resp.json())
 
     def get_webauthn_credentials(self) -> WebAuthnCredentialsResponse:
-        resp = self._client.get(
-            f"{self._base}/_fakecloud/cognito/webauthn-credentials"
-        )
+        resp = self._client.get(f"{self._base}/_fakecloud/cognito/webauthn-credentials")
         _check(resp)
         return WebAuthnCredentialsResponse.from_dict(resp.json())
 

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -55,6 +55,9 @@ from fakecloud.types import (
     LifecycleTickResponse,
     MintAuthorizationCodeRequest,
     MintAuthorizationCodeResponse,
+    CompromisedPasswordsRequest,
+    CompromisedPasswordsResponse,
+    WebAuthnCredentialsResponse,
     PendingConfirmationsResponse,
     RdsInstancesResponse,
     ResetResponse,
@@ -767,6 +770,23 @@ class CognitoClient:
         _check(resp)
         return MintAuthorizationCodeResponse.from_dict(resp.json())
 
+    async def set_compromised_passwords(
+        self, req: CompromisedPasswordsRequest
+    ) -> CompromisedPasswordsResponse:
+        resp = await self._client.post(
+            f"{self._base}/_fakecloud/cognito/compromised-passwords",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return CompromisedPasswordsResponse.from_dict(resp.json())
+
+    async def get_webauthn_credentials(self) -> WebAuthnCredentialsResponse:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/cognito/webauthn-credentials"
+        )
+        _check(resp)
+        return WebAuthnCredentialsResponse.from_dict(resp.json())
+
 
 class ApiGatewayV2Client:
     """Async API Gateway v2 introspection client."""
@@ -1139,6 +1159,23 @@ class _SyncCognitoClient:
         )
         _check(resp)
         return MintAuthorizationCodeResponse.from_dict(resp.json())
+
+    def set_compromised_passwords(
+        self, req: CompromisedPasswordsRequest
+    ) -> CompromisedPasswordsResponse:
+        resp = self._client.post(
+            f"{self._base}/_fakecloud/cognito/compromised-passwords",
+            json=req.to_dict(),
+        )
+        _check(resp)
+        return CompromisedPasswordsResponse.from_dict(resp.json())
+
+    def get_webauthn_credentials(self) -> WebAuthnCredentialsResponse:
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/cognito/webauthn-credentials"
+        )
+        _check(resp)
+        return WebAuthnCredentialsResponse.from_dict(resp.json())
 
 
 class _SyncApiGatewayV2Client:

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -948,6 +948,73 @@ class MintAuthorizationCodeResponse:
         return cls(code=data["code"])
 
 
+@dataclass
+class CompromisedPasswordsRequest:
+    """Payload for `POST /_fakecloud/cognito/compromised-passwords`.
+
+    Each plaintext is SHA-256 hashed server-side and added to the
+    per-account compromised-password set; subsequent `SignUp` /
+    `AdminInitiateAuth` calls fail with `InvalidPasswordException` on
+    any pool whose
+    `CompromisedCredentialsRiskConfiguration.Actions.EventAction` is
+    `BLOCK`.
+    """
+
+    passwords: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"passwords": list(self.passwords)}
+
+
+@dataclass
+class CompromisedPasswordsResponse:
+    added: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CompromisedPasswordsResponse:
+        return cls(added=int(data["added"]))
+
+
+@dataclass
+class WebAuthnCredential:
+    """Registered WebAuthn credential surfaced by introspection.
+
+    `attestation_info` is the parsed-attestation JSON object (packed
+    format details, AAGUID, certificate chain summary, signature
+    counter); its shape depends on the attestation format so it is
+    surfaced as an opaque mapping.
+    """
+
+    account_id: str
+    pool_user: str
+    credential_id: str
+    relying_party_id: str
+    attestation_info: Any
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> WebAuthnCredential:
+        return cls(
+            account_id=data["account_id"],
+            pool_user=data["pool_user"],
+            credential_id=data["credential_id"],
+            relying_party_id=data["relying_party_id"],
+            attestation_info=data.get("attestation_info"),
+        )
+
+
+@dataclass
+class WebAuthnCredentialsResponse:
+    credentials: List[WebAuthnCredential]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> WebAuthnCredentialsResponse:
+        return cls(
+            credentials=[
+                WebAuthnCredential.from_dict(c) for c in data.get("credentials", [])
+            ],
+        )
+
+
 # ── Step Functions ──────────────────────────────────────────────────
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -51,6 +51,9 @@ import type {
   AuthEventsResponse,
   MintAuthorizationCodeRequest,
   MintAuthorizationCodeResponse,
+  CompromisedPasswordsRequest,
+  CompromisedPasswordsResponse,
+  WebAuthnCredentialsResponse,
   StepFunctionsExecutionsResponse,
   EcsClustersResponse,
   Elbv2LoadBalancersResponse,
@@ -408,6 +411,27 @@ export class CognitoClient {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(req),
       },
+    );
+    return parse(resp);
+  }
+
+  async setCompromisedPasswords(
+    req: CompromisedPasswordsRequest,
+  ): Promise<CompromisedPasswordsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/cognito/compromised-passwords`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      },
+    );
+    return parse(resp);
+  }
+
+  async getWebAuthnCredentials(): Promise<WebAuthnCredentialsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/cognito/webauthn-credentials`,
     );
     return parse(resp);
   }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -406,6 +406,41 @@ export interface MintAuthorizationCodeResponse {
   code: string;
 }
 
+/**
+ * Payload for `POST /_fakecloud/cognito/compromised-passwords`. Each
+ * plaintext is SHA-256 hashed server-side and added to the
+ * compromised-password set; subsequent `SignUp` / `AdminInitiateAuth`
+ * fail with `InvalidPasswordException` on pools whose
+ * `CompromisedCredentialsRiskConfiguration.Actions.EventAction` is
+ * `BLOCK`.
+ */
+export interface CompromisedPasswordsRequest {
+  passwords: string[];
+}
+
+export interface CompromisedPasswordsResponse {
+  added: number;
+}
+
+/**
+ * Registered WebAuthn credential from
+ * `GET /_fakecloud/cognito/webauthn-credentials`. `attestationInfo` is
+ * the parsed-attestation JSON (packed format details, AAGUID,
+ * certificate chain summary, signature counter); its shape depends on
+ * the attestation format so it is left untyped.
+ */
+export interface WebAuthnCredential {
+  account_id: string;
+  pool_user: string;
+  credential_id: string;
+  relying_party_id: string;
+  attestation_info: unknown;
+}
+
+export interface WebAuthnCredentialsResponse {
+  credentials: WebAuthnCredential[];
+}
+
 // ── Step Functions ────────────────────────────────────────────────
 
 export interface StepFunctionsExecution {

--- a/website/content/cognito-emulator.md
+++ b/website/content/cognito-emulator.md
@@ -16,8 +16,9 @@ Point your AWS SDK at `http://localhost:4566`.
 ## Why fakecloud for Cognito
 
 - **122 Cognito User Pools operations** at 100% conformance — user pools, app clients, users, groups, MFA (SMS, TOTP, WebAuthn), identity providers (Google, Facebook, SAML, OIDC), resource servers, domains, devices.
-- **Full authentication flows** — `USER_PASSWORD_AUTH`, `USER_SRP_AUTH`, `REFRESH_TOKEN_AUTH`, `CUSTOM_AUTH`, `ADMIN_USER_PASSWORD_AUTH`. Real SRP crypto, real JWTs signed with per-pool keys.
-- **Triggers fire.** Pre-sign-up, post-confirmation, pre-token-generation, custom-message, custom-auth triggers all invoke your Lambda for real.
+- **Full authentication flows** — `USER_PASSWORD_AUTH`, `USER_SRP_AUTH`, `REFRESH_TOKEN_AUTH`, `CUSTOM_AUTH`, `ADMIN_USER_PASSWORD_AUTH`. Real SRP crypto, real JWTs signed with per-pool keys. `GetSigningCertificate` returns a real, parseable X.509 certificate wrapping the same key.
+- **Triggers fire.** All 12 triggers — pre-sign-up, post-confirmation, pre/post-authentication, pre-token-generation, custom-message, custom-auth (define/create/verify), user-migration, custom email/SMS sender — invoke your Lambda for real. `PreTokenGeneration` `claimsOverrideDetails` (claims to add/suppress, group overrides) are merged into issued tokens before signing.
+- **WebAuthn passkeys.** Real `packed`-attestation parsing and verification at registration. The introspection endpoint `/_fakecloud/cognito/webauthn-credentials` surfaces parsed AAGUID, certificate chain summary, and signature counter.
 - **Confirmation code introspection.** Tests read codes via `/_fakecloud/cognito/confirmation-codes` without checking email.
 - **Cognito as an SNS/SES consumer.** Verification emails/SMS flow through the real SES/SNS emulation — test assertions work on those too.
 - **Paid on LocalStack; free here.** Cognito moved to LocalStack Pro in March 2026.

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -13,6 +13,7 @@ fakecloud implements **122 of 122** Cognito User Pools operations at 100% Smithy
 - **Users** — admin create/delete/update, self-signup, group membership
 - **Groups** — CRUD, user membership, precedence
 - **MFA** — SMS, TOTP, software token setup/verification
+- **WebAuthn** — passkey registration and assertion, with real `packed`-format attestation parsing (AAGUID, certificate chain summary, signature counter) and verification at registration
 - **Identity providers** — SAML, OIDC, social
 - **Resource servers** — CRUD, custom scopes
 - **Domains** — user pool domains
@@ -20,7 +21,9 @@ fakecloud implements **122 of 122** Cognito User Pools operations at 100% Smithy
 - **Password management** — ChangePassword, ForgotPassword, ConfirmForgotPassword
 - **Confirmation codes** — email/SMS confirmation flows
 - **Devices** — Confirm, update, forget, track
-- **Tokens** — access, refresh, ID tokens with real JWT structure
+- **Tokens** — access, refresh, ID tokens with real JWT structure. The `PreTokenGeneration` trigger's `claimsOverrideDetails` (claims to add/suppress and group overrides) is merged into the issued access and ID tokens before signing
+- **Compromised credentials** — `CompromisedCredentialsRiskConfiguration` with `Actions.EventAction = BLOCK` rejects `SignUp` / `AdminInitiateAuth` when the supplied password's SHA-256 hash is in the configured compromised set
+- **Signing keys** — `GetSigningCertificate` returns a real, parseable X.509 certificate that wraps the pool's RSA-2048 signing key (same key served via JWKS), matching the AWS response shape
 - **Auth events** — sign-up, sign-in, failures, password changes
 
 ## Protocol
@@ -30,7 +33,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 ## OAuth2 / OIDC endpoints
 
 - `GET /oauth2/authorize` — Hosted UI authorization endpoint. Supports `response_type=code` (Authorization Code grant, with optional PKCE `S256`/`plain`) and `response_type=token` (Implicit grant). Validates `client_id`, `redirect_uri` (must match the client's `CallbackURLs`), and `scope` (must be a subset of `AllowedOAuthScopes`). For scripted tests, accepts `username`/`password` query params in lieu of the real Cognito Hosted UI HTML form.
-- `POST /oauth2/token` — token endpoint with `authorization_code`, `client_credentials`, and `refresh_token` grants. RFC 6749 §2.3.1 Basic auth supported. PKCE (S256/plain) verified for `authorization_code`.
+- `POST /oauth2/token` — token endpoint with `authorization_code`, `client_credentials`, and `refresh_token` grants. RFC 6749 §2.3.1 Basic auth supported. PKCE (S256/plain) verified for `authorization_code`. `PreTokenGeneration` `claimsOverrideDetails` are merged into the access and ID tokens before signing.
 - `GET|POST /oauth2/userInfo` — RFC 7662 user info (bearer access token -> standard OIDC claims).
 - `POST /oauth2/revoke` — RFC 7009 token revocation.
 - `GET /<pool_id>/.well-known/jwks.json` — RS256 public key for token verification.
@@ -45,6 +48,8 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 - `POST /_fakecloud/cognito/expire-tokens` — expire tokens for a pool/user
 - `GET /_fakecloud/cognito/auth-events` — list auth events (signup, signin, failures)
 - `POST /_fakecloud/cognito/authorization-codes` — mint a single-use OAuth2 authorization code for the `authorization_code` grant (programmatic alternative to driving `/oauth2/authorize`)
+- `POST /_fakecloud/cognito/compromised-passwords` — register plaintext passwords as compromised; each is SHA-256 hashed server-side and added to the per-account set checked by `CompromisedCredentialsRiskConfiguration` enforcement
+- `GET /_fakecloud/cognito/webauthn-credentials` — list registered WebAuthn credentials with parsed `packed`-attestation info (AAGUID, certificate chain summary, signature counter)
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

Batch B2 of the 2026-05-11 sync-audit. Brings Cognito docs and SDKs back in line with already-merged backend work.

### Docs
- `website/content/docs/services/cognito.md`: note PreTokenGeneration `claimsOverrideDetails` merge into issued tokens (#1299), real `packed`-format WebAuthn attestation parsing (#1300), real X.509 from `GetSigningCertificate` (#1302), `CompromisedCredentialsRiskConfiguration.Actions.EventAction = BLOCK` enforcement (#1298). Add `/oauth2/authorize` to the OAuth2/OIDC list (was implicit; now explicit). Add the three new admin endpoints to the introspection list.
- `website/content/cognito-emulator.md`: list all 12 triggers (no more pre-token-generation caveat), note `claimsOverrideDetails` merge, note WebAuthn packed-attestation introspection, note `GetSigningCertificate` returns a real X.509.

### SDKs (Go / Java / PHP / Python / TypeScript)
Mirror two missing helpers across all five SDKs:

- `setCompromisedPasswords` -> `POST /_fakecloud/cognito/compromised-passwords`
- `getWebAuthnCredentials` -> `GET /_fakecloud/cognito/webauthn-credentials`

`mintAuthorizationCode` was already wrapped everywhere from the earlier OAuth2 batch, so no third helper added.

## Test plan
- [ ] Go: `go build ./...` in `sdks/go` (verified locally)
- [ ] TypeScript: `npm run build` in `sdks/typescript` (verified locally)
- [ ] Java: `./gradlew compileJava` in `sdks/java` (verified locally)
- [ ] Python: byte-compile of `client.py` + `types.py` (verified locally)
- [ ] PHP: CI runs static analysis
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs Cognito docs and SDK helpers with recent backend changes. Adds helpers for compromised password registration and WebAuthn credential introspection, and updates docs for token overrides, packed attestation, real signing certs, and BLOCK enforcement.

- **New Features**
  - Docs: `PreTokenGeneration` `claimsOverrideDetails` merged into tokens; real `packed` WebAuthn attestation parsed and exposed via `/_fakecloud/cognito/webauthn-credentials`; `GetSigningCertificate` returns a real X.509; `CompromisedCredentialsRiskConfiguration` with `EventAction=BLOCK` enforced; explicitly list `GET /oauth2/authorize`; add new admin endpoints.
  - SDKs (Go, Java, PHP, Python, TypeScript): add `setCompromisedPasswords` (POST `/_fakecloud/cognito/compromised-passwords`) and `getWebAuthnCredentials` (GET `/_fakecloud/cognito/webauthn-credentials`).

- **Refactors**
  - Python SDK: ruff formatting and import sort.

<sup>Written for commit ae3bf6f6a4d63d0d35d8647b6c9b6430696bfe07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

