### PR TITLE
feat(elasticache): introspection endpoint — ACLs (I8)

### DIFF
--- a/crates/fakecloud-e2e/tests/sdk.rs
+++ b/crates/fakecloud-e2e/tests/sdk.rs
@@ -238,6 +238,112 @@ async fn sdk_elasticache_get_serverless_caches() {
     assert_eq!(cache.status, "available");
 }
 
+#[tokio::test]
+async fn sdk_elasticache_get_acls() {
+    // Needs Docker because the replication group must actually come up
+    // before its `UserGroupIds` is committed.
+    if std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        if std::env::var("CI").is_ok() {
+            panic!("docker is required for sdk_elasticache_get_acls in CI");
+        }
+        eprintln!("Skipping sdk_elasticache_get_acls: docker not available");
+        return;
+    }
+
+    let server = TestServer::start().await;
+    let fc = FakeCloud::new(server.endpoint());
+    let ec = server.elasticache_client().await;
+
+    // Create a non-default user with a real password (no_password_required=false).
+    ec.create_user()
+        .user_id("acl-app")
+        .user_name("acl-app")
+        .engine("redis")
+        .access_string("on ~app:* +get +set")
+        .passwords("s3cret-token-of-acceptable-length")
+        .send()
+        .await
+        .unwrap();
+
+    // Attach the user to a user group.
+    ec.create_user_group()
+        .user_group_id("acl-ug")
+        .engine("redis")
+        .user_ids("default")
+        .user_ids("acl-app")
+        .send()
+        .await
+        .unwrap();
+
+    // Pin the user group onto a replication group.
+    ec.create_replication_group()
+        .replication_group_id("sdk-acl-rg")
+        .replication_group_description("ACL introspection")
+        .cache_node_type("cache.t3.micro")
+        .engine("redis")
+        .engine_version("7.1")
+        .transit_encryption_enabled(true)
+        .user_group_ids("acl-ug")
+        .send()
+        .await
+        .unwrap();
+
+    // Second replication group without any ACL — should be filtered out.
+    ec.create_replication_group()
+        .replication_group_id("sdk-noacl-rg")
+        .replication_group_description("no ACL")
+        .cache_node_type("cache.t3.micro")
+        .engine("redis")
+        .engine_version("7.1")
+        .send()
+        .await
+        .unwrap();
+
+    let resp = fc
+        .elasticache()
+        .get_acls()
+        .await
+        .expect("get ElastiCache ACLs");
+
+    assert_eq!(
+        resp.acls.len(),
+        1,
+        "only replication groups with user groups attached should appear: {:?}",
+        resp.acls.iter().map(|a| &a.cluster_id).collect::<Vec<_>>()
+    );
+    let cluster = &resp.acls[0];
+    assert_eq!(cluster.cluster_id, "sdk-acl-rg");
+    assert_eq!(cluster.engine, "redis");
+    assert_eq!(cluster.groups.len(), 1);
+    assert_eq!(cluster.groups[0].name, "acl-ug");
+    assert!(cluster.groups[0].members.contains(&"default".to_string()));
+    assert!(cluster.groups[0].members.contains(&"acl-app".to_string()));
+
+    let app = cluster
+        .users
+        .iter()
+        .find(|u| u.name == "acl-app")
+        .expect("acl-app user in ACL response");
+    assert!(!app.no_password_required);
+    assert_eq!(app.password_count, 1);
+    assert_eq!(app.access_string, "on ~app:* +get +set");
+
+    let default_user = cluster
+        .users
+        .iter()
+        .find(|u| u.name == "default")
+        .expect("default user in ACL response");
+    assert!(default_user.no_password_required);
+    assert_eq!(default_user.password_count, 0);
+}
+
 // ── SQS ────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/fakecloud-sdk/src/client.rs
+++ b/crates/fakecloud-sdk/src/client.rs
@@ -235,6 +235,18 @@ impl ElastiCacheClient<'_> {
             .await?;
         FakeCloud::parse(resp).await
     }
