### PR TITLE
fix(conformance): bump default flake margin to 100

### DIFF
--- a/crates/fakecloud-conformance/src/main.rs
+++ b/crates/fakecloud-conformance/src/main.rs
@@ -483,7 +483,7 @@ fn cmd_check(
     let flake_margin: usize = std::env::var("FAKECLOUD_CONFORMANCE_FLAKE_MARGIN")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(50);
+        .unwrap_or(100);
     let mut regressions = Vec::new();
 
     let current_by_service: HashMap<&str, usize> = report_data


### PR DESCRIPTION
## Summary

#1392 introduced a 50-variant flake margin, but CI shows cognito-idp drifting up to 67 variants below the local baseline. Bump default to 100.

## Test plan
- [x] cargo check
- [ ] CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default flake margin in `fakecloud-conformance` from 50 to 100 to stabilize CI conformance checks. This absorbs observed `cognito-idp` drift of up to 67 variants between local runs and CI.

<sup>Written for commit b9b97a6b911b301dcaa5040ca3fb1c38fc2b2069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

