### PR TITLE
feat(ecs): introspection endpoint — task metadata (I11)

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_metadata_endpoint.rs
+++ b/crates/fakecloud-e2e/tests/ecs_metadata_endpoint.rs
@@ -110,3 +110,97 @@ async fn ecs_metadata_endpoint_v3_v4() {
     .expect("not_found request");
     assert_eq!(not_found.status(), 404);
 }
+
+/// I11: `/_fakecloud/ecs/metadata/{task_arn}` returns the aggregated v4 dump
+/// keyed by full (URL-encoded) task ARN. This is the assertion-friendly path
+/// tests reach for after holding a RunTask response.
+#[tokio::test]
+async fn ecs_introspection_metadata_by_arn() {
+    let server = TestServer::start().await;
+    let ecs = server.ecs_client().await;
+
+    ecs.create_cluster()
+        .cluster_name("intro-meta-cluster")
+        .send()
+        .await
+        .expect("create_cluster");
+
+    ecs.register_task_definition()
+        .family("intro-meta-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("alpine:3.19")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .expect("register_task_definition");
+
+    let run = ecs
+        .run_task()
+        .cluster("intro-meta-cluster")
+        .task_definition("intro-meta-family")
+        .send()
+        .await
+        .expect("run_task");
+    let arn = run.tasks()[0].task_arn().unwrap().to_string();
+
+    // Minimal percent-encoding sufficient for an ECS task ARN
+    // (`arn:aws:ecs:...:task/<cluster>/<id>`).
+    let encoded = arn.replace(':', "%3A").replace('/', "%2F");
+    let resp = reqwest::get(format!(
+        "{}/_fakecloud/ecs/metadata/{}",
+        server.endpoint(),
+        encoded
+    ))
+    .await
+    .expect("metadata request");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("metadata json");
+
+    let task = body.get("task").expect("task field");
+    assert_eq!(
+        task.get("cluster").and_then(|v| v.as_str()),
+        Some("intro-meta-cluster")
+    );
+    assert_eq!(
+        task.get("taskArn").and_then(|v| v.as_str()),
+        Some(arn.as_str())
+    );
+    assert_eq!(
+        task.get("family").and_then(|v| v.as_str()),
+        Some("intro-meta-family")
+    );
+    assert!(task.get("revision").and_then(|v| v.as_i64()).is_some());
+    assert!(task.get("desiredStatus").and_then(|v| v.as_str()).is_some());
+    assert!(task.get("knownStatus").and_then(|v| v.as_str()).is_some());
+    assert!(task.get("launchType").and_then(|v| v.as_str()).is_some());
+    assert!(task
+        .get("availabilityZone")
+        .and_then(|v| v.as_str())
+        .is_some());
+    let containers = task
+        .get("containers")
+        .and_then(|v| v.as_array())
+        .expect("containers array");
+    assert_eq!(containers.len(), 1);
+    let c0 = &containers[0];
+    assert_eq!(c0.get("name").and_then(|v| v.as_str()), Some("app"));
+    assert_eq!(
+        c0.get("image").and_then(|v| v.as_str()),
+        Some("alpine:3.19")
+    );
+    assert!(c0.get("limits").is_some());
+    assert!(c0.get("ports").and_then(|v| v.as_array()).is_some());
+    assert!(c0.get("labels").is_some());
+
+    let not_found = reqwest::get(format!(
+        "{}/_fakecloud/ecs/metadata/arn%3Aaws%3Aecs%3Aus-east-1%3A000000000000%3Atask%2Fnope%2Fnope",
+        server.endpoint()
+    ))
+    .await
+    .expect("nf request");
+    assert_eq!(not_found.status(), 404);
+}

--- a/crates/fakecloud-sdk/src/types.rs
+++ b/crates/fakecloud-sdk/src/types.rs
@@ -1486,6 +1486,72 @@ pub struct EcsEventsResponse {
     pub events: Vec<EcsLifecycleEvent>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskMetadataLimits {
+    pub cpu: Option<f64>,
+    pub memory: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskMetadataPort {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_port: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_port: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskMetadataContainer {
+    pub name: String,
+    pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_id: Option<String>,
+    pub ports: Vec<EcsTaskMetadataPort>,
+    pub labels: std::collections::BTreeMap<String, String>,
+    pub desired_status: String,
+    pub known_status: String,
+    pub limits: EcsTaskMetadataLimits,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskMetadata {
+    pub cluster: String,
+    pub task_arn: String,
+    pub family: String,
+    pub revision: i32,
+    pub desired_status: String,
+    pub known_status: String,
+    pub containers: Vec<EcsTaskMetadataContainer>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull_started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull_stopped_at: Option<String>,
+    pub availability_zone: String,
+    pub launch_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eni_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcsTaskMetadataResponse {
+    pub task: EcsTaskMetadata,
+}
+
 // ── ELBv2 ───────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -132,6 +132,82 @@ pub(crate) fn ecs_task_response(task: &fakecloud_ecs::Task) -> types::EcsTask {
     }
 }
 
+pub(crate) fn ecs_task_metadata_response(
+    task: &fakecloud_ecs::Task,
+) -> types::EcsTaskMetadataResponse {
+    // Pull the ENI/VPC bits out of the awsvpc attachment, if any.
+    let mut eni_id: Option<String> = None;
+    let mut vpc_id: Option<String> = None;
+    for att in &task.attachments {
+        if att.attachment_type.eq_ignore_ascii_case("eni") {
+            eni_id = Some(att.id.clone());
+            for d in &att.details {
+                if d.name == "vpcId" {
+                    vpc_id = Some(d.value.clone());
+                }
+            }
+        }
+    }
+    // fakecloud doesn't model a separate VPC store today, so synthesise a
+    // stable placeholder if the task has an ENI but no explicit vpcId.
+    if eni_id.is_some() && vpc_id.is_none() {
+        vpc_id = Some("vpc-fakecloud".into());
+    }
+
+    let containers = task
+        .containers
+        .iter()
+        .map(|c| {
+            let ports = c
+                .network_bindings
+                .iter()
+                .map(|nb| types::EcsTaskMetadataPort {
+                    container_port: nb.get("containerPort").and_then(|v| v.as_i64()),
+                    host_port: nb.get("hostPort").and_then(|v| v.as_i64()),
+                    protocol: nb
+                        .get("protocol")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                })
+                .collect();
+            types::EcsTaskMetadataContainer {
+                name: c.name.clone(),
+                image: c.image.clone(),
+                image_id: c.image_digest.clone(),
+                ports,
+                labels: std::collections::BTreeMap::new(),
+                desired_status: c.last_status.clone(),
+                known_status: c.last_status.clone(),
+                limits: types::EcsTaskMetadataLimits {
+                    cpu: c.cpu.as_ref().and_then(|v| v.parse::<f64>().ok()),
+                    memory: c.memory.as_ref().and_then(|v| v.parse::<i64>().ok()),
+                },
+                created_at: Some(task.created_at.to_rfc3339()),
+                started_at: task.started_at.map(|d| d.to_rfc3339()),
+                exit_code: c.exit_code,
+            }
+        })
+        .collect();
+
+    types::EcsTaskMetadataResponse {
+        task: types::EcsTaskMetadata {
+            cluster: task.cluster_name.clone(),
+            task_arn: task.task_arn.clone(),
+            family: task.family.clone(),
+            revision: task.revision,
+            desired_status: task.desired_status.clone(),
+            known_status: task.last_status.clone(),
+            containers,
+            pull_started_at: task.pull_started_at.map(|d| d.to_rfc3339()),
+            pull_stopped_at: task.pull_stopped_at.map(|d| d.to_rfc3339()),
+            availability_zone: "us-east-1a".into(),
+            launch_type: task.launch_type.clone(),
+            vpc_id,
+            eni_id,
+        },
+    }
+}
+
 pub(crate) fn ecs_lifecycle_event(
     event: &fakecloud_ecs::LifecycleEvent,
 ) -> types::EcsLifecycleEvent {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -28,8 +28,8 @@ use cli::Cli;
 use dynamodb_streams_lambda_poller::DynamoDbStreamsLambdaPoller;
 use introspection::{
     athena_named_query_response, ecr_image_response, ecr_pull_through_rule_response,
-    ecr_repository_response, ecs_cluster_response, ecs_lifecycle_event, ecs_task_response,
-    elasticache_acls_response, elasticache_cluster_response,
+    ecr_repository_response, ecs_cluster_response, ecs_lifecycle_event, ecs_task_metadata_response,
+    ecs_task_response, elasticache_acls_response, elasticache_cluster_response,
     elasticache_replication_group_response, elasticache_serverless_cache_response,
     elbv2_listener_response, elbv2_load_balancer_response, elbv2_rule_response,
     elbv2_target_group_response, rds_instance_response,
@@ -5660,6 +5660,41 @@ async fn main() {
                                     axum::http::StatusCode::OK,
                                     axum::Json(serde_json::to_value(ecs_task_response(t)).unwrap()),
                                 );
+                            }
+                        }
+                        (
+                            axum::http::StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "task not found"})),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            // ECS task-metadata introspection (v4 dump). Looks up a task by
+            // its full ARN (URL-encoded) and returns the aggregated shape a
+            // container would see at `ECS_CONTAINER_METADATA_URI_V4`. Unlike
+            // `/_fakecloud/ecs/v4/{task_id}` (which is what the container
+            // itself hits), this is keyed by ARN for assertion-friendly use
+            // from tests holding the RunTask response.
+            "/_fakecloud/ecs/metadata/{task_arn}",
+            axum::routing::get({
+                let ec = ecs_introspection_state.clone();
+                move |axum::extract::Path(task_arn): axum::extract::Path<String>| {
+                    let ec = ec.clone();
+                    async move {
+                        let accounts = ec.read();
+                        for (_, state) in accounts.iter() {
+                            for t in state.tasks.values() {
+                                if t.task_arn == task_arn {
+                                    return (
+                                        axum::http::StatusCode::OK,
+                                        axum::Json(
+                                            serde_json::to_value(ecs_task_metadata_response(t))
+                                                .unwrap(),
+                                        ),
+                                    );
+                                }
                             }
                         }
                         (

--- a/sdks/go/ecs.go
+++ b/sdks/go/ecs.go
@@ -89,3 +89,15 @@ func (c *ECSClient) GetEvents(ctx context.Context) (*EcsEventsResponse, error) {
 	}
 	return &out, nil
 }
+
+// GetTaskMetadata returns the aggregated v4 metadata dump (the same shape
+// `ECS_CONTAINER_METADATA_URI_V4` exposes to a container) for the task with
+// the given full ARN. The ARN is URL-encoded before insertion into the path.
+func (c *ECSClient) GetTaskMetadata(ctx context.Context, taskArn string) (*EcsTaskMetadataResponse, error) {
+	var out EcsTaskMetadataResponse
+	path := fmt.Sprintf("/_fakecloud/ecs/metadata/%s", url.PathEscape(taskArn))
+	if err := c.fc.doGet(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1078,6 +1078,57 @@ type EcsEventsResponse struct {
 	Events []EcsLifecycleEvent `json:"events"`
 }
 
+// EcsTaskMetadataLimits mirrors the `Limits` block of the ECS
+// container-metadata v4 response.
+type EcsTaskMetadataLimits struct {
+	CPU    *float64 `json:"cpu,omitempty"`
+	Memory *int64   `json:"memory,omitempty"`
+}
+
+// EcsTaskMetadataPort is one entry in a container's published port list.
+type EcsTaskMetadataPort struct {
+	ContainerPort *int64  `json:"containerPort,omitempty"`
+	HostPort      *int64  `json:"hostPort,omitempty"`
+	Protocol      *string `json:"protocol,omitempty"`
+}
+
+// EcsTaskMetadataContainer is one container inside a task-metadata dump.
+type EcsTaskMetadataContainer struct {
+	Name          string                `json:"name"`
+	Image         string                `json:"image"`
+	ImageID       *string               `json:"imageId,omitempty"`
+	Ports         []EcsTaskMetadataPort `json:"ports"`
+	Labels        map[string]string     `json:"labels"`
+	DesiredStatus string                `json:"desiredStatus"`
+	KnownStatus   string                `json:"knownStatus"`
+	Limits        EcsTaskMetadataLimits `json:"limits"`
+	CreatedAt     *string               `json:"createdAt,omitempty"`
+	StartedAt     *string               `json:"startedAt,omitempty"`
+	ExitCode      *int64                `json:"exitCode,omitempty"`
+}
+
+// EcsTaskMetadata is the v4 metadata-URI aggregate for one task.
+type EcsTaskMetadata struct {
+	Cluster          string                     `json:"cluster"`
+	TaskArn          string                     `json:"taskArn"`
+	Family           string                     `json:"family"`
+	Revision         int32                      `json:"revision"`
+	DesiredStatus    string                     `json:"desiredStatus"`
+	KnownStatus      string                     `json:"knownStatus"`
+	Containers       []EcsTaskMetadataContainer `json:"containers"`
+	PullStartedAt    *string                    `json:"pullStartedAt,omitempty"`
+	PullStoppedAt    *string                    `json:"pullStoppedAt,omitempty"`
+	AvailabilityZone string                     `json:"availabilityZone"`
+	LaunchType       string                     `json:"launchType"`
+	VpcID            *string                    `json:"vpcId,omitempty"`
+	EniID            *string                    `json:"eniId,omitempty"`
+}
+
+// EcsTaskMetadataResponse wraps a single task's metadata dump.
+type EcsTaskMetadataResponse struct {
+	Task EcsTaskMetadata `json:"task"`
+}
+
 // ── ELBv2 ──────────────────────────────────────────────────────────
 
 type Elbv2Tag struct {

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -31,6 +31,7 @@ import dev.fakecloud.Types.EcrPullThroughRulesResponse;
 import dev.fakecloud.Types.EcrRepositoriesResponse;
 import dev.fakecloud.Types.EcsClustersResponse;
 import dev.fakecloud.Types.EcsEventsResponse;
+import dev.fakecloud.Types.EcsTaskMetadataResponse;
 import dev.fakecloud.Types.EcsMarkFailedRequest;
 import dev.fakecloud.Types.EcsTask;
 import dev.fakecloud.Types.EcsTaskLogsResponse;
@@ -822,6 +823,18 @@ public final class FakeCloud {
         /** Replay the lifecycle event log. */
         public EcsEventsResponse getEvents() {
             return http.get("/_fakecloud/ecs/events", EcsEventsResponse.class);
+        }
+
+        /**
+         * Return the aggregated v4 metadata dump (the same shape
+         * {@code ECS_CONTAINER_METADATA_URI_V4} exposes to a container) for
+         * the task with the given full ARN. The ARN is URL-encoded into the
+         * path before the request is issued.
+         */
+        public EcsTaskMetadataResponse getTaskMetadata(String taskArn) {
+            return http.get(
+                    "/_fakecloud/ecs/metadata/" + encodePath(taskArn),
+                    EcsTaskMetadataResponse.class);
         }
     }
 

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -880,6 +880,45 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record EcsEventsResponse(List<EcsLifecycleEvent> events) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskMetadataLimits(Double cpu, Long memory) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskMetadataPort(Long containerPort, Long hostPort, String protocol) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskMetadataContainer(
+            String name,
+            String image,
+            String imageId,
+            List<EcsTaskMetadataPort> ports,
+            java.util.Map<String, String> labels,
+            String desiredStatus,
+            String knownStatus,
+            EcsTaskMetadataLimits limits,
+            String createdAt,
+            String startedAt,
+            Long exitCode) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskMetadata(
+            String cluster,
+            String taskArn,
+            String family,
+            Integer revision,
+            String desiredStatus,
+            String knownStatus,
+            List<EcsTaskMetadataContainer> containers,
+            String pullStartedAt,
+            String pullStoppedAt,
+            String availabilityZone,
+            String launchType,
+            String vpcId,
+            String eniId) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EcsTaskMetadataResponse(EcsTaskMetadata task) {}
+
     // ── ELBv2 ─────────────────────────────────────────────────────
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -866,6 +866,21 @@ final class EcsClient
             $this->http->get('/_fakecloud/ecs/events')
         );
     }
+
+    /**
+     * Return the aggregated v4 metadata dump (the same shape
+     * `ECS_CONTAINER_METADATA_URI_V4` exposes to a container) for the
+     * task with the given full ARN. The ARN is URL-encoded into the
+     * path before the request is issued.
+     */
+    public function getTaskMetadata(string $taskArn): EcsTaskMetadataResponse
+    {
+        return EcsTaskMetadataResponse::fromArray(
+            $this->http->get(
+                '/_fakecloud/ecs/metadata/' . HttpTransport::encodePath($taskArn)
+            )
+        );
+    }
 }
 
 final class Elbv2Client

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -2614,6 +2614,125 @@ final class EcsEventsResponse
     }
 }
 
+final class EcsTaskMetadataLimits
+{
+    public function __construct(
+        public readonly ?float $cpu,
+        public readonly ?int $memory,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            isset($data['cpu']) ? (float) $data['cpu'] : null,
+            isset($data['memory']) ? (int) $data['memory'] : null,
+        );
+    }
+}
+
+final class EcsTaskMetadataPort
+{
+    public function __construct(
+        public readonly ?int $containerPort,
+        public readonly ?int $hostPort,
+        public readonly ?string $protocol,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            isset($data['containerPort']) ? (int) $data['containerPort'] : null,
+            isset($data['hostPort']) ? (int) $data['hostPort'] : null,
+            $data['protocol'] ?? null,
+        );
+    }
+}
+
+final class EcsTaskMetadataContainer
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $image,
+        public readonly ?string $imageId,
+        /** @var EcsTaskMetadataPort[] */
+        public readonly array $ports,
+        /** @var array<string, string> */
+        public readonly array $labels,
+        public readonly string $desiredStatus,
+        public readonly string $knownStatus,
+        public readonly EcsTaskMetadataLimits $limits,
+        public readonly ?string $createdAt,
+        public readonly ?string $startedAt,
+        public readonly ?int $exitCode,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['name'],
+            $data['image'],
+            $data['imageId'] ?? null,
+            array_map(EcsTaskMetadataPort::fromArray(...), $data['ports'] ?? []),
+            $data['labels'] ?? [],
+            $data['desiredStatus'],
+            $data['knownStatus'],
+            EcsTaskMetadataLimits::fromArray($data['limits'] ?? []),
+            $data['createdAt'] ?? null,
+            $data['startedAt'] ?? null,
+            isset($data['exitCode']) ? (int) $data['exitCode'] : null,
+        );
+    }
+}
+
+final class EcsTaskMetadata
+{
+    public function __construct(
+        public readonly string $cluster,
+        public readonly string $taskArn,
+        public readonly string $family,
+        public readonly int $revision,
+        public readonly string $desiredStatus,
+        public readonly string $knownStatus,
+        /** @var EcsTaskMetadataContainer[] */
+        public readonly array $containers,
+        public readonly ?string $pullStartedAt,
+        public readonly ?string $pullStoppedAt,
+        public readonly string $availabilityZone,
+        public readonly string $launchType,
+        public readonly ?string $vpcId,
+        public readonly ?string $eniId,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['cluster'],
+            $data['taskArn'],
+            $data['family'],
+            (int) $data['revision'],
+            $data['desiredStatus'],
+            $data['knownStatus'],
+            array_map(EcsTaskMetadataContainer::fromArray(...), $data['containers'] ?? []),
+            $data['pullStartedAt'] ?? null,
+            $data['pullStoppedAt'] ?? null,
+            $data['availabilityZone'],
+            $data['launchType'],
+            $data['vpcId'] ?? null,
+            $data['eniId'] ?? null,
+        );
+    }
+}
+
+final class EcsTaskMetadataResponse
+{
+    public function __construct(public readonly EcsTaskMetadata $task) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(EcsTaskMetadata::fromArray($data['task']));
+    }
+}
+
 // ── ELBv2 ──────────────────────────────────────────────────────
 
 final class Elbv2Tag

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Optional, cast
+from urllib.parse import quote as _urlquote
 
 import httpx
 
