### PR TITLE
fix(ci/release): correct crates publish topological order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,46 +161,48 @@ jobs:
           # Layer 2: depends on fakecloud-aws
           publish fakecloud-core
 
-          # Layer 3: depend on aws + core only
+          # Layer 3a: depend on aws + core + persistence only
           publish fakecloud-sqs
-          publish fakecloud-sns
           publish fakecloud-iam
-          publish fakecloud-organizations  # depends on core only
+          publish fakecloud-organizations
           publish fakecloud-lambda
-          publish fakecloud-secretsmanager
           publish fakecloud-logs
           publish fakecloud-kms
           publish fakecloud-ses
-          publish fakecloud-cognito
           publish fakecloud-rds
           publish fakecloud-elasticache
           publish fakecloud-kinesis
-          publish fakecloud-scheduler      # depends on aws + core + persistence
-          publish fakecloud-apigatewayv2   # depends on core only
-          publish fakecloud-apigateway     # depends on core + persistence
-          publish fakecloud-bedrock        # depends on aws + core
-          publish fakecloud-elbv2          # depends on aws + core + persistence
-          publish fakecloud-cloudfront     # depends on aws + core + persistence
-          publish fakecloud-route53        # depends on aws + core + persistence
-          publish fakecloud-acm            # depends on aws + core
-          publish fakecloud-application-autoscaling  # depends on aws + core
-          publish fakecloud-wafv2          # depends on aws + core
-          publish fakecloud-athena         # depends on aws + core
-          publish fakecloud-cloudwatch     # depends on aws + core
-          publish fakecloud-glue           # depends on aws + core
-          publish fakecloud-bedrock-agent  # depends on core only
+          publish fakecloud-scheduler
+          publish fakecloud-bedrock
+          publish fakecloud-cloudfront
+          publish fakecloud-acm
+          publish fakecloud-application-autoscaling
+          publish fakecloud-wafv2
+          publish fakecloud-cloudwatch
+          publish fakecloud-glue
+          publish fakecloud-bedrock-agent
 
-          # Layer 4: depend on layer 3 crates
+          # Layer 3b: depend on layer 3a
+          publish fakecloud-sns            # depends on ses
+          publish fakecloud-secretsmanager # depends on iam
+          publish fakecloud-cognito        # depends on iam
+          publish fakecloud-elbv2          # depends on wafv2
+          publish fakecloud-apigatewayv2   # depends on wafv2
+          publish fakecloud-bedrock-agent-runtime  # depends on bedrock-agent
+          publish fakecloud-eventbridge    # depends on iam, lambda, logs
+
+          # Layer 4: depend on layer 3a/3b crates
           publish fakecloud-s3             # depends on kms
-          publish fakecloud-ecr            # depends on kms
+          publish fakecloud-ecr            # depends on iam, kms
           publish fakecloud-ssm            # depends on secretsmanager
-          publish fakecloud-eventbridge    # depends on lambda, logs
-          publish fakecloud-bedrock-agent-runtime  # depends on bedrock-agent + core
+          publish fakecloud-apigateway     # depends on elbv2, wafv2
 
-          # Layer 5: depends on layer 4
+          # Layer 5: depend on layer 4
           publish fakecloud-dynamodb       # depends on s3
+          publish fakecloud-firehose       # depends on s3
+          publish fakecloud-athena         # depends on glue, s3
+          publish fakecloud-route53        # depends on cloudfront, elbv2, logs, s3
           publish fakecloud-ecs            # depends on logs, secretsmanager, ssm
-          publish fakecloud-firehose       # depends on aws + core + s3
 
           # Layer 6: depends on layer 5
           publish fakecloud-stepfunctions  # depends on dynamodb


### PR DESCRIPTION
## Summary

v0.14.0 release crashed on `Publish Crates` step with:

```
ERROR publishing fakecloud-sns:
error: failed to prepare local package for uploading
Caused by:
  failed to select a version for the requirement `fakecloud-ses = "^0.14.0"`
  candidate versions found which didn't match: 0.13.3, 0.13.2, 0.13.1, ...
```

The workflow was publishing several crates before their dependencies:

- `sns` -> `ses`
- `elbv2` -> `wafv2`
- `apigatewayv2` -> `wafv2`
- `apigateway` -> `elbv2`
- `ssm` -> `secretsmanager`
- `athena` -> `s3`, `glue`
- `route53` -> `s3`, `elbv2`, `cloudfront`, `logs`
- `bedrock-agent-runtime` -> `bedrock-agent`

These bugs were latent in previous releases because prior versions of each crate already on crates.io satisfied the version requirement during dependency resolution. The fresh 0.14.0 bump broke this: `^0.14.0` cannot resolve against published 0.13.x.

Reorganized into strict layers 3a -> 3b -> 4 -> 5 -> ... so every dep is published before its dependents.

After merge: force-move the `v0.14.0` tag to the merge commit, push it, and the release workflow re-runs. Already-published crates skip via existing 'already uploaded' branch. SDK/binary/GH-release jobs handle re-runs idempotently.

## Test plan

- [x] No code changes, workflow file only
- [ ] CI green
- [ ] Force-move v0.14.0 tag and verify publish-crates job succeeds end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the release workflow to publish crates in the correct dependency order, unblocking the v0.14.0 release. This prevents cargo publish failures when a crate’s required deps aren’t yet on crates.io.

- **Bug Fixes**
  - Reordered publish steps into strict layers: `3a` -> `3b` -> `4` -> `5` -> `6`.
  - Key fixes: `fakecloud-sns` after `fakecloud-ses`; `fakecloud-elbv2`/`fakecloud-apigatewayv2` after `fakecloud-wafv2`; `fakecloud-apigateway` after `fakecloud-elbv2`; `fakecloud-ssm` after `fakecloud-secretsmanager`; `fakecloud-athena` after `fakecloud-s3` + `fakecloud-glue`; `fakecloud-route53` after `fakecloud-s3` + `fakecloud-elbv2` + `fakecloud-cloudfront` + `fakecloud-logs`; `fakecloud-bedrock-agent-runtime` after `fakecloud-bedrock-agent`; `fakecloud-ecr` after `fakecloud-iam` + `fakecloud-kms`; `fakecloud-eventbridge` after `fakecloud-iam` + `fakecloud-lambda` + `fakecloud-logs`.

- **Migration**
  - After merge: move the `v0.14.0` tag to this commit and push to re-run the release.
  - Already-published crates will be skipped; SDK/binary/GitHub release steps remain idempotent.

<sup>Written for commit d0db714adbf95f69ae4e61ca44359250febcc7ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

