### PR TITLE
fix(iam): emit Smithy-declared error codes

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/account.rs
+++ b/crates/fakecloud-iam/src/iam_service/account.rs
@@ -6,7 +6,10 @@ use fakecloud_core::validation::*;
 
 use crate::state::{AccountPasswordPolicy, IamState, VirtualMfaDevice};
 
-use super::{attached_policy_name, empty_response, parse_tags, tags_xml, url_encode, IamService};
+use super::{
+    attached_policy_name, empty_response, parse_tags, required_param_with_code,
+    resolve_calling_user, tags_xml, url_encode, validate_string_length_with_code, IamService,
+};
 use fakecloud_core::query::required_param;
 
 use fakecloud_aws::xml::xml_escape;
@@ -737,7 +740,11 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let virtual_mfa_device_name = required_param(&req.query_params, "VirtualMFADeviceName")?;
+        // Declared: ConcurrentModification, EntityAlreadyExists,
+        // InvalidInputException, LimitExceeded, ServiceFailure -> InvalidInput
+        // for all bad inputs (path/name).
+        let virtual_mfa_device_name =
+            required_param_with_code(&req.query_params, "VirtualMFADeviceName", "InvalidInput")?;
         let path = req
             .query_params
             .get("Path")
@@ -749,7 +756,7 @@ impl IamService {
         if path.len() > 512 {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ValidationError",
+                "InvalidInput",
                 format!(
                     "1 validation error detected: Value \"{}\" at \"path\" failed to satisfy constraint: Member must have length less than or equal to 512",
                     path
@@ -761,7 +768,7 @@ impl IamService {
         if !is_valid_iam_path(&path) {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ValidationError",
+                "InvalidInput",
                 "The specified value for path is invalid. It must begin and end with / and contain only alphanumeric characters and/or / characters.",
             ));
         }
@@ -1009,8 +1016,13 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let _user_name = required_param(&req.query_params, "UserName")?;
-        let serial_number = required_param(&req.query_params, "SerialNumber")?;
+        // Declared: ConcurrentModification, EntityTemporarilyUnmodifiable,
+        // LimitExceeded, NoSuchEntity, ServiceFailure -> NoSuchEntity for bad
+        // UserName/SerialNumber input.
+        let _user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        let serial_number =
+            required_param_with_code(&req.query_params, "SerialNumber", "NoSuchEntity")?;
+        validate_string_length_with_code("serialNumber", &serial_number, 9, 256, "NoSuchEntity")?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1028,10 +1040,16 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // UserName optional per Smithy; only NoSuchEntity + ServiceFailure declared.
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| resolve_calling_user(state, &req.account_id));
 
         let devices: Vec<&VirtualMfaDevice> = state
             .virtual_mfa_devices

--- a/crates/fakecloud-iam/src/iam_service/extras.rs
+++ b/crates/fakecloud-iam/src/iam_service/extras.rs
@@ -13,7 +13,10 @@ use crate::state::{
     IamState, OrganizationsAccessReport, ServiceLastAccessedJob, ServiceSpecificCredential,
 };
 
-use super::{empty_response, parse_tags, tags_xml, IamService};
+use super::{
+    empty_response, parse_tags, required_param_with_code, resolve_calling_user, tags_xml,
+    validate_string_length_with_code, IamService,
+};
 use fakecloud_core::query::required_param;
 
 use fakecloud_aws::xml::xml_escape;
@@ -291,8 +294,29 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        let cred_id = required_param(&req.query_params, "ServiceSpecificCredentialId")?;
+        // Declared: NoSuchEntity (only). UserName optional per Smithy.
+        let cred_id = required_param_with_code(
+            &req.query_params,
+            "ServiceSpecificCredentialId",
+            "NoSuchEntity",
+        )?;
+        validate_string_length_with_code(
+            "serviceSpecificCredentialId",
+            &cred_id,
+            20,
+            128,
+            "NoSuchEntity",
+        )?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| {
+                let accts = self.state.read();
+                let st = accts.get(&req.account_id);
+                resolve_calling_user(st.unwrap_or(accts.default_ref()), &req.account_id)
+            });
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         if let Some(list) = state.service_specific_credentials.get_mut(&user_name) {
@@ -308,11 +332,18 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // Declared: NoSuchEntity, ServiceNotSupportedException. UserName
+        // optional per Smithy (defaults to caller).
         let service_name = req.query_params.get("ServiceName").cloned();
         let accounts = self.state.read();
         let empty = IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| resolve_calling_user(state, &req.account_id));
         let creds: Vec<&ServiceSpecificCredential> = state
             .service_specific_credentials
             .get(&user_name)

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -776,6 +776,68 @@ pub(crate) fn attached_policy_name(state: &crate::state::IamState, arn: &str) ->
         .unwrap_or_else(|| arn.rsplit('/').next().unwrap_or(arn).to_string())
 }
 
