### PR TITLE
feat(athena): introspection endpoint — named queries (I7)

### DIFF
--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -687,6 +687,7 @@ impl AthenaService {
                 database,
                 query_string,
                 work_group,
+                last_used_at: None,
             },
         );
         Ok(AwsResponse::ok_json(json!({ "NamedQueryId": id })))
@@ -978,20 +979,23 @@ impl AthenaService {
             .map(str::to_owned);
 
         // Resolve query string from NamedQueryId or QueryString.
-        let mut query =
-            if let Some(named_query_id) = body.get("NamedQueryId").and_then(Value::as_str) {
-                let state = self.state.read();
-                let account = state
-                    .accounts
-                    .get(&req.account_id)
-                    .ok_or_else(|| invalid_request("Account not found"))?;
-                let nq = account.named_queries.get(named_query_id).ok_or_else(|| {
-                    invalid_request(format!("NamedQuery {named_query_id} not found"))
-                })?;
-                nq.query_string.clone()
-            } else {
-                require_str(&body, "QueryString")?
-            };
+        let mut query = if let Some(named_query_id) =
+            body.get("NamedQueryId").and_then(Value::as_str)
+        {
+            let mut state = self.state.write();
+            let account = state
+                .accounts
+                .get_mut(&req.account_id)
+                .ok_or_else(|| invalid_request(format!("NamedQuery {named_query_id} not found")))?;
+            let nq = account
+                .named_queries
+                .get_mut(named_query_id)
+                .ok_or_else(|| invalid_request(format!("NamedQuery {named_query_id} not found")))?;
+            nq.last_used_at = Some(Utc::now());
+            nq.query_string.clone()
+        } else {
+            require_str(&body, "QueryString")?
+        };
 
         // Apply ExecutionParameters substitution.
         if let Some(params) = body.get("ExecutionParameters").and_then(Value::as_array) {
@@ -2686,6 +2690,50 @@ mod tests {
             .unwrap();
         let qe = parse_json(&qe_resp).get("QueryExecution").unwrap().clone();
         assert_eq!(qe.get("Query").unwrap(), "SELECT 1 AS id");
+    }
+
+    #[test]
+    fn start_query_execution_bumps_named_query_last_used_at() {
+        let svc = AthenaService::new(SharedAthenaState::default());
+        let create_resp = svc
+            .create_named_query(&req(
+                "CreateNamedQuery",
+                json!({
+                    "Name": "tracked",
+                    "Database": "default",
+                    "QueryString": "SELECT 1",
+                    "WorkGroup": "primary"
+                }),
+            ))
+            .unwrap();
+        let nq_id = parse_json(&create_resp)
+            .get("NamedQueryId")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Before any StartQueryExecution the named query has no last_used_at.
+        {
+            let state = svc.state.read();
+            let account = state.accounts.values().next().unwrap();
+            let nq = account.named_queries.get(&nq_id).unwrap();
+            assert!(nq.last_used_at.is_none());
+        }
+
+        svc.start_query_execution(&req(
+            "StartQueryExecution",
+            json!({ "NamedQueryId": nq_id }),
+        ))
+        .unwrap();
+
+        let state = svc.state.read();
+        let account = state.accounts.values().next().unwrap();
+        let nq = account.named_queries.get(&nq_id).unwrap();
+        assert!(
+            nq.last_used_at.is_some(),
+            "last_used_at must be populated after StartQueryExecution",
+        );
     }
 
     #[test]

--- a/crates/fakecloud-athena/src/state.rs
+++ b/crates/fakecloud-athena/src/state.rs
@@ -98,6 +98,12 @@ pub struct NamedQuery {
     pub database: String,
     pub query_string: String,
     pub work_group: String,
+    /// Last time this named query was referenced by `StartQueryExecution`.
+    /// `None` until the first invocation; populated by the
+    /// `/_fakecloud/athena/named-queries` introspection endpoint so test
+    /// authors can assert that a saved query was actually used.
+    #[serde(default)]
+    pub last_used_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -17362,6 +17362,7 @@ impl ResourceProvisioner {
             database,
             query_string,
             work_group,
+            last_used_at: None,
         };
         account.named_queries.insert(id.clone(), nq);
         Ok(ProvisionResult::new(id.clone()).with("NamedQueryId", id))

--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -342,6 +342,8 @@ async fn sdk_elasticache_get_acls() {
         .expect("default user in ACL response");
     assert!(default_user.no_password_required);
     assert_eq!(default_user.password_count, 0);
+}
+
 // ── Athena ─────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -342,6 +342,77 @@ async fn sdk_elasticache_get_acls() {
         .expect("default user in ACL response");
     assert!(default_user.no_password_required);
     assert_eq!(default_user.password_count, 0);
+// ── Athena ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sdk_athena_get_named_queries() {
+    let server = TestServer::start().await;
+    let fc = FakeCloud::new(server.endpoint());
+    let athena = server.athena_client().await;
+
+    let created = athena
+        .create_named_query()
+        .name("sdk-nq")
+        .description("SDK introspection test")
+        .database("default")
+        .query_string("SELECT 1 AS id")
+        .work_group("primary")
+        .send()
+        .await
+        .expect("create named query");
+    let nq_id = created.named_query_id().expect("nq id").to_owned();
+
+    // Before StartQueryExecution: last_used_at is unset.
+    let initial = fc
+        .athena()
+        .get_named_queries()
+        .await
+        .expect("get named queries");
+    let row = initial
+        .queries
+        .iter()
+        .find(|q| q.named_query_id == nq_id)
+        .expect("named query in listing");
+    assert_eq!(row.name, "sdk-nq");
+    assert_eq!(row.database, "default");
+    assert_eq!(row.workgroup, "primary");
+    assert_eq!(row.query_string, "SELECT 1 AS id");
+    assert!(row.last_used_at.is_none());
+
+    // Resolve query by id; server bumps last_used_at. The aws-sdk-athena
+    // builder doesn't expose `NamedQueryId` on StartQueryExecution, so
+    // the call is dispatched via raw JSON 1.1.
+    reqwest::Client::new()
+        .post(server.endpoint())
+        .header("X-Amz-Target", "AmazonAthena.StartQueryExecution")
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .header(
+            "Authorization",
+            "AWS4-HMAC-SHA256 \
+             Credential=root/20260101/us-east-1/athena/aws4_request, \
+             SignedHeaders=host, Signature=00",
+        )
+        .body(serde_json::json!({ "NamedQueryId": nq_id }).to_string())
+        .send()
+        .await
+        .expect("raw start query")
+        .error_for_status()
+        .expect("start query 2xx");
+
+    let after = fc
+        .athena()
+        .get_named_queries()
+        .await
+        .expect("get named queries");
+    let bumped = after
+        .queries
+        .iter()
+        .find(|q| q.named_query_id == nq_id)
+        .expect("named query still present");
+    assert!(
+        bumped.last_used_at.is_some(),
+        "last_used_at must be populated after StartQueryExecution",
+    );
 }
 
 // ── SQS ────────────────────────────────────────────────────────────

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -152,6 +152,10 @@ impl FakeCloud {
         ApplicationAutoScalingClient { fc: self }
     }
 
+    pub fn athena(&self) -> AthenaClient<'_> {
+        AthenaClient { fc: self }
+    }
+
     // ── Internal helpers ────────────────────────────────────────────
 
     async fn parse<T: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<T, Error> {
@@ -986,6 +990,31 @@ impl EcsClient<'_> {
             .fc
             .client
             .get(format!("{}/_fakecloud/ecs/events", self.fc.base_url))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
+}
+
+// ── Athena ──────────────────────────────────────────────────────────
+
+pub struct AthenaClient<'a> {
+    fc: &'a FakeCloud,
+}
+
+impl AthenaClient<'_> {
+    /// List every named query stored in the Athena named-query registry
+    /// across all workgroups for the default account. Bumps `last_used_at`
+    /// each time `StartQueryExecution` resolves a query by id so test
+    /// authors can assert that a saved query was actually exercised.
+    pub async fn get_named_queries(&self) -> Result<AthenaNamedQueriesResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!(
+                "{}/_fakecloud/athena/named-queries",
+                self.fc.base_url
+            ))
             .send()
             .await?;
         FakeCloud::parse(resp).await

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -1498,6 +1498,8 @@ pub struct GlueJob {
     pub number_of_workers: Option<i64>,
     pub created_on: String,
     pub last_modified_on: String,
+}
+
 // ── Athena ──────────────────────────────────────────────────────────
 
 /// One row in the Athena named-query introspection list returned by
