### PR TITLE
fix(bedrock-runtime): close input-validation conformance gaps

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -79,7 +79,7 @@
       "total": 951
     },
     "bedrock-runtime": {
-      "passed": 264,
+      "passed": 383,
       "total": 447
     },
     "bedrock-agent": {

--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -19,6 +19,13 @@ pub(crate) fn start_async_invoke(
             "modelId is required",
         )
     })?;
+    // AsyncInvokeIdentifier: @length min=1 max=256.
+    crate::runtime_validation::validate_short_model_id(model_id)?;
+
+    // AsyncInvokeIdempotencyToken: @length min=1 max=256 when present.
+    if let Some(token) = body.get("clientRequestToken").and_then(|v| v.as_str()) {
+        crate::runtime_validation::validate_length("clientRequestToken", token, 1, 256)?;
+    }
 
     let output_data_config = body.get("outputDataConfig").ok_or_else(|| {
         AwsServiceError::aws_error(
@@ -58,7 +65,7 @@ pub(crate) fn start_async_invoke(
         model_input: model_input.clone(),
         output_data_config: output_data_config.clone(),
         client_request_token: body["clientRequestToken"].as_str().map(|s| s.to_string()),
-        status: "Completed".to_string(),
+        status: "COMPLETED".to_string(),
         submit_time: now,
         last_modified_time: now,
         end_time: Some(now),
@@ -80,6 +87,8 @@ pub(crate) fn get_async_invoke(
     req: &AwsRequest,
     invocation_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // InvocationArn / AsyncInvokeIdentifier: @length min=1 max=2048.
+    crate::runtime_validation::validate_length("invocationArn", invocation_id, 1, 2048)?;
     let accts = state.read();
     let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
     let s = accts.get(&req.account_id).unwrap_or(&empty);
@@ -93,9 +102,12 @@ pub(crate) fn get_async_invoke(
                 .find(|inv| inv.invocation_arn.ends_with(invocation_id))
         })
         .ok_or_else(|| {
+            // AWS Bedrock's GetAsyncInvoke Smithy model only declares
+            // ValidationException (not ResourceNotFoundException); a missing
+            // invocation surfaces as a validation failure on the input ARN.
             AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "ResourceNotFoundException",
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
                 format!("Async invocation {invocation_id} not found"),
             )
         })?;
@@ -107,14 +119,40 @@ pub(crate) fn list_async_invokes(
     state: &SharedBedrockState,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    let max_results = req
-        .query_params
-        .get("maxResults")
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(100)
-        .max(1);
+    // MaxResults: @range min=1 max=1000.
+    let max_results = if let Some(raw) = req.query_params.get("maxResults") {
+        let n: i64 = raw
+            .parse()
+            .map_err(|_| crate::runtime_validation::validation("maxResults must be an integer"))?;
+        crate::runtime_validation::validate_range_i64("maxResults", n, 1, 1000)?;
+        n as usize
+    } else {
+        100
+    };
     let next_token = req.query_params.get("nextToken");
+    // PaginationToken: @length min=1 max=2048, @pattern ^\S*$.
+    if let Some(t) = next_token {
+        crate::runtime_validation::validate_length("nextToken", t, 1, 2048)?;
+        if t.chars().any(|c| c.is_whitespace()) {
+            return Err(crate::runtime_validation::validation(
+                "Value at 'nextToken' failed to satisfy constraint: Member must match pattern ^\\S*$",
+            ));
+        }
+    }
     let status_filter = req.query_params.get("statusEquals");
+    if let Some(s) = status_filter {
+        crate::runtime_validation::validate_enum(
+            "statusEquals",
+            s,
+            &["IN_PROGRESS", "COMPLETED", "FAILED"],
+        )?;
+    }
+    if let Some(s) = req.query_params.get("sortBy") {
+        crate::runtime_validation::validate_enum("sortBy", s, &["SUBMISSION_TIME"])?;
+    }
+    if let Some(s) = req.query_params.get("sortOrder") {
+        crate::runtime_validation::validate_enum("sortOrder", s, &["ASCENDING", "DESCENDING"])?;
+    }
 
     let accts = state.read();
     let empty = crate::state::BedrockState::new(&req.account_id, &req.region);
@@ -307,10 +345,13 @@ mod tests {
     }
 
     #[test]
-    fn get_unknown_returns_not_found() {
+    fn get_unknown_returns_validation_exception() {
+        // GetAsyncInvoke's Smithy model only declares ValidationException
+        // (no ResourceNotFoundException), so a missing invocation surfaces
+        // as a 400 validation failure rather than a 404.
         let s = shared();
         let err = get_async_invoke(&s, &req(), "missing").err().unwrap();
-        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]
@@ -324,11 +365,11 @@ mod tests {
             let mut st = s.write();
             let acct = st.default_mut();
             let arn = acct.async_invocations.keys().next().unwrap().clone();
-            acct.async_invocations.get_mut(&arn).unwrap().status = "Failed".to_string();
+            acct.async_invocations.get_mut(&arn).unwrap().status = "FAILED".to_string();
         }
         let mut r = req();
         r.query_params
-            .insert("statusEquals".to_string(), "Failed".to_string());
+            .insert("statusEquals".to_string(), "FAILED".to_string());
         let resp = list_async_invokes(&s, &r).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();

--- a/crates/fakecloud-bedrock/src/invoke.rs
+++ b/crates/fakecloud-bedrock/src/invoke.rs
@@ -196,6 +196,15 @@ pub(crate) fn count_tokens(
 
     let input: Value = serde_json::from_slice(body).unwrap_or_default();
 
+    // CountTokensRequest declares `input` as @required; missing/null fails fast.
+    if input.get("input").is_none() || input["input"].is_null() {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "input is required",
+        ));
+    }
+
     // Extract text from either invokeModel or converse format
     let text = if let Some(invoke_input) = input.get("input") {
         if let Some(invoke_model) = invoke_input.get("invokeModel") {
@@ -716,8 +725,10 @@ mod tests {
 
     #[test]
     fn count_tokens_unknown_input_falls_back_to_raw_json_count() {
+        // CountTokens requires the @required `input` field; anything else
+        // inside it is fair game and we fall back to a raw JSON token count.
         let s = shared();
-        let body = br#"{"other":"field"}"#;
+        let body = br#"{"input":{"other":"field"}}"#;
         let resp = count_tokens(&s, &req(), "m", body).unwrap();
         let v: Value =
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
@@ -725,13 +736,11 @@ mod tests {
     }
 
     #[test]
-    fn count_tokens_empty_body_parses_cleanly() {
+    fn count_tokens_missing_input_field_errors() {
+        // Omitting `input` is a validation failure (mirrors AWS).
         let s = shared();
-        let body = b"";
-        let resp = count_tokens(&s, &req(), "m", body).unwrap();
-        let v: Value =
-            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
-        // Empty body produces Null JSON serialized to "null" (4 chars, 1 token)
-        assert!(v["inputTokens"].is_u64());
+        let body = b"{}";
+        let err = count_tokens(&s, &req(), "m", body).err().unwrap();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/fakecloud-bedrock/src/lib.rs
+++ b/crates/fakecloud-bedrock/src/lib.rs
@@ -22,6 +22,7 @@ pub mod models;
 pub mod prompt;
 pub mod prompt_routers;
 pub mod resource_policies;
+pub(crate) mod runtime_validation;
 pub(crate) mod service;
 pub(crate) mod state;
 pub mod streaming;

--- a/crates/fakecloud-bedrock/src/runtime_validation.rs
+++ b/crates/fakecloud-bedrock/src/runtime_validation.rs
@@ -1,0 +1,164 @@
+//! Shared input validation for Bedrock runtime operations
+//! (InvokeModel, InvokeModelWithResponseStream, InvokeModelWithBidirectionalStream,
+//! Converse, ConverseStream, CountTokens, StartAsyncInvoke, GetAsyncInvoke,
+//! ListAsyncInvokes).
+//!
+//! These checks mirror the `@length`, `@range`, `@pattern` and enum constraints
+//! declared in the upstream Smithy model so that out-of-band requests surface
+//! the same `ValidationException` real AWS would return, instead of slipping
+//! through to the canned handlers.
+
+use fakecloud_core::service::{AwsRequest, AwsServiceError};
+use http::StatusCode;
+
+/// `@length: min=1 max=2048` on `InvokeModelIdentifier` / `ConversationalModelId`
+/// (used by InvokeModel, InvokeModelWithResponseStream,
+/// InvokeModelWithBidirectionalStream, Converse, ConverseStream).
+pub(crate) fn validate_invoke_model_id(model_id: &str) -> Result<(), AwsServiceError> {
+    validate_length("modelId", model_id, 1, 2048)?;
+    validate_model_id_pattern(model_id)
+}
+
+/// `@length: min=1 max=256` on `FoundationModelVersionIdentifier`
+/// (CountTokens) and `AsyncInvokeIdentifier` (StartAsyncInvoke modelId).
+pub(crate) fn validate_short_model_id(model_id: &str) -> Result<(), AwsServiceError> {
+    validate_length("modelId", model_id, 1, 256)?;
+    validate_model_id_pattern(model_id)
+}
+
+/// Reject obviously-bogus modelId values. The upstream Smithy regex is a
+/// 600-character alternation — rather than mirror it byte-for-byte we
+/// enforce the cheap structural checks that distinguish a real model
+/// identifier from a stray URI template (`{modelId}`), an empty
+/// percent-encoded path segment, or whitespace.
+fn validate_model_id_pattern(model_id: &str) -> Result<(), AwsServiceError> {
+    if model_id.contains('{') || model_id.contains('}') {
+        return Err(validation(format!(
+            "Value '{model_id}' at 'modelId' failed to satisfy constraint: Member must match a valid model identifier pattern"
+        )));
+    }
+    if model_id.chars().any(|c| c.is_whitespace()) {
+        return Err(validation(format!(
+            "Value '{model_id}' at 'modelId' failed to satisfy constraint: whitespace is not allowed"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a string length against `min..=max`. Pass `min=0` to skip the
+/// lower bound. Empty values trip the min check when `min >= 1`.
+pub(crate) fn validate_length(
+    field: &str,
+    value: &str,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    let len = value.chars().count();
+    if len < min {
+        return Err(validation(format!(
+            "'{value}' at '{field}' failed to satisfy constraint: Member must have length greater than or equal to {min}"
+        )));
+    }
+    if len > max {
+        return Err(validation(format!(
+            "Value at '{field}' failed to satisfy constraint: Member must have length less than or equal to {max}"
+        )));
+    }
+    Ok(())
+}
+
+/// `@range: min=1 max=1000` on `MaxResults` (ListAsyncInvokes).
+pub(crate) fn validate_range_i64(
+    field: &str,
+    value: i64,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    if value < min {
+        return Err(validation(format!(
+            "Value '{value}' at '{field}' failed to satisfy constraint: Member must have value greater than or equal to {min}"
+        )));
+    }
+    if value > max {
+        return Err(validation(format!(
+            "Value '{value}' at '{field}' failed to satisfy constraint: Member must have value less than or equal to {max}"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an enum value against the allowed set.
+pub(crate) fn validate_enum(
+    field: &str,
+    value: &str,
+    allowed: &[&str],
+) -> Result<(), AwsServiceError> {
+    if allowed.contains(&value) {
+        return Ok(());
+    }
+    Err(validation(format!(
+        "Value '{value}' at '{field}' failed to satisfy constraint: Member must satisfy enum value set: [{}]",
+        allowed.join(", ")
+    )))
+}
+
+/// Allowed values for `@httpHeader X-Amzn-Bedrock-PerformanceConfig-Latency`.
+const PERFORMANCE_CONFIG_LATENCY: &[&str] = &["standard", "optimized"];
+
+/// Allowed values for `@httpHeader X-Amzn-Bedrock-Service-Tier`.
+const SERVICE_TIER: &[&str] = &["priority", "default", "flex", "reserved"];
+
+/// Allowed values for `@httpHeader X-Amzn-Bedrock-Trace`.
+const TRACE: &[&str] = &["ENABLED", "DISABLED", "ENABLED_FULL"];
+
+/// Validate shared invoke/converse headers (performanceConfigLatency,
+/// serviceTier, trace) and the body-size cap on Body (max 25_000_000 bytes).
+/// Returns the validation error on first violation.
+pub(crate) fn validate_runtime_headers(req: &AwsRequest) -> Result<(), AwsServiceError> {
+    if let Some(v) = req
+        .headers
+        .get("x-amzn-bedrock-performanceconfig-latency")
+        .and_then(|h| h.to_str().ok())
+    {
+        validate_enum("performanceConfigLatency", v, PERFORMANCE_CONFIG_LATENCY)?;
+    }
+    if let Some(v) = req
+        .headers
+        .get("x-amzn-bedrock-service-tier")
+        .and_then(|h| h.to_str().ok())
+    {
+        validate_enum("serviceTier", v, SERVICE_TIER)?;
+    }
+    if let Some(v) = req
+        .headers
+        .get("x-amzn-bedrock-trace")
+        .and_then(|h| h.to_str().ok())
+    {
+        validate_enum("trace", v, TRACE)?;
+    }
+    // GuardrailIdentifier: @length max=2048 (no min). Header form.
+    if let Some(v) = req
+        .headers
+        .get("x-amzn-bedrock-guardrailidentifier")
+        .and_then(|h| h.to_str().ok())
+    {
+        validate_length("guardrailIdentifier", v, 0, 2048)?;
+    }
+    Ok(())
+}
+
+/// Validate the body-size cap on InvokeModel-style payloads (`@length max=25_000_000`).
+pub(crate) fn validate_invoke_body_size(body: &[u8]) -> Result<(), AwsServiceError> {
+    if body.len() > 25_000_000 {
+        return Err(validation(
+            "Value at 'body' failed to satisfy constraint: Member must have length less than or equal to 25000000",
+        ));
+    }
+    Ok(())
+}
+
+/// Build a `ValidationException` with 400 status — the response shape declared
+/// by every runtime operation we care about here.
+pub(crate) fn validation<S: Into<String>>(message: S) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", message)
+}

--- a/crates/fakecloud-bedrock/src/service.rs
+++ b/crates/fakecloud-bedrock/src/service.rs
@@ -684,12 +684,41 @@ impl BedrockService {
             (Method::POST, 3) if segs[0] == "model" && segs[2] == "count-tokens" => {
                 Some(("CountTokens", Some(decode(&segs[1])), None))
             }
+            // `POST /model//<op>` (empty modelId, length validator surfaces it).
+            (Method::POST, 2) if segs[0] == "model" => {
+                let op = match segs[1].as_str() {
+                    "invoke" => Some("InvokeModel"),
+                    "invoke-with-response-stream" => Some("InvokeModelWithResponseStream"),
+                    "invoke-with-bidirectional-stream" => {
+                        Some("InvokeModelWithBidirectionalStream")
+                    }
+                    "converse" => Some("Converse"),
+                    "converse-stream" => Some("ConverseStream"),
+                    "count-tokens" => Some("CountTokens"),
+                    _ => None,
+                };
+                op.map(|action| (action, Some(String::new()), None))
+            }
 
             // Runtime: async invoke
             (Method::POST, 1) if segs[0] == "async-invoke" => {
                 Some(("StartAsyncInvoke", None, None))
             }
-            (Method::GET, 1) if segs[0] == "async-invoke" => Some(("ListAsyncInvokes", None, None)),
+            (Method::GET, 1)
+                if segs[0] == "async-invoke"
+                    && !req.raw_path.trim_end_matches('?').ends_with('/') =>
+            {
+                Some(("ListAsyncInvokes", None, None))
+            }
+            // `GET /async-invoke/` (trailing slash, empty invocationArn) routes
+            // to GetAsyncInvoke so the length validator surfaces the missing
+            // identifier instead of silently listing.
+            (Method::GET, 1)
+                if segs[0] == "async-invoke"
+                    && req.raw_path.trim_end_matches('?').ends_with('/') =>
+            {
+                Some(("GetAsyncInvoke", Some(String::new()), None))
+            }
             (Method::GET, 2) if segs[0] == "async-invoke" => {
                 Some(("GetAsyncInvoke", Some(decode(&segs[1])), None))
             }
@@ -1432,26 +1461,41 @@ impl AwsService for BedrockService {
                 crate::logging::delete_model_invocation_logging_configuration(&self.state, &req)
             }
             // Runtime operations
-            "InvokeModel" => crate::invoke::invoke_model(
-                &self.state,
-                &req,
-                &resource_id.unwrap_or_default(),
-                &req.body,
-            ),
-            "CountTokens" => crate::invoke::count_tokens(
-                &self.state,
-                &req,
-                &resource_id.unwrap_or_default(),
-                &req.body,
-            ),
-            "Converse" => crate::converse::converse(
-                &self.state,
-                &req,
-                &resource_id.unwrap_or_default(),
-                &req.body,
-            ),
+            "InvokeModel" => {
+                let model_id = resource_id.unwrap_or_default();
+                crate::runtime_validation::validate_invoke_model_id(&model_id)?;
+                crate::runtime_validation::validate_runtime_headers(&req)?;
+                crate::runtime_validation::validate_invoke_body_size(&req.body)?;
+                crate::invoke::invoke_model(&self.state, &req, &model_id, &req.body)
+            }
+            "CountTokens" => {
+                let model_id = resource_id.unwrap_or_default();
+                crate::runtime_validation::validate_short_model_id(&model_id)?;
+                crate::invoke::count_tokens(&self.state, &req, &model_id, &req.body)
+            }
+            "Converse" => {
+                let model_id = resource_id.unwrap_or_default();
+                crate::runtime_validation::validate_invoke_model_id(&model_id)?;
+                crate::converse::converse(&self.state, &req, &model_id, &req.body)
+            }
             "InvokeModelWithResponseStream" | "InvokeModelWithBidirectionalStream" => {
                 let model_id = resource_id.unwrap_or_default();
+                crate::runtime_validation::validate_invoke_model_id(&model_id)?;
+                if action == "InvokeModelWithResponseStream" {
+                    crate::runtime_validation::validate_runtime_headers(&req)?;
+                    crate::runtime_validation::validate_invoke_body_size(&req.body)?;
+                }
+                if action == "InvokeModelWithBidirectionalStream" {
+                    // body is @required and @httpPayload (an event-stream input).
+                    // Reject both an empty wire payload and a JSON `{}` that
+                    // represents the structural-default of "no input given".
+                    let trimmed = std::str::from_utf8(&req.body).unwrap_or("").trim();
+                    if req.body.is_empty() || trimmed == "{}" {
+                        return Err(crate::runtime_validation::validation(
+                            "body is required for InvokeModelWithBidirectionalStream",
+                        ));
+                    }
+                }
                 if let Some(fault) = crate::faults::take_matching_fault(
                     &self.state,
                     &req,
@@ -1494,6 +1538,7 @@ impl AwsService for BedrockService {
             }
             "ConverseStream" => {
                 let model_id = resource_id.unwrap_or_default();
+                crate::runtime_validation::validate_invoke_model_id(&model_id)?;
                 if let Some(fault) = crate::faults::take_matching_fault(
                     &self.state,
                     &req,

--- a/crates/fakecloud-e2e/tests/bedrock.rs
+++ b/crates/fakecloud-e2e/tests/bedrock.rs
@@ -1221,7 +1221,9 @@ async fn bedrock_async_invoke_lifecycle_raw() {
 
     assert_eq!(resp.status(), 200);
     let result: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(result["status"], "Completed");
+    // AsyncInvokeStatus is serialized in upstream UPPERCASE form
+    // (COMPLETED/FAILED/IN_PROGRESS) to match the Smithy enum.
+    assert_eq!(result["status"], "COMPLETED");
     assert_eq!(result["invocationArn"], invocation_arn);
 
     // List async invokes


### PR DESCRIPTION
## Summary

Adds Smithy-matching input validation across all Bedrock runtime operations so out-of-band requests surface the same `ValidationException` real AWS would return instead of slipping through to the canned handlers.

Concretely:

- modelId length (1..=2048 / 1..=256 for the short variant on CountTokens / StartAsyncInvoke) and structural pattern checks
- runtime header enums: `performanceConfigLatency`, `serviceTier`, `trace`
- guardrailIdentifier and body size caps (@length max=25,000,000 on Body)
- ListAsyncInvokes maxResults range, nextToken length+pattern, sortBy/sortOrder/statusEquals enums
- StartAsyncInvoke clientRequestToken length
- GetAsyncInvoke invocationArn length; trailing-slash routing so `GET /async-invoke/` surfaces the missing-id check instead of silently listing
- `POST /model//<op>` (empty modelId) routes to the model op with empty modelId so the length validator triggers instead of returning 501
- InvokeModelWithBidirectionalStream rejects `{}` body as "no input given"
- AsyncInvokeStatus is now serialized in the upstream UPPERCASE form (`COMPLETED` / `FAILED` / `IN_PROGRESS`) to match the Smithy enum
- GetAsyncInvoke now returns `ValidationException` (not `ResourceNotFoundException`) for a missing invocation, because `ValidationException` is the only error declared in its Smithy contract

## Conformance

- **Before**: 264/447 (59.1%)
- **After**: 383/447 (85.7%) — **+26.6pp**

The 64 remaining failures are all SHAPE_MISMATCH on Bedrock's `@httpPayload` blob (`InvokeModelResponse.body`) and `smithy.api#Document` (`ToolUseBlock.input`) outputs that the probe's JSON shape validator does not yet model — fixing those requires changes in the conformance probe, not the server.

## Test plan

- [x] `cargo test -p fakecloud-bedrock --release` (342 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `fakecloud-conformance run --services bedrock-runtime` -> 383/447

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Smithy-aligned input validation across all Bedrock runtime operations so invalid requests return `ValidationException` like AWS. Conformance improves from 264/447 (59.1%) to 383/447 (85.7%).

- **Bug Fixes**
  - Enforce `modelId` length/pattern (1..=2048; 1..=256 for short IDs), header enums (`performanceConfigLatency`, `serviceTier`, `trace`), `guardrailIdentifier` length, and a 25MB body cap.
  - Validate ListAsyncInvokes params: `maxResults` range, `nextToken` length/pattern, and enums for `sortBy`, `sortOrder`, `statusEquals`.
  - Validate StartAsyncInvoke `clientRequestToken` length and GetAsyncInvoke `invocationArn` length; missing invocation now returns `ValidationException` (400).
  - Serialize async status in UPPERCASE (`COMPLETED`, `FAILED`, `IN_PROGRESS`).
  - Route `GET /async-invoke/` (trailing slash) to GetAsyncInvoke and `POST /model//<op>` to model ops to surface length checks.
  - Require `input` for CountTokens; reject empty or `{}` bodies for `InvokeModelWithBidirectionalStream`.

<sup>Written for commit b034fdea7db606a31628c78cedbabef4946431bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

