### PR TITLE
fix(conformance): bump KMS baseline to 2227/2227 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83017,
+  "variants_passed": 83192,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -135,7 +135,7 @@
       "total": 506
     },
     "kms": {
-      "passed": 2052,
+      "passed": 2227,
       "total": 2227
     },
     "route53": {


### PR DESCRIPTION
## Summary
- KMS conformance now stable at 2227/2227 variants (100%, 53/53 ops) against `aws-models/kms.json`.
- Recent shape-validator improvements (httpPayload empty-body handling, undeclared-error rules from #1414 and friends) closed the remaining gap; this PR just ratchets the baseline so CI reflects the honest current number.
- No source/runtime changes. Only `conformance-baseline.json` updated: kms `2052 -> 2227`, `variants_passed 83017 -> 83192`.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services kms` reports `Variants: 2227/2227 passed (100.0%)` on three consecutive runs.
- [x] `Operations: 53/53 implemented (100.0%), 53/53 fully passing (100.0%)`.
- [ ] CI conformance check passes (per-service ratchet OK, total ratchet OK).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update conformance baseline to reflect KMS at 100% passing (2227/2227 variants, 53/53 ops) against `aws-models/kms.json`. No code changes; only `conformance-baseline.json` updated (KMS 2052→2227, `variants_passed` 83017→83192).

<sup>Written for commit 7f6bada71467d80553d98cb716d1e7bf6a7595aa. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1416?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

