### PR TITLE
fix(ses): close round-trip input drops to reach 100% conformance

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 83755,
+  "variants_passed": 83881,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -23,7 +23,7 @@
       "total": 2378
     },
     "ses": {
-      "passed": 2738,
+      "passed": 2864,
       "total": 2864
     },
     "application-autoscaling": {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -16506,7 +16506,7 @@ impl ResourceProvisioner {
                 .and_then(|v| v.get("ArchiveArn"))
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            archiving_options_present: props.get("ArchivingOptions").is_some(),
+            archiving_options_present: props.get("ArchivingOptions").is_some_and(|v| v.is_object()),
         };
         let mut accounts = self.ses_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner.rs
@@ -16506,6 +16506,7 @@ impl ResourceProvisioner {
                 .and_then(|v| v.get("ArchiveArn"))
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            archiving_options_present: props.get("ArchivingOptions").is_some(),
         };
         let mut accounts = self.ses_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-ses/src/fanout.rs
+++ b/crates/fakecloud-ses/src/fanout.rs
@@ -766,6 +766,7 @@ mod tests {
                     reputation_metrics_enabled: false,
                     vdm_options: None,
                     archive_arn: None,
+                    archiving_options_present: false,
                 },
             );
         }
@@ -807,6 +808,7 @@ mod tests {
                     reputation_metrics_enabled: false,
                     vdm_options: None,
                     archive_arn: None,
+                    archiving_options_present: false,
                 },
             );
         }

--- a/crates/fakecloud-ses/src/service/configuration_sets.rs
+++ b/crates/fakecloud-ses/src/service/configuration_sets.rs
@@ -39,21 +39,79 @@ impl SesV2Service {
             ));
         }
 
+        // Honor every optional sub-structure on the input — the Smithy
+        // model declares them all and the GetConfigurationSet reader
+        // round-trips them, so silently dropping any here is a real
+        // conformance gap (caught by the round_trip probe). Each block
+        // mirrors the field-by-field handling in the dedicated
+        // `PutConfigurationSet*Options` op.
+        let sending_enabled = body["SendingOptions"]["SendingEnabled"]
+            .as_bool()
+            .unwrap_or(true);
+        let tls_policy = body["DeliveryOptions"]["TlsPolicy"]
+            .as_str()
+            .unwrap_or("OPTIONAL")
+            .to_string();
+        let sending_pool_name = body["DeliveryOptions"]["SendingPoolName"]
+            .as_str()
+            .map(|s| s.to_string());
+        let custom_redirect_domain = body["TrackingOptions"]["CustomRedirectDomain"]
+            .as_str()
+            .map(|s| s.to_string());
+        let https_policy = body["TrackingOptions"]["HttpsPolicy"]
+            .as_str()
+            .map(|s| s.to_string());
+        let suppressed_reasons =
+            extract_string_array(&body["SuppressionOptions"]["SuppressedReasons"]);
+        let reputation_metrics_enabled = body["ReputationOptions"]["ReputationMetricsEnabled"]
+            .as_bool()
+            .unwrap_or(false);
+        let vdm_options = if body["VdmOptions"].is_object() {
+            Some(body["VdmOptions"].clone())
+        } else {
+            None
+        };
+        let archive_arn = body["ArchivingOptions"]["ArchiveArn"]
+            .as_str()
+            .map(|s| s.to_string());
+        // ArchivingOptions may be present as `{}` (no ArchiveArn). The
+        // Smithy round-trip echoes the structure itself, so track whether
+        // the caller sent it at all — that's what GetConfigurationSet
+        // needs to mirror back.
+        let archiving_options_present = body["ArchivingOptions"].is_object();
+
         state.configuration_sets.insert(
             name.clone(),
             ConfigurationSet {
-                name,
-                sending_enabled: true,
-                tls_policy: "OPTIONAL".to_string(),
-                sending_pool_name: None,
-                custom_redirect_domain: None,
-                https_policy: None,
-                suppressed_reasons: Vec::new(),
-                reputation_metrics_enabled: false,
-                vdm_options: None,
-                archive_arn: None,
+                name: name.clone(),
+                sending_enabled,
+                tls_policy,
+                sending_pool_name,
+                custom_redirect_domain,
+                https_policy,
+                suppressed_reasons,
+                reputation_metrics_enabled,
+                vdm_options,
+                archive_arn,
+                archiving_options_present,
             },
         );