+
+    /// List ACL state (users + user groups) for ElastiCache replication groups
+    /// that have one or more user groups attached.
+    pub async fn get_acls(&self) -> Result<ElastiCacheAclsResponse, Error> {
+        let resp = self
+            .fc
+            .client
+            .get(format!("{}/_fakecloud/elasticache/acls", self.fc.base_url))
+            .send()
+            .await?;
+        FakeCloud::parse(resp).await
+    }
 }
 
 // ── Lambda ──────────────────────────────────────────────────────────

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -662,6 +662,38 @@ pub struct ElastiCacheServerlessCachesResponse {
     pub serverless_caches: Vec<ElastiCacheServerlessCacheIntrospection>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElastiCacheAclUser {
+    pub name: String,
+    pub status: String,
+    pub access_string: String,
+    pub no_password_required: bool,
+    pub password_count: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElastiCacheAclGroup {
+    pub name: String,
+    pub members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElastiCacheAclCluster {
+    pub cluster_id: String,
+    pub engine: String,
+    pub users: Vec<ElastiCacheAclUser>,
+    pub groups: Vec<ElastiCacheAclGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElastiCacheAclsResponse {
+    pub acls: Vec<ElastiCacheAclCluster>,
+}
+
 // ── Step Functions ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -201,6 +201,61 @@ pub(crate) fn elasticache_replication_group_response(
     }
 }
 
+/// Aggregate ACL state (users + user groups) for every replication group
+/// that has at least one user group attached.
+///
+/// AWS ElastiCache exposes user/usergroup state via `DescribeUsers` and
+/// `DescribeUserGroups`, but pinning the membership graph to specific
+/// clusters requires correlating `ReplicationGroup.user_group_ids` →
+/// `UserGroup.user_ids` → `User`. We do that join here so test authors
+/// can assert against a single shape.
+pub(crate) fn elasticache_acls_response(
+    state: &fakecloud_elasticache::ElastiCacheState,
+) -> types::ElastiCacheAclsResponse {
+    let mut acls: Vec<types::ElastiCacheAclCluster> = state
+        .replication_groups
+        .values()
+        .filter(|rg| !rg.user_group_ids.is_empty())
+        .map(|rg| {
+            let groups: Vec<types::ElastiCacheAclGroup> = rg
+                .user_group_ids
+                .iter()
+                .filter_map(|gid| state.user_groups.get(gid))
+                .map(|g| types::ElastiCacheAclGroup {
+                    name: g.user_group_id.clone(),
+                    members: g.user_ids.clone(),
+                })
+                .collect();
+            // Collect the unique user ids referenced by all attached groups.
+            let mut user_ids: Vec<String> = groups
+                .iter()
+                .flat_map(|g| g.members.iter().cloned())
+                .collect();
+            user_ids.sort();
+            user_ids.dedup();
+            let users: Vec<types::ElastiCacheAclUser> = user_ids
+                .iter()
+                .filter_map(|uid| state.users.get(uid))
+                .map(|u| types::ElastiCacheAclUser {
+                    name: u.user_name.clone(),
+                    status: u.status.clone(),
+                    access_string: u.access_string.clone(),
+                    no_password_required: u.authentication_type == "no-password",
+                    password_count: u.password_count,
+                })
+                .collect();
+            types::ElastiCacheAclCluster {
+                cluster_id: rg.replication_group_id.clone(),
+                engine: rg.engine.clone(),
+                users,
+                groups,
+            }
+        })
+        .collect();
+    acls.sort_by(|a, b| a.cluster_id.cmp(&b.cluster_id));
+    types::ElastiCacheAclsResponse { acls }
+}
+
 pub(crate) fn elasticache_serverless_cache_response(
     cache: &fakecloud_elasticache::ServerlessCache,
 ) -> types::ElastiCacheServerlessCacheIntrospection {
@@ -320,9 +375,134 @@ pub(crate) fn elbv2_rule_response(r: &fakecloud_elbv2::Rule) -> types::Elbv2Rule
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use fakecloud_elasticache::{
+        ElastiCacheState, ElastiCacheUser, ElastiCacheUserGroup, ReplicationGroup,
+    };
     use fakecloud_rds::DbInstance;
 
-    use super::rds_instance_response;
+    use super::{elasticache_acls_response, rds_instance_response};
+
+    fn test_replication_group(id: &str, user_group_ids: Vec<String>) -> ReplicationGroup {
+        ReplicationGroup {
+            replication_group_id: id.to_string(),
+            description: "test".to_string(),
+            global_replication_group_id: None,
+            global_replication_group_role: None,
+            status: "available".to_string(),
+            cache_node_type: "cache.t3.micro".to_string(),
+            engine: "redis".to_string(),
+            engine_version: "7.1".to_string(),
+            num_cache_clusters: 1,
+            automatic_failover_enabled: false,
+            endpoint_address: "127.0.0.1".to_string(),
+            endpoint_port: 6379,
+            arn: format!("arn:aws:elasticache:us-east-1:123456789012:replicationgroup:{id}"),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            container_id: "abc123".to_string(),
+            host_port: 12345,
+            member_clusters: vec![format!("{id}-001")],
+            snapshot_retention_limit: 0,
+            snapshot_window: "05:00-09:00".to_string(),
+            transit_encryption_enabled: false,
+            at_rest_encryption_enabled: false,
+            cluster_enabled: false,
+            kms_key_id: None,
+            auth_token_enabled: false,
+            user_group_ids,
+            multi_az_enabled: false,
+            log_delivery_configurations: Vec::new(),
+            data_tiering: None,
+            ip_discovery: None,
+            network_type: None,
+            transit_encryption_mode: None,
+            num_node_groups: 1,
+            configuration_endpoint_address: None,
+            configuration_endpoint_port: None,
+            replicas_per_node_group: None,
+            auth_token: None,
+            port: 6379,
+            notification_topic_arn: None,
+            cluster_mode: None,
+            data_tiering_enabled: None,
+            notification_topic_status: None,
+            cache_parameter_group_name: None,
+            cache_subnet_group_name: None,
+            security_group_ids: Vec::new(),
+            preferred_maintenance_window: None,
+            snapshot_name: None,
+            snapshot_arns: Vec::new(),
+            auto_minor_version_upgrade: true,
+        }
+    }
+
+    #[test]
+    fn elasticache_acls_aggregates_users_groups_per_cluster() {
+        let mut state = ElastiCacheState::new("123456789012", "us-east-1");
+
+        // Replication group with an attached user group; should appear in ACLs.
+        state.replication_groups.insert(
+            "rg-acl".to_string(),
+            test_replication_group("rg-acl", vec!["ug-prod".to_string()]),
+        );
+        // Replication group with no user groups; should be filtered out.
+        state.replication_groups.insert(
+            "rg-noacl".to_string(),
+            test_replication_group("rg-noacl", Vec::new()),
+        );
+
+        state.user_groups.insert(
+            "ug-prod".to_string(),
+            ElastiCacheUserGroup {
+                user_group_id: "ug-prod".to_string(),
+                engine: "redis".to_string(),
+                status: "active".to_string(),
+                user_ids: vec!["default".to_string(), "appuser".to_string()],
+                arn: "arn:aws:elasticache:us-east-1:123456789012:usergroup:ug-prod".to_string(),
+                minimum_engine_version: "6.0".to_string(),
+                pending_changes: None,
+                replication_groups: vec!["rg-acl".to_string()],
+            },
+        );
+        state.users.insert(
+            "appuser".to_string(),
+            ElastiCacheUser {
+                user_id: "appuser".to_string(),
+                user_name: "appuser".to_string(),
+                engine: "redis".to_string(),
+                access_string: "on ~app:* +get +set".to_string(),
+                status: "active".to_string(),
+                authentication_type: "password".to_string(),
+                password_count: 1,
+                arn: "arn:aws:elasticache:us-east-1:123456789012:user:appuser".to_string(),
+                minimum_engine_version: "6.0".to_string(),
+                user_group_ids: vec!["ug-prod".to_string()],
+            },
+        );
+
+        let resp = elasticache_acls_response(&state);
+
+        assert_eq!(resp.acls.len(), 1, "only clusters with ACLs included");
+        let cluster = &resp.acls[0];
+        assert_eq!(cluster.cluster_id, "rg-acl");
+        assert_eq!(cluster.engine, "redis");
+        assert_eq!(cluster.groups.len(), 1);
+        assert_eq!(cluster.groups[0].name, "ug-prod");
+        assert_eq!(cluster.groups[0].members, vec!["default", "appuser"]);
+
+        assert_eq!(cluster.users.len(), 2);
+        let names: Vec<&str> = cluster.users.iter().map(|u| u.name.as_str()).collect();
+        assert!(names.contains(&"default"));
+        assert!(names.contains(&"appuser"));
+
+        let default_user = cluster.users.iter().find(|u| u.name == "default").unwrap();
+        assert!(default_user.no_password_required);
+        assert_eq!(default_user.password_count, 0);
+        assert_eq!(default_user.access_string, "on ~* +@all");
+
+        let app_user = cluster.users.iter().find(|u| u.name == "appuser").unwrap();
+        assert!(!app_user.no_password_required);
+        assert_eq!(app_user.password_count, 1);
+    }
 
     #[test]
     fn rds_instance_response_omits_password_but_keeps_runtime_metadata() {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -30,9 +30,8 @@ use introspection::{
     ecr_image_response, ecr_pull_through_rule_response, ecr_repository_response,
     ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_acls_response,
     elasticache_cluster_response, elasticache_replication_group_response,
-    elasticache_serverless_cache_response,
-    elbv2_listener_response, elbv2_load_balancer_response, elbv2_rule_response,
-    elbv2_target_group_response, rds_instance_response,
+    elasticache_serverless_cache_response, elbv2_listener_response, elbv2_load_balancer_response,
+    elbv2_rule_response, elbv2_target_group_response, rds_instance_response,
 };
 use kinesis_lambda_poller::KinesisLambdaPoller;
 use reset::ResetState;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -28,8 +28,9 @@ use cli::Cli;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use introspection::{
     ecr_image_response, ecr_pull_through_rule_response, ecr_repository_response,
-    ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_cluster_response,
-    elasticache_replication_group_response, elasticache_serverless_cache_response,
+    ecs_cluster_response, ecs_lifecycle_event, ecs_task_response, elasticache_acls_response,
+    elasticache_cluster_response, elasticache_replication_group_response,
+    elasticache_serverless_cache_response,
     elbv2_listener_response, elbv2_load_balancer_response, elbv2_rule_response,
     elbv2_target_group_response, rds_instance_response,
 };
@@ -4843,7 +4844,7 @@ async fn main() {
         .route(
             "/_fakecloud/elasticache/serverless-caches",
             axum::routing::get({
-                let ec = elasticache_introspection_state;
+                let ec = elasticache_introspection_state.clone();
                 move || {
                     let ec = ec.clone();
                     async move {
@@ -4859,6 +4860,20 @@ async fn main() {
                         serverless_caches
                             .sort_by(|a, b| a.serverless_cache_name.cmp(&b.serverless_cache_name));
                         axum::Json(types::ElastiCacheServerlessCachesResponse { serverless_caches })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/elasticache/acls",
+            axum::routing::get({
+                let ec = elasticache_introspection_state;
+                move || {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        let state = accounts.default_ref();
+                        axum::Json(elasticache_acls_response(state))
                     }
                 }
             }),

--- a/sdks/go/e2e/e2e_test.go
+++ b/sdks/go/e2e/e2e_test.go
@@ -349,6 +349,81 @@ func TestE2EElastiCacheServerlessCaches(t *testing.T) {
 	}
 }
 
+func TestE2EElastiCacheAcls(t *testing.T) {
+	resetState(t)
+	ctx := context.Background()
+	cfg := awsConfig(t)
+
+	ecClient := elasticache.NewFromConfig(cfg, func(o *elasticache.Options) {
+		o.BaseEndpoint = aws.String(fakecloudURL)
+	})
+
+	_, err := ecClient.CreateUser(ctx, &elasticache.CreateUserInput{
+		UserId:       aws.String("sdk-go-acl-app"),
+		UserName:     aws.String("sdk-go-acl-app"),
+		Engine:       aws.String("redis"),
+		AccessString: aws.String("on ~app:* +get +set"),
+		Passwords:    []string{"s3cret-token-of-acceptable-length"},
+	})
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+
+	_, err = ecClient.CreateUserGroup(ctx, &elasticache.CreateUserGroupInput{
+		UserGroupId: aws.String("sdk-go-acl-ug"),
+		Engine:      aws.String("redis"),
+		UserIds:     []string{"default", "sdk-go-acl-app"},
+	})
+	if err != nil {
+		t.Fatalf("CreateUserGroup failed: %v", err)
+	}
+
+	_, err = ecClient.CreateReplicationGroup(ctx, &elasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("sdk-go-acl-rg"),
+		ReplicationGroupDescription: aws.String("ACL introspection"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+		EngineVersion:               aws.String("7.1"),
+		TransitEncryptionEnabled:    aws.Bool(true),
+		UserGroupIds:                []string{"sdk-go-acl-ug"},
+	})
+	if err != nil {
+		t.Fatalf("CreateReplicationGroup failed: %v", err)
+	}
+
+	fc := fakecloud.New(fakecloudURL)
+	resp, err := fc.ElastiCache().GetElastiCacheAcls(ctx)
+	if err != nil {
+		t.Fatalf("ElastiCache().GetElastiCacheAcls() failed: %v", err)
+	}
+
+	if len(resp.Acls) != 1 {
+		t.Fatalf("expected 1 ACL cluster, got %d", len(resp.Acls))
+	}
+	cluster := resp.Acls[0]
+	if cluster.ClusterID != "sdk-go-acl-rg" {
+		t.Fatalf("expected sdk-go-acl-rg cluster id, got %s", cluster.ClusterID)
+	}
+	if len(cluster.Groups) != 1 || cluster.Groups[0].Name != "sdk-go-acl-ug" {
+		t.Fatalf("expected sdk-go-acl-ug user group, got %+v", cluster.Groups)
+	}
+	gotApp := false
+	for _, u := range cluster.Users {
+		if u.Name == "sdk-go-acl-app" {
+			gotApp = true
+			if u.NoPasswordRequired {
+				t.Fatal("expected sdk-go-acl-app to require a password")
+			}
+			if u.PasswordCount != 1 {
+				t.Fatalf("expected password count 1, got %d", u.PasswordCount)
+			}
+		}
+	}
+	if !gotApp {
+		t.Fatal("expected sdk-go-acl-app user in ACL response")
+	}
+}
+
 // ── Reset ─────────────────────────────────────────────────────────
 
 func TestE2EReset(t *testing.T) {

--- a/sdks/go/elasticache.go
+++ b/sdks/go/elasticache.go
@@ -33,3 +33,13 @@ func (c *ElastiCacheClient) GetServerlessCaches(ctx context.Context) (*ElastiCac
 	}
 	return &out, nil
 }
+
+// GetElastiCacheAcls returns ACL state (users + user groups) for ElastiCache
+// replication groups that have one or more user groups attached.
+func (c *ElastiCacheClient) GetElastiCacheAcls(ctx context.Context) (*ElastiCacheAclsResponse, error) {
+	var out ElastiCacheAclsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/elasticache/acls", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -101,6 +101,30 @@ type ElastiCacheServerlessCachesResponse struct {
 	ServerlessCaches []ElastiCacheServerlessCacheIntrospection `json:"serverlessCaches"`
 }
 
+type ElastiCacheAclUser struct {
+	Name               string `json:"name"`
+	Status             string `json:"status"`
+	AccessString       string `json:"accessString"`
+	NoPasswordRequired bool   `json:"noPasswordRequired"`
+	PasswordCount      int32  `json:"passwordCount"`
+}
+
+type ElastiCacheAclGroup struct {
+	Name    string   `json:"name"`
+	Members []string `json:"members"`
+}
+
+type ElastiCacheAclCluster struct {
+	ClusterID string                `json:"clusterId"`
+	Engine    string                `json:"engine"`
+	Users     []ElastiCacheAclUser  `json:"users"`
+	Groups    []ElastiCacheAclGroup `json:"groups"`
+}
+
+type ElastiCacheAclsResponse struct {
+	Acls []ElastiCacheAclCluster `json:"acls"`
+}
+
 // ── Lambda ─────────────────────────────────────────────────────────
 
 // LambdaInvocation represents a recorded Lambda invocation.

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -38,6 +38,7 @@ import dev.fakecloud.Types.Elbv2ListenersResponse;
 import dev.fakecloud.Types.Elbv2LoadBalancersResponse;
 import dev.fakecloud.Types.Elbv2RulesResponse;
 import dev.fakecloud.Types.Elbv2TargetGroupsResponse;
+import dev.fakecloud.Types.ElastiCacheAclsResponse;
 import dev.fakecloud.Types.ElastiCacheClustersResponse;
 import dev.fakecloud.Types.ElastiCacheReplicationGroupsResponse;
 import dev.fakecloud.Types.ElastiCacheServerlessCachesResponse;
@@ -265,6 +266,12 @@ public final class FakeCloud {
             return http.get(
                     "/_fakecloud/elasticache/serverless-caches",
                     ElastiCacheServerlessCachesResponse.class);
+        }
+
+        public ElastiCacheAclsResponse getElastiCacheAcls() {
+            return http.get(
+                    "/_fakecloud/elasticache/acls",
+                    ElastiCacheAclsResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -102,6 +102,27 @@ public final class Types {
     public record ElastiCacheServerlessCachesResponse(
             List<ElastiCacheServerlessCacheIntrospection> serverlessCaches) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ElastiCacheAclUser(
+            String name,
+            String status,
+            String accessString,
+            boolean noPasswordRequired,
+            int passwordCount) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ElastiCacheAclGroup(String name, List<String> members) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ElastiCacheAclCluster(
+            String clusterId,
+            String engine,
+            List<ElastiCacheAclUser> users,
+            List<ElastiCacheAclGroup> groups) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ElastiCacheAclsResponse(List<ElastiCacheAclCluster> acls) {}
+
     // ── Lambda ─────────────────────────────────────────────────────
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record LambdaInvocation(

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -201,6 +201,13 @@ final class ElastiCacheClient
             $this->http->get('/_fakecloud/elasticache/serverless-caches')
         );
     }
+
+    public function getElastiCacheAcls(): ElastiCacheAclsResponse
+    {
+        return ElastiCacheAclsResponse::fromArray(
+            $this->http->get('/_fakecloud/elasticache/acls')
+        );
+    }
 }
 
 final class EcrClient

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -250,6 +250,77 @@ final class ElastiCacheServerlessCachesResponse
     }
 }
 
+final class ElastiCacheAclUser
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $status,
+        public readonly string $accessString,
+        public readonly bool $noPasswordRequired,
+        public readonly int $passwordCount,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['name'],
+            $data['status'],
+            $data['accessString'],
+            $data['noPasswordRequired'],
+            $data['passwordCount'],
+        );
+    }
+}
+
+final class ElastiCacheAclGroup
+{
+    public function __construct(
+        public readonly string $name,
+        /** @var string[] */
+        public readonly array $members,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['name'], $data['members'] ?? []);
+    }
+}
+
+final class ElastiCacheAclCluster
+{
+    public function __construct(
+        public readonly string $clusterId,
+        public readonly string $engine,
+        /** @var ElastiCacheAclUser[] */
+        public readonly array $users,
+        /** @var ElastiCacheAclGroup[] */
+        public readonly array $groups,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['clusterId'],
+            $data['engine'],
+            array_map(ElastiCacheAclUser::fromArray(...), $data['users'] ?? []),
+            array_map(ElastiCacheAclGroup::fromArray(...), $data['groups'] ?? []),
+        );
+    }
+}
+
+final class ElastiCacheAclsResponse
+{
+    public function __construct(
+        /** @var ElastiCacheAclCluster[] */
+        public readonly array $acls,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(ElastiCacheAclCluster::fromArray(...), $data['acls'] ?? []));
+    }
+}
+
 // ── Lambda ─────────────────────────────────────────────────────
 
 final class LambdaInvocation

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -35,6 +35,7 @@ from fakecloud.types import (
     EcsTask,
     EcsTaskLogsResponse,
     EcsTasksResponse,
+    ElastiCacheAclsResponse,
     ElastiCacheClustersResponse,
     ElastiCacheReplicationGroupsResponse,
     ElastiCacheServerlessCachesResponse,
@@ -160,6 +161,13 @@ class ElastiCacheClient:
         )
         _check(resp)
         return ElastiCacheServerlessCachesResponse.from_dict(resp.json())
+
+    async def get_elasti_cache_acls(self) -> ElastiCacheAclsResponse:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/elasticache/acls"
+        )
+        _check(resp)
+        return ElastiCacheAclsResponse.from_dict(resp.json())
 
 
 class EcrClient:
@@ -1074,6 +1082,11 @@ class _SyncElastiCacheClient:
         )
         _check(resp)
         return ElastiCacheServerlessCachesResponse.from_dict(resp.json())
