### PR TITLE
fix(conformance): gate awsQueryError wire-code by protocol

### DIFF
--- a/crates/fakecloud-conformance/src/probe.rs
+++ b/crates/fakecloud-conformance/src/probe.rs
@@ -156,6 +156,16 @@ pub fn service_protocol(service_name: &str) -> Protocol {
     }
 }
 
+/// Services whose wire format is awsJson1.x but which carry the
+/// `aws.protocols#awsQueryCompatible` trait, so their `__type` values
+/// follow the awsQuery `<Code>` convention (preserved for legacy
+/// SDK compatibility). The shape-level `awsQueryError` trait is the
+/// authoritative wire code for these services even though they speak
+/// JSON. Currently SQS is the only such service in the vendored models.
+fn is_aws_query_compatible_service(service_name: &str) -> bool {
+    matches!(service_name, "sqs")
+}
+
 /// Probe a single test variant against a running fakecloud server.
 /// If `model` and `output_shape_id` are provided, also validates the response shape.
 pub fn probe_variant(
@@ -215,9 +225,20 @@ pub fn probe_variant_with_model(
     // against the right service, not silently accepted.
     //
     // For each declared shape we derive the wire code: the
-    // `aws.protocols#awsQueryError.code` trait if present (covers
-    // IAM/RDS/etc. where the shape name and wire `<Code>` differ), else
-    // the shape's short name (after `#`).
+    // `aws.protocols#awsQueryError.code` trait if present AND the service
+    // wire format is awsQuery or awsQueryCompatible (covers IAM/RDS/etc.
+    // where the shape name and `<Code>` differ, and SQS which is awsJson1.0
+    // + awsQueryCompatible), else the shape's short name (after `#`).
+    //
+    // Why the protocol gate: a handful of awsJson1.x services (KMS, ACM,
+    // DynamoDB, SSM, application-autoscaling) carry `awsQueryError` traits
+    // on their error shapes for historical reasons (the same shape is
+    // shared with sibling awsQuery models). For awsJson1.x wire encoding
+    // the trait is inert — the wire `__type` is the shape's short name.
+    // Using the trait there mis-resolves codes like `NotFoundException`
+    // to `NotFound` and flags every real handler error as undeclared.
+    let honor_query_error_trait =
+        matches!(protocol, Protocol::Query) || is_aws_query_compatible_service(service_name);
     let op_error_shapes: Option<Vec<String>> = model_info.map(|(m, _)| {
         let declared_shape_ids: Vec<String> = m
             .operations
@@ -228,9 +249,11 @@ pub fn probe_variant_with_model(
         declared_shape_ids
             .iter()
             .map(|shape_id| {
-                if let Some(shape) = m.shapes.get(shape_id) {
-                    if let Some(code) = &shape.traits.aws_query_error_code {
-                        return code.clone();
+                if honor_query_error_trait {
+                    if let Some(shape) = m.shapes.get(shape_id) {
+                        if let Some(code) = &shape.traits.aws_query_error_code {
+                            return code.clone();
+                        }
                     }
                 }
                 shape_id.rsplit('#').next().unwrap_or(shape_id).to_string()
@@ -2209,5 +2232,19 @@ mod tests {
         // Routing-miss body shape — no recognisable AWS error code.
         let body = r#"{"message":"Unknown URL"}"#;
         assert_eq!(extract_aws_error_code(body), None);
+    }
+
+    #[test]
+    fn aws_query_error_trait_gated_by_protocol() {
+        // KMS is awsJson1.1; its `NotFoundException` shape carries a
+        // legacy `awsQueryError.code = "NotFound"` trait that is inert
+        // for JSON wire encoding. The probe must NOT honor the trait
+        // for non-query services — the wire `__type` is the shape's
+        // short name. SQS (awsJson1.0 + awsQueryCompatible) is the
+        // only awsJson service where the trait does apply.
+        assert!(matches!(service_protocol("kms"), Protocol::Json { .. }));
+        assert!(!is_aws_query_compatible_service("kms"));
+        assert!(is_aws_query_compatible_service("sqs"));
+        assert!(matches!(service_protocol("iam"), Protocol::Query));
     }
 }


### PR DESCRIPTION
## Problem

Strict-mode conformance flags ~1300 KMS variants as \`HTTP 400 with undeclared error 'NotFoundException' (not in op's Smithy error_shapes)\` across 40 ops (CancelKeyDeletion, CreateAlias, CreateGrant, DeleteAlias, DescribeKey, Encrypt, GenerateDataKey*, GetKeyPolicy, GetPublicKey, ImportKeyMaterial, Sign, Verify, VerifyMac, TagResource, UpdateAlias, UpdatePrimaryRegion, ReplicateKey, ...).

Every one of these ops DOES declare \`NotFoundException\` in its Smithy \`errors\` list, and fakecloud-kms emits exactly that wire code. The mismatch comes from the probe's wire-code resolver, not from fakecloud-kms.

## Root cause

\`probe_variant_with_model\` resolves the declared wire code as \`aws.protocols#awsQueryError.code\` when the trait is present, otherwise the shape's short name. That's the right rule for awsQuery services. But the vendored KMS / ACM / DynamoDB / SSM / application-autoscaling models all carry \`awsQueryError\` traits on their error shapes for historical / shared-shape reasons:

\`\`\`json
"com.amazonaws.kms#NotFoundException": {
  "traits": {
    "aws.protocols#awsQueryError": { "code": "NotFound", "httpResponseCode": 404 },
    "smithy.api#error": "client",
    "smithy.api#httpError": 404
  }
}
\`\`\`

KMS is \`awsJson1_1\`; the wire \`__type\` is the shape short name (\`NotFoundException\`), not the awsQueryError code (\`NotFound\`). The resolver was incorrectly flipping the declared code to \`NotFound\`, so every real \`NotFoundException\` response failed strict matching.

## Fix

Only honor the \`awsQueryError\` trait when:
- the service protocol is \`Query\` (IAM, RDS, ELBv2, SNS, STS, CloudFormation, ...), OR
- the service name is in a small awsJson + \`awsQueryCompatible\` allow-list (currently just \`sqs\`).

For other awsJson1.x / restJson1 / restXml services, fall back to the shape's short name. This matches what the awsJson / restJson wire encodings actually put on the wire.

## Why not change fakecloud-kms

The task asked to make fakecloud-kms emit the Smithy-declared wire code. It already does — the Smithy-declared wire code for KMS (awsJson1.1) is \`NotFoundException\`. The probe was misinterpreting an inert legacy trait. Flipping fakecloud-kms to emit \`NotFound\` would break real AWS SDK clients.

## Impact

Closes ~1300 KMS strict failures (40 ops x ~30 variants). Same gate also fixes future analogous failures on ACM / DynamoDB / SSM / application-autoscaling error shapes that carry the same trait.

## Test plan

- [x] \`cargo test -p fakecloud-conformance --lib probe::\` (29 passed including new \`aws_query_error_trait_gated_by_protocol\`)
- [x] \`cargo test -p fakecloud-kms\` (175 passed)
- [x] Conformance CI on the PR confirms KMS NotFoundException variants flip from UNEXPECTED to Pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `awsQueryError` wire-code resolution by protocol to match actual wire encodings. This fixes false "undeclared error 'NotFoundException'" failures in KMS and similar services.

- **Bug Fixes**
  - Honor `aws.protocols#awsQueryError.code` only for `Query` services or awsQuery-compatible services (`sqs`).
  - For others (awsJson1.x, restJson1, restXml), use the shape short name as the wire code.
  - Added `is_aws_query_compatible_service` and a unit test to pin the protocol gate.
  - Resolves ~1300 KMS strict failures and prevents similar issues in ACM, DynamoDB, SSM, and application-autoscaling.

<sup>Written for commit fefb5052120bd77ef532fc00df4fef4114ce747c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

