### PR TITLE
fix(s3): reject bucket subresource ops with no bucket name

### DIFF
--- a/crates/fakecloud-s3/src/service/config.rs
+++ b/crates/fakecloud-s3/src/service/config.rs
@@ -1845,8 +1845,23 @@ impl S3Service {
     pub(super) fn list_directory_buckets(
         &self,
         account_id: &str,
-        _req: &AwsRequest,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // The Smithy model constrains `max-directory-buckets` to the
+        // range [0, 1000]; values outside that range are an
+        // InvalidArgument from real S3 Express.
+        if let Some(raw) = req.query_params.get("max-directory-buckets") {
+            match raw.parse::<i64>() {
+                Ok(v) if (0..=1000).contains(&v) => {}
+                _ => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidArgument",
+                        format!("max-directory-buckets must be between 0 and 1000 (was {raw})"),
+                    ));
+                }
+            }
+        }
         // S3 Express directory buckets are not modeled separately in
         // fakecloud; return an empty list per the documented schema so
         // SDK calls succeed.

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -473,6 +473,62 @@ impl AwsService for S3Service {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
+        // Bucket-scoped sub-resource query params. If a request targets one
+        // of these without a bucket in the path, S3 returns an error rather
+        // than silently treating it as a top-level (service) operation.
+        // Real AWS rejects e.g. `GET /?tagging` with a routing/validation
+        // error; mirroring that prevents bucket-required ops from being
+        // accidentally answered by ListBuckets / WriteGetObjectResponse.
+        let bucket_subresources: &[&str] = &[
+            "tagging",
+            "acl",
+            "versioning",
+            "cors",
+            "notification",
+            "website",
+            "accelerate",
+            "publicAccessBlock",
+            "encryption",
+            "lifecycle",
+            "logging",
+            "policy",
+            "policyStatus",
+            "replication",
+            "ownershipControls",
+            "inventory",
+            "analytics",
+            "intelligent-tiering",
+            "metrics",
+            "requestPayment",
+            "abac",
+            "metadataConfiguration",
+            "metadataTable",
+            "metadataInventoryTable",
+            "metadataJournalTable",
+            "object-lock",
+            "versions",
+            "session",
+            "retention",
+            "legal-hold",
+            "attributes",
+            "torrent",
+            "renameObject",
+            "uploads",
+            "restore",
+            "select",
+        ];
+        if bucket.is_none()
+            && bucket_subresources
+                .iter()
+                .any(|q| req.query_params.contains_key(*q))
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidBucketName",
+                "The specified bucket is not valid: bucket name is required for this operation",
+            ));
+        }
+
         let mut result = match (&req.method, bucket, key.as_deref()) {
             // ListBuckets: GET /
             (&Method::GET, None, None) => {

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3112,6 +3112,41 @@ fn head_bucket_missing_errors() {
     assert_aws_err(svc.head_bucket("123456789012", "nope"), "NoSuchBucket");
 }
 
+#[tokio::test]
+async fn bucket_subresource_without_bucket_errors() {
+    // Regression: requests like `GET /?tagging` (bucket name omitted)
+    // used to fall through to `list_buckets` and return 200, masking the
+    // missing required bucket. Real S3 rejects these with a validation
+    // error; mirror that so conformance probes targeting required-field
+    // omission see the expected 4xx.
+    use fakecloud_core::service::AwsService;
+    let svc = make_service();
+    let cases: &[(Method, &str)] = &[
+        (Method::GET, "tagging"),
+        (Method::GET, "acl"),
+        (Method::GET, "lifecycle"),
+        (Method::GET, "encryption"),
+        (Method::PUT, "tagging"),
+        (Method::PUT, "encryption"),
+        (Method::DELETE, "tagging"),
+        (Method::DELETE, "lifecycle"),
+    ];
+    for (method, q) in cases {
+        let req = make_request(method.clone(), "/", &[(q, "")], b"");
+        let resp = svc.handle(req).await;
+        let err = match resp {
+            Ok(_) => panic!("{method} /?{q} should error, got Ok"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.code(),
+            "InvalidBucketName",
+            "method={method} q={q} got {:?}",
+            err.code()
+        );
+    }
+}
+
 #[test]
 fn head_bucket_exists_returns_ok() {
     let svc = make_service();


### PR DESCRIPTION
## Summary
- Requests like `GET /?tagging` or `DELETE /?lifecycle` (Bucket member omitted) used to fall through to `(Method, None, None)` and be answered by `list_buckets` with HTTP 200, masking the missing required bucket name.
- Reject these up front with `InvalidBucketName` to mirror real S3 behaviour: bucket sub-resource query params (`tagging`, `acl`, `lifecycle`, `encryption`, `cors`, `policy`, `versioning`, `versions`, etc.) require a bucket name in the path.
- Conformance pass rate on s3 moves from 3134/3669 (85.42%) to 3144/3669 (85.69%). The 10 newly-passing variants are `negative_omit_Bucket` cases on the bucket sub-resource ops listed in the route table.

## Notes on conformance ceiling
The remaining ~525 failures fall into buckets that cannot be fixed by editing `fakecloud-s3` alone without changing the conformance probe (which is out of scope for this PR):

- **331 NoSuchBucket "undeclared error"** — probe sends ops like `CopyObject`, `PutObject`, `HeadObject`, `GetObjectAttributes` against `test-conformance-bucket` which is never created. Real AWS S3 returns `NoSuchBucket`, but the Smithy model only declares per-op errors like `ObjectNotInActiveTierError`, so the classifier treats `NoSuchBucket` as undeclared. Fixing requires either seeding the test bucket in the probe harness or extending the classifier to accept S3 common errors.
- **68 HEAD-method "no AWS error code in body"** — `HeadBucket`/`HeadObject` against a missing bucket correctly return 404 with an empty body (HEAD responses cannot carry a body per HTTP). Probe classifier reads the body, not the response headers, and flags the empty body as a routing miss.
- **72 `negative_omit_Bucket`** on ops not in the probe's hand-curated S3 route table (`GetBucketAbac`, `RestoreObject`, `UpdateObjectEncryption`, …). These fall to the default `GET /{bucket}` template; with the bucket omitted, the URL collapses to `GET /` with no sub-resource query param, so this PR's gate cannot tell them apart from a real `ListBuckets`.
- **54 `InvalidBucketName`** on `CreateBucket` — Smithy declares only `BucketAlreadyExists` and `BucketAlreadyOwnedByYou`; real AWS returns `InvalidBucketName` for many of the variant combinations, but the Smithy model doesn't list it.

## Test plan
- [x] `cargo test -p fakecloud-s3 --lib` (322 + 1 new test pass)
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p fakecloud-conformance -- run --services s3` — pass rate up from 3134 to 3144 of 3669

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject bucket subresource requests without a bucket name and validate `max-directory-buckets` for `ListDirectoryBuckets`. Aligns with real S3 behavior and improves S3 conformance from 3134 to 3144 of 3669.

- **Bug Fixes**
  - Block subresource queries when `bucket` is missing (e.g., `tagging`, `acl`, `lifecycle`, `encryption`, `cors`, `policy`, `versioning`, `versions`).
  - Return 400 `InvalidBucketName` for these cases to prevent accidental `ListBuckets` responses.
  - Validate `max-directory-buckets` in `ListDirectoryBuckets`; values outside [0, 1000] now return 400 `InvalidArgument`.
  - Add a unit test covering GET/PUT/DELETE across representative subresource queries.

<sup>Written for commit ecc81cb231b3c957c4a6057266f74aa6b1ce647f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

