### PR TITLE
feat(logs): introspection endpoints — delivery config + field indexes (I9)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8181,6 +8181,7 @@ impl ResourceProvisioner {
             service,
             log_type,
             tags: BTreeMap::new(),
+            created_at: chrono::Utc::now().timestamp_millis(),
         };
 
         let mut logs_accounts = self.logs_state.write();
@@ -8236,6 +8237,7 @@ impl ResourceProvisioner {
             field_delimiter: None,
             record_fields: Vec::new(),
             s3_delivery_configuration: None,
+            created_at: chrono::Utc::now().timestamp_millis(),
         };
 
         let mut logs_accounts = self.logs_state.write();

--- a/crates/fakecloud-e2e/tests/logs_introspection.rs
+++ b/crates/fakecloud-e2e/tests/logs_introspection.rs
@@ -1,0 +1,157 @@
+//! CloudWatch Logs introspection endpoints (I9): delivery configuration
+//! and field indexes. Exercises the AWS-shaped ops + the
+//! `/_fakecloud/logs/...` admin endpoints in the same flow.
+
+mod helpers;
+
+use helpers::TestServer;
+
+#[tokio::test]
+async fn logs_delivery_config_introspection_returns_create_delivery_state() {
+    let server = TestServer::start().await;
+    let logs = server.logs_client().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("intro-delivery-cfg")
+        .send()
+        .await
+        .unwrap();
+
+    logs.create_log_group()
+        .log_group_name("/intro/delivery-cfg")
+        .send()
+        .await
+        .unwrap();
+
+    let groups = logs
+        .describe_log_groups()
+        .log_group_name_prefix("/intro/delivery-cfg")
+        .send()
+        .await
+        .unwrap();
+    let group_arn = groups.log_groups()[0].arn().unwrap().to_string();
+
+    logs.put_delivery_source()
+        .name("intro-src")
+        .resource_arn(&group_arn)
+        .log_type("APPLICATION_LOGS")
+        .send()
+        .await
+        .unwrap();
+
+    let dest = logs
+        .put_delivery_destination()
+        .name("intro-dest")
+        .delivery_destination_configuration(
+            aws_sdk_cloudwatchlogs::types::DeliveryDestinationConfiguration::builder()
+                .destination_resource_arn("arn:aws:s3:::intro-delivery-cfg")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+    let dest_arn = dest
+        .delivery_destination()
+        .unwrap()
+        .arn()
+        .unwrap()
+        .to_string();
+
+    logs.create_delivery()
+        .delivery_source_name("intro-src")
+        .delivery_destination_arn(&dest_arn)
+        .record_fields("timestamp")
+        .record_fields("message")
+        .field_delimiter("|")
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/logs/delivery-config",
+        server.endpoint()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let configurations = body["configurations"].as_array().unwrap();
+    assert_eq!(
+        configurations.len(),
+        1,
+        "expected 1 delivery configuration, got {configurations:?}"
+    );
+    let cfg = &configurations[0];
+    assert_eq!(cfg["deliverySourceName"], "intro-src");
+    assert_eq!(cfg["deliveryDestinationArn"], dest_arn);
+    assert_eq!(cfg["logType"], "APPLICATION_LOGS");
+    assert_eq!(cfg["fieldDelimiter"], "|");
+    let fields: Vec<&str> = cfg["recordFields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(fields, vec!["timestamp", "message"]);
+    assert!(cfg["createdAt"].as_i64().unwrap() > 0);
+    assert_eq!(cfg["id"], cfg["name"]);
+}
+
+#[tokio::test]
+async fn logs_field_indexes_introspection_returns_parsed_index_policy_fields() {
+    let server = TestServer::start().await;
+    let logs = server.logs_client().await;
+
+    logs.create_log_group()
+        .log_group_name("intro-field-indexes")
+        .send()
+        .await
+        .unwrap();
+
+    let policy_doc = r#"{"Fields":["@timestamp","requestId","userId"]}"#;
+    logs.put_index_policy()
+        .log_group_identifier("intro-field-indexes")
+        .policy_document(policy_doc)
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = reqwest::get(format!(
+        "{}/_fakecloud/logs/field-indexes/intro-field-indexes",
+        server.endpoint(),
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    assert_eq!(body["logGroupName"], "intro-field-indexes");
+    let indexes = body["indexes"].as_array().unwrap();
+    assert_eq!(indexes.len(), 1);
+    let fields: Vec<&str> = indexes[0]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(fields, vec!["@timestamp", "requestId", "userId"]);
+    assert!(indexes[0]["createdAt"].as_i64().unwrap() > 0);
+    assert_eq!(indexes[0]["createdAt"], indexes[0]["lastUsedAt"]);
+}
+
+#[tokio::test]
+async fn logs_field_indexes_unknown_group_returns_404() {
+    let server = TestServer::start().await;
+    let resp = reqwest::get(format!(
+        "{}/_fakecloud/logs/field-indexes/does-not-exist",
+        server.endpoint(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status().as_u16(), 404);
+}

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -468,6 +468,13 @@ impl LogsService {
             state.region, state.account_id, name
         );
 
+        let created_at = state
+            .delivery_sources
+            .get(&name)
+            .map(|d| d.created_at)
+            .filter(|t| *t > 0)
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+
         let ds = DeliverySource {
             name: name.clone(),
             arn: arn.clone(),
@@ -475,6 +482,7 @@ impl LogsService {
             service: service.clone(),
             log_type: log_type.clone(),
             tags: tags.clone(),
+            created_at,
         };
 
         state.delivery_sources.insert(name.clone(), ds);
@@ -728,6 +736,7 @@ impl LogsService {
             } else {
                 Some(s3_delivery_config.clone())
             },
+            created_at: chrono::Utc::now().timestamp_millis(),
         };
 
         state.deliveries.insert(delivery_id.clone(), delivery);
@@ -1360,5 +1369,77 @@ mod tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         let filtered = body["configurationTemplates"].as_array().unwrap();
         assert!(filtered.iter().all(|t| t["service"] == "AWS/Lambda"));
+    }
+
+    #[test]
+    fn delivery_and_source_record_created_at_for_introspection() {
+        let svc = make_service();
+        create_group(&svc, "intro-grp");
+
+        let req = make_request(
+            "DescribeLogGroups",
+            json!({ "logGroupNamePrefix": "intro-grp" }),
+        );
+        let resp = svc.describe_log_groups(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let group_arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
+
+        // Source
+        let before = chrono::Utc::now().timestamp_millis();
+        let req = make_request(
+            "PutDeliverySource",
+            json!({
+                "name": "intro-src",
+                "resourceArn": group_arn,
+                "logType": "APPLICATION_LOGS",
+            }),
+        );
+        svc.put_delivery_source(&req).unwrap();
+
+        // Destination
+        let req = make_request(
+            "PutDeliveryDestination",
+            json!({
+                "name": "intro-dest",
+                "deliveryDestinationConfiguration": {
+                    "destinationResourceArn": "arn:aws:s3:::intro-bucket"
+                }
+            }),
+        );
+        svc.put_delivery_destination(&req).unwrap();
+        let req = make_request("GetDeliveryDestination", json!({ "name": "intro-dest" }));
+        let resp = svc.get_delivery_destination(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let dest_arn = body["deliveryDestination"]["arn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let req = make_request(
+            "CreateDelivery",
+            json!({
+                "deliverySourceName": "intro-src",
+                "deliveryDestinationArn": dest_arn,
+                "recordFields": ["timestamp", "message"],
+                "fieldDelimiter": "|",
+            }),
+        );
+        svc.create_delivery(&req).unwrap();
+
+        let accounts = svc.state.read();
+        let state = accounts
+            .get("123456789012")
+            .expect("default account state");
+        let src = state.delivery_sources.get("intro-src").unwrap();
+        assert!(
+            src.created_at >= before,
+            "delivery source created_at not populated (got {})",
+            src.created_at
+        );
+        let delivery = state.deliveries.values().next().unwrap();
+        assert!(delivery.created_at >= before);
+        assert_eq!(delivery.delivery_source_name, "intro-src");
+        assert_eq!(delivery.record_fields, vec!["timestamp", "message"]);
+        assert_eq!(delivery.field_delimiter.as_deref(), Some("|"));
     }
 }

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -1427,9 +1427,7 @@ mod tests {
         svc.create_delivery(&req).unwrap();
 
         let accounts = svc.state.read();
-        let state = accounts
-            .get("123456789012")
-            .expect("default account state");
+        let state = accounts.get("123456789012").expect("default account state");
         let src = state.delivery_sources.get("intro-src").unwrap();
         assert!(
             src.created_at >= before,

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -287,6 +287,8 @@ pub struct DeliverySource {
     pub service: String,
     pub log_type: String,
     pub tags: BTreeMap<String, String>,
+    #[serde(default)]
+    pub created_at: i64,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -303,6 +305,8 @@ pub struct Delivery {
     pub record_fields: Vec<String>,
     #[serde(default)]
     pub s3_delivery_configuration: Option<serde_json::Value>,
+    #[serde(default)]
+    pub created_at: i64,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -174,6 +174,60 @@ pub struct LogsAnomalyInjectResponse {
     pub anomaly_id: String,
 }
 
+/// One entry in the `/_fakecloud/logs/delivery-config` introspection
+/// response. Combines a `Delivery` with the `log_type` from its
+/// associated `DeliverySource` so test code can assert end-to-end
+/// configuration without joining state manually.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsDeliveryConfiguration {
+    pub id: String,
+    /// Delivery identifier (same value as `id`; mirrors AWS naming).
+    pub name: String,
+    pub delivery_destination_arn: String,
+    pub delivery_source_name: String,
+    /// Log type from the associated `DeliverySource` (e.g. `ACCESS_LOGS`).
+    /// Empty string when the source has been deleted out from under the
+    /// delivery.
+    pub log_type: String,
+    #[serde(default)]
+    pub record_fields: Vec<String>,
+    #[serde(default)]
+    pub field_delimiter: Option<String>,
+    #[serde(default)]
+    pub s3_delivery_configuration: Option<serde_json::Value>,
+    /// Unix-ms timestamp of `CreateDelivery`. `0` for deliveries
+    /// recovered from older snapshots without this field.
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsDeliveryConfigResponse {
+    pub configurations: Vec<LogsDeliveryConfiguration>,
+}
+
+/// One `Fields` entry parsed from a log group's index policy document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsFieldIndex {
+    /// Fields list from `IndexPolicy.policy_document.Fields`.
+    pub fields: Vec<String>,
+    /// Unix-ms when the policy was created. Mirrors `last_updated_time`
+    /// since fakecloud doesn't track a separate creation timestamp.
+    pub created_at: i64,
+    /// Unix-ms when the policy was last touched
+    /// (PutIndexPolicy updates).
+    pub last_used_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsFieldIndexesResponse {
+    pub log_group_name: String,
+    pub indexes: Vec<LogsFieldIndex>,
+}
+
 /// Admin payload for `/_fakecloud/cognito/compromised-passwords`.
 /// Plaintext passwords are hashed (sha256) and added to the
 /// compromised-credentials set consulted by `InitiateAuth` /

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3501,6 +3501,91 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/logs/delivery-config",
+            axum::routing::get({
+                let ls = logs_state.clone();
+                move || {
+                    let ls = ls.clone();
+                    async move {
+                        let accounts = ls.read();
+                        let mut configurations: Vec<types::LogsDeliveryConfiguration> = Vec::new();
+                        for (_account, state) in accounts.iter() {
+                            for delivery in state.deliveries.values() {
+                                let log_type = state
+                                    .delivery_sources
+                                    .get(&delivery.delivery_source_name)
+                                    .map(|s| s.log_type.clone())
+                                    .unwrap_or_default();
+                                configurations.push(types::LogsDeliveryConfiguration {
+                                    id: delivery.id.clone(),
+                                    name: delivery.id.clone(),
+                                    delivery_destination_arn: delivery
+                                        .delivery_destination_arn
+                                        .clone(),
+                                    delivery_source_name: delivery.delivery_source_name.clone(),
+                                    log_type,
+                                    record_fields: delivery.record_fields.clone(),
+                                    field_delimiter: delivery.field_delimiter.clone(),
+                                    s3_delivery_configuration: delivery
+                                        .s3_delivery_configuration
+                                        .clone(),
+                                    created_at: delivery.created_at,
+                                });
+                            }
+                        }
+                        axum::Json(types::LogsDeliveryConfigResponse { configurations })
+                    }
+                }
+            }),
+        )
+        .route(
+            "/_fakecloud/logs/field-indexes/{log_group_name}",
+            axum::routing::get({
+                let ls = logs_state.clone();
+                move |axum::extract::Path(log_group_name): axum::extract::Path<String>| {
+                    let ls = ls.clone();
+                    async move {
+                        let accounts = ls.read();
+                        let mut indexes: Vec<types::LogsFieldIndex> = Vec::new();
+                        let mut found = false;
+                        for (_account, state) in accounts.iter() {
+                            let Some(group) = state.log_groups.get(&log_group_name) else {
+                                continue;
+                            };
+                            found = true;
+                            for policy in &group.index_policies {
+                                let parsed: serde_json::Value =
+                                    serde_json::from_str(&policy.policy_document)
+                                        .unwrap_or(serde_json::Value::Null);
+                                let fields: Vec<String> = parsed
+                                    .get("Fields")
+                                    .and_then(|v| v.as_array())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .filter_map(|f| f.as_str().map(|s| s.to_string()))
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+                                indexes.push(types::LogsFieldIndex {
+                                    fields,
+                                    created_at: policy.last_updated_time,
+                                    last_used_at: policy.last_updated_time,
+                                });
+                            }
+                        }
+                        if !found {
+                            return axum::http::StatusCode::NOT_FOUND.into_response();
+                        }
+                        axum::Json(types::LogsFieldIndexesResponse {
+                            log_group_name,
+                            indexes,
+                        })
+                        .into_response()
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/sqs/messages",
             axum::routing::get({
                 let ss = sqs_introspection_state;

--- a/sdks/go/logs.go
+++ b/sdks/go/logs.go
@@ -1,6 +1,10 @@
 package fakecloud
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
 
 // LogsClient provides access to CloudWatch Logs admin/introspection endpoints.
 type LogsClient struct {
@@ -28,4 +32,60 @@ type LogsAnomalyInjectRequest struct {
 // LogsAnomalyInjectResponse is returned by the inject endpoint.
 type LogsAnomalyInjectResponse struct {
 	AnomalyID string `json:"anomalyId"`
+}
+
+// GetDeliveryConfig returns persisted CloudWatch Logs delivery
+// configurations (PutDeliverySource + PutDeliveryDestination +
+// CreateDelivery) so tests can assert what fakecloud has wired up
+// without joining state by hand.
+func (c *LogsClient) GetDeliveryConfig(ctx context.Context) (*LogsDeliveryConfigResponse, error) {
+	var out LogsDeliveryConfigResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/logs/delivery-config", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetFieldIndexes returns the index policies registered on a log
+// group, with the `Fields` array parsed from each policy document.
+// Returns 404 when the log group does not exist.
+func (c *LogsClient) GetFieldIndexes(ctx context.Context, logGroupName string) (*LogsFieldIndexesResponse, error) {
+	var out LogsFieldIndexesResponse
+	path := fmt.Sprintf("/_fakecloud/logs/field-indexes/%s", url.PathEscape(logGroupName))
+	if err := c.fc.doGet(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// LogsDeliveryConfiguration mirrors one entry of the delivery-config
+// introspection response.
+type LogsDeliveryConfiguration struct {
+	ID                       string                 `json:"id"`
+	Name                     string                 `json:"name"`
+	DeliveryDestinationARN   string                 `json:"deliveryDestinationArn"`
+	DeliverySourceName       string                 `json:"deliverySourceName"`
+	LogType                  string                 `json:"logType"`
+	RecordFields             []string               `json:"recordFields,omitempty"`
+	FieldDelimiter           *string                `json:"fieldDelimiter,omitempty"`
+	S3DeliveryConfiguration  map[string]interface{} `json:"s3DeliveryConfiguration,omitempty"`
+	CreatedAt                int64                  `json:"createdAt"`
+}
+
+// LogsDeliveryConfigResponse is returned by GetDeliveryConfig.
+type LogsDeliveryConfigResponse struct {
+	Configurations []LogsDeliveryConfiguration `json:"configurations"`
+}
+
+// LogsFieldIndex is one parsed IndexPolicy.
+type LogsFieldIndex struct {
+	Fields     []string `json:"fields"`
+	CreatedAt  int64    `json:"createdAt"`
+	LastUsedAt int64    `json:"lastUsedAt"`
+}
+
+// LogsFieldIndexesResponse is returned by GetFieldIndexes.
+type LogsFieldIndexesResponse struct {
+	LogGroupName string           `json:"logGroupName"`
+	Indexes      []LogsFieldIndex `json:"indexes"`
 }

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -56,6 +56,8 @@ import dev.fakecloud.Types.LambdaInvocationsResponse;
 import dev.fakecloud.Types.LifecycleTickResponse;
 import dev.fakecloud.Types.LogsAnomalyInjectRequest;
 import dev.fakecloud.Types.LogsAnomalyInjectResponse;
+import dev.fakecloud.Types.LogsDeliveryConfigResponse;
+import dev.fakecloud.Types.LogsFieldIndexesResponse;
 import dev.fakecloud.Types.PendingConfirmationsResponse;
 import dev.fakecloud.Types.RdsInstancesResponse;
 import dev.fakecloud.Types.ResetResponse;
@@ -301,6 +303,19 @@ public final class FakeCloud {
         public LogsAnomalyInjectResponse injectAnomaly(LogsAnomalyInjectRequest req) {
             return http.postJson(
                     "/_fakecloud/logs/anomalies/inject", req, LogsAnomalyInjectResponse.class);
+        }
+
+        /** Persisted CloudWatch Logs delivery configurations. */
+        public LogsDeliveryConfigResponse getDeliveryConfig() {
+            return http.get(
+                    "/_fakecloud/logs/delivery-config", LogsDeliveryConfigResponse.class);
+        }
+
+        /** Parsed {@code Fields} from index policies on the given log group. */
+        public LogsFieldIndexesResponse getFieldIndexes(String logGroupName) {
+            return http.get(
+                    "/_fakecloud/logs/field-indexes/" + encodePath(logGroupName),
+                    LogsFieldIndexesResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -768,6 +768,36 @@ public final class Types {
     public record LogsAnomalyInjectResponse(String anomalyId) {}
 
     /**
+     * One entry of {@code GET /_fakecloud/logs/delivery-config}. Joins a
+     * delivery with the {@code logType} from its delivery source so test
+     * code does not have to re-query the AWS-shaped APIs.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record LogsDeliveryConfiguration(
+            String id,
+            String name,
+            String deliveryDestinationArn,
+            String deliverySourceName,
+            String logType,
+            List<String> recordFields,
+            String fieldDelimiter,
+            Object s3DeliveryConfiguration,
+            long createdAt) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record LogsDeliveryConfigResponse(
+            List<LogsDeliveryConfiguration> configurations) {}
+
+    /** One parsed {@code IndexPolicy} on a log group. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record LogsFieldIndex(
+            List<String> fields, long createdAt, long lastUsedAt) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record LogsFieldIndexesResponse(
+            String logGroupName, List<LogsFieldIndex> indexes) {}
+
+    /**
      * Response from {@code GET /_fakecloud/acm/certificates/{arn-or-id}/chain-info}.
      *
      * <p>fakecloud is not a PKI: {@code externalCaValidated} is always

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -241,6 +241,20 @@ final class LogsClient
             $this->http->postJson('/_fakecloud/logs/anomalies/inject', $req->toArray())
         );
     }
+
+    public function getDeliveryConfig(): LogsDeliveryConfigResponse
+    {
+        return LogsDeliveryConfigResponse::fromArray(
+            $this->http->get('/_fakecloud/logs/delivery-config')
+        );
+    }
+
+    public function getFieldIndexes(string $logGroupName): LogsFieldIndexesResponse
+    {
+        return LogsFieldIndexesResponse::fromArray(
+            $this->http->get('/_fakecloud/logs/field-indexes/' . rawurlencode($logGroupName))
+        );
+    }
 }
 
 final class SesClient

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -2183,3 +2183,100 @@ final class LogsAnomalyInjectResponse
         return new self((string) $data['anomalyId']);
     }
 }
+
+/**
+ * One entry of GET /_fakecloud/logs/delivery-config. Joins a Delivery
+ * with the logType from its DeliverySource so test code can assert
+ * end-to-end wiring without re-querying the AWS-shaped APIs.
+ */
+final class LogsDeliveryConfiguration
+{
+    /**
+     * @param string[] $recordFields
+     * @param mixed $s3DeliveryConfiguration
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $deliveryDestinationArn,
+        public readonly string $deliverySourceName,
+        public readonly string $logType,
+        public readonly int $createdAt,
+        public readonly array $recordFields = [],
+        public readonly ?string $fieldDelimiter = null,
+        public readonly mixed $s3DeliveryConfiguration = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) ($data['id'] ?? ''),
+            (string) ($data['name'] ?? ''),
+            (string) ($data['deliveryDestinationArn'] ?? ''),
+            (string) ($data['deliverySourceName'] ?? ''),
+            (string) ($data['logType'] ?? ''),
+            (int) ($data['createdAt'] ?? 0),
+            array_values(array_map('strval', $data['recordFields'] ?? [])),
+            isset($data['fieldDelimiter']) ? (string) $data['fieldDelimiter'] : null,
+            $data['s3DeliveryConfiguration'] ?? null,
+        );
+    }
+}
+
+final class LogsDeliveryConfigResponse
+{
+    /** @param LogsDeliveryConfiguration[] $configurations */
+    public function __construct(
+        public readonly array $configurations,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        $items = array_map(
+            static fn ($c) => LogsDeliveryConfiguration::fromArray($c),
+            $data['configurations'] ?? []
+        );
+        return new self(array_values($items));
+    }
+}
+
+/** One parsed IndexPolicy on a log group. */
+final class LogsFieldIndex
+{
+    /** @param string[] $fields */
+    public function __construct(
+        public readonly array $fields,
+        public readonly int $createdAt,
+        public readonly int $lastUsedAt,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            array_values(array_map('strval', $data['fields'] ?? [])),
+            (int) ($data['createdAt'] ?? 0),
+            (int) ($data['lastUsedAt'] ?? 0),
+        );
+    }
+}
+
+final class LogsFieldIndexesResponse
+{
+    /** @param LogsFieldIndex[] $indexes */
+    public function __construct(
+        public readonly string $logGroupName,
+        public readonly array $indexes,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        $indexes = array_map(
+            static fn ($i) => LogsFieldIndex::fromArray($i),
+            $data['indexes'] ?? []
+        );
+        return new self(
+            (string) ($data['logGroupName'] ?? ''),
+            array_values($indexes),
+        );
+    }
+}

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -58,6 +58,8 @@ from fakecloud.types import (
     LifecycleTickResponse,
     LogsAnomalyInjectRequest,
     LogsAnomalyInjectResponse,
+    LogsDeliveryConfigResponse,
+    LogsFieldIndexesResponse,
     MintAuthorizationCodeRequest,
     MintAuthorizationCodeResponse,
     PendingConfirmationsResponse,
@@ -571,6 +573,26 @@ class LogsClient:
         )
         _check(resp)
         return LogsAnomalyInjectResponse.from_dict(resp.json())
+
+    async def get_delivery_config(self) -> LogsDeliveryConfigResponse:
+        """Return persisted CloudWatch Logs delivery configurations."""
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/logs/delivery-config"
+        )
+        _check(resp)
+        return LogsDeliveryConfigResponse.from_dict(resp.json())
+
+    async def get_field_indexes(
+        self, log_group_name: str
+    ) -> LogsFieldIndexesResponse:
+        """Return parsed `Fields` from index policies on a log group."""
+        from urllib.parse import quote
+
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/logs/field-indexes/{quote(log_group_name, safe='')}"
+        )
+        _check(resp)
+        return LogsFieldIndexesResponse.from_dict(resp.json())
 
 
 class SesClient:
@@ -1089,6 +1111,22 @@ class _SyncLogsClient:
         )
         _check(resp)
         return LogsAnomalyInjectResponse.from_dict(resp.json())
+
+    def get_delivery_config(self) -> LogsDeliveryConfigResponse:
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/logs/delivery-config"
+        )
+        _check(resp)
+        return LogsDeliveryConfigResponse.from_dict(resp.json())
+
+    def get_field_indexes(self, log_group_name: str) -> LogsFieldIndexesResponse:
+        from urllib.parse import quote
+
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/logs/field-indexes/{quote(log_group_name, safe='')}"
+        )
+        _check(resp)
+        return LogsFieldIndexesResponse.from_dict(resp.json())
 
 
 class _SyncSesClient:

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -576,20 +576,17 @@ class LogsClient:
 
     async def get_delivery_config(self) -> LogsDeliveryConfigResponse:
         """Return persisted CloudWatch Logs delivery configurations."""
-        resp = await self._client.get(
-            f"{self._base}/_fakecloud/logs/delivery-config"
-        )
+        resp = await self._client.get(f"{self._base}/_fakecloud/logs/delivery-config")
         _check(resp)
         return LogsDeliveryConfigResponse.from_dict(resp.json())
 
-    async def get_field_indexes(
-        self, log_group_name: str
-    ) -> LogsFieldIndexesResponse:
+    async def get_field_indexes(self, log_group_name: str) -> LogsFieldIndexesResponse:
         """Return parsed `Fields` from index policies on a log group."""
         from urllib.parse import quote
 
         resp = await self._client.get(
-            f"{self._base}/_fakecloud/logs/field-indexes/{quote(log_group_name, safe='')}"
+            f"{self._base}/_fakecloud/logs/field-indexes/"
+            f"{quote(log_group_name, safe='')}"
         )
         _check(resp)
         return LogsFieldIndexesResponse.from_dict(resp.json())
@@ -1113,9 +1110,7 @@ class _SyncLogsClient:
         return LogsAnomalyInjectResponse.from_dict(resp.json())
 
     def get_delivery_config(self) -> LogsDeliveryConfigResponse:
-        resp = self._client.get(
-            f"{self._base}/_fakecloud/logs/delivery-config"
-        )
+        resp = self._client.get(f"{self._base}/_fakecloud/logs/delivery-config")
         _check(resp)
         return LogsDeliveryConfigResponse.from_dict(resp.json())
 
@@ -1123,7 +1118,8 @@ class _SyncLogsClient:
         from urllib.parse import quote
 
         resp = self._client.get(
-            f"{self._base}/_fakecloud/logs/field-indexes/{quote(log_group_name, safe='')}"
+            f"{self._base}/_fakecloud/logs/field-indexes/"
+            f"{quote(log_group_name, safe='')}"
         )
         _check(resp)
         return LogsFieldIndexesResponse.from_dict(resp.json())

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1836,3 +1836,73 @@ class LogsAnomalyInjectResponse:
     def from_dict(cls, data: Dict[str, Any]) -> LogsAnomalyInjectResponse:
         d = _convert_keys(data)
         return cls(**d)
+
+
+@dataclass
+class LogsDeliveryConfiguration:
+    """One entry of `/_fakecloud/logs/delivery-config`.
+
+    Joins a `Delivery` with the `log_type` from its `DeliverySource`
+    so callers can assert end-to-end wiring without re-querying the
+    AWS-shaped APIs.
+    """
+
+    id: str
+    name: str
+    delivery_destination_arn: str
+    delivery_source_name: str
+    log_type: str
+    created_at: int
+    record_fields: List[str] = field(default_factory=list)
+    field_delimiter: Optional[str] = None
+    s3_delivery_configuration: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> LogsDeliveryConfiguration:
+        d = _convert_keys(data)
+        valid = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in valid})
+
+
+@dataclass
+class LogsDeliveryConfigResponse:
+    configurations: List[LogsDeliveryConfiguration] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> LogsDeliveryConfigResponse:
+        return cls(
+            configurations=[
+                LogsDeliveryConfiguration.from_dict(c)
+                for c in data.get("configurations", [])
+            ]
+        )
+
+
+@dataclass
+class LogsFieldIndex:
+    """One parsed `Fields` entry from an index policy on a log group."""
+
+    fields: List[str] = field(default_factory=list)
+    created_at: int = 0
+    last_used_at: int = 0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> LogsFieldIndex:
+        return cls(
+            fields=list(data.get("fields", [])),
+            created_at=int(data.get("createdAt", 0)),
+            last_used_at=int(data.get("lastUsedAt", 0)),
+        )
+
+
+@dataclass
+class LogsFieldIndexesResponse:
+    log_group_name: str
+    indexes: List[LogsFieldIndex] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> LogsFieldIndexesResponse:
+        return cls(
+            log_group_name=data.get("logGroupName", ""),
+            indexes=[LogsFieldIndex.from_dict(i) for i in data.get("indexes", [])],
+        )

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -20,6 +20,8 @@ import type {
   LambdaInvocationsResponse,
   LogsAnomalyInjectRequest,
   LogsAnomalyInjectResponse,
+  LogsDeliveryConfigResponse,
+  LogsFieldIndexesResponse,
   WarmContainersResponse,
   EvictContainerResponse,
   SesEmailsResponse,
@@ -245,6 +247,22 @@ export class LogsClient {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(req),
       },
+    );
+    return parse(resp);
+  }
+
+  /** Persisted CloudWatch Logs delivery configurations. */
+  async getDeliveryConfig(): Promise<LogsDeliveryConfigResponse> {
+    const resp = await fetch(`${this.baseUrl}/_fakecloud/logs/delivery-config`);
+    return parse(resp);
+  }
+
+  /** Parsed `Fields` from index policies on a log group. 404 on unknown group. */
+  async getFieldIndexes(
+    logGroupName: string,
+  ): Promise<LogsFieldIndexesResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/logs/field-indexes/${encodeURIComponent(logGroupName)}`,
     );
     return parse(resp);
   }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -846,3 +846,37 @@ export interface LogsAnomalyInjectRequest {
 export interface LogsAnomalyInjectResponse {
   anomalyId: string;
 }
+
+/** One entry of `/_fakecloud/logs/delivery-config`. Joins a Delivery
+ * with the `logType` from its DeliverySource for assertion-friendly
+ * test shape. */
+export interface LogsDeliveryConfiguration {
+  id: string;
+  /** Mirrors `id`; AWS deliveries are referenced by ID, not name. */
+  name: string;
+  deliveryDestinationArn: string;
+  deliverySourceName: string;
+  logType: string;
+  recordFields?: string[];
+  fieldDelimiter?: string;
+  s3DeliveryConfiguration?: unknown;
+  /** Unix-ms timestamp of CreateDelivery. */
+  createdAt: number;
+}
+
+export interface LogsDeliveryConfigResponse {
+  configurations: LogsDeliveryConfiguration[];
+}
+
+/** One parsed IndexPolicy on a log group. */
+export interface LogsFieldIndex {
+  fields: string[];
+  /** Unix-ms when the policy was created (mirrors `last_updated_time`). */
+  createdAt: number;
+  lastUsedAt: number;
+}
+
+export interface LogsFieldIndexesResponse {
+  logGroupName: string;
+  indexes: LogsFieldIndex[];
+}

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -166,7 +166,9 @@ curl http://localhost:4566/_fakecloud/health
 
 | Endpoint | Method | Description |
 | -------- | ------ | ----------- |
-| `/_fakecloud/logs/anomalies/inject` | POST | **NEW** -- Inject anomaly findings against a log group/anomaly detector. |
+| `/_fakecloud/logs/anomalies/inject` | POST | Inject anomaly findings against a log group/anomaly detector. |
+| `/_fakecloud/logs/delivery-config` | GET | **NEW** -- Persisted delivery configurations: `Delivery` joined with its `DeliverySource.logType`, plus `recordFields`, `fieldDelimiter`, `s3DeliveryConfiguration`, `createdAt`. |
+| `/_fakecloud/logs/field-indexes/{log_group_name}` | GET | **NEW** -- Parsed `Fields` from each index policy on a log group. 404 when the group does not exist. |
 
 ## RDS
 

--- a/website/content/docs/services/logs.md
+++ b/website/content/docs/services/logs.md
@@ -50,6 +50,10 @@ JSON protocol. `X-Amz-Target` header, JSON body, JSON responses.
 
   Returns `{ "anomalyId": "<uuid>" }`. Available on every fakecloud SDK as `fc.logs().injectAnomaly(...)`.
 
+- `GET /_fakecloud/logs/delivery-config` — Persisted CloudWatch Logs delivery configurations (the joined output of `PutDeliverySource` + `PutDeliveryDestination` + `CreateDelivery`). Each entry contains `id`, `name`, `deliveryDestinationArn`, `deliverySourceName`, the `logType` carried over from the source, plus `recordFields`, `fieldDelimiter`, `s3DeliveryConfiguration`, and `createdAt` (unix-ms). Available on every fakecloud SDK as `fc.logs().getDeliveryConfig()`.
+
+- `GET /_fakecloud/logs/field-indexes/{logGroupName}` — Parsed `Fields` arrays from each `IndexPolicy` on a log group, plus `createdAt` and `lastUsedAt` timestamps. Returns `404` when the log group does not exist. Available on every fakecloud SDK as `fc.logs().getFieldIndexes(logGroupName)`.
+
 ## Gotchas
 
 - Anomaly *detection* (pattern mining) does not run. Anomalies appear in `ListAnomalies` only after being seeded through the admin endpoint above.


### PR DESCRIPTION
## Summary

Adds introspection endpoints per /Users/lucas/.claude/plans/introspection-endpoints-2026-05-11.md.

## Test plan

- [ ] CI green
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds logs introspection endpoints to inspect delivery configurations and parsed field indexes, and persists `created_at` on deliveries/sources for reliable timeline assertions. Implements I9 requirements across server and SDKs.

- **New Features**
  - Added `GET /_fakecloud/logs/delivery-config` returning `LogsDeliveryConfiguration` with `id/name`, `deliveryDestinationArn`, `deliverySourceName`, `logType`, `recordFields`, `fieldDelimiter`, `s3DeliveryConfiguration`, and `createdAt`.
  - Added `GET /_fakecloud/logs/field-indexes/{log_group_name}` returning parsed `Fields` per index policy with `createdAt`/`lastUsedAt`; returns 404 for unknown groups.
  - Persist `created_at` on `DeliverySource` and `Delivery` (set at create; defaults to 0 for older snapshots).
  - SDKs: added `getDeliveryConfig()` and `getFieldIndexes()` with typed responses in Go, Java, PHP, Python (async/sync), and TypeScript.
  - Docs and e2e tests added for both endpoints.

- **Bug Fixes**
  - Python SDK: wrapped long endpoint URLs to satisfy `ruff` E501.

<sup>Written for commit f98723412a0a7b4c9322662ef3a8d1a070191852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

