### PR TITLE
fix(conformance): compact CI summary, single-pass JSON

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -80,25 +80,20 @@ jobs:
         id: check
         run: |
           set -o pipefail
-          cargo run -p fakecloud-conformance -- check 2>&1 | tee conformance-report.txt
+          cargo run -p fakecloud-conformance -- check \
+            --json-out conformance-report.json \
+            --markdown-summary-out conformance-summary.md \
+            2>&1 | tee conformance-report.txt
 
       - name: Audit handwritten tests (fails if implemented action lacks a test)
         if: always() && steps.check.outcome != 'skipped'
         run: cargo run -p fakecloud-conformance -- audit
 
-      - name: Generate JSON report
-        if: always()
-        run: cargo run -p fakecloud-conformance -- run --format json > conformance-report.json 2>/dev/null || true
-
       - name: Post summary
         if: always()
         run: |
-          echo '## Conformance Report' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          if [ -f conformance-report.txt ]; then
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            grep -E "^(Conformance|  |Operations|Variants)" conformance-report.txt >> $GITHUB_STEP_SUMMARY || true
-            echo '```' >> $GITHUB_STEP_SUMMARY
+          if [ -f conformance-summary.md ]; then
+            cat conformance-summary.md >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload report
@@ -109,4 +104,5 @@ jobs:
           path: |
             conformance-report.txt
             conformance-report.json
+            conformance-summary.md
           retention-days: 90

