### PR TITLE
fix(conformance): bump states baseline to 1292/1292 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 84745,
+  "variants_passed": 84787,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -123,7 +123,7 @@
       "total": 2133
     },
     "states": {
-      "passed": 1250,
+      "passed": 1292,
       "total": 1292
     },
     "bedrock": {


### PR DESCRIPTION
## Summary
- The states (Step Functions) conformance probe currently reports 37/37 operations fully passing across all 1292 variants
- Bump the recorded baseline from 1250/1292 to 1292/1292 to reflect the honest probe result
- Closes the last 42-variant gap that lingered in the baseline after recent SFN parity work

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services states` reports 1292/1292 (100%)
- [x] `cargo run -p fakecloud-conformance --release -- check` passes with no regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the conformance baseline for Step Functions (`states`) to 1292/1292 (100%) to match current probe results. This removes the remaining 42-variant gap and prevents false regressions in conformance checks.

<sup>Written for commit 3f810049dc351b9712e0061ceaf91c7381ca8c51. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1425?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

