### PR TITLE
fix(secretsmanager): tighten input validation, raise conformance to 99.9%

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,146 +1,146 @@
 {
-  "variants_passed": 85006,
+  "variants_passed": 85007,
   "total_variants": 86666,
   "per_service": {
-    "s3": {
-      "passed": 3144,
-      "total": 3669
-    },
-    "logs": {
-      "passed": 3844,
-      "total": 3914
-    },
     "athena": {
       "passed": 2256,
       "total": 2320
-    },
-    "cloudformation": {
-      "passed": 3428,
-      "total": 3433
-    },
-    "scheduler": {
-      "passed": 508,
-      "total": 508
-    },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "sts": {
-      "passed": 448,
-      "total": 448
-    },
-    "sns": {
-      "passed": 1021,
-      "total": 1027
-    },
-    "states": {
-      "passed": 1295,
-      "total": 1295
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "bedrock": {
-      "passed": 3760,
-      "total": 3841
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "lambda": {
-      "passed": 3170,
-      "total": 3176
-    },
-    "rds": {
-      "passed": 5422,
-      "total": 5497
-    },
-    "apigatewayv2": {
-      "passed": 2784,
-      "total": 2794
-    },
-    "events": {
-      "passed": 2067,
-      "total": 2119
-    },
-    "elasticache": {
-      "passed": 2097,
-      "total": 2258
     },
     "kinesis": {
       "passed": 1599,
       "total": 1611
     },
-    "bedrock-agent-runtime": {
-      "passed": 1173,
-      "total": 1173
+    "kms": {
+      "passed": 2231,
+      "total": 2231
     },
-    "elasticloadbalancing": {
-      "passed": 1587,
-      "total": 1587
-    },
-    "route53": {
-      "passed": 2368,
-      "total": 2400
-    },
-    "ssm": {
-      "passed": 5239,
-      "total": 5309
+    "rds": {
+      "passed": 5422,
+      "total": 5497
     },
     "wafv2": {
       "passed": 2141,
       "total": 2141
     },
-    "cognito-identity": {
-      "passed": 779,
-      "total": 779
+    "ssm": {
+      "passed": 5239,
+      "total": 5309
     },
-    "ecr": {
-      "passed": 1764,
-      "total": 1805
+    "application-autoscaling": {
+      "passed": 934,
+      "total": 951
     },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
+    "sqs": {
+      "passed": 549,
+      "total": 549
     },
-    "bedrock-runtime": {
-      "passed": 383,
-      "total": 447
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
+    },
+    "cloudformation": {
+      "passed": 3428,
+      "total": 3433
+    },
+    "apigatewayv2": {
+      "passed": 2784,
+      "total": 2794
     },
     "apigatewayv1": {
       "passed": 3255,
       "total": 3375
     },
-    "secretsmanager": {
-      "passed": 852,
-      "total": 875
+    "sns": {
+      "passed": 1021,
+      "total": 1027
     },
-    "ecs": {
-      "passed": 2333,
-      "total": 2401
+    "bedrock-agent-runtime": {
+      "passed": 1173,
+      "total": 1173
+    },
+    "route53": {
+      "passed": 2368,
+      "total": 2400
+    },
+    "elasticloadbalancing": {
+      "passed": 1587,
+      "total": 1587
+    },
+    "elasticache": {
+      "passed": 2096,
+      "total": 2258
     },
     "cloudfront": {
       "passed": 4047,
       "total": 4115
     },
-    "bedrock-agent": {
-      "passed": 2532,
-      "total": 2532
+    "iam": {
+      "passed": 6000,
+      "total": 6000
     },
-    "ses": {
-      "passed": 2791,
-      "total": 2867
+    "sts": {
+      "passed": 448,
+      "total": 448
     },
     "cognito-idp": {
       "passed": 4483,
       "total": 4484
     },
-    "application-autoscaling": {
-      "passed": 934,
-      "total": 951
+    "bedrock-runtime": {
+      "passed": 383,
+      "total": 447
+    },
+    "cognito-identity": {
+      "passed": 779,
+      "total": 779
+    },
+    "events": {
+      "passed": 2067,
+      "total": 2119
+    },
+    "scheduler": {
+      "passed": 508,
+      "total": 508
+    },
+    "secretsmanager": {
+      "passed": 874,
+      "total": 875
+    },
+    "ecr": {
+      "passed": 1764,
+      "total": 1805
+    },
+    "ses": {
+      "passed": 2772,
+      "total": 2867
+    },
+    "s3": {
+      "passed": 3144,
+      "total": 3669
+    },
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "states": {
+      "passed": 1295,
+      "total": 1295
+    },
+    "ecs": {
+      "passed": 2332,
+      "total": 2401
+    },
+    "bedrock-agent": {
+      "passed": 2532,
+      "total": 2532
+    },
+    "logs": {
+      "passed": 3844,
+      "total": 3914
     },
     "dynamodb": {
       "passed": 2121,

--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,26 +1,18 @@
 {
-  "variants_passed": 85007,
+  "variants_passed": 85033,
   "total_variants": 86666,
   "per_service": {
-    "athena": {
-      "passed": 2256,
-      "total": 2320
+    "cloudfront": {
+      "passed": 4047,
+      "total": 4115
     },
-    "kinesis": {
-      "passed": 1599,
-      "total": 1611
-    },
-    "kms": {
-      "passed": 2231,
-      "total": 2231
+    "states": {
+      "passed": 1295,
+      "total": 1295
     },
     "rds": {
       "passed": 5422,
       "total": 5497
-    },
-    "wafv2": {
-      "passed": 2141,
-      "total": 2141
     },
     "ssm": {
       "passed": 5239,
@@ -30,65 +22,25 @@
       "passed": 934,
       "total": 951
     },
-    "sqs": {
-      "passed": 549,
-      "total": 549
-    },
-    "bedrock": {
-      "passed": 3760,
-      "total": 3841
-    },
-    "cloudformation": {
-      "passed": 3428,
-      "total": 3433
-    },
-    "apigatewayv2": {
-      "passed": 2784,
-      "total": 2794
-    },
-    "apigatewayv1": {
-      "passed": 3255,
-      "total": 3375
-    },
-    "sns": {
-      "passed": 1021,
-      "total": 1027
-    },
     "bedrock-agent-runtime": {
       "passed": 1173,
       "total": 1173
     },
-    "route53": {
-      "passed": 2368,
-      "total": 2400
+    "kinesis": {
+      "passed": 1599,
+      "total": 1611
     },
-    "elasticloadbalancing": {
-      "passed": 1587,
-      "total": 1587
-    },
-    "elasticache": {
-      "passed": 2096,
-      "total": 2258
-    },
-    "cloudfront": {
-      "passed": 4047,
-      "total": 4115
-    },
-    "iam": {
-      "passed": 6000,
-      "total": 6000
-    },
-    "sts": {
-      "passed": 448,
-      "total": 448
-    },
-    "cognito-idp": {
-      "passed": 4483,
-      "total": 4484
+    "wafv2": {
+      "passed": 2141,
+      "total": 2141
     },
     "bedrock-runtime": {
       "passed": 383,
       "total": 447
+    },
+    "ses": {
+      "passed": 2791,
+      "total": 2867
     },
     "cognito-identity": {
       "passed": 779,
@@ -98,53 +50,101 @@
       "passed": 2067,
       "total": 2119
     },
-    "scheduler": {
-      "passed": 508,
-      "total": 508
-    },
-    "secretsmanager": {
-      "passed": 874,
-      "total": 875
+    "iam": {
+      "passed": 6000,
+      "total": 6000
     },
     "ecr": {
       "passed": 1764,
       "total": 1805
     },
-    "ses": {
-      "passed": 2772,
-      "total": 2867
-    },
     "s3": {
       "passed": 3144,
       "total": 3669
     },
-    "lambda": {
-      "passed": 3170,
-      "total": 3176
-    },
-    "acm": {
-      "passed": 601,
-      "total": 601
-    },
-    "states": {
-      "passed": 1295,
-      "total": 1295
+    "bedrock": {
+      "passed": 3760,
+      "total": 3841
     },
     "ecs": {
-      "passed": 2332,
+      "passed": 2333,
       "total": 2401
     },
-    "bedrock-agent": {
-      "passed": 2532,
-      "total": 2532
+    "apigatewayv2": {
+      "passed": 2784,
+      "total": 2794
+    },
+    "secretsmanager": {
+      "passed": 874,
+      "total": 875
+    },
+    "kms": {
+      "passed": 2231,
+      "total": 2231
     },
     "logs": {
       "passed": 3844,
       "total": 3914
     },
+    "sts": {
+      "passed": 448,
+      "total": 448
+    },
+    "cloudformation": {
+      "passed": 3428,
+      "total": 3433
+    },
+    "elasticache": {
+      "passed": 2102,
+      "total": 2258
+    },
+    "sns": {
+      "passed": 1021,
+      "total": 1027
+    },
+    "athena": {
+      "passed": 2256,
+      "total": 2320
+    },
+    "acm": {
+      "passed": 601,
+      "total": 601
+    },
+    "route53": {
+      "passed": 2368,
+      "total": 2400
+    },
+    "scheduler": {
+      "passed": 508,
+      "total": 508
+    },
+    "elasticloadbalancing": {
+      "passed": 1587,
+      "total": 1587
+    },
+    "cognito-idp": {
+      "passed": 4483,
+      "total": 4484
+    },
     "dynamodb": {
       "passed": 2121,
       "total": 2134
+    },
+    "apigatewayv1": {
+      "passed": 3255,
+      "total": 3375
+    },
+    "sqs": {
+      "passed": 549,
+      "total": 549
+    },
+    "lambda": {
+      "passed": 3170,
+      "total": 3176
+    },
+    "bedrock-agent": {
+      "passed": 2532,
+      "total": 2532
     }
   }
 }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -992,27 +992,23 @@ impl SecretsManagerService {
             .skip(start_idx)
             .take(max_results)
             .map(|s| {
+                // AWS always echoes `Description` and `SecretVersionsToStages`
+                // on every SecretListEntry. The documented `@examples` for
+                // ListSecrets relies on the fields being present even when
+                // empty, and SDK consumers index into them unconditionally.
+                let mut version_ids_to_stages: serde_json::Map<String, Value> =
+                    serde_json::Map::new();
+                for (vid, version) in &s.versions {
+                    version_ids_to_stages.insert(vid.clone(), json!(version.stages));
+                }
                 let mut entry = json!({
                     "ARN": s.arn,
                     "Name": s.name,
                     "CreatedDate": s.created_at.timestamp_millis() as f64 / 1000.0,
                     "LastChangedDate": s.last_changed_at.timestamp_millis() as f64 / 1000.0,
+                    "Description": s.description.clone().unwrap_or_default(),
+                    "SecretVersionsToStages": Value::Object(version_ids_to_stages),
                 });
-
-                if !s.versions.is_empty() {
-                    let mut version_ids_to_stages: serde_json::Map<String, Value> =
-                        serde_json::Map::new();
-                    for (vid, version) in &s.versions {
-                        version_ids_to_stages.insert(vid.clone(), json!(version.stages));
-                    }
-                    entry["SecretVersionsToStages"] = Value::Object(version_ids_to_stages);
-                }
-
-                if let Some(ref desc) = s.description {
-                    if !desc.is_empty() {
-                        entry["Description"] = json!(desc);
-                    }
-                }
 
                 if s.tags_ever_set || !s.tags.is_empty() {
                     entry["Tags"] = json!(tags_to_json(&s.tags));
@@ -1690,14 +1686,15 @@ impl SecretsManagerService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let secret = self.find_secret_ref(state, &secret_id)?;
 
-        let mut response = json!({
+        // `ResourcePolicy` is documented to be present on every
+        // GetResourcePolicyResponse — real AWS returns an empty string
+        // when no policy has been attached. The documented `@examples`
+        // also expects the key, so we always emit it.
+        let response = json!({
             "ARN": secret.arn,
             "Name": secret.name,
+            "ResourcePolicy": secret.resource_policy.clone().unwrap_or_default(),
         });
-
-        if let Some(ref policy) = secret.resource_policy {
-            response["ResourcePolicy"] = json!(policy);
-        }
 
         Ok(AwsResponse::ok_json(response))
     }
@@ -2028,7 +2025,7 @@ impl AwsService for SecretsManagerService {
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
             self.save_snapshot().await;
         }
-        result
+        result.map_err(remap_validation_error)
     }
 
     fn supported_actions(&self) -> &[&str] {
@@ -2063,6 +2060,31 @@ impl AwsService for SecretsManagerService {
 #[path = "service_helpers.rs"]
 mod service_helpers;
 pub(crate) use service_helpers::*;
+
+/// The shared `fakecloud_core::validation` helpers raise
+/// `ValidationException`, but the Secrets Manager Smithy model does not
+/// declare `ValidationException` on any operation — its declared input
+/// error is `InvalidParameterException`. Translate at the dispatcher
+/// boundary so the wire-level error code matches real AWS without
+/// duplicating every validator.
+fn remap_validation_error(err: AwsServiceError) -> AwsServiceError {
+    match err {
+        AwsServiceError::AwsError {
+            status,
+            code,
+            message,
+            extra_fields,
+            headers,
+        } if code == "ValidationException" => AwsServiceError::AwsError {
+            status,
+            code: "InvalidParameterException".to_string(),
+            message,
+            extra_fields,
+            headers,
+        },
+        other => other,
+    }
+}
 
 /// Extract the owning account-id from an `arn:aws:secretsmanager:...:ACCOUNT:secret:...`
 /// secret id. Returns `caller_account` when the input is a bare name

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -1686,15 +1686,15 @@ impl SecretsManagerService {
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         let secret = self.find_secret_ref(state, &secret_id)?;
 
-        // `ResourcePolicy` is documented to be present on every
-        // GetResourcePolicyResponse — real AWS returns an empty string
-        // when no policy has been attached. The documented `@examples`
-        // also expects the key, so we always emit it.
-        let response = json!({
+        // Real AWS omits ResourcePolicy when none is attached; terraform
+        // provider and the SDK choke on an empty-string policy.
+        let mut response = json!({
             "ARN": secret.arn,
             "Name": secret.name,
-            "ResourcePolicy": secret.resource_policy.clone().unwrap_or_default(),
         });
+        if let Some(ref policy) = secret.resource_policy {
+            response["ResourcePolicy"] = json!(policy);
+        }
 
         Ok(AwsResponse::ok_json(response))
     }

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -854,9 +854,7 @@ async fn test_put_get_delete_resource_policy() {
     let resp = svc.handle(req).await.unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["Name"], "policy-secret");
-    // Real AWS always emits ResourcePolicy on the response; empty string
-    // when no policy is attached.
-    assert_eq!(body["ResourcePolicy"], "");
+    assert!(body.get("ResourcePolicy").is_none());
 
     // Put policy
     let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
@@ -883,7 +881,7 @@ async fn test_put_get_delete_resource_policy() {
     let req = make_request("GetResourcePolicy", r#"{"SecretId": "policy-secret"}"#);
     let resp = svc.handle(req).await.unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert_eq!(body["ResourcePolicy"], "");
+    assert!(body.get("ResourcePolicy").is_none());
 }
 
 #[tokio::test]

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -241,8 +241,8 @@ async fn test_secret_id_length_validation() {
     let long_id = "x".repeat(2049);
     let req = make_request("GetSecretValue", &format!(r#"{{"SecretId": "{long_id}"}}"#));
     match svc.handle(req).await {
-        Err(e) => assert!(e.to_string().contains("ValidationException")),
-        Ok(_) => panic!("expected ValidationException"),
+        Err(e) => assert!(e.to_string().contains("InvalidParameterException")),
+        Ok(_) => panic!("expected InvalidParameterException"),
     }
 }
 
@@ -258,8 +258,8 @@ async fn test_name_length_validation() {
         &format!(r#"{{"Name": "{long_name}", "SecretString": "val"}}"#),
     );
     match svc.handle(req).await {
-        Err(e) => assert!(e.to_string().contains("ValidationException")),
-        Ok(_) => panic!("expected ValidationException"),
+        Err(e) => assert!(e.to_string().contains("InvalidParameterException")),
+        Ok(_) => panic!("expected InvalidParameterException"),
     }
 }
 
@@ -275,8 +275,8 @@ async fn test_next_token_length_validation() {
         &format!(r#"{{"NextToken": "{long_token}"}}"#),
     );
     match svc.handle(req).await {
-        Err(e) => assert!(e.to_string().contains("ValidationException")),
-        Ok(_) => panic!("expected ValidationException"),
+        Err(e) => assert!(e.to_string().contains("InvalidParameterException")),
+        Ok(_) => panic!("expected InvalidParameterException"),
     }
 }
 
@@ -291,8 +291,8 @@ async fn test_client_request_token_length_validation() {
         r#"{"Name": "test", "SecretString": "val", "ClientRequestToken": "short"}"#,
     );
     match svc.handle(req).await {
-        Err(e) => assert!(e.to_string().contains("ValidationException")),
-        Ok(_) => panic!("expected ValidationException"),
+        Err(e) => assert!(e.to_string().contains("InvalidParameterException")),
+        Ok(_) => panic!("expected InvalidParameterException"),
     }
 }
 
@@ -854,7 +854,9 @@ async fn test_put_get_delete_resource_policy() {
     let resp = svc.handle(req).await.unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["Name"], "policy-secret");
-    assert!(body.get("ResourcePolicy").is_none());
+    // Real AWS always emits ResourcePolicy on the response; empty string
+    // when no policy is attached.
+    assert_eq!(body["ResourcePolicy"], "");
 
     // Put policy
     let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
@@ -881,7 +883,7 @@ async fn test_put_get_delete_resource_policy() {
     let req = make_request("GetResourcePolicy", r#"{"SecretId": "policy-secret"}"#);
     let resp = svc.handle(req).await.unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert!(body.get("ResourcePolicy").is_none());
+    assert_eq!(body["ResourcePolicy"], "");
 }
 
 #[tokio::test]
@@ -1579,7 +1581,7 @@ async fn list_secrets_invalid_filter_key() {
     });
     let req = make_request("ListSecrets", &body.to_string());
     let err = expect_err(svc.handle(req).await);
-    assert!(err.to_string().contains("ValidationException"));
+    assert!(err.to_string().contains("InvalidParameterException"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

secretsmanager variants 852/875 (97.4%) -> 874/875 (99.9%).

Input validation aligned with Smithy constraints across handlers.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services secretsmanager`
- [x] `cargo clippy -p fakecloud-secretsmanager -- -D warnings`
- [x] `cargo fmt`
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises Secrets Manager conformance to 99.9% by aligning input validation with the Smithy model and matching AWS response shapes in `fakecloud-secretsmanager`.

- **Bug Fixes**
  - ListSecrets: always include `Description` (empty string when none) and `SecretVersionsToStages` (object, may be empty).
  - GetResourcePolicy: omit `ResourcePolicy` when no policy is attached.
  - Remap `ValidationException` to `InvalidParameterException` to match AWS.

<sup>Written for commit 09f31c0907a704791981079acc5f8e1b10b37a0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

