### PR TITLE
fix(test): supply AllowUnauthenticatedIdentities in cognito-identity tests

### DIFF
--- a/crates/fakecloud-conformance/tests/cognito_identity.rs
+++ b/crates/fakecloud-conformance/tests/cognito_identity.rs
@@ -14,6 +14,7 @@ async fn cognito_identity_create_identity_pool() {
     let resp = client
         .create_identity_pool()
         .identity_pool_name("conformance-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -30,6 +31,7 @@ async fn cognito_identity_list_identity_pools() {
     client
         .create_identity_pool()
         .identity_pool_name("pool-a")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -52,6 +54,7 @@ async fn cognito_identity_describe_identity_pool() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("desc-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -75,6 +78,7 @@ async fn cognito_identity_update_identity_pool() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("update-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -100,6 +104,7 @@ async fn cognito_identity_delete_identity_pool() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("delete-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -244,6 +249,7 @@ async fn cognito_identity_get_open_id_token_for_developer_identity() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("dev-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -272,6 +278,7 @@ async fn cognito_identity_lookup_developer_identity() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("lookup-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -307,6 +314,7 @@ async fn cognito_identity_merge_developer_identities() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("merge-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -353,6 +361,7 @@ async fn cognito_identity_unlink_developer_identity() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("unlink-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -454,6 +463,7 @@ async fn cognito_identity_set_identity_pool_roles() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("roles-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -502,6 +512,7 @@ async fn cognito_identity_get_identity_pool_roles() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("get-roles-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -525,6 +536,7 @@ async fn cognito_identity_tag_resource() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("tag-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -563,6 +575,7 @@ async fn cognito_identity_untag_resource() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("untag-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();
@@ -606,6 +619,7 @@ async fn cognito_identity_list_tags_for_resource() {
     let create = client
         .create_identity_pool()
         .identity_pool_name("list-tags-pool")
+        .allow_unauthenticated_identities(false)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-conformance/tests/cognito_identity.rs
+++ b/crates/fakecloud-conformance/tests/cognito_identity.rs
@@ -683,3 +683,94 @@ async fn cognito_identity_unlink_identity() {
         .await
         .unwrap();
 }
+
+#[test_action("cognito-identity", "DeleteIdentities", checksum = "794b8494")]
+#[tokio::test]
+async fn cognito_identity_delete_identities() {
+    let server = TestServer::start().await;
+    let client = server.cognito_identity_client().await;
+
+    let create = client
+        .create_identity_pool()
+        .identity_pool_name("delete-ids-pool")
+        .allow_unauthenticated_identities(true)
+        .send()
+        .await
+        .unwrap();
+    let pool_id = create.identity_pool_id().to_string();
+
+    let get_id = client
+        .get_id()
+        .identity_pool_id(&pool_id)
+        .send()
+        .await
+        .unwrap();
+    let identity_id = get_id.identity_id().unwrap().to_string();
+
+    let resp = client
+        .delete_identities()
+        .identity_ids_to_delete(identity_id)
+        .identity_ids_to_delete("us-east-1:00000000-0000-0000-0000-000000000000")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp
+        .unprocessed_identity_ids()
+        .iter()
+        .any(|u| u.identity_id() == Some("us-east-1:00000000-0000-0000-0000-000000000000")));
+}
+
+#[test_action("cognito-identity", "SetPrincipalTagAttributeMap", checksum = "865e3d7e")]
+#[tokio::test]
+async fn cognito_identity_set_principal_tag_attribute_map() {
+    let server = TestServer::start().await;
+    let client = server.cognito_identity_client().await;
+
+    let create = client
+        .create_identity_pool()
+        .identity_pool_name("set-ptam-pool")
+        .allow_unauthenticated_identities(true)
+        .send()
+        .await
+        .unwrap();
+    let pool_id = create.identity_pool_id().to_string();
+
+    let mut tags = HashMap::new();
+    tags.insert("custom:role".to_string(), "role".to_string());
+
+    let resp = client
+        .set_principal_tag_attribute_map()
+        .identity_pool_id(&pool_id)
+        .identity_provider_name("login.provider")
+        .use_defaults(false)
+        .set_principal_tags(Some(tags))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.identity_pool_id(), Some(pool_id.as_str()));
+}
+
+#[test_action("cognito-identity", "GetPrincipalTagAttributeMap", checksum = "89cfe04f")]
+#[tokio::test]
+async fn cognito_identity_get_principal_tag_attribute_map() {
+    let server = TestServer::start().await;
+    let client = server.cognito_identity_client().await;
+
+    let create = client
+        .create_identity_pool()
+        .identity_pool_name("get-ptam-pool")
+        .allow_unauthenticated_identities(true)
+        .send()
+        .await
+        .unwrap();
+    let pool_id = create.identity_pool_id().to_string();
+
+    let resp = client
+        .get_principal_tag_attribute_map()
+        .identity_pool_id(&pool_id)
+        .identity_provider_name("login.provider")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.identity_pool_id(), Some(pool_id.as_str()));
+}

--- a/crates/fakecloud-conformance/tests/cognito_identity.rs
+++ b/crates/fakecloud-conformance/tests/cognito_identity.rs
@@ -720,7 +720,11 @@ async fn cognito_identity_delete_identities() {
         .any(|u| u.identity_id() == Some("us-east-1:00000000-0000-0000-0000-000000000000")));
 }
 
-#[test_action("cognito-identity", "SetPrincipalTagAttributeMap", checksum = "865e3d7e")]
+#[test_action(
+    "cognito-identity",
+    "SetPrincipalTagAttributeMap",
+    checksum = "865e3d7e"
+)]
 #[tokio::test]
 async fn cognito_identity_set_principal_tag_attribute_map() {
     let server = TestServer::start().await;
@@ -750,7 +754,11 @@ async fn cognito_identity_set_principal_tag_attribute_map() {
     assert_eq!(resp.identity_pool_id(), Some(pool_id.as_str()));
 }
 
-#[test_action("cognito-identity", "GetPrincipalTagAttributeMap", checksum = "89cfe04f")]
+#[test_action(
+    "cognito-identity",
+    "GetPrincipalTagAttributeMap",
+    checksum = "89cfe04f"
+)]
 #[tokio::test]
 async fn cognito_identity_get_principal_tag_attribute_map() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -149,3 +149,34 @@ async fn sts_assume_root() {
         .unwrap();
     assert!(resp.credentials().is_some());
 }
+
+#[test_action("sts", "GetWebIdentityToken", checksum = "9ea6bbde")]
+#[tokio::test]
+async fn sts_get_web_identity_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_web_identity_token()
+        .audience("fakecloud-test")
+        .duration_seconds(900)
+        .signing_algorithm("RS256")
+        .send()
+        .await
+        .unwrap();
+    let token = resp.web_identity_token().unwrap();
+    assert!(token.split('.').count() == 3, "expected JWT triple, got {token}");
+}
+
+#[test_action("sts", "GetDelegatedAccessToken", checksum = "93cb2870")]
+#[tokio::test]
+async fn sts_get_delegated_access_token() {
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    let resp = client
+        .get_delegated_access_token()
+        .trade_in_token("fakecloud-trade-in-token")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.credentials().is_some());
+}

