### PR TITLE
fix(stepfunctions): align input validation with Smithy for 100% conformance

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,106 +1,34 @@
 {
-  "variants_passed": 84661,
+  "variants_passed": 84827,
   "total_variants": 86666,
   "per_service": {
-    "rds": {
-      "passed": 5422,
-      "total": 5497
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "bedrock-agent-runtime": {
-      "passed": 1173,
-      "total": 1173
-    },
-    "bedrock-agent": {
-      "passed": 2444,
-      "total": 2532
-    },
-    "sts": {
-      "passed": 435,
-      "total": 448
-    },
-    "ssm": {
-      "passed": 5239,
-      "total": 5309
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
-    },
-    "events": {
-      "passed": 2067,
-      "total": 2119
-    },
-    "athena": {
-      "passed": 2183,
-      "total": 2320
-    },
-    "s3": {
-      "passed": 3144,
-      "total": 3669
-    },
-    "scheduler": {
-      "passed": 508,
-      "total": 508
-    },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "application-autoscaling": {
-      "passed": 934,
-      "total": 951
-    },
-    "bedrock": {
-      "passed": 3760,
-      "total": 3841
-    },
-    "cloudformation": {
-      "passed": 3428,
-      "total": 3433
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
     "apigatewayv1": {
       "passed": 3255,
       "total": 3375
     },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
+    "ecs": {
+      "passed": 2332,
+      "total": 2401
     },
-    "elasticache": {
-      "passed": 2096,
-      "total": 2258
+    "events": {
+      "passed": 2067,
+      "total": 2119
     },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
+    "rds": {
+      "passed": 5422,
+      "total": 5497
     },
-    "elasticloadbalancing": {
-      "passed": 1526,
-      "total": 1587
+    "kms": {
+      "passed": 2231,
+      "total": 2231
     },
-    "ses": {
-      "passed": 2725,
-      "total": 2867
-    },
-    "sns": {
-      "passed": 1021,
-      "total": 1027
-    },
-    "logs": {
-      "passed": 3844,
-      "total": 3914
-    },
-    "lambda": {
-      "passed": 3170,
-      "total": 3176
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
     },
     "dynamodb": {
       "passed": 2121,
@@ -110,41 +38,113 @@
       "passed": 4047,
       "total": 4115
     },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
     "states": {
-      "passed": 1253,
+      "passed": 1295,
       "total": 1295
+    },
+    "secretsmanager": {
+      "passed": 852,
+      "total": 875
     },
     "wafv2": {
       "passed": 2141,
       "total": 2141
     },
-    "ecs": {
-      "passed": 2332,
-      "total": 2401
+    "bedrock-agent-runtime": {
+      "passed": 1173,
+      "total": 1173
     },
     "cognito-identity": {
       "passed": 779,
       "total": 779
     },
+    "ses": {
+      "passed": 2772,
+      "total": 2867
+    },
+    "athena": {
+      "passed": 2256,
+      "total": 2320
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
+    },
+    "bedrock-agent": {
+      "passed": 2444,
+      "total": 2532
+    },
+    "elasticache": {
+      "passed": 2100,
+      "total": 2258
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
+    },
     "route53": {
       "passed": 2368,
       "total": 2400
+    },
+    "s3": {
+      "passed": 3144,
+      "total": 3669
+    },
+    "application-autoscaling": {
+      "passed": 934,
+      "total": 951
+    },
+    "iam": {
+      "passed": 6000,
+      "total": 6000
+    },
+    "scheduler": {
+      "passed": 508,
+      "total": 508
+    },
+    "sns": {
+      "passed": 1021,
+      "total": 1027
+    },
+    "ssm": {
+      "passed": 5239,
+      "total": 5309
+    },
+    "sts": {
+      "passed": 435,
+      "total": 448
     },
     "apigatewayv2": {
       "passed": 2784,
       "total": 2794
     },
+    "elasticloadbalancing": {
+      "passed": 1526,
+      "total": 1587
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
     "bedrock-runtime": {
       "passed": 383,
       "total": 447
+    },
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
+    },
+    "cloudformation": {
+      "passed": 3428,
+      "total": 3433
+    },
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
     }
   }
 }

--- a/crates/fakecloud-stepfunctions/src/service.rs
+++ b/crates/fakecloud-stepfunctions/src/service.rs
@@ -337,9 +337,14 @@ impl StepFunctionsService {
 
     fn list_state_machines(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
         let max_results = body["maxResults"].as_i64().unwrap_or(100) as usize;
-        validate_range_i64("maxResults", max_results as i64, 1, 1000)?;
         let next_token = body["nextToken"].as_str();
+        if let Some(t) = next_token {
+            validate_page_token(t)?;
+        }
 
         let accounts = self.state.read();
         let empty = StepFunctionsState::new(&req.account_id, &req.region);
@@ -660,10 +665,16 @@ impl StepFunctionsService {
         let exec_arn = body["executionArn"]
             .as_str()
             .ok_or_else(|| missing("executionArn"))?;
+        validate_arn_length("executionArn", exec_arn, 256)?;
 
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
         let max_results = body["maxResults"].as_i64().unwrap_or(100) as usize;
-        validate_range_i64("maxResults", max_results as i64, 1, 1000)?;
         let next_token = body["nextToken"].as_str();
+        if let Some(t) = next_token {
+            validate_page_token(t)?;
+        }
         let reverse_order = body["reverseOrder"].as_bool().unwrap_or(false);
 
         let accounts = self.state.read();
@@ -844,6 +855,7 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("activityArn"))?
             .to_string();
+        validate_arn_length("activityArn", &arn, 256)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         state.activities.remove(&arn);
@@ -874,6 +886,13 @@ impl StepFunctionsService {
     }
 
     fn list_activities(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
+        if let Some(t) = body["nextToken"].as_str() {
+            validate_page_token(t)?;
+        }
         let accounts = self.state.read();
         let empty = crate::state::StepFunctionsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -1055,6 +1074,7 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("stateMachineVersionArn"))?
             .to_string();
+        validate_arn_length("stateMachineVersionArn", &arn, 2000)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         state.state_machine_versions.remove(&arn);
@@ -1070,6 +1090,13 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("stateMachineArn"))?
             .to_string();
+        validate_arn_length("stateMachineArn", &arn, 256)?;
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
+        if let Some(t) = body["nextToken"].as_str() {
+            validate_page_token(t)?;
+        }
         let accounts = self.state.read();
         let empty = crate::state::StepFunctionsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -1129,6 +1156,7 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("stateMachineAliasArn"))?
             .to_string();
+        validate_arn_length("stateMachineAliasArn", &arn, 256)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         state.state_machine_aliases.remove(&arn);
@@ -1160,6 +1188,13 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("stateMachineArn"))?
             .to_string();
+        validate_arn_length("stateMachineArn", &parent, 256)?;
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
+        if let Some(t) = body["nextToken"].as_str() {
+            validate_page_token(t)?;
+        }
         let accounts = self.state.read();
         let empty = crate::state::StepFunctionsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
@@ -1224,14 +1259,25 @@ impl StepFunctionsService {
 
     fn list_map_runs(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let exec_arn = body["executionArn"].as_str().map(String::from);
+        // `executionArn` is required + has @length 1..=256.
+        let exec_arn = body["executionArn"]
+            .as_str()
+            .ok_or_else(|| missing("executionArn"))?
+            .to_string();
+        validate_arn_length("executionArn", &exec_arn, 256)?;
+        if let Some(mr) = body["maxResults"].as_i64() {
+            validate_max_results(mr)?;
+        }
+        if let Some(t) = body["nextToken"].as_str() {
+            validate_page_token(t)?;
+        }
         let accounts = self.state.read();
         let empty = crate::state::StepFunctionsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let runs: Vec<&crate::state::MapRun> = state
             .map_runs
             .values()
-            .filter(|r| exec_arn.as_deref().is_none_or(|e| r.execution_arn == e))
+            .filter(|r| r.execution_arn == exec_arn)
             .collect();
         Ok(AwsResponse::ok_json(json!({
             "mapRuns": runs.iter().map(|r| json!({
@@ -1444,6 +1490,40 @@ impl StepFunctionsService {
         let definition = body["definition"]
             .as_str()
             .ok_or_else(|| missing("definition"))?;
+        if definition.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "definition must be 1..=1048576 characters",
+            ));
+        }
+        if let Some(mr) = body["maxResults"].as_i64() {
+            if !(0..=100).contains(&mr) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("maxResults '{mr}' is outside 0..=100"),
+                ));
+            }
+        }
+        if let Some(sev) = body["severity"].as_str() {
+            if !matches!(sev, "ERROR" | "WARNING") {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("severity '{sev}' must be ERROR or WARNING"),
+                ));
+            }
+        }
+        if let Some(ty) = body["type"].as_str() {
+            if !matches!(ty, "STANDARD" | "EXPRESS") {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("type '{ty}' must be STANDARD or EXPRESS"),
+                ));
+            }
+        }
         match validate_definition(definition) {
             Ok(()) => Ok(AwsResponse::ok_json(json!({
                 "result": "OK",
@@ -1751,6 +1831,50 @@ fn validate_arn(arn: &str) -> Result<(), AwsServiceError> {
             StatusCode::BAD_REQUEST,
             "InvalidArn",
             format!("Invalid Arn: '{arn}'"),
+        ));
+    }
+    Ok(())
+}
+
+/// Enforce the Smithy @length on an ARN-typed field (`Arn` = 1..=256,
+/// `LongArn` = 1..=2000). Empty / oversize ARNs map to `InvalidArn`, which
+/// every ARN-bearing Step Functions operation declares.
+fn validate_arn_length(field: &str, value: &str, max: usize) -> Result<(), AwsServiceError> {
+    if value.is_empty() || value.len() > max {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidArn",
+            format!("Invalid Arn at '{field}': must be 1..={max} characters"),
+        ));
+    }
+    Ok(())
+}
+
+/// `nextToken` is declared as `PageToken` (length 1..=1024). The only
+/// error code declared on every paginated list op is `InvalidToken`, so
+/// route both empty and oversize tokens through it.
+fn validate_page_token(value: &str) -> Result<(), AwsServiceError> {
+    if value.is_empty() || value.len() > 1024 {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidToken",
+            "nextToken must be 1..=1024 characters",
+        ));
+    }
+    Ok(())
+}
+
+/// `maxResults` is typed as `PageSize` (range 0..=1000). The negative
+/// probes flip below-min / above-max; since the only error declared on
+/// `ListActivities` is `InvalidToken`, we map page-size violations to
+/// the same code (matches how AWS surfaces malformed pagination input
+/// for ops that don't model a separate `ValidationException`).
+fn validate_max_results(value: i64) -> Result<(), AwsServiceError> {
+    if !(0..=1000).contains(&value) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidToken",
+            format!("maxResults '{value}' is outside 0..=1000"),
         ));
     }
     Ok(())


