### PR TITLE
feat(cognito): introspection endpoint — pretokengen invocation log (I2)

### DIFF
--- a/crates/fakecloud-cognito/src/lib.rs
+++ b/crates/fakecloud-cognito/src/lib.rs
@@ -17,9 +17,9 @@ pub use state::{
     default_schema_attributes, AccountRecoverySetting, AdminCreateUserConfig,
     AuthorizationCodeData, CognitoIdentityProvider, CognitoSnapshot, CognitoState,
     CustomDomainConfig, EmailConfiguration, FederatedIdentity, IdentityPool,
-    IdentityPoolRoleAttachment, PasswordPolicy, PoolPolicies, RecoveryOption, SchemaAttribute,
-    SharedCognitoState, SignInPolicy, SmsConfiguration, UserPool, UserPoolClient, UserPoolDomain,
-    COGNITO_SNAPSHOT_SCHEMA_VERSION,
+    IdentityPoolRoleAttachment, PasswordPolicy, PoolPolicies, PreTokenGenInvocation,
+    RecoveryOption, SchemaAttribute, SharedCognitoState, SignInPolicy, SmsConfiguration, UserPool,
+    UserPoolClient, UserPoolDomain, COGNITO_SNAPSHOT_SCHEMA_VERSION,
 };
 
 /// `CognitoJwtVerifier` impl backed by the in-process Cognito state.

--- a/crates/fakecloud-cognito/src/service/auth.rs
+++ b/crates/fakecloud-cognito/src/service/auth.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::state::{
-    AccessTokenData, AuthEvent, ChallengeResult, CognitoState, RefreshTokenData, SessionData,
-    UserAttribute,
+    AccessTokenData, AuthEvent, ChallengeResult, CognitoState, PreTokenGenInvocation,
+    RefreshTokenData, SessionData, SharedCognitoState, UserAttribute,
 };
 use crate::triggers::{self, TriggerSource};
 use crate::user_status;
@@ -680,9 +680,29 @@ impl CognitoService {
                     &region,
                     &account_id,
                 );
-                triggers::invoke_trigger(ctx, &function_arn, &event)
-                    .await
-                    .and_then(|resp| resp.get("response").cloned())
+                let started = std::time::Instant::now();
+                let invoked_at = chrono::Utc::now();
+                let raw_response = triggers::invoke_trigger(ctx, &function_arn, &event).await;
+                let duration_ms = started.elapsed().as_millis() as u64;
+                let overrides = raw_response
+                    .as_ref()
+                    .and_then(|resp| resp.get("response").cloned());
+
+                record_pre_token_gen_invocation(
+                    &self.state,
+                    &req.account_id,
+                    pool_id,
+                    &region,
+                    &account_id,
+                    username,
+                    &function_arn,
+                    &event,
+                    raw_response.as_ref(),
+                    invoked_at,
+                    duration_ms,
+                );
+
+                overrides
             } else {
                 None
             }
@@ -2408,6 +2428,100 @@ impl CognitoService {
     }
 }
 
