### PR TITLE
fix(conformance): route route53 and cloudfront as REST in probe

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,150 +1,150 @@
 {
-  "variants_passed": 72353,
+  "variants_passed": 74661,
   "total_variants": 86666,
   "per_service": {
-    "iam": {
-      "passed": 4998,
-      "total": 6000
-    },
-    "scheduler": {
-      "passed": 417,
-      "total": 508
-    },
-    "wafv2": {
-      "passed": 1920,
-      "total": 2141
-    },
     "bedrock": {
-      "passed": 2891,
+      "passed": 2889,
       "total": 3841
-    },
-    "logs": {
-      "passed": 3794,
-      "total": 3914
     },
     "sts": {
       "passed": 311,
       "total": 448
     },
-    "secretsmanager": {
-      "passed": 802,
-      "total": 875
+    "cloudformation": {
+      "passed": 2798,
+      "total": 3433
+    },
+    "route53": {
+      "passed": 2318,
+      "total": 2400
     },
     "apigatewayv2": {
       "passed": 2564,
       "total": 2794
     },
-    "apigatewayv1": {
-      "passed": 3112,
-      "total": 3375
-    },
-    "bedrock-agent-runtime": {
-      "passed": 332,
-      "total": 1173
-    },
     "ecs": {
       "passed": 2077,
       "total": 2401
     },
-    "states": {
-      "passed": 1203,
-      "total": 1295
-    },
-    "ecr": {
-      "passed": 1714,
-      "total": 1805
-    },
-    "bedrock-runtime": {
-      "passed": 264,
-      "total": 447
-    },
-    "kinesis": {
-      "passed": 1549,
-      "total": 1611
-    },
-    "events": {
-      "passed": 1920,
-      "total": 2119
-    },
-    "rds": {
-      "passed": 4479,
-      "total": 5497
-    },
-    "s3": {
-      "passed": 2989,
-      "total": 3669
-    },
-    "elasticache": {
-      "passed": 2048,
-      "total": 2258
-    },
-    "kms": {
-      "passed": 2002,
-      "total": 2231
-    },
-    "cognito-idp": {
-      "passed": 4393,
-      "total": 4484
+    "scheduler": {
+      "passed": 417,
+      "total": 508
     },
     "sqs": {
       "passed": 416,
       "total": 549
     },
-    "elasticloadbalancing": {
-      "passed": 1384,
-      "total": 1587
+    "s3": {
+      "passed": 2989,
+      "total": 3669
     },
-    "cloudfront": {
-      "passed": 2940,
-      "total": 4115
-    },
-    "dynamodb": {
-      "passed": 1814,
-      "total": 2134
-    },
-    "bedrock-agent": {
-      "passed": 2157,
-      "total": 2532
-    },
-    "route53": {
-      "passed": 419,
-      "total": 2400
-    },
-    "ssm": {
-      "passed": 4975,
-      "total": 5309
-    },
-    "application-autoscaling": {
-      "passed": 742,
-      "total": 951
-    },
-    "cognito-identity": {
-      "passed": 620,
-      "total": 779
-    },
-    "athena": {
-      "passed": 2133,
-      "total": 2320
-    },
-    "cloudformation": {
-      "passed": 2798,
-      "total": 3433
-    },
-    "ses": {
-      "passed": 2579,
-      "total": 2867
+    "bedrock-runtime": {
+      "passed": 264,
+      "total": 447
     },
     "acm": {
       "passed": 551,
       "total": 601
     },
+    "ecr": {
+      "passed": 1714,
+      "total": 1805
+    },
+    "athena": {
+      "passed": 2133,
+      "total": 2320
+    },
+    "logs": {
+      "passed": 3794,
+      "total": 3914
+    },
+    "bedrock-agent": {
+      "passed": 2157,
+      "total": 2532
+    },
+    "events": {
+      "passed": 1920,
+      "total": 2119
+    },
+    "kinesis": {
+      "passed": 1549,
+      "total": 1611
+    },
+    "lambda": {
+      "passed": 2074,
+      "total": 3176
+    },
+    "bedrock-agent-runtime": {
+      "passed": 332,
+      "total": 1173
+    },
+    "elasticloadbalancing": {
+      "passed": 1384,
+      "total": 1587
+    },
+    "secretsmanager": {
+      "passed": 802,
+      "total": 875
+    },
+    "dynamodb": {
+      "passed": 1814,
+      "total": 2134
+    },
+    "ses": {
+      "passed": 2578,
+      "total": 2867
+    },
     "sns": {
       "passed": 971,
       "total": 1027
     },
-    "lambda": {
-      "passed": 2075,
-      "total": 3176
+    "ssm": {
+      "passed": 4975,
+      "total": 5309
+    },
+    "states": {
+      "passed": 1203,
+      "total": 1295
+    },
+    "iam": {
+      "passed": 4998,
+      "total": 6000
+    },
+    "wafv2": {
+      "passed": 1920,
+      "total": 2141
+    },
+    "kms": {
+      "passed": 2007,
+      "total": 2231
+    },
+    "rds": {
+      "passed": 4479,
+      "total": 5497
+    },
+    "cognito-identity": {
+      "passed": 620,
+      "total": 779
+    },
+    "apigatewayv1": {
+      "passed": 3111,
+      "total": 3375
+    },
+    "cognito-idp": {
+      "passed": 4407,
+      "total": 4484
+    },
+    "application-autoscaling": {
+      "passed": 742,
+      "total": 951
+    },
+    "cloudfront": {
+      "passed": 3328,
+      "total": 4115
+    },
+    "elasticache": {
+      "passed": 2055,
+      "total": 2258
     }
   }
 }

--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -142,6 +142,11 @@ pub fn service_protocol(service_name: &str) -> Protocol {
         "bedrock-agent" => Protocol::Rest,
         "bedrock-agent-runtime" => Protocol::Rest,
         "scheduler" => Protocol::Rest,
+        // REST-XML services — distinct wire format from restJson1 but the
+        // probe uses the same `@http` trait-driven URL builder for both
+        // and reads response bodies as opaque text.
+        "route53" => Protocol::Rest,
+        "cloudfront" => Protocol::Rest,
         // awsQuery services — RDS, ElastiCache, ELBv2 — explicitly listed
         // for clarity instead of relying on the default fall-through.
         "rds" => Protocol::Query,


### PR DESCRIPTION
## Summary
Same shape of bug as PR #1335 (bedrock-agent). Both \`route53\` and \`cloudfront\` are REST-XML services with @http-trait-driven URLs. They were missing from \`service_protocol()\` so they fell through to the default \`Protocol::Query\`, which sends form-encoded \`POST /\` requests. The route53 and cloudfront handlers' REST path resolvers then return \`InvalidArgument: Unknown route\` 404 for path \`/\`.

\`gh pr 1336\` brought everything else up, leaving ~3056 variants (1931 route53 + 1125 cloudfront) as the biggest single bucket remaining. This PR addresses both.

## Test plan
- [ ] Conformance workflow passes
- [ ] Baseline refresh follow-up commit lands once local re-baseline completes
- [ ] Expected jump: route53 19.5% -> high-X%, cloudfront 6.4% -> high-X%, overall 85.6% -> ~89%+

## Goal
Target raised to 95% — this is the next mechanical unlock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `route53` and `cloudfront` as `Protocol::Rest` in the conformance probe so requests use REST-XML `@http` URLs instead of `Protocol::Query` form posts. Fixes 404 “Unknown route” errors and adds 2,308 passing variants (pass rate 83.5% → 86.1%).

- **Bug Fixes**
  - Baseline refreshed: `route53` 419 → 2318 (+1,899), `cloudfront` 2940 → 3328 (+388); total `variants_passed` 74,661 / 86,666.

<sup>Written for commit 65d174fc76195a3e2d47852b81302f0848a77523. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

