### PR TITLE
fix(sqs): align queue-missing wire codes with op-declared errors

### DIFF
--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -315,7 +315,7 @@ pub(crate) fn validate_redrive_policy_target(
     let Some(dlq) = dlq else {
         return Err(AwsServiceError::aws_error_with_headers(
             StatusCode::BAD_REQUEST,
-            "QueueDoesNotExist",
+            "AWS.SimpleQueueService.NonExistentQueue",
             format!(
                 "Dead letter target does not exist: {}",
                 rp.dead_letter_target_arn
@@ -1159,9 +1159,16 @@ pub(crate) fn missing_param(name: &str) -> AwsServiceError {
 }
 
 pub(crate) fn queue_not_found() -> AwsServiceError {
+    // AWS SQS uses the awsQueryError-renamed wire code
+    // `AWS.SimpleQueueService.NonExistentQueue` for the `QueueDoesNotExist`
+    // shape (see `aws.protocols#awsQueryError.code` on the shape in the
+    // upstream Smithy model). Real AWS puts this string in `<Code>`, and
+    // it's also what's listed in each op's declared `errors`. Returning the
+    // short shape name `QueueDoesNotExist` instead would be undeclared by
+    // every operation per the model.
     AwsServiceError::aws_error_with_headers(
         StatusCode::BAD_REQUEST,
-        "QueueDoesNotExist",
+        "AWS.SimpleQueueService.NonExistentQueue",
         "The specified queue does not exist.",
         vec![(
             "x-amzn-query-error".to_string(),

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -200,7 +200,9 @@ fn get_queue_url_nonexistent() {
     let svc = make_service();
     let req = make_request("GetQueueUrl", json!({ "QueueName": "nope" }));
     let err = expect_err(svc.get_queue_url(&req));
-    assert!(err.to_string().contains("QueueDoesNotExist"));
+    assert!(err
+        .to_string()
+        .contains("AWS.SimpleQueueService.NonExistentQueue"));
 }
 
 #[test]
@@ -1224,7 +1226,7 @@ fn get_queue_url_not_found() {
     let svc = make_service();
     let req = make_request("GetQueueUrl", json!({"QueueName": "ghost"}));
     let err = expect_err(svc.get_queue_url(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1235,7 +1237,7 @@ fn delete_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost"}),
     );
     let err = expect_err(svc.delete_queue(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1246,7 +1248,7 @@ fn send_message_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "MessageBody": "hi"}),
     );
     let err = expect_err(svc.send_message(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[tokio::test]
@@ -1257,7 +1259,7 @@ async fn receive_message_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost"}),
     );
     let err = expect_err(svc.receive_message(&req).await);
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1268,7 +1270,7 @@ fn get_queue_attributes_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "AttributeNames": ["All"]}),
     );
     let err = expect_err(svc.get_queue_attributes(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1279,7 +1281,7 @@ fn set_queue_attributes_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "Attributes": {"VisibilityTimeout": "30"}}),
     );
     let err = expect_err(svc.set_queue_attributes(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1290,7 +1292,7 @@ fn purge_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost"}),
     );
     let err = expect_err(svc.purge_queue(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1301,7 +1303,7 @@ fn tag_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "Tags": {"k": "v"}}),
     );
     let err = expect_err(svc.tag_queue(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1312,7 +1314,7 @@ fn untag_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "TagKeys": ["k"]}),
     );
     let err = expect_err(svc.untag_queue(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1323,7 +1325,7 @@ fn list_queue_tags_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost"}),
     );
     let err = expect_err(svc.list_queue_tags(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1334,7 +1336,7 @@ fn change_message_visibility_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "ReceiptHandle": "rh", "VisibilityTimeout": 30}),
     );
     let err = expect_err(svc.change_message_visibility(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]
@@ -1345,7 +1347,7 @@ fn delete_message_queue_not_found() {
         json!({"QueueUrl": "http://localhost/123/ghost", "ReceiptHandle": "rh"}),
     );
     let err = expect_err(svc.delete_message(&req));
-    assert_eq!(err.code(), "QueueDoesNotExist");
+    assert_eq!(err.code(), "AWS.SimpleQueueService.NonExistentQueue");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Conformance strict mode (#1352) flagged 317 SQS variants across 15 ops as `UNEXPECTED: HTTP 400 with undeclared error 'QueueDoesNotExist'`. Root cause: the body's `<Code>` element emitted the Smithy shape's short name, but the shape carries an `aws.protocols#awsQueryError.code` trait of `AWS.SimpleQueueService.NonExistentQueue` — that's the wire code real AWS SQS puts on the wire, and that's the value the probe resolves out of each op's `errors[]` list.

Switch the two helpers (`queue_not_found`, DLQ redrive-target validation) to emit `AWS.SimpleQueueService.NonExistentQueue` as the body code. The header `x-amzn-query-error` already carried the right value; this change is body-only.

## Ops affected (15)

ChangeMessageVisibility, ChangeMessageVisibilityBatch, DeleteMessage, DeleteMessageBatch, DeleteQueue, GetQueueAttributes, GetQueueUrl, ListDeadLetterSourceQueues, ListQueueTags, PurgeQueue, ReceiveMessage, RemovePermission, SendMessage, SendMessageBatch, SetQueueAttributes.

Expected conformance pass count delta: +317 variants (149 -> 466 / 549).

## Test plan

- [x] `cargo test -p fakecloud-sqs` (148 passed; updated unit assertions)
- [x] `cargo test -p fakecloud-parity --test sqs` (3 passed)
- [x] `cargo fmt --all`
- [x] `cargo clippy -p fakecloud-sqs --all-targets -- -D warnings`
- [ ] CI conformance check: sqs ratchet moves up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align SQS “queue not found” error with AWS by returning AWS.SimpleQueueService.NonExistentQueue in the response body code. Fixes strict per-op error matching across 15 operations and clears 317 conformance failures.

- **Bug Fixes**
  - Emit `AWS.SimpleQueueService.NonExistentQueue` for missing queues in `queue_not_found` and DLQ redrive target validation; header `x-amzn-query-error` already correct.
  - Updated tests; expected conformance improvement: +317 passing variants (149 -> 466/549).

<sup>Written for commit 5d25789d5f514b466c0238fb7f9afd737605d1dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

