### PR TITLE
fix(elbv2): emit Smithy-declared error codes

### DIFF
--- a/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
+++ b/crates/fakecloud-e2e/tests/ddb_partiql_filter.rs
@@ -190,7 +190,11 @@ async fn ddb_partiql_insert_missing_sort_key_validation() {
         .await
         .expect_err("insert without sort key must fail");
     let msg = format!("{:?}", err.into_service_error());
-    assert!(msg.contains("ValidationException"), "got {msg}");
+    // PartiQL INSERT with a missing required key surfaces as
+    // ResourceNotFoundException after #1359 — DynamoDB's Smithy errors
+    // list for ExecuteStatement doesn't declare ValidationException, so
+    // fakecloud now emits the declared shape instead.
+    assert!(msg.contains("ResourceNotFoundException"), "got {msg}");
     assert!(msg.contains("Missing the key sk"), "got {msg}");
 }
 

--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1028,7 +1028,7 @@ impl Elbv2Service {
         let arn = required_query_param(req, "TargetGroupArn")?;
         let targets = parse_target_descriptions(req);
         if targets.is_empty() {
-            return Err(invalid_param("Targets is required"));
+            return Err(invalid_target("Targets is required"));
         }
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
@@ -1048,7 +1048,7 @@ impl Elbv2Service {
         let arn = required_query_param(req, "TargetGroupArn")?;
         let targets = parse_target_descriptions(req);
         if targets.is_empty() {
-            return Err(invalid_param("Targets is required"));
+            return Err(invalid_target("Targets is required"));
         }
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -107,8 +107,24 @@ pub(crate) fn validate_lb_name(name: &str) -> Result<(), AwsServiceError> {
     Ok(())
 }
 
+/// Generic "bad input" error for ELBv2 control-plane ops. ELBv2 doesn't
+/// model a top-level `ValidationException`; the closest declared shape on
+/// most create/modify ops is `InvalidConfigurationRequestException`
+/// (wire code `InvalidConfigurationRequest`). Strict-Smithy probes reject
+/// the legacy awsQuery `ValidationError` because no op declares it.
 pub(crate) fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
-    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", msg.into())
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidConfigurationRequest",
+        msg.into(),
+    )
+}
+
+/// Variant of `invalid_param` for target register/deregister paths. Both
+/// ops declare `InvalidTargetException` (wire `InvalidTarget`); use that
+/// when the supplied target list is malformed.
+pub(crate) fn invalid_target(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidTarget", msg.into())
 }
 
 /// Listener protocols accepted by ELBv2: HTTP/HTTPS for ALB, TCP/UDP/
@@ -1158,9 +1174,36 @@ pub(crate) fn resolve_taggable<'a>(
     if st.trust_stores.contains_key(arn) {
         return Ok(&mut st.trust_stores.get_mut(arn).unwrap().tags);
     }
-    Err(AwsServiceError::aws_error(
+    Err(taggable_not_found(arn))
+}
+
+/// Map an unresolved tag-target ARN to the specific *NotFound error declared
+/// on the tag operations (AddTags / RemoveTags / DescribeTags all share the
+/// same Listener/LoadBalancer/Rule/TargetGroup/TrustStore NotFound set).
+/// awsQuery probes reject a generic "ResourceNotFound" because it isn't in
+/// any op's Smithy errors list; the closest declared shape comes from the
+/// ARN resource type.
+pub(crate) fn taggable_not_found(arn: &str) -> AwsServiceError {
+    let (code, label) = if arn.contains(":loadbalancer/") {
+        ("LoadBalancerNotFound", "Load balancer")
+    } else if arn.contains(":targetgroup/") {
+        ("TargetGroupNotFound", "Target group")
+    } else if arn.contains(":listener-rule/") {
+        ("RuleNotFound", "Rule")
+    } else if arn.contains(":listener/") {
+        ("ListenerNotFound", "Listener")
+    } else if arn.contains(":truststore/") {
+        ("TrustStoreNotFound", "Trust store")
+    } else {
+        // ARN didn't match any known ELBv2 resource type. The tag ops only
+        // declare specific *NotFound shapes — pick LoadBalancerNotFound as
+        // the catch-all since it's declared on every tag op and matches
+        // what AWS returns for unparseable ARNs.
+        ("LoadBalancerNotFound", "Resource")
+    };
+    AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
-        "ResourceNotFound",
-        format!("Resource '{arn}' not found"),
-    ))
+        code,
+        format!("{label} '{arn}' not found"),
+    )
 }

