### PR TITLE
fix(rds): recover backing containers on restart + real Start/StopDBInstance (#1338)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds_eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/rds_eventbridge.rs
@@ -1,6 +1,7 @@
 //! RDS lifecycle ops emit `aws.rds` events on the default EventBridge
-//! bus, deliverable to rule targets. Start/StopDBInstance take the no-
-//! runtime path so the test runs on every CI shard.
+//! bus, deliverable to rule targets. Start/StopDBInstance now drive
+//! real container lifecycle (see #1338) so these tests need Docker to
+//! create the instance before toggling it.
 
 mod helpers;
 
@@ -8,8 +9,48 @@ use aws_sdk_eventbridge::types::Target;
 use aws_sdk_sqs::types::QueueAttributeName;
 use helpers::TestServer;
 
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+async fn create_running_db(rds: &aws_sdk_rds::Client, id: &str) {
+    rds.create_db_instance()
+        .db_instance_identifier(id)
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .unwrap();
+    let _ = helpers::wait_for_db_available(rds, id, 240).await;
+}
+
 #[tokio::test]
 async fn rds_start_db_instance_emits_eventbridge_event() {
+    if !require_docker_or_skip("rds_start_db_instance_emits_eventbridge_event") {
+        return;
+    }
     let server = TestServer::start().await;
     let rds = server.rds_client().await;
     let eb = server.eventbridge_client().await;
@@ -61,6 +102,12 @@ async fn rds_start_db_instance_emits_eventbridge_event() {
         .await
         .unwrap();
 
+    create_running_db(&rds, "my-db").await;
+    rds.stop_db_instance()
+        .db_instance_identifier("my-db")
+        .send()
+        .await
+        .unwrap();
     rds.start_db_instance()
         .db_instance_identifier("my-db")
         .send()
@@ -105,6 +152,9 @@ async fn rds_start_db_instance_emits_eventbridge_event() {
 
 #[tokio::test]
 async fn rds_stop_db_instance_emits_eventbridge_event() {
+    if !require_docker_or_skip("rds_stop_db_instance_emits_eventbridge_event") {
+        return;
+    }
     let server = TestServer::start().await;
     let rds = server.rds_client().await;
     let eb = server.eventbridge_client().await;
@@ -150,6 +200,7 @@ async fn rds_stop_db_instance_emits_eventbridge_event() {
         .await
         .unwrap();
 
+    create_running_db(&rds, "prod-db").await;
     rds.stop_db_instance()
         .db_instance_identifier("prod-db")
         .send()
@@ -187,6 +238,9 @@ async fn rds_stop_db_instance_emits_eventbridge_event() {
 
 #[tokio::test]
 async fn rds_event_delivers_to_sns_target() {
+    if !require_docker_or_skip("rds_event_delivers_to_sns_target") {
+        return;
+    }
     let server = TestServer::start().await;
     let rds = server.rds_client().await;
     let eb = server.eventbridge_client().await;
@@ -249,6 +303,12 @@ async fn rds_event_delivers_to_sns_target() {
         .await
         .unwrap();
 
+    create_running_db(&rds, "sns-db").await;
+    rds.stop_db_instance()
+        .db_instance_identifier("sns-db")
+        .send()
+        .await
+        .unwrap();
     rds.start_db_instance()
         .db_instance_identifier("sns-db")
         .send()

--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -1,6 +1,32 @@
 mod helpers;
 
 use helpers::TestServer;
+use tokio_postgres::NoTls;
+
+async fn connect_postgres_with_retry(
+    host: &str,
+    port: i32,
+    user: &str,
+    password: &str,
+    dbname: &str,
+) -> Result<tokio_postgres::Client, tokio_postgres::Error> {
+    let connection_string =
+        format!("host={host} port={port} user={user} password={password} dbname={dbname}");
+    let mut last_error = None;
+    for _ in 0..40 {
+        match tokio_postgres::connect(&connection_string, NoTls).await {
+            Ok((client, conn)) => {
+                tokio::spawn(conn);
+                return Ok(client);
+            }
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+        }
+    }
+    Err(last_error.expect("postgres connection error"))
+}
 
 /// DB instances survive a restart. Reproduces issue #914: a DB instance
 /// created with `aws rds create-db-instance` disappeared after restart
@@ -56,6 +82,136 @@ async fn persistence_round_trip_db_instance() {
         Some("available"),
         "status should persist as `available`, not be dropped as `creating`",
     );
+}
+
+/// Backing container is recreated on restart so the persisted DB
+/// endpoint is actually usable. Reproduces issue #1338: pre-fix,
+/// `DescribeDBInstances` returned `available` but `tokio_postgres::connect`
+/// failed because the container was gone.
+#[tokio::test]
+async fn persistence_db_endpoint_works_after_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("restart-db")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .unwrap();
+    let _ = helpers::wait_for_db_available(&client, "restart-db", 240).await;
+
+    drop(client);
+    server.restart().await;
+    let client = server.rds_client().await;
+
+    let inst = helpers::wait_for_db_available(&client, "restart-db", 240).await;
+    let endpoint = inst.endpoint().expect("endpoint");
+    let host = endpoint.address().expect("address");
+    let port = endpoint.port().expect("port");
+
+    let db = connect_postgres_with_retry(host, port, "admin", "secret123", "appdb")
+        .await
+        .expect("connect to recovered postgres container");
+    let row = db.query_one("SELECT 1", &[]).await.expect("select 1");
+    let value: i32 = row.get(0);
+    assert_eq!(value, 1);
+}
+
+/// StopDBInstance and StartDBInstance actually toggle the backing
+/// container, not just emit events. Pre-fix the ops were XML stubs and
+/// the container kept running regardless of the reported status.
+#[tokio::test]
+async fn start_stop_db_instance_toggles_backing_container() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_instance()
+        .db_instance_identifier("toggle-db")
+        .allocated_storage(20)
+        .db_instance_class("db.t3.micro")
+        .engine("postgres")
+        .engine_version("16.3")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .db_name("appdb")
+        .send()
+        .await
+        .unwrap();
+    let inst = helpers::wait_for_db_available(&client, "toggle-db", 240).await;
+    let endpoint = inst.endpoint().expect("endpoint");
+    let host = endpoint.address().expect("address").to_string();
+    let port_before = endpoint.port().expect("port");
+
+    // Sanity: endpoint works before stopping.
+    let _ = connect_postgres_with_retry(&host, port_before, "admin", "secret123", "appdb")
+        .await
+        .expect("connect before stop");
+
+    client
+        .stop_db_instance()
+        .db_instance_identifier("toggle-db")
+        .send()
+        .await
+        .unwrap();
+
+    let stopped = client
+        .describe_db_instances()
+        .db_instance_identifier("toggle-db")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        stopped.db_instances()[0].db_instance_status(),
+        Some("stopped"),
+    );
+    // Endpoint must not be reachable now.
+    let connect = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        tokio_postgres::connect(
+            &format!(
+                "host={host} port={port_before} user=admin password=secret123 dbname=appdb"
+            ),
+            NoTls,
+        ),
+    )
+    .await;
+    assert!(
+        matches!(connect, Err(_) | Ok(Err(_))),
+        "stopped DB endpoint should not accept connections",
+    );
+
+    client
+        .start_db_instance()
+        .db_instance_identifier("toggle-db")
+        .send()
+        .await
+        .unwrap();
+    let restarted = helpers::wait_for_db_available(&client, "toggle-db", 240).await;
+    let endpoint = restarted.endpoint().expect("endpoint");
+    let host_after = endpoint.address().expect("address");
+    let port_after = endpoint.port().expect("port");
+
+    let db = connect_postgres_with_retry(host_after, port_after, "admin", "secret123", "appdb")
+        .await
+        .expect("connect after start");
+    let row = db.query_one("SELECT 1", &[]).await.expect("select 1");
+    let value: i32 = row.get(0);
+    assert_eq!(value, 1);
 }
 
 /// Parameter groups survive a restart.

--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -65,23 +65,14 @@ async fn persistence_round_trip_db_instance() {
     server.restart().await;
     let client = server.rds_client().await;
 
-    let resp = client
-        .describe_db_instances()
-        .db_instance_identifier("persist-db")
-        .send()
-        .await
-        .unwrap();
-    let instances = resp.db_instances();
-    assert_eq!(instances.len(), 1, "DB instance should survive restart");
-    let inst = &instances[0];
+    // Container recovery is async (#1338): the row reloads as
+    // `starting`, then flips back to `available` once the container is
+    // healthy. Wait rather than asserting an instantaneous status.
+    let inst = helpers::wait_for_db_available(&client, "persist-db", 240).await;
     assert_eq!(inst.db_instance_identifier(), Some("persist-db"));
     assert_eq!(inst.engine(), Some("postgres"));
     assert_eq!(inst.master_username(), Some("admin"));
-    assert_eq!(
-        inst.db_instance_status(),
-        Some("available"),
-        "status should persist as `available`, not be dropped as `creating`",
-    );
+    assert_eq!(inst.db_instance_status(), Some("available"));
 }
 
 /// Backing container is recreated on restart so the persisted DB

--- a/crates/fakecloud-e2e/tests/rds_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_persistence.rs
@@ -183,9 +183,7 @@ async fn start_stop_db_instance_toggles_backing_container() {
     let connect = tokio::time::timeout(
         std::time::Duration::from_secs(2),
         tokio_postgres::connect(
-            &format!(
-                "host={host} port={port_before} user=admin password=secret123 dbname=appdb"
-            ),
+            &format!("host={host} port={port_before} user=admin password=secret123 dbname=appdb"),
             NoTls,
         ),
     )

--- a/crates/fakecloud-rds/src/extras.rs
+++ b/crates/fakecloud-rds/src/extras.rs
@@ -1059,33 +1059,6 @@ impl RdsService {
             // ── Database read replicas ──
             "PromoteReadReplica" => promote_read_replica_action(self, &aid, req, &rid),
             "SwitchoverReadReplica" => switchover_read_replica_action(self, &aid, req, &rid),
-            "StartDBInstance" | "StopDBInstance" => {
-                if let Some(id) = get_param(req, "DBInstanceIdentifier") {
-                    let (event_id, categories, msg) = if action == "StartDBInstance" {
-                        ("RDS-EVENT-0088", ["notification"], "DB instance started")
-                    } else {
-                        ("RDS-EVENT-0089", ["notification"], "DB instance stopped")
-                    };
-                    let arn = {
-                        let accounts = self.state_handle().read();
-                        accounts
-                            .get(&aid)
-                            .and_then(|s| s.instances.get(&id).map(|i| i.db_instance_arn.clone()))
-                            .unwrap_or_else(|| {
-                                Arn::new("rds", region, &aid, &format!("db:{id}")).to_string()
-                            })
-                    };
-                    self.emit_event(
-                        RdsSourceType::DbInstance,
-                        &id,
-                        &arn,
-                        event_id,
-                        &categories,
-                        msg,
-                    );
-                }
-                Ok(xml_response(action.as_str(), "    <DBInstance/>".to_string(), &rid))
-            }
             "StartDBInstanceAutomatedBackupsReplication" | "StopDBInstanceAutomatedBackupsReplication" => Ok(xml_response(action.as_str(), "    <DBInstanceAutomatedBackup/>".to_string(), &rid)),
             "DeleteDBInstanceAutomatedBackup" => Ok(xml_response("DeleteDBInstanceAutomatedBackup", "    <DBInstanceAutomatedBackup/>".to_string(), &rid)),
             "DescribeDBInstanceAutomatedBackups" => Ok(xml_response("DescribeDBInstanceAutomatedBackups", "    <DBInstanceAutomatedBackups/>".to_string(), &rid)),
@@ -3245,8 +3218,9 @@ mod tests {
         ok("DescribeReservedDBInstancesOfferings", &[]);
         // PromoteReadReplica + SwitchoverReadReplica need a real
         // replica instance; covered by the dedicated tests below.
-        ok("StartDBInstance", &[]);
-        ok("StopDBInstance", &[]);
+        // StartDBInstance / StopDBInstance moved to the service-level
+        // dispatch (they need the container runtime); see the
+        // dedicated E2E coverage in fakecloud-e2e/tests/rds_persistence.rs.
         ok("StartDBInstanceAutomatedBackupsReplication", &[]);
         ok("StopDBInstanceAutomatedBackupsReplication", &[]);
         ok("DeleteDBInstanceAutomatedBackup", &[]);

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -467,10 +467,7 @@ impl RdsService {
     /// real `stopped` status by the time the response goes back; mirrors
     /// the AWS contract that `StartDBInstance`/`StopDBInstance` change
     /// the visible status immediately.
-    async fn stop_db_instance(
-        &self,
-        request: &AwsRequest,
-    ) -> Result<AwsResponse, AwsServiceError> {
+    async fn stop_db_instance(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let db_instance_identifier = required_query_param(request, "DBInstanceIdentifier")?;
         let runtime = self.require_runtime()?;
 

--- a/crates/fakecloud-rds/src/service.rs
+++ b/crates/fakecloud-rds/src/service.rs
@@ -325,6 +325,287 @@ impl RdsService {
         )
         .await;
     }
+
+    /// Recreate the backing Docker/Podman containers for persisted DB
+    /// instances after a fakecloud restart. Without this, persistent
+    /// mode loads the row back into memory with `db_instance_status =
+    /// available` but the container is gone, so the endpoint is dead
+    /// (issue #1338). Each candidate is flipped to `starting`
+    /// synchronously, then a background task brings the container back
+    /// and flips it back to `available`. Instances persisted as
+    /// `stopped` are skipped — `StartDBInstance` revives those.
+    pub async fn recover_persisted_containers(&self) {
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+
+        struct Pending {
+            account_id: String,
+            region: String,
+            id: String,
+            arn: String,
+            engine: String,
+            engine_version: String,
+            username: String,
+            password: String,
+            db_name: String,
+        }
+
+        let pending: Vec<Pending> = {
+            let mut accounts = self.state.write();
+            let mut out = Vec::new();
+            for (_, state) in accounts.iter_mut() {
+                let account_id = state.account_id.clone();
+                let region = state.region.clone();
+                for (id, inst) in state.instances.iter_mut() {
+                    if !matches!(
+                        inst.db_instance_status.as_str(),
+                        "available" | "starting" | "modifying" | "rebooting" | "backing-up"
+                    ) {
+                        continue;
+                    }
+                    inst.db_instance_status = "starting".to_string();
+                    out.push(Pending {
+                        account_id: account_id.clone(),
+                        region: region.clone(),
+                        id: id.clone(),
+                        arn: inst.db_instance_arn.clone(),
+                        engine: inst.engine.clone(),
+                        engine_version: inst.engine_version.clone(),
+                        username: inst.master_username.clone(),
+                        password: inst.master_user_password.clone(),
+                        db_name: inst
+                            .db_name
+                            .clone()
+                            .unwrap_or_else(|| default_db_name(&inst.engine).to_string()),
+                    });
+                }
+            }
+            out
+        };
+
+        if pending.is_empty() {
+            return;
+        }
+        tracing::info!(
+            count = pending.len(),
+            "recovering backing containers for persisted rds instances",
+        );
+
+        for p in pending {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let delivery_bus = self.delivery_bus.clone();
+            tokio::spawn(async move {
+                match runtime
+                    .ensure_postgres(
+                        &p.id,
+                        &p.engine,
+                        &p.engine_version,
+                        &p.username,
+                        &p.password,
+                        &p.db_name,
+                        &p.account_id,
+                        &p.region,
+                    )
+                    .await
+                {
+                    Ok(running) => {
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&p.account_id) {
+                                if let Some(inst) = s.instances.get_mut(&p.id) {
+                                    inst.db_instance_status = "available".to_string();
+                                    inst.endpoint_address = "127.0.0.1".to_string();
+                                    inst.port = i32::from(running.host_port);
+                                    inst.host_port = running.host_port;
+                                    inst.container_id = running.container_id;
+                                }
+                            }
+                        }
+                        save_snapshot_static(
+                            state.clone(),
+                            snapshot_store.clone(),
+                            snapshot_lock.clone(),
+                        )
+                        .await;
+                        emit_event_static(
+                            delivery_bus.as_ref(),
+                            RdsSourceType::DbInstance,
+                            &p.id,
+                            &p.arn,
+                            "RDS-EVENT-0088",
+                            &["notification"],
+                            "DB instance restarted after fakecloud restart",
+                        );
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            db_instance_identifier = %p.id,
+                            "failed to recover rds backing container after restart",
+                        );
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&p.account_id) {
+                                if let Some(inst) = s.instances.get_mut(&p.id) {
+                                    inst.db_instance_status = "failed".to_string();
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                }
+            });
+        }
+    }
+
+    /// Stop the backing container for `db_instance_identifier` and mark
+    /// the row `stopped`. Synchronous wrt the runtime so callers see a
+    /// real `stopped` status by the time the response goes back; mirrors
+    /// the AWS contract that `StartDBInstance`/`StopDBInstance` change
+    /// the visible status immediately.
+    async fn stop_db_instance(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_query_param(request, "DBInstanceIdentifier")?;
+        let runtime = self.require_runtime()?;
+
+        let arn = {
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
+            state
+                .instances
+                .get(&db_instance_identifier)
+                .map(|i| i.db_instance_arn.clone())
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?
+        };
+
+        runtime.stop_container(&db_instance_identifier).await;
+
+        let instance = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let inst = state
+                .instances
+                .get_mut(&db_instance_identifier)
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+            inst.db_instance_status = "stopped".to_string();
+            inst.container_id = String::new();
+            inst.clone()
+        };
+
+        self.emit_event(
+            RdsSourceType::DbInstance,
+            &db_instance_identifier,
+            &arn,
+            "RDS-EVENT-0089",
+            &["notification"],
+            "DB instance stopped",
+        );
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml(
+                "StopDBInstance",
+                RDS_NS,
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(&instance, Some("stopped"))
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
+
+    /// Restart a stopped DB instance: spin up the backing container and
+    /// flip the row back to `available`. Mirrors AWS `StartDBInstance`.
+    async fn start_db_instance(
+        &self,
+        request: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let db_instance_identifier = required_query_param(request, "DBInstanceIdentifier")?;
+        let runtime = self.require_runtime()?;
+
+        let instance = {
+            let accounts = self.state.read();
+            let empty = RdsState::new(&request.account_id, &request.region);
+            let state = accounts.get(&request.account_id).unwrap_or(&empty);
+            state
+                .instances
+                .get(&db_instance_identifier)
+                .cloned()
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?
+        };
+
+        // Flip to `starting` so concurrent DescribeDBInstances callers
+        // see the in-flight state.
+        {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            if let Some(inst) = state.instances.get_mut(&db_instance_identifier) {
+                inst.db_instance_status = "starting".to_string();
+            }
+        }
+
+        let running = runtime
+            .ensure_postgres(
+                &db_instance_identifier,
+                &instance.engine,
+                &instance.engine_version,
+                &instance.master_username,
+                &instance.master_user_password,
+                instance
+                    .db_name
+                    .as_deref()
+                    .unwrap_or(default_db_name(&instance.engine)),
+                &request.account_id,
+                &request.region,
+            )
+            .await
+            .map_err(runtime_error_to_service_error)?;
+
+        let instance = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&request.account_id);
+            let inst = state
+                .instances
+                .get_mut(&db_instance_identifier)
+                .ok_or_else(|| db_instance_not_found(&db_instance_identifier))?;
+            inst.db_instance_status = "available".to_string();
+            inst.endpoint_address = "127.0.0.1".to_string();
+            inst.port = i32::from(running.host_port);
+            inst.host_port = running.host_port;
+            inst.container_id = running.container_id;
+            inst.clone()
+        };
+
+        self.emit_event(
+            RdsSourceType::DbInstance,
+            &db_instance_identifier,
+            &instance.db_instance_arn,
+            "RDS-EVENT-0088",
+            &["notification"],
+            "DB instance started",
+        );
+
+        Ok(AwsResponse::xml(
+            StatusCode::OK,
+            query_response_xml(
+                "StartDBInstance",
+                RDS_NS,
+                &format!(
+                    "<DBInstance>{}</DBInstance>",
+                    db_instance_xml(&instance, None)
+                ),
+                &request.request_id,
+            ),
+        ))
+    }
 }
 
 /// Persist the current `RdsState` to the configured snapshot store. Free
@@ -408,6 +689,8 @@ impl AwsService for RdsService {
             "ModifyDBParameterGroup" => self.modify_db_parameter_group(&request),
             "ModifyDBSubnetGroup" => self.modify_db_subnet_group(&request),
             "RebootDBInstance" => self.reboot_db_instance(&request).await,
+            "StartDBInstance" => self.start_db_instance(&request).await,
+            "StopDBInstance" => self.stop_db_instance(&request).await,
             "RemoveTagsFromResource" => self.remove_tags_from_resource(&request),
             "RestoreDBInstanceFromDBSnapshot" => {
                 self.restore_db_instance_from_db_snapshot(&request).await

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1959,6 +1959,11 @@ async fn main() {
     }
     let rds_delivery_bus = Arc::new(rds_bus);
     rds_service = rds_service.with_delivery_bus(rds_delivery_bus.clone());
+    // Recreate backing containers for persisted DB instances that the
+    // snapshot claims should be running. Fire-and-forget: the method
+    // spawns one task per instance and returns immediately, so a slow
+    // postgres bring-up doesn't block server startup. (Issue #1338.)
+    rds_service.recover_persisted_containers().await;
     registry.register(Arc::new(rds_service));
     let elasticache_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
         if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {


### PR DESCRIPTION
## Summary

Fixes #1338. After restart in persistent storage mode, `DescribeDBInstances` returned `DBInstanceStatus=available` for persisted DB instances even though the backing Docker/Podman container was gone, so the endpoint was unreachable.

- On startup, iterate persisted instances and for each row in an active state (`available`/`starting`/`modifying`/`rebooting`/`backing-up`), flip to `starting` and spawn a background task that calls `runtime.ensure_postgres(...)` then flips back to `available` when the container is healthy. Failed recovery transitions the row to `failed` instead of leaving a fake `available`.
- Replace the `StartDBInstance`/`StopDBInstance` stubs (event-only, container untouched) with real implementations that stop / recreate the container and toggle status accordingly.

Similar restart-bug audit covered with this PR:
- **Lambda** — warm containers are tracked in memory only and re-spawned per invoke; no persisted "running" state, no bug.
- **ElastiCache** — same pattern as RDS; will fix in a follow-up PR.
- **ECS** — task containers persisted as `RUNNING` survive in state but the docker container is gone; follow-up PR.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p fakecloud-rds` 205 passing
- [ ] CI: new E2E tests `persistence_db_endpoint_works_after_restart` and `start_stop_db_instance_toggles_backing_container` exercise post-restart `tokio_postgres::connect` and the real Start/Stop container toggle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers RDS backing containers on restart in persistent mode and implements real `StartDBInstance`/`StopDBInstance` that manage containers, fixing dead endpoints and wrong statuses after restarts. Fixes #1338.

- **Bug Fixes**
  - On startup, scan persisted RDS instances; for active states, set to “starting”, recreate the container in the background, then set to “available” on success or “failed” on error. Skips instances persisted as “stopped”.
  - Hooked recovery into `fakecloud-server` startup; recovery runs asynchronously and doesn’t block boot.
  - `StartDBInstance`/`StopDBInstance` now return `DBInstanceNotFound` for unknown identifiers, matching AWS.

- **New Features**
  - Implemented real `StartDBInstance` and `StopDBInstance`: stop/start the backing container, update status immediately, and emit the correct events and XML response.
  - Added E2E tests in `fakecloud-e2e` to verify post-restart connectivity and start/stop toggling; persistence tests wait for async recovery; EventBridge tests now create a real DB and are gated on Docker.

<sup>Written for commit 8a079dfc22251011e111eb1e652ecc4521cbb936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