@@ -1549,6 +1551,10 @@ pub struct GlueJobRun {
 #[serde(rename_all = "camelCase")]
 pub struct GlueJobRunsResponse {
     pub runs: Vec<GlueJobRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AthenaNamedQueriesResponse {
     pub queries: Vec<AthenaNamedQuery>,
 }

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -1498,6 +1498,27 @@ pub struct GlueJob {
     pub number_of_workers: Option<i64>,
     pub created_on: String,
     pub last_modified_on: String,
+// ── Athena ──────────────────────────────────────────────────────────
+
+/// One row in the Athena named-query introspection list returned by
+/// `GET /_fakecloud/athena/named-queries`. Mirrors the underlying named
+/// query record plus a `last_used_at` timestamp the server bumps every
+/// time `StartQueryExecution` resolves the query by id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AthenaNamedQuery {
+    pub named_query_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub database: String,
+    pub query_string: String,
+    pub workgroup: String,
+    /// RFC3339 timestamp of the most recent `StartQueryExecution` that
+    /// resolved its query string from this named query. `None` until the
+    /// first such invocation.
+    #[serde(default)]
+    pub last_used_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1528,6 +1549,8 @@ pub struct GlueJobRun {
 #[serde(rename_all = "camelCase")]
 pub struct GlueJobRunsResponse {
     pub runs: Vec<GlueJobRun>,
+pub struct AthenaNamedQueriesResponse {
+    pub queries: Vec<AthenaNamedQuery>,
 }
 
 /// Body for `POST /_fakecloud/cloudfront/distributions/{id}/status`. The

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -268,6 +268,20 @@ pub(crate) fn elasticache_serverless_cache_response(
     }
 }
 
+pub(crate) fn athena_named_query_response(
+    q: &fakecloud_athena::NamedQuery,
+) -> types::AthenaNamedQuery {
+    types::AthenaNamedQuery {
+        named_query_id: q.named_query_id.clone(),
+        name: q.name.clone(),
+        description: q.description.clone(),
+        database: q.database.clone(),
+        query_string: q.query_string.clone(),
+        workgroup: q.work_group.clone(),
+        last_used_at: q.last_used_at.map(|t| t.to_rfc3339()),
+    }
+}
+
 pub(crate) fn elbv2_load_balancer_response(
     lb: &fakecloud_elbv2::LoadBalancer,
 ) -> types::Elbv2LoadBalancer {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -27,13 +27,12 @@ mod stepfunctions_delivery;
 use cli::Cli;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use introspection::{
-    ecr_image_response, ecr_pull_through_rule_response, ecr_repository_response,
-    ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_acls_response,
     athena_named_query_response, ecr_image_response, ecr_pull_through_rule_response,
     ecr_repository_response, ecs_cluster_response, ecs_lifecycle_event, ecs_task_response,
-    elasticache_cluster_response, elasticache_replication_group_response,
-    elasticache_serverless_cache_response, elbv2_listener_response, elbv2_load_balancer_response,
-    elbv2_rule_response, elbv2_target_group_response, rds_instance_response,
+    elasticache_acls_response, elasticache_cluster_response,
+    elasticache_replication_group_response, elasticache_serverless_cache_response,
+    elbv2_listener_response, elbv2_load_balancer_response, elbv2_rule_response,
+    elbv2_target_group_response, rds_instance_response,
 };
 use kinesis_lambda_poller::KinesisLambdaPoller;
 use reset::ResetState;
@@ -5022,6 +5021,11 @@ async fn main() {
                         let accounts = ec.read();
                         let state = accounts.default_ref();
                         axum::Json(elasticache_acls_response(state))
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/athena/named-queries",
             axum::routing::get({
                 let athena = athena_introspection_state.clone();

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -29,6 +29,8 @@ use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use introspection::{
     ecr_image_response, ecr_pull_through_rule_response, ecr_repository_response,
     ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_acls_response,
+    athena_named_query_response, ecr_image_response, ecr_pull_through_rule_response,
+    ecr_repository_response, ecs_cluster_response, ecs_lifecycle_event, ecs_task_response,
     elasticache_cluster_response, elasticache_replication_group_response,
     elasticache_serverless_cache_response, elbv2_listener_response, elbv2_load_balancer_response,
     elbv2_rule_response, elbv2_target_group_response, rds_instance_response,
@@ -625,6 +627,7 @@ async fn main() {
     let rds_bridge_s3_state = s3_state.clone();
     let rds_introspection_state = rds_state.clone();
     let elasticache_introspection_state = elasticache_state.clone();
+    let athena_introspection_state = athena_state.clone();
     let ecr_introspection_state = ecr_state.clone();
     let ecs_introspection_state = ecs_state.clone();
     let dynamodb_ttl_state = dynamodb_state.clone();
@@ -5019,6 +5022,21 @@ async fn main() {
                         let accounts = ec.read();
                         let state = accounts.default_ref();
                         axum::Json(elasticache_acls_response(state))
+            "/_fakecloud/athena/named-queries",
+            axum::routing::get({
+                let athena = athena_introspection_state.clone();
+                move || {
+                    let athena = athena.clone();
+                    async move {
+                        let accounts = athena.read();
+                        let mut queries: Vec<types::AthenaNamedQuery> = accounts
+                            .accounts
+                            .values()
+                            .flat_map(|acc| acc.named_queries.values())
+                            .map(athena_named_query_response)
+                            .collect();
+                        queries.sort_by(|a, b| a.named_query_id.cmp(&b.named_query_id));
+                        axum::Json(types::AthenaNamedQueriesResponse { queries })
                     }
                 }
             }),

--- a/sdks/go/athena.go
+++ b/sdks/go/athena.go
@@ -1,0 +1,20 @@
+package fakecloud
+
+import "context"
+
+// AthenaClient provides access to Athena introspection endpoints.
+type AthenaClient struct {
+	fc *FakeCloud
+}
+
+// GetNamedQueries lists every named query stored in the Athena registry
+// across all workgroups for the default account. The response includes a
+// LastUsedAt timestamp that the server bumps each time StartQueryExecution
+// resolves the query string by NamedQueryId.
+func (c *AthenaClient) GetNamedQueries(ctx context.Context) (*AthenaNamedQueriesResponse, error) {
+	var out AthenaNamedQueriesResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/athena/named-queries", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/fakecloud.go
+++ b/sdks/go/fakecloud.go
@@ -94,6 +94,9 @@ func (fc *FakeCloud) RDS() *RDSClient { return &RDSClient{fc: fc} }
 // ElastiCache returns the ElastiCache sub-client.
 func (fc *FakeCloud) ElastiCache() *ElastiCacheClient { return &ElastiCacheClient{fc: fc} }
 
+// Athena returns the Athena sub-client.
+func (fc *FakeCloud) Athena() *AthenaClient { return &AthenaClient{fc: fc} }
+
 // ECR returns the ECR sub-client.
 func (fc *FakeCloud) ECR() *ECRClient { return &ECRClient{fc: fc} }
 

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1017,6 +1017,8 @@ type GlueJobRun struct {
 // optionally filtered by job name.
 type GlueJobRunsResponse struct {
 	Runs []GlueJobRun `json:"runs"`
+}
+
 // AthenaNamedQuery is one row in the Athena named-query introspection
 // listing returned by GET /_fakecloud/athena/named-queries.
 type AthenaNamedQuery struct {

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1017,4 +1017,21 @@ type GlueJobRun struct {
 // optionally filtered by job name.
 type GlueJobRunsResponse struct {
 	Runs []GlueJobRun `json:"runs"`
+// AthenaNamedQuery is one row in the Athena named-query introspection
+// listing returned by GET /_fakecloud/athena/named-queries.
+type AthenaNamedQuery struct {
+	NamedQueryID string  `json:"namedQueryId"`
+	Name         string  `json:"name"`
+	Description  *string `json:"description,omitempty"`
+	Database     string  `json:"database"`
+	QueryString  string  `json:"queryString"`
+	Workgroup    string  `json:"workgroup"`
+	// LastUsedAt is the RFC3339 timestamp of the most recent
+	// StartQueryExecution that resolved its query string from this named
+	// query. Nil until the first such invocation.
+	LastUsedAt *string `json:"lastUsedAt,omitempty"`
+}
+
+type AthenaNamedQueriesResponse struct {
+	Queries []AthenaNamedQuery `json:"queries"`
 }

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -3,6 +3,7 @@ package dev.fakecloud;
 import static dev.fakecloud.HttpTransport.encodePath;
 
 import dev.fakecloud.Types.ApiGatewayV2RequestsResponse;
+import dev.fakecloud.Types.AthenaNamedQueriesResponse;
 import dev.fakecloud.Types.AppAsScheduledTickResponse;
 import dev.fakecloud.Types.AppAsTickResponse;
 import dev.fakecloud.Types.AuthEventsResponse;
@@ -127,6 +128,7 @@ public final class FakeCloud {
     private final Route53Client route53;
     private final AcmClient acm;
     private final ApplicationAutoScalingClient applicationAutoscaling;
+    private final AthenaClient athena;
 
     public FakeCloud() {
         this(DEFAULT_BASE_URL);
@@ -159,6 +161,7 @@ public final class FakeCloud {
         this.route53 = new Route53Client(http);
         this.acm = new AcmClient(http);
         this.applicationAutoscaling = new ApplicationAutoScalingClient(http);
+        this.athena = new AthenaClient(http);
     }
 
     static String trimTrailingSlashes(String url) {
@@ -223,6 +226,7 @@ public final class FakeCloud {
     public Route53Client route53() { return route53; }
     public AcmClient acm() { return acm; }
     public ApplicationAutoScalingClient applicationAutoscaling() { return applicationAutoscaling; }
+    public AthenaClient athena() { return athena; }
 
     // ── Sub-clients ────────────────────────────────────────────────
 
@@ -420,6 +424,23 @@ public final class FakeCloud {
             return http.postEmpty(
                     "/_fakecloud/application-autoscaling/scheduled-tick",
                     AppAsScheduledTickResponse.class);
+        }
+    }
+
+    public static final class AthenaClient {
+        private final HttpTransport http;
+        AthenaClient(HttpTransport http) { this.http = http; }
+
+        /**
+         * List every named query stored in the Athena registry across all
+         * workgroups for the default account. The response includes a
+         * {@code lastUsedAt} timestamp the server bumps each time
+         * {@code StartQueryExecution} resolves the query by id.
+         */
+        public AthenaNamedQueriesResponse getNamedQueries() {
+            return http.get(
+                    "/_fakecloud/athena/named-queries",
+                    AthenaNamedQueriesResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -897,4 +897,18 @@ public final class Types {
             @JsonProperty("external_ca_validated") boolean externalCaValidated,
             @JsonProperty("status") String status,
             @JsonProperty("cert_type") String certType) {}
+
+    // ── Athena ────────────────────────────────────────────────────
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AthenaNamedQuery(
+            String namedQueryId,
+            String name,
+            String description,
+            String database,
+            String queryString,
+            String workgroup,
+            String lastUsedAt) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AthenaNamedQueriesResponse(List<AthenaNamedQuery> queries) {}
 }

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -43,6 +43,7 @@ final class FakeCloud
     private Route53Client $route53;
     private AcmClient $acm;
     private ApplicationAutoScalingClient $applicationAutoscaling;
+    private AthenaClient $athena;
 
     public function __construct(string $baseUrl = self::DEFAULT_BASE_URL)
     {
@@ -72,6 +73,7 @@ final class FakeCloud
         $this->route53 = new Route53Client($this->http);
         $this->acm = new AcmClient($this->http);
         $this->applicationAutoscaling = new ApplicationAutoScalingClient($this->http);
+        $this->athena = new AthenaClient($this->http);
     }
 
     public function baseUrl(): string
@@ -138,6 +140,7 @@ final class FakeCloud
     public function route53(): Route53Client { return $this->route53; }
     public function acm(): AcmClient { return $this->acm; }
     public function applicationAutoscaling(): ApplicationAutoScalingClient { return $this->applicationAutoscaling; }
+    public function athena(): AthenaClient { return $this->athena; }
 }
 
 // ── Sub-clients ────────────────────────────────────────────────
@@ -386,6 +389,24 @@ final class ApplicationAutoScalingClient
     {
         return AppAsScheduledTickResponse::fromArray(
             $this->http->postEmpty('/_fakecloud/application-autoscaling/scheduled-tick')
+        );
+    }
+}
+
+final class AthenaClient
+{
+    public function __construct(private readonly HttpTransport $http) {}
+
+    /**
+     * List every named query stored in the Athena registry across all
+     * workgroups for the default account. The response includes a
+     * `lastUsedAt` timestamp the server bumps each time
+     * `StartQueryExecution` resolves the query string by id.
+     */
+    public function getNamedQueries(): AthenaNamedQueriesResponse
+    {
+        return AthenaNamedQueriesResponse::fromArray(
+            $this->http->get('/_fakecloud/athena/named-queries')
         );
     }
 }

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -2443,6 +2443,23 @@ final class LogsDeliveryConfiguration
         public readonly array $recordFields = [],
         public readonly ?string $fieldDelimiter = null,
         public readonly mixed $s3DeliveryConfiguration = null,
+// ── Athena ────────────────────────────────────────────────────────
+
+final class AthenaNamedQuery
+{
+    public function __construct(
+        public readonly string $namedQueryId,
+        public readonly string $name,
+        public readonly ?string $description,
+        public readonly string $database,
+        public readonly string $queryString,
+        public readonly string $workgroup,
+        /**
+         * RFC3339 timestamp of the most recent StartQueryExecution that
+         * resolved its query string from this named query. Null until the
+         * first such invocation.
+         */
+        public readonly ?string $lastUsedAt,
     ) {}
 
     public static function fromArray(array $data): self
@@ -2457,6 +2474,13 @@ final class LogsDeliveryConfiguration
             array_values(array_map('strval', $data['recordFields'] ?? [])),
             isset($data['fieldDelimiter']) ? (string) $data['fieldDelimiter'] : null,
             $data['s3DeliveryConfiguration'] ?? null,
+            (string) $data['namedQueryId'],
+            (string) $data['name'],
+            isset($data['description']) ? (string) $data['description'] : null,
+            (string) $data['database'],
+            (string) $data['queryString'],
+            (string) $data['workgroup'],
+            isset($data['lastUsedAt']) ? (string) $data['lastUsedAt'] : null,
         );
     }
 }
@@ -2466,6 +2490,11 @@ final class LogsDeliveryConfigResponse
     /** @param LogsDeliveryConfiguration[] $configurations */
     public function __construct(
         public readonly array $configurations,
+final class AthenaNamedQueriesResponse
+{
+    public function __construct(
+        /** @var AthenaNamedQuery[] */
+        public readonly array $queries,
     ) {}
 
     public static function fromArray(array $data): self
@@ -2516,5 +2545,6 @@ final class LogsFieldIndexesResponse
             (string) ($data['logGroupName'] ?? ''),
             array_values($indexes),
         );
+        return new self(array_map(AthenaNamedQuery::fromArray(...), $data['queries'] ?? []));
     }
 }

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -2443,23 +2443,6 @@ final class LogsDeliveryConfiguration
         public readonly array $recordFields = [],
         public readonly ?string $fieldDelimiter = null,
         public readonly mixed $s3DeliveryConfiguration = null,
-// ── Athena ────────────────────────────────────────────────────────
-
-final class AthenaNamedQuery
-{
-    public function __construct(
-        public readonly string $namedQueryId,
-        public readonly string $name,
-        public readonly ?string $description,
-        public readonly string $database,
-        public readonly string $queryString,
-        public readonly string $workgroup,
-        /**
-         * RFC3339 timestamp of the most recent StartQueryExecution that
-         * resolved its query string from this named query. Null until the
-         * first such invocation.
-         */
-        public readonly ?string $lastUsedAt,
     ) {}
 
     public static function fromArray(array $data): self
@@ -2474,13 +2457,6 @@ final class AthenaNamedQuery
             array_values(array_map('strval', $data['recordFields'] ?? [])),
             isset($data['fieldDelimiter']) ? (string) $data['fieldDelimiter'] : null,
             $data['s3DeliveryConfiguration'] ?? null,
-            (string) $data['namedQueryId'],
-            (string) $data['name'],
-            isset($data['description']) ? (string) $data['description'] : null,
-            (string) $data['database'],
-            (string) $data['queryString'],
-            (string) $data['workgroup'],
-            isset($data['lastUsedAt']) ? (string) $data['lastUsedAt'] : null,
         );
     }
 }
@@ -2490,11 +2466,6 @@ final class LogsDeliveryConfigResponse
     /** @param LogsDeliveryConfiguration[] $configurations */
     public function __construct(
         public readonly array $configurations,
-final class AthenaNamedQueriesResponse
-{
-    public function __construct(
-        /** @var AthenaNamedQuery[] */
-        public readonly array $queries,
     ) {}
 
     public static function fromArray(array $data): self
@@ -2545,6 +2516,46 @@ final class LogsFieldIndexesResponse
             (string) ($data['logGroupName'] ?? ''),
             array_values($indexes),
         );
+    }
+}
+
+// ── Athena ────────────────────────────────────────────────────────
+
+final class AthenaNamedQuery
+{
+    public function __construct(
+        public readonly string $namedQueryId,
+        public readonly string $name,
+        public readonly ?string $description,
+        public readonly string $database,
+        public readonly string $queryString,
+        public readonly string $workgroup,
+        public readonly ?string $lastUsedAt,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) ($data['namedQueryId'] ?? ''),
+            (string) ($data['name'] ?? ''),
+            isset($data['description']) ? (string) $data['description'] : null,
+            (string) ($data['database'] ?? ''),
+            (string) ($data['queryString'] ?? ''),
+            (string) ($data['workgroup'] ?? ''),
+            isset($data['lastUsedAt']) ? (string) $data['lastUsedAt'] : null,
+        );
+    }
+}
+
+final class AthenaNamedQueriesResponse
+{
+    public function __construct(
+        /** @var AthenaNamedQuery[] */
+        public readonly array $queries,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
         return new self(array_map(AthenaNamedQuery::fromArray(...), $data['queries'] ?? []));
     }
 }

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -11,6 +11,7 @@ from fakecloud.types import (
     ApiGatewayV2RequestsResponse,
     AppAsScheduledTickResponse,
     AppAsTickResponse,
+    AthenaNamedQueriesResponse,
     AuthEventsResponse,
     BedrockFaultRule,
     BedrockFaultsResponse,
@@ -171,6 +172,37 @@ class ElastiCacheClient:
         resp = await self._client.get(f"{self._base}/_fakecloud/elasticache/acls")
         _check(resp)
         return ElastiCacheAclsResponse.from_dict(resp.json())
+
+
+class AthenaClient:
+    """Async Athena introspection client."""
+
+    def __init__(self, client: httpx.AsyncClient, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+    async def get_named_queries(self) -> AthenaNamedQueriesResponse:
+        """List every named query across workgroups for the default account.
+
+        The response includes a ``last_used_at`` timestamp the server bumps
+        each time ``StartQueryExecution`` resolves the query by id.
+        """
+        resp = await self._client.get(f"{self._base}/_fakecloud/athena/named-queries")
+        _check(resp)
+        return AthenaNamedQueriesResponse.from_dict(resp.json())
+
+
+class _SyncAthenaClient:
+    """Sync Athena introspection client."""
+
+    def __init__(self, client: httpx.Client, base_url: str) -> None:
+        self._client = client
+        self._base = base_url
+
+    def get_named_queries(self) -> AthenaNamedQueriesResponse:
+        resp = self._client.get(f"{self._base}/_fakecloud/athena/named-queries")
+        _check(resp)
+        return AthenaNamedQueriesResponse.from_dict(resp.json())
 
 
 class EcrClient:
@@ -1714,6 +1746,10 @@ class FakeCloud:
     def application_autoscaling(self) -> ApplicationAutoScalingClient:
         return ApplicationAutoScalingClient(self._client, self._base)
 
+    @property
+    def athena(self) -> AthenaClient:
+        return AthenaClient(self._client, self._base)
+
     # ── Lifecycle ───────────────────────────────────────────────────
 
     async def aclose(self) -> None:
@@ -1863,6 +1899,10 @@ class FakeCloudSync:
     @property
     def application_autoscaling(self) -> _SyncApplicationAutoScalingClient:
         return _SyncApplicationAutoScalingClient(self._client, self._base)
+
+    @property
+    def athena(self) -> _SyncAthenaClient:
+        return _SyncAthenaClient(self._client, self._base)
 
     # ── Lifecycle ───────────────────────────────────────────────────
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -2056,6 +2056,9 @@ class LogsDeliveryConfigResponse:
                 LogsDeliveryConfiguration.from_dict(c)
                 for c in data.get("configurations", [])
             ]
+        )
+
+
 # ── Athena ──────────────────────────────────────────────────────────
 
 
@@ -2115,6 +2118,10 @@ class LogsFieldIndexesResponse:
         return cls(
             log_group_name=data.get("logGroupName", ""),
             indexes=[LogsFieldIndex.from_dict(i) for i in data.get("indexes", [])],
+        )
+
+
+@dataclass
 class AthenaNamedQueriesResponse:
     queries: List[AthenaNamedQuery]
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -2056,6 +2056,35 @@ class LogsDeliveryConfigResponse:
                 LogsDeliveryConfiguration.from_dict(c)
                 for c in data.get("configurations", [])
             ]
+# ── Athena ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class AthenaNamedQuery:
+    """One row in the Athena named-query introspection listing."""
+
+    named_query_id: str
+    name: str
+    description: Optional[str]
+    database: str
+    query_string: str
+    workgroup: str
+    # RFC3339 timestamp of the most recent ``StartQueryExecution`` that
+    # resolved its query string from this named query. ``None`` until the
+    # first such invocation.
+    last_used_at: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AthenaNamedQuery:
+        d = _convert_keys(data)
+        return cls(
+            named_query_id=d["named_query_id"],
+            name=d["name"],
+            description=d.get("description"),
+            database=d["database"],
+            query_string=d["query_string"],
+            workgroup=d["workgroup"],
+            last_used_at=d.get("last_used_at"),
         )
 
 
@@ -2086,4 +2115,12 @@ class LogsFieldIndexesResponse:
         return cls(
             log_group_name=data.get("logGroupName", ""),
             indexes=[LogsFieldIndex.from_dict(i) for i in data.get("indexes", [])],
+class AthenaNamedQueriesResponse:
+    queries: List[AthenaNamedQuery]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AthenaNamedQueriesResponse:
+        d = _convert_keys(data)
+        return cls(
+            queries=[AthenaNamedQuery.from_dict(q) for q in d.get("queries", [])],
         )

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AthenaNamedQueriesResponse,
   CreateAdminResponse,
   ApiGatewayV2RequestsResponse,
   BedrockFaultRule,
@@ -726,6 +727,7 @@ export class FakeCloud {
   private readonly _route53: Route53Client;
   private readonly _acm: AcmClient;
   private readonly _applicationAutoscaling: ApplicationAutoScalingClient;
+  private readonly _athena: AthenaClient;
 
   constructor(baseUrl: string = "http://localhost:4566") {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
@@ -757,6 +759,7 @@ export class FakeCloud {
     this._applicationAutoscaling = new ApplicationAutoScalingClient(
       this.baseUrl,
     );
+    this._athena = new AthenaClient(this.baseUrl);
   }
 
   // ── Health & Reset ─────────────────────────────────────────────
@@ -893,6 +896,27 @@ export class FakeCloud {
 
   get applicationAutoscaling(): ApplicationAutoScalingClient {
     return this._applicationAutoscaling;
+  }
+
+  get athena(): AthenaClient {
+    return this._athena;
+  }
+}
+
+export class AthenaClient {
+  constructor(private baseUrl: string) {}
+
+  /**
+   * List every named query stored in the Athena registry across all
+   * workgroups for the default account. The response includes a
+   * `lastUsedAt` timestamp the server bumps each time
+   * `StartQueryExecution` resolves the query string by id.
+   */
+  async getNamedQueries(): Promise<AthenaNamedQueriesResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/athena/named-queries`,
+    );
+    return parse(resp);
   }
 }
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -913,9 +913,7 @@ export class AthenaClient {
    * `StartQueryExecution` resolves the query string by id.
    */
   async getNamedQueries(): Promise<AthenaNamedQueriesResponse> {
-    const resp = await fetch(
-      `${this.baseUrl}/_fakecloud/athena/named-queries`,
-    );
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/athena/named-queries`);
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -19,5 +19,6 @@ export {
   BedrockAgentClient,
   BedrockAgentRuntimeClient,
   EcsClient,
+  AthenaClient,
 } from "./client.js";
 export type * from "./types.js";

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -968,4 +968,29 @@ export interface LogsFieldIndex {
 export interface LogsFieldIndexesResponse {
   logGroupName: string;
   indexes: LogsFieldIndex[];
+// ── Athena ─────────────────────────────────────────────────────────
+
+/**
+ * One row in the Athena named-query introspection listing returned by
+ * `GET /_fakecloud/athena/named-queries`. Mirrors the underlying named
+ * query record plus a `lastUsedAt` timestamp the server bumps every
+ * time `StartQueryExecution` resolves the query by id.
+ */
+export interface AthenaNamedQuery {
+  namedQueryId: string;
+  name: string;
+  description?: string | null;
+  database: string;
+  queryString: string;
+  workgroup: string;
+  /**
+   * RFC3339 timestamp of the most recent `StartQueryExecution` that
+   * resolved its query string from this named query. `null` until the
+   * first such invocation.
+   */
+  lastUsedAt?: string | null;
+}
+
+export interface AthenaNamedQueriesResponse {
+  queries: AthenaNamedQuery[];
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -968,6 +968,8 @@ export interface LogsFieldIndex {
 export interface LogsFieldIndexesResponse {
   logGroupName: string;
   indexes: LogsFieldIndex[];
+}
+
 // ── Athena ─────────────────────────────────────────────────────────
 
 /**

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -57,6 +57,12 @@ curl http://localhost:4566/_fakecloud/health
 | `/_fakecloud/application-autoscaling/tick` | POST | Trigger one policy-evaluation tick. |
 | `/_fakecloud/application-autoscaling/scheduled-tick` | POST | Run scheduled scaling actions that are due. |
 
+## Athena
+
+| Endpoint | Method | Description |
+| -------- | ------ | ----------- |
+| `/_fakecloud/athena/named-queries` | GET | **NEW** -- List every named query across workgroups with `lastUsedAt` bumped each time `StartQueryExecution` resolves the query by id. |
+
 ## Bedrock
 
 | Endpoint | Method | Description |

--- a/website/content/docs/services/athena.md
+++ b/website/content/docs/services/athena.md
@@ -77,6 +77,27 @@ Capacity reservations are stored verbatim; `allocated_dpus` mirrors `target_dpus
 
 The managed engine version catalog (`ListEngineVersions`) is a static seed: `AUTO`, `Athena engine version 2`, `Athena engine version 3`. New engine versions shipped by AWS will not appear until the seed is updated.
 
+## Introspection
+
+`GET /_fakecloud/athena/named-queries` returns every named query stored in the registry across all workgroups for the default account. Useful when test code needs to assert that a saved query was created, or that `StartQueryExecution` resolved a query by id — the response includes a `lastUsedAt` timestamp that is bumped each time the query is referenced.
+
+```bash
+curl -s http://localhost:4566/_fakecloud/athena/named-queries | jq
+# {
+#   "queries": [
+#     {
+#       "namedQueryId": "abc-123",
+#       "name": "daily-rollup",
+#       "description": "Aggregates yesterday's events",
+#       "database": "analytics",
+#       "queryString": "SELECT count(*) FROM events",
+#       "workgroup": "primary",
+#       "lastUsedAt": "2026-05-11T12:34:56Z"
+#     }
+#   ]
+# }
+```
+
 ## Source
 
 - [`crates/fakecloud-athena`](https://github.com/faiscadev/fakecloud/tree/main/crates/fakecloud-athena)


### PR DESCRIPTION
## Summary

Adds introspection endpoints per /Users/lucas/.claude/plans/introspection-endpoints-2026-05-11.md.

## Test plan

- [ ] CI green
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Athena introspection endpoint to list named queries with a last-used timestamp. Implements I7 so tests can verify `StartQueryExecution` resolved a saved query by id.

- **New Features**
  - Added `GET /_fakecloud/athena/named-queries` to list named queries across workgroups, including `lastUsedAt` (RFC3339; null until first use).
  - `StartQueryExecution` now bumps `lastUsedAt` when resolving `NamedQueryId`.
  - SDKs: Rust `FakeCloud::athena().get_named_queries()`, Go `AthenaClient.GetNamedQueries`, TypeScript `AthenaClient.getNamedQueries`, Python (async/sync) `athena.get_named_queries()`, Java `fakecloud.athena().getNamedQueries()`, PHP `$fc->athena()->getNamedQueries()`. Docs updated and an e2e test verifies `lastUsedAt`.

- **Bug Fixes**
  - Go SDK: fixed `GlueJobRunsResponse` struct definition.

<sup>Written for commit f64e87863d4bfc7596a00d2ffb084d5825d1072f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