+/// Extract a required query parameter, returning the supplied IAM-specific
+/// wire error code when missing. The shared `required_param` helper hard-codes
+/// `MissingParameter`, which isn't in any IAM operation's Smithy error list.
+/// IAM ops must surface one of their declared errors (usually
+/// `InvalidInputException` -> `InvalidInput`, or `NoSuchEntity` when the
+/// missing field identifies an entity).
+pub(crate) fn required_param_with_code(
+    params: &std::collections::HashMap<String, String>,
+    name: &str,
+    code: &str,
+) -> Result<String, AwsServiceError> {
+    params
+        .get(name)
+        .cloned()
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                code,
+                format!("The request must contain the parameter {name}."),
+            )
+        })
+}
+
+/// Length-validate a string, emitting the supplied IAM-declared wire error
+/// code. Mirrors `fakecloud_core::validation::validate_string_length` but
+/// avoids its hard-coded `ValidationException` (not declared on any IAM op).
+pub(crate) fn validate_string_length_with_code(
+    field: &str,
+    value: &str,
+    min: usize,
+    max: usize,
+    code: &str,
+) -> Result<(), AwsServiceError> {
+    let len = value.len();
+    if len < min || len > max {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            code,
+            format!(
+                "Value at '{field}' failed to satisfy constraint: \
+                 Member must have length between {min} and {max}",
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Length-validate an optional string with an IAM-declared wire error code.
+pub(crate) fn validate_optional_string_length_with_code(
+    field: &str,
+    value: Option<&str>,
+    min: usize,
+    max: usize,
+    code: &str,
+) -> Result<(), AwsServiceError> {
+    if let Some(v) = value {
+        validate_string_length_with_code(field, v, min, max, code)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn empty_response(action: &str, request_id: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/fakecloud-iam/src/iam_service/oidc.rs
+++ b/crates/fakecloud-iam/src/iam_service/oidc.rs
@@ -36,7 +36,7 @@ fn validate_oidc_provider_input(
     if thumbprints.len() > 5 {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
-            "ValidationError",
+            "InvalidInput",
             "Thumbprint list must contain fewer than 5 entries.".to_string(),
         ));
     }
@@ -71,7 +71,7 @@ fn validate_oidc_provider_input(
         );
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
-            "ValidationError",
+            "InvalidInput",
             msg,
         ));
     }
@@ -79,7 +79,7 @@ fn validate_oidc_provider_input(
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
-            "ValidationError",
+            "InvalidInput",
             "Invalid Open ID Connect Provider URL".to_string(),
         ));
     }
@@ -232,8 +232,16 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let arn = required_param(&req.query_params, "SAMLProviderArn")?;
-        let saml_metadata_document = required_param(&req.query_params, "SAMLMetadataDocument")?;
+        // Declared: ConcurrentModification, InvalidInputException, LimitExceeded,
+        // NoSuchEntity, ServiceFailure. SAMLMetadataDocument is optional in
+        // the Smithy model (AddPrivateKey / RemovePrivateKey are alternatives).
+        let arn =
+            super::required_param_with_code(&req.query_params, "SAMLProviderArn", "InvalidInput")?;
+        let saml_metadata_document = req
+            .query_params
+            .get("SAMLMetadataDocument")
+            .cloned()
+            .filter(|v| !v.is_empty());
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -246,7 +254,9 @@ impl IamService {
             )
         })?;
 
-        provider.saml_metadata_document = saml_metadata_document;
+        if let Some(doc) = saml_metadata_document {
+            provider.saml_metadata_document = doc;
+        }
 
         let xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -269,7 +279,10 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let url = required_param(&req.query_params, "Url")?;
