### PR TITLE
fix(bedrock): emit required fields on list-summary responses

### DIFF
--- a/crates/fakecloud-bedrock/src/custom_model_deployments.rs
+++ b/crates/fakecloud-bedrock/src/custom_model_deployments.rs
@@ -201,7 +201,7 @@ fn deployment_to_json(d: &CustomModelDeployment) -> Value {
 fn deployment_summary_json(d: &CustomModelDeployment) -> Value {
     let mut obj = json!({
         "customModelDeploymentArn": d.deployment_arn,
-        "modelDeploymentName": d.deployment_name,
+        "customModelDeploymentName": d.deployment_name,
         "modelArn": d.model_arn,
         "status": d.status,
         "createdAt": d.created_at.to_rfc3339(),

--- a/crates/fakecloud-bedrock/src/custom_models.rs
+++ b/crates/fakecloud-bedrock/src/custom_models.rs
@@ -21,9 +21,25 @@ pub(crate) fn create_custom_model(
         req.region, req.account_id, model_id
     );
 
+    let base_model_name = body["baseModelIdentifier"]
+        .as_str()
+        .or_else(|| body["baseModelName"].as_str())
+        .unwrap_or("amazon.titan-text-express-v1")
+        .to_string();
+    let base_model_arn = if base_model_name.starts_with("arn:") {
+        base_model_name.clone()
+    } else {
+        format!(
+            "arn:aws:bedrock:{}::foundation-model/{}",
+            req.region, base_model_name
+        )
+    };
+
     let model = CustomModel {
         model_arn: model_arn.clone(),
         model_name: model_name.to_string(),
+        base_model_arn,
+        base_model_name,
         model_source_config: body.get("modelSourceConfig").cloned().unwrap_or(json!({})),
         model_kms_key_arn: body["modelKmsKeyArn"].as_str().map(|s| s.to_string()),
         role_arn: body["roleArn"].as_str().map(|s| s.to_string()),
@@ -69,6 +85,7 @@ pub(crate) fn get_custom_model(
     Ok(AwsResponse::ok_json(json!({
         "modelArn": model.model_arn,
         "modelName": model.model_name,
+        "baseModelArn": model.base_model_arn,
         "modelStatus": model.model_status,
         "creationTime": model.creation_time.to_rfc3339(),
     })))
@@ -109,6 +126,8 @@ pub(crate) fn list_custom_models(
             json!({
                 "modelArn": m.model_arn,
                 "modelName": m.model_name,
+                "baseModelArn": m.base_model_arn,
+                "baseModelName": m.base_model_name,
                 "modelStatus": m.model_status,
                 "creationTime": m.creation_time.to_rfc3339(),
             })

--- a/crates/fakecloud-bedrock/src/customization.rs
+++ b/crates/fakecloud-bedrock/src/customization.rs
@@ -156,7 +156,7 @@ pub(crate) fn list_model_customization_jobs(
                 "jobArn": j.job_arn,
                 "jobName": j.job_name,
                 "status": j.status,
-                "baseModelIdentifier": j.base_model_identifier,
+                "baseModelArn": base_model_arn(&j.base_model_identifier, &req.region),
                 "customModelName": j.custom_model_name,
                 "creationTime": j.created_at.to_rfc3339(),
                 "lastModifiedTime": j.last_modified_at.to_rfc3339(),
@@ -173,6 +173,16 @@ pub(crate) fn list_model_customization_jobs(
     }
 
     Ok(AwsResponse::ok_json(resp))
+}
+
+/// Normalize the customization job's stored base model identifier into a
+/// full foundation-model ARN, since the Smithy summary requires `baseModelArn`.
+fn base_model_arn(base_model_identifier: &str, region: &str) -> String {
+    if base_model_identifier.starts_with("arn:") {
+        base_model_identifier.to_string()
+    } else {
+        format!("arn:aws:bedrock:{region}::foundation-model/{base_model_identifier}")
+    }
 }
 
 pub(crate) fn stop_model_customization_job(

--- a/crates/fakecloud-bedrock/src/evaluation.rs
+++ b/crates/fakecloud-bedrock/src/evaluation.rs
@@ -113,6 +113,7 @@ pub(crate) fn list_evaluation_jobs(
                 "status": j.status,
                 "jobType": j.job_type,
                 "creationTime": j.creation_time.to_rfc3339(),
+                "evaluationTaskTypes": ["Generation"],
             })
         })
         .collect();

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -88,9 +88,11 @@ pub(crate) fn get_inference_profile(
 
     Ok(AwsResponse::ok_json(json!({
         "inferenceProfileArn": profile.inference_profile_arn,
+        "inferenceProfileId": profile_id_from_arn(&profile.inference_profile_arn),
         "inferenceProfileName": profile.inference_profile_name,
         "description": profile.description,
         "modelSource": profile.model_source,
+        "models": profile_models(&profile.model_source),
         "status": profile.status,
         "type": profile.inference_profile_type,
         "createdAt": profile.created_at.to_rfc3339(),
@@ -132,8 +134,10 @@ pub(crate) fn list_inference_profiles(
         .map(|p| {
             json!({
                 "inferenceProfileArn": p.inference_profile_arn,
+                "inferenceProfileId": profile_id_from_arn(&p.inference_profile_arn),
                 "inferenceProfileName": p.inference_profile_name,
                 "description": p.description,
+                "models": profile_models(&p.model_source),
                 "status": p.status,
                 "type": p.inference_profile_type,
                 "createdAt": p.created_at.to_rfc3339(),
@@ -151,6 +155,25 @@ pub(crate) fn list_inference_profiles(
     }
 
     Ok(AwsResponse::ok_json(resp))
+}
+
+/// The last segment of the inference-profile ARN is the unique ID Bedrock
+/// echoes back in the summary, so we just split on `/`.
+fn profile_id_from_arn(arn: &str) -> String {
+    arn.rsplit('/').next().unwrap_or(arn).to_string()
+}
+
+/// Build the `models` summary list. We try to extract a copyFrom model ARN
+/// from the user-supplied `modelSource`, otherwise emit one synthesized entry
+/// pointing at a real foundation-model ARN so the response satisfies the
+/// `min: 1` length constraint on `InferenceProfileModels`.
+fn profile_models(model_source: &Value) -> Value {
+    if let Some(copy_from) = model_source.get("copyFrom").and_then(Value::as_str) {
+        return json!([{ "modelArn": copy_from }]);
+    }
+    json!([{
+        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
+    }])
 }
 
 pub(crate) fn delete_inference_profile(

--- a/crates/fakecloud-bedrock/src/invocation_jobs.rs
+++ b/crates/fakecloud-bedrock/src/invocation_jobs.rs
@@ -62,8 +62,8 @@ pub(crate) fn get_model_invocation_job(
         "modelId": job.model_id,
         "roleArn": job.role_arn,
         "status": job.status,
-        "inputDataConfig": job.input_data_config,
-        "outputDataConfig": job.output_data_config,
+        "inputDataConfig": ensure_input_data_config(&job.input_data_config),
+        "outputDataConfig": ensure_output_data_config(&job.output_data_config),
         "submitTime": job.submit_time.to_rfc3339(),
         "lastModifiedTime": job.last_modified_time.to_rfc3339(),
     });
@@ -110,9 +110,12 @@ pub(crate) fn list_model_invocation_jobs(
                 "jobArn": j.job_arn,
                 "jobName": j.job_name,
                 "modelId": j.model_id,
+                "roleArn": j.role_arn,
                 "status": j.status,
                 "submitTime": j.submit_time.to_rfc3339(),
                 "lastModifiedTime": j.last_modified_time.to_rfc3339(),
+                "inputDataConfig": ensure_input_data_config(&j.input_data_config),
+                "outputDataConfig": ensure_output_data_config(&j.output_data_config),
             })
         })
         .collect();
@@ -155,6 +158,28 @@ pub(crate) fn stop_model_invocation_job(
     job.end_time = Some(now);
 
     Ok(AwsResponse::json(StatusCode::OK, "{}".to_string()))
+}
+
+fn ensure_input_data_config(cfg: &Value) -> Value {
+    if cfg.get("s3InputDataConfig").is_some() {
+        return cfg.clone();
+    }
+    json!({
+        "s3InputDataConfig": {
+            "s3Uri": "s3://fakecloud-bedrock-batch/input/"
+        }
+    })
+}
+
+fn ensure_output_data_config(cfg: &Value) -> Value {
+    if cfg.get("s3OutputDataConfig").is_some() {
+        return cfg.clone();
+    }
+    json!({
+        "s3OutputDataConfig": {
+            "s3Uri": "s3://fakecloud-bedrock-batch/output/"
+        }
+    })
 }
 
 fn find_job<'a>(

--- a/crates/fakecloud-bedrock/src/model_copy.rs
+++ b/crates/fakecloud-bedrock/src/model_copy.rs
@@ -72,6 +72,7 @@ pub(crate) fn get_model_copy_job(
         "jobArn": job.job_arn,
         "status": job.status,
         "creationTime": job.creation_time.to_rfc3339(),
+        "sourceAccountId": source_account_id(&job.source_model_arn, &req.account_id),
         "sourceModelArn": job.source_model_arn,
         "targetModelArn": job.target_model_arn,
         "targetModelName": job.target_model_name,
@@ -114,8 +115,10 @@ pub(crate) fn list_model_copy_jobs(
                 "jobArn": j.job_arn,
                 "status": j.status,
                 "creationTime": j.creation_time.to_rfc3339(),
+                "sourceAccountId": source_account_id(&j.source_model_arn, &req.account_id),
                 "sourceModelArn": j.source_model_arn,
                 "targetModelArn": j.target_model_arn,
+                "targetModelName": j.target_model_name,
             })
         })
         .collect();
@@ -129,6 +132,17 @@ pub(crate) fn list_model_copy_jobs(
     }
 
     Ok(AwsResponse::ok_json(resp))
+}
+
+/// Extract the AWS account ID from an ARN, falling back to the caller's
+/// account when the ARN is malformed or missing.
+fn source_account_id(source_model_arn: &str, fallback: &str) -> String {
+    source_model_arn
+        .split(':')
+        .nth(4)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-bedrock/src/models.rs
+++ b/crates/fakecloud-bedrock/src/models.rs
@@ -14,8 +14,13 @@ pub struct FoundationModel {
 }
 
 impl FoundationModel {
-    pub(crate) fn to_summary_json(&self) -> Value {
+    pub(crate) fn to_summary_json(&self, region: &str) -> Value {
+        let arn = format!(
+            "arn:aws:bedrock:{}::foundation-model/{}",
+            region, self.model_id
+        );
         json!({
+            "modelArn": arn,
             "modelId": self.model_id,
             "modelName": self.model_name,
             "providerName": self.provider_name,
@@ -271,8 +276,12 @@ mod tests {
     #[test]
     fn summary_json_shape() {
         let m = find_model("amazon.titan-embed-text-v1").unwrap();
-        let v = m.to_summary_json();
+        let v = m.to_summary_json("us-east-1");
         assert_eq!(v["modelId"], "amazon.titan-embed-text-v1");
+        assert_eq!(
+            v["modelArn"],
+            "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+        );
         assert_eq!(v["providerName"], "Amazon");
         assert_eq!(v["outputModalities"][0], "EMBEDDING");
         assert_eq!(v["responseStreamingSupported"], false);

--- a/crates/fakecloud-bedrock/src/prompt_routers.rs
+++ b/crates/fakecloud-bedrock/src/prompt_routers.rs
@@ -74,9 +74,9 @@ pub(crate) fn get_prompt_router(
         "promptRouterArn": router.prompt_router_arn,
         "promptRouterName": router.prompt_router_name,
         "description": router.description,
-        "models": router.models,
-        "routingCriteria": router.routing_criteria,
-        "fallbackModel": router.fallback_model,
+        "models": ensure_router_models(&router.models),
+        "routingCriteria": ensure_routing_criteria(&router.routing_criteria),
+        "fallbackModel": ensure_fallback_model(&router.fallback_model),
         "status": router.status,
         "type": router.prompt_router_type,
         "createdAt": router.created_at.to_rfc3339(),
@@ -120,6 +120,9 @@ pub(crate) fn list_prompt_routers(
                 "promptRouterArn": r.prompt_router_arn,
                 "promptRouterName": r.prompt_router_name,
                 "description": r.description,
+                "routingCriteria": ensure_routing_criteria(&r.routing_criteria),
+                "models": ensure_router_models(&r.models),
+                "fallbackModel": ensure_fallback_model(&r.fallback_model),
                 "status": r.status,
                 "type": r.prompt_router_type,
                 "createdAt": r.created_at.to_rfc3339(),
@@ -137,6 +140,39 @@ pub(crate) fn list_prompt_routers(
     }
 
     Ok(AwsResponse::ok_json(resp))
+}
+
+/// Synthesize a minimal default `routingCriteria` when the router was created
+/// without one, so the summary satisfies the Smithy required field.
+fn ensure_routing_criteria(criteria: &Value) -> Value {
+    if criteria.get("responseQualityDifference").is_some() {
+        return criteria.clone();
+    }
+    json!({ "responseQualityDifference": 0.0 })
+}
+
+/// Default the router's target models to a single Titan entry when none were
+/// supplied at create time, matching the required Smithy field.
+fn ensure_router_models(models: &Value) -> Value {
+    if let Some(arr) = models.as_array() {
+        if !arr.is_empty() {
+            return models.clone();
+        }
+    }
+    json!([{
+        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
+    }])
+}
+
+/// Default the fallback model when not provided. `fallbackModel` is required
+/// in the summary even though it's optional on create.
+fn ensure_fallback_model(fallback: &Value) -> Value {
+    if fallback.get("modelArn").is_some() {
+        return fallback.clone();
+    }
+    json!({
+        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
+    })
 }
 
 pub(crate) fn delete_prompt_router(

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -746,7 +746,7 @@ impl BedrockService {
                     continue;
                 }
             }
-            model_summaries.push(model.to_summary_json());
+            model_summaries.push(model.to_summary_json(&req.region));
         }
 
         Ok(AwsResponse::ok_json(json!({

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -340,6 +340,8 @@ pub struct AsyncInvocation {
 pub struct CustomModel {
     pub model_arn: String,
     pub model_name: String,
+    pub base_model_arn: String,
+    pub base_model_name: String,
     pub model_source_config: serde_json::Value,
     pub model_kms_key_arn: Option<String>,
     pub role_arn: Option<String>,

--- a/crates/fakecloud-bedrock/src/state.rs
+++ b/crates/fakecloud-bedrock/src/state.rs
@@ -340,7 +340,9 @@ pub struct AsyncInvocation {
 pub struct CustomModel {
     pub model_arn: String,
     pub model_name: String,
+    #[serde(default)]
     pub base_model_arn: String,
+    #[serde(default)]
     pub base_model_name: String,
     pub model_source_config: serde_json::Value,
     pub model_kms_key_arn: Option<String>,


### PR DESCRIPTION
## Summary

Fixes Bedrock list/summary responses that were missing Smithy-required fields, so the AWS SDKs and the conformance probe stop rejecting them. Where the underlying state didn't carry the data, the handler synthesizes a plausible value (ARN-shaped string, valid enum, structurally-correct union variant) instead of returning an empty struct.

## Shapes touched

- `EvaluationSummary` -> add `evaluationTaskTypes` (defaults to `["Generation"]`).
- `ModelInvocationJobSummary` -> add `roleArn`, `inputDataConfig`, `outputDataConfig`; if a job was created without an explicit S3 config, fall back to a synthesized `s3InputDataConfig`/`s3OutputDataConfig`. Same fix applied to `GetModelInvocationJob`.
- `CustomModelSummary` -> persist `baseModelArn`/`baseModelName` at create time (from `baseModelIdentifier` or `baseModelName`, defaulting to `amazon.titan-text-express-v1`) and emit them in the summary; `GetCustomModel` echoes `baseModelArn` too.
- `ModelCopyJobSummary` -> add `sourceAccountId` (parsed from the source ARN, falling back to the caller's account) and `targetModelName`; same in `GetModelCopyJob`.
- `ModelCustomizationJobSummary` -> swap the non-spec `baseModelIdentifier` for the required `baseModelArn`, normalizing bare model IDs into full foundation-model ARNs.
- `CustomModelDeploymentSummary` -> rename `modelDeploymentName` -> `customModelDeploymentName` so the field matches the Smithy `@jsonName`.
- `FoundationModelSummary` -> include `modelArn` on every summary (threaded `region` into `FoundationModel::to_summary_json`).
- `InferenceProfileSummary` -> add `inferenceProfileId` and `models` (with a Titan-ARN fallback to satisfy `min: 1`) on both list and get.
- `PromptRouterSummary` -> add `routingCriteria`, `models`, and `fallbackModel`, with sensible defaults when the router was created without them; same in `GetPromptRouter`.

## Test plan

- [x] `cargo test -p fakecloud-bedrock` (342 passing)
- [x] `cargo build --bin fakecloud`
- [ ] CI conformance run to confirm the listed gaps close

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing fields in Bedrock list/get summaries so they match Smithy shapes and pass SDK/conformance checks. Adds required fields with safe defaults and preserves back-compat for existing CustomModel state.

- **Bug Fixes**
  - Invocation jobs: add roleArn, inputDataConfig, outputDataConfig; default S3 input/output configs when absent (List/Get).
  - Custom models: persist/emit baseModelArn/baseModelName; normalize or default to amazon.titan-text-express-v1; Get returns baseModelArn; back-compat for old persisted models via serde defaults.
  - Model copy/customization: add sourceAccountId (from source ARN or caller) and targetModelName to copy jobs; replace baseModelIdentifier with baseModelArn in customization summaries.
  - Inference profiles: add inferenceProfileId and models; synthesize a Titan model when none provided (List/Get).
  - Prompt routers: add routingCriteria, models, and fallbackModel with sensible defaults (List/Get).
  - Foundation models/evaluations: include modelArn in summaries; add evaluationTaskTypes with ["Generation"].

- **Migration**
  - Deployment summaries now use customModelDeploymentName (was modelDeploymentName). Update any consumers expecting the old field.

<sup>Written for commit 540996a85bf6f41ca4c025432b2c59fab7f02bd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

