### PR TITLE
fix(conformance): raise elasticloadbalancing baseline to 1569/1569 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83694,
+  "variants_passed": 83755,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -55,7 +55,7 @@
       "total": 3373
     },
     "elasticloadbalancing": {
-      "passed": 1508,
+      "passed": 1569,
       "total": 1569
     },
     "s3": {


### PR DESCRIPTION
## Summary

- ELBv2 strict conformance probe already reports **1569/1569 (100%)** locally; baseline was lagging at 1508/1569 since the broad refresh in 6bf4ecfa
- Validation enforcing the Smithy model (range/length/enum gates on Create*, PageSize bounds on Describe*, declared error codes on tag ops) was already shipped in 82daed4e
- This PR just ratchets the baseline back up to match honest probe output

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services elasticloadbalancing` -> `Variants: 1569/1569 passed (100.0%)`
- [ ] CI conformance gate passes
- [ ] Cubic clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `elasticloadbalancing` conformance baseline from 1508/1569 to 1569/1569 (100%) to match current strict probe results and prevent false regressions. Also bumps aggregate `variants_passed` in `conformance-baseline.json` to 83755.

<sup>Written for commit 0e770993089ab00f56def059c81845bf1dd5d2e8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1420?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

