### PR TITLE
fix(ecs): reconcile persisted task state on restart

### DIFF
--- a/crates/fakecloud-e2e/tests/ecs_persistence.rs
+++ b/crates/fakecloud-e2e/tests/ecs_persistence.rs
@@ -1,0 +1,99 @@
+mod helpers;
+
+use aws_sdk_ecs::types::ContainerDefinition;
+use helpers::TestServer;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("Skipping {test}: docker not available");
+    false
+}
+
+/// Persisted RUNNING tasks must be reconciled to STOPPED on restart —
+/// their docker containers are gone and reporting them as RUNNING is a
+/// lie. Same restart-bug class as RDS #1338.
+#[tokio::test]
+async fn persistence_running_tasks_reconciled_to_stopped_after_restart() {
+    if !require_docker_or_skip("persistence_running_tasks_reconciled_to_stopped_after_restart") {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let data_path = tmp.path().display().to_string();
+    let extra_args = ["--storage-mode", "persistent", "--data-path", &data_path];
+    let mut server = TestServer::start_full(&[], &extra_args).await;
+    let client = server.ecs_client().await;
+
+    client
+        .create_cluster()
+        .cluster_name("reconcile-cluster")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .register_task_definition()
+        .family("reconcile-family")
+        .container_definitions(
+            ContainerDefinition::builder()
+                .name("app")
+                .image("public.ecr.aws/library/alpine:latest")
+                .essential(true)
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let arn = client
+        .run_task()
+        .cluster("reconcile-cluster")
+        .task_definition("reconcile-family")
+        .send()
+        .await
+        .expect("run_task")
+        .tasks()
+        .first()
+        .and_then(|t| t.task_arn())
+        .expect("task arn")
+        .to_string();
+
+    drop(client);
+    server.restart().await;
+    let client = server.ecs_client().await;
+
+    let resp = client
+        .describe_tasks()
+        .cluster("reconcile-cluster")
+        .tasks(arn.clone())
+        .send()
+        .await
+        .expect("describe_tasks");
+    let task = &resp.tasks()[0];
+    assert_eq!(
+        task.last_status(),
+        Some("STOPPED"),
+        "persisted task must reconcile to STOPPED after restart, not phantom-RUNNING",
+    );
+    assert_eq!(task.desired_status(), Some("STOPPED"));
+    assert!(
+        task.stopped_reason()
+            .is_some_and(|reason| reason.contains("restart")),
+        "stoppedReason should explain the restart, got {:?}",
+        task.stopped_reason(),
+    );
+}

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -196,9 +196,8 @@ impl EcsService {
                         task.last_status = "STOPPED".to_string();
                         task.desired_status = "STOPPED".to_string();
                         task.stop_code = Some("EssentialContainerExited".to_string());
-                        task.stopped_reason = Some(
-                            "fakecloud restart - backing container lost".to_string(),
-                        );
+                        task.stopped_reason =
+                            Some("fakecloud restart - backing container lost".to_string());
                         if task.stopping_at.is_none() {
                             task.stopping_at = Some(now);
                         }

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -171,6 +171,69 @@ impl EcsService {
             Err(err) => tracing::error!(%err, "ecs snapshot task panicked"),
         }
     }
+
+    /// Reconcile persisted task state with reality after a fakecloud
+    /// restart. Same bug class as RDS #1338: tasks were persisted with
+    /// `lastStatus = RUNNING` but their docker containers are gone, so
+    /// DescribeTasks reported phantom-running tasks and `docker exec`
+    /// (for ECS Exec) would fail.
+    ///
+    /// Mark every non-STOPPED task as STOPPED with a `stoppedReason`
+    /// that explains the restart, and reset service `runningCount` /
+    /// `pendingCount` to zero. The service scheduler ticker then
+    /// reconciles desiredCount and launches fresh tasks. Standalone
+    /// `RunTask` tasks aren't auto-respawned because we don't have
+    /// enough context to replay them safely; callers re-invoke.
+    pub async fn reconcile_persisted_tasks(&self) {
+        let touched = {
+            let mut accounts = self.state.write();
+            let mut touched_tasks = 0usize;
+            let mut touched_services = 0usize;
+            let now = chrono::Utc::now();
+            for (_, state) in accounts.iter_mut() {
+                for task in state.tasks.values_mut() {
+                    if task.last_status != "STOPPED" {
+                        task.last_status = "STOPPED".to_string();
+                        task.desired_status = "STOPPED".to_string();
+                        task.stop_code = Some("EssentialContainerExited".to_string());
+                        task.stopped_reason = Some(
+                            "fakecloud restart - backing container lost".to_string(),
+                        );
+                        if task.stopping_at.is_none() {
+                            task.stopping_at = Some(now);
+                        }
+                        if task.stopped_at.is_none() {
+                            task.stopped_at = Some(now);
+                        }
+                        for container in task.containers.iter_mut() {
+                            container.last_status = "STOPPED".to_string();
+                        }
+                        touched_tasks += 1;
+                    }
+                }
+                for service in state.services.values_mut() {
+                    if service.running_count != 0 || service.pending_count != 0 {
+                        service.running_count = 0;
+                        service.pending_count = 0;
+                        for deployment in service.deployments.iter_mut() {
+                            deployment.running_count = 0;
+                            deployment.pending_count = 0;
+                        }
+                        touched_services += 1;
+                    }
+                }
+            }
+            (touched_tasks, touched_services)
+        };
+        if touched.0 + touched.1 > 0 {
+            tracing::info!(
+                tasks = touched.0,
+                services = touched.1,
+                "reconciled persisted ecs tasks / service counts after restart",
+            );
+            self.save_snapshot().await;
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -229,4 +229,3 @@ fn matches_filter_respects_none() {
     assert!(matches_filter(Some("x"), "x"));
     assert!(!matches_filter(Some("x"), "y"));
 }
-

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -229,3 +229,4 @@ fn matches_filter_respects_none() {
     assert!(matches_filter(Some("x"), "x"));
     assert!(!matches_filter(Some("x"), "y"));
 }
+

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2143,6 +2143,12 @@ async fn main() {
     if let Some(ref rt) = ecs_runtime {
         ecs_service = ecs_service.with_runtime(rt.clone());
     }
+    // Reconcile persisted task state with reality: persisted tasks
+    // marked RUNNING survive a restart but the docker container does
+    // not, so flip them to STOPPED and zero service counts. The
+    // scheduler ticker brings services back to desiredCount. Same
+    // restart-bug class as RDS #1338.
+    ecs_service.reconcile_persisted_tasks().await;
     let ecs_service = Arc::new(ecs_service);
     let ecs_service_for_scheduler = ecs_service.clone();
     registry.register(ecs_service);


### PR DESCRIPTION
## Summary

Sibling fix to #1340 / #1341 / #1338. Persisted tasks marked `lastStatus=RUNNING` survive a restart but their Docker containers are gone, so `DescribeTasks` reported phantom-running tasks and ECS Exec (`docker exec`) would fail.

- On startup, flip every non-STOPPED task to STOPPED with `stoppedReason='fakecloud restart - backing container lost'` and zero `runningCount`/`pendingCount` on services (and per-deployment).
- Service scheduler ticker reconciles `desiredCount` and launches fresh tasks for service-managed work.
- Standalone `RunTask` tasks are not auto-respawned because we can't safely reconstruct the caller's invocation context — caller re-invokes.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p fakecloud-ecs` 88 passing
- [ ] CI: new E2E test `persistence_running_tasks_reconciled_to_stopped_after_restart`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles persisted ECS task state on restart to prevent phantom RUNNING tasks and broken ECS Exec. On startup, we mark non-STOPPED tasks as STOPPED and reset service counts; the scheduler relaunches as needed.

- **Bug Fixes**
  - Implemented startup reconciliation in `fakecloud-ecs` and wired it in `fakecloud-server`.
  - Set `stoppedReason='fakecloud restart - backing container lost'`, `stopCode='EssentialContainerExited'`, stop timestamps, and container statuses; zeroed service and per-deployment `runningCount`/`pendingCount`.
  - Do not auto-respawn standalone `RunTask` tasks; callers re-run if needed.
  - Added E2E test to verify RUNNING tasks are reconciled to STOPPED after restart.

<sup>Written for commit afc862cfd82e1ae50ede62329e868cb8aa38b38a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

