### PR TITLE
fix(conformance): treat JSON null as absent optional member in shape validator

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,110 +1,142 @@
 {
-  "variants_passed": 78424,
+  "variants_passed": 78602,
   "total_variants": 86666,
   "per_service": {
-    "rds": {
-      "passed": 5095,
-      "total": 5497
-    },
-    "dynamodb": {
-      "passed": 2084,
-      "total": 2134
-    },
-    "cognito-identity": {
-      "passed": 620,
-      "total": 779
-    },
-    "ecs": {
-      "passed": 2282,
-      "total": 2401
-    },
-    "bedrock-agent": {
-      "passed": 2157,
-      "total": 2532
-    },
-    "cloudformation": {
-      "passed": 2957,
-      "total": 3433
-    },
-    "iam": {
-      "passed": 5429,
-      "total": 6000
-    },
-    "apigatewayv1": {
-      "passed": 3110,
-      "total": 3375
-    },
-    "events": {
-      "passed": 2055,
-      "total": 2119
-    },
-    "scheduler": {
-      "passed": 417,
-      "total": 508
-    },
-    "kms": {
-      "passed": 2165,
-      "total": 2231
-    },
-    "ssm": {
-      "passed": 5201,
-      "total": 5309
-    },
-    "bedrock": {
-      "passed": 2893,
-      "total": 3841
-    },
-    "kinesis": {
-      "passed": 1561,
-      "total": 1611
-    },
-    "ecr": {
-      "passed": 1714,
-      "total": 1805
-    },
-    "sqs": {
-      "passed": 499,
-      "total": 549
-    },
     "acm": {
       "passed": 551,
       "total": 601
     },
-    "bedrock-agent-runtime": {
-      "passed": 332,
-      "total": 1173
+    "apigatewayv1": {
+      "passed": 3111,
+      "total": 3375
+    },
+    "apigatewayv2": {
+      "passed": 2744,
+      "total": 2794
     },
     "application-autoscaling": {
       "passed": 884,
       "total": 951
     },
-    "elasticache": {
-      "passed": 2074,
-      "total": 2258
+    "athena": {
+      "passed": 2133,
+      "total": 2320
     },
-    "route53": {
-      "passed": 2318,
-      "total": 2400
+    "bedrock": {
+      "passed": 2893,
+      "total": 3841
     },
-    "logs": {
-      "passed": 3833,
-      "total": 3914
+    "bedrock-agent": {
+      "passed": 2157,
+      "total": 2532
+    },
+    "bedrock-agent-runtime": {
+      "passed": 332,
+      "total": 1173
     },
     "bedrock-runtime": {
       "passed": 293,
       "total": 447
     },
-    "athena": {
-      "passed": 2133,
-      "total": 2320
+    "cloudformation": {
+      "passed": 2957,
+      "total": 3433
     },
-    "states": {
-      "passed": 1209,
-      "total": 1295
+    "cloudfront": {
+      "passed": 3473,
+      "total": 4115
+    },
+    "cognito-identity": {
+      "passed": 620,
+      "total": 779
+    },
+    "cognito-idp": {
+      "passed": 4370,
+      "total": 4484
+    },
+    "dynamodb": {
+      "passed": 2084,
+      "total": 2134
+    },
+    "ecr": {
+      "passed": 1714,
+      "total": 1805
+    },
+    "ecs": {
+      "passed": 2282,
+      "total": 2401
+    },
+    "elasticache": {
+      "passed": 2206,
+      "total": 2258
     },
     "elasticloadbalancing": {
       "passed": 1500,
       "total": 1587
+    },
+    "events": {
+      "passed": 2055,
+      "total": 2119
+    },
+    "iam": {
+      "passed": 5429,
+      "total": 6000
+    },
+    "kinesis": {
+      "passed": 1561,
+      "total": 1611
+    },
+    "kms": {
+      "passed": 2157,
+      "total": 2231
+    },
+    "lambda": {
+      "passed": 2211,
+      "total": 3176
+    },
+    "logs": {
+      "passed": 3833,
+      "total": 3914
+    },
+    "rds": {
+      "passed": 5190,
+      "total": 5497
+    },
+    "route53": {
+      "passed": 2318,
+      "total": 2400
+    },
+    "s3": {
+      "passed": 3474,
+      "total": 3669
+    },
+    "scheduler": {
+      "passed": 417,
+      "total": 508
+    },
+    "secretsmanager": {
+      "passed": 823,
+      "total": 875
+    },
+    "ses": {
+      "passed": 2691,
+      "total": 2867
+    },
+    "sns": {
+      "passed": 971,
+      "total": 1027
+    },
+    "sqs": {
+      "passed": 499,
+      "total": 549
+    },
+    "ssm": {
+      "passed": 5201,
+      "total": 5309
+    },
+    "states": {
+      "passed": 1209,
+      "total": 1295
     },
     "sts": {
       "passed": 339,
@@ -113,38 +145,6 @@
     "wafv2": {
       "passed": 1920,
       "total": 2141
-    },
-    "apigatewayv2": {
-      "passed": 2744,
-      "total": 2794
-    },
-    "lambda": {
-      "passed": 2209,
-      "total": 3176
-    },
-    "ses": {
-      "passed": 2674,
-      "total": 2867
-    },
-    "s3": {
-      "passed": 3474,
-      "total": 3669
-    },
-    "cognito-idp": {
-      "passed": 4431,
-      "total": 4484
-    },
-    "secretsmanager": {
-      "passed": 823,
-      "total": 875
-    },
-    "sns": {
-      "passed": 971,
-      "total": 1027
-    },
-    "cloudfront": {
-      "passed": 3473,
-      "total": 4115
     }
   }
 }

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,150 +1,150 @@
 {
-  "variants_passed": 78153,
+  "variants_passed": 78424,
   "total_variants": 86666,
   "per_service": {
-    "cloudfront": {
-      "passed": 3473,
-      "total": 4115
+    "rds": {
+      "passed": 5095,
+      "total": 5497
     },
-    "cognito-idp": {
-      "passed": 4422,
-      "total": 4484
+    "dynamodb": {
+      "passed": 2084,
+      "total": 2134
+    },
+    "cognito-identity": {
+      "passed": 620,
+      "total": 779
+    },
+    "ecs": {
+      "passed": 2282,
+      "total": 2401
+    },
+    "bedrock-agent": {
+      "passed": 2157,
+      "total": 2532
+    },
+    "cloudformation": {
+      "passed": 2957,
+      "total": 3433
+    },
+    "iam": {
+      "passed": 5429,
+      "total": 6000
+    },
+    "apigatewayv1": {
+      "passed": 3110,
+      "total": 3375
+    },
+    "events": {
+      "passed": 2055,
+      "total": 2119
+    },
+    "scheduler": {
+      "passed": 417,
+      "total": 508
+    },
+    "kms": {
+      "passed": 2165,
+      "total": 2231
+    },
+    "ssm": {
+      "passed": 5201,
+      "total": 5309
+    },
+    "bedrock": {
+      "passed": 2893,
+      "total": 3841
+    },
+    "kinesis": {
+      "passed": 1561,
+      "total": 1611
+    },
+    "ecr": {
+      "passed": 1714,
+      "total": 1805
+    },
+    "sqs": {
+      "passed": 499,
+      "total": 549
     },
     "acm": {
       "passed": 551,
       "total": 601
     },
-    "bedrock": {
-      "passed": 2891,
-      "total": 3841
+    "bedrock-agent-runtime": {
+      "passed": 332,
+      "total": 1173
+    },
+    "application-autoscaling": {
+      "passed": 884,
+      "total": 951
+    },
+    "elasticache": {
+      "passed": 2074,
+      "total": 2258
+    },
+    "route53": {
+      "passed": 2318,
+      "total": 2400
+    },
+    "logs": {
+      "passed": 3833,
+      "total": 3914
+    },
+    "bedrock-runtime": {
+      "passed": 293,
+      "total": 447
+    },
+    "athena": {
+      "passed": 2133,
+      "total": 2320
+    },
+    "states": {
+      "passed": 1209,
+      "total": 1295
+    },
+    "elasticloadbalancing": {
+      "passed": 1500,
+      "total": 1587
+    },
+    "sts": {
+      "passed": 339,
+      "total": 448
+    },
+    "wafv2": {
+      "passed": 1920,
+      "total": 2141
+    },
+    "apigatewayv2": {
+      "passed": 2744,
+      "total": 2794
+    },
+    "lambda": {
+      "passed": 2209,
+      "total": 3176
     },
     "ses": {
-      "passed": 2560,
+      "passed": 2674,
       "total": 2867
     },
     "s3": {
       "passed": 3474,
       "total": 3669
     },
-    "cognito-identity": {
-      "passed": 620,
-      "total": 779
-    },
-    "apigatewayv1": {
-      "passed": 3111,
-      "total": 3375
-    },
-    "bedrock-agent": {
-      "passed": 2157,
-      "total": 2532
-    },
-    "ssm": {
-      "passed": 5202,
-      "total": 5309
-    },
-    "lambda": {
-      "passed": 2211,
-      "total": 3176
-    },
-    "states": {
-      "passed": 1209,
-      "total": 1295
-    },
-    "sns": {
-      "passed": 971,
-      "total": 1027
-    },
-    "elasticache": {
-      "passed": 2084,
-      "total": 2258
-    },
-    "cloudformation": {
-      "passed": 2957,
-      "total": 3433
-    },
-    "logs": {
-      "passed": 3833,
-      "total": 3914
-    },
-    "sqs": {
-      "passed": 499,
-      "total": 549
-    },
-    "events": {
-      "passed": 2055,
-      "total": 2119
-    },
-    "wafv2": {
-      "passed": 1920,
-      "total": 2141
-    },
-    "bedrock-agent-runtime": {
-      "passed": 332,
-      "total": 1173
-    },
-    "kinesis": {
-      "passed": 1561,
-      "total": 1611
-    },
-    "bedrock-runtime": {
-      "passed": 293,
-      "total": 447
-    },
-    "ecr": {
-      "passed": 1714,
-      "total": 1805
-    },
-    "iam": {
-      "passed": 5429,
-      "total": 6000
-    },
-    "route53": {
-      "passed": 2318,
-      "total": 2400
+    "cognito-idp": {
+      "passed": 4431,
+      "total": 4484
     },
     "secretsmanager": {
       "passed": 823,
       "total": 875
     },
-    "sts": {
-      "passed": 339,
-      "total": 448
+    "sns": {
+      "passed": 971,
+      "total": 1027
     },
-    "kms": {
-      "passed": 2165,
-      "total": 2231
-    },
-    "dynamodb": {
-      "passed": 2084,
-      "total": 2134
-    },
-    "ecs": {
-      "passed": 2077,
-      "total": 2401
-    },
-    "application-autoscaling": {
-      "passed": 884,
-      "total": 951
-    },
-    "athena": {
-      "passed": 2133,
-      "total": 2320
-    },
-    "elasticloadbalancing": {
-      "passed": 1500,
-      "total": 1587
-    },
-    "rds": {
-      "passed": 5140,
-      "total": 5497
-    },
-    "scheduler": {
-      "passed": 417,
-      "total": 508
-    },
-    "apigatewayv2": {
-      "passed": 2744,
-      "total": 2794
+    "cloudfront": {
+      "passed": 3473,
+      "total": 4115
     }
   }
 }

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -375,6 +375,18 @@ fn validate_shape(
         return;
     }
 
+    // JSON `null` represents an absent optional member. Required members
+    // are already enforced by `validate_structure` via the missing-key
+    // check on `obj.contains_key(...)` — but `null` is technically a
+    // present key, so we'd previously fall through to a string-vs-null
+    // WrongType error. That's wrong: AWS services routinely emit
+    // `"NextToken": null` to indicate no further pages, and the SDK
+    // treats it identically to the field being absent. Skip primitive
+    // type validation when the value is null.
+    if value.is_null() {
+        return;
+    }
+
     let shape_type = match effective_shape_type(model, shape_id) {
         Some(st) => st,
         None => return, // Unknown shape; skip validation


### PR DESCRIPTION
## Summary
AWS services routinely emit \`"NextToken": null\` to indicate no further pages, and the SDK treats it identically to the field being absent. The probe's shape validator was running primitive-type validation on the null value and bucketing those responses as \`SHAPE_MISMATCH: wrong type at $.NextToken: expected string, got null\`.

Required-field enforcement happens earlier in \`validate_structure\` via the \`obj.contains_key(...)\` check, so skipping all type validation when value is null is safe — required-missing still fires elsewhere if the key is genuinely absent.

~141 variants affected (73 NextToken + 68 nextToken across paginated ops).

## Test plan
- [ ] Conformance workflow passes
- [ ] Baseline refresh follow-up commit lands once local re-baseline completes
- [ ] Expected jump: 92.4% -> ~92.6%

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat JSON null as an absent optional member in the shape validator to match AWS behavior (e.g., "NextToken": null). Baseline rebased on CI numbers and refreshed with a -50/svc margin to capture the improvement.

- **Bug Fixes**
  - Skip primitive type validation when the value is null; required members are still enforced earlier in validate_structure.
  - Removes wrong-type errors for NextToken/nextToken and similar fields; more variants now pass. Baseline rebased on CI numbers.

<sup>Written for commit 25e1a3dd09692e412dff2a549e4b05538fca24da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

