### PR TITLE
fix(bedrock-runtime): raise conformance to 100% (313 -> 446 variants)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 82884,
+  "variants_passed": 83017,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -43,7 +43,7 @@
       "total": 1018
     },
     "bedrock-runtime": {
-      "passed": 313,
+      "passed": 446,
       "total": 446
     },
     "iam": {

--- a/crates/fakecloud-conformance/src/checksum.rs
+++ b/crates/fakecloud-conformance/src/checksum.rs
@@ -203,6 +203,7 @@ fn shape_type_name(st: &ShapeType) -> String {
         ShapeType::Boolean => "boolean".to_string(),
         ShapeType::Blob => "blob".to_string(),
         ShapeType::Timestamp => "timestamp".to_string(),
+        ShapeType::Document => "document".to_string(),
         ShapeType::Service => "service".to_string(),
         ShapeType::Operation => "operation".to_string(),
         ShapeType::Resource => "resource".to_string(),

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -188,6 +188,7 @@ fn default_value_for_shape_def(model: &ServiceModel, shape: &Shape, depth: usize
         ShapeType::Boolean => Value::Bool(true),
         ShapeType::Blob => Value::String("dGVzdA==".to_string()), // base64("test")
         ShapeType::Timestamp => Value::String("2024-01-01T00:00:00Z".to_string()),
+        ShapeType::Document => Value::Object(serde_json::Map::new()),
         _ => Value::Null,
     }
 }

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -272,6 +272,10 @@ fn random_value_for_shape_def(
                 year, month, day, hour, minute, second
             ))
         }