--- a/crates/fakecloud-elbv2/src/service_tests.rs
+++ b/crates/fakecloud-elbv2/src/service_tests.rs
@@ -70,7 +70,7 @@ async fn create_validates_name() {
         .await
         .err()
         .expect("expected error");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
 }
 
 async fn create_lb_and_get_arn(svc: &Elbv2Service, name: &str) -> String {
@@ -315,7 +315,7 @@ async fn create_listener_rejects_invalid_protocol() {
         .await
         .err()
         .expect("expected validation error");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     assert!(format!("{err:?}").contains("BOGUS"));
 }
 
@@ -337,7 +337,7 @@ async fn create_listener_rejects_port_zero() {
         .await
         .err()
         .expect("expected validation error");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
 }
 
 #[tokio::test]
@@ -358,7 +358,7 @@ async fn create_listener_rejects_port_above_65535() {
         .await
         .err()
         .expect("expected validation error");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
 }
 
 #[tokio::test]
@@ -423,7 +423,7 @@ async fn create_listener_alb_rejects_tcp() {
         .await
         .err()
         .expect("TCP should be rejected on an ALB");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     assert!(format!("{err:?}").contains("application"));
 }
 
@@ -448,7 +448,7 @@ async fn create_listener_nlb_rejects_http() {
         .await
         .err()
         .expect("HTTP should be rejected on an NLB");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
 }
 
 #[tokio::test]
@@ -499,7 +499,7 @@ async fn create_listener_gwlb_requires_geneve_on_6081() {
         .await
         .err()
         .expect("TCP should be rejected on a GWLB");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     // GENEVE but wrong port.
     let err = svc
         .handle(req(
@@ -518,7 +518,7 @@ async fn create_listener_gwlb_requires_geneve_on_6081() {
         .await
         .err()
         .expect("GENEVE on port 443 should be rejected on a GWLB");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     // GENEVE on 6081 succeeds.
     let res = svc
         .handle(req(
@@ -559,7 +559,7 @@ async fn modify_load_balancer_attributes_validates_ipv6_source_nat_value() {
         .await
         .err()
         .expect("non-bool ipv6 SNAT value should be rejected");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     // All four supported values round-trip without error.
     for v in ["true", "false", "on", "off"] {
         let res = svc
@@ -622,7 +622,7 @@ async fn modify_listener_validates_protocol_and_port() {
         .await
         .err()
         .expect("port 0 should fail");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
     let err = svc
         .handle(req(
             "ModifyListener",
@@ -631,7 +631,7 @@ async fn modify_listener_validates_protocol_and_port() {
         .await
         .err()
         .expect("bogus protocol should fail");
-    assert_eq!(err.code(), "ValidationError");
+    assert_eq!(err.code(), "InvalidConfigurationRequest");
 }
 
 #[tokio::test]


### PR DESCRIPTION
ELBv2 is awsQuery; each operation has its own Smithy \`errors\` list, and the strict-Smithy conformance probe rejects wire codes that aren't in that list. Two generic codes were leaking out of fakecloud:

- **\`ValidationError\`** (from \`invalid_param\` in \`service_helpers.rs\`). No ELBv2 operation declares a generic \`ValidationException\`; the closest declared shape on most create/modify operations is \`InvalidConfigurationRequestException\` (wire \`InvalidConfigurationRequest\`). \`invalid_param\` now emits that, and a new \`invalid_target\` helper covers \`RegisterTargets\` / \`DeregisterTargets\` (which declare \`InvalidTargetException\`).
- **\`ResourceNotFound\`** (from \`resolve_taggable\`). Not declared on \`AddTags\` / \`RemoveTags\` / \`DescribeTags\` either. Replaced with an ARN-dispatched \`taggable_not_found\` that returns the specific declared \*NotFound code (\`LoadBalancerNotFound\`, \`TargetGroupNotFound\`, \`ListenerNotFound\`, \`RuleNotFound\`, \`TrustStoreNotFound\`).

Service tests updated to assert the new wire codes.

## Test plan
- [x] \`cargo build -p fakecloud-elbv2\`
- [x] \`cargo test -p fakecloud-elbv2 --lib\` (45 passed)
- [x] \`cargo fmt -p fakecloud-elbv2\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align ELBv2 error responses with Smithy by replacing generic `ValidationError`/`ResourceNotFound` with operation-declared wire codes. Also update the DynamoDB PartiQL test to expect the Smithy-declared error for missing keys.

- **Bug Fixes**
  - Emit `InvalidConfigurationRequest` for generic validation failures; add `invalid_target` for Register/DeregisterTargets to return `InvalidTarget`.
  - Map taggable not-found to ARN-specific codes: `LoadBalancerNotFound`, `TargetGroupNotFound`, `ListenerNotFound`, `RuleNotFound`, `TrustStoreNotFound`.
  - Update ELBv2 service tests for the new wire codes.
  - Update DynamoDB e2e test: `ExecuteStatement` missing sort key now expects `ResourceNotFoundException` (matches #1359).

<sup>Written for commit b213353c620cd9fe4cd41b7ce29041a397d3fa26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

