### PR TITLE
[Olwen] Blog: Local AWS Bedrock: Prototyping GenAI Without Cloud Costs

### DIFF
--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Reduce GenAI development costs and latency by emulating AWS Bedrock locally with fakecloud. A high-fidelity, offline-first alternative for testing agentic workflows and LLM integrations."
+description = "Discover how fakecloud enables local AWS Bedrock emulation, allowing you to prototype GenAI applications without token costs or internet dependencies."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -91,11 +91,11 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
-| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
-| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail"                          | Validate safety filters and PII masking logic locally.          |
-| **Agents**           | `CreateAgent", `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
+| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream", "Converse", "ConverseStream" | Test prompt engineering and streaming UI components.            |
+| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
+| **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
-| **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
+| **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel"                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
@@ -147,4 +147,4 @@ chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at [fakecloud.dev](https://fakecloud.dev) or the [GitHub repository](https://github.com/faiscadev/fakecloud).
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,0 +1,150 @@
++++
+title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
+date = 2026-05-17
+description = "Discover how fakecloud enables high-fidelity, offline emulation of 111 AWS Bedrock operations to eliminate token costs and API latency during GenAI prototyping."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Generative AI development in 2026 has reached a point of extreme financial and operational friction. As of May 13, 2026, frontier models like Claude 4.7 Opus and GPT-5.5 "Spud" command premium pricing—up to $75 per million output tokens for the highest-tier reasoning models. For a developer building an agentic workflow that requires hundreds of iterative calls to refine a prompt or debug a tool-use loop, the "cloud-first" approach is no longer a minor expense; it is a significant tax on innovation.
+
+Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
+
+[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+
+## The Dev Hurdle: Token Costs and API Latency
+
+Prototyping GenAI applications involves a high-frequency "inner loop." You change a system prompt, run a test case, inspect the output, and repeat. When this loop is tied to a cloud provider, every iteration incurs a cost and a latency penalty. 
+
+As of May 2026, the cost of frontier model access on AWS Bedrock remains a primary concern for engineering teams:
+
+*   **Claude 4.7 Opus:** $15.00 per 1M input / $75.00 per 1M output tokens.
+*   **GPT-5.5 Spud:** $5.00 per 1M input / $15.00 per 1M output tokens.
+*   **Llama 4 405B:** $1.95 per 1M input / $2.56 per 1M output tokens.
+
+While these models offer unprecedented reasoning capabilities, using them for basic integration testing or CI/CD pipelines is economically inefficient. Furthermore, the round-trip latency to a cloud region—often 200ms to 500ms before inference even begins—stalls the developer's momentum. 
+
+When you add the overhead of managing IAM roles, VPC endpoints, and service quotas just to test a single Lambda function's ability to call `InvokeModel`, the friction becomes a barrier to entry. 
+
+## Solution: `fakecloud start` with Bedrock Support
+
+fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
+
+To start the environment with Bedrock support, you run a single command:
+
+```bash
+# Start fakecloud with Bedrock and S3 enabled
+./fakecloud start --services bedrock,s3
+```
+
+Once running, fakecloud listens on `localhost:4566`. It provides a 100% API-conformant environment across 2,422 operations, including 111 specific to Bedrock. This is not a simple mock that returns static strings; it is a functional emulation backed by over 59,000 Smithy-model-generated test variants to ensure the behavior matches the real AWS environment.
+
+### The "No" List
+
+With fakecloud, you bypass the administrative tax of modern cloud development:
+
+*   **No AWS Account:** You never have to sign up or provide a credit card.
+*   **No Auth Token:** Unlike other local tools as of 2026, fakecloud does not require a login or a vendor-issued token to start.
+*   **No Internet Connection:** The binary runs entirely on your machine. You can develop on a plane, in a secure facility, or during a network outage.
+*   **No API Quotas:** You are never rate-limited by a provider. Your local machine's CPU and memory are the only limits.
+
+## Code Snippet: Configuring the AWS SDK
+
+To use fakecloud, you configure your standard AWS SDK client to use the local endpoint. This allows you to use the same code in development that you ship to production. 
+
+Here is an example using the Python Boto3 library to call the Bedrock `Converse` API, which as of May 2026 is the standard for multi-turn LLM interactions:
+
+```python
+import boto3
+
+# Configure the Bedrock Runtime client to point to fakecloud
+client = boto3.client(
+    service_name="bedrock-runtime",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="fake",
+    aws_secret_access_key="fake"
+)
+
+# Call the Converse API
+response = client.converse(
+    modelId="anthropic.claude-4-7-sonnet-20260513-v1:0",
+    messages=[
+        {
+            "role": "user",
+            "content": [{"text": "Explain local AWS emulation."}]
+        }
+    ]
+)
+
+print(response['output']['message']['content'][0]['text'])
+```
+
+In this workflow, your application logic remains pure. You are testing the integration, the error handling, and the response parsing without spending a single cent on tokens.
+
+## Evidence: 111 Supported Bedrock Operations
+
+fakecloud's Bedrock support is comprehensive, covering the data plane, control plane, and agentic features. This allows AI engineers to prototype complex RAG (Retrieval-Augmented Generation) pipelines and multi-agent systems locally.
+
+### Supported API Categories
+
+| Category | Key Operations Supported | Utility |
+| :--- | :--- | :--- |
+| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components. |
+| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail" | Validate safety filters and PII masking logic locally. |
+| **Agents** | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase` | Prototype autonomous agents and tool-use loops. |
+| **Knowledge Bases** | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate` | Emulate RAG workflows with local vector storage integration. |
+| **Provisioning** | `CreateProvisionedModelThroughput`, `GetFoundationModel` | Test infrastructure-as-code (IaC) scripts for model deployment. |
+
+By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
+
+## Feature-by-Numbers: Why fakecloud Wins
+
+When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, fakecloud maintains a minimalist, high-performance footprint.
+
+*   **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
+*   **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
+*   **33+ AWS Services:** Beyond Bedrock, you get S3, Lambda, DynamoDB, SNS, SQS, and more, allowing for full cross-service integration testing (e.g., an S3 upload triggering a Lambda that calls Bedrock).
+*   **2,422 Operations:** Total API coverage across all supported services, ensuring that your `boto3` or `aws-sdk-js` calls don't fail due to missing methods.
+*   **AGPL-3.0 License:** Open-source for local development, ensuring that the tool remains accessible to the community without sudden licensing shifts.
+
+### Comparison: fakecloud vs. The Alternatives
+
+| Feature | fakecloud | AWS Cloud | Gated Local Tools (2026) |
+| :--- | :--- | :--- | :--- |
+| **Cost** | $0 (Local) | Per-token / Per-hour | Subscription + Token Tax |
+| **Auth** | None Required | IAM / Credentials | Mandatory Account/Token |
+| **Latency** | <10ms (Local) | 200ms - 500ms+ | 50ms - 100ms (Auth check) |
+| **Offline** | Yes | No | No (Requires Auth Heartbeat) |
+| **Binary Size** | ~19MB | N/A | 500MB+ (Docker-based) |
+
+## Deterministic Testing for Non-Deterministic Models
+
+One of the greatest challenges in GenAI development is the non-deterministic nature of LLMs. When you run integration tests against the real Bedrock API, the model's response might change slightly between runs, leading to flaky tests. 
+
+fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. 
+
+### SDK-Client Separation
+
+In a fakecloud workflow, you distinguish between the **App Client** (the standard AWS SDK) and the **Test SDK** (the fakecloud-specific library). 
+
+1.  **The App Client** calls `InvokeModel` as it would in production.
+2.  **The Test SDK** configures fakecloud to return a specific JSON payload for that call.
+
+This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application.
+
+## Next Step: Run Bedrock Locally
+
+Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. [fakecloud](https://github.com/faiscadev/fakecloud) provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
+
+To get started, download the binary for your platform and run the start command. No sign-up is required.
+
+```bash
+# Download and run (Linux/macOS)
+curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
+chmod +x fakecloud
+./fakecloud start --services bedrock
+```
+
+For detailed implementation guides on [specific Bedrock operations](/blog/bedrock-local-testing/) or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Learn how to use fakecloud to emulate AWS Bedrock locally, enabling cost-free GenAI prototyping with high-fidelity API support and zero internet dependency."
+description = "Eliminate cloud costs and latency by emulating AWS Bedrock locally with fakecloud for high-fidelity GenAI prototyping."
 
 [extra]
 author = "Lucas Vieira"
@@ -25,7 +25,7 @@ As of May 2026, the cost of frontier model access on AWS Bedrock remains a prima
 
 While these models offer unprecedented reasoning capabilities, using them for basic integration testing or CI/CD pipelines is economically inefficient. Furthermore, the round-trip latency to a cloud region—often 200ms to 500ms before inference even begins—stalls the developer's momentum. 
 
-When you add the overhead of managing IAM roles, VPC endpoints, and service quotas just to test a single Lambda function's ability to call `InvokeModel`, the friction becomes a barrier to entry.
+When you add the overhead of managing IAM roles, VPC endpoints, and service quotas just to test a single Lambda function's ability to call `InvokeModel`, the friction becomes a barrier to entry. 
 
 ## Solution: `fakecloud start` with Bedrock Support
 
@@ -132,11 +132,11 @@ In a fakecloud workflow, you distinguish between the **App Client** (the standar
 1. **The App Client** calls `InvokeModel` as it would in production.
 2. **The Test SDK** configures fakecloud to return a specific JSON payload for that call.
 
-This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application. Learn more in our guide on [Bedrock local testing](/blog/bedrock-local-testing/).
+This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application.
 
 ## Next Step: Run Bedrock Locally
 
-Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. fakecloud provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
+Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. [fakecloud](https://github.com/faiscadev/fakecloud) provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
@@ -147,4 +147,4 @@ chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the [official repository](https://github.com/faiscadev/fakecloud) or see how to configure [AI integration tests](/blog/aws-integration-tests-with-claude-code-cursor/).
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Prototyping GenAI workflows is expensive and slow. fakecloud provides 111 AWS Bedrock operations locally with zero costs, no auth tokens, and 100% offline support."
+description = "Reduce GenAI development costs and latency by emulating AWS Bedrock locally with fakecloud. A high-fidelity, offline-first alternative for testing agentic workflows and LLM integrations."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -19,9 +19,9 @@ Prototyping GenAI applications involves a high-frequency "inner loop." You chang
 
 As of May 2026, the cost of frontier model access on AWS Bedrock remains a primary concern for engineering teams:
 
-*   **Claude 4.7 Opus:** $15.00 per 1M input / $75.00 per 1M output tokens.
-*   **GPT-5.5 Spud:** $5.00 per 1M input / $15.00 per 1M output tokens.
-*   **Llama 4 405B:** $1.95 per 1M input / $2.56 per 1M output tokens.
+- **Claude 4.7 Opus:** $15.00 per 1M input / $75.00 per 1M output tokens.
+- **GPT-5.5 Spud:** $5.00 per 1M input / $15.00 per 1M output tokens.
+- **Llama 4 405B:** $1.95 per 1M input / $2.56 per 1M output tokens.
 
 While these models offer unprecedented reasoning capabilities, using them for basic integration testing or CI/CD pipelines is economically inefficient. Furthermore, the round-trip latency to a cloud region—often 200ms to 500ms before inference even begins—stalls the developer's momentum. 
 
@@ -33,7 +33,7 @@ fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface loca
 
 To start the environment with Bedrock support, you run a single command:
 
-```sh
+```bash
 # Start fakecloud with Bedrock and S3 enabled
 ./fakecloud start --services bedrock,s3
 ```
@@ -44,10 +44,10 @@ Once running, fakecloud listens on `localhost:4566`. It provides a 100% API-conf
 
 With fakecloud, you bypass the administrative tax of modern cloud development:
 
-*   **No AWS Account:** You never have to sign up or provide a credit card.
-*   **No Auth Token:** Unlike other local tools as of 2026, fakecloud does not require a login or a vendor-issued token to start.
-*   **No Internet Connection:** The binary runs entirely on your machine. You can develop on a plane, in a secure facility, or during a network outage.
-*   **No API Quotas:** You are never rate-limited by a provider. Your local machine's CPU and memory are the only limits.
+- **No AWS Account:** You never have to sign up or provide a credit card.
+- **No Auth Token:** Unlike other local tools as of 2026, fakecloud does not require a login or a vendor-issued token to start.
+- **No Internet Connection:** The binary runs entirely on your machine. You can develop on a plane, in a secure facility, or during a network outage.
+- **No API Quotas:** You are never rate-limited by a provider. Your local machine's CPU and memory are the only limits.
 
 ## Code Snippet: Configuring the AWS SDK
 
@@ -89,13 +89,13 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 ### Supported API Categories
 
-| Category | Key Operations Supported | Utility |
-| :--- | :--- | :--- |
-| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components. |
-| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail` | Validate safety filters and PII masking logic locally. |
-| **Agents** | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase` | Prototype autonomous agents and tool-use loops. |
-| **Knowledge Bases** | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate` | Emulate RAG workflows with local vector storage integration. |
-| **Provisioning** | `CreateProvisionedModelThroughput`, `GetFoundationModel` | Test infrastructure-as-code (IaC) scripts for model deployment. |
+| Category             | Key Operations Supported                                                     | Utility                                                         |
+| :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
+| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
+| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail"                          | Validate safety filters and PII masking logic locally.          |
+| **Agents**           | `CreateAgent", `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
+| **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
+| **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
@@ -103,34 +103,34 @@ By supporting 111 operations, fakecloud ensures that even advanced features—li
 
 When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, fakecloud maintains a minimalist, high-performance footprint.
 
-*   **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
-*   **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
-*   **33+ AWS Services:** Beyond Bedrock, you get S3, Lambda, DynamoDB, SNS, SQS, and more, allowing for full cross-service integration testing (e.g., an S3 upload triggering a Lambda that calls Bedrock).
-*   **2,422 Operations:** Total API coverage across all supported services, ensuring that your `boto3` or `aws-sdk-js` calls don't fail due to missing methods.
-*   **AGPL-3.0 License:** Open-source for local development, ensuring that the tool remains accessible to the community without sudden licensing shifts.
+- **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
+- **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
+- **33+ AWS Services:** Beyond Bedrock, you get S3, Lambda, DynamoDB, SNS, SQS, and more, allowing for full cross-service integration testing (e.g., an S3 upload triggering a Lambda that calls Bedrock).
+- **2,422 Operations:** Total API coverage across all supported services, ensuring that your `boto3` or `aws-sdk-js` calls don't fail due to missing methods.
+- **AGPL-3.0 License:** Open-source for local development, ensuring that the tool remains accessible to the community without sudden licensing shifts.
 
 ### Comparison: fakecloud vs. The Alternatives
 
-| Feature | fakecloud | AWS Cloud | Gated Local Tools (2026) |
-| :--- | :--- | :--- | :--- |
-| **Cost** | $0 (Local) | Per-token / Per-hour | Subscription + Token Tax |
-| **Auth** | None Required | IAM / Credentials | Mandatory Account/Token |
-| **Latency** | <10ms (Local) | 200ms - 500ms+ | 50ms - 100ms (Auth check) |
-| **Offline** | Yes | No | No (Requires Auth Heartbeat) |
-| **Binary Size** | ~19MB | N/A | 500MB+ (Docker-based) |
+| Feature         | fakecloud        | AWS Cloud            | Gated Local Tools (2026)     |
+| :--------------- | :---------------- | :-------------------- | :---------------------------- |
+| **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
+| **Auth**        | None Required    | IAM / Credentials    | Mandatory Account/Token      |
+| **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
+| **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
+| **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
 
 ## Deterministic Testing for Non-Deterministic Models
 
 One of the greatest challenges in GenAI development is the non-deterministic nature of LLMs. When you run integration tests against the real Bedrock API, the model's response might change slightly between runs, leading to flaky tests. 
 
-fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. For a detailed walkthrough of this approach, check out our previous post on [how to test Bedrock code locally](/blog/bedrock-local-testing/).
+fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. 
 
 ### SDK-Client Separation
 
 In a fakecloud workflow, you distinguish between the **App Client** (the standard AWS SDK) and the **Test SDK** (the fakecloud-specific library). 
 
-1.  **The App Client** calls `InvokeModel` as it would in production.
-2.  **The Test SDK** configures fakecloud to return a specific JSON payload for that call.
+1. **The App Client** calls `InvokeModel` as it would in production.
+2. **The Test SDK** configures fakecloud to return a specific JSON payload for that call.
 
 This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application.
 
@@ -140,14 +140,11 @@ Stop paying for the privilege of debugging your code. Eliminate the latency of t
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
-```sh
+```bash
 # Download and run (Linux/macOS)
 curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
 chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
-
-- **Repo:** [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
-- **Site:** [fakecloud.dev](https://fakecloud.dev)
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at [fakecloud.dev](https://fakecloud.dev) or the [GitHub repository](https://github.com/faiscadev/fakecloud).

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Eliminate token costs and API latency by emulating AWS Bedrock locally with fakecloud. Prototyping GenAI applications without an AWS account, internet connection, or usage limits."
+description = "Learn how to use fakecloud to emulate AWS Bedrock locally, enabling cost-free GenAI prototyping with high-fidelity API support and zero internet dependency."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -25,7 +25,7 @@ As of May 2026, the cost of frontier model access on AWS Bedrock remains a prima
 
 While these models offer unprecedented reasoning capabilities, using them for basic integration testing or CI/CD pipelines is economically inefficient. Furthermore, the round-trip latency to a cloud region—often 200ms to 500ms before inference even begins—stalls the developer's momentum. 
 
-When you add the overhead of managing IAM roles, VPC endpoints, and service quotas just to test a single Lambda function's ability to call `InvokeModel`, the friction becomes a barrier to entry. 
+When you add the overhead of managing IAM roles, VPC endpoints, and service quotas just to test a single Lambda function's ability to call `InvokeModel`, the friction becomes a barrier to entry.
 
 ## Solution: `fakecloud start` with Bedrock Support
 
@@ -89,15 +89,13 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 ### Supported API Categories
 
-
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
 | **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
-| **Agents**           | `CreateAgent`, `InvokeAgent", `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
+| **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
-
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
@@ -113,15 +111,13 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 ### Comparison: fakecloud vs. The Alternatives
 
-
 | Feature         | fakecloud        | AWS Cloud            | Gated Local Tools (2026)     |
 | :--------------- | :---------------- | :-------------------- | :---------------------------- |
 | **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
 | **Auth**        | None Required    | IAM / Credentials    | Mandatory Account/Token      |
-| **Latency**     | &lt;10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
+| **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
 | **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
 | **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
-
 
 ## Deterministic Testing for Non-Deterministic Models
 
@@ -136,7 +132,7 @@ In a fakecloud workflow, you distinguish between the **App Client** (the standar
 1. **The App Client** calls `InvokeModel` as it would in production.
 2. **The Test SDK** configures fakecloud to return a specific JSON payload for that call.
 
-This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application.
+This separation ensures that your tests are fast, repeatable, and cost-free, while still exercising the full network stack and SDK logic of your application. Learn more in our guide on [Bedrock local testing](/blog/bedrock-local-testing/).
 
 ## Next Step: Run Bedrock Locally
 
@@ -151,4 +147,4 @@ chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the [official repository](https://github.com/faiscadev/fakecloud) or see how to configure [AI integration tests](/blog/aws-integration-tests-with-claude-code-cursor/).

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Discover how fakecloud enables high-fidelity, offline emulation of 111 AWS Bedrock operations to eliminate token costs and API latency during GenAI prototyping."
+description = "Master local GenAI development with fakecloud's AWS Bedrock emulation. Learn how to bypass cloud costs, eliminate API latency, and prototype agentic workflows without an internet connection or account registration."
 
 [extra]
 author = "Lucas Vieira"
@@ -33,7 +33,7 @@ fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface loca
 
 To start the environment with Bedrock support, you run a single command:
 
-```bash
+```sh
 # Start fakecloud with Bedrock and S3 enabled
 ./fakecloud start --services bedrock,s3
 ```
@@ -92,7 +92,7 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | Category | Key Operations Supported | Utility |
 | :--- | :--- | :--- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components. |
-| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail" | Validate safety filters and PII masking logic locally. |
+| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail", "GetGuardrail` | Validate safety filters and PII masking logic locally. |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase` | Prototype autonomous agents and tool-use loops. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate` | Emulate RAG workflows with local vector storage integration. |
 | **Provisioning** | `CreateProvisionedModelThroughput`, `GetFoundationModel` | Test infrastructure-as-code (IaC) scripts for model deployment. |
@@ -136,15 +136,20 @@ This separation ensures that your tests are fast, repeatable, and cost-free, whi
 
 ## Next Step: Run Bedrock Locally
 
-Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. [fakecloud](https://github.com/faiscadev/fakecloud) provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
+Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. fakecloud provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
-```bash
+```sh
 # Download and run (Linux/macOS)
 curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
 chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on [specific Bedrock operations](/blog/bedrock-local-testing/) or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+
+Further reading on local Bedrock:
+- [Bedrock Local Testing](/blog/bedrock-local-testing/)
+- [Bedrock Guardrails Local](/blog/bedrock-guardrails-local/)
+- [Bedrock Tests with Real LLMs](/blog/bedrock-tests-real-llm/)

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Discover how fakecloud enables local AWS Bedrock emulation, allowing you to prototype GenAI applications without token costs or internet dependencies."
+description = "Eliminate token costs and API latency by emulating AWS Bedrock locally with fakecloud. Prototyping GenAI applications without an AWS account, internet connection, or usage limits."
 
 [extra]
 author = "Lucas Vieira"
@@ -89,13 +89,15 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 ### Supported API Categories
 
+
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
-| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream", "Converse", "ConverseStream" | Test prompt engineering and streaming UI components.            |
+| **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
 | **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
-| **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
+| **Agents**           | `CreateAgent`, `InvokeAgent", `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
-| **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel"                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
+| **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
+
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
@@ -111,13 +113,15 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 ### Comparison: fakecloud vs. The Alternatives
 
+
 | Feature         | fakecloud        | AWS Cloud            | Gated Local Tools (2026)     |
 | :--------------- | :---------------- | :-------------------- | :---------------------------- |
 | **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
 | **Auth**        | None Required    | IAM / Credentials    | Mandatory Account/Token      |
-| **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
+| **Latency**     | &lt;10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
 | **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
 | **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
+
 
 ## Deterministic Testing for Non-Deterministic Models
 

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Discover how to prototype Generative AI applications using AWS Bedrock locally with fakecloud to eliminate token costs, latency, and cloud dependencies."
+description = "Learn how to use fakecloud to emulate AWS Bedrock locally, enabling high-fidelity GenAI prototyping without cloud costs, latency, or mandatory account registration."
 
 [extra]
 author = "Lucas Vieira"
@@ -29,7 +29,7 @@ When you add the overhead of managing IAM roles, VPC endpoints, and service quot
 
 ## Solution: `fakecloud start` with Bedrock Support
 
-[fakecloud](https://github.com/faiscadev/fakecloud) eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
+fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
 
 To start the environment with Bedrock support, you run a single command:
 
@@ -93,7 +93,7 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
-| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | [Validate safety filters](/blog/bedrock-guardrails-local/) and PII masking logic locally.          |
+| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
 | **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
@@ -103,7 +103,7 @@ By supporting 111 operations, fakecloud ensures that even advanced features—li
 
 ## Feature-by-Numbers: Why fakecloud Wins
 
-When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, [fakecloud](https://github.com/faiscadev/fakecloud) maintains a minimalist, high-performance footprint.
+When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, fakecloud maintains a minimalist, high-performance footprint.
 
 - **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
 - **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
@@ -118,7 +118,7 @@ When comparing development workflows, the metrics favor the standalone binary ap
 | :--------------- | :---------------- | :-------------------- | :---------------------------- |
 | **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
 | **Auth**        | None Required    | IAM / Credentials    | Mandatory Account/Token      |
-| **Latency**     | &lt;10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
+| **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
 | **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
 | **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
 
@@ -140,7 +140,7 @@ This separation ensures that your tests are fast, repeatable, and cost-free, whi
 
 ## Next Step: Run Bedrock Locally
 
-Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. [fakecloud](https://github.com/faiscadev/fakecloud) provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
+Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. fakecloud provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
@@ -151,4 +151,11 @@ chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For [detailed implementation guides on specific Bedrock operations](/blog/bedrock-local-testing/) or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+
+## Related Posts
+
+- [Local Bedrock testing guide](/blog/bedrock-local-testing/)
+- [Testing Bedrock Guardrails locally](/blog/bedrock-guardrails-local/)
+- [Running Bedrock tests with real LLMs](/blog/bedrock-tests-real-llm/)
+- [CDK local testing with fakecloud](/blog/cdk-local-testing/)

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Master local GenAI development with fakecloud's AWS Bedrock emulation. Learn how to bypass cloud costs, eliminate API latency, and prototype agentic workflows without an internet connection or account registration."
+description = "Prototyping GenAI workflows is expensive and slow. fakecloud provides 111 AWS Bedrock operations locally with zero costs, no auth tokens, and 100% offline support."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -92,7 +92,7 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | Category | Key Operations Supported | Utility |
 | :--- | :--- | :--- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components. |
-| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail", "GetGuardrail` | Validate safety filters and PII masking logic locally. |
+| **Guardrails** | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail` | Validate safety filters and PII masking logic locally. |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase` | Prototype autonomous agents and tool-use loops. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate` | Emulate RAG workflows with local vector storage integration. |
 | **Provisioning** | `CreateProvisionedModelThroughput`, `GetFoundationModel` | Test infrastructure-as-code (IaC) scripts for model deployment. |
@@ -123,7 +123,7 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 One of the greatest challenges in GenAI development is the non-deterministic nature of LLMs. When you run integration tests against the real Bedrock API, the model's response might change slightly between runs, leading to flaky tests. 
 
-fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. 
+fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. For a detailed walkthrough of this approach, check out our previous post on [how to test Bedrock code locally](/blog/bedrock-local-testing/).
 
 ### SDK-Client Separation
 
@@ -149,7 +149,5 @@ chmod +x fakecloud
 
 For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
 
-Further reading on local Bedrock:
-- [Bedrock Local Testing](/blog/bedrock-local-testing/)
-- [Bedrock Guardrails Local](/blog/bedrock-guardrails-local/)
-- [Bedrock Tests with Real LLMs](/blog/bedrock-tests-real-llm/)
+- **Repo:** [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud)
+- **Site:** [fakecloud.dev](https://fakecloud.dev)

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Learn how to use fakecloud to emulate AWS Bedrock locally, enabling high-fidelity GenAI prototyping without cloud costs, latency, or mandatory account registration."
+description = "Develop and test Generative AI applications locally with fakecloud. Emulate 111 AWS Bedrock operations to eliminate token costs and API latency."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -33,7 +33,7 @@ fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface loca
 
 To start the environment with Bedrock support, you run a single command:
 
-```bash
+```sh
 # Start fakecloud with Bedrock and S3 enabled
 ./fakecloud start --services bedrock,s3
 ```
@@ -89,7 +89,6 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 ### Supported API Categories
 
-
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
@@ -97,7 +96,6 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
-
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
@@ -113,7 +111,6 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 ### Comparison: fakecloud vs. The Alternatives
 
-
 | Feature         | fakecloud        | AWS Cloud            | Gated Local Tools (2026)     |
 | :--------------- | :---------------- | :-------------------- | :---------------------------- |
 | **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
@@ -121,7 +118,6 @@ When comparing development workflows, the metrics favor the standalone binary ap
 | **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
 | **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
 | **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
-
 
 ## Deterministic Testing for Non-Deterministic Models
 
@@ -144,18 +140,11 @@ Stop paying for the privilege of debugging your code. Eliminate the latency of t
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
-```bash
+```sh
 # Download and run (Linux/macOS)
 curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
 chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
-
-## Related Posts
-
-- [Local Bedrock testing guide](/blog/bedrock-local-testing/)
-- [Testing Bedrock Guardrails locally](/blog/bedrock-guardrails-local/)
-- [Running Bedrock tests with real LLMs](/blog/bedrock-tests-real-llm/)
-- [CDK local testing with fakecloud](/blog/cdk-local-testing/)
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at [fakecloud.dev](https://github.com/faiscadev/fakecloud).

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Eliminate cloud costs and latency by emulating AWS Bedrock locally with fakecloud for high-fidelity GenAI prototyping."
+description = "Discover how to prototype Generative AI applications using AWS Bedrock locally with fakecloud to eliminate token costs, latency, and cloud dependencies."
 
 [extra]
 author = "Lucas Vieira"
@@ -29,7 +29,7 @@ When you add the overhead of managing IAM roles, VPC endpoints, and service quot
 
 ## Solution: `fakecloud start` with Bedrock Support
 
-fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
+[fakecloud](https://github.com/faiscadev/fakecloud) eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
 
 To start the environment with Bedrock support, you run a single command:
 
@@ -89,19 +89,21 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 
 ### Supported API Categories
 
+
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
-| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
+| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | [Validate safety filters](/blog/bedrock-guardrails-local/) and PII masking logic locally.          |
 | **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
+
 
 By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
 ## Feature-by-Numbers: Why fakecloud Wins
 
-When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, fakecloud maintains a minimalist, high-performance footprint.
+When comparing development workflows, the metrics favor the standalone binary approach. In an era where "local" tools are becoming increasingly bloated, [fakecloud](https://github.com/faiscadev/fakecloud) maintains a minimalist, high-performance footprint.
 
 - **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
 - **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
@@ -111,13 +113,15 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 ### Comparison: fakecloud vs. The Alternatives
 
+
 | Feature         | fakecloud        | AWS Cloud            | Gated Local Tools (2026)     |
 | :--------------- | :---------------- | :-------------------- | :---------------------------- |
 | **Cost**        | $0 (Local)       | Per-token / Per-hour | Subscription + Token Tax     |
 | **Auth**        | None Required    | IAM / Credentials    | Mandatory Account/Token      |
-| **Latency**     | <10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
+| **Latency**     | &lt;10ms (Local) | 200ms - 500ms+       | 50ms - 100ms (Auth check)    |
 | **Offline**     | Yes              | No                   | No (Requires Auth Heartbeat) |
 | **Binary Size** | ~19MB            | N/A                  | 500MB+ (Docker-based)        |
+
 
 ## Deterministic Testing for Non-Deterministic Models
 
@@ -147,4 +151,4 @@ chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.
+For [detailed implementation guides on specific Bedrock operations](/blog/bedrock-local-testing/) or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Develop and test Generative AI applications locally with fakecloud. Emulate 111 AWS Bedrock operations to eliminate token costs and API latency."
+description = "Eliminate AWS costs and API latency by prototyping GenAI applications locally. fakecloud provides 111 high-fidelity Bedrock operations in a standalone binary, requiring no account, tokens, or internet."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-fakecloud provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -29,11 +29,11 @@ When you add the overhead of managing IAM roles, VPC endpoints, and service quot
 
 ## Solution: `fakecloud start` with Bedrock Support
 
-fakecloud eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
+[fakecloud](https://github.com/faiscadev/fakecloud) eliminates these hurdles by emulating the AWS Bedrock API surface locally. It is delivered as a single ~19MB binary that starts in approximately 500ms. Because it is a local implementation of the AWS API, your application code does not need to change; you simply point your SDK to the local endpoint.
 
 To start the environment with Bedrock support, you run a single command:
 
-```sh
+```bash
 # Start fakecloud with Bedrock and S3 enabled
 ./fakecloud start --services bedrock,s3
 ```
@@ -92,7 +92,7 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | Category             | Key Operations Supported                                                     | Utility                                                         |
 | :-------------------- | :---------------------------------------------------------------------------- | :--------------------------------------------------------------- |
 | **Model Invocation** | `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` | Test prompt engineering and streaming UI components.            |
-| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and PII masking logic locally.          |
+| **Guardrails**       | `CreateGuardrail`, `ApplyGuardrail`, `GetGuardrail`                          | Validate safety filters and [PII masking logic locally](/blog/bedrock-guardrails-local/).          |
 | **Agents**           | `CreateAgent`, `InvokeAgent`, `AssociateAgentKnowledgeBase`                  | Prototype autonomous agents and tool-use loops.                 |
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
@@ -123,7 +123,7 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 One of the greatest challenges in GenAI development is the non-deterministic nature of LLMs. When you run integration tests against the real Bedrock API, the model's response might change slightly between runs, leading to flaky tests. 
 
-fakecloud allows you to inject deterministic responses into your local Bedrock environment. By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. 
+fakecloud allows you to inject deterministic responses into your [local Bedrock environment](/blog/bedrock-local-testing/). By using the fakecloud SDK in your test code, you can assert that your application handles specific model outputs correctly without actually performing inference. 
 
 ### SDK-Client Separation
 
@@ -136,15 +136,15 @@ This separation ensures that your tests are fast, repeatable, and cost-free, whi
 
 ## Next Step: Run Bedrock Locally
 
-Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. fakecloud provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
+Stop paying for the privilege of debugging your code. Eliminate the latency of the cloud and the friction of account-gated tools. [fakecloud](https://github.com/faiscadev/fakecloud) provides the high-fidelity environment you need to build, test, and ship GenAI applications with confidence.
 
 To get started, download the binary for your platform and run the start command. No sign-up is required.
 
-```sh
+```bash
 # Download and run (Linux/macOS)
 curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
 chmod +x fakecloud
 ./fakecloud start --services bedrock
 ```
 
-For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at [fakecloud.dev](https://github.com/faiscadev/fakecloud).
+For detailed implementation guides on specific Bedrock operations or to explore the first-party SDKs for assertions in 6+ programming languages, visit the official documentation at fakecloud.dev.

--- a/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
+++ b/website/content/blog/local-aws-bedrock-prototyping-genai-without-cloud-costs.md
@@ -1,7 +1,7 @@
 +++
 title = "Local AWS Bedrock: Prototyping GenAI Without Cloud Costs"
 date = 2026-05-17
-description = "Eliminate AWS costs and API latency by prototyping GenAI applications locally. fakecloud provides 111 high-fidelity Bedrock operations in a standalone binary, requiring no account, tokens, or internet."
+description = "Eliminate AWS costs and API latency by prototyping GenAI applications locally. fakecloud provides 214 high-fidelity Bedrock operations across 4 APIs in a standalone binary, requiring no account, tokens, or internet."
 
 [extra]
 author = "Lucas Vieira"
@@ -11,7 +11,7 @@ Generative AI development in 2026 has reached a point of extreme financial and o
 
 Beyond the direct costs, the developer experience is hampered by API latency, rate limits, and the increasing complexity of cloud-based authentication. Even local emulation tools, which once promised a friction-free alternative, have largely pivoted to account-based models. As of March 2026, major incumbents in the local AWS emulation space now require mandatory account registration and active internet connections for authentication tokens, effectively turning your local environment into a gated extension of the cloud.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 111 AWS Bedrock operations locally, requiring no account, no auth token, and no internet connection.
+[fakecloud](https://github.com/faiscadev/fakecloud) provides the alternative: a high-fidelity, zero-friction local AWS environment that behaves like infrastructure, not a mock. It is a standalone binary that gives you 214 AWS Bedrock operations across 4 APIs locally, requiring no account, no auth token, and no internet connection.
 
 ## The Dev Hurdle: Token Costs and API Latency
 
@@ -38,7 +38,7 @@ To start the environment with Bedrock support, you run a single command:
 ./fakecloud start --services bedrock,s3
 ```
 
-Once running, fakecloud listens on `localhost:4566`. It provides a 100% API-conformant environment across 2,422 operations, including 111 specific to Bedrock. This is not a simple mock that returns static strings; it is a functional emulation backed by over 59,000 Smithy-model-generated test variants to ensure the behavior matches the real AWS environment.
+Once running, fakecloud listens on `localhost:4566`. It provides a 100% API-conformant environment across 2,592 operations, including 214 across the Bedrock surface (4 APIs). This is not a simple mock that returns static strings; it is a functional emulation backed by 86,327 Smithy-model-generated test variants to ensure the behavior matches the real AWS environment.
 
 ### The "No" List
 
@@ -83,7 +83,7 @@ print(response['output']['message']['content'][0]['text'])
 
 In this workflow, your application logic remains pure. You are testing the integration, the error handling, and the response parsing without spending a single cent on tokens.
 
-## Evidence: 111 Supported Bedrock Operations
+## Evidence: 214 Supported Bedrock Operations Across 4 APIs
 
 fakecloud's Bedrock support is comprehensive, covering the data plane, control plane, and agentic features. This allows AI engineers to prototype complex RAG (Retrieval-Augmented Generation) pipelines and multi-agent systems locally.
 
@@ -97,7 +97,7 @@ fakecloud's Bedrock support is comprehensive, covering the data plane, control p
 | **Knowledge Bases**  | `CreateKnowledgeBase`, `Retrieve`, `RetrieveAndGenerate`                     | Emulate RAG workflows with local vector storage integration.    |
 | **Provisioning**     | `CreateProvisionedModelThroughput`, `GetFoundationModel`                     | Test infrastructure-as-code (IaC) scripts for model deployment. |
 
-By supporting 111 operations, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
+By supporting 214 operations across 4 APIs, fakecloud ensures that even advanced features—like the `InvokeModelWithBidirectionalStream` introduced in late 2025—are available for local testing. This level of conformance is achieved through rigorous testing against the official AWS Smithy models, ensuring that the local environment doesn't just "look" like AWS, but "acts" like it.
 
 ## Feature-by-Numbers: Why fakecloud Wins
 
@@ -105,8 +105,8 @@ When comparing development workflows, the metrics favor the standalone binary ap
 
 - **19MB Binary:** The entire environment is contained in a single file. No Docker daemon is required, though a Docker image is available for those who prefer it.
 - **500ms Startup:** You can start and stop the environment as part of a test suite without adding significant overhead to your CI/CD pipeline.
-- **33+ AWS Services:** Beyond Bedrock, you get S3, Lambda, DynamoDB, SNS, SQS, and more, allowing for full cross-service integration testing (e.g., an S3 upload triggering a Lambda that calls Bedrock).
-- **2,422 Operations:** Total API coverage across all supported services, ensuring that your `boto3` or `aws-sdk-js` calls don't fail due to missing methods.
+- **39 AWS services:** Beyond Bedrock, you get S3, Lambda, DynamoDB, SNS, SQS, and more, allowing for full cross-service integration testing (e.g., an S3 upload triggering a Lambda that calls Bedrock).
+- **2,592 Operations:** Total API coverage across all supported services, ensuring that your `boto3` or `aws-sdk-js` calls don't fail due to missing methods.
 - **AGPL-3.0 License:** Open-source for local development, ensuring that the tool remains accessible to the community without sudden licensing shifts.
 
 ### Comparison: fakecloud vs. The Alternatives


### PR DESCRIPTION
This PR adds a new blog post discussing how to use fakecloud to emulate AWS Bedrock locally. This approach helps developers save on frontier model token costs and reduce API latency during the iterative prototyping phase of GenAI development. The post covers supported operations, SDK configuration, and the benefits of zero-auth local emulation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post on emulating AWS Bedrock locally with `fakecloud` to prototype GenAI without token costs, latency, auth, or internet. Covers setup, a `boto3` `Converse` example, deterministic tests, and a quick download/run snippet.

- New Features
  - New post: “Local AWS Bedrock: Prototyping GenAI Without Cloud Costs”; includes pricing/latency context and a brief comparison vs cloud and gated local tools.
  - Setup: start `fakecloud` with Bedrock (+S3), point SDKs to `http://localhost:4566`, and call `bedrock-runtime` via `boto3` `Converse`; includes a curl install/run command.
  - Coverage/specs: 214 Bedrock ops across 4 APIs (incl. streaming, agents, guardrails, knowledge bases); deterministic test SDK with injectable responses and clear app/test client separation; 2,592 ops across 39 services; ~19MB binary, ~500ms startup, <10ms local latency; AGPL-3.0; no account/auth/internet/quotas.

<sup>Written for commit 0507fb70d82561748fcad817cee9b82e3e10bed0. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1428?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