+        // Declared: ConcurrentModification, EntityAlreadyExists,
+        // InvalidInputException, LimitExceeded, OpenIdIdpCommunicationError,
+        // ServiceFailure -> InvalidInput for missing/invalid Url.
+        let url = super::required_param_with_code(&req.query_params, "Url", "InvalidInput")?;
         let tags = parse_tags(&req.query_params);
 
         let mut client_ids = Vec::new();

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -499,8 +499,19 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let policy_arn = required_param(&req.query_params, "PolicyArn")?;
-        let version_id = required_param(&req.query_params, "VersionId")?;
+        // Declared: InvalidInputException, LimitExceeded, NoSuchEntity,
+        // ServiceFailure -> InvalidInput for all generic input validation.
+        let policy_arn =
+            super::required_param_with_code(&req.query_params, "PolicyArn", "InvalidInput")?;
+        super::validate_string_length_with_code(
+            "policyArn",
+            &policy_arn,
+            20,
+            2048,
+            "InvalidInput",
+        )?;
+        let version_id =
+            super::required_param_with_code(&req.query_params, "VersionId", "InvalidInput")?;
 
         // Validate version ID format: must match v[1-9][0-9]*(\.[A-Za-z0-9-]*)?
         let valid_format = version_id.starts_with('v')
