### PR TITLE
fix(conformance): bump wafv2 baseline to 2133/2133 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83192,
+  "variants_passed": 83362,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -119,7 +119,7 @@
       "total": 864
     },
     "wafv2": {
-      "passed": 1963,
+      "passed": 2133,
       "total": 2133
     },
     "states": {


### PR DESCRIPTION
## Summary
- Live `cargo run -p fakecloud-conformance --release -- run --services wafv2` already reports 2133/2133 (100%); the committed baseline still held the stale 1963/2133 (92%) snapshot.
- Ratchet wafv2 to 2133/2133 so any future regression actually trips CI.
- No source changes — every wafv2 op already enforces its Smithy constraints (length/required/enum/scope) inline in `service.rs`, so no validation table or handler edits were necessary.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services wafv2` -> `Variants: 2133/2133 passed (100.0%)`
- [x] Baseline `variants_passed` and per-service `wafv2.passed` updated coherently (delta +170)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update WAFv2 conformance baseline to 2133/2133 (100%) to match the current run and ensure CI blocks regressions. Only `conformance-baseline.json` changed: `variants_passed` 83192 -> 83362 and `wafv2.passed` 1963 -> 2133.

<sup>Written for commit 7bea8fb95245750364e319ca1884ee00c0c921f8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

