### PR TITLE
fix(lambda): return required output fields on config-op responses

### DIFF
--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -619,6 +619,60 @@ fn rest_request_config(
                 format!("{}/account-settings", LAMBDA_PREFIX),
                 None,
             ),
+            // Function URL config (uses 2021-10-31 prefix in AWS but the
+            // route is prefix-agnostic in fakecloud).
+            "CreateFunctionUrlConfig" => (
+                reqwest::Method::POST,
+                format!("/2021-10-31/functions/{}/url", FUNC),
+                None,
+            ),
+            "GetFunctionUrlConfig" => (
+                reqwest::Method::GET,
+                format!("/2021-10-31/functions/{}/url", FUNC),
+                None,
+            ),
+            "UpdateFunctionUrlConfig" => (
+                reqwest::Method::PUT,
+                format!("/2021-10-31/functions/{}/url", FUNC),
+                None,
+            ),
+            "DeleteFunctionUrlConfig" => (
+                reqwest::Method::DELETE,
+                format!("/2021-10-31/functions/{}/url", FUNC),
+                None,
+            ),
+            "ListFunctionUrlConfigs" => (
+                reqwest::Method::GET,
+                format!("/2021-10-31/functions/{}/urls", FUNC),
+                None,
+            ),
+            // Per-function code-signing config (2020-06-30 in AWS).
+            "PutFunctionCodeSigningConfig" => (
+                reqwest::Method::PUT,
+                format!("/2020-06-30/functions/{}/code-signing-config", FUNC),
+                None,
+            ),
+            "GetFunctionCodeSigningConfig" => (
+                reqwest::Method::GET,
+                format!("/2020-06-30/functions/{}/code-signing-config", FUNC),
+                None,
+            ),
+            "DeleteFunctionCodeSigningConfig" => (
+                reqwest::Method::DELETE,
+                format!("/2020-06-30/functions/{}/code-signing-config", FUNC),
+                None,
+            ),
+            // Runtime management config (2021-07-20 in AWS).
+            "PutRuntimeManagementConfig" => (
+                reqwest::Method::PUT,
+                format!("/2021-07-20/functions/{}/runtime-management-config", FUNC),
+                None,
+            ),
+            "GetRuntimeManagementConfig" => (
+                reqwest::Method::GET,
+                format!("/2021-07-20/functions/{}/runtime-management-config", FUNC),
+                None,
+            ),
             // Default: POST to functions path
             _ => (
                 reqwest::Method::POST,


### PR DESCRIPTION
## Summary

The conformance probe's per-operation HTTP route table was missing entries for several Lambda config operations. Without an explicit entry those ops fell through to the default `POST /functions` route (which hits CreateFunction), so the response was a function configuration JSON. The shape validator then flagged every required field of the *expected* response (AuthType, CreationTime, FunctionUrl, ...) as missing.

Added explicit probe routes for:

- `CreateFunctionUrlConfig`, `GetFunctionUrlConfig`, `UpdateFunctionUrlConfig`, `DeleteFunctionUrlConfig`, `ListFunctionUrlConfigs` (2021-10-31)
- `PutFunctionCodeSigningConfig`, `GetFunctionCodeSigningConfig`, `DeleteFunctionCodeSigningConfig` (2020-06-30)
- `PutRuntimeManagementConfig`, `GetRuntimeManagementConfig` (2021-07-20)

The fakecloud-lambda handlers themselves already returned the correct Smithy-declared response shapes (`function_url_config_json` emits all required fields; `put_function_code_signing` / `get_function_code_signing` return both required fields; `put_runtime_management` / `get_runtime_management` return both required fields). This was a probe-routing bug, not a server bug.

## Per-op deltas (passed/total)

| Op | Before | After |
| --- | --- | --- |
| CreateFunctionUrlConfig | 24/48 | 41/48 |
| GetFunctionUrlConfig | 18/38 | 37/38 |
| UpdateFunctionUrlConfig | 28/48 | 47/48 |
| ListFunctionUrlConfigs | 20/40 | 35/40 |
| DeleteFunctionUrlConfig | 18/38 | 33/38 |
| GetFunctionCodeSigningConfig | 12/32 | 29/32 |
| PutFunctionCodeSigningConfig | 17/37 | 33/37 |
| DeleteFunctionCodeSigningConfig | 12/32 | 29/32 |
| PutRuntimeManagementConfig | 31/51 | 41/51 |
| GetRuntimeManagementConfig | 18/38 | 33/38 |

Lambda total variants passing: 2617 -> 2767 (+150). Remaining failures are all `negative_*` input-validation variants (out of scope here) plus one round-trip qualifier mismatch on `PutRuntimeManagementConfig`.

## Test plan

- [x] `cargo test -p fakecloud-lambda` (138 passed)
- [x] `cargo test -p fakecloud-conformance --lib` (82 passed)
- [x] `fakecloud-conformance run --services lambda` confirms the per-op deltas above
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conformance probe routing for Lambda config operations so each hits the correct versioned path and returns the expected response shape. Increases Lambda conformance pass count by 150 (2617 → 2767).

- **Bug Fixes**
  - Added explicit routes for Function URL config (Create/Get/Update/Delete/List) under `/2021-10-31`.
  - Added explicit routes for per-function Code Signing config (Put/Get/Delete) under `/2020-06-30`.
  - Added explicit routes for Runtime Management config (Put/Get) under `/2021-07-20`.

<sup>Written for commit e631370db3ffc11bf0fc1584b128e28f0b3a7628. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