+
+    def get_elasti_cache_acls(self) -> ElastiCacheAclsResponse:
+        resp = self._client.get(f"{self._base}/_fakecloud/elasticache/acls")
+        _check(resp)
+        return ElastiCacheAclsResponse.from_dict(resp.json())
 
 
 class _SyncLogsClient:

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -163,9 +163,7 @@ class ElastiCacheClient:
         return ElastiCacheServerlessCachesResponse.from_dict(resp.json())
 
     async def get_elasti_cache_acls(self) -> ElastiCacheAclsResponse:
-        resp = await self._client.get(
-            f"{self._base}/_fakecloud/elasticache/acls"
-        )
+        resp = await self._client.get(f"{self._base}/_fakecloud/elasticache/acls")
         _check(resp)
         return ElastiCacheAclsResponse.from_dict(resp.json())
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -218,6 +218,61 @@ class ElastiCacheServerlessCachesResponse:
         )
 
 
+@dataclass
+class ElastiCacheAclUser:
+    name: str
+    status: str
+    access_string: str
+    no_password_required: bool
+    password_count: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheAclUser:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
+class ElastiCacheAclGroup:
+    name: str
+    members: List[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheAclGroup:
+        d = _convert_keys(data)
+        return cls(name=d["name"], members=list(d.get("members", [])))
+
+
+@dataclass
+class ElastiCacheAclCluster:
+    cluster_id: str
+    engine: str
+    users: List[ElastiCacheAclUser]
+    groups: List[ElastiCacheAclGroup]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheAclCluster:
+        d = _convert_keys(data)
+        return cls(
+            cluster_id=d["cluster_id"],
+            engine=d["engine"],
+            users=[ElastiCacheAclUser.from_dict(u) for u in d.get("users", [])],
+            groups=[ElastiCacheAclGroup.from_dict(g) for g in d.get("groups", [])],
+        )
+
+
+@dataclass
+class ElastiCacheAclsResponse:
+    acls: List[ElastiCacheAclCluster]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ElastiCacheAclsResponse:
+        d = _convert_keys(data)
+        return cls(
+            acls=[ElastiCacheAclCluster.from_dict(a) for a in d.get("acls", [])],
+        )
+
+
 # ── Lambda ──────────────────────────────────────────────────────────
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -11,6 +11,7 @@ import type {
   ResetResponse,
   ResetServiceResponse,
   RdsInstancesResponse,
+  ElastiCacheAclsResponse,
   ElastiCacheClustersResponse,
   ElastiCacheReplicationGroupsResponse,
   ElastiCacheServerlessCachesResponse,
@@ -148,6 +149,11 @@ export class ElastiCacheClient {
     const resp = await fetch(
       `${this.baseUrl}/_fakecloud/elasticache/serverless-caches`,
     );
+    return parse(resp);
+  }
+
+  async getElastiCacheAcls(): Promise<ElastiCacheAclsResponse> {
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/elasticache/acls`);
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -94,6 +94,30 @@ export interface ElastiCacheServerlessCachesResponse {
   serverlessCaches: ElastiCacheServerlessCacheIntrospection[];
 }
 
+export interface ElastiCacheAclUser {
+  name: string;
+  status: string;
+  accessString: string;
+  noPasswordRequired: boolean;
+  passwordCount: number;
+}
+
+export interface ElastiCacheAclGroup {
+  name: string;
+  members: string[];
+}
+
+export interface ElastiCacheAclCluster {
+  clusterId: string;
+  engine: string;
+  users: ElastiCacheAclUser[];
+  groups: ElastiCacheAclGroup[];
+}
+
+export interface ElastiCacheAclsResponse {
+  acls: ElastiCacheAclCluster[];
+}
+
 // ── Lambda ─────────────────────────────────────────────────────────
 
 export interface LambdaInvocation {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -122,6 +122,7 @@ curl http://localhost:4566/_fakecloud/health
 | `/_fakecloud/elasticache/clusters` | GET | List cache clusters and node state. |
 | `/_fakecloud/elasticache/replication-groups` | GET | List replication groups with primary/replica layout. |
 | `/_fakecloud/elasticache/serverless-caches` | GET | List serverless cache resources. |
+| `/_fakecloud/elasticache/acls` | GET | List ACL state (users + user groups) for replication groups with user groups attached. |
 
 ## ELBv2
 

--- a/website/content/docs/services/elasticache.md
+++ b/website/content/docs/services/elasticache.md
@@ -40,8 +40,9 @@ When you call `CreateCacheCluster` (or `CreateReplicationGroup` for Redis/Valkey
 - `GET /_fakecloud/elasticache/clusters` — current cache clusters (id, engine, status, mapped port)
 - `GET /_fakecloud/elasticache/replication-groups` — replication groups with node members and ports
 - `GET /_fakecloud/elasticache/serverless-caches` — serverless caches with endpoints
+- `GET /_fakecloud/elasticache/acls` — ACL state (users + user groups) for replication groups with one or more user groups attached
 
-All three are exposed by the introspection SDKs (`fakecloud.elasticache.clusters()`, etc.) for assertions in tests.
+All four are exposed by the introspection SDKs (`fakecloud.elasticache.clusters()`, `getElastiCacheAcls()`, etc.) for assertions in tests.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Adds introspection endpoints per /Users/lucas/.claude/plans/introspection-endpoints-2026-05-11.md.

## Test plan

- [ ] CI green
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ElastiCache ACL introspection endpoint and SDK methods to fetch merged users and user groups per replication group. Implements I8 so tests can assert ACL config in one call.

- **New Features**
  - Added `GET /_fakecloud/elasticache/acls` returning ACL state per replication group (only those with user groups). Response includes `clusterId`, `engine`, `groups` (name, members), and `users` (name, status, `accessString`, `noPasswordRequired`, `passwordCount`).
  - SDK support in Rust (`get_acls()`), Go (`GetElastiCacheAcls`), Java (`getElastiCacheAcls()`), PHP (`getElastiCacheAcls()`), Python (`get_elasti_cache_acls()` sync + async), TypeScript (`getElastiCacheAcls()`).
  - Added Go and Rust e2e tests; updated docs under Introspection and ElastiCache.

<sup>Written for commit 89e7da54b7e1a8b608a4850bde2cae93169f437f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

