### PR TITLE
fix(conformance): athena baseline 2180->2310 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83564,
+  "variants_passed": 83694,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -87,7 +87,7 @@
       "total": 5265
     },
     "athena": {
-      "passed": 2180,
+      "passed": 2310,
       "total": 2310
     },
     "events": {


### PR DESCRIPTION
## Summary

- Update the athena entry in conformance-baseline.json from 2180/2310 (94.4%) to 2310/2310 (100%).
- The Smithy input-constraint enforcement landed in d8163152 (fix(athena): enforce Smithy input constraints for 100% conformance); the probe has been reporting 2310/2310 consistently since.
- The stale baseline was understating real coverage. Updating it honestly so coverage tracking reflects actual probe output.
- All other services left untouched.

Verified locally:

\`\`\`
cargo run -p fakecloud-conformance --release -- run --services athena
# athena: 70/70 operations handled, 70/70 fully passing
# Variants: 2310/2310 passed (100.0%)
\`\`\`

## Test plan

- [x] cargo run -p fakecloud-conformance --release -- run --services athena -> 2310/2310
- [x] cargo run -p fakecloud-conformance --release -- check -> PASSED (no regressions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `conformance-baseline.json` to set Athena coverage from 2180/2310 to 2310/2310 (100%), aligning the baseline with current probe results after Smithy input-constraint enforcement. No other services changed.

<sup>Written for commit 7d730d88bb1d2f097a1fedf6a353e3ef140d7312. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1419?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