--- a/crates/fakecloud-conformance/tests/sts.rs
+++ b/crates/fakecloud-conformance/tests/sts.rs
@@ -164,7 +164,10 @@ async fn sts_get_web_identity_token() {
         .await
         .unwrap();
     let token = resp.web_identity_token().unwrap();
-    assert!(token.split('.').count() == 3, "expected JWT triple, got {token}");
+    assert!(
+        token.split('.').count() == 3,
+        "expected JWT triple, got {token}"
+    );
 }
 
 #[test_action("sts", "GetDelegatedAccessToken", checksum = "93cb2870")]


### PR DESCRIPTION
## Summary
PR #1369 made fakecloud-cognito reject \`CreateIdentityPool\` requests missing \`AllowUnauthenticatedIdentities\`, matching the Smithy \`@required\` contract and real Cognito's behavior. The handwritten conformance and e2e tests were silently relying on the prior default-to-false fallback, so they broke on \`main\` once #1369 landed — main has been red since.

Add \`.allow_unauthenticated_identities(false)\` to every \`create_identity_pool\` builder chain in the affected tests.

## Test plan
- [x] Local \`cargo nextest run -P ci --test cognito_identity\` green
- [ ] Conformance workflow on main turns green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cognito Identity conformance tests by setting `allow_unauthenticated_identities` on all `create_identity_pool` requests to match `fakecloud-cognito`’s required field. Add tests for `DeleteIdentities`, `SetPrincipalTagAttributeMap`, `GetPrincipalTagAttributeMap`, `GetWebIdentityToken`, and `GetDelegatedAccessToken`; also ran cargo fmt.

<sup>Written for commit d0a54c98e871ec81c84df0d5b5552563e4c2f085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

