### PR TITLE
docs(ecs): sync docs + SDK helpers (B4)

### DIFF
--- a/sdks/go/ecs.go
+++ b/sdks/go/ecs.go
@@ -42,6 +42,16 @@ func (c *ECSClient) GetTasks(ctx context.Context, cluster, status string) (*EcsT
 	return &out, nil
 }
 
+// GetTask returns a single task snapshot by task ID. Returns 404 if the
+// task is unknown.
+func (c *ECSClient) GetTask(ctx context.Context, taskID string) (*EcsTask, error) {
+	var out EcsTask
+	if err := c.fc.doGet(ctx, fmt.Sprintf("/_fakecloud/ecs/tasks/%s", taskID), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // GetTaskLogs returns the captured docker stdout/stderr for a task.
 func (c *ECSClient) GetTaskLogs(ctx context.Context, taskID string) (*EcsTaskLogsResponse, error) {
 	var out EcsTaskLogsResponse

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -25,6 +25,11 @@ import dev.fakecloud.Types.EcrImagesResponse;
 import dev.fakecloud.Types.EcrPullThroughRulesResponse;
 import dev.fakecloud.Types.EcrRepositoriesResponse;
 import dev.fakecloud.Types.EcsClustersResponse;
+import dev.fakecloud.Types.EcsEventsResponse;
+import dev.fakecloud.Types.EcsMarkFailedRequest;
+import dev.fakecloud.Types.EcsTask;
+import dev.fakecloud.Types.EcsTaskLogsResponse;
+import dev.fakecloud.Types.EcsTasksResponse;
 import dev.fakecloud.Types.Elbv2FlushAccessLogsResponse;
 import dev.fakecloud.Types.Elbv2ListenersResponse;
 import dev.fakecloud.Types.Elbv2LoadBalancersResponse;
@@ -549,6 +554,61 @@ public final class FakeCloud {
 
         public EcsClustersResponse getClusters() {
             return http.get("/_fakecloud/ecs/clusters", EcsClustersResponse.class);
+        }
+
+        /** List every task fakecloud is tracking, optionally filtered by cluster and status. */
+        public EcsTasksResponse getTasks(String cluster, String status) {
+            StringBuilder path = new StringBuilder("/_fakecloud/ecs/tasks");
+            StringBuilder qs = new StringBuilder();
+            if (cluster != null && !cluster.isEmpty()) {
+                qs.append("cluster=").append(encodePath(cluster));
+            }
+            if (status != null && !status.isEmpty()) {
+                if (qs.length() > 0) qs.append('&');
+                qs.append("status=").append(encodePath(status));
+            }
+            if (qs.length() > 0) {
+                path.append('?').append(qs);
+            }
+            return http.get(path.toString(), EcsTasksResponse.class);
+        }
+
+        /** Fetch a single task snapshot by task ID. */
+        public EcsTask getTask(String taskId) {
+            return http.get("/_fakecloud/ecs/tasks/" + encodePath(taskId), EcsTask.class);
+        }
+
+        /** Captured docker stdout/stderr for a task plus its exit code if known. */
+        public EcsTaskLogsResponse getTaskLogs(String taskId) {
+            return http.get(
+                    "/_fakecloud/ecs/tasks/" + encodePath(taskId) + "/logs",
+                    EcsTaskLogsResponse.class);
+        }
+
+        /**
+         * SIGTERM (then SIGKILL after 10s) the task's running container via
+         * the runtime. Returns the updated task snapshot.
+         */
+        public EcsTask forceStopTask(String taskId) {
+            return http.postEmpty(
+                    "/_fakecloud/ecs/tasks/" + encodePath(taskId) + "/force-stop",
+                    EcsTask.class);
+        }
+
+        /**
+         * Flip a task to STOPPED without killing the container — useful for
+         * simulating failed tasks deterministically in tests.
+         */
+        public EcsTask markTaskFailed(String taskId, EcsMarkFailedRequest req) {
+            return http.postJson(
+                    "/_fakecloud/ecs/tasks/" + encodePath(taskId) + "/mark-failed",
+                    req,
+                    EcsTask.class);
+        }
+
+        /** Replay the lifecycle event log. */
+        public EcsEventsResponse getEvents() {
+            return http.get("/_fakecloud/ecs/events", EcsEventsResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -510,6 +510,60 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record EcsClustersResponse(List<EcsCluster> clusters) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskContainer(
+            String name,
+            String image,
+            String lastStatus,
+            Long exitCode,
+            String runtimeId,
+            boolean essential) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTask(
+            String taskArn,
+            String taskId,
+            String clusterArn,
+            String clusterName,
+            String taskDefinitionArn,
+            String family,
+            int revision,
+            String lastStatus,
+            String desiredStatus,
+            String launchType,
+            String createdAt,
+            String startedAt,
+            String stoppingAt,
+            String stoppedAt,
+            String stopCode,
+            String stoppedReason,
+            List<EcsTaskContainer> containers,
+            long capturedLogBytes) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTasksResponse(List<EcsTask> tasks) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskLogsResponse(
+            String taskArn,
+            String logs,
+            String lastStatus,
+            Long exitCode) {}
+
+    public record EcsMarkFailedRequest(Long exitCode, String reason) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsLifecycleEvent(
+            String at,
+            String eventType,
+            String taskArn,
+            String clusterArn,
+            String lastStatus,
+            Object detail) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsEventsResponse(List<EcsLifecycleEvent> events) {}
+
     // ── ELBv2 ─────────────────────────────────────────────────────
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -568,6 +568,75 @@ final class EcsClient
             $this->http->get('/_fakecloud/ecs/clusters')
         );
     }
+
+    /**
+     * List every task fakecloud is tracking. Pass null to skip a filter;
+     * both parameters map to the server's `cluster` and `status` query args.
+     */
+    public function getTasks(?string $cluster = null, ?string $status = null): EcsTasksResponse
+    {
+        $path = '/_fakecloud/ecs/tasks';
+        $params = [];
+        if ($cluster !== null && $cluster !== '') {
+            $params['cluster'] = $cluster;
+        }
+        if ($status !== null && $status !== '') {
+            $params['status'] = $status;
+        }
+        if ($params !== []) {
+            $path .= '?' . http_build_query($params);
+        }
+        return EcsTasksResponse::fromArray($this->http->get($path));
+    }
+
+    /** Fetch a single task snapshot by task ID. */
+    public function getTask(string $taskId): EcsTask
+    {
+        return EcsTask::fromArray(
+            $this->http->get('/_fakecloud/ecs/tasks/' . HttpTransport::encodePath($taskId))
+        );
+    }
+
+    /** Captured docker stdout/stderr for a task plus its exit code if known. */
+    public function getTaskLogs(string $taskId): EcsTaskLogsResponse
+    {
+        return EcsTaskLogsResponse::fromArray(
+            $this->http->get('/_fakecloud/ecs/tasks/' . HttpTransport::encodePath($taskId) . '/logs')
+        );
+    }
+
+    /**
+     * SIGTERM (then SIGKILL after 10s) the task's running container via the
+     * runtime. Returns the updated task snapshot.
+     */
+    public function forceStopTask(string $taskId): EcsTask
+    {
+        return EcsTask::fromArray(
+            $this->http->postEmpty('/_fakecloud/ecs/tasks/' . HttpTransport::encodePath($taskId) . '/force-stop')
+        );
+    }
+
+    /**
+     * Flip a task to STOPPED without killing the container — useful for
+     * simulating failed tasks deterministically in tests.
+     */
+    public function markTaskFailed(string $taskId, EcsMarkFailedRequest $req): EcsTask
+    {
+        return EcsTask::fromArray(
+            $this->http->postJson(
+                '/_fakecloud/ecs/tasks/' . HttpTransport::encodePath($taskId) . '/mark-failed',
+                $req->toArray()
+            )
+        );
+    }
+
+    /** Replay the lifecycle event log. */
+    public function getEvents(): EcsEventsResponse
+    {
+        return EcsEventsResponse::fromArray(
+            $this->http->get('/_fakecloud/ecs/events')
+        );
+    }
 }
 
 final class Elbv2Client

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1549,6 +1549,169 @@ final class EcsClustersResponse
     }
 }
 
+final class EcsTaskContainer
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $image,
+        public readonly string $lastStatus,
+        public readonly ?int $exitCode,
+        public readonly ?string $runtimeId,
+        public readonly bool $essential,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['name'] ?? '',
+            $data['image'] ?? '',
+            $data['lastStatus'] ?? '',
+            isset($data['exitCode']) ? (int) $data['exitCode'] : null,
+            $data['runtimeId'] ?? null,
+            (bool) ($data['essential'] ?? false),
+        );
+    }
+}
+
+final class EcsTask
+{
+    public function __construct(
+        public readonly string $taskArn,
+        public readonly string $taskId,
+        public readonly string $clusterArn,
+        public readonly string $clusterName,
+        public readonly string $taskDefinitionArn,
+        public readonly string $family,
+        public readonly int $revision,
+        public readonly string $lastStatus,
+        public readonly string $desiredStatus,
+        public readonly string $launchType,
+        public readonly string $createdAt,
+        public readonly ?string $startedAt,
+        public readonly ?string $stoppingAt,
+        public readonly ?string $stoppedAt,
+        public readonly ?string $stopCode,
+        public readonly ?string $stoppedReason,
+        /** @var EcsTaskContainer[] */
+        public readonly array $containers,
+        public readonly int $capturedLogBytes,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['taskArn'] ?? '',
+            $data['taskId'] ?? '',
+            $data['clusterArn'] ?? '',
+            $data['clusterName'] ?? '',
+            $data['taskDefinitionArn'] ?? '',
+            $data['family'] ?? '',
+            (int) ($data['revision'] ?? 0),
+            $data['lastStatus'] ?? '',
+            $data['desiredStatus'] ?? '',
+            $data['launchType'] ?? '',
+            $data['createdAt'] ?? '',
+            $data['startedAt'] ?? null,
+            $data['stoppingAt'] ?? null,
+            $data['stoppedAt'] ?? null,
+            $data['stopCode'] ?? null,
+            $data['stoppedReason'] ?? null,
+            array_map(EcsTaskContainer::fromArray(...), $data['containers'] ?? []),
+            (int) ($data['capturedLogBytes'] ?? 0),
+        );
+    }
+}
+
+final class EcsTasksResponse
+{
+    public function __construct(
+        /** @var EcsTask[] */
+        public readonly array $tasks,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(EcsTask::fromArray(...), $data['tasks'] ?? []));
+    }
+}
+
+final class EcsTaskLogsResponse
+{
+    public function __construct(
+        public readonly string $taskArn,
+        public readonly string $logs,
+        public readonly string $lastStatus,
+        public readonly ?int $exitCode,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['taskArn'] ?? '',
+            $data['logs'] ?? '',
+            $data['lastStatus'] ?? '',
+            isset($data['exitCode']) ? (int) $data['exitCode'] : null,
+        );
+    }
+}
+
+final class EcsMarkFailedRequest
+{
+    public function __construct(
+        public readonly ?int $exitCode = null,
+        public readonly ?string $reason = null,
+    ) {}
+
+    public function toArray(): array
+    {
+        $out = [];
+        if ($this->exitCode !== null) {
+            $out['exitCode'] = $this->exitCode;
+        }
+        if ($this->reason !== null) {
+            $out['reason'] = $this->reason;
+        }
+        return $out;
+    }
+}
+
+final class EcsLifecycleEvent
+{
+    public function __construct(
+        public readonly string $at,
+        public readonly string $eventType,
+        public readonly ?string $taskArn,
+        public readonly ?string $clusterArn,
+        public readonly ?string $lastStatus,
+        public readonly mixed $detail,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['at'] ?? '',
+            $data['eventType'] ?? '',
+            $data['taskArn'] ?? null,
+            $data['clusterArn'] ?? null,
+            $data['lastStatus'] ?? null,
+            $data['detail'] ?? null,
+        );
+    }
+}
+
+final class EcsEventsResponse
+{
+    public function __construct(
+        /** @var EcsLifecycleEvent[] */
+        public readonly array $events,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(EcsLifecycleEvent::fromArray(...), $data['events'] ?? []));
+    }
+}
+
 // ── ELBv2 ──────────────────────────────────────────────────────
 
 final class Elbv2Tag

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -207,9 +207,7 @@ class EcsClient:
         return EcsTasksResponse.from_dict(resp.json())
 
     async def get_task(self, task_id: str) -> EcsTask:
-        resp = await self._client.get(
-            f"{self._base}/_fakecloud/ecs/tasks/{task_id}"
-        )
+        resp = await self._client.get(f"{self._base}/_fakecloud/ecs/tasks/{task_id}")
         _check(resp)
         return EcsTask.from_dict(resp.json())
 

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -206,6 +206,13 @@ class EcsClient:
         _check(resp)
         return EcsTasksResponse.from_dict(resp.json())
 
+    async def get_task(self, task_id: str) -> EcsTask:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/ecs/tasks/{task_id}"
+        )
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
+
     async def get_task_logs(self, task_id: str) -> EcsTaskLogsResponse:
         resp = await self._client.get(
             f"{self._base}/_fakecloud/ecs/tasks/{task_id}/logs"
@@ -261,6 +268,11 @@ class _SyncEcsClient:
         resp = self._client.get(f"{self._base}/_fakecloud/ecs/tasks", params=params)
         _check(resp)
         return EcsTasksResponse.from_dict(resp.json())
+
+    def get_task(self, task_id: str) -> EcsTask:
+        resp = self._client.get(f"{self._base}/_fakecloud/ecs/tasks/{task_id}")
+        _check(resp)
+        return EcsTask.from_dict(resp.json())
 
     def get_task_logs(self, task_id: str) -> EcsTaskLogsResponse:
         resp = self._client.get(f"{self._base}/_fakecloud/ecs/tasks/{task_id}/logs")

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -53,6 +53,11 @@ import type {
   MintAuthorizationCodeResponse,
   StepFunctionsExecutionsResponse,
   EcsClustersResponse,
+  EcsTask,
+  EcsTasksResponse,
+  EcsTaskLogsResponse,
+  EcsMarkFailedRequest,
+  EcsEventsResponse,
   Elbv2LoadBalancersResponse,
   Elbv2TargetGroupsResponse,
   Elbv2ListenersResponse,
@@ -692,6 +697,77 @@ export class EcsClient {
   /** List every ECS cluster fakecloud has seen, across every account. */
   async getClusters(): Promise<EcsClustersResponse> {
     const resp = await fetch(`${this.baseUrl}/_fakecloud/ecs/clusters`);
+    return parse(resp);
+  }
+
+  /**
+   * List every task fakecloud is tracking. Pass `cluster` and/or `status`
+   * to narrow the result set; both filters match the server's query params.
+   */
+  async getTasks(opts?: {
+    cluster?: string;
+    status?: string;
+  }): Promise<EcsTasksResponse> {
+    const params = new URLSearchParams();
+    if (opts?.cluster) params.set("cluster", opts.cluster);
+    if (opts?.status) params.set("status", opts.status);
+    const qs = params.toString();
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/tasks${qs ? `?${qs}` : ""}`,
+    );
+    return parse(resp);
+  }
+
+  /** Fetch a single task snapshot by task ID. */
+  async getTask(taskId: string): Promise<EcsTask> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/tasks/${encodeURIComponent(taskId)}`,
+    );
+    return parse(resp);
+  }
+
+  /** Captured docker stdout/stderr for a task plus its exit code if known. */
+  async getTaskLogs(taskId: string): Promise<EcsTaskLogsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/tasks/${encodeURIComponent(taskId)}/logs`,
+    );
+    return parse(resp);
+  }
+
+  /**
+   * SIGTERM (then SIGKILL after 10s) the task's running container via the
+   * runtime. Returns the updated task snapshot.
+   */
+  async forceStopTask(taskId: string): Promise<EcsTask> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/tasks/${encodeURIComponent(taskId)}/force-stop`,
+      { method: "POST" },
+    );
+    return parse(resp);
+  }
+
+  /**
+   * Flip a task to STOPPED without killing the container — useful for
+   * simulating failed tasks deterministically in tests.
+   */
+  async markTaskFailed(
+    taskId: string,
+    req: EcsMarkFailedRequest,
+  ): Promise<EcsTask> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/tasks/${encodeURIComponent(taskId)}/mark-failed`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      },
+    );
+    return parse(resp);
+  }
+
+  /** Replay the lifecycle event log. */
+  async getEvents(): Promise<EcsEventsResponse> {
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/ecs/events`);
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -610,6 +610,65 @@ export interface EcsClustersResponse {
   clusters: EcsCluster[];
 }
 
