### PR TITLE
fix(lambda): make GetFunction Code.Location actually downloadable (#1375)

### DIFF
--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -68,6 +68,78 @@ async fn lambda_create_get_delete_function() {
 }
 
 #[tokio::test]
+async fn lambda_get_function_code_location_is_downloadable() {
+    // Regression for #1375: AWS Toolkit + `aws lambda get-function` need
+    // Code.Location to resolve to the actual ZIP body.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let zip = make_python_zip();
+    client
+        .create_function()
+        .function_name("dl-target")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(zip.clone()))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_function()
+        .function_name("dl-target")
+        .send()
+        .await
+        .unwrap();
+    let location = resp.code().unwrap().location().unwrap();
+    assert!(
+        location.contains("/_fakecloud/lambda/function-code/"),
+        "Code.Location should point at fakecloud route, got {location}"
+    );
+
+    let body = reqwest::get(location)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), zip.as_slice());
+
+    // Published version is downloadable through the same route.
+    let publish = client
+        .publish_version()
+        .function_name("dl-target")
+        .send()
+        .await
+        .unwrap();
+    let v = publish.version().unwrap();
+    let resp = client
+        .get_function()
+        .function_name("dl-target")
+        .qualifier(v)
+        .send()
+        .await
+        .unwrap();
+    let location = resp.code().unwrap().location().unwrap();
+    let body = reqwest::get(location)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), zip.as_slice());
+}
+
+#[tokio::test]
 async fn lambda_get_function_accepts_arn_partial_arn_and_qualifier() {
     let server = TestServer::start().await;
     let client = server.lambda_client().await;

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -142,6 +142,34 @@ fn layer_content_url(req: &AwsRequest, account_id: &str, layer_name: &str, versi
     )
 }
 