--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -63,6 +63,12 @@ enum CliCommand {
         /// Connect to an already-running fakecloud at this endpoint
         #[arg(long)]
         endpoint: Option<String>,
+        /// Also write the full JSON report to this path
+        #[arg(long)]
+        json_out: Option<PathBuf>,
+        /// Also write a compact markdown summary (suitable for $GITHUB_STEP_SUMMARY) to this path
+        #[arg(long)]
+        markdown_summary_out: Option<PathBuf>,
     },
     /// Update the baseline file with current conformance results
     UpdateBaseline {
@@ -95,7 +101,18 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        CliCommand::Check { baseline, endpoint } => cmd_check(&cli.models_dir, &baseline, endpoint),
+        CliCommand::Check {
+            baseline,
+            endpoint,
+            json_out,
+            markdown_summary_out,
+        } => cmd_check(
+            &cli.models_dir,
+            &baseline,
+            endpoint,
+            json_out.as_deref(),
+            markdown_summary_out.as_deref(),
+        ),
         CliCommand::UpdateBaseline { baseline, endpoint } => {
             cmd_update_baseline(&cli.models_dir, &baseline, endpoint)
         }
@@ -436,6 +453,8 @@ fn cmd_check(
     models_dir: &std::path::Path,
     baseline_path: &std::path::Path,
     endpoint: Option<String>,
+    json_out: Option<&std::path::Path>,
+    markdown_summary_out: Option<&std::path::Path>,
 ) {
     let baseline_content = std::fs::read_to_string(baseline_path).unwrap_or_else(|e| {
         eprintln!("Failed to read baseline {}: {}", baseline_path.display(), e);
@@ -449,6 +468,13 @@ fn cmd_check(
     let report_data = run_probes(models_dir, None, endpoint);
 
     report::print_text_report(&report_data);
+
+    if let Some(path) = json_out {
+        let json = serde_json::to_string_pretty(&report_data).unwrap();
+        if let Err(e) = std::fs::write(path, format!("{}\n", json)) {
+            eprintln!("Failed to write JSON report {}: {}", path.display(), e);
+        }
+    }
 
     // Check per-service ratchet
     let mut regressions = Vec::new();
@@ -489,6 +515,24 @@ fn cmd_check(
             current_total_passed,
             baseline.variants_passed - current_total_passed,
         ));
+    }
+
+    if let Some(path) = markdown_summary_out {
+        let baseline_passed: HashMap<String, usize> = baseline
+            .per_service
+            .iter()
+            .map(|(k, v)| (k.clone(), v.passed))
+            .collect();
+        let md = report::render_markdown_summary(
+            &report_data,
+            baseline.variants_passed,
+            baseline.total_variants,
+            &baseline_passed,
+            &regressions,
+        );
+        if let Err(e) = std::fs::write(path, md) {
+            eprintln!("Failed to write markdown summary {}: {}", path.display(), e);
+        }
     }
 
     if regressions.is_empty() {

--- a/crates/fakecloud-conformance/src/report.rs
+++ b/crates/fakecloud-conformance/src/report.rs
@@ -215,6 +215,85 @@ pub fn print_text_report(report: &ConformanceReport) {
     );
 }
 
+/// Build a compact markdown summary suitable for `$GITHUB_STEP_SUMMARY`
+/// (max ~1MB). One row per service plus an overall row; per-variant
+/// failure detail is intentionally omitted — the full report.json and
+/// report.txt artifacts cover that.
+pub fn render_markdown_summary(
+    report: &ConformanceReport,
+    baseline_passed_total: usize,
+    baseline_total: usize,
+    baseline_per_service: &HashMap<String, usize>,
+    regressions: &[String],
+) -> String {
+    fn pct(num: usize, den: usize) -> String {
+        if den == 0 {
+            "—".to_string()
+        } else {
+            format!("{:.1}%", num as f64 / den as f64 * 100.0)
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str("## Conformance Report\n\n");
+
+    if regressions.is_empty() {
+        out.push_str("**Status:** PASSED (no regressions vs baseline)\n\n");
+    } else {
+        out.push_str("**Status:** FAILED — coverage dropped\n\n");
+        for r in regressions {
+            out.push_str(&format!("- {}\n", r));
+        }
+        out.push('\n');
+    }
+
+    let cur_passed = report.summary.variants_passed;
+    let cur_total = report.summary.total_variants;
+    out.push_str(&format!(
+        "**Overall:** {}/{} variants pass ({}). Baseline: {}/{} ({}). Delta: {:+}.\n\n",
+        cur_passed,
+        cur_total,
+        pct(cur_passed, cur_total),
+        baseline_passed_total,
+        baseline_total,
+        pct(baseline_passed_total, baseline_total),
+        cur_passed as i64 - baseline_passed_total as i64,
+    ));
+
+    out.push_str("| Service | Ops impl | Ops passing | Variants pass | Pct | Δ vs baseline |\n");
+    out.push_str("|---|---:|---:|---:|---:|---:|\n");
+
+    for svc in &report.services {
+        let implemented = svc.operations.iter().filter(|o| !o.not_implemented).count();
+        let ops_passing = svc
+            .operations
+            .iter()
+            .filter(|o| !o.not_implemented && o.failed == 0)
+            .count();
+        let v_passed: usize = svc.operations.iter().map(|o| o.passed).sum();
+        let v_total: usize = svc.operations.iter().map(|o| o.total_variants).sum();
+        let baseline = baseline_per_service
+            .get(&svc.service_name)
+            .copied()
+            .unwrap_or(0);
+        let delta = v_passed as i64 - baseline as i64;
+        out.push_str(&format!(
+            "| {} | {}/{} | {}/{} | {}/{} | {} | {:+} |\n",
+            svc.service_name,
+            implemented,
+            svc.total_operations,
+            ops_passing,
+            implemented,
+            v_passed,
+            v_total,
+            pct(v_passed, v_total),
+            delta,
+        ));
+    }
+
+    out
+}
+
 /// Print the report as JSON to stdout.
 pub fn print_json_report(report: &ConformanceReport) {
     println!(


### PR DESCRIPTION
## Summary
- `Post summary` step in `.github/workflows/conformance.yml` was failing every run with `$GITHUB_STEP_SUMMARY upload aborted, got 5076k`. Cause: `grep -E "^(Conformance|  |Operations|Variants)"` matched every per-variant failure line in the text report (~40k of them) — way past the 1MB cap.
- Added `--json-out` and `--markdown-summary-out` to `fakecloud-conformance check`. One probing pass now writes text (via `tee`), full JSON, and a compact markdown summary with one row per service (overall delta + per-service delta vs baseline).
- Dropped the separate `cargo run -- run --format json` step in the workflow. It was re-running the entire probe suite (~half of the 39min job) purely to produce the JSON file that `check` can now emit directly.

## Test plan
- [ ] Conformance workflow passes on this PR
- [ ] `Post summary` step succeeds; the rendered Summary tab shows per-service table + overall delta
- [ ] `conformance-summary.md` shows up in the uploaded artifact
- [ ] Total job runtime drops (one probe pass instead of two)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing CI conformance summary by generating a compact markdown and JSON report in a single probe run. Keeps the Summary tab under GitHub’s 1MB limit and removes the redundant second run.

- **New Features**
  - `fakecloud-conformance check` adds `--json-out` and `--markdown-summary-out` to emit full JSON and a compact markdown summary in the same pass.
  - Summary shows overall coverage and per-service deltas vs baseline; sized for `$GITHUB_STEP_SUMMARY`.

- **Bug Fixes**
  - Replaces grep-based summary with `conformance-summary.md` to avoid the “upload aborted, got 5076k” error.
  - Drops the extra `cargo run -- run --format json` invocation; workflow now writes `conformance-report.json` and `conformance-summary.md` during `check` and posts the markdown to the Summary tab.

<sup>Written for commit 55ef1c3c7366d9f8afa46c720616bccc0ddb6beb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

