### PR TITLE
release(v0.14.0): bump workspace + SDK versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,16 +186,21 @@ jobs:
           publish fakecloud-application-autoscaling  # depends on aws + core
           publish fakecloud-wafv2          # depends on aws + core
           publish fakecloud-athena         # depends on aws + core
+          publish fakecloud-cloudwatch     # depends on aws + core
+          publish fakecloud-glue           # depends on aws + core
+          publish fakecloud-bedrock-agent  # depends on core only
 
           # Layer 4: depend on layer 3 crates
           publish fakecloud-s3             # depends on kms
           publish fakecloud-ecr            # depends on kms
           publish fakecloud-ssm            # depends on secretsmanager
           publish fakecloud-eventbridge    # depends on lambda, logs
+          publish fakecloud-bedrock-agent-runtime  # depends on bedrock-agent + core
 
           # Layer 5: depends on layer 4
           publish fakecloud-dynamodb       # depends on s3
           publish fakecloud-ecs            # depends on logs, secretsmanager, ssm
+          publish fakecloud-firehose       # depends on aws + core + s3
 
           # Layer 6: depends on layer 5
           publish fakecloud-stepfunctions  # depends on dynamodb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,164 +101,164 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.13.3"
+version = "0.14.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.13.3"
+version = "0.14.0"

--- a/crates/fakecloud-bedrock-agent-runtime/Cargo.toml
+++ b/crates/fakecloud-bedrock-agent-runtime/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.13.3"
-edition = "2021"
+description = "Bedrock Agent Runtime implementation for FakeCloud"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
@@ -15,8 +19,8 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
-fakecloud-bedrock-agent = { path = "../fakecloud-bedrock-agent" }
-fakecloud-core = { path = "../fakecloud-core" }
+fakecloud-bedrock-agent = { workspace = true }
+fakecloud-core = { workspace = true }
 
 [dev-dependencies]
 fakecloud-testkit = { path = "../fakecloud-testkit" }

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.13.3"
+version = "0.14.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.13.3"
+version = "0.14.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.13.3 -> 0.14.0 across the workspace and language SDKs (TS / Python / Java). Tag will be cut after merge to trigger the release workflow.

This minor bump captures everything merged since v0.13.3, dominated by the introspection-endpoints batch across SES, Cognito, S3, Step Functions, Bedrock Agent, Glue, Athena, ElastiCache, Logs, Organizations, ECS, plus the cross-service guide refresh and accumulated lint/test fixes.

### Release workflow changes

Added previously-missing publishable crates to `.github/workflows/release.yml` so they ship to crates.io alongside the rest:

- Layer 3: `fakecloud-cloudwatch`, `fakecloud-glue`, `fakecloud-bedrock-agent`
- Layer 4: `fakecloud-bedrock-agent-runtime`
- Layer 5: `fakecloud-firehose`

Also normalized `fakecloud-bedrock-agent-runtime/Cargo.toml` to use `workspace` package fields + `workspace = true` internal deps (was hardcoded `version`/`edition` + `path` deps, which would have failed `cargo publish`).

## Test plan

- [x] cargo build green on bedrock-agent-runtime after workspace conversion
- [x] cargo update -w to sync lockfile (all crates 0.13.3 -> 0.14.0)
- [ ] CI green on this PR
- [ ] After merge, tag v0.14.0 to trigger release workflow (binaries, crates.io, npm, PyPI, Maven Central, Packagist, Go module tag)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped all workspace crates and SDKs to 0.14.0 to ship recent changes, including new introspection endpoints across key services. Updated the release workflow to publish missing crates and made `fakecloud-bedrock-agent-runtime` publishable.

- **Dependencies**
  - Set all workspace crate versions to 0.14.0.
  - Bumped SDKs to 0.14.0 for TypeScript, Python, and Java.

- **Release workflow**
  - Added publish steps for `fakecloud-cloudwatch`, `fakecloud-glue`, `fakecloud-bedrock-agent`, `fakecloud-bedrock-agent-runtime`, and `fakecloud-firehose`.
  - Converted `fakecloud-bedrock-agent-runtime` to workspace package fields and workspace deps for crates.io publishing.

<sup>Written for commit 6c7cd37406ad21b416a581d74ecaae2666bd17c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

