### PR TITLE
fix(conformance/wafv2): supply required inputs in handwritten tests

### DIFF
--- a/crates/fakecloud-conformance/tests/wafv2.rs
+++ b/crates/fakecloud-conformance/tests/wafv2.rs
@@ -772,6 +772,7 @@ async fn waf_describe_all_managed_products() {
         .wafv2_client()
         .await
         .describe_all_managed_products()
+        .scope(Scope::Regional)
         .send()
         .await
         .unwrap();
@@ -967,6 +968,28 @@ async fn waf_check_capacity() {
         .await
         .check_capacity()
         .scope(Scope::Regional)
+        .rules(
+            aws_sdk_wafv2::types::Rule::builder()
+                .name("Rule1")
+                .priority(0)
+                .statement(
+                    aws_sdk_wafv2::types::Statement::builder()
+                        .geo_match_statement(
+                            aws_sdk_wafv2::types::GeoMatchStatement::builder()
+                                .country_codes(aws_sdk_wafv2::types::CountryCode::Us)
+                                .build(),
+                        )
+                        .build(),
+                )
+                .action(
+                    aws_sdk_wafv2::types::RuleAction::builder()
+                        .allow(aws_sdk_wafv2::types::AllowAction::builder().build())
+                        .build(),
+                )
+                .visibility_config(vis("Rule1"))
+                .build()
+                .unwrap(),
+        )
         .send()
         .await
         .unwrap();
@@ -1019,6 +1042,8 @@ async fn waf_get_top_path_statistics_by_traffic() {
                 .build()
                 .unwrap(),
         )
+        .limit(10)
+        .number_of_top_traffic_bots_per_path(5)
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
Three handwritten wafv2 conformance tests relied on the pre-#1381 laxity around missing required fields. Supply them now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated three WAFv2 conformance tests to include required inputs now enforced by validation, keeping tests aligned with the AWS contract.

- **Bug Fixes**
  - waf_describe_all_managed_products: set Scope to Regional.
  - waf_check_capacity: provide Rules with a basic GeoMatch allow rule and visibility config.
  - waf_get_top_path_statistics_by_traffic: set Limit to 10 and NumberOfTopTrafficBotsPerPath to 5.

<sup>Written for commit e2f9f4534850566794831bbfeb43951d1e53fe1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