@@ -520,7 +531,7 @@ impl IamService {
         if !valid_format {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ValidationError",
+                "InvalidInput",
                 format!(
                     "Value '{}' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\\.[A-Za-z0-9-]*)?",
                     version_id

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -469,9 +469,24 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let role_name = required_param(&req.query_params, "RoleName")?;
-        validate_string_length("roleName", &role_name, 1, 64)?;
-        let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
+        // Declared: InvalidInputException, NoSuchEntityException,
+        // PolicyNotAttachableException, ServiceFailureException,
+        // UnmodifiableEntityException -> InvalidInput for bad input shape.
+        let role_name =
+            super::required_param_with_code(&req.query_params, "RoleName", "InvalidInput")?;
+        super::validate_string_length_with_code("roleName", &role_name, 1, 64, "InvalidInput")?;
+        let boundary = super::required_param_with_code(
+            &req.query_params,
+            "PermissionsBoundary",
+            "InvalidInput",
+        )?;
+        super::validate_string_length_with_code(
+            "permissionsBoundary",
+            &boundary,
+            20,
+            2048,
+            "InvalidInput",
+        )?;
 
         if boundary
             .parse::<Arn>()
@@ -481,7 +496,7 @@ impl IamService {
         {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ValidationError",
+                "InvalidInput",
                 format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
             ));
         }
@@ -968,9 +983,15 @@ impl CreateRoleInput {
     fn from_query(
         params: &std::collections::HashMap<String, String>,
     ) -> Result<Self, AwsServiceError> {
-        let role_name = required_param(params, "RoleName")?;
-        validate_string_length("roleName", &role_name, 1, 64)?;
-        let assume_role_policy = required_param(params, "AssumeRolePolicyDocument")?;
+        // CreateRole's Smithy-declared errors: ConcurrentModification,
+        // EntityAlreadyExists, InvalidInputException, LimitExceeded,
+        // MalformedPolicyDocument, ServiceFailure -> InvalidInput for all
+        // generic input validation; MalformedPolicyDocument is reserved for
+        // policy-document parse failures handled downstream.
+        let role_name = super::required_param_with_code(params, "RoleName", "InvalidInput")?;
+        super::validate_string_length_with_code("roleName", &role_name, 1, 64, "InvalidInput")?;
+        let assume_role_policy =
+            super::required_param_with_code(params, "AssumeRolePolicyDocument", "InvalidInput")?;
         let path = params
             .get("Path")
             .cloned()
@@ -984,10 +1005,17 @@ impl CreateRoleInput {
         validate_tags(&tags, 0)?;
         let permissions_boundary = params.get("PermissionsBoundary").cloned();
         if let Some(ref boundary) = permissions_boundary {
+            super::validate_string_length_with_code(
+                "permissionsBoundary",
+                boundary,
+                20,
+                2048,
+                "InvalidInput",
+            )?;
             if !boundary.contains(":policy/") {
                 return Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
-                    "ValidationError",
+                    "InvalidInput",
                     format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
                 ));
             }

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4101,3 +4101,161 @@ fn resync_mfa_device_updates_enable_date() {
         "ResyncMFADevice should freshen EnableDate, got age {age}s"
     );
 }
+
+// ---- Smithy-declared wire error code tests ----
+//
+// Strict-mode conformance probes require every error returned by an op to be
+// one of the Smithy-declared shapes. These regression tests pin the wire codes
+// for input-validation failures on ops where we previously leaked the framework
+// codes `MissingParameter`, `ValidationError`, or `ValidationException`.
+
+fn assert_error_code(err: AwsServiceError, expected: &str) {
+    match err {
+        AwsServiceError::AwsError { code, .. } => {
+            assert_eq!(code, expected, "wrong wire error code");
+        }
+        other => panic!("expected AwsError, got {other:?}"),
+    }
+}
+
+#[test]
+fn create_role_short_permissions_boundary_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", "r"),
+                ("AssumeRolePolicyDocument", "{}"),
+                ("PermissionsBoundary", "short"),
+            ],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn put_role_permissions_boundary_short_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .put_role_permissions_boundary(&make_request(
+            "PutRolePermissionsBoundary",
+            vec![("RoleName", "r"), ("PermissionsBoundary", "short")],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn put_user_permissions_boundary_short_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .put_user_permissions_boundary(&make_request(
+            "PutUserPermissionsBoundary",
+            vec![("UserName", "u"), ("PermissionsBoundary", "short")],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn set_default_policy_version_short_arn_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .set_default_policy_version(&make_request(
+            "SetDefaultPolicyVersion",
+            vec![("PolicyArn", "short"), ("VersionId", "v1")],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn create_login_profile_missing_password_emits_password_policy_violation() {
+    let svc = make_service();
+    let err = svc
+        .create_login_profile(&make_request(
+            "CreateLoginProfile",
+            vec![("UserName", "u")],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "PasswordPolicyViolation");
+}
+
+#[test]
+fn create_access_key_unresolved_user_emits_no_such_entity() {
+    let svc = make_service();
+    let err = svc
+        .create_access_key(&make_request("CreateAccessKey", vec![]))
+        .err()
+        .unwrap();
+    assert_error_code(err, "NoSuchEntity");
+}
+
+#[test]
+fn delete_user_oversize_name_emits_no_such_entity() {
+    let svc = make_service();
+    let long = "a".repeat(129);
+    let err = svc
+        .delete_user(&make_request("DeleteUser", vec![("UserName", &long)]))
+        .err()
+        .unwrap();
+    assert_error_code(err, "NoSuchEntity");
+}
+
+#[test]
+fn tag_user_oversize_name_emits_invalid_input() {
+    let svc = make_service();
+    let long = "a".repeat(129);
+    let err = svc
+        .tag_user(&make_request("TagUser", vec![("UserName", &long)]))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn list_mfa_devices_no_username_does_not_emit_missing_parameter() {
+    // ListMFADevices declares NoSuchEntity + ServiceFailure only. Sending no
+    // UserName must not leak `MissingParameter` from the shared helper.
+    let svc = make_service();
+    let resp = svc.list_mfa_devices(&make_request("ListMFADevices", vec![]));
+    match resp {
+        Ok(_) => {}
+        Err(AwsServiceError::AwsError { code, .. }) => {
+            assert_ne!(
+                code, "MissingParameter",
+                "ListMFADevices leaked MissingParameter"
+            );
+        }
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn create_open_id_connect_provider_missing_url_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .create_oidc_provider(&make_request("CreateOpenIDConnectProvider", vec![]))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}
+
+#[test]
+fn create_virtual_mfa_device_bad_path_emits_invalid_input() {
+    let svc = make_service();
+    let err = svc
+        .create_virtual_mfa_device(&make_request(
+            "CreateVirtualMFADevice",
+            vec![("VirtualMFADeviceName", "d"), ("Path", "x")],
+        ))
+        .err()
+        .unwrap();
+    assert_error_code(err, "InvalidInput");
+}

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -4178,10 +4178,7 @@ fn set_default_policy_version_short_arn_emits_invalid_input() {
 fn create_login_profile_missing_password_emits_password_policy_violation() {
     let svc = make_service();
     let err = svc
-        .create_login_profile(&make_request(
-            "CreateLoginProfile",
-            vec![("UserName", "u")],
-        ))
+        .create_login_profile(&make_request("CreateLoginProfile", vec![("UserName", "u")]))
         .err()
         .unwrap();
     assert_error_code(err, "PasswordPolicyViolation");

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -10,7 +10,8 @@ use crate::xml_responses;
 
 use super::{
     empty_response, extract_access_key, generate_id, generate_long_id, parse_tag_keys, parse_tags,
-    partition_for_region, resolve_calling_user, tags_xml, url_encode, IamService,
+    partition_for_region, required_param_with_code, resolve_calling_user, tags_xml, url_encode,
+    validate_optional_string_length_with_code, validate_string_length_with_code, IamService,
 };
 use fakecloud_core::query::required_param;
 
@@ -94,10 +95,16 @@ fn resolve_create_access_key_target(
                 .then(|| user.clone())
         })
         .ok_or_else(|| {
+            // CreateAccessKey's Smithy-declared errors are NoSuchEntityException,
+            // LimitExceededException, ServiceFailureException. When no UserName
+            // is given and the caller can't be resolved from the access key,
+            // there is no user to attach the key to -> NoSuchEntity.
             AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "MissingParameter",
-                "The request must contain the parameter UserName".to_string(),
+                StatusCode::NOT_FOUND,
+                "NoSuchEntity",
+                "Cannot resolve target user: provide a UserName or call with credentials \
+                 that map to an existing user."
+                    .to_string(),
             )
         })
 }
@@ -235,8 +242,11 @@ impl IamService {
     }
 
     pub(super) fn delete_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
+        // Declared: ConcurrentModification, DeleteConflict, LimitExceeded,
+        // NoSuchEntity, ServiceFailure. Missing/out-of-range UserName ->
+        // NoSuchEntity (no user can match an out-of-range name).
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "NoSuchEntity")?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -297,8 +307,11 @@ impl IamService {
     }
 
     pub(super) fn update_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
+        // Declared: ConcurrentModification, EntityAlreadyExists,
+        // EntityTemporarilyUnmodifiable, LimitExceeded, NoSuchEntity,
+        // ServiceFailure -> NoSuchEntity for missing/oversize UserName.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "NoSuchEntity")?;
         let new_path = req.query_params.get("NewPath").cloned();
         let new_user_name = req.query_params.get("NewUserName").cloned();
 
@@ -349,8 +362,10 @@ impl IamService {
     }
 
     pub(super) fn tag_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
+        // Declared: ConcurrentModification, InvalidInputException, LimitExceeded,
+        // NoSuchEntity, ServiceFailure -> InvalidInput for bad UserName values.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "InvalidInput")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "InvalidInput")?;
         let new_tags = parse_tags(&req.query_params);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -376,8 +391,10 @@ impl IamService {
     }
 
     pub(super) fn untag_user(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
+        // Declared: ConcurrentModification, NoSuchEntity, ServiceFailure
+        // (no InvalidInputException) -> NoSuchEntity for bad UserName values.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "NoSuchEntity")?;
         let tag_keys = parse_tag_keys(&req.query_params);
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -397,8 +414,9 @@ impl IamService {
     }
 
     pub(super) fn list_user_tags(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
+        // Declared: NoSuchEntity, ServiceFailure -> NoSuchEntity for bad UserName.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "NoSuchEntity")?;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -438,11 +456,15 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        validate_optional_string_length(
+        // CreateAccessKey only declares NoSuchEntity/LimitExceeded/ServiceFailure
+        // -> route invalid UserName through NoSuchEntity (no such user with that
+        // out-of-range name exists).
+        validate_optional_string_length_with_code(
             "userName",
             req.query_params.get("UserName").map(|s| s.as_str()),
             1,
             128,
+            "NoSuchEntity",
         )?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -661,8 +683,12 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        let password = required_param(&req.query_params, "Password")?;
+        // Declared errors: EntityAlreadyExists, LimitExceeded, NoSuchEntity,
+        // PasswordPolicyViolation, ServiceFailure. Missing UserName -> NoSuchEntity,
+        // missing/empty Password -> PasswordPolicyViolation.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        let password =
+            required_param_with_code(&req.query_params, "Password", "PasswordPolicyViolation")?;
         let password_reset_required = req
             .query_params
             .get("PasswordResetRequired")
@@ -723,7 +749,8 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // Declared: NoSuchEntity, ServiceFailure -> NoSuchEntity for missing param.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -803,7 +830,9 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // Declared: EntityTemporarilyUnmodifiable, LimitExceeded, NoSuchEntity,
+        // ServiceFailure -> NoSuchEntity for missing UserName.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -835,8 +864,13 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        let certificate_body = required_param(&req.query_params, "CertificateBody")?;
+        // Declared: ConcurrentModification, DuplicateCertificate, EntityAlreadyExists,
+        // InvalidCertificate, LimitExceeded, MalformedCertificate, NoSuchEntity,
+        // ServiceFailure. UserName missing -> NoSuchEntity; CertificateBody
+        // missing/too-short -> MalformedCertificate.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
+        let certificate_body =
+            required_param_with_code(&req.query_params, "CertificateBody", "MalformedCertificate")?;
 
         // Validate certificate body looks like a PEM certificate
         if !certificate_body.contains("-----BEGIN CERTIFICATE-----")
@@ -912,10 +946,18 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // UserName is optional in the Smithy model (defaults to the caller).
+        // Marker/MaxItems are optional pagination tokens we accept verbatim
+        // since the op only declares NoSuchEntity and ServiceFailure.
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| resolve_calling_user(state, &req.account_id));
 
         if !state.users.contains_key(&user_name) {
             return Err(AwsServiceError::aws_error(
@@ -968,9 +1010,29 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        let certificate_id = required_param(&req.query_params, "CertificateId")?;
-        let status = required_param(&req.query_params, "Status")?;
+        // Declared: InvalidInputException, LimitExceededException,
+        // NoSuchEntityException, ServiceFailureException. UserName is optional
+        // (defaults to caller). CertificateId/Status missing -> InvalidInput.
+        let certificate_id =
+            required_param_with_code(&req.query_params, "CertificateId", "InvalidInput")?;
+        validate_string_length_with_code(
+            "certificateId",
+            &certificate_id,
+            24,
+            128,
+            "InvalidInput",
+        )?;
+        let status = required_param_with_code(&req.query_params, "Status", "InvalidInput")?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| {
+                let accts = self.state.read();
+                let st = accts.get(&req.account_id);
+                resolve_calling_user(st.unwrap_or(accts.default_ref()), &req.account_id)
+            });
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1016,8 +1078,28 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        let certificate_id = required_param(&req.query_params, "CertificateId")?;
+        // Declared: ConcurrentModification, LimitExceeded, NoSuchEntity,
+        // ServiceFailure. CertificateId required, missing/oversize -> NoSuchEntity.
+        // UserName is optional in Smithy (defaults to caller).
+        let certificate_id =
+            required_param_with_code(&req.query_params, "CertificateId", "NoSuchEntity")?;
+        validate_string_length_with_code(
+            "certificateId",
+            &certificate_id,
+            24,
+            128,
+            "NoSuchEntity",
+        )?;
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| {
+                let accts = self.state.read();
+                let st = accts.get(&req.account_id);
+                resolve_calling_user(st.unwrap_or(accts.default_ref()), &req.account_id)
+            });
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1172,10 +1254,16 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
+        // UserName optional per Smithy; only NoSuchEntity is declared.
         let accounts = self.state.read();
         let empty = crate::state::IamState::new(&req.account_id);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
+        let user_name = req
+            .query_params
+            .get("UserName")
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| resolve_calling_user(state, &req.account_id));
 
         let keys = state.ssh_public_keys.get(&user_name);
         let members: String = keys
@@ -1636,9 +1724,19 @@ impl IamService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let user_name = required_param(&req.query_params, "UserName")?;
-        validate_string_length("userName", &user_name, 1, 64)?;
-        let boundary = required_param(&req.query_params, "PermissionsBoundary")?;
+        // Declared: InvalidInputException, NoSuchEntityException,
+        // PolicyNotAttachableException, ServiceFailureException -> InvalidInput.
+        let user_name = required_param_with_code(&req.query_params, "UserName", "InvalidInput")?;
+        validate_string_length_with_code("userName", &user_name, 1, 64, "InvalidInput")?;
+        let boundary =
+            required_param_with_code(&req.query_params, "PermissionsBoundary", "InvalidInput")?;
+        validate_string_length_with_code(
+            "permissionsBoundary",
+            &boundary,
+            20,
+            2048,
+            "InvalidInput",
+        )?;
 
         if boundary
             .parse::<Arn>()
@@ -1648,7 +1746,7 @@ impl IamService {
         {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ValidationError",
+                "InvalidInput",
                 format!("Value ({boundary}) for parameter PermissionsBoundary is invalid."),
             ));
         }


### PR DESCRIPTION
## Summary

Strict-mode conformance probes were rejecting ~431 IAM responses because we leaked three framework codes (`MissingParameter`, `ValidationError`, `ValidationException`) that aren't declared on any IAM op in the Smithy model. This PR routes every input-validation path on the failing ops to one of the op's declared shapes (mostly `InvalidInputException` -> wire `InvalidInput`, or `NoSuchEntityException` -> `NoSuchEntity` where InvalidInput isn't declared).

### Ops touched
CreateAccessKey, CreateLoginProfile, CreateOpenIDConnectProvider, CreateRole, CreateVirtualMFADevice, DeactivateMFADevice, DeleteLoginProfile, DeleteServiceSpecificCredential, DeleteSigningCertificate, DeleteUser, GetLoginProfile, ListMFADevices, ListServiceSpecificCredentials, ListSigningCertificates, ListSSHPublicKeys, ListUserTags, PutRolePermissionsBoundary, PutUserPermissionsBoundary, SetDefaultPolicyVersion, TagUser, UntagUser, UpdateSAMLProvider, UpdateSigningCertificate, UpdateUser, UploadSigningCertificate.

### Wire code remapping

- `InvalidInput` for ops declaring `InvalidInputException` (CreateRole, CreateOpenIDConnectProvider, CreateVirtualMFADevice, Put{Role,User}PermissionsBoundary, SetDefaultPolicyVersion, TagUser, UpdateSAMLProvider, UpdateSigningCertificate)
- `NoSuchEntity` for ops without InvalidInputException whose semantics map to "not found" (DeleteUser, UpdateUser, UntagUser, ListUserTags, DeactivateMFADevice, Delete{ServiceSpecificCredential,SigningCertificate,LoginProfile}, GetLoginProfile, CreateAccessKey)
- `PasswordPolicyViolation` for empty Password on CreateLoginProfile
- `MalformedCertificate` for empty CertificateBody on UploadSigningCertificate

### Structural fixes (alongside code remapping)

Per Smithy, several List* / Update* / Delete* ops declare UserName as optional (defaults to caller), but our handlers were treating it as required. Fixed in ListMFADevices, ListSSHPublicKeys, ListSigningCertificates, ListServiceSpecificCredentials, UpdateSigningCertificate, DeleteSigningCertificate, DeleteServiceSpecificCredential.

UpdateSAMLProvider no longer requires SAMLMetadataDocument (it's optional in the model alongside AddPrivateKey/RemovePrivateKey).

## Test plan

- [x] `cargo test -p fakecloud-iam --lib` (447 passing, 11 new pinning the wire codes)
- [x] `cargo clippy -p fakecloud-iam --lib` clean
- [x] `cargo check --workspace` clean
- [ ] Conformance CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IAM to return Smithy-declared error codes instead of framework codes, restoring strict-mode conformance. Also fixes optional `UserName` handling across list/update/delete ops and makes `SAMLMetadataDocument` optional on UpdateSAMLProvider.

- **Bug Fixes**
  - Route input validation to declared errors:
    - `InvalidInput` (CreateRole, OIDC provider, VirtualMFA, Put*PermissionsBoundary, SetDefaultPolicyVersion, TagUser, UpdateSAMLProvider, UpdateSigningCertificate).
    - `NoSuchEntity` where input implies “not found” (DeleteUser, UpdateUser, UntagUser, ListUserTags, DeactivateMFADevice, Delete{LoginProfile,ServiceSpecificCredential,SigningCertificate}, GetLoginProfile, CreateAccessKey).
    - `PasswordPolicyViolation` for empty password on CreateLoginProfile.
    - `MalformedCertificate` for empty `CertificateBody` on UploadSigningCertificate.
  - Add IAM-local helpers to avoid leaking `MissingParameter`/`Validation*` codes (`required_param_with_code`, `validate_string_length_with_code`, `validate_optional_string_length_with_code`), and ensure length/format checks emit declared codes.
  - Treat `UserName` as optional (defaults to caller) for ListMFADevices, ListSSHPublicKeys, ListServiceSpecificCredentials, ListSigningCertificates, UpdateSigningCertificate, DeleteSigningCertificate, DeleteServiceSpecificCredential.
  - Make `SAMLMetadataDocument` optional on UpdateSAMLProvider.
  - Add 11 regression tests to pin wire codes.

<sup>Written for commit 5341413ad25b37697411774ae50a8a7987db3195. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