+        // `smithy.api#Document` accepts any JSON; emit a small object so
+        // downstream validation sees a non-null value but doesn't impose
+        // any structural expectation.
+        ShapeType::Document => Value::Object(serde_json::Map::new()),
         _ => Value::Null,
     }
 }

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -297,18 +297,31 @@ pub fn validate_response(
     protocol: Protocol,
 ) -> Vec<ShapeViolation> {
     if response_body.is_empty() {
-        // An empty body is valid if the output shape is Unit or has no required members.
-        // Members bound to HTTP headers / query / labels / response code are not
-        // expected to appear in the JSON body, so they don't count as "missing".
-        // A required `@httpPayload` member with an empty wire body is also OK
-        // when the payload's own target shape is structurally empty — but we
-        // don't try to be that clever here; an empty body with a required
-        // payload member is reported as MissingField like before.
+        // An empty body is valid if the output shape is Unit or has no
+        // required members. Members bound to HTTP headers / query / labels
+        // are not expected to appear in the JSON body, so they don't count
+        // as "missing" here. A required `@httpPayload` member is a special
+        // case: when its target is Blob or String the wire body can
+        // legitimately be empty (an empty blob, an empty string), so it's
+        // not a violation; but when the target is a structure / list /
+        // map, an empty body means the required payload is genuinely
+        // absent and must be reported.
         if let Some(ShapeType::Structure { members }) = effective_shape_type(model, output_shape_id)
         {
             let required: Vec<_> = members
                 .iter()
-                .filter(|m| m.required && is_json_body_member(m))
+                .filter(|m| {
+                    if !m.required {
+                        return false;
+                    }
+                    if m.traits.http_payload {
+                        return !matches!(
+                            effective_shape_type(model, &m.target),
+                            Some(ShapeType::Blob) | Some(ShapeType::String { .. })
+                        );
+                    }
+                    is_json_body_member(m)
+                })
                 .collect();
             if !required.is_empty() {
                 return required
@@ -1271,6 +1284,68 @@ mod tests {
             violations.is_empty(),
             "expected no violations (httpPayload Blob is opaque), got {:?}",
             violations
+        );
+    }
+
+    /// Model where the output has a `@httpPayload` member targeting a
+    /// structure (not Blob/String). Empty wire body must still report
+    /// the payload as missing.
+    fn http_payload_struct_model() -> ServiceModel {
+        let mut shapes = HashMap::new();
+
+        shapes.insert(
+            "test#GetThingOutput".to_string(),
+            Shape {
+                shape_id: "test#GetThingOutput".to_string(),
+                shape_type: ShapeType::Structure {
+                    members: vec![Member {
+                        name: "thing".to_string(),
+                        target: "test#Thing".to_string(),
+                        required: true,
+                        traits: ShapeTraits {
+                            http_payload: true,
+                            ..ShapeTraits::default()
+                        },
+                    }],
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+        shapes.insert(
+            "test#Thing".to_string(),
+            Shape {
+                shape_id: "test#Thing".to_string(),
+                shape_type: ShapeType::Structure {
+                    members: vec![Member {
+                        name: "id".to_string(),
+                        target: "smithy.api#String".to_string(),
+                        required: true,
+                        traits: ShapeTraits::default(),
+                    }],
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+
+        ServiceModel {
+            service_name: "test".to_string(),
+            operations: Vec::new(),
+            shapes,
+        }
+    }
+
+    #[test]
+    fn empty_body_flags_required_struct_payload() {
+        // Required `@httpPayload` targeting a structure: empty wire body
+        // genuinely means the payload is missing — must report.
+        let model = http_payload_struct_model();
+        let v = validate_response(&model, "test#GetThingOutput", "", Protocol::Rest);
+        assert!(
+            v.iter().any(
+                |x| matches!(x, ShapeViolation::MissingField { field, .. } if field == "thing")
+            ),
+            "expected MissingField(thing) for empty body, got {:?}",
+            v
         );
     }
 

--- a/crates/fakecloud-conformance/src/shape_validator.rs
+++ b/crates/fakecloud-conformance/src/shape_validator.rs
@@ -274,6 +274,19 @@ fn diff_at(actual: &Value, documented: &Value, path: &str, out: &mut Vec<ShapeVi
     }
 }
 
+/// Members bound via REST HTTP traits (`@httpHeader`, `@httpQuery`,
+/// `@httpLabel`, `@httpPayload`) are serialised somewhere other than the
+/// JSON document, so they must be filtered out before checking which
+/// structure members must appear in the body. We keep `@httpPayload` here
+/// because the body validator routes payload members separately via
+/// `validate_json_response`.
+fn is_json_body_member(m: &crate::smithy::Member) -> bool {
+    !(m.traits.http_header.is_some()
+        || m.traits.http_query.is_some()
+        || m.traits.http_label
+        || m.traits.http_payload)
+}
+
 /// Validate a response body against the expected output shape from the Smithy model.
 ///
 /// Returns a list of violations. An empty list means the response conforms to the model.
@@ -285,9 +298,18 @@ pub fn validate_response(
 ) -> Vec<ShapeViolation> {
     if response_body.is_empty() {
         // An empty body is valid if the output shape is Unit or has no required members.
+        // Members bound to HTTP headers / query / labels / response code are not
+        // expected to appear in the JSON body, so they don't count as "missing".
+        // A required `@httpPayload` member with an empty wire body is also OK
+        // when the payload's own target shape is structurally empty — but we
+        // don't try to be that clever here; an empty body with a required
+        // payload member is reported as MissingField like before.
         if let Some(ShapeType::Structure { members }) = effective_shape_type(model, output_shape_id)
         {
-            let required: Vec<_> = members.iter().filter(|m| m.required).collect();
+            let required: Vec<_> = members
+                .iter()
+                .filter(|m| m.required && is_json_body_member(m))
+                .collect();
             if !required.is_empty() {
                 return required
                     .iter()
@@ -328,6 +350,33 @@ fn validate_json_response(
         return Vec::new();
     }
 
+    // `@httpPayload` redirects body validation to the payload member's target
+    // shape, not the parent structure. Bedrock `InvokeModel` is the canonical
+    // example: the response body IS the provider-specific blob declared on
+    // member `body`, while `contentType` rides on the Content-Type header
+    // and `performanceConfigLatency` / `serviceTier` ride on response
+    // headers. Without this redirect we'd flag a perfectly-formed Bedrock
+    // payload as "missing required field 'body'" because no JSON envelope
+    // wraps it.
+    //
+    // When the payload's target is a Blob or String, the body is raw bytes
+    // (e.g. a provider-specific JSON blob, a binary upload, an arbitrary
+    // string). We can't validate it structurally — AWS returns whatever
+    // the underlying model/object produced — so accept it as opaque.
+    let effective_shape_id = match effective_shape_type(model, output_shape_id) {
+        Some(ShapeType::Structure { members }) => {
+            if let Some(payload) = members.iter().find(|m| m.traits.http_payload) {
+                match effective_shape_type(model, &payload.target) {
+                    Some(ShapeType::Blob) | Some(ShapeType::String { .. }) => return Vec::new(),
+                    _ => payload.target.clone(),
+                }
+            } else {
+                output_shape_id.to_string()
+            }
+        }
+        _ => output_shape_id.to_string(),
+    };
+
     let value: Value = match serde_json::from_str(response_body) {
         Ok(v) => v,
         Err(e) => {
@@ -338,7 +387,7 @@ fn validate_json_response(
     };
 
     let mut violations = Vec::new();
-    validate_shape(model, output_shape_id, &value, "$", 0, &mut violations);
+    validate_shape(model, &effective_shape_id, &value, "$", 0, &mut violations);
     violations
 }
 
@@ -537,6 +586,9 @@ fn validate_shape(
                 });
             }
         }
+        // `smithy.api#Document` is an arbitrary JSON value — any type
+        // (object, array, string, number, bool, null) is acceptable.
+        ShapeType::Document => {}
         // Service, Operation, Resource shapes are not value types
         ShapeType::Service | ShapeType::Operation | ShapeType::Resource => {}
     }
@@ -578,8 +630,14 @@ fn validate_structure(
         m.name.clone()
     };
 
-    // Check required fields are present
+    // Check required fields are present. Members bound to HTTP headers,
+    // query strings, labels, or the response status code don't appear in
+    // the JSON body, so skip them here — the probe asserts those bindings
+    // elsewhere (header presence, status code classification).
     for member in members {
+        if !is_json_body_member(member) {
+            continue;
+        }
         let key = member_key(member);
         if member.required && !obj.contains_key(&key) {
             violations.push(ShapeViolation::MissingField {
@@ -1147,6 +1205,153 @@ mod tests {
             "expected an UnexpectedField(Items) violation, got {:?}",
             violations
         );
+    }
+
+    /// Model where the output has a `@httpPayload` member targeting a
+    /// blob (Bedrock `InvokeModelResponse.body` pattern) plus a header
+    /// member (`contentType`) that must NOT be required-in-body.
+    fn http_payload_blob_model() -> ServiceModel {
+        let mut shapes = HashMap::new();
+
+        shapes.insert(
+            "test#InvokeOutput".to_string(),
+            Shape {
+                shape_id: "test#InvokeOutput".to_string(),
+                shape_type: ShapeType::Structure {
+                    members: vec![
+                        Member {
+                            name: "body".to_string(),
+                            target: "test#Body".to_string(),
+                            required: true,
+                            traits: ShapeTraits {
+                                http_payload: true,
+                                ..ShapeTraits::default()
+                            },
+                        },
+                        Member {
+                            name: "contentType".to_string(),
+                            target: "smithy.api#String".to_string(),
+                            required: true,
+                            traits: ShapeTraits {
+                                http_header: Some("Content-Type".to_string()),
+                                ..ShapeTraits::default()
+                            },
+                        },
+                    ],
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+        shapes.insert(
+            "test#Body".to_string(),
+            Shape {
+                shape_id: "test#Body".to_string(),
+                shape_type: ShapeType::Blob,
+                traits: ShapeTraits::default(),
+            },
+        );
+
+        ServiceModel {
+            service_name: "test".to_string(),
+            operations: Vec::new(),
+            shapes,
+        }
+    }
+
+    #[test]
+    fn http_payload_blob_body_is_opaque() {
+        // Bedrock InvokeModel: the wire body IS the blob (a provider JSON
+        // payload). The validator must not look up `body` / `contentType`
+        // as structure fields and must not flag unknown keys inside the
+        // provider JSON.
+        let model = http_payload_blob_model();
+        let body = r#"{"completion": "hello", "stop_reason": "end_turn"}"#;
+        let violations = validate_response(&model, "test#InvokeOutput", body, Protocol::Rest);
+        assert!(
+            violations.is_empty(),
+            "expected no violations (httpPayload Blob is opaque), got {:?}",
+            violations
+        );
+    }
+
+    #[test]
+    fn empty_body_skips_http_bound_required_members() {
+        // An empty body must not be reported as missing `contentType` —
+        // that member rides on a response header. Same for `body` because
+        // it's `@httpPayload` (we drop both via `is_json_body_member`).
+        let model = http_payload_blob_model();
+        let violations = validate_response(&model, "test#InvokeOutput", "", Protocol::Rest);
+        assert!(
+            violations.is_empty(),
+            "empty body shouldn't flag header-bound required members, got {:?}",
+            violations
+        );
+    }
+
+    /// Model where a structure member targets `smithy.api#Document`. A
+    /// Document accepts any JSON value, not just strings.
+    fn document_model() -> ServiceModel {
+        let mut shapes = HashMap::new();
+        shapes.insert(
+            "test#ToolUseBlock".to_string(),
+            Shape {
+                shape_id: "test#ToolUseBlock".to_string(),
+                shape_type: ShapeType::Structure {
+                    members: vec![Member {
+                        name: "input".to_string(),
+                        target: "smithy.api#Document".to_string(),
+                        required: true,
+                        traits: ShapeTraits::default(),
+                    }],
+                },
+                traits: ShapeTraits::default(),
+            },
+        );
+        ServiceModel {
+            service_name: "test".to_string(),
+            operations: Vec::new(),
+            shapes,
+        }
+    }
+
+    #[test]
+    fn document_member_accepts_arbitrary_json() {
+        let model = document_model();
+        // Object Document.
+        let body = r#"{"input": {"location": "Seattle"}}"#;
+        let v = validate_response(
+            &model,
+            "test#ToolUseBlock",
+            body,
+            Protocol::Json {
+                target_prefix: "Test",
+            },
+        );
+        assert!(v.is_empty(), "object Document should pass, got {:?}", v);
+
+        // String Document.
+        let body = r#"{"input": "raw"}"#;
+        let v = validate_response(
+            &model,
+            "test#ToolUseBlock",
+            body,
+            Protocol::Json {
+                target_prefix: "Test",
+            },
+        );
+        assert!(v.is_empty(), "string Document should pass, got {:?}", v);
+
+        // Array Document.
+        let body = r#"{"input": [1, 2, 3]}"#;
+        let v = validate_response(
+            &model,
+            "test#ToolUseBlock",
+            body,
+            Protocol::Json {
+                target_prefix: "Test",
+            },
+        );
+        assert!(v.is_empty(), "array Document should pass, got {:?}", v);
     }
 
     // ----- diff_against_example -----

--- a/crates/fakecloud-conformance/src/smithy.rs
+++ b/crates/fakecloud-conformance/src/smithy.rs
@@ -72,6 +72,10 @@ pub enum ShapeType {
     Boolean,
     Blob,
     Timestamp,
+    /// `smithy.api#Document` — an arbitrary JSON value (object, array,
+    /// string, number, bool, null). Used by Bedrock `ToolUseBlock.input`
+    /// and similar dynamic payloads.
+    Document,
     /// Service, operation, resource — not directly useful for value generation.
     Service,
     Operation,
@@ -419,6 +423,7 @@ fn parse_shape(shape_id: &str, def: &Value) -> Option<Shape> {
         "boolean" => ShapeType::Boolean,
         "blob" => ShapeType::Blob,
         "timestamp" => ShapeType::Timestamp,
+        "document" => ShapeType::Document,
         "service" => ShapeType::Service,
         "operation" => ShapeType::Operation,
         "resource" => ShapeType::Resource,
@@ -587,7 +592,7 @@ pub fn prelude_shape_type(shape_id: &str) -> Option<ShapeType> {
         "smithy.api#Timestamp" => Some(ShapeType::Timestamp),
         "smithy.api#BigInteger" => Some(ShapeType::Long),
         "smithy.api#BigDecimal" => Some(ShapeType::Double),
-        "smithy.api#Document" => Some(ShapeType::String { enum_values: None }),
+        "smithy.api#Document" => Some(ShapeType::Document),
         "smithy.api#Unit" => Some(ShapeType::Structure {
             members: Vec::new(),
         }),


### PR DESCRIPTION
## Summary

- Bedrock runtime conformance jumps from 313/446 (70.2%) to 446/446 (100%) by teaching the response-shape validator about two REST/Smithy traits it was ignoring.
- Root causes: \`@httpPayload\` (\`InvokeModelResponse.body\` is the wire body, not a JSON field) and \`smithy.api#Document\` (\`ToolUseBlock.input\` accepts any JSON, not just strings).
- Validator fix also lifts several other services off latent false negatives: overall pass count rises from 82884 to 85239 across 86327 variants. Baseline only bumps bedrock-runtime so the rest get a flake-margin headroom, not a forced ceiling.

## Changes

- \`shape_validator.rs\`: redirect body validation to the \`@httpPayload\` member's target; treat Blob/String payloads as opaque (raw bytes). Filter members bound via \`@httpHeader\`/\`@httpQuery\`/\`@httpLabel\`/\`@httpPayload\` from JSON body required-checks (they ride on HTTP envelopes).
- \`smithy.rs\`: new \`ShapeType::Document\` variant; \`smithy.api#Document\` no longer aliases String.
- \`checksum.rs\`, generators: cover the new variant.
- 3 new unit tests covering @httpPayload-Blob opacity, empty-body required-member filtering, and Document accepting object/string/array.

## Test plan

- [x] \`cargo run -p fakecloud-conformance --release -- run --services bedrock-runtime\` -> 446/446 (100%)
- [x] \`cargo run -p fakecloud-conformance --release -- check\` -> passes baseline
- [x] \`cargo test -p fakecloud-conformance --lib\` -> 86 passed
- [x] \`cargo test -p fakecloud-conformance --test bedrock\` -> 37 passed
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` -> clean
- [x] \`cargo fmt\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the response-shape validator to honor `@httpPayload` and `smithy.api#Document`, raising Bedrock Runtime conformance from 313/446 to 446/446 (100%). Baseline now reports 83017/86327 variants passing (+133), with refined empty-body handling for required `@httpPayload` structures.

- **Bug Fixes**
  - Route body validation to the `@httpPayload` member’s target; treat Blob/String payloads as opaque bytes (no structural checks).
  - Add a `Document` shape type; map `smithy.api#Document` to it and accept any JSON value. Update generators and checksums to handle it.
  - Required-field checks: ignore `@httpHeader`/`@httpQuery`/`@httpLabel` in the JSON body. For `@httpPayload`, skip only when the target is Blob/String; otherwise an empty body reports the payload as missing.

<sup>Written for commit e742060ca829f877d913e951ece298621d37941c. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1414?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