+export interface EcsTaskContainer {
+  name: string;
+  image: string;
+  lastStatus: string;
+  exitCode?: number | null;
+  runtimeId?: string | null;
+  essential: boolean;
+}
+
+export interface EcsTask {
+  taskArn: string;
+  taskId: string;
+  clusterArn: string;
+  clusterName: string;
+  taskDefinitionArn: string;
+  family: string;
+  revision: number;
+  lastStatus: string;
+  desiredStatus: string;
+  launchType: string;
+  createdAt: string;
+  startedAt?: string | null;
+  stoppingAt?: string | null;
+  stoppedAt?: string | null;
+  stopCode?: string | null;
+  stoppedReason?: string | null;
+  containers: EcsTaskContainer[];
+  capturedLogBytes: number;
+}
+
+export interface EcsTasksResponse {
+  tasks: EcsTask[];
+}
+
+export interface EcsTaskLogsResponse {
+  taskArn: string;
+  logs: string;
+  lastStatus: string;
+  exitCode?: number | null;
+}
+
+export interface EcsMarkFailedRequest {
+  exitCode?: number | null;
+  reason?: string | null;
+}
+
+export interface EcsLifecycleEvent {
+  at: string;
+  eventType: string;
+  taskArn?: string | null;
+  clusterArn?: string | null;
+  lastStatus?: string | null;
+  detail: unknown;
+}
+
+export interface EcsEventsResponse {
+  events: EcsLifecycleEvent[];
+}
+
 // ── ELBv2 ───────────────────────────────────────────────────────────
 
 export interface Elbv2Tag {

--- a/website/content/docs/services/ecs.md
+++ b/website/content/docs/services/ecs.md
@@ -4,9 +4,9 @@ description = "Elastic Container Service — full API: clusters, task definition
 weight = 22
 +++
 
-fakecloud implements Amazon Elastic Container Service (ECS) with full API coverage. 60 operations.
+fakecloud implements Amazon Elastic Container Service (ECS) with full API coverage. 76 operations.
 
-**Status: full API.** Covers clusters, task definitions, real Fargate-style task execution, services with rolling deployments, task sets, container instances, capacity providers, attributes, task protection, ECS Exec, and the agent-side `Submit*` / `DiscoverPollEndpoint` surface.
+**Status: full API.** Covers clusters, task definitions, real Fargate-style task execution, services with rolling deployments + CODE_DEPLOY blue/green task sets, daemons, ExpressGatewayService, task sets, container instances, capacity providers, attributes, task protection, ECS Exec, placement constraints / strategies, awsvpc ENI binding, and the agent-side `Submit*` / `DiscoverPollEndpoint` surface.
 
 ## Supported today (full API)
 
@@ -24,6 +24,8 @@ fakecloud implements Amazon Elastic Container Service (ECS) with full API covera
 - **Agent surface** — `SubmitContainerStateChange`, `SubmitTaskStateChange`, `SubmitAttachmentStateChanges`, `DiscoverPollEndpoint`
 - **Tagging** — `TagResource`, `UntagResource`, `ListTagsForResource` (clusters and task definitions)
 - **Account settings** — `PutAccountSetting`, `PutAccountSettingDefault`, `DeleteAccountSetting`, `ListAccountSettings`
+- **Daemons** — `RegisterDaemonTaskDefinition`, `DescribeDaemonTaskDefinition`, `DeleteDaemonTaskDefinition`, `ListDaemonTaskDefinitions`, `CreateDaemon`, `DescribeDaemon`, `UpdateDaemon`, `DeleteDaemon`, `ListDaemons`, `DescribeDaemonDeployments`, `ListDaemonDeployments`, `DescribeDaemonRevisions`. `CreateDaemon` spawns one task per matching capacity-provider host so the daemon scales with the cluster.
+- **Express gateway services** — `CreateExpressGatewayService`, `DescribeExpressGatewayService`, `UpdateExpressGatewayService`, `DeleteExpressGatewayService` (2026 ECS Express deployment controller)
 
 ### Services + rolling deployments
 
@@ -33,6 +35,18 @@ fakecloud implements Amazon Elastic Container Service (ECS) with full API covera
 - **Rolling deployment** — pass a new `taskDefinition`. The service marks the previous PRIMARY deployment as `ACTIVE`, creates a new `PRIMARY` deployment for the target revision, and drains tasks on the old task definition while new ones come up. Deployment circuit breaker + `minimumHealthyPercent` / `maximumPercent` are honoured in `deploymentConfiguration`.
 
 `DeleteService` refuses while `desiredCount > 0` unless `force=true`; the forced path scales to 0 and stops every running task under the service before removing it.
+
+#### Placement constraints + strategies
+
+Both `RunTask` and `CreateService` honour `placementConstraints[]` (`distinctInstance`, `memberOf <expression>` against container-instance attributes) and `placementStrategy[]` (`random`, `spread` by attribute, `binpack` by `cpu` / `memory`). The scheduler ranks eligible container instances per strategy before launching; tasks fail with `unable to place a task` when no instance satisfies the constraints, matching real ECS.
+
+#### awsvpc networking
+
+Task definitions with `networkMode=awsvpc` allocate a per-task ENI from the subnet supplied via `networkConfiguration.awsvpcConfiguration.subnets[]`. The ENI is recorded on the task's `attachments[]` (`type=ElasticNetworkInterface`) with `privateIPv4Address`, `subnetId`, and `securityGroups[]` filled in. `assignPublicIp=ENABLED` flags the ENI as having a public address. Tasks sharing the same `awsvpc` network mode each get a distinct ENI; subnet exhaustion fails the task with `stopCode=TaskFailedToStart`.
+
+#### CODE_DEPLOY blue/green task sets
+
+Services declared with `deploymentController.type=CODE_DEPLOY` skip the in-line rolling deployment and require external task-set churn. `CreateTaskSet` registers a non-primary (`BLUE`) set, `UpdateServicePrimaryTaskSet` flips traffic, and the old set is drained on `DeleteTaskSet`. This matches the AWS deployment pattern CodeDeploy uses to drive blue/green cutovers.
 
 Task-definition families track revisions monotonically; `DeleteTaskDefinitions` requires `DeregisterTaskDefinition` first (real AWS behaviour), and the result flips status to `DELETE_IN_PROGRESS`.
 
@@ -46,7 +60,26 @@ Task-definition families track revisions monotonically; `DeleteTaskDefinitions` 
 4. `docker logs <id>` (captured stdout/stderr stored on the task + exposed via the introspection endpoint)
 5. `docker rm <id>` (cleanup)
 
-Environment variables from the task definition are forwarded with `localhost` / `127.0.0.1` rewritten to `host.docker.internal` so containers reach fakecloud itself the same way Lambda does.
+Environment variables from the task definition are forwarded with `localhost` / `127.0.0.1` rewritten to `host.docker.internal` so containers reach fakecloud itself the same way Lambda does. `ECS_CONTAINER_METADATA_URI` and `ECS_CONTAINER_METADATA_URI_V4` are also injected, pointing at fakecloud's task-metadata endpoint (`/_fakecloud/ecs/v3/{task_id}` and `/_fakecloud/ecs/v4/{task_id}`) so SDKs and sidecars that read task metadata work out of the box.
+
+### Container definition fidelity
+
+The runtime translates the following task-definition fields straight into `docker run` flags so containers see the same shape they would on real ECS:
+
+- `linuxParameters.capabilities.add[]` / `drop[]` -> `--cap-add` / `--cap-drop`
+- `linuxParameters.initProcessEnabled=true` -> `--init`
+- `linuxParameters.sharedMemorySize` -> `--shm-size <MiB>m`
+- `linuxParameters.tmpfs[]` -> `--tmpfs <containerPath>:size=<size>,...`
+- `ulimits[]` -> `--ulimit <name>=<soft>:<hard>`
+- `user` -> `--user`
+- `readonlyRootFilesystem=true` -> `--read-only`
+- `pseudoTerminal=true` -> `--tty`
+- `stopTimeout` -> `--stop-timeout` (also bounds the SIGTERM→SIGKILL grace inside force-stop)
+- `volumeConfigurations[]` (per-task EBS attachments) -> volume per task with size, encryption, and FS type recorded on the task's `attachments[]` and bind-mounted at the declared `mountPoint`
+
+### awslogs flush before STOPPED
+
+Before a task transitions to `STOPPED`, the runtime drains any buffered `awslogs` events for that task synchronously, so `GetLogEvents` immediately after a `DescribeTasks` STOPPED response sees every line the container emitted. No probabilistic delay, no flake-prone polling in tests.
 
 Without a container runtime (docker/podman missing), `RunTask` still returns tasks but they immediately transition to `STOPPED` with `stopCode=TaskFailedToStart`. This keeps the API surface shape-correct so tests on CI agents without Docker can still drive the control-plane surface.
 
@@ -73,6 +106,10 @@ Container definitions that declare the `awslogs` log driver get their captured s
 ```
 
 The runtime creates the log group on demand when `awslogs-create-group=true`, creates a stream named `<prefix>/<container-name>/<task-id>`, and appends one `LogEvent` per captured line. The usual fakecloud-logs API (`DescribeLogStreams`, `GetLogEvents`, subscription filters) then sees the container's output with no additional wiring.
+
+### loadBalancers -> ELBv2 RegisterTargets
+
+Services declared with `loadBalancers[]` register each task's primary IP (awsvpc) or container-instance/container-port pair (bridge/host) into the matching ELBv2 target group via `RegisterTargets` when the task transitions to `RUNNING`, and `DeregisterTargets` when it drains. The cutover happens inline as part of the rolling deployment so health-check and target-state assertions on the target group match what real ECS would produce.
 
 ### EventBridge task state change events
 

--- a/website/content/local-ecs.md
+++ b/website/content/local-ecs.md
@@ -1,6 +1,6 @@
 +++
 title = "Local ECS for integration tests"
-description = "Run local Amazon ECS for tests with fakecloud. Full 60-operation API, real Fargate-style task execution via Docker, rolling deployments, ECS Exec. Free, AGPL-3.0."
+description = "Run local Amazon ECS for tests with fakecloud. Full 76-operation API, real Fargate-style task execution via Docker, rolling + CODE_DEPLOY blue/green deployments, daemons, ECS Exec. Free, AGPL-3.0."
 template = "page.html"
 +++
 
@@ -15,13 +15,20 @@ Point your AWS SDK at `http://localhost:4566`. Tasks really run — `RunTask` sh
 
 ## Why fakecloud for ECS
 
-- **Full API — 60 operations at 100% conformance.** Clusters, task definitions, tasks, services, service deployments, task sets, container instances, attributes, capacity providers, task protection, ECS Exec, and the agent-side `Submit*` / `DiscoverPollEndpoint` surface.
+- **Full API — 76 operations at 100% conformance.** Clusters, task definitions, tasks, services, service deployments, task sets, container instances, attributes, capacity providers, task protection, daemons, ExpressGatewayService, ECS Exec, and the agent-side `Submit*` / `DiscoverPollEndpoint` surface.
 - **Real Fargate-style task execution.** `RunTask` does `docker pull <image>` -> `docker run -d` -> `docker wait` (blocks on exit) -> `docker logs` (captures stdout/stderr) -> `docker rm`. Exit code lands on `containers[].exitCode`; `pullStartedAt` / `pullStoppedAt` timestamps are recorded the way real ECS does.
 - **Services with rolling deployments.** `CreateService` spawns tasks to match `desiredCount` and tags each with `startedBy=ecs-svc/<name>`. `UpdateService` flips the previous PRIMARY deployment to `ACTIVE`, creates a new PRIMARY for the target revision, and drains old tasks while new ones come up. `minimumHealthyPercent` / `maximumPercent` and the deployment circuit breaker are honored.
+- **CODE_DEPLOY blue/green task sets.** Services with `deploymentController.type=CODE_DEPLOY` skip the inline rolling deployment and let CodeDeploy-style external task-set churn drive the cutover via `CreateTaskSet` / `UpdateServicePrimaryTaskSet` / `DeleteTaskSet`.
+- **Placement constraints + strategies.** Both `RunTask` and `CreateService` honour `placementConstraints[]` (`distinctInstance`, `memberOf <expression>`) and `placementStrategy[]` (`random`, `spread`, `binpack` by `cpu` / `memory`).
+- **awsvpc networking.** Task definitions with `networkMode=awsvpc` allocate a per-task ENI from the supplied subnets; the ENI shows up on `attachments[]` with `privateIPv4Address`, `subnetId`, and `securityGroups[]`. Subnet exhaustion fails the task with `stopCode=TaskFailedToStart`.
+- **Daemons + ExpressGatewayService.** `CreateDaemon` spawns one task per matching capacity-provider host so the daemon scales with the cluster. The 2026 ExpressGatewayService deployment controller is wired end-to-end.
 - **ECS Exec.** `ExecuteCommand` proxies to `docker exec` against the running container so `aws ecs execute-command --interactive` shells in.
-- **awslogs -> CloudWatch Logs.** Container definitions with `logDriver=awslogs` get their captured output forwarded to fakecloud Logs, with `awslogs-create-group=true` and `<prefix>/<container-name>/<task-id>` stream naming honored end-to-end.
+- **awslogs -> CloudWatch Logs.** Container definitions with `logDriver=awslogs` get their captured output forwarded to fakecloud Logs, with `awslogs-create-group=true` and `<prefix>/<container-name>/<task-id>` stream naming honored end-to-end. Buffered events are flushed synchronously before a task transitions to STOPPED, so `GetLogEvents` right after STOPPED sees every line.
+- **Container definition fidelity.** `ulimits`, `linuxParameters.capabilities` / `initProcessEnabled` / `sharedMemorySize` / `tmpfs`, `user`, `pseudoTerminal`, `readonlyRootFilesystem`, `stopTimeout`, and per-task EBS `volumeConfigurations[]` are all rendered into real `docker run` flags.
+- **Task metadata endpoints.** `ECS_CONTAINER_METADATA_URI` / `ECS_CONTAINER_METADATA_URI_V4` are injected into every container, pointing at fakecloud's task-metadata v3/v4 endpoints so SDKs and sidecars that read task metadata work out of the box.
 - **Task role credentials.** Tasks with a `taskRoleArn` get `AWS_CONTAINER_CREDENTIALS_FULL_URI` injected, pointing at a fakecloud IMDS-format endpoint. AWS SDKs inside the container pick this up via the default credential-provider chain — `aws sts get-caller-identity` works from inside the container.
 - **Secrets injection.** Container `secrets[]` ARNs (Secrets Manager + SSM Parameter Store) resolve at task launch and inject as environment variables before `docker run`. Missing values fail the task with `stopCode=TaskFailedToStart` matching real ECS.
+- **loadBalancers -> ELBv2.** Service `loadBalancers[]` register/deregister against the matching ELBv2 target group on task RUNNING/STOPPED transitions, inline with the rolling deployment.
 - **Pulling from local ECR.** AWS-private ECR URIs (`<account>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>`) resolve to fakecloud's local OCI v2 endpoint. Push to the local registry, run the task, get the image — no external pulls.
 - **EventBridge events.** Task state transitions emit `aws.ecs` / `ECS Task State Change` events on the default bus so EB rules can fan out to SQS / SNS / Lambda / Step Functions.
 


### PR DESCRIPTION
## Summary

Batch B4 of the sync-audit: bring ECS docs and SDK helpers up to the real implementation surface.

**SDK helpers**
- TS / Java / PHP `EcsClient` grow `getTasks`, `getTask`, `getTaskLogs`, `forceStopTask`, `markTaskFailed`, `getEvents` to match Go and Python (they previously only exposed `getClusters`).
- Go and Python gain the missing `GetTask(taskId)` / `get_task(task_id)` single-task helper.
- New `EcsTask` / `EcsTasksResponse` / `EcsTaskLogsResponse` / `EcsMarkFailedRequest` / `EcsLifecycleEvent` / `EcsEventsResponse` type records / interfaces in TS, Java, PHP mirror the existing Go and Python shapes.

**Docs** (`website/content/docs/services/ecs.md` + `website/content/local-ecs.md`)
- Operation count refreshed from 60 to 76 (Daemons + ExpressGatewayService 2026 ops).
- New sections / bullets for: placement constraints + strategies, awsvpc per-task ENIs, CODE_DEPLOY blue/green task sets, `CreateDaemon` per capacity provider, per-task EBS `volumeConfigurations[]`, `ECS_CONTAINER_METADATA_URI` / `_V4` injection, `loadBalancers[]` -> ELBv2 RegisterTargets hook, container-definition fidelity (`ulimits`, `linuxParameters.capabilities` / `initProcessEnabled` / `sharedMemorySize` / `tmpfs`, `user`, `pseudoTerminal`, `readonlyRootFilesystem`, `stopTimeout`), and synchronous awslogs flush before STOPPED.

No `parity.md`, no `crates/` changes.

## Test plan

- [x] `npm run build` (TypeScript SDK)
- [x] `go build ./...` (Go SDK)
- [x] `python -m compileall src` (Python SDK)
- [x] `javac` against Jackson classpath (Java SDK — `mvn` unavailable locally)
- [ ] PHP `php -l` (PHP unavailable locally; relies on CI)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync ECS docs and SDK helpers to the real implementation. All SDKs now expose task introspection and control, and docs reflect the 76‑operation surface plus new runtime behaviors.

- **New Features**
  - TypeScript/Java/PHP `EcsClient`: added `getTasks`, `getTask`, `getTaskLogs`, `forceStopTask`, `markTaskFailed`, `getEvents`.
  - Go/Python: added single-task helper (`GetTask` / `get_task`).
  - Added ECS types across languages: `EcsTask`, `EcsTaskContainer`, `EcsTasksResponse`, `EcsTaskLogsResponse`, `EcsMarkFailedRequest`, `EcsLifecycleEvent`, `EcsEventsResponse`.

- **Docs**
  - Operation count updated to 76; added Daemons and ExpressGatewayService coverage.
  - Documented placement constraints/strategies, awsvpc per-task ENIs, and CODE_DEPLOY blue/green task sets.
  - Container/runtime fidelity: `ulimits`, `linuxParameters.*`, `user`, `tty`, `readonlyRootFilesystem`, `stopTimeout`, per-task EBS `volumeConfigurations[]`; inject `ECS_CONTAINER_METADATA_URI`/`_V4`.
  - Service `loadBalancers[]` -> ELBv2 RegisterTargets flow; awslogs flushed synchronously before STOPPED.

<sup>Written for commit c00434972805d33533fac5bf44a383a9fc0b29d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

