### PR TITLE
fix(conformance): refresh sts baseline to 447/447 (100%)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 84787,
+  "variants_passed": 84799,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -99,7 +99,7 @@
       "total": 541
     },
     "sts": {
-      "passed": 435,
+      "passed": 447,
       "total": 447
     },
     "cognito-idp": {


### PR DESCRIPTION
## Summary

- STS implementation already rejects all 12 negative variants honestly via Smithy-declared error codes (landed in 7451bb6c).
- A later baseline refresh (6bf4ecfa) re-pinned sts to 435/447 alongside other regressions; this PR restores it to 447/447.
- Running `cargo run -p fakecloud-conformance --release -- run --services sts` confirms 447/447.

Honest validation in `crates/fakecloud-iam/src/sts_service.rs`:
- AssumeRoot: ExpiredTokenException on missing TargetPrincipal/TaskPolicyArn, TargetPrincipal length outside 12..=2048, DurationSeconds outside 0..=900.
- GetWebIdentityToken: SessionDurationEscalationException on empty Audience, SigningAlgorithm != 5 chars, DurationSeconds outside 60..=3600.
- GetDelegatedAccessToken: ExpiredTradeInTokenException on missing TradeInToken.

No source changes; baseline only.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services sts` -> 447/447
- [x] `cargo run -p fakecloud-conformance --release -- check --baseline conformance-baseline.json` -> PASSED, no regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh STS conformance baseline to 447/447 (100%) to match the current implementation that rejects all negative variants with Smithy-declared errors. Updates `conformance-baseline.json` only (variants_passed +12); no source changes.

<sup>Written for commit d93631fc01eda34f2106d7b1e7de31f2dcff2440. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

