### PR TITLE
fix(cloudfront): emit Smithy-declared error shape names

### DIFF
--- a/crates/fakecloud-cloudfront/src/policies.rs
+++ b/crates/fakecloud-cloudfront/src/policies.rs
@@ -753,10 +753,43 @@ pub(crate) fn require_if_match(req: &AwsRequest) -> Result<String, AwsServiceErr
         })
 }
 
+/// Map a logical resource "kind" to the Smithy-declared error shape name used
+/// on the CloudFront wire. Most resources use the `NoSuch{Kind}` pattern, but
+/// several do not:
+///
+/// - `Function` -> `NoSuchFunctionExists` (the actual Smithy shape name)
+/// - `KeyGroup` -> `NoSuchResource` (per Get/Update/DeleteKeyGroup errors)
+/// - `FieldLevelEncryption` -> `NoSuchFieldLevelEncryptionConfig`
+/// - Newer "tenant-era" resources (DistributionTenant, ConnectionGroup,
+///   ConnectionFunction, VpcOrigin, AnycastIpList, KeyValueStore, TrustStore,
+///   ResourcePolicy) all share the unified `EntityNotFound` error shape.
+fn not_found_code(kind: &str) -> &'static str {
+    match kind {
+        "Function" => "NoSuchFunctionExists",
+        "KeyGroup" => "NoSuchResource",
+        "FieldLevelEncryption" => "NoSuchFieldLevelEncryptionConfig",
+        "AnycastIpList" | "ConnectionFunction" | "ConnectionGroup" | "DistributionTenant"
+        | "KeyValueStore" | "ResourcePolicy" | "TrustStore" | "VpcOrigin" => "EntityNotFound",
+        _ => "",
+    }
+}
+
 pub(crate) fn not_found(kind: &str, id: &str) -> AwsServiceError {
+    let code = not_found_code(kind);
+    let code = if code.is_empty() {
+        // Default to `NoSuch{Kind}` for the long tail of resources whose
+        // Smithy shape follows that convention (Distribution, CachePolicy,
+        // PublicKey, OriginAccessControl, OriginRequestPolicy,
+        // ResponseHeadersPolicy, ContinuousDeploymentPolicy,
+        // StreamingDistribution, FieldLevelEncryptionProfile,
+        // CloudFrontOriginAccessIdentity, RealtimeLogConfig, Invalidation).
+        format!("NoSuch{kind}")
+    } else {
+        code.to_string()
+    };
     aws_error(
         StatusCode::NOT_FOUND,
-        format!("NoSuch{kind}"),
+        code,
         format!("The specified {kind} does not exist: {id}"),
     )
 }


### PR DESCRIPTION
## Summary

The `not_found` helper in `crates/fakecloud-cloudfront/src/policies.rs` blindly emitted `NoSuch{kind}` for every resource. Strict-mode conformance surfaced ~400 variants across four error codes that don't match the upstream CloudFront Smithy model:

- 119 `NoSuchDistributionTenant`
- 102 `NoSuchFunction`
- 96  `NoSuchConnectionFunction`
- 63  `NoSuchConnectionGroup`

## Fix

Added a small kind -> Smithy-shape mapping table in `not_found`:

- `Function` -> `NoSuchFunctionExists` (the actual declared shape name)
- `KeyGroup` -> `NoSuchResource`
- `FieldLevelEncryption` -> `NoSuchFieldLevelEncryptionConfig`
- Tenant-era resources (DistributionTenant, ConnectionGroup, ConnectionFunction, VpcOrigin, AnycastIpList, KeyValueStore, TrustStore, ResourcePolicy) -> unified `EntityNotFound`

All other kinds keep the `NoSuch{Kind}` default, which already matches the model.

## Upstream model gaps

None remaining. Every kind we pass to `not_found` now maps to a shape that is declared in `aws-models/cloudfront.json`. No fallback (option (b)) was needed.

## Test plan
- [x] `cargo build -p fakecloud-cloudfront`
- [x] `cargo test -p fakecloud-cloudfront --lib` (45 passed)
- [x] `cargo clippy -p fakecloud-cloudfront --all-targets -- -D warnings`
- [x] `cargo fmt`
- [ ] Conformance strict-mode shows ~400 variants flipped across the four affected codes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CloudFront to emit the Smithy-declared error shape names instead of always using `NoSuch{Kind}`, resolving strict-mode conformance mismatches across ~400 variants. Unaffected kinds still use the `NoSuch{Kind}` default.

- **Bug Fixes**
  - Added `not_found_code` mapping in `crates/fakecloud-cloudfront/src/policies.rs`.
  - Mapped: `Function` → `NoSuchFunctionExists`, `KeyGroup` → `NoSuchResource`, `FieldLevelEncryption` → `NoSuchFieldLevelEncryptionConfig`, and tenant-era resources (e.g., `DistributionTenant`, `ConnectionGroup`, `VpcOrigin`, etc.) → `EntityNotFound`.
  - All other kinds continue to use `NoSuch{Kind}`.
  - Result: all emitted codes align with `aws-models/cloudfront.json`.

<sup>Written for commit cce5909e7120f508a618c6a93d3cd3f9f71e2cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