+/// Append one PreTokenGeneration trigger invocation to the per-account
+/// introspection log. Pulls out the override block already so callers
+/// at `/_fakecloud/cognito/pretokengen/invocations` get parsed
+/// `claims_added` / `claims_overridden` / `group_overrides` instead of
+/// having to walk the raw Lambda response themselves.
+#[allow(clippy::too_many_arguments)]
+fn record_pre_token_gen_invocation(
+    state: &SharedCognitoState,
+    account_id_key: &str,
+    pool_id: &str,
+    region: &str,
+    account_id: &str,
+    username: &str,
+    function_arn: &str,
+    event: &Value,
+    raw_response: Option<&Value>,
+    invoked_at: chrono::DateTime<Utc>,
+    duration_ms: u64,
+) {
+    let user_pool_arn = format!("arn:aws:cognito-idp:{region}:{account_id}:userpool/{pool_id}");
+
+    let mut claims_added: Vec<String> = Vec::new();
+    let mut claims_overridden: Vec<String> = Vec::new();
+    let mut group_overrides: Vec<String> = Vec::new();
+
+    if let Some(resp) = raw_response {
+        let ov = &resp["response"];
+        let v2 = &ov["claimsAndScopeOverrideDetails"];
+        let v1 = &ov["claimsOverrideDetails"];
+        let id_block = if !v2.is_null() {
+            &v2["idTokenGeneration"]
+        } else {
+            v1
+        };
+        let access_block = if !v2.is_null() {
+            &v2["accessTokenGeneration"]
+        } else {
+            v1
+        };
+        let group_block = if !v2.is_null() {
+            &v2["groupOverrideDetails"]
+        } else {
+            &v1["groupOverrideDetails"]
+        };
+        for block in [id_block, access_block] {
+            if let Some(adds) = block["claimsToAddOrOverride"].as_object() {
+                for k in adds.keys() {
+                    if !claims_added.contains(k) {
+                        claims_added.push(k.clone());
+                    }
+                }
+            }
+            if let Some(suppress) = block["claimsToSuppress"].as_array() {
+                for v in suppress {
+                    if let Some(k) = v.as_str() {
+                        let k = k.to_string();
+                        if !claims_overridden.contains(&k) {
+                            claims_overridden.push(k);
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(arr) = group_block["groupsToOverride"].as_array() {
+            for v in arr {
+                if let Some(s) = v.as_str() {
+                    group_overrides.push(s.to_string());
+                }
+            }
+        }
+    }
+
+    let invocation = PreTokenGenInvocation {
+        pool_id: pool_id.to_string(),
+        user_pool_arn,
+        username: username.to_string(),
+        trigger_source: TriggerSource::TokenGenerationAuthentication
+            .as_str()
+            .to_string(),
+        lambda_arn: function_arn.to_string(),
+        request_payload: event.clone(),
+        response_payload: raw_response.cloned(),
+        claims_added,
+        claims_overridden,
+        group_overrides,
+        invoked_at,
+        duration_ms,
+    };
+
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id_key);
+    s.pre_token_gen_invocations.push(invocation);
+}
+
 #[cfg(test)]
 mod risk_tests {
     use super::*;
@@ -2483,6 +2597,100 @@ mod risk_tests {
             "DifferentPassword!",
         );
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn pretokengen_invocation_records_parsed_overrides() {
+        let svc = make_service();
+        let event = json!({
+            "version": "2",
+            "triggerSource": "TokenGeneration_Authentication",
+            "userPoolId": "pool-x",
+            "userName": "alice",
+        });
+        let response = json!({
+            "response": {
+                "claimsAndScopeOverrideDetails": {
+                    "idTokenGeneration": {
+                        "claimsToAddOrOverride": {"role": "admin", "tier": "gold"},
+                        "claimsToSuppress": ["email"],
+                    },
+                    "accessTokenGeneration": {
+                        "claimsToAddOrOverride": {"scope_extra": "x"},
+                        "claimsToSuppress": ["phone_number"],
+                    },
+                    "groupOverrideDetails": {
+                        "groupsToOverride": ["admins", "beta"],
+                    },
+                }
+            }
+        });
+        record_pre_token_gen_invocation(
+            &svc.state,
+            "123456789012",
+            "pool-x",
+            "us-east-1",
+            "123456789012",
+            "alice",
+            "arn:aws:lambda:us-east-1:123456789012:function:pretoken",
+            &event,
+            Some(&response),
+            chrono::Utc::now(),
+            42,
+        );
+
+        let accounts = svc.state.read();
+        let s = accounts.get("123456789012").expect("account exists");
+        assert_eq!(s.pre_token_gen_invocations.len(), 1);
+        let inv = &s.pre_token_gen_invocations[0];
+        assert_eq!(inv.pool_id, "pool-x");
+        assert_eq!(inv.username, "alice");
+        assert_eq!(
+            inv.user_pool_arn,
+            "arn:aws:cognito-idp:us-east-1:123456789012:userpool/pool-x"
+        );
+        assert_eq!(
+            inv.lambda_arn,
+            "arn:aws:lambda:us-east-1:123456789012:function:pretoken"
+        );
+        assert_eq!(inv.duration_ms, 42);
+        assert!(inv.claims_added.contains(&"role".to_string()));
+        assert!(inv.claims_added.contains(&"tier".to_string()));
+        assert!(inv.claims_added.contains(&"scope_extra".to_string()));
+        assert!(inv.claims_overridden.contains(&"email".to_string()));
+        assert!(inv.claims_overridden.contains(&"phone_number".to_string()));
+        assert_eq!(
+            inv.group_overrides,
+            vec!["admins".to_string(), "beta".to_string()]
+        );
+        assert_eq!(inv.trigger_source, "TokenGeneration_Authentication");
+    }
+
+    #[test]
+    fn pretokengen_invocation_records_no_overrides() {
+        let svc = make_service();
+        let event = json!({"triggerSource": "TokenGeneration_Authentication"});
+        record_pre_token_gen_invocation(
+            &svc.state,
+            "123456789012",
+            "pool-x",
+            "us-east-1",
+            "123456789012",
+            "bob",
+            "arn:aws:lambda:us-east-1:123456789012:function:pretoken",
+            &event,
+            None,
+            chrono::Utc::now(),
+            7,
+        );
+        let accounts = svc.state.read();
+        let s = accounts.get("123456789012").expect("account exists");
+        assert_eq!(s.pre_token_gen_invocations.len(), 1);
+        let inv = &s.pre_token_gen_invocations[0];
+        assert!(inv.claims_added.is_empty());
+        assert!(inv.claims_overridden.is_empty());
+        assert!(inv.group_overrides.is_empty());
+        assert!(inv.response_payload.is_none());
     }
 
     #[test]

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -111,6 +111,41 @@ pub struct CognitoState {
     /// `EventAction = BLOCK`.
     #[serde(default)]
     pub compromised_password_hashes: std::collections::BTreeSet<String>,
+    /// PreTokenGeneration Lambda trigger invocation log.
+    /// Captured every time `InitiateAuth` fires the
+    /// `TokenGeneration_Authentication` trigger and the Lambda returns,
+    /// regardless of whether the response actually contained an override
+    /// block. Surfaced via `/_fakecloud/cognito/pretokengen/invocations`
+    /// so tests can assert the claim mutation flow end-to-end without
+    /// inspecting the JWT they just received.
+    #[serde(default, skip)]
+    pub pre_token_gen_invocations: Vec<PreTokenGenInvocation>,
+}
+
+/// One PreTokenGeneration Lambda trigger invocation captured for
+/// introspection. `claims_added` / `claims_overridden` /
+/// `group_overrides` are pre-parsed from the trigger response so test
+/// callers don't have to walk the `claimsAndScopeOverrideDetails`
+/// shape themselves.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreTokenGenInvocation {
+    pub pool_id: String,
+    pub user_pool_arn: String,
+    pub username: String,
+    pub trigger_source: String,
+    pub lambda_arn: String,
+    pub request_payload: serde_json::Value,
+    pub response_payload: Option<serde_json::Value>,
+    /// Keys added or overridden across both id-token and access-token
+    /// `claimsToAddOrOverride` blocks.
+    pub claims_added: Vec<String>,
+    /// Keys suppressed across both id-token and access-token
+    /// `claimsToSuppress` blocks.
+    pub claims_overridden: Vec<String>,
+    /// Contents of `groupOverrideDetails.groupsToOverride` if present.
+    pub group_overrides: Vec<String>,
+    pub invoked_at: DateTime<Utc>,
+    pub duration_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -194,6 +229,7 @@ impl CognitoState {
             identity_pool_role_attachments: BTreeMap::new(),
             federated_identities: BTreeMap::new(),
             compromised_password_hashes: std::collections::BTreeSet::new(),
+            pre_token_gen_invocations: Vec::new(),
         }
     }
 
@@ -222,6 +258,7 @@ impl CognitoState {
         self.identity_pools.clear();
         self.identity_pool_role_attachments.clear();
         self.federated_identities.clear();
+        self.pre_token_gen_invocations.clear();
     }
 }
 

--- a/crates/fakecloud-e2e/tests/cognito_dispatch.rs
+++ b/crates/fakecloud-e2e/tests/cognito_dispatch.rs
@@ -368,6 +368,10 @@ async fn cognito_custom_email_sender_lambda_takes_precedence_over_ses() {
 }
 
 fn build_python_handler_zip() -> Vec<u8> {
+    build_python_handler_zip_with_source("def handler(event, context):\n    return event\n")
+}
+
+fn build_python_handler_zip_with_source(src: &str) -> Vec<u8> {
     use std::io::Write;
     let mut buf = Vec::new();
     {
@@ -375,9 +379,217 @@ fn build_python_handler_zip() -> Vec<u8> {
         let opts: zip::write::FileOptions<'_, ()> =
             zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
         zip.start_file("index.py", opts).unwrap();
-        zip.write_all(b"def handler(event, context):\n    return event\n")
-            .unwrap();
+        zip.write_all(src.as_bytes()).unwrap();
         zip.finish().unwrap();
     }
     buf
+}
+
+#[tokio::test]
+async fn cognito_pretokengen_invocation_is_recorded() {
+    use aws_sdk_cognitoidentityprovider::types::{
+        AuthFlowType, MessageActionType, UserPoolMfaType,
+    };
+    use aws_sdk_lambda::types::{FunctionCode, Runtime};
+
+    let server = TestServer::start().await;
+    let cognito = server.cognito_client().await;
+    let lambda = server.lambda_client().await;
+    let iam = server.iam_client().await;
+    let http = reqwest::Client::new();
+
+    iam.create_role()
+        .role_name("cognito-pretokengen-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // PreTokenGen Lambda that injects a custom claim, suppresses one,
+    // and overrides the cognito:groups list. The merge expects v2
+    // shape under `response.claimsAndScopeOverrideDetails`.
+    let src = r#"
+def handler(event, context):
+    event["response"] = {
+        "claimsAndScopeOverrideDetails": {
+            "idTokenGeneration": {
+                "claimsToAddOrOverride": {"tier": "gold"},
+                "claimsToSuppress": ["email"],
+            },
+            "accessTokenGeneration": {
+                "claimsToAddOrOverride": {},
+                "claimsToSuppress": [],
+            },
+            "groupOverrideDetails": {
+                "groupsToOverride": ["admins"],
+            },
+        }
+    }
+    return event
+"#;
+    let zip_bytes = build_python_handler_zip_with_source(src);
+    lambda
+        .create_function()
+        .function_name("pretokengen-fn")
+        .runtime(Runtime::Python311)
+        .role("arn:aws:iam::123456789012:role/cognito-pretokengen-role")
+        .handler("index.handler")
+        .code(FunctionCode::builder().zip_file(zip_bytes.into()).build())
+        .send()
+        .await
+        .unwrap();
+
+    let pool = cognito
+        .create_user_pool()
+        .pool_name("pretokengen-pool")
+        .mfa_configuration(UserPoolMfaType::Off)
+        .lambda_config(
+            aws_sdk_cognitoidentityprovider::types::LambdaConfigType::builder()
+                .pre_token_generation(
+                    "arn:aws:lambda:us-east-1:123456789012:function:pretokengen-fn",
+                )
+                .build(),
+        )
+        .policies(
+            UserPoolPolicyType::builder()
+                .password_policy(
+                    PasswordPolicyType::builder()
+                        .minimum_length(6)
+                        .require_uppercase(false)
+                        .require_lowercase(false)
+                        .require_numbers(false)
+                        .require_symbols(false)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let pool_id = pool.user_pool().unwrap().id().unwrap().to_string();
+
+    let pc = cognito
+        .create_user_pool_client()
+        .user_pool_id(&pool_id)
+        .client_name("pretokengen-client")
+        .explicit_auth_flows(ExplicitAuthFlowsType::AllowUserPasswordAuth)
+        .send()
+        .await
+        .unwrap();
+    let client_id = pc
+        .user_pool_client()
+        .unwrap()
+        .client_id()
+        .unwrap()
+        .to_string();
+
+    // AdminCreateUser + AdminSetUserPassword so the user is confirmed
+    // and we can drive InitiateAuth without a confirmation step.
+    cognito
+        .admin_create_user()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .message_action(MessageActionType::Suppress)
+        .send()
+        .await
+        .unwrap();
+    cognito
+        .admin_set_user_password()
+        .user_pool_id(&pool_id)
+        .username("alice")
+        .password("hunter2")
+        .permanent(true)
+        .send()
+        .await
+        .unwrap();
+
+    let auth = cognito
+        .initiate_auth()
+        .client_id(&client_id)
+        .auth_flow(AuthFlowType::UserPasswordAuth)
+        .auth_parameters("USERNAME", "alice")
+        .auth_parameters("PASSWORD", "hunter2")
+        .send()
+        .await
+        .expect("initiate_auth should succeed");
+    assert!(auth.authentication_result().is_some());
+
+    // Pull invocation log from the new introspection endpoint.
+    let resp: serde_json::Value = http
+        .get(format!(
+            "{}/_fakecloud/cognito/pretokengen/invocations",
+            server.endpoint()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let invs = resp["invocations"].as_array().expect("invocations array");
+    let inv = invs
+        .iter()
+        .find(|i| i["poolId"].as_str() == Some(pool_id.as_str()))
+        .expect("invocation for our pool");
+    assert_eq!(inv["username"].as_str(), Some("alice"));
+    assert_eq!(
+        inv["triggerSource"].as_str(),
+        Some("TokenGeneration_Authentication")
+    );
+    assert_eq!(
+        inv["lambdaArn"].as_str(),
+        Some("arn:aws:lambda:us-east-1:123456789012:function:pretokengen-fn")
+    );
+    assert_eq!(
+        inv["userPoolArn"].as_str(),
+        Some(
+            format!("arn:aws:cognito-idp:us-east-1:123456789012:userpool/{pool_id}")
+                .as_str()
+        )
+    );
+    let claims_added: Vec<&str> = inv["claimsAdded"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(
+        claims_added.contains(&"tier"),
+        "expected `tier` in claims_added, got {claims_added:?}"
+    );
+    let claims_overridden: Vec<&str> = inv["claimsOverridden"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(
+        claims_overridden.contains(&"email"),
+        "expected `email` suppressed, got {claims_overridden:?}"
+    );
+    let group_overrides: Vec<&str> = inv["groupOverrides"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(group_overrides, vec!["admins"]);
+    assert!(inv["requestPayload"].is_object());
+    assert!(inv["responsePayload"].is_object());
+    assert!(inv["invokedAt"].is_string());
+    assert!(inv["durationMs"].is_number());
+
+    // Confirm the SDK helper sees the same entry.
+    let sdk = fakecloud_sdk::FakeCloud::new(&server.endpoint());
+    let sdk_resp = sdk
+        .cognito()
+        .get_pre_token_gen_invocations()
+        .await
+        .expect("sdk getPreTokenGenInvocations");
+    assert!(sdk_resp
+        .invocations
+        .iter()
+        .any(|i| i.pool_id == pool_id && i.username == "alice"));
 }

--- a/crates/fakecloud-e2e/tests/cognito_dispatch.rs
+++ b/crates/fakecloud-e2e/tests/cognito_dispatch.rs
@@ -544,10 +544,7 @@ def handler(event, context):
     );
     assert_eq!(
         inv["userPoolArn"].as_str(),
-        Some(
-            format!("arn:aws:cognito-idp:us-east-1:123456789012:userpool/{pool_id}")
-                .as_str()
-        )
+        Some(format!("arn:aws:cognito-idp:us-east-1:123456789012:userpool/{pool_id}").as_str())
     );
     let claims_added: Vec<&str> = inv["claimsAdded"]
         .as_array()

--- a/crates/fakecloud-e2e/tests/cognito_dispatch.rs
+++ b/crates/fakecloud-e2e/tests/cognito_dispatch.rs
@@ -579,7 +579,7 @@ def handler(event, context):
     assert!(inv["durationMs"].is_number());
 
     // Confirm the SDK helper sees the same entry.
-    let sdk = fakecloud_sdk::FakeCloud::new(&server.endpoint());
+    let sdk = fakecloud_sdk::FakeCloud::new(server.endpoint());
     let sdk_resp = sdk
         .cognito()
         .get_pre_token_gen_invocations()

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -679,6 +679,26 @@ impl CognitoClient<'_> {
             .await?;
         FakeCloud::parse(resp).await
     }
+
+    /// List PreTokenGeneration Lambda trigger invocations recorded
+    /// during `InitiateAuth`. Each entry includes the full request /
+    /// response payloads plus pre-parsed `claims_added`,
+    /// `claims_overridden`, and `group_overrides` so tests can assert
+    /// the claim mutation flow without inspecting the issued JWT.
+    pub async fn get_pre_token_gen_invocations(
+        &self,
+    ) -> Result<PreTokenGenInvocationsResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!(
+                "{}/_fakecloud/cognito/pretokengen/invocations",
+                self.fc.base_url
+            ))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
 }
 
 // ── API Gateway v2 ──────────────────────────────────────────────────

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -795,6 +795,35 @@ pub struct AuthEventsResponse {
     pub events: Vec<AuthEvent>,
 }
 
+/// One PreTokenGeneration Lambda trigger invocation captured for
+/// introspection at `/_fakecloud/cognito/pretokengen/invocations`.
+/// `claims_added` / `claims_overridden` / `group_overrides` are
+/// pre-parsed from the Lambda response so test callers don't have to
+/// walk the raw `claimsAndScopeOverrideDetails` shape themselves.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreTokenGenInvocation {
+    pub pool_id: String,
+    pub user_pool_arn: String,
+    pub username: String,
+    pub trigger_source: String,
+    pub lambda_arn: String,
+    pub request_payload: serde_json::Value,
+    pub response_payload: Option<serde_json::Value>,
+    pub claims_added: Vec<String>,
+    pub claims_overridden: Vec<String>,
+    pub group_overrides: Vec<String>,
+    /// RFC3339 timestamp.
+    pub invoked_at: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreTokenGenInvocationsResponse {
+    pub invocations: Vec<PreTokenGenInvocation>,
+}
+
 /// Request body for the `/_fakecloud/cognito/authorization-codes` admin
 /// mint endpoint. Lets test harnesses (and any caller that wants to
 /// drive the `authorization_code` grant before the Y4 hosted-UI lands)

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -6238,6 +6238,40 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/cognito/pretokengen/invocations",
+            axum::routing::get({
+                let cs = cognito_state.clone();
+                move || {
+                    let cs = cs.clone();
+                    async move {
+                        let accounts = cs.read();
+                        let mut out: Vec<types::PreTokenGenInvocation> = Vec::new();
+                        for (_account_id, state) in accounts.iter() {
+                            for inv in &state.pre_token_gen_invocations {
+                                out.push(types::PreTokenGenInvocation {
+                                    pool_id: inv.pool_id.clone(),
+                                    user_pool_arn: inv.user_pool_arn.clone(),
+                                    username: inv.username.clone(),
+                                    trigger_source: inv.trigger_source.clone(),
+                                    lambda_arn: inv.lambda_arn.clone(),
+                                    request_payload: inv.request_payload.clone(),
+                                    response_payload: inv.response_payload.clone(),
+                                    claims_added: inv.claims_added.clone(),
+                                    claims_overridden: inv.claims_overridden.clone(),
+                                    group_overrides: inv.group_overrides.clone(),
+                                    invoked_at: inv.invoked_at.to_rfc3339(),
+                                    duration_ms: inv.duration_ms,
+                                });
+                            }
+                        }
+                        axum::Json(types::PreTokenGenInvocationsResponse {
+                            invocations: out,
+                        })
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/cognito/webauthn-credentials",
             axum::routing::get({
                 let cs = cognito_state.clone();

--- a/sdks/go/cognito.go
+++ b/sdks/go/cognito.go
@@ -131,6 +131,19 @@ func (c *CognitoClient) SetCompromisedPasswords(ctx context.Context, req *Compro
 	return &out, nil
 }
 
+// GetPreTokenGenInvocations returns the PreTokenGeneration Lambda
+// trigger invocation log recorded by InitiateAuth. Each entry has the
+// full request/response payloads plus pre-parsed ClaimsAdded,
+// ClaimsOverridden, and GroupOverrides so tests can assert claim
+// mutation flows without inspecting the issued JWT.
+func (c *CognitoClient) GetPreTokenGenInvocations(ctx context.Context) (*PreTokenGenInvocationsResponse, error) {
+	var out PreTokenGenInvocationsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/cognito/pretokengen/invocations", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // GetWebAuthnCredentials lists every registered WebAuthn credential
 // across pools and users, including the parsed packed-attestation
 // info captured at registration time.

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -491,6 +491,30 @@ type AuthEventsResponse struct {
 	Events []AuthEvent `json:"events"`
 }
 
+// PreTokenGenInvocation is one PreTokenGeneration Lambda trigger
+// invocation captured by InitiateAuth. ClaimsAdded / ClaimsOverridden /
+// GroupOverrides are pre-parsed from the Lambda response.
+type PreTokenGenInvocation struct {
+	PoolID           string                 `json:"poolId"`
+	UserPoolARN      string                 `json:"userPoolArn"`
+	Username         string                 `json:"username"`
+	TriggerSource    string                 `json:"triggerSource"`
+	LambdaARN        string                 `json:"lambdaArn"`
+	RequestPayload   map[string]interface{} `json:"requestPayload"`
+	ResponsePayload  map[string]interface{} `json:"responsePayload,omitempty"`
+	ClaimsAdded      []string               `json:"claimsAdded"`
+	ClaimsOverridden []string               `json:"claimsOverridden"`
+	GroupOverrides   []string               `json:"groupOverrides"`
+	InvokedAt        string                 `json:"invokedAt"`
+	DurationMs       uint64                 `json:"durationMs"`
+}
+
+// PreTokenGenInvocationsResponse is the shape returned by
+// /_fakecloud/cognito/pretokengen/invocations.
+type PreTokenGenInvocationsResponse struct {
+	Invocations []PreTokenGenInvocation `json:"invocations"`
+}
+
 // MintAuthorizationCodeRequest is the payload for the
 // /_fakecloud/cognito/authorization-codes admin endpoint. Lets test
 // harnesses mint a single-use OAuth2 authorization code that the

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -6,6 +6,7 @@ import dev.fakecloud.Types.ApiGatewayV2RequestsResponse;
 import dev.fakecloud.Types.AppAsScheduledTickResponse;
 import dev.fakecloud.Types.AppAsTickResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
+import dev.fakecloud.Types.PreTokenGenInvocationsResponse;
 import dev.fakecloud.Types.MintAuthorizationCodeRequest;
 import dev.fakecloud.Types.MintAuthorizationCodeResponse;
 import dev.fakecloud.Types.CompromisedPasswordsRequest;
@@ -528,6 +529,18 @@ public final class FakeCloud {
 
         public AuthEventsResponse getAuthEvents() {
             return http.get("/_fakecloud/cognito/auth-events", AuthEventsResponse.class);
+        }
+
+        /**
+         * Returns the PreTokenGeneration Lambda trigger invocation log
+         * recorded by {@code InitiateAuth}. Each entry has the full
+         * request/response payloads plus pre-parsed claim additions,
+         * suppressions, and group overrides.
+         */
+        public PreTokenGenInvocationsResponse getPreTokenGenInvocations() {
+            return http.get(
+                    "/_fakecloud/cognito/pretokengen/invocations",
+                    PreTokenGenInvocationsResponse.class);
         }
 
         public MintAuthorizationCodeResponse mintAuthorizationCode(

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -359,6 +359,31 @@ public final class Types {
     public record AuthEventsResponse(List<AuthEvent> events) {}
 
     /**
+     * One PreTokenGeneration Lambda trigger invocation captured by
+     * {@code InitiateAuth}. {@code claimsAdded} / {@code claimsOverridden} /
+     * {@code groupOverrides} are pre-parsed from the Lambda response so
+     * tests don't have to walk the raw
+     * {@code claimsAndScopeOverrideDetails} shape themselves.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PreTokenGenInvocation(
+            String poolId,
+            String userPoolArn,
+            String username,
+            String triggerSource,
+            String lambdaArn,
+            Map<String, Object> requestPayload,
+            Map<String, Object> responsePayload,
+            List<String> claimsAdded,
+            List<String> claimsOverridden,
+            List<String> groupOverrides,
+            String invokedAt,
+            long durationMs) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PreTokenGenInvocationsResponse(List<PreTokenGenInvocation> invocations) {}
+
+    /**
      * Payload for {@code POST /_fakecloud/cognito/authorization-codes}.
      * Lets test harnesses pre-allocate a single-use OAuth2 authorization
      * code that the {@code /oauth2/token} {@code authorization_code}

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -513,6 +513,20 @@ final class CognitoClient
         );
     }
 
+    /**
+     * Returns the PreTokenGeneration Lambda trigger invocation log
+     * recorded by `InitiateAuth`. Each entry has the full request /
+     * response payloads plus pre-parsed `claims_added`,
+     * `claims_overridden`, and `group_overrides` so tests can assert
+     * claim mutation flows without inspecting the issued JWT.
+     */
+    public function getPreTokenGenInvocations(): PreTokenGenInvocationsResponse
+    {
+        return PreTokenGenInvocationsResponse::fromArray(
+            $this->http->get('/_fakecloud/cognito/pretokengen/invocations')
+        );
+    }
+
     public function mintAuthorizationCode(
         MintAuthorizationCodeRequest $req
     ): MintAuthorizationCodeResponse {

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1099,6 +1099,67 @@ final class AuthEventsResponse
 }
 
 /**
+ * One PreTokenGeneration Lambda trigger invocation captured by
+ * `InitiateAuth`. `claimsAdded` / `claimsOverridden` / `groupOverrides`
+ * are pre-parsed from the Lambda response.
+ */
+final class PreTokenGenInvocation
+{
+    public function __construct(
+        public readonly string $poolId,
+        public readonly string $userPoolArn,
+        public readonly string $username,
+        public readonly string $triggerSource,
+        public readonly string $lambdaArn,
+        /** @var array<string, mixed> */
+        public readonly array $requestPayload,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $responsePayload,
+        /** @var string[] */
+        public readonly array $claimsAdded,
+        /** @var string[] */
+        public readonly array $claimsOverridden,
+        /** @var string[] */
+        public readonly array $groupOverrides,
+        public readonly string $invokedAt,
+        public readonly int $durationMs,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['poolId'],
+            $data['userPoolArn'],
+            $data['username'],
+            $data['triggerSource'],
+            $data['lambdaArn'],
+            $data['requestPayload'] ?? [],
+            $data['responsePayload'] ?? null,
+            $data['claimsAdded'] ?? [],
+            $data['claimsOverridden'] ?? [],
+            $data['groupOverrides'] ?? [],
+            $data['invokedAt'],
+            (int) $data['durationMs'],
+        );
+    }
+}
+
+final class PreTokenGenInvocationsResponse
+{
+    public function __construct(
+        /** @var PreTokenGenInvocation[] */
+        public readonly array $invocations,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_map(PreTokenGenInvocation::fromArray(...), $data['invocations'] ?? []),
+        );
+    }
+}
+
+/**
  * Payload for `POST /_fakecloud/cognito/authorization-codes`. Lets
  * test harnesses pre-allocate a single-use OAuth2 authorization code
  * that the `/oauth2/token` `authorization_code` grant later consumes.

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -61,6 +61,7 @@ from fakecloud.types import (
     MintAuthorizationCodeRequest,
     MintAuthorizationCodeResponse,
     PendingConfirmationsResponse,
+    PreTokenGenInvocationsResponse,
     RdsInstancesResponse,
     ResetResponse,
     ResetServiceResponse,
@@ -853,6 +854,16 @@ class CognitoClient:
         _check(resp)
         return AuthEventsResponse.from_dict(resp.json())
 
+    async def get_pre_token_gen_invocations(
+        self,
+    ) -> PreTokenGenInvocationsResponse:
+        """Return the PreTokenGeneration Lambda trigger invocation log."""
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/cognito/pretokengen/invocations"
+        )
+        _check(resp)
+        return PreTokenGenInvocationsResponse.from_dict(resp.json())
+
     async def mint_authorization_code(
         self, req: MintAuthorizationCodeRequest
     ) -> MintAuthorizationCodeResponse:
@@ -1326,6 +1337,14 @@ class _SyncCognitoClient:
         resp = self._client.get(f"{self._base}/_fakecloud/cognito/auth-events")
         _check(resp)
         return AuthEventsResponse.from_dict(resp.json())
+
+    def get_pre_token_gen_invocations(self) -> PreTokenGenInvocationsResponse:
+        """Return the PreTokenGeneration Lambda trigger invocation log."""
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/cognito/pretokengen/invocations"
+        )
+        _check(resp)
+        return PreTokenGenInvocationsResponse.from_dict(resp.json())
 
     def mint_authorization_code(
         self, req: MintAuthorizationCodeRequest

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1028,8 +1028,7 @@ class PreTokenGenInvocationsResponse:
     def from_dict(cls, data: Dict[str, Any]) -> PreTokenGenInvocationsResponse:
         return cls(
             invocations=[
-                PreTokenGenInvocation.from_dict(e)
-                for e in data.get("invocations", [])
+                PreTokenGenInvocation.from_dict(e) for e in data.get("invocations", [])
             ],
         )
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -993,6 +993,48 @@ class AuthEventsResponse:
 
 
 @dataclass
+class PreTokenGenInvocation:
+    """One PreTokenGeneration Lambda trigger invocation captured by
+    ``InitiateAuth``. ``claims_added`` / ``claims_overridden`` /
+    ``group_overrides`` are pre-parsed from the Lambda response so test
+    code doesn't have to walk the raw ``claimsAndScopeOverrideDetails``
+    shape itself.
+    """
+
+    pool_id: str
+    user_pool_arn: str
+    username: str
+    trigger_source: str
+    lambda_arn: str
+    request_payload: Dict[str, Any]
+    response_payload: Optional[Dict[str, Any]]
+    claims_added: List[str]
+    claims_overridden: List[str]
+    group_overrides: List[str]
+    invoked_at: str
+    duration_ms: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> PreTokenGenInvocation:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
+class PreTokenGenInvocationsResponse:
+    invocations: List[PreTokenGenInvocation]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> PreTokenGenInvocationsResponse:
+        return cls(
+            invocations=[
+                PreTokenGenInvocation.from_dict(e)
+                for e in data.get("invocations", [])
+            ],
+        )
+
+
+@dataclass
 class MintAuthorizationCodeRequest:
     """Payload for `POST /_fakecloud/cognito/authorization-codes`.
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -56,6 +56,7 @@ import type {
   ExpireTokensRequest,
   ExpireTokensResponse,
   AuthEventsResponse,
+  PreTokenGenInvocationsResponse,
   MintAuthorizationCodeRequest,
   MintAuthorizationCodeResponse,
   CompromisedPasswordsRequest,
@@ -466,6 +467,20 @@ export class CognitoClient {
 
   async getAuthEvents(): Promise<AuthEventsResponse> {
     const resp = await fetch(`${this.baseUrl}/_fakecloud/cognito/auth-events`);
+    return parse(resp);
+  }
+
+  /**
+   * Returns the PreTokenGeneration Lambda trigger invocation log
+   * recorded by `InitiateAuth`. Each entry includes the full request /
+   * response payloads plus pre-parsed `claimsAdded`,
+   * `claimsOverridden`, and `groupOverrides` so tests can assert claim
+   * mutation flows without inspecting the issued JWT.
+   */
+  async getPreTokenGenInvocations(): Promise<PreTokenGenInvocationsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/cognito/pretokengen/invocations`,
+    );
     return parse(resp);
   }
 

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -410,6 +410,32 @@ export interface AuthEventsResponse {
 }
 
 /**
+ * One PreTokenGeneration Lambda trigger invocation captured by
+ * `InitiateAuth`. `claimsAdded` / `claimsOverridden` / `groupOverrides`
+ * are pre-parsed from the Lambda response so tests don't have to walk
+ * the raw `claimsAndScopeOverrideDetails` shape themselves.
+ */
+export interface PreTokenGenInvocation {
+  poolId: string;
+  userPoolArn: string;
+  username: string;
+  triggerSource: string;
+  lambdaArn: string;
+  requestPayload: Record<string, unknown>;
+  responsePayload?: Record<string, unknown> | null;
+  claimsAdded: string[];
+  claimsOverridden: string[];
+  groupOverrides: string[];
+  /** RFC3339 timestamp. */
+  invokedAt: string;
+  durationMs: number;
+}
+
+export interface PreTokenGenInvocationsResponse {
+  invocations: PreTokenGenInvocation[];
+}
+
+/**
  * Payload for `POST /_fakecloud/cognito/authorization-codes`. Lets
  * test harnesses pre-allocate a single-use OAuth2 authorization code
  * that the `/oauth2/token` `authorization_code` grant later consumes.

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -85,6 +85,7 @@ curl http://localhost:4566/_fakecloud/health
 | `/_fakecloud/cognito/authorization-codes` | POST | Mint an OAuth2 authorization code (for hosted-UI flow simulation). |
 | `/_fakecloud/cognito/compromised-passwords` | POST | **NEW** -- Mark a password as compromised so the next AdminInitiateAuth surfaces the advisory. |
 | `/_fakecloud/cognito/webauthn-credentials` | GET | **NEW** -- List registered WebAuthn credentials with their attestation details. |
+| `/_fakecloud/cognito/pretokengen/invocations` | GET | **NEW** -- List PreTokenGeneration Lambda trigger invocations with parsed claim overrides, suppressed claims, and group overrides. |
 
 ## DynamoDB
 

--- a/website/content/docs/services/cognito.md
+++ b/website/content/docs/services/cognito.md
@@ -50,6 +50,7 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 - `POST /_fakecloud/cognito/authorization-codes` — mint a single-use OAuth2 authorization code for the `authorization_code` grant (programmatic alternative to driving `/oauth2/authorize`)
 - `POST /_fakecloud/cognito/compromised-passwords` — register plaintext passwords as compromised; each is SHA-256 hashed server-side and added to the per-account set checked by `CompromisedCredentialsRiskConfiguration` enforcement
 - `GET /_fakecloud/cognito/webauthn-credentials` — list registered WebAuthn credentials with parsed `packed`-attestation info (AAGUID, certificate chain summary, signature counter)
+- `GET /_fakecloud/cognito/pretokengen/invocations` — list PreTokenGeneration Lambda trigger invocations recorded by `InitiateAuth`, with full request/response payloads plus pre-parsed `claims_added`, `claims_overridden`, and `group_overrides` so tests can assert claim mutation flows without inspecting the issued JWT
 
 ## Cross-service delivery
 


### PR DESCRIPTION
## Summary

Adds introspection endpoints per /Users/lucas/.claude/plans/introspection-endpoints-2026-05-11.md.

## Test plan

- [ ] CI green
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cognito introspection endpoint to list PreTokenGeneration Lambda invocations from `InitiateAuth`, with parsed claim and group overrides. This helps verify claim mutation without decoding JWTs.

- **New Features**
  - New GET `/_fakecloud/cognito/pretokengen/invocations` returns each invocation with pool/user, Lambda ARN, request/response, `claimsAdded`, `claimsOverridden`, `groupOverrides`, `invokedAt`, and `durationMs`.
  - Service records every invocation during `InitiateAuth` (even with no overrides), parsing both v1 (`claimsOverrideDetails`) and v2 (`claimsAndScopeOverrideDetails`) response shapes.
  - SDKs add `getPreTokenGenInvocations` in TypeScript, Python, Go, Java, and PHP with types; E2E test covers logging and endpoint output; docs updated.

<sup>Written for commit ce836b1de202133e07f611a9cc5f3979265449c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

