### PR TITLE
fix(bedrock-agent): validate path, query, and body inputs against Smithy constraints

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,150 +1,150 @@
 {
-  "variants_passed": 84815,
+  "variants_passed": 84944,
   "total_variants": 86666,
   "per_service": {
-    "states": {
-      "passed": 1253,
-      "total": 1295
-    },
-    "s3": {
-      "passed": 3144,
-      "total": 3669
-    },
-    "apigatewayv1": {
-      "passed": 3256,
-      "total": 3375
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "bedrock-agent-runtime": {
-      "passed": 1173,
-      "total": 1173
-    },
-    "athena": {
-      "passed": 2256,
-      "total": 2320
-    },
-    "sts": {
-      "passed": 448,
-      "total": 448
-    },
-    "sns": {
-      "passed": 1021,
-      "total": 1027
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
-    },
-    "events": {
-      "passed": 2067,
-      "total": 2119
-    },
-    "route53": {
-      "passed": 2368,
-      "total": 2400
-    },
-    "cognito-identity": {
-      "passed": 779,
-      "total": 779
-    },
-    "ses": {
-      "passed": 2791,
-      "total": 2867
-    },
-    "ecs": {
-      "passed": 2332,
-      "total": 2401
-    },
-    "ssm": {
-      "passed": 5239,
-      "total": 5309
-    },
-    "scheduler": {
-      "passed": 508,
-      "total": 508
-    },
-    "rds": {
-      "passed": 5422,
-      "total": 5497
-    },
-    "elasticloadbalancing": {
-      "passed": 1526,
-      "total": 1587
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
-    },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "application-autoscaling": {
-      "passed": 934,
-      "total": 951
-    },
-    "bedrock-runtime": {
-      "passed": 383,
-      "total": 447
-    },
-    "cloudformation": {
-      "passed": 3428,
-      "total": 3433
-    },
-    "apigatewayv2": {
-      "passed": 2784,
-      "total": 2794
-    },
-    "dynamodb": {
-      "passed": 2121,
-      "total": 2134
-    },
     "ecr": {
       "passed": 1764,
       "total": 1805
-    },
-    "elasticache": {
-      "passed": 2097,
-      "total": 2258
-    },
-    "lambda": {
-      "passed": 3170,
-      "total": 3176
     },
     "logs": {
       "passed": 3844,
       "total": 3914
     },
-    "bedrock": {
-      "passed": 3760,
-      "total": 3841
+    "athena": {
+      "passed": 2256,
+      "total": 2320
     },
-    "acm": {
-      "passed": 601,
-      "total": 601
+    "events": {
+      "passed": 2067,
+      "total": 2119
+    },
+    "bedrock-agent-runtime": {
+      "passed": 1173,
+      "total": 1173
+    },
+    "kms": {
+      "passed": 2231,
+      "total": 2231
+    },
+    "route53": {
+      "passed": 2368,
+      "total": 2400
+    },
+    "iam": {
+      "passed": 6000,
+      "total": 6000
+    },
+    "sts": {
+      "passed": 448,
+      "total": 448
+    },
+    "scheduler": {
+      "passed": 508,
+      "total": 508
     },
     "cloudfront": {
       "passed": 4047,
       "total": 4115
     },
+    "application-autoscaling": {
+      "passed": 934,
+      "total": 951
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
+    "rds": {
+      "passed": 5422,
+      "total": 5497
+    },
+    "cloudformation": {
+      "passed": 3428,
+      "total": 3433
+    },
+    "ses": {
+      "passed": 2791,
+      "total": 2867
+    },
+    "bedrock-agent": {
+      "passed": 2532,
+      "total": 2532
+    },
+    "s3": {
+      "passed": 3144,
+      "total": 3669
+    },
+    "elasticache": {
+      "passed": 2096,
+      "total": 2258
+    },
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
+    },
+    "dynamodb": {
+      "passed": 2121,
+      "total": 2134
+    },
+    "ecs": {
+      "passed": 2333,
+      "total": 2401
+    },
+    "cognito-identity": {
+      "passed": 779,
+      "total": 779
+    },
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
+    },
+    "apigatewayv2": {
+      "passed": 2784,
+      "total": 2794
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
+    },
+    "ssm": {
+      "passed": 5239,
+      "total": 5309
+    },
+    "states": {
+      "passed": 1295,
+      "total": 1295
+    },
+    "elasticloadbalancing": {
+      "passed": 1526,
+      "total": 1587
+    },
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "bedrock-runtime": {
+      "passed": 383,
+      "total": 447
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
     "wafv2": {
       "passed": 2141,
       "total": 2141
     },
-    "bedrock-agent": {
-      "passed": 2444,
-      "total": 2532
+    "sns": {
+      "passed": 1021,
+      "total": 1027
+    },
+    "apigatewayv1": {
+      "passed": 3255,
+      "total": 3375
     }
   }
 }

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,42 +1,114 @@
 {
-  "variants_passed": 84944,
+  "variants_passed": 84925,
   "total_variants": 86666,
   "per_service": {
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
+    "apigatewayv2": {
+      "passed": 2784,
+      "total": 2794
     },
-    "logs": {
-      "passed": 3844,
-      "total": 3914
-    },
-    "athena": {
-      "passed": 2256,
-      "total": 2320
-    },
-    "events": {
-      "passed": 2067,
-      "total": 2119
-    },
-    "bedrock-agent-runtime": {
-      "passed": 1173,
-      "total": 1173
-    },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
-    },
-    "route53": {
-      "passed": 2368,
-      "total": 2400
+    "bedrock-agent": {
+      "passed": 2532,
+      "total": 2532
     },
     "iam": {
       "passed": 6000,
       "total": 6000
     },
+    "s3": {
+      "passed": 3144,
+      "total": 3669
+    },
+    "ssm": {
+      "passed": 5239,
+      "total": 5309
+    },
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
+    },
+    "states": {
+      "passed": 1295,
+      "total": 1295
+    },
+    "application-autoscaling": {
+      "passed": 934,
+      "total": 951
+    },
+    "wafv2": {
+      "passed": 2141,
+      "total": 2141
+    },
+    "route53": {
+      "passed": 2368,
+      "total": 2400
+    },
     "sts": {
       "passed": 448,
       "total": 448
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
+    "events": {
+      "passed": 2067,
+      "total": 2119
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
+    "elasticloadbalancing": {
+      "passed": 1526,
+      "total": 1587
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "cognito-identity": {
+      "passed": 779,
+      "total": 779
+    },
+    "dynamodb": {
+      "passed": 2121,
+      "total": 2134
+    },
+    "kms": {
+      "passed": 2231,
+      "total": 2231
+    },
+    "bedrock-agent-runtime": {
+      "passed": 1173,
+      "total": 1173
+    },
+    "cloudformation": {
+      "passed": 3428,
+      "total": 3433
+    },
+    "ses": {
+      "passed": 2772,
+      "total": 2867
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "athena": {
+      "passed": 2256,
+      "total": 2320
+    },
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
+    },
+    "sns": {
+      "passed": 1021,
+      "total": 1027
+    },
+    "apigatewayv1": {
+      "passed": 3256,
+      "total": 3375
     },
     "scheduler": {
       "passed": 508,
@@ -46,105 +118,33 @@
       "passed": 4047,
       "total": 4115
     },
-    "application-autoscaling": {
-      "passed": 934,
-      "total": 951
-    },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
     },
     "rds": {
       "passed": 5422,
       "total": 5497
     },
-    "cloudformation": {
-      "passed": 3428,
-      "total": 3433
-    },
-    "ses": {
-      "passed": 2791,
-      "total": 2867
-    },
-    "bedrock-agent": {
-      "passed": 2532,
-      "total": 2532
-    },
-    "s3": {
-      "passed": 3144,
-      "total": 3669
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
     },
     "elasticache": {
       "passed": 2096,
       "total": 2258
     },
-    "bedrock": {
-      "passed": 3760,
-      "total": 3841
-    },
-    "dynamodb": {
-      "passed": 2121,
-      "total": 2134
-    },
     "ecs": {
-      "passed": 2333,
+      "passed": 2332,
       "total": 2401
-    },
-    "cognito-identity": {
-      "passed": 779,
-      "total": 779
-    },
-    "lambda": {
-      "passed": 3170,
-      "total": 3176
-    },
-    "apigatewayv2": {
-      "passed": 2784,
-      "total": 2794
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "ssm": {
-      "passed": 5239,
-      "total": 5309
-    },
-    "states": {
-      "passed": 1295,
-      "total": 1295
-    },
-    "elasticloadbalancing": {
-      "passed": 1526,
-      "total": 1587
-    },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
     },
     "bedrock-runtime": {
       "passed": 383,
       "total": 447
     },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "wafv2": {
-      "passed": 2141,
-      "total": 2141
-    },
-    "sns": {
-      "passed": 1021,
-      "total": 1027
-    },
-    "apigatewayv1": {
-      "passed": 3255,
-      "total": 3375
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
     }
   }
 }

--- a/crates/fakecloud-bedrock-agent/src/service.rs
+++ b/crates/fakecloud-bedrock-agent/src/service.rs
@@ -104,8 +104,26 @@ impl BedrockAgentService {
     }
 
     fn resolve_action(req: &AwsRequest) -> Option<(&'static str, Vec<(String, String)>)> {
-        let segs = &req.path_segments;
-        if segs.is_empty() {
+        // Preserve empty path segments so synthetic probes that drop a
+        // required `@httpLabel` (e.g. an empty `agentVersion` -> `//`) still
+        // reach the right action and surface as a ValidationException rather
+        // than a routing miss.
+        let raw_segs: Vec<String> = req
+            .raw_path
+            .trim_start_matches('/')
+            .split('/')
+            .map(|s| s.to_string())
+            .collect();
+        let raw_segs: Vec<String> =
+            if raw_segs.last().map(|s| s.is_empty()).unwrap_or(false) && raw_segs.len() > 1 {
+                // Drop a trailing empty caused by a trailing slash on the URL,
+                // which is purely cosmetic. Keep interior empties.
+                raw_segs[..raw_segs.len() - 1].to_vec()
+            } else {
+                raw_segs
+            };
+        let segs = &raw_segs;
+        if segs.is_empty() || segs.iter().all(|s| s.is_empty()) {
             return None;
         }
 
@@ -557,6 +575,8 @@ impl AwsService for BedrockAgentService {
             req.body = serde_json::to_vec(&body).unwrap_or_default().into();
         }
 
+        validate_inputs(action, &req)?;
+
         match action {
             "CreateAgent" => self.create_agent(&req),
             "CreateAgentActionGroup" => self.create_agent_action_group(&req),
@@ -644,6 +664,226 @@ fn missing(field: &str) -> AwsServiceError {
         "ValidationException",
         format!("Missing required field: {field}"),
     )
+}
+
+fn validation(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg.into())
+}
+
+/// Smithy `Id` shape: `^[0-9a-zA-Z]{10}$`.
+fn is_valid_id(s: &str) -> bool {
+    s.len() == 10 && s.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
+/// Smithy `Version` shape: length 1..=5, pattern `^(DRAFT|[0-9]{0,4}[1-9][0-9]{0,4})$`.
+fn is_valid_version(s: &str) -> bool {
+    if s.is_empty() || s.len() > 5 {
+        return false;
+    }
+    if s == "DRAFT" {
+        return true;
+    }
+    if !s.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    // Must contain at least one non-zero digit (i.e. not "0", "00", etc.) and
+    // the first digit must not be zero unless the whole value is a single zero
+    // (which is disallowed by the pattern's `[1-9]` requirement).
+    if s.starts_with('0') {
+        return false;
+    }
+    s.bytes().any(|b| b != b'0')
+}
+
+/// Validate path-bound `Id`-shape field. Empty/missing also rejected.
+fn check_id(body: &Value, field: &str) -> Result<(), AwsServiceError> {
+    let v = body
+        .get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| missing(field))?;
+    if !is_valid_id(v) {
+        return Err(validation(format!(
+            "Value at '{field}' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[0-9a-zA-Z]{{10}}$"
+        )));
+    }
+    Ok(())
+}
+
+fn check_version(body: &Value, field: &str) -> Result<(), AwsServiceError> {
+    let v = body
+        .get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| missing(field))?;
+    if !is_valid_version(v) {
+        return Err(validation(format!(
+            "Value at '{field}' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(DRAFT|[0-9]{{0,4}}[1-9][0-9]{{0,4}})$"
+        )));
+    }
+    Ok(())
+}
+
+fn check_resource_arn(body: &Value, field: &str) -> Result<(), AwsServiceError> {
+    let v = body
+        .get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| missing(field))?;
+    let len = v.len();
+    if !(20..=1011).contains(&len) {
+        return Err(validation(format!(
+            "Value at '{field}' failed to satisfy constraint: Member must have length between 20 and 1011, inclusive"
+        )));
+    }
+    Ok(())
+}
+
+fn check_max_results(req: &AwsRequest, body: &Value) -> Result<(), AwsServiceError> {
+    // `maxResults` lives in the query string for REST list ops, but the body
+    // for body-only list ops (e.g. ListAgents, ListKnowledgeBases).
+    let from_query = req.query_params.get("maxResults").map(|s| s.as_str());
+    let from_body = body.get("maxResults");
+    let parsed: Option<i64> = match (from_query, from_body) {
+        (Some(s), _) => s.parse().ok(),
+        (None, Some(v)) => v.as_i64(),
+        _ => None,
+    };
+    if from_query.is_some() || from_body.is_some() {
+        match parsed {
+            Some(n) if (1..=1000).contains(&n) => Ok(()),
+            _ => Err(validation(
+                "Value at 'maxResults' failed to satisfy constraint: Member must be between 1 and 1000, inclusive",
+            )),
+        }
+    } else {
+        Ok(())
+    }
+}
+
+fn check_next_token(req: &AwsRequest, body: &Value) -> Result<(), AwsServiceError> {
+    let from_query = req.query_params.get("nextToken").map(|s| s.as_str());
+    let from_body = body.get("nextToken").and_then(|v| v.as_str());
+    let token = from_query.or(from_body);
+    if let Some(raw) = token {
+        let len = raw.len();
+        if !(1..=2048).contains(&len) || raw.chars().any(|c| c.is_whitespace()) {
+            return Err(validation(
+                "Value at 'nextToken' failed to satisfy constraint: Member must have length between 1 and 2048, inclusive and match pattern ^\\S*$",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn check_tag_keys_required(req: &AwsRequest) -> Result<(), AwsServiceError> {
+    // `tagKeys` is `@httpQuery("tagKeys")` and `@required` on UntagResource.
+    // It can arrive as repeated `tagKeys=a&tagKeys=b` (only the last is in
+    // `query_params`) — anything is fine, but the absence is a validation error.
+    if !req.raw_query.split('&').any(|kv| {
+        let k = kv.split_once('=').map(|(k, _)| k).unwrap_or(kv);
+        k == "tagKeys"
+    }) {
+        return Err(missing("tagKeys"));
+    }
+    Ok(())
+}
+
+fn check_string_length(
+    body: &Value,
+    field: &str,
+    min: usize,
+    max: usize,
+    required: bool,
+) -> Result<(), AwsServiceError> {
+    match body.get(field).and_then(|v| v.as_str()) {
+        Some(v) => {
+            let len = v.len();
+            if !(min..=max).contains(&len) {
+                return Err(validation(format!(
+                    "Value at '{field}' failed to satisfy constraint: Member must have length between {min} and {max}, inclusive"
+                )));
+            }
+            Ok(())
+        }
+        None => {
+            if required {
+                Err(missing(field))
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+fn check_required_present(body: &Value, field: &str) -> Result<(), AwsServiceError> {
+    if body.get(field).is_none() || body.get(field).map(|v| v.is_null()).unwrap_or(false) {
+        return Err(missing(field));
+    }
+    Ok(())
+}
+
+fn validate_inputs(action: &str, req: &AwsRequest) -> Result<(), AwsServiceError> {
+    let body = req.json_body();
+
+    // Common pagination guards on every list/scan operation.
+    let is_list = action.starts_with("List");
+    if is_list {
+        check_max_results(req, &body)?;
+        check_next_token(req, &body)?;
+    }
+
+    match action {
+        // Path-bound agentId only.
+        "ListAgentAliases" | "ListAgentVersions" => {
+            check_id(&body, "agentId")?;
+        }
+        // Path-bound agentId + agentVersion.
+        "ListAgentActionGroups"
+        | "ListAgentCollaborators"
+        | "ListAgentKnowledgeBases"
+        | "GetAgentActionGroup"
+        | "GetAgentCollaborator"
+        | "GetAgentKnowledgeBase" => {
+            check_id(&body, "agentId")?;
+            check_version(&body, "agentVersion")?;
+        }
+        // Path-bound knowledgeBaseId.
+        "ListDataSources" => {
+            check_id(&body, "knowledgeBaseId")?;
+        }
+        // Path-bound knowledgeBaseId + dataSourceId.
+        "ListIngestionJobs" => {
+            check_id(&body, "knowledgeBaseId")?;
+            check_id(&body, "dataSourceId")?;
+        }
+        // Tag-resource family: validate ARN length/presence and (for Untag)
+        // the required `tagKeys` query parameter.
+        "TagResource" | "ListTagsForResource" => {
+            check_resource_arn(&body, "resourceArn")?;
+        }
+        "UntagResource" => {
+            check_resource_arn(&body, "resourceArn")?;
+            check_tag_keys_required(req)?;
+        }
+        "CreateFlow" => {
+            check_string_length(&body, "executionRoleArn", 1, 2048, true)?;
+            check_string_length(&body, "clientToken", 33, 256, false)?;
+            check_string_length(&body, "customerEncryptionKeyArn", 1, 2048, false)?;
+            check_string_length(&body, "description", 1, 200, false)?;
+        }
+        "CreateKnowledgeBase" => {
+            check_required_present(&body, "knowledgeBaseConfiguration")?;
+            check_string_length(&body, "roleArn", 1, 2048, true)?;
+            check_string_length(&body, "clientToken", 33, 256, false)?;
+            check_string_length(&body, "description", 1, 200, false)?;
+        }
+        "CreatePrompt" => {
+            check_string_length(&body, "clientToken", 33, 256, false)?;
+            check_string_length(&body, "customerEncryptionKeyArn", 1, 2048, false)?;
+            check_string_length(&body, "description", 1, 200, false)?;
+        }
+        _ => {}
+    }
+
+    Ok(())
 }
 
 fn not_found(msg: impl Into<String>) -> AwsServiceError {

--- a/crates/fakecloud-bedrock-agent/src/service.rs
+++ b/crates/fakecloud-bedrock-agent/src/service.rs
@@ -925,7 +925,11 @@ fn now() -> DateTime<Utc> {
 }
 
 fn short_id() -> String {
-    uuid::Uuid::new_v4().to_string()[..8].to_string()
+    // Smithy ResourceIdentifier shape is @pattern("^[0-9a-zA-Z]{10}$").
+    // Use the first 10 hex chars of a v4 UUID (alphanumeric, deterministic
+    // length, no dashes).
+    let s = uuid::Uuid::new_v4().simple().to_string();
+    s[..10].to_string()
 }
 
 fn agent_json(a: &Agent) -> Value {

--- a/crates/fakecloud-bedrock-agent/src/service.rs
+++ b/crates/fakecloud-bedrock-agent/src/service.rs
@@ -686,12 +686,9 @@ fn is_valid_version(s: &str) -> bool {
     if !s.bytes().all(|b| b.is_ascii_digit()) {
         return false;
     }
-    // Must contain at least one non-zero digit (i.e. not "0", "00", etc.) and
-    // the first digit must not be zero unless the whole value is a single zero
-    // (which is disallowed by the pattern's `[1-9]` requirement).
-    if s.starts_with('0') {
-        return false;
-    }
+    // The pattern `[0-9]{0,4}[1-9][0-9]{0,4}` requires at least one non-zero
+    // digit anywhere in the string. Leading zeros are explicitly allowed
+    // (e.g. `"00001"` parses as the same five-character form AWS accepts).
     s.bytes().any(|b| b != b'0')
 }
 

--- a/crates/fakecloud-conformance/tests/bedrock_agent.rs
+++ b/crates/fakecloud-conformance/tests/bedrock_agent.rs
@@ -111,6 +111,21 @@ async fn bedrock_agent_knowledge_base_crud() {
     let create_resp = client
         .create_knowledge_base()
         .name("test-kb")
+        .role_arn("arn:aws:iam::123456789012:role/bedrock-kb-role")
+        .knowledge_base_configuration(
+            aws_sdk_bedrockagent::types::KnowledgeBaseConfiguration::builder()
+                .r#type(aws_sdk_bedrockagent::types::KnowledgeBaseType::Vector)
+                .vector_knowledge_base_configuration(
+                    aws_sdk_bedrockagent::types::VectorKnowledgeBaseConfiguration::builder()
+                        .embedding_model_arn(
+                            "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1",
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- Adds pre-dispatch `validate_inputs` to the Bedrock Agent service that walks path/query/body and enforces Smithy `@length` / `@range` / `@pattern` / `@required` constraints the handlers were silently accepting.
- Preserves empty `@httpLabel` segments through `resolve_action` so probes that drop a required path param surface as `ValidationException` instead of a routing miss.
- Brings bedrock-agent conformance from **2444/2532 (96.5%)** to **2532/2532 (100%)**.

## Test plan
- [x] `cargo run -p fakecloud-conformance -- run --services bedrock-agent` — 72/72 ops passing, 2532/2532 variants.
- [x] `cargo run -p fakecloud-conformance -- update-baseline` — baseline ratchet committed.
- [x] `cargo clippy -p fakecloud-bedrock-agent --all-targets -- -D warnings` clean.
- [x] `cargo fmt -p fakecloud-bedrock-agent` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pre-dispatch input validation to Bedrock Agent to enforce Smithy constraints across path, query, and body. Also switches resource ID generation to 10-char alphanumeric; bedrock-agent conformance is now 100%.

- **Bug Fixes**
  - Preserve empty path segments so missing `@httpLabel` values return `ValidationException`.
  - Validate path labels: Id `^[0-9a-zA-Z]{10}$`; Version `^(DRAFT|[0-9]{0,4}[1-9][0-9]{0,4})$` (1–5 chars, leading zeros allowed).
  - Enforce pagination: `maxResults` 1–1000; `nextToken` length 1–2048 and no whitespace, from query or body.
  - Tag APIs: `resourceArn` length 20–1011; `UntagResource` requires `tagKeys` query param (repeated keys supported).
  - CreateFlow/CreateKnowledgeBase/CreatePrompt: enforce required fields and length ranges for `clientToken`, `description`, `executionRoleArn`/`roleArn`, `customerEncryptionKeyArn`, `knowledgeBaseConfiguration`.
  - Generate 10-char alphanumeric resource IDs to match the `ResourceIdentifier` pattern.

<sup>Written for commit 76d30e6e83020d374094bf22c639994b35338aa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

