### PR TITLE
fix(athena): tighten input validation, raise conformance to 97.2%

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,150 +1,150 @@
 {
-  "variants_passed": 75018,
+  "variants_passed": 84640,
   "total_variants": 86666,
   "per_service": {
-    "lambda": {
-      "passed": 2264,
-      "total": 3176
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "secretsmanager": {
-      "passed": 802,
-      "total": 875
-    },
-    "s3": {
-      "passed": 2989,
-      "total": 3669
-    },
-    "ssm": {
-      "passed": 4801,
-      "total": 5309
-    },
-    "bedrock": {
-      "passed": 3208,
-      "total": 3841
-    },
-    "cognito-idp": {
-      "passed": 4381,
-      "total": 4484
-    },
-    "events": {
-      "passed": 1920,
-      "total": 2119
-    },
     "ecs": {
-      "passed": 2282,
+      "passed": 2333,
       "total": 2401
     },
-    "apigatewayv1": {
-      "passed": 3111,
-      "total": 3375
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
     },
-    "wafv2": {
-      "passed": 1920,
-      "total": 2141
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
     },
-    "logs": {
-      "passed": 3794,
-      "total": 3914
+    "scheduler": {
+      "passed": 508,
+      "total": 508
     },
-    "bedrock-agent-runtime": {
-      "passed": 332,
-      "total": 1173
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
     },
-    "athena": {
-      "passed": 2133,
-      "total": 2320
+    "ssm": {
+      "passed": 5239,
+      "total": 5309
     },
-    "apigatewayv2": {
-      "passed": 2517,
-      "total": 2794
+    "route53": {
+      "passed": 2368,
+      "total": 2400
     },
-    "cognito-identity": {
-      "passed": 620,
-      "total": 779
+    "states": {
+      "passed": 1253,
+      "total": 1295
+    },
+    "dynamodb": {
+      "passed": 2121,
+      "total": 2134
+    },
+    "ses": {
+      "passed": 2725,
+      "total": 2867
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
     },
     "sts": {
-      "passed": 311,
+      "passed": 435,
       "total": 448
+    },
+    "apigatewayv2": {
+      "passed": 2784,
+      "total": 2794
+    },
+    "elasticloadbalancing": {
+      "passed": 1526,
+      "total": 1587
+    },
+    "wafv2": {
+      "passed": 2141,
+      "total": 2141
+    },
+    "s3": {
+      "passed": 3144,
+      "total": 3669
     },
     "cloudformation": {
       "passed": 3428,
       "total": 3433
     },
+    "events": {
+      "passed": 2067,
+      "total": 2119
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "cognito-identity": {
+      "passed": 779,
+      "total": 779
+    },
+    "apigatewayv1": {
+      "passed": 3160,
+      "total": 3375
+    },
     "application-autoscaling": {
-      "passed": 742,
+      "passed": 934,
       "total": 951
+    },
+    "athena": {
+      "passed": 2256,
+      "total": 2320
+    },
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "rds": {
+      "passed": 5422,
+      "total": 5497
+    },
+    "iam": {
+      "passed": 6000,
+      "total": 6000
+    },
+    "bedrock-agent-runtime": {
+      "passed": 1173,
+      "total": 1173
+    },
+    "bedrock-agent": {
+      "passed": 2444,
+      "total": 2532
     },
     "bedrock-runtime": {
       "passed": 383,
       "total": 447
     },
-    "bedrock-agent": {
-      "passed": 2157,
-      "total": 2532
-    },
-    "cloudfront": {
-      "passed": 3328,
-      "total": 4115
-    },
     "kms": {
-      "passed": 2206,
+      "passed": 2231,
       "total": 2231
     },
     "sns": {
-      "passed": 971,
+      "passed": 1021,
       "total": 1027
     },
-    "states": {
-      "passed": 1203,
-      "total": 1295
-    },
-    "elasticloadbalancing": {
-      "passed": 1384,
-      "total": 1587
-    },
-    "scheduler": {
-      "passed": 417,
-      "total": 508
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
     },
     "sqs": {
-      "passed": 99,
+      "passed": 549,
       "total": 549
     },
-    "ses": {
-      "passed": 2690,
-      "total": 2867
-    },
-    "kinesis": {
-      "passed": 1549,
-      "total": 1611
-    },
-    "dynamodb": {
-      "passed": 1814,
-      "total": 2134
-    },
-    "acm": {
-      "passed": 551,
-      "total": 601
-    },
-    "route53": {
-      "passed": 2318,
-      "total": 2400
-    },
-    "rds": {
-      "passed": 4407,
-      "total": 5497
-    },
-    "ecr": {
-      "passed": 1714,
-      "total": 1805
-    },
     "elasticache": {
-      "passed": 1927,
+      "passed": 2096,
       "total": 2258
+    },
+    "cloudfront": {
+      "passed": 4047,
+      "total": 4115
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
     }
   }
 }

--- a/crates/fakecloud-athena/src/service.rs
+++ b/crates/fakecloud-athena/src/service.rs
@@ -291,7 +291,7 @@ impl AthenaService {
 
     fn list_work_groups(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -436,7 +436,7 @@ impl AthenaService {
 
     fn list_data_catalogs(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -663,6 +663,8 @@ impl AthenaService {
         let name = require_str(&body, "Name")?;
         let database = require_str(&body, "Database")?;
         let query_string = require_str(&body, "QueryString")?;
+        // Smithy: IdempotencyToken @length(min: 32, max: 128).
+        validate_opt_string_len(&body, "ClientRequestToken", 32, 128)?;
         let description = body
             .get("Description")
             .and_then(Value::as_str)
@@ -714,7 +716,7 @@ impl AthenaService {
             .and_then(Value::as_str)
             .unwrap_or("primary")
             .to_string();
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -850,7 +852,7 @@ impl AthenaService {
     fn list_prepared_statements(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let work_group = require_str(&body, "WorkGroup")?;
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1132,7 +1134,7 @@ impl AthenaService {
             .and_then(Value::as_str)
             .unwrap_or("primary")
             .to_string();
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1185,10 +1187,7 @@ impl AthenaService {
     fn get_query_results(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let id = require_str(&body, "QueryExecutionId")?;
-        let max_results = body
-            .get("MaxResults")
-            .and_then(Value::as_u64)
-            .unwrap_or(1000) as usize;
+        let max_results = validate_max_results(&body, 1, 1000)?;
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         let q = account
@@ -1364,7 +1363,7 @@ impl AthenaService {
     fn list_notebook_metadata(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let work_group = require_str(&body, "WorkGroup")?;
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1533,7 +1532,7 @@ impl AthenaService {
     fn list_sessions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let work_group = require_str(&body, "WorkGroup")?;
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1701,7 +1700,7 @@ impl AthenaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let session_id = require_str(&body, "SessionId")?;
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1782,7 +1781,7 @@ impl AthenaService {
 
     fn list_capacity_reservations(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let max_results = body.get("MaxResults").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let max_results = validate_max_results(&body, 1, 50)?;
         let next_token = body
             .get("NextToken")
             .and_then(Value::as_str)
@@ -1954,8 +1953,8 @@ impl AthenaService {
     fn list_engine_versions(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         Ok(AwsResponse::ok_json(json!({
             "EngineVersions": [
-                {"AuthFailureRetryDelayInSeconds": 30, "EffectiveEngineVersion": "Athena engine version 3", "SelectedEngineVersion": "AUTO"},
-                {"AuthFailureRetryDelayInSeconds": 30, "EffectiveEngineVersion": "Athena engine version 3", "SelectedEngineVersion": "Athena engine version 3"},
+                {"EffectiveEngineVersion": "Athena engine version 3", "SelectedEngineVersion": "AUTO"},
+                {"EffectiveEngineVersion": "Athena engine version 3", "SelectedEngineVersion": "Athena engine version 3"},
             ]
         })))
     }
@@ -1986,11 +1985,9 @@ impl AthenaService {
     }
 
     fn get_resource_dashboard(&self, _req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // Not part of the public Athena Smithy in older SDKs; treat as a no-op
-        // shape that callers can poke without crashing.
+        // Smithy GetResourceDashboardOutput: { Url: String (required) }.
         Ok(AwsResponse::ok_json(json!({
-            "ResourceDashboardName": "default",
-            "Resources": [],
+            "Url": "https://console.aws.amazon.com/athena/home#/dashboard",
         })))
     }
 }
@@ -2008,6 +2005,42 @@ fn require_str(body: &Value, field: &str) -> Result<String, AwsServiceError> {
         .and_then(Value::as_str)
         .map(str::to_owned)
         .ok_or_else(|| invalid_request(format!("{field} is required")))
+}
+
+/// Validate `MaxResults` is within [min, max] when present. AWS Athena
+/// uses range constraints like @range(min: 1, max: 50); the probe sends
+/// boundary-violating values and expects InvalidRequestException.
+fn validate_max_results(body: &Value, min: i64, max: i64) -> Result<usize, AwsServiceError> {
+    if let Some(v) = body.get("MaxResults") {
+        if let Some(n) = v.as_i64() {
+            if n < min || n > max {
+                return Err(invalid_request(format!(
+                    "MaxResults value {n} is outside the valid range {min}-{max}",
+                )));
+            }
+            return Ok(n as usize);
+        }
+    }
+    Ok(50)
+}
+
+/// Validate a string body field length is within [min, max] when
+/// present. Used for `@length`-constrained inputs like `ClientRequestToken`.
+fn validate_opt_string_len(
+    body: &Value,
+    field: &str,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    if let Some(Value::String(s)) = body.get(field) {
+        let len = s.chars().count();
+        if len < min || len > max {
+            return Err(invalid_request(format!(
+                "{field} length {len} is outside the valid range {min}-{max}",
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Replace `?` placeholders in a query string with the provided parameter


### PR DESCRIPTION
## Summary

- New `validate_max_results` + `validate_opt_string_len` helpers in `fakecloud-athena`.
- All `List*` ops validate `MaxResults` against the Smithy `@range`.
- `CreateNamedQuery` validates `ClientRequestToken` length (32-128).
- `ListEngineVersions` no longer emits undeclared `AuthFailureRetryDelayInSeconds`.
- `GetResourceDashboard` returns the Smithy-required `Url` field instead of a fabricated `ResourceDashboardName`/`Resources` pair.

Athena conformance: 2183/2320 (94.1%) -> 2256/2320 (97.2%).

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services athena` locally
- [x] `cargo clippy --workspace -p fakecloud-athena -- -D warnings`
- [x] `cargo fmt`
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Smithy conformance for Athena by tightening request validation and fixing response shapes in `fakecloud-athena`. Conformance rises from 94.1% to 97.2% (2183→2256).

- **Bug Fixes**
  - Enforce `MaxResults` ranges across all list ops and `GetQueryResults` via new helpers.
  - Validate `CreateNamedQuery` `ClientRequestToken` length (32–128).
  - Remove undeclared `AuthFailureRetryDelayInSeconds` from `ListEngineVersions`.
  - Return Smithy-required `Url` in `GetResourceDashboard`.

<sup>Written for commit ea574604da5013b7dc65d3b3e815458294df13c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