@@ -37,6 +38,7 @@ from fakecloud.types import (
     EcsMarkFailedRequest,
     EcsTask,
     EcsTaskLogsResponse,
+    EcsTaskMetadataResponse,
     EcsTasksResponse,
     ElastiCacheAclsResponse,
     ElastiCacheClustersResponse,
@@ -303,6 +305,15 @@ class EcsClient:
         _check(resp)
         return EcsEventsResponse.from_dict(resp.json())
 
+    async def get_task_metadata(self, task_arn: str) -> EcsTaskMetadataResponse:
+        """Return the v4 metadata-URI dump for the task with the given ARN."""
+        encoded = _urlquote(task_arn, safe="")
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/ecs/metadata/{encoded}"
+        )
+        _check(resp)
+        return EcsTaskMetadataResponse.from_dict(resp.json())
+
 
 class _SyncEcsClient:
     """Sync ECS introspection client."""
@@ -359,6 +370,13 @@ class _SyncEcsClient:
         resp = self._client.get(f"{self._base}/_fakecloud/ecs/events")
         _check(resp)
         return EcsEventsResponse.from_dict(resp.json())
+
+    def get_task_metadata(self, task_arn: str) -> EcsTaskMetadataResponse:
+        """Return the v4 metadata-URI dump for the task with the given ARN."""
+        encoded = _urlquote(task_arn, safe="")
+        resp = self._client.get(f"{self._base}/_fakecloud/ecs/metadata/{encoded}")
+        _check(resp)
+        return EcsTaskMetadataResponse.from_dict(resp.json())
 
 
 class Elbv2Client:

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -308,9 +308,7 @@ class EcsClient:
     async def get_task_metadata(self, task_arn: str) -> EcsTaskMetadataResponse:
         """Return the v4 metadata-URI dump for the task with the given ARN."""
         encoded = _urlquote(task_arn, safe="")
