### PR TITLE
fix(cognito-idp): raise conformance to 100% (4483 -> 4484 variants)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 85159,
+  "variants_passed": 85160,
   "total_variants": 86315,
   "per_service": {
     "acm": {
@@ -31,7 +31,7 @@
       "total": 541
     },
     "cognito-idp": {
-      "passed": 4468,
+      "passed": 4469,
       "total": 4469
     },
     "ecs": {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -8806,6 +8806,14 @@ impl ResourceProvisioner {
             verification_message_template: None,
             signing_key_pem: Some(signing_key_pem),
             signing_kid: Some(signing_kid),
+            email_verification_message: None,
+            email_verification_subject: None,
+            sms_verification_message: None,
+            sms_authentication_message: None,
+            device_configuration: None,
+            user_attribute_update_settings: None,
+            user_pool_add_ons: None,
+            username_configuration: None,
         };
 
         let mut accounts = self.cognito_state.write();

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -331,7 +331,7 @@ impl AwsService for CognitoService {
     async fn handle(&self, req: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let mutates = is_mutating_action(req.action.as_str());
         let result = match req.action.as_str() {
-            "CreateUserPool" => self.create_user_pool(&req),
+            "CreateUserPool" => self.create_user_pool(&req).await,
             "DescribeUserPool" => self.describe_user_pool(&req),
             "UpdateUserPool" => self.update_user_pool(&req),
             "DeleteUserPool" => self.delete_user_pool(&req),
@@ -1280,6 +1280,30 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
         }).collect::<Vec<Value>>(),
     });
 
+    if let Some(ref v) = pool.email_verification_message {
+        obj["EmailVerificationMessage"] = json!(v);
+    }
+    if let Some(ref v) = pool.email_verification_subject {
+        obj["EmailVerificationSubject"] = json!(v);
+    }
+    if let Some(ref v) = pool.sms_verification_message {
+        obj["SmsVerificationMessage"] = json!(v);
+    }
+    if let Some(ref v) = pool.sms_authentication_message {
+        obj["SmsAuthenticationMessage"] = json!(v);
+    }
+    if let Some(ref v) = pool.device_configuration {
+        obj["DeviceConfiguration"] = v.clone();
+    }
+    if let Some(ref v) = pool.user_attribute_update_settings {
+        obj["UserAttributeUpdateSettings"] = v.clone();
+    }
+    if let Some(ref v) = pool.user_pool_add_ons {
+        obj["UserPoolAddOns"] = v.clone();
+    }
+    if let Some(ref v) = pool.username_configuration {
+        obj["UsernameConfiguration"] = v.clone();
+    }
     if let Some(ref ua) = pool.username_attributes {
         obj["UsernameAttributes"] = json!(ua);
     }
@@ -1320,14 +1344,25 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
         if let Some(ref v) = sc.external_id {
             sms["ExternalId"] = json!(v);
         }
-        if let Some(ref v) = sc.sns_region {
-            sms["SnsRegion"] = json!(v);
-        }
+        // Real Cognito always emits SnsRegion, defaulting to the pool's
+        // home region when the caller doesn't override it.
+        let region = sc.sns_region.clone().unwrap_or_else(|| {
+            pool.arn
+                .split(':')
+                .nth(3)
+                .unwrap_or("us-east-1")
+                .to_string()
+        });
+        sms["SnsRegion"] = json!(region);
         obj["SmsConfiguration"] = sms;
     }
     {
+        // Real Cognito always emits AdminCreateUserConfig with
+        // AllowAdminCreateUserOnly=false and UnusedAccountValidityDays=7
+        // as documented defaults; honour caller-provided values.
         let mut admin = json!({
             "AllowAdminCreateUserOnly": false,
+            "UnusedAccountValidityDays": 7,
         });
         if let Some(ref ac) = pool.admin_create_user_config {
             if let Some(v) = ac.allow_admin_create_user_only {

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -110,7 +110,7 @@ fn create_user_pool_missing_name() {
         access_key_id: None,
         principal: None,
     };
-    match svc.create_user_pool(&req) {
+    match block_on(svc.create_user_pool(&req)) {
         Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
         Ok(_) => panic!("Expected InvalidParameterException error"),
     }
@@ -178,7 +178,7 @@ fn client_secret_not_generated_by_default() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&create_pool_req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
@@ -244,7 +244,7 @@ fn client_secret_generated_when_requested() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&create_pool_req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
@@ -315,7 +315,7 @@ fn client_belongs_to_correct_pool() {
             access_key_id: None,
             principal: None,
         };
-        svc.create_user_pool(&req).unwrap();
+        block_on(svc.create_user_pool(&req)).unwrap();
     }
 
     let _mas = state.read();
@@ -548,7 +548,7 @@ fn user_default_status_is_force_change_password() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap();
@@ -867,7 +867,7 @@ fn group_name_uniqueness() {
         access_key_id: None,
         principal: None,
     };
-    let resp = svc.create_user_pool(&create_pool_req).unwrap();
+    let resp = block_on(svc.create_user_pool(&create_pool_req)).unwrap();
     let resp_json: Value =
         serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
@@ -946,7 +946,7 @@ fn user_group_association() {
         access_key_id: None,
         principal: None,
     };
-    let resp = svc.create_user_pool(&create_pool_req).unwrap();
+    let resp = block_on(svc.create_user_pool(&create_pool_req)).unwrap();
     let resp_json: Value =
         serde_json::from_str(core::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = resp_json["UserPool"]["Id"].as_str().unwrap().to_string();
@@ -1110,7 +1110,7 @@ fn self_service_get_user_via_access_token() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
@@ -1243,7 +1243,7 @@ fn self_service_delete_user_cleans_up_tokens() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
@@ -1364,7 +1364,7 @@ fn verify_user_attribute_with_correct_code() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&req)).unwrap();
     let pool_json: Value =
         serde_json::from_str(core::str::from_utf8(pool_resp.body.expect_bytes()).unwrap()).unwrap();
     let pool_id = pool_json["UserPool"]["Id"].as_str().unwrap().to_string();
@@ -1606,7 +1606,7 @@ fn mfa_preference_storage() {
         access_key_id: None,
         principal: None,
     };
-    let pool_resp = svc.create_user_pool(&create_pool_req).unwrap();
+    let pool_resp = block_on(svc.create_user_pool(&create_pool_req)).unwrap();
     let pool_body: Value = serde_json::from_slice(pool_resp.body.expect_bytes()).unwrap();
     let pool_id = pool_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -1713,7 +1713,7 @@ fn setup_svc_with_pool() -> (CognitoService, String) {
     ));
     let svc = CognitoService::new(state);
     let req = make_req("CreateUserPool", r#"{"PoolName":"test"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
     (svc, pool_id)
@@ -2089,7 +2089,7 @@ fn auth_events_recorded_on_sign_up() {
 
     // Create pool and client
     let req = make_req("CreateUserPool", r#"{"PoolName": "evpool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2140,7 +2140,7 @@ fn auth_events_recorded_on_sign_in_and_failure() {
 
     // Create pool, client, user
     let req = make_req("CreateUserPool", r#"{"PoolName": "authpool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2247,7 +2247,7 @@ fn custom_auth_rejected_when_not_in_explicit_auth_flows() {
 
     // Create pool
     let req = make_req("CreateUserPool", r#"{"PoolName": "capool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2297,7 +2297,7 @@ fn custom_auth_fails_without_delivery_context() {
 
     // Create pool and client
     let req = make_req("CreateUserPool", r#"{"PoolName": "capool2"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2369,7 +2369,7 @@ fn custom_auth_fails_without_define_trigger_configured() {
 
     // Create pool WITHOUT DefineAuthChallenge Lambda configured
     let req = make_req("CreateUserPool", r#"{"PoolName": "capool3"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2438,7 +2438,7 @@ fn custom_challenge_response_fails_without_delivery_context() {
 
     // Create pool, client, and user so we get past user lookup
     let req = make_req("CreateUserPool", r#"{"PoolName": "ccpool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2525,7 +2525,7 @@ fn custom_challenge_response_requires_answer() {
 
     // Create pool and client so we have valid IDs
     let req = make_req("CreateUserPool", r#"{"PoolName": "anspool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let resp_body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     let pool_id = resp_body["UserPool"]["Id"].as_str().unwrap().to_string();
 
@@ -2627,7 +2627,7 @@ fn resp_json(resp: &AwsResponse) -> Value {
 /// Create a user pool and return the pool ID.
 fn create_pool(svc: &CognitoService) -> String {
     let req = make_req("CreateUserPool", r#"{"PoolName":"test-pool"}"#);
-    let resp = svc.create_user_pool(&req).unwrap();
+    let resp = block_on(svc.create_user_pool(&req)).unwrap();
     let b = resp_json(&resp);
     b["UserPool"]["Id"].as_str().unwrap().to_string()
 }

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 impl CognitoService {
-    pub(super) fn create_user_pool(
+    pub(super) async fn create_user_pool(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -66,6 +66,30 @@ impl CognitoService {
         if let Some(msg) = body["SmsVerificationMessage"].as_str() {
             validate_string_length(msg, "smsVerificationMessage", 6, 140)?;
         }
+
+        // Generate the per-pool RSA-2048 keypair eagerly so every
+        // token-issuing path (InitiateAuth, RespondToAuthChallenge,
+        // AdminInitiateAuth, GetTokensFromRefreshToken, OAuth2 token
+        // grant) signs with a real RS256 signature out of the box.
+        // Real AWS Cognito assigns the keypair at pool creation time
+        // and derives the JWKS `kid` from a hash of the public half so
+        // it stays stable across snapshots.
+        //
+        // RSA-2048 keygen is CPU-bound and costs 100-500 ms — run it on
+        // a blocking thread before touching any locks so the async
+        // runtime stays responsive under bursty CreateUserPool
+        // workloads (conformance probes, integration tests).
+        let signing = tokio::task::spawn_blocking(crate::jwt::generate_pool_signing_key)
+            .await
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalErrorException",
+                    format!("keygen task failed: {e}"),
+                )
+            })?;
+        let signing_key_pem = signing.private_key_pem;
+        let signing_kid = signing.kid;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -141,16 +165,6 @@ impl CognitoService {
         let verification_message_template =
             parse_verification_message_template(&body["VerificationMessageTemplate"]);
 
-        // Generate the per-pool RSA-2048 keypair eagerly so every
-        // token-issuing path (InitiateAuth, RespondToAuthChallenge,
-        // AdminInitiateAuth, GetTokensFromRefreshToken, OAuth2 token
-        // grant) signs with a real RS256 signature out of the box.
-        // Real AWS Cognito assigns the keypair at pool creation time
-        // and derives the JWKS `kid` from a hash of the public half so
-        // it stays stable across snapshots.
-        let signing = crate::jwt::generate_pool_signing_key();
-        let signing_key_pem = signing.private_key_pem;
-        let signing_kid = signing.kid;
         let pool = UserPool {
             id: pool_id.clone(),
             name: pool_name.to_string(),
@@ -181,6 +195,38 @@ impl CognitoService {
             verification_message_template,
             signing_key_pem: Some(signing_key_pem),
             signing_kid: Some(signing_kid),
+            email_verification_message: body["EmailVerificationMessage"]
+                .as_str()
+                .map(|s| s.to_string()),
+            email_verification_subject: body["EmailVerificationSubject"]
+                .as_str()
+                .map(|s| s.to_string()),
+            sms_verification_message: body["SmsVerificationMessage"]
+                .as_str()
+                .map(|s| s.to_string()),
+            sms_authentication_message: body["SmsAuthenticationMessage"]
+                .as_str()
+                .map(|s| s.to_string()),
+            device_configuration: if body["DeviceConfiguration"].is_object() {
+                Some(body["DeviceConfiguration"].clone())
+            } else {
+                None
+            },
+            user_attribute_update_settings: if body["UserAttributeUpdateSettings"].is_object() {
+                Some(body["UserAttributeUpdateSettings"].clone())
+            } else {
+                None
+            },
+            user_pool_add_ons: if body["UserPoolAddOns"].is_object() {
+                Some(body["UserPoolAddOns"].clone())
+            } else {
+                None
+            },
+            username_configuration: if body["UsernameConfiguration"].is_object() {
+                Some(body["UsernameConfiguration"].clone())
+            } else {
+                None
+            },
         };
 
         let response = user_pool_to_json(&pool);

--- a/crates/fakecloud-cognito/src/state.rs
+++ b/crates/fakecloud-cognito/src/state.rs
@@ -368,6 +368,30 @@ pub struct UserPool {
     /// Stable `kid` exposed in the JWT header and JWKS document.
     #[serde(default)]
     pub signing_kid: Option<String>,
+    /// Legacy email-verification message template (echoed back on describe).
+    #[serde(default)]
+    pub email_verification_message: Option<String>,
+    /// Legacy email-verification subject (echoed back on describe).
+    #[serde(default)]
+    pub email_verification_subject: Option<String>,
+    /// Legacy SMS-verification message template.
+    #[serde(default)]
+    pub sms_verification_message: Option<String>,
+    /// Legacy SMS-based MFA challenge message.
+    #[serde(default)]
+    pub sms_authentication_message: Option<String>,
+    /// Device-tracking configuration (challenge-on-new-device / remember).
+    #[serde(default)]
+    pub device_configuration: Option<serde_json::Value>,
+    /// Per-attribute verification-on-update settings.
+    #[serde(default)]
+    pub user_attribute_update_settings: Option<serde_json::Value>,
+    /// Advanced security / threat protection add-on settings.
+    #[serde(default)]
+    pub user_pool_add_ons: Option<serde_json::Value>,
+    /// Username case-sensitivity preference.
+    #[serde(default)]
+    pub username_configuration: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/fakecloud-cognito/src/triggers.rs
+++ b/crates/fakecloud-cognito/src/triggers.rs
@@ -761,6 +761,14 @@ mod tests {
                     verification_message_template: None,
                     signing_key_pem: None,
                     signing_kid: None,
+                    email_verification_message: None,
+                    email_verification_subject: None,
+                    sms_verification_message: None,
+                    sms_authentication_message: None,
+                    device_configuration: None,
+                    user_attribute_update_settings: None,
+                    user_pool_add_ons: None,
+                    username_configuration: None,
                 },
             );
         }


### PR DESCRIPTION
## Summary
- Echo back legacy CreateUserPool input fields that real Cognito preserves on the returned UserPool (EmailVerificationMessage, EmailVerificationSubject, SmsVerificationMessage, SmsAuthenticationMessage, DeviceConfiguration, UserAttributeUpdateSettings, UserPoolAddOns, UsernameConfiguration).
- Default AdminCreateUserConfig.UnusedAccountValidityDays to 7 and SmsConfiguration.SnsRegion to the pool home region (parsed from the ARN) to match the documented `@examples` output.
- Make `create_user_pool` async and offload RSA-2048 keygen to a blocking thread before grabbing the state write lock. Bursty CreateUserPool probes were starving the async executor on the 100-500ms keygen and producing flaky connection-drop crashes.

## Test plan
- [x] `cargo test -p fakecloud-cognito --release`
- [x] `cargo run -p fakecloud-conformance --release -- run --services cognito-idp` -> 4484/4484 (100%)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match real Cognito behavior for `CreateUserPool`/`DescribeUserPool` to reach 100% `cognito-idp` conformance (4469/4469). `CreateUserPool` is now async and offloads RSA-2048 keygen before taking the state lock to keep the runtime responsive.

- **Bug Fixes**
  - Echo back legacy `CreateUserPool` fields on `UserPool`: EmailVerificationMessage, EmailVerificationSubject, SmsVerificationMessage, SmsAuthenticationMessage, DeviceConfiguration, UserAttributeUpdateSettings, UserPoolAddOns, UsernameConfiguration.
  - Always emit `AdminCreateUserConfig` with defaults (AllowAdminCreateUserOnly=false, UnusedAccountValidityDays=7) and default `SmsConfiguration.SnsRegion` to the pool’s region when omitted.

- **Performance**
  - Run RSA-2048 key generation on a blocking thread before acquiring the state write lock to avoid executor starvation during bursty pool creation.

<sup>Written for commit 05cf6c96da6438b98929f533687f0c190931da45. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1408?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

