### PR TITLE
fix(conformance): refresh scheduler baseline to honest 506/506

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83362,
+  "variants_passed": 83403,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -131,7 +131,7 @@
       "total": 3834
     },
     "scheduler": {
-      "passed": 465,
+      "passed": 506,
       "total": 506
     },
     "kms": {


### PR DESCRIPTION
## Summary

- Bump `per_service.scheduler.passed` from 465 to 506 in `conformance-baseline.json` and recompute the aggregate (`variants_passed` 83017 -> 83058) so the conformance gate reflects current honest probe output.
- No code changes. Scheduler input validation in `crates/fakecloud-scheduler/src/service.rs` already enforces every Smithy constraint in `aws-models/scheduler.json` (Name 1..64 + `[0-9a-zA-Z-_.]`, NamePrefix same shape, MaxResults 1..100, NextToken 1..2048, ResourceArn 1..1600, empty-label trailing-slash promotion).

## Context

The honest-baseline sweep in 6bf4ecfa lowered scheduler from 506 to 465 to match probe results at that snapshot. The 41 negative variants that had regressed were re-fixed by 00fdc4f8 ("tighten input validation to match Smithy constraints"), but the baseline wasn't bumped back. The conformance gate therefore tolerates regressions up to 41 variants for scheduler. This PR closes that drift.

## Verification

Live probe against the worktree built from main + this branch:

```
$ cargo run -p fakecloud-conformance --release -- run --services scheduler
scheduler: 12/12 operations handled, 12/12 fully passing
Variants: 506/506 passed (100.0%)
```

`fakecloud-conformance check` passes with the new baseline.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services scheduler` reports 506/506
- [x] `cargo run -p fakecloud-conformance --release -- check` exits 0 with the bumped baseline
- [x] No other service rows touched (only scheduler + aggregate)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the conformance baseline for scheduler to 506/506 and bump the aggregate `variants_passed` to 83403 so the gate matches current probe results and blocks regressions. No code changes; existing scheduler input validation already enforces the model constraints.

<sup>Written for commit 4e938bd9ba3ff85a2c6342c0c0fc47ce89869796. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1417?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