+/// Build a fakecloud-hosted download URL for a function version's ZIP. AWS
+/// Toolkit (and `aws lambda get-function --query 'Code.Location'`) expects
+/// this to resolve to an actual ZIP body, so the URL points back at the
+/// running fakecloud instance on the same authority the SDK used.
+pub(crate) fn function_code_url(
+    req: &AwsRequest,
+    account_id: &str,
+    function_name: &str,
+    version_label: &str,
+) -> String {
+    let host = req
+        .headers
+        .get(http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost");
+    let scheme = req
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("http");
+    let file = if version_label == "$LATEST" {
+        "latest.zip".to_string()
+    } else {
+        format!("{version_label}.zip")
+    };
+    format!("{scheme}://{host}/_fakecloud/lambda/function-code/{account_id}/{function_name}/{file}")
+}
+
 /// AWS layer-version ARN: `arn:aws:lambda:<region>:<account>:layer:<name>:<version>`.
 /// Returns `(account_id, layer_name, version)`. Used to resolve cross-account
 /// layer references attached to a function.

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1183,6 +1183,7 @@ impl LambdaService {
 
     fn get_function(
         &self,
+        req: &AwsRequest,
         function_name: &str,
         account_id: &str,
         region: &str,
@@ -1241,16 +1242,15 @@ impl LambdaService {
                 "RepositoryType": "ECR",
             })
         } else {
-            // fakecloud doesn't expose a presigned-download path yet; we
-            // synthesize a `_fakecloud/`-namespaced URL so it's obvious to
-            // operators that the URL isn't a real S3 link. (Real
-            // download support is tracked under follow-up GG batch.)
-            let region = func.function_arn.split(':').nth(3).unwrap_or("us-east-1");
+            // Serve the function's stored ZIP from a fakecloud-hosted route on
+            // the same authority the SDK used, so AWS Toolkit / `aws lambda
+            // get-function --query 'Code.Location'` can actually download it.
             json!({
-                "Location": format!(
-                    "https://prod-{region}-starport-layer-bucket.s3.{region}.amazonaws.com/_fakecloud/{account}/{name}/code.zip",
-                    account = state.account_id,
-                    name = function_name,
+                "Location": crate::extras::function_code_url(
+                    req,
+                    &state.account_id,
+                    function_name,
+                    &version_label,
                 ),
                 "RepositoryType": "S3",
             })
@@ -2160,6 +2160,7 @@ impl AwsService for LambdaService {
                 req.query_params.get("FunctionVersion").map(String::as_str),
             ),
             "GetFunction" => self.get_function(
+                &req,
                 resource_name.as_deref().unwrap_or(""),
                 aid,
                 req.region.as_str(),

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1122,8 +1122,9 @@ async fn publish_version_unknown_function_errors() {
 #[tokio::test]
 async fn get_function_unknown_errors() {
     let svc = LambdaService::new(make_state());
+    let req = make_request(Method::GET, "/2015-03-31/functions/ghost", "");
     assert!(svc
-        .get_function("ghost", "123456789012", "us-east-1", None)
+        .get_function(&req, "ghost", "123456789012", "us-east-1", None)
         .is_err());
 }
 

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -6340,6 +6340,54 @@ async fn main() {
             }),
         )
         .route(
+            "/_fakecloud/lambda/function-code/{account_id}/{function_name}/{file}",
+            axum::routing::get({
+                let ls = lambda_state.clone();
+                move |axum::extract::Path((account_id, function_name, file)): axum::extract::Path<(String, String, String)>| {
+                    let ls = ls.clone();
+                    async move {
+                        let qualifier: Option<String> = file
+                            .strip_suffix(".zip")
+                            .map(|s| s.to_string());
+                        let Some(qualifier) = qualifier else {
+                            return (
+                                axum::http::StatusCode::NOT_FOUND,
+                                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                                axum::body::Bytes::from_static(b"function code not found"),
+                            );
+                        };
+                        let bytes_opt: Option<Vec<u8>> = {
+                            let accounts = ls.read();
+                            accounts.get(&account_id).and_then(|s| {
+                                if qualifier == "latest" {
+                                    s.functions
+                                        .get(&function_name)
+                                        .and_then(|f| f.code_zip.clone())
+                                } else {
+                                    s.function_version_snapshots
+                                        .get(&function_name)
+                                        .and_then(|m| m.get(&qualifier))
+                                        .and_then(|f| f.code_zip.clone())
+                                }
+                            })
+                        };
+                        match bytes_opt {
+                            Some(bytes) => (
+                                axum::http::StatusCode::OK,
+                                [(axum::http::header::CONTENT_TYPE, "application/zip")],
+                                axum::body::Bytes::from(bytes),
+                            ),
+                            None => (
+                                axum::http::StatusCode::NOT_FOUND,
+                                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                                axum::body::Bytes::from_static(b"function code not found"),
+                            ),
+                        }
+                    }
+                }
+            }),
+        )
+        .route(
             "/_fakecloud/sns/pending-confirmations",
             axum::routing::get({
                 let ss = sns_sim_pending_state;


### PR DESCRIPTION
Closes #1375.

## Summary
- `GetFunction` used to return a synthetic `prod-<region>-starport-layer-bucket.s3.amazonaws.com/_fakecloud/...` URL that didn't resolve, so AWS Toolkit for VS Code rendered "Failed to load resources" for any fakecloud Lambda function.
- `Code.Location` now points at a real fakecloud-hosted route `/_fakecloud/lambda/function-code/{account_id}/{function_name}/{file}` (file = `latest.zip` for `$LATEST`, `{N}.zip` for numbered versions) that streams the stored ZIP back as `application/zip`.
- URL is built on the same authority the SDK used (mirrors the existing `layer-content` helper), so it works whether fakecloud is hit via `localhost`, a Docker DNS name, or a forwarded scheme.

## Test plan
- [x] New E2E `lambda_get_function_code_location_is_downloadable` covers `$LATEST` + a published numeric version; HTTP-GETs the returned URL and asserts the body equals the original ZIP.
- [x] `cargo test -p fakecloud-lambda` (138 passed)
- [x] `cargo clippy -p fakecloud-lambda -p fakecloud --all-targets -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Lambda GetFunction Code.Location actually downloadable by serving the stored ZIP from fakecloud. Fixes #1375 and restores AWS Toolkit/CLI ability to fetch function code.

- **Bug Fixes**
  - Return a real URL: `/_fakecloud/lambda/function-code/{account_id}/{function_name}/{file}` that streams the ZIP (`latest.zip` or `{N}.zip`).
  - Build the URL from the request host and scheme (`Host`, `x-forwarded-proto`) so it works via localhost, Docker DNS, or proxies.
  - Add a server route to serve the bytes with `application/zip` and 404 when missing; add an E2E test for `$LATEST` and a published version.

<sup>Written for commit 6f8439d5e49b2bb0adb426482ab61783b1328b5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

