### PR TITLE
fix(application-autoscaling): emit Smithy-declared error codes

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -692,7 +692,11 @@ impl ApplicationAutoScalingService {
             .get(&req.account_id)
             .and_then(|a| a.scaling_policies.get(&policy_key))
             .ok_or_else(|| {
-                object_not_found(format!(
+                // GetPredictiveScalingForecast's Smithy model only declares
+                // InternalServiceException and ValidationException. Missing
+                // policies surface as ValidationException, not the
+                // ObjectNotFoundException used by the Delete/Put ops.
+                invalid_param(format!(
                     "No predictive scaling policy named {policy_name} found for ServiceNamespace={namespace} ResourceId={resource_id} ScalableDimension={dimension}"
                 ))
             })?;
@@ -729,12 +733,14 @@ impl ApplicationAutoScalingService {
         let arn = require_str(&body, "ResourceARN")?;
         let state = self.state.read();
         let account = state.accounts.get(&req.account_id);
-        // Real AWS rejects unknown ARNs with ObjectNotFoundException rather
+        // Real AWS rejects unknown ARNs with ResourceNotFoundException rather
         // than returning an empty tag set — match that so callers can tell
-        // a missing target apart from a target with no tags.
+        // a missing target apart from a target with no tags. The Smithy
+        // model for the tag-* ops declares ResourceNotFoundException, not the
+        // ObjectNotFoundException used by the Delete/Put scaling-target ops.
         let exists = account.is_some_and(|a| resource_exists(a, &arn));
         if !exists {
-            return Err(object_not_found(format!("Resource {arn} not found")));
+            return Err(resource_not_found(format!("Resource {arn} not found")));
         }
         let tags = account
             .and_then(|a| a.tags.get(&arn))
@@ -753,7 +759,7 @@ impl ApplicationAutoScalingService {
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         if !resource_exists(account, &arn) {
-            return Err(object_not_found(format!("Resource {arn} not found")));
+            return Err(resource_not_found(format!("Resource {arn} not found")));
         }
         let entry = account.tags.entry(arn).or_default();
         for (k, v) in tags_in {
@@ -779,7 +785,7 @@ impl ApplicationAutoScalingService {
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         if !resource_exists(account, &arn) {
-            return Err(object_not_found(format!("Resource {arn} not found")));
+            return Err(resource_not_found(format!("Resource {arn} not found")));
         }
         if let Some(tags) = account.tags.get_mut(&arn) {
             for k in keys {
@@ -810,6 +816,10 @@ fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
 
 fn object_not_found(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ObjectNotFoundException", msg)
+}
+
+fn resource_not_found(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ResourceNotFoundException", msg)
 }
 
 fn parse_suspended_state(value: &Value) -> SuspendedState {

--- a/crates/fakecloud-e2e/tests/application_autoscaling.rs
+++ b/crates/fakecloud-e2e/tests/application_autoscaling.rs
@@ -497,7 +497,11 @@ async fn tag_untag_list_tags_round_trip() {
 }
 
 #[tokio::test]
-async fn list_tags_unknown_resource_returns_object_not_found() {
+async fn list_tags_unknown_resource_returns_resource_not_found() {
+    // ListTagsForResource's Smithy model only declares
+    // ResourceNotFoundException, so unknown ARNs surface that code
+    // (not the ObjectNotFoundException used by the Delete/Put
+    // scaling-target/policy/scheduled-action ops).
     let server = TestServer::start().await;
     let aas = server.application_autoscaling_client().await;
     let err = aas
@@ -508,7 +512,7 @@ async fn list_tags_unknown_resource_returns_object_not_found() {
         .send()
         .await
         .expect_err("missing arn");
-    assert!(format!("{err:?}").contains("ObjectNotFound"));
+    assert!(format!("{err:?}").contains("ResourceNotFound"));
 }
 
 #[tokio::test]
@@ -578,7 +582,10 @@ async fn describe_with_stale_next_token_does_not_panic() {
 }
 
 #[tokio::test]
-async fn tag_unknown_resource_returns_object_not_found() {
+async fn tag_unknown_resource_returns_resource_not_found() {
+    // TagResource declares ResourceNotFoundException in its Smithy model;
+    // ObjectNotFoundException is reserved for the Delete/Put
+    // scaling-target/policy/scheduled-action ops.
     let server = TestServer::start().await;
     let aas = server.application_autoscaling_client().await;
     let mut tags = HashMap::new();
@@ -593,7 +600,7 @@ async fn tag_unknown_resource_returns_object_not_found() {
         .send()
         .await
         .expect_err("missing arn");
-    assert!(format!("{err:?}").contains("ObjectNotFound"));
+    assert!(format!("{err:?}").contains("ResourceNotFound"));
 }
 
 /// POST `/_fakecloud/application-autoscaling/tick` to force the


### PR DESCRIPTION
## Summary
- `GetPredictiveScalingForecast` declares only `InternalServiceException` and `ValidationException`. The missing-policy path emitted `ObjectNotFoundException`, which is undeclared on this op; remap to `ValidationException`.
- `ListTagsForResource`, `TagResource`, and `UntagResource` declare `ResourceNotFoundException` (not `ObjectNotFoundException`, which is only valid on the Delete*/Put* scaling-target/policy/scheduled-action ops). Swap the unknown-ARN path to `ResourceNotFoundException`.

## Test plan
- [x] `cargo build -p fakecloud-application-autoscaling`
- [x] `cargo test -p fakecloud-application-autoscaling`
- [x] `cargo clippy -p fakecloud-application-autoscaling --no-deps -- -D warnings`
- [ ] Conformance: strict-mode error-shape pass rate for `application-autoscaling` rises.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit Smithy-declared error codes in Application Auto Scaling and update e2e tests accordingly. Matches the AWS model and improves strict-mode conformance.

- **Bug Fixes**
  - GetPredictiveScalingForecast: missing policy now returns ValidationException (was ObjectNotFoundException).
  - ListTagsForResource/TagResource/UntagResource: unknown ARN now returns ResourceNotFoundException (was ObjectNotFoundException).

<sup>Written for commit d04a1a82d99473bf53f7ad41a6f0d4fe8e7f9f52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