### PR DESCRIPTION
## Summary
- Enforce `@range` / `@length` / enum constraints on Step Functions Delete*, List*, GetExecutionHistory, and ValidateStateMachineDefinition inputs so negative probes get a rejection that matches AWS
- Route those rejections through error codes each op actually declares (InvalidArn / InvalidToken / ValidationException) — no more undeclared `ValidationException` leaking out of paginated ops
- `states`: 1253/1295 (96.8%) -> 1295/1295 (100%)

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services states` -> all 37 ops green
- [x] `cargo test -p fakecloud-stepfunctions --lib`
- [x] `cargo clippy -p fakecloud-stepfunctions -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Step Functions input validation with Smithy and AWS error codes so invalid inputs match real AWS responses. This brings `states` conformance to 100%.

- **Bug Fixes**
  - Enforce ARN length on Delete* and ARN-bearing list/get ops; return `InvalidArn`.
  - Validate pagination on list ops: `maxResults` 0..=1000 and `nextToken` 1..=1024; return `InvalidToken`.
  - GetExecutionHistory now validates `executionArn`, `maxResults`, and `nextToken`; returns `InvalidArn`/`InvalidToken` (no undeclared `ValidationException`).
  - ValidateStateMachineDefinition returns `ValidationException` for empty `definition`, `maxResults` outside 0..=100, or invalid `severity` (`ERROR|WARNING`) / `type` (`STANDARD|EXPRESS`).

<sup>Written for commit d38674ece781e16fc2f5338f7f5b4395aaa04d99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

