### PR TITLE
fix(conformance): bump IAM baseline to 5970/5970 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 82123,
+  "variants_passed": 82655,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -47,7 +47,7 @@
       "total": 446
     },
     "iam": {
-      "passed": 5438,
+      "passed": 5970,
       "total": 5970
     },
     "apigatewayv1": {


### PR DESCRIPTION
## Summary

IAM is honestly at 100% probe pass-rate on main HEAD: a fresh `cargo run -p fakecloud-conformance --release -- run --services iam` returns `5970/5970 (100.0%)`, including every `negative_too_long_*`, `negative_below_min_*`, and `negative_above_max_*` variant. Smithy length/range constraints are enforced by the existing IAM validation paths (recent merges: `f245c9d7 fix(iam): improve conformance pass rate to 100%`, `7451bb6c fix(sts): enforce Smithy input constraints on AssumeRoot / GetWebIdentityToken / GetDelegatedAccessToken`, `e5f8ba6a fix(iam): emit Smithy-declared error codes`).

The baseline still tracked the pre-fix figure (`5438/5970`) from `6bf4ecfa`'s honest-numbers refresh, leaving 532 already-passing variants uncredited. This PR aligns the gate with reality so future regressions surface honestly.

- `per_service.iam.passed`: `5438 -> 5970`
- `variants_passed`: `82123 -> 82655`

No code changes -- validation is already real. Other services that have also climbed since the last baseline refresh stay at their previous numbers; each gets its own dedicated bump PR.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services iam` reports `5970/5970 (100.0%)`
- [x] `cargo run -p fakecloud-conformance --release -- check --baseline conformance-baseline.json` passes (`82655/86327` baseline vs `85163/86327` current)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update IAM conformance baseline to 5970/5970 (100%) to match current probe results and catch future regressions. Also bump `variants_passed` to 82655 (from 82123); no code changes.

<sup>Written for commit b58f6d29addc4d7caed2000c74cdddf97d1cc9fe. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1412?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