+
+        // Persist Tags via the same per-ARN map TagResource uses, so
+        // ListTagsForResource on the new configuration-set ARN returns
+        // what the caller sent.
+        if let Some(tags_arr) = body["Tags"].as_array() {
+            let arn = format!(
+                "arn:aws:ses:{}:{}:configuration-set/{}",
+                req.region, req.account_id, name
+            );
+            let tag_map = state.tags.entry(arn).or_default();
+            for tag in tags_arr {
+                if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                    tag_map.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -136,10 +194,23 @@ impl SesV2Service {
             response["VdmOptions"] = vdm.clone();
         }
 
-        if let Some(ref arn) = cs.archive_arn {
-            response["ArchivingOptions"] = json!({
-                "ArchiveArn": arn,
-            });
+        if cs.archiving_options_present || cs.archive_arn.is_some() {
+            let mut archiving = serde_json::Map::new();
+            if let Some(ref arn) = cs.archive_arn {
+                archiving.insert("ArchiveArn".to_string(), json!(arn));
+            }
+            response["ArchivingOptions"] = Value::Object(archiving);
+        }
+
+        // Surface the per-ARN tag map on Get so the round-trip echo for
+        // Tags is honored end-to-end.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:configuration-set/{}",
+            req.region, req.account_id, name
+        );
+        if let Some(tag_map) = state.tags.get(&arn) {
+            response["Tags"] =
+                Value::Array(fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value"));
         }
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
@@ -361,6 +432,7 @@ impl SesV2Service {
         };
 
         cs.archive_arn = body["ArchiveArn"].as_str().map(|s| s.to_string());
+        cs.archiving_options_present = true;
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ses/src/service/configuration_sets.rs
+++ b/crates/fakecloud-ses/src/service/configuration_sets.rs
@@ -99,18 +99,23 @@ impl SesV2Service {
 
         // Persist Tags via the same per-ARN map TagResource uses, so
         // ListTagsForResource on the new configuration-set ARN returns
-        // what the caller sent.
+        // what the caller sent. Replace rather than merge so a Create
+        // after Delete (or a Create that omits Tags) doesn't inherit
+        // stale entries from a previous incarnation of the ARN.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:configuration-set/{}",
+            req.region, req.account_id, name
+        );
         if let Some(tags_arr) = body["Tags"].as_array() {
-            let arn = format!(
-                "arn:aws:ses:{}:{}:configuration-set/{}",
-                req.region, req.account_id, name
-            );
-            let tag_map = state.tags.entry(arn).or_default();
+            let mut tag_map = std::collections::BTreeMap::new();
             for tag in tags_arr {
                 if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
                     tag_map.insert(k.to_string(), v.to_string());
                 }
             }
+            state.tags.insert(arn, tag_map);
+        } else {
+            state.tags.remove(&arn);
         }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -71,6 +71,11 @@ impl SesV2Service {
             "DOMAIN"
         };
 
+        // Honor the optional `ConfigurationSetName` from the input — the
+        // Smithy model round-trips it on GetEmailIdentity, so dropping it
+        // here is a real input-drop bug.
+        let configuration_set_name = body["ConfigurationSetName"].as_str().map(|s| s.to_string());
+
         // Easy DKIM auto-provisions a fresh RSA-2048 keypair when the
         // identity is created so SendEmail can stamp DKIM-Signature
         // headers without a follow-up PutEmailIdentityDkimSigningAttributes.
@@ -90,10 +95,25 @@ impl SesV2Service {
             mail_from_domain: None,
             mail_from_behavior_on_mx_failure: "USE_DEFAULT_VALUE".to_string(),
             mail_from_domain_status: "NotStarted".to_string(),
-            configuration_set_name: None,
+            configuration_set_name,
         };
 
-        state.identities.insert(identity_name, identity);
+        state.identities.insert(identity_name.clone(), identity);
+
+        // Persist Tags via the per-ARN tag map TagResource/ListTagsForResource
+        // use, so the round-trip echo for Tags is honored end-to-end.
+        if let Some(tags_arr) = body["Tags"].as_array() {
+            let arn = format!(
+                "arn:aws:ses:{}:{}:identity/{}",
+                req.region, req.account_id, identity_name
+            );
+            let tag_map = state.tags.entry(arn).or_default();
+            for tag in tags_arr {
+                if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                    tag_map.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
 
         let response = json!({
             "IdentityType": identity_type,
@@ -205,8 +225,23 @@ impl SesV2Service {
             response["MailFromAttributes"]["MailFromDomainDnsRecords"] = json!(mail_from_dns);
         }
 
-        if let Some(ref cs) = identity.configuration_set_name {
+        let configuration_set_name = identity.configuration_set_name.clone();
+        // Release the &mut on `identity` before borrowing `state.tags`.
+        let _ = identity;
+        if let Some(cs) = configuration_set_name {
             response["ConfigurationSetName"] = json!(cs);
+        }
+
+        // Surface stored tags from the per-ARN tag map. Echoing keeps
+        // the round-trip honest: anything CreateEmailIdentity/TagResource
+        // wrote is visible on the read side.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:identity/{}",
+            req.region, req.account_id, identity_name
+        );
+        if let Some(tag_map) = state.tags.get(&arn) {
+            response["Tags"] =
+                Value::Array(fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value"));
         }
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -102,17 +102,23 @@ impl SesV2Service {
 
         // Persist Tags via the per-ARN tag map TagResource/ListTagsForResource
         // use, so the round-trip echo for Tags is honored end-to-end.
+        // Replace rather than merge so a Create after Delete (or a
+        // Create that omits Tags) doesn't inherit stale entries from a
+        // previous incarnation of the ARN.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:identity/{}",
+            req.region, req.account_id, identity_name
+        );
         if let Some(tags_arr) = body["Tags"].as_array() {
-            let arn = format!(
-                "arn:aws:ses:{}:{}:identity/{}",
-                req.region, req.account_id, identity_name
-            );
-            let tag_map = state.tags.entry(arn).or_default();
+            let mut tag_map = std::collections::BTreeMap::new();
             for tag in tags_arr {
                 if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
                     tag_map.insert(k.to_string(), v.to_string());
                 }
             }
+            state.tags.insert(arn, tag_map);
+        } else {
+            state.tags.remove(&arn);
         }
 
         let response = json!({

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -222,7 +222,7 @@ impl SesV2Service {
         state.custom_verification_email_templates.insert(
             template_name.clone(),
             CustomVerificationEmailTemplate {
-                template_name,
+                template_name: template_name.clone(),
                 from_email_address: from_email,
                 template_subject: subject,
                 template_content: content,
@@ -231,6 +231,22 @@ impl SesV2Service {
                 created_at: Utc::now(),
             },
         );
+
+        // Persist Tags via the per-ARN tag map. The Smithy
+        // `GetCustomVerificationEmailTemplateResponse` round-trips Tags,
+        // so dropping them on Create is a real input-drop bug.
+        if let Some(tags_arr) = body["Tags"].as_array() {
+            let arn = format!(
+                "arn:aws:ses:{}:{}:custom-verification-email-template/{}",
+                req.region, req.account_id, template_name
+            );
+            let tag_map = state.tags.entry(arn).or_default();
+            for tag in tags_arr {
+                if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                    tag_map.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -254,7 +270,7 @@ impl SesV2Service {
             }
         };
 
-        let response = json!({
+        let mut response = json!({
             "TemplateName": tmpl.template_name,
             "FromEmailAddress": tmpl.from_email_address,
             "TemplateSubject": tmpl.template_subject,
@@ -262,6 +278,15 @@ impl SesV2Service {
             "SuccessRedirectionURL": tmpl.success_redirection_url,
             "FailureRedirectionURL": tmpl.failure_redirection_url,
         });
+
+        let arn = format!(
+            "arn:aws:ses:{}:{}:custom-verification-email-template/{}",
+            req.region, req.account_id, name
+        );
+        if let Some(tag_map) = state.tags.get(&arn) {
+            response["Tags"] =
+                Value::Array(fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value"));
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -234,18 +234,24 @@ impl SesV2Service {
 
         // Persist Tags via the per-ARN tag map. The Smithy
         // `GetCustomVerificationEmailTemplateResponse` round-trips Tags,
-        // so dropping them on Create is a real input-drop bug.
+        // so dropping them on Create is a real input-drop bug. Replace
+        // rather than merge so a Create after Delete (or a Create that
+        // omits Tags) doesn't inherit stale entries from a previous
+        // incarnation of the ARN.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:custom-verification-email-template/{}",
+            req.region, req.account_id, template_name
+        );
         if let Some(tags_arr) = body["Tags"].as_array() {
-            let arn = format!(
-                "arn:aws:ses:{}:{}:custom-verification-email-template/{}",
-                req.region, req.account_id, template_name
-            );
-            let tag_map = state.tags.entry(arn).or_default();
+            let mut tag_map = std::collections::BTreeMap::new();
             for tag in tags_arr {
                 if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
                     tag_map.insert(k.to_string(), v.to_string());
                 }
             }
+            state.tags.insert(arn, tag_map);
+        } else {
+            state.tags.remove(&arn);
         }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
@@ -406,6 +412,12 @@ impl SesV2Service {
                 &format!("Custom verification email template {} does not exist", name),
             ));
         }
+
+        let arn = format!(
+            "arn:aws:ses:{}:{}:custom-verification-email-template/{}",
+            req.region, req.account_id, name
+        );
+        state.tags.remove(&arn);
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ses/src/service/templates.rs
+++ b/crates/fakecloud-ses/src/service/templates.rs
@@ -60,7 +60,23 @@ impl SesV2Service {
             created_at: Utc::now(),
         };
 
-        state.templates.insert(template_name, template);
+        state.templates.insert(template_name.clone(), template);
+
+        // Persist Tags via the per-ARN tag map. The Smithy
+        // `GetEmailTemplateResponse` round-trips Tags, so dropping them
+        // on Create is a real input-drop bug.
+        if let Some(tags_arr) = body["Tags"].as_array() {
+            let arn = format!(
+                "arn:aws:ses:{}:{}:template/{}",
+                req.region, req.account_id, template_name
+            );
+            let tag_map = state.tags.entry(arn).or_default();
+            for tag in tags_arr {
+                if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
+                    tag_map.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }
@@ -109,7 +125,7 @@ impl SesV2Service {
             }
         };
 
-        let response = json!({
+        let mut response = json!({
             "TemplateName": template.template_name,
             "TemplateContent": {
                 "Subject": template.subject,
@@ -117,6 +133,15 @@ impl SesV2Service {
                 "Text": template.text_body,
             },
         });
+
+        let arn = format!(
+            "arn:aws:ses:{}:{}:template/{}",
+            req.region, req.account_id, name
+        );
+        if let Some(tag_map) = state.tags.get(&arn) {
+            response["Tags"] =
+                Value::Array(fakecloud_core::tags::tags_to_json(tag_map, "Key", "Value"));
+        }
 
         Ok(AwsResponse::json(StatusCode::OK, response.to_string()))
     }

--- a/crates/fakecloud-ses/src/service/templates.rs
+++ b/crates/fakecloud-ses/src/service/templates.rs
@@ -64,18 +64,23 @@ impl SesV2Service {
 
         // Persist Tags via the per-ARN tag map. The Smithy
         // `GetEmailTemplateResponse` round-trips Tags, so dropping them
-        // on Create is a real input-drop bug.
+        // on Create is a real input-drop bug. Replace rather than merge
+        // so a Create after Delete (or a Create that omits Tags) doesn't
+        // inherit stale entries from a previous incarnation of the ARN.
+        let arn = format!(
+            "arn:aws:ses:{}:{}:template/{}",
+            req.region, req.account_id, template_name
+        );
         if let Some(tags_arr) = body["Tags"].as_array() {
-            let arn = format!(
-                "arn:aws:ses:{}:{}:template/{}",
-                req.region, req.account_id, template_name
-            );
-            let tag_map = state.tags.entry(arn).or_default();
+            let mut tag_map = std::collections::BTreeMap::new();
             for tag in tags_arr {
                 if let (Some(k), Some(v)) = (tag["Key"].as_str(), tag["Value"].as_str()) {
                     tag_map.insert(k.to_string(), v.to_string());
                 }
             }
+            state.tags.insert(arn, tag_map);
+        } else {
+            state.tags.remove(&arn);
         }
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
@@ -194,6 +199,12 @@ impl SesV2Service {
                 &format!("Template {} does not exist", name),
             ));
         }
+
+        let arn = format!(
+            "arn:aws:ses:{}:{}:template/{}",
+            req.region, req.account_id, name
+        );
+        state.tags.remove(&arn);
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
     }

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -651,6 +651,7 @@ async fn test_send_email_rejects_when_config_set_paused() {
                 reputation_metrics_enabled: false,
                 vdm_options: None,
                 archive_arn: None,
+                archiving_options_present: false,
             },
         );
     }
@@ -4307,6 +4308,7 @@ async fn send_email_v2_rejects_when_config_set_sending_paused() {
                 reputation_metrics_enabled: false,
                 vdm_options: None,
                 archive_arn: None,
+                archiving_options_present: false,
             },
         );
     }

--- a/crates/fakecloud-ses/src/state.rs
+++ b/crates/fakecloud-ses/src/state.rs
@@ -63,6 +63,14 @@ pub struct ConfigurationSet {
     pub vdm_options: Option<serde_json::Value>,
     // Archiving options
     pub archive_arn: Option<String>,
+    /// Tracks whether `ArchivingOptions` was set on the configuration set
+    /// (via Create or PutConfigurationSetArchivingOptions). AWS surfaces
+    /// the structure on GetConfigurationSet even when only `ArchiveArn`
+    /// is empty, so a missing field on Create round-trips would be a
+    /// silent input drop. Defaults to `false` for snapshots created
+    /// before the field existed.
+    #[serde(default)]
+    pub archiving_options_present: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1892,6 +1892,7 @@ pub(crate) fn create_configuration_set(
             reputation_metrics_enabled: false,
             vdm_options: None,
             archive_arn: None,
+            archiving_options_present: false,
         },
     );
     Ok(xml_metadata_only("CreateConfigurationSet", &req.request_id))

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -1651,6 +1651,7 @@ fn send_email_v1_config_set_pause() {
                 reputation_metrics_enabled: false,
                 vdm_options: None,
                 archive_arn: None,
+                archiving_options_present: false,
             },
         );
     }


### PR DESCRIPTION
## Summary

SES conformance climbs from 2738/2864 (95.6%) to 2864/2864 (100%) by closing four real input-drop bugs surfaced by the `round_trip` probe:

- **CreateConfigurationSet** now honors every optional sub-structure on the input (SendingOptions, DeliveryOptions, TrackingOptions, ReputationOptions, SuppressionOptions, VdmOptions, ArchivingOptions, Tags) and persists Tags via the per-ARN map. A new `archiving_options_present` flag lets GetConfigurationSet echo back an empty `{}` ArchivingOptions faithfully (the Smithy model treats the structure itself as the echoed value).
- **CreateEmailIdentity** persists the optional `ConfigurationSetName` from the input (was hardcoded to None) and stores Tags. GetEmailIdentity surfaces stored tags.
- **CreateCustomVerificationEmailTemplate** persists Tags. GetCustomVerificationEmailTemplate echoes them back.
- **CreateEmailTemplate** persists Tags. GetEmailTemplate echoes them back.

Each fix mirrors what the dedicated `PutConfigurationSet*Options` / `TagResource` ops were already doing — Create just wasn't routing the same fields into state.

Baseline `conformance-baseline.json` updated for `ses` only (2738 -> 2864); other services unchanged.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services ses` -> 2864/2864 (100%)
- [x] `cargo test -p fakecloud-ses --lib` -> 247/247
- [x] `cargo test -p fakecloud-conformance --test ses` -> 43/43
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SES Create* input-drop bugs and reaches 100% conformance (2864/2864). Optional fields and Tags now persist and round-trip via Get APIs; Create uses replace-or-clear semantics and Deletes clear tag entries to prevent leaks.

- **Bug Fixes**
  - CreateConfigurationSet: honors SendingOptions, DeliveryOptions, TrackingOptions, ReputationOptions, SuppressionOptions, VdmOptions, ArchivingOptions; persists Tags via per-ARN map (replace-or-clear); tracks `archiving_options_present` to echo `{}` when sent. GetConfigurationSet returns Tags and ArchivingOptions.
  - CreateEmailIdentity: persists `ConfigurationSetName` and Tags (replace-or-clear). GetEmailIdentity returns stored Tags.
  - CreateCustomVerificationEmailTemplate: persists Tags (replace-or-clear). GetCustomVerificationEmailTemplate returns stored Tags; Delete removes the tag entry.
  - CreateEmailTemplate: persists Tags (replace-or-clear). GetEmailTemplate returns stored Tags; Delete removes the tag entry.
  - CloudFormation: sets `archiving_options_present` when `ArchivingOptions` is provided to preserve round-trip echo.

<sup>Written for commit 26f10749692bde98683e3912a2b3cee2e826cd40. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1421?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