-        resp = await self._client.get(
-            f"{self._base}/_fakecloud/ecs/metadata/{encoded}"
-        )
+        resp = await self._client.get(f"{self._base}/_fakecloud/ecs/metadata/{encoded}")
         _check(resp)
         return EcsTaskMetadataResponse.from_dict(resp.json())
 

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -2201,6 +2201,106 @@ class EcsEventsResponse:
         )
 
 
+@dataclass
+class EcsTaskMetadataLimits:
+    cpu: Optional[float] = None
+    memory: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskMetadataLimits:
+        return cls(cpu=data.get("cpu"), memory=data.get("memory"))
+
+
+@dataclass
+class EcsTaskMetadataPort:
+    container_port: Optional[int] = None
+    host_port: Optional[int] = None
+    protocol: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskMetadataPort:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
+class EcsTaskMetadataContainer:
+    name: str
+    image: str
+    desired_status: str
+    known_status: str
+    ports: List[EcsTaskMetadataPort]
+    labels: Dict[str, str]
+    limits: EcsTaskMetadataLimits
+    image_id: Optional[str] = None
+    created_at: Optional[str] = None
+    started_at: Optional[str] = None
+    exit_code: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskMetadataContainer:
+        return cls(
+            name=data["name"],
+            image=data["image"],
+            image_id=data.get("imageId"),
+            ports=[EcsTaskMetadataPort.from_dict(p) for p in data.get("ports", [])],
+            labels=data.get("labels", {}) or {},
+            desired_status=data["desiredStatus"],
+            known_status=data["knownStatus"],
+            limits=EcsTaskMetadataLimits.from_dict(data.get("limits", {}) or {}),
+            created_at=data.get("createdAt"),
+            started_at=data.get("startedAt"),
+            exit_code=data.get("exitCode"),
+        )
+
+
+@dataclass
+class EcsTaskMetadata:
+    cluster: str
+    task_arn: str
+    family: str
+    revision: int
+    desired_status: str
+    known_status: str
+    containers: List[EcsTaskMetadataContainer]
+    availability_zone: str
+    launch_type: str
+    pull_started_at: Optional[str] = None
+    pull_stopped_at: Optional[str] = None
+    vpc_id: Optional[str] = None
+    eni_id: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskMetadata:
+        return cls(
+            cluster=data["cluster"],
+            task_arn=data["taskArn"],
+            family=data["family"],
+            revision=data["revision"],
+            desired_status=data["desiredStatus"],
+            known_status=data["knownStatus"],
+            containers=[
+                EcsTaskMetadataContainer.from_dict(c)
+                for c in data.get("containers", [])
+            ],
+            pull_started_at=data.get("pullStartedAt"),
+            pull_stopped_at=data.get("pullStoppedAt"),
+            availability_zone=data["availabilityZone"],
+            launch_type=data["launchType"],
+            vpc_id=data.get("vpcId"),
+            eni_id=data.get("eniId"),
+        )
+
+
+@dataclass
+class EcsTaskMetadataResponse:
+    task: EcsTaskMetadata
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EcsTaskMetadataResponse:
+        return cls(task=EcsTaskMetadata.from_dict(data["task"]))
+
+
 # ── ELBv2 ───────────────────────────────────────────────────────────
 
 

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -85,6 +85,7 @@ import type {
   EcsTaskLogsResponse,
   EcsMarkFailedRequest,
   EcsEventsResponse,
+  EcsTaskMetadataResponse,
   Elbv2LoadBalancersResponse,
   Elbv2TargetGroupsResponse,
   Elbv2ListenersResponse,
@@ -1049,6 +1050,18 @@ export class EcsClient {
   /** Replay the lifecycle event log. */
   async getEvents(): Promise<EcsEventsResponse> {
     const resp = await fetch(`${this.baseUrl}/_fakecloud/ecs/events`);
+    return parse(resp);
+  }
+
+  /**
+   * Return the aggregated v4 metadata dump (the same shape
+   * `ECS_CONTAINER_METADATA_URI_V4` exposes to a container) for the task
+   * with the given full ARN. The ARN is URL-encoded into the path.
+   */
+  async getTaskMetadata(taskArn: string): Promise<EcsTaskMetadataResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/ecs/metadata/${encodeURIComponent(taskArn)}`,
+    );
     return parse(resp);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -1002,6 +1002,51 @@ export interface EcsEventsResponse {
   events: EcsLifecycleEvent[];
 }
 
+export interface EcsTaskMetadataLimits {
+  cpu?: number;
+  memory?: number;
+}
+
+export interface EcsTaskMetadataPort {
+  containerPort?: number;
+  hostPort?: number;
+  protocol?: string;
+}
+
+export interface EcsTaskMetadataContainer {
+  name: string;
+  image: string;
+  imageId?: string;
+  ports: EcsTaskMetadataPort[];
+  labels: Record<string, string>;
+  desiredStatus: string;
+  knownStatus: string;
+  limits: EcsTaskMetadataLimits;
+  createdAt?: string;
+  startedAt?: string;
+  exitCode?: number;
+}
+
+export interface EcsTaskMetadata {
+  cluster: string;
+  taskArn: string;
+  family: string;
+  revision: number;
+  desiredStatus: string;
+  knownStatus: string;
+  containers: EcsTaskMetadataContainer[];
+  pullStartedAt?: string;
+  pullStoppedAt?: string;
+  availabilityZone: string;
+  launchType: string;
+  vpcId?: string;
+  eniId?: string;
+}
+
+export interface EcsTaskMetadataResponse {
+  task: EcsTaskMetadata;
+}
+
 // ── ELBv2 ───────────────────────────────────────────────────────────
 
 export interface Elbv2Tag {

--- a/website/content/docs/reference/introspection.md
+++ b/website/content/docs/reference/introspection.md
@@ -133,6 +133,7 @@ curl http://localhost:4566/_fakecloud/health
 | `/_fakecloud/ecs/creds/{task_id}` | GET | Task IAM credentials (used by the ECS Exec data plane). |
 | `/_fakecloud/ecs/v3/{task_id}` | GET | **NEW** -- ECS metadata v3 endpoint exposed to task containers. |
 | `/_fakecloud/ecs/v4/{task_id}` | GET | **NEW** -- ECS metadata v4 endpoint exposed to task containers. |
+| `/_fakecloud/ecs/metadata/{task_arn}` | GET | Aggregated v4 metadata dump keyed by full task ARN (URL-encoded). Same shape as `ECS_CONTAINER_METADATA_URI_V4`, addressable from tests holding a RunTask response. |
 
 ## ElastiCache
 

--- a/website/content/docs/services/ecs.md
+++ b/website/content/docs/services/ecs.md
@@ -172,6 +172,46 @@ Endpoints bypass the public AWS API so tests can assert deterministic state with
 | `/_fakecloud/ecs/tasks/{taskId}/force-stop` | POST | SIGTERM + SIGKILL the running container |
 | `/_fakecloud/ecs/tasks/{taskId}/mark-failed` | POST | Flip to STOPPED without killing the container (inject exit code + reason) |
 | `/_fakecloud/ecs/events` | GET | Replay the lifecycle event log |
+| `/_fakecloud/ecs/metadata/{taskArn}` | GET | Aggregated v4 metadata dump keyed by full task ARN (URL-encode it) |
+
+### Task metadata by ARN
+
+`GET /_fakecloud/ecs/metadata/{taskArn}` returns the same shape a container would see at `ECS_CONTAINER_METADATA_URI_V4`, but addressable from outside the container by full task ARN -- handy when a test holds the `RunTask` response and wants to assert what the in-container SDK metadata loader would observe.
+
+The path segment must be URL-encoded (`arn:aws:ecs:us-east-1:000000000000:task/cluster/<id>` -> `arn%3Aaws%3Aecs%3Aus-east-1%3A000000000000%3Atask%2Fcluster%2F<id>`). SDK helpers (`getEcsTaskMetadata` / `get_task_metadata`) handle the encoding for you.
+
+```json
+{
+  "task": {
+    "cluster": "prod",
+    "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/prod/abc123",
+    "family": "web",
+    "revision": 4,
+    "desiredStatus": "RUNNING",
+    "knownStatus": "RUNNING",
+    "containers": [
+      {
+        "name": "app",
+        "image": "nginx:1.27",
+        "imageId": "sha256:...",
+        "ports": [{"containerPort": 8080, "hostPort": 32768, "protocol": "tcp"}],
+        "labels": {},
+        "desiredStatus": "RUNNING",
+        "knownStatus": "RUNNING",
+        "limits": {"cpu": 0.25, "memory": 512},
+        "createdAt": "2026-05-11T10:00:00Z",
+        "startedAt": "2026-05-11T10:00:02Z"
+      }
+    ],
+    "pullStartedAt": "2026-05-11T10:00:00Z",
+    "pullStoppedAt": "2026-05-11T10:00:01Z",
+    "availabilityZone": "us-east-1a",
+    "launchType": "FARGATE",
+    "vpcId": "vpc-fakecloud",
+    "eniId": "eni-..."
+  }
+}
+```
 
 All endpoints are sorted deterministically (by ARN for clusters/tasks, by timestamp for events) so test assertions don't flake on map iteration order.
 


### PR DESCRIPTION
## Summary

Adds introspection endpoints per /Users/lucas/.claude/plans/introspection-endpoints-2026-05-11.md.

## Test plan

- [ ] CI green
- [ ] Cubic review clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ECS introspection endpoint `/_fakecloud/ecs/metadata/{task_arn}` to return aggregated v4 task metadata by full task ARN, with typed SDK helpers. Lets tests assert container metadata directly from a RunTask response (I11).

- **New Features**
  - New GET `/_fakecloud/ecs/metadata/{task_arn}` returns the same shape as `ECS_CONTAINER_METADATA_URI_V4`; ARN must be URL-encoded; 404 if task not found (SDK helpers handle encoding).
  - Server aggregates metadata from task state: containers, ports, limits, timestamps, launch type, AZ, pullStartedAt/pullStoppedAt, ENI/VPC IDs.
  - SDKs (TypeScript, Python async/sync, Go, Java, PHP): `getTaskMetadata`/`get_task_metadata` plus new metadata types; helpers URL-encode the ARN.
  - Added e2e tests for ARN lookup and 404; updated reference and ECS docs with usage and example response.

<sup>Written for commit e0a5ad8f5512eb14fcf76f262b2918f3697a9f94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

