### PR TITLE
fix(elasticache): recover backing containers on restart

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache_persistence.rs
+++ b/crates/fakecloud-e2e/tests/elasticache_persistence.rs
@@ -2,6 +2,87 @@ mod helpers;
 
 use helpers::TestServer;
 
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Cache cluster endpoint survives a restart. Pre-fix, the cluster row
+/// was persisted with `cache_cluster_status=available` but the Docker
+/// container was gone, so the endpoint TCP-port wouldn't accept
+/// connections after restart. Same bug class as RDS #1338.
+#[tokio::test]
+async fn persistence_cache_cluster_endpoint_works_after_restart() {
+    if !require_docker_or_skip("persistence_cache_cluster_endpoint_works_after_restart") {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.elasticache_client().await;
+
+    client
+        .create_cache_cluster()
+        .cache_cluster_id("restart-cache")
+        .cache_node_type("cache.t3.micro")
+        .preferred_availability_zone("us-east-1a")
+        .send()
+        .await
+        .unwrap();
+
+    drop(client);
+    server.restart().await;
+    let client = server.elasticache_client().await;
+
+    // Poll status back to available after recovery.
+    let mut status_ok = false;
+    let mut port = 0;
+    for _ in 0..60 {
+        let resp = client
+            .describe_cache_clusters()
+            .cache_cluster_id("restart-cache")
+            .show_cache_node_info(true)
+            .send()
+            .await
+            .unwrap();
+        let clusters = resp.cache_clusters();
+        if let Some(cluster) = clusters.first() {
+            if cluster.cache_cluster_status() == Some("available") {
+                let endpoint = cluster.cache_nodes()[0]
+                    .endpoint()
+                    .expect("cache node endpoint");
+                port = endpoint.port().expect("port");
+                status_ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    assert!(status_ok, "cache cluster did not recover to `available`");
+    let stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}")).await;
+    assert!(
+        stream.is_ok(),
+        "recovered cache cluster endpoint must accept connections: {stream:?}",
+    );
+}
+
 /// Users and user groups survive a restart.
 #[tokio::test]
 async fn persistence_round_trip_user_and_group() {

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -186,26 +186,253 @@ impl ElastiCacheService {
     }
 
     async fn save_snapshot(&self) {
-        let Some(store) = self.snapshot_store.clone() else {
+        save_snapshot_static(
+            self.state.clone(),
+            self.snapshot_store.clone(),
+            self.snapshot_lock.clone(),
+        )
+        .await;
+    }
+
+    /// Recreate the backing Docker/Podman containers for persisted cache
+    /// clusters, replication groups, and serverless caches after a
+    /// fakecloud restart. Same bug class as RDS #1338 — without this,
+    /// describe ops report the cluster as `available` while the
+    /// container is gone, so the endpoint is dead.
+    pub async fn recover_persisted_containers(&self) {
+        let Some(runtime) = self.runtime.clone() else {
             return;
         };
-        let _guard = self.snapshot_lock.lock().await;
-        let snapshot = ElastiCacheSnapshot {
-            schema_version: ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
-            state: None,
-            accounts: Some(self.state.read().clone()),
-        };
-        let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            let bytes = serde_json::to_vec(&snapshot)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            store.save(&bytes)
-        })
-        .await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => tracing::error!(%err, "failed to write elasticache snapshot"),
-            Err(err) => tracing::error!(%err, "elasticache snapshot task panicked"),
+
+        struct PendingCluster {
+            account_id: String,
+            id: String,
+            engine: String,
         }
+        struct PendingReplication {
+            account_id: String,
+            id: String,
+            engine: String,
+        }
+        struct PendingServerless {
+            account_id: String,
+            name: String,
+        }
+
+        let (clusters, replications, serverless) = {
+            let mut accounts = self.state.write();
+            let mut clusters = Vec::new();
+            let mut replications = Vec::new();
+            let mut serverless = Vec::new();
+            for (_, state) in accounts.iter_mut() {
+                let account_id = state.account_id.clone();
+                for (id, cluster) in state.cache_clusters.iter_mut() {
+                    if cluster.cache_cluster_status == "available" {
+                        cluster.cache_cluster_status = "starting".to_string();
+                        clusters.push(PendingCluster {
+                            account_id: account_id.clone(),
+                            id: id.clone(),
+                            engine: cluster.engine.clone(),
+                        });
+                    }
+                }
+                for (id, rg) in state.replication_groups.iter_mut() {
+                    if rg.status == "available" {
+                        rg.status = "starting".to_string();
+                        replications.push(PendingReplication {
+                            account_id: account_id.clone(),
+                            id: id.clone(),
+                            engine: rg.engine.clone(),
+                        });
+                    }
+                }
+                for (name, sc) in state.serverless_caches.iter_mut() {
+                    if sc.status == "available" {
+                        sc.status = "creating".to_string();
+                        serverless.push(PendingServerless {
+                            account_id: account_id.clone(),
+                            name: name.clone(),
+                        });
+                    }
+                }
+            }
+            (clusters, replications, serverless)
+        };
+
+        let total = clusters.len() + replications.len() + serverless.len();
+        if total == 0 {
+            return;
+        }
+        tracing::info!(
+            count = total,
+            "recovering backing containers for persisted elasticache resources",
+        );
+
+        for c in clusters {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            tokio::spawn(async move {
+                let result = if c.engine == "memcached" {
+                    runtime.ensure_memcached(&c.id).await
+                } else {
+                    runtime.ensure_redis(&c.id, None).await
+                };
+                match result {
+                    Ok(running) => {
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&c.account_id) {
+                                if let Some(cluster) = s.cache_clusters.get_mut(&c.id) {
+                                    cluster.cache_cluster_status = "available".to_string();
+                                    cluster.endpoint_address = "127.0.0.1".to_string();
+                                    cluster.endpoint_port = running.host_port;
+                                    cluster.host_port = running.host_port;
+                                    cluster.container_id = running.container_id;
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            cache_cluster_id = %c.id,
+                            "failed to recover elasticache cache cluster after restart",
+                        );
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&c.account_id) {
+                                if let Some(cluster) = s.cache_clusters.get_mut(&c.id) {
+                                    cluster.cache_cluster_status = "incompatible-network"
+                                        .to_string();
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                }
+            });
+        }
+
+        for r in replications {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            tokio::spawn(async move {
+                let result = if r.engine == "memcached" {
+                    runtime.ensure_memcached(&r.id).await
+                } else {
+                    runtime.ensure_redis(&r.id, None).await
+                };
+                match result {
+                    Ok(running) => {
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&r.account_id) {
+                                if let Some(rg) = s.replication_groups.get_mut(&r.id) {
+                                    rg.status = "available".to_string();
+                                    rg.endpoint_address = "127.0.0.1".to_string();
+                                    rg.endpoint_port = running.host_port;
+                                    rg.host_port = running.host_port;
+                                    rg.container_id = running.container_id;
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            replication_group_id = %r.id,
+                            "failed to recover elasticache replication group after restart",
+                        );
+                        {
+                            let mut accounts = state.write();
+                            if let Some(s) = accounts.get_mut(&r.account_id) {
+                                if let Some(rg) = s.replication_groups.get_mut(&r.id) {
+                                    rg.status = "incompatible-network".to_string();
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                }
+            });
+        }
+
+        for s in serverless {
+            let runtime = runtime.clone();
+            let state = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            tokio::spawn(async move {
+                match runtime.ensure_redis(&s.name, None).await {
+                    Ok(running) => {
+                        {
+                            let mut accounts = state.write();
+                            if let Some(st) = accounts.get_mut(&s.account_id) {
+                                if let Some(cache) = st.serverless_caches.get_mut(&s.name) {
+                                    cache.status = "available".to_string();
+                                    cache.endpoint.address = "127.0.0.1".to_string();
+                                    cache.endpoint.port = running.host_port;
+                                    cache.reader_endpoint.address = "127.0.0.1".to_string();
+                                    cache.reader_endpoint.port = running.host_port;
+                                    cache.host_port = running.host_port;
+                                    cache.container_id = running.container_id;
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            serverless_cache_name = %s.name,
+                            "failed to recover elasticache serverless cache after restart",
+                        );
+                        {
+                            let mut accounts = state.write();
+                            if let Some(st) = accounts.get_mut(&s.account_id) {
+                                if let Some(cache) = st.serverless_caches.get_mut(&s.name) {
+                                    cache.status = "create-failed".to_string();
+                                }
+                            }
+                        }
+                        save_snapshot_static(state, snapshot_store, snapshot_lock).await;
+                    }
+                }
+            });
+        }
+    }
+}
+
+async fn save_snapshot_static(
+    state: SharedElastiCacheState,
+    store: Option<Arc<dyn SnapshotStore>>,
+    lock: Arc<AsyncMutex<()>>,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let _guard = lock.lock().await;
+    let snapshot = ElastiCacheSnapshot {
+        schema_version: ELASTICACHE_SNAPSHOT_SCHEMA_VERSION,
+        state: None,
+        accounts: Some(state.read().clone()),
+    };
+    let join = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        store.save(&bytes)
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => tracing::error!(%err, "failed to write elasticache snapshot"),
+        Err(err) => tracing::error!(%err, "elasticache snapshot task panicked"),
     }
 }
 

--- a/crates/fakecloud-elasticache/src/service.rs
+++ b/crates/fakecloud-elasticache/src/service.rs
@@ -305,8 +305,8 @@ impl ElastiCacheService {
                             let mut accounts = state.write();
                             if let Some(s) = accounts.get_mut(&c.account_id) {
                                 if let Some(cluster) = s.cache_clusters.get_mut(&c.id) {
-                                    cluster.cache_cluster_status = "incompatible-network"
-                                        .to_string();
+                                    cluster.cache_cluster_status =
+                                        "incompatible-network".to_string();
                                 }
                             }
                         }

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2025,6 +2025,11 @@ async fn main() {
     if let Some(store) = elasticache_snapshot_store {
         elasticache_service = elasticache_service.with_snapshot_store(store);
     }
+    // Same restart-recovery contract as RDS: persisted clusters /
+    // replication groups / serverless caches survive a restart but
+    // their Docker containers don't, so respawn them on startup. See
+    // RDS #1338 for the original bug class.
+    elasticache_service.recover_persisted_containers().await;
     registry.register(Arc::new(elasticache_service));
 
     let ecr_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =


### PR DESCRIPTION
## Summary

Sibling fix to #1340 / #1338. Persistent mode persisted ElastiCache cache clusters, replication groups, and serverless caches with `status=available`, but the backing Docker containers were gone after restart so the endpoint was unreachable.

- On startup, iterate persisted resources and flip `available` rows to `starting` (or `creating` for serverless caches), then spawn a background task per resource that calls `runtime.ensure_redis` / `ensure_memcached` and flips back to `available` once the container is healthy.
- Failed recovery transitions to `incompatible-network` / `create-failed` instead of leaving a fake `available`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p fakecloud-elasticache` 216 passing
- [ ] CI: new E2E test `persistence_cache_cluster_endpoint_works_after_restart` opens a TCP connection to the recovered cluster endpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ElastiCache persistence by respawning missing Docker containers on server restart so endpoints work again. Adds an E2E test to confirm a recovered cache cluster accepts connections after restart.

- **Bug Fixes**
  - On startup, recover containers for persisted cache clusters, replication groups, and serverless caches: flip `available` to `starting`/`creating`, call `runtime.ensure_redis`/`ensure_memcached`, then return to `available` with localhost endpoint and port.
  - On failure, set `incompatible-network` (clusters/replication groups) or `create-failed` (serverless) instead of a fake `available`.
  - Persist after each transition via shared `save_snapshot_static`, and invoke recovery during server startup.
  - Add E2E `persistence_cache_cluster_endpoint_works_after_restart`; skips locally if Docker is missing, required in CI.

<sup>Written for commit d4c1b6314f6108a44efc1de07fd8a83cfe3cf961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

