### PR TITLE
[Olwen] Blog: Local Generative AI: Implementing Bedrock with fakecloud

### DIFF
--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,19 +1,19 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to use fakecloud to implement and test 111 AWS Bedrock operations locally, eliminating latency and reducing costs for generative AI development loops."
+description = "Learn how to optimize your Generative AI development loop by running AWS Bedrock locally with fakecloud, supporting 111 operations with zero latency."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity.
+Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
 Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial.
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex [Guardrail configurations](/blog/bedrock-guardrails-local/), the overhead is not just financial. 
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -56,7 +56,7 @@ To use fakecloud, you do not need to change your application logic. You only cha
 
 Run the standalone binary. It occupies ~19MB of disk space and starts in roughly 500ms.
 
-```sh
+```bash
 # Download and run
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
@@ -93,7 +93,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 ## Verifying Outputs: Using the fakecloud SDK
 
-Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**.
+Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
 
 While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline.
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -137,7 +137,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
-```sh
+```bash
 # Create a guardrail via CLI
 aws --endpoint-url http://localhost:4566 bedrock create-guardrail \
     --name "PII-Filter" \
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
-fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop.
+fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
 To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Generative AI development on AWS Bedrock is governed by the cost of the feedback loop. fakecloud eliminates this friction by providing a high-fidelity local AWS environment."
+description = "Implement and test 111 AWS Bedrock operations locally with fakecloud. High-fidelity emulation of Agents, Knowledge Bases, and Guardrails with zero cost and deterministic responses."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,11 +9,11 @@ author = "Lucas Vieira"
 
 Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms (see our guide on [local Bedrock testing](/blog/bedrock-local-testing/)).
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex [Guardrail configurations](/blog/bedrock-guardrails-local/), the overhead is not just financial. 
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -23,7 +23,7 @@ fakecloud operates on a different philosophy. It requires no account, no auth to
 
 ## Bedrock Locally: Support for 111 Operations
 
-fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape, similar to the approach discussed in our post on [local Bedrock testing](/blog/bedrock-local-testing/). This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
+fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape. This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
 
 ### Data Plane: Runtime Operations
 
@@ -32,7 +32,7 @@ The runtime operations are where your application spends most of its time. fakec
 *   **InvokeModel**: Standard synchronous inference.
 *   **InvokeModelWithResponseStream**: Server-Sent Events (SSE) for streaming responses.
 *   **Converse / ConverseStream**: The unified conversation API for multi-turn dialogues.
-*   **ApplyGuardrail**: Real-time content filtering and PII detection logic.
+*   **ApplyGuardrail**: Real-time content filtering and [PII detection logic](/blog/bedrock-guardrails-local/).
 
 Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses. You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
 
@@ -95,7 +95,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
 
-While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
+While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
 ```python
 from fakecloud_sdk import FakeCloudClient
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"&mdash;the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -133,7 +133,7 @@ For Bedrock specifically, this means that when you call `ConverseStream`, the ch
 
 As of 2026, AI applications are moving beyond simple chat interfaces into complex agentic workflows. fakecloud supports these advanced scenarios out of the box.
 
-### Local Guardrail Testing
+### Local [Guardrail Testing](/blog/bedrock-guardrails-local/)
 
 You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock).

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to optimize your Generative AI development loop by running AWS Bedrock locally with fakecloud, supporting 111 operations with zero latency."
+description = "Testing generative AI on live infrastructure is inefficient. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment for Bedrock."
 
 [extra]
 author = "Lucas Vieira"
@@ -13,7 +13,7 @@ Testing generative AI on live infrastructure is inefficient. It introduces netwo
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex [Guardrail configurations](/blog/bedrock-guardrails-local/), the overhead is not just financial. 
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a [Guardrail locally](/blog/bedrock-guardrails-local/) to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
 ```bash
 # Create a guardrail via CLI
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock).

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,0 +1,185 @@
++++
+title = "Local Generative AI: Implementing Bedrock with fakecloud"
+date = 2026-05-17
+description = "Reduce costs and eliminate network dependencies by implementing 111 AWS Bedrock operations locally with fakecloud's zero-friction emulator."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
+
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+
+## The Cost of Iteration: Why Live Infrastructure Fails Developers
+
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
+
+1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
+2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
+3.  **Auth Friction**: As of March 2026, the primary incumbent in the local AWS emulation space consolidated its offerings into a proprietary image requiring an account and an auth token. This forces developers to manage credentials even for local-only work.
+
+fakecloud operates on a different philosophy. It requires no account, no auth token, and no internet connection. You run the binary, point your SDK at the local endpoint, and execute your logic against a 100% API-conformant environment.
+
+## Bedrock Locally: Support for 111 Operations
+
+fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape. This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
+
+### Data Plane: Runtime Operations
+
+The runtime operations are where your application spends most of its time. fakecloud supports the full suite of invocation methods:
+
+*   **InvokeModel**: Standard synchronous inference.
+*   **InvokeModelWithResponseStream**: Server-Sent Events (SSE) for streaming responses.
+*   **Converse / ConverseStream**: The unified conversation API for multi-turn dialogues.
+*   **ApplyGuardrail**: Real-time content filtering and PII detection logic.
+
+Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses. You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
+
+### Control Plane: Infrastructure Management
+
+Building AI applications often involves more than just calling an LLM. You need to manage the surrounding infrastructure. fakecloud supports 111 operations, including:
+
+| Category | Operations Supported | Key Features |
+| :--- | :--- | :--- |
+| **Agents** | `CreateAgent`, `InvokeAgent`, `CreateAgentAlias` | Full agentic loop emulation with action group triggers. |
+| **Knowledge Bases** | `CreateKnowledgeBase`, `IngestContent`, `Retrieve` | Local RAG workflows using integrated vector storage. |
+| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails` | Policy-based content filtering and sensitive information masking. |
+| **Provisioned Throughput** | `CreateProvisionedModelThroughput` | Testing code that relies on dedicated capacity identifiers. |
+| **Custom Models** | `CreateModelImportJob`, `ListCustomModels` | Simulating the lifecycle of fine-tuned or imported weights. |
+
+## Coding the Mock: Python Implementation
+
+To use fakecloud, you do not need to change your application logic. You only change the configuration of your AWS client. In Python, using `boto3`, you direct the `endpoint_url` to your local fakecloud instance (defaulting to port 4566).
+
+### Step 1: Start fakecloud
+
+Run the standalone binary. It occupies ~19MB of disk space and starts in roughly 500ms.
+
+```sh
+# Download and run
+curl -fsSL https://fakecloud.dev/install.sh | bash
+fakecloud
+```
+
+### Step 2: Configure the Client
+
+Your application code remains clean. You inject the endpoint URL via environment variables or direct client configuration.
+
+```python
+import boto3
+import os
+
+# Use dummy credentials - fakecloud doesn't validate them
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+# Point the client at fakecloud
+bedrock_runtime = boto3.client(
+    service_name="bedrock-runtime",
+    endpoint_url="http://localhost:4566"
+)
+
+def generate_response(prompt):
+    response = bedrock_runtime.invoke_model(
+        modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+        body=f'{{"prompt": "{prompt}", "max_tokens": 100}}'
+    )
+    return response['body'].read()
+```
+
+This code is identical to what you would run in production, minus the `endpoint_url`. By keeping the SDK usage standard, you ensure that your integration tests are actually testing the code you ship, not a simplified mock object.
+
+## Verifying Outputs: Using the fakecloud SDK
+
+Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
+
+While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
+
+```python
+from fakecloud_sdk import FakeCloudClient
+
+# The test client connects to fakecloud's internal management API
+fc = FakeCloudClient("http://localhost:4566")
+
+def test_ai_logic():
+    # 1. Run the application logic
+    generate_response("Explain quantum physics to a cat.")
+
+    # 2. Assert on the invocation using the fakecloud SDK
+    invocations = fc.bedrock.list_invocations()
+    
+    assert len(invocations) == 1
+    assert "quantum physics" in invocations[0].request_body['prompt']
+    assert invocations[0].model_id == "anthropic.claude-3-sonnet-20240229-v1:0"
+```
+
+This approach eliminates the need for complex monkey-patching or manual mocking of the `boto3` client. You are asserting against the actual state of the local infrastructure.
+
+## Reliability Through Conformance
+
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. [fakecloud](https://github.com/faiscadev/fakecloud) mitigates this through a rigorous conformance pipeline. 
+
+Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
+
+*   **Field Presence**: Ensuring that optional fields are handled correctly and required fields trigger the appropriate 400-series errors when missing.
+*   **Boundary Values**: Testing the limits of string lengths, integer ranges, and collection sizes as defined by the AWS specification.
+*   **Error Shapes**: Verifying that the JSON structure of error responses (e.g., `ThrottlingException`, `ValidationException`) matches the official SDK expectations.
+
+For Bedrock specifically, this means that when you call `ConverseStream`, the chunks returned by fakecloud follow the exact binary framing and JSON structure required by the AWS SDK's event stream parser. If your code works against fakecloud, it will work against the real Bedrock endpoint.
+
+## Advanced Scenarios: Guardrails and Agents
+
+As of 2026, AI applications are moving beyond simple chat interfaces into complex agentic workflows. fakecloud supports these advanced scenarios out of the box.
+
+### Local Guardrail Testing
+
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics. For more details on this specific workflow, see our post on [Bedrock Guardrails locally](/blog/bedrock-guardrails-local/).
+
+```sh
+# Create a guardrail via CLI
+aws --endpoint-url http://localhost:4566 bedrock create-guardrail \
+    --name "PII-Filter" \
+    --sensitive-information-policy-config '{"piiEntitiesConfig": [{"type": "EMAIL", "action": "BLOCK"}]}'
+```
+
+When your application calls `InvokeModel` with a prompt containing an email address, fakecloud will return a `GuardrailAction: BLOCK` response, allowing you to test your UI's "Content Blocked" state without ever touching a live model.
+
+### Agentic Loops
+
+fakecloud's support for `InvokeAgent` includes the ability to trigger local Lambda functions as action groups. This allows for full end-to-end testing of the agentic loop:
+
+1.  **App** calls `InvokeAgent` on fakecloud.
+2.  **fakecloud** parses the request and identifies the required Action Group.
+3.  **fakecloud** triggers a local **Lambda** (running in a local Docker container).
+4.  **Lambda** returns data to fakecloud.
+5.  **fakecloud** formats the final response for the **App**.
+
+This entire flow happens locally, with zero latency from the public internet and zero cost from AWS.
+
+## Comparison: fakecloud vs. Alternatives
+
+| Feature | fakecloud | LocalStack (2026) | Live AWS |
+| :--- | :--- | :--- | :--- |
+| **Binary Size** | ~19MB | ~1.2GB (Docker Image) | N/A |
+| **Startup Time** | ~500ms | ~15-30s | N/A |
+| **Account Required** | No | Yes (as of March 2026) | Yes |
+| **Auth Token** | No | Yes | Yes |
+| **Bedrock Ops** | 111 | 4 (Ultimate Tier) | All |
+| **Cost** | Free (AGPL-3.0) | Paid Subscription | Pay-per-token |
+| **Offline Mode** | Yes | Limited | No |
+
+## Implementation Strategy for Teams
+
+To maximize the utility of fakecloud in your organization, follow these three steps:
+
+1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
+2.  **CI Integration**: Add [fakecloud](https://github.com/faiscadev/fakecloud) to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
+3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+
+## Next Steps
+
+fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
+
+To begin implementing local Bedrock workflows, view our guide on [Bedrock local testing](/blog/bedrock-local-testing/) or browse the detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,19 +1,19 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Discover how fakecloud enables high-fidelity local emulation of 111 AWS Bedrock operations, allowing developers to test GenAI workflows without AWS costs or latency."
+description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to reduce costs, eliminate network latency, and ensure deterministic AI application testing."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
+Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity.
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial.
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -56,7 +56,7 @@ To use fakecloud, you do not need to change your application logic. You only cha
 
 Run the standalone binary. It occupies ~19MB of disk space and starts in roughly 500ms.
 
-```bash
+```sh
 # Download and run
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
@@ -93,7 +93,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 ## Verifying Outputs: Using the fakecloud SDK
 
-Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
+Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**.
 
 While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline.
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -135,9 +135,9 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a [Guardrail](/blog/bedrock-guardrails-local/) locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
-```bash
+```sh
 # Create a guardrail via CLI
 aws --endpoint-url http://localhost:4566 bedrock create-guardrail \
     --name "PII-Filter" \
@@ -160,7 +160,7 @@ This entire flow happens locally, with zero latency from the public internet and
 
 ## Comparison: fakecloud vs. Alternatives
 
-| Feature | fakecloud | [LocalStack Alternatives](/blog/localstack-alternative/) | Live AWS |
+| Feature | fakecloud | LocalStack (2026) | Live AWS |
 | :--- | :--- | :--- | :--- |
 | **Binary Size** | ~19MB | ~1.2GB (Docker Image) | N/A |
 | **Startup Time** | ~500ms | ~15-30s | N/A |
@@ -180,6 +180,6 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 ## Next Steps
 
-fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
+fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop.
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud).

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,19 +1,19 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Generative AI development on AWS Bedrock is governed by the cost of the feedback loop. fakecloud eliminates this friction by providing a high-fidelity local AWS environment for testing 111 Bedrock operations."
+description = "Learn how to use fakecloud to implement and test 111 AWS Bedrock operations locally, eliminating latency and reducing costs for generative AI development loops."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
+Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity.
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial.
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -34,7 +34,7 @@ The runtime operations are where your application spends most of its time. fakec
 *   **Converse / ConverseStream**: The unified conversation API for multi-turn dialogues.
 *   **ApplyGuardrail**: Real-time content filtering and PII detection logic.
 
-Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses (see our guide on [Bedrock local testing](/blog/bedrock-local-testing/)). You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
+Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses. You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
 
 ### Control Plane: Infrastructure Management
 
@@ -93,7 +93,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 ## Verifying Outputs: Using the fakecloud SDK
 
-Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
+Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**.
 
 While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline.
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics (see more on [local guardrail testing](/blog/bedrock-guardrails-local/)).
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
 ```sh
 # Create a guardrail via CLI
@@ -180,6 +180,6 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 ## Next Steps
 
-fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
+fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop.
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock). Check out the repository at [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud).
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to eliminate costs and reduce latency."
+description = "Generative AI development on AWS Bedrock is governed by the cost of the feedback loop. fakecloud eliminates this friction by providing a high-fidelity local AWS environment."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
@@ -23,7 +23,7 @@ fakecloud operates on a different philosophy. It requires no account, no auth to
 
 ## Bedrock Locally: Support for 111 Operations
 
-fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape. This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
+fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape, similar to the approach discussed in our post on [local Bedrock testing](/blog/bedrock-local-testing/). This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
 
 ### Data Plane: Runtime Operations
 
@@ -44,7 +44,7 @@ Building AI applications often involves more than just calling an LLM. You need 
 | :--- | :--- | :--- |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `CreateAgentAlias` | Full agentic loop emulation with action group triggers. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `IngestContent`, `Retrieve` | Local RAG workflows using integrated vector storage. |
-| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails" | Policy-based content filtering and sensitive information masking. |
+| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails` | Policy-based content filtering and sensitive information masking. |
 | **Provisioned Throughput** | `CreateProvisionedModelThroughput` | Testing code that relies on dedicated capacity identifiers. |
 | **Custom Models** | `CreateModelImportJob`, `ListCustomModels` | Simulating the lifecycle of fine-tuned or imported weights. |
 
@@ -95,7 +95,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
 
-While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
+While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
 ```python
 from fakecloud_sdk import FakeCloudClient
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
+One of the primary risks of using a local emulator is "drift"&mdash;the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the [fakecloud-sdk](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation. You can also read about [Bedrock guardrails local](/blog/bedrock-guardrails-local/) for more specific use cases.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Implement and test 111 AWS Bedrock operations locally with fakecloud. High-fidelity emulation of Agents, Knowledge Bases, and Guardrails with zero cost and deterministic responses."
+description = "Learn how to use fakecloud to implement and test 111 AWS Bedrock operations locally, reducing costs and increasing development velocity with a high-fidelity emulator."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,11 +9,11 @@ author = "Lucas Vieira"
 
 Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms (see our guide on [local Bedrock testing](/blog/bedrock-local-testing/)).
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to [test 111 Bedrock operations locally](/blog/bedrock-local-testing/) with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex [Guardrail configurations](/blog/bedrock-guardrails-local/), the overhead is not just financial. 
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -32,7 +32,7 @@ The runtime operations are where your application spends most of its time. fakec
 *   **InvokeModel**: Standard synchronous inference.
 *   **InvokeModelWithResponseStream**: Server-Sent Events (SSE) for streaming responses.
 *   **Converse / ConverseStream**: The unified conversation API for multi-turn dialogues.
-*   **ApplyGuardrail**: Real-time content filtering and [PII detection logic](/blog/bedrock-guardrails-local/).
+*   **ApplyGuardrail**: Real-time content filtering and PII detection logic.
 
 Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses. You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
 
@@ -56,7 +56,7 @@ To use fakecloud, you do not need to change your application logic. You only cha
 
 Run the standalone binary. It occupies ~19MB of disk space and starts in roughly 500ms.
 
-```sh
+```bash
 # Download and run
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
@@ -133,11 +133,11 @@ For Bedrock specifically, this means that when you call `ConverseStream`, the ch
 
 As of 2026, AI applications are moving beyond simple chat interfaces into complex agentic workflows. fakecloud supports these advanced scenarios out of the box.
 
-### Local [Guardrail Testing](/blog/bedrock-guardrails-local/)
+### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's [Guardrail implementation](/blog/bedrock-guardrails-local/) actually evaluates the input against the configured sensitive information filters and denied topics.
 
-```sh
+```bash
 # Create a guardrail via CLI
 aws --endpoint-url http://localhost:4566 bedrock create-guardrail \
     --name "PII-Filter" \
@@ -182,4 +182,4 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock).
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to use fakecloud to implement and test 111 AWS Bedrock operations locally, reducing costs and increasing development velocity with a high-fidelity emulator."
+description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to reduce costs and latency while maintaining full API conformance."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to [test 111 Bedrock operations locally](/blog/bedrock-local-testing/) with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
@@ -44,7 +44,7 @@ Building AI applications often involves more than just calling an LLM. You need 
 | :--- | :--- | :--- |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `CreateAgentAlias` | Full agentic loop emulation with action group triggers. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `IngestContent`, `Retrieve` | Local RAG workflows using integrated vector storage. |
-| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails` | Policy-based content filtering and sensitive information masking. |
+| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails"` | Policy-based content filtering and sensitive information masking. |
 | **Provisioned Throughput** | `CreateProvisionedModelThroughput` | Testing code that relies on dedicated capacity identifiers. |
 | **Custom Models** | `CreateModelImportJob`, `ListCustomModels` | Simulating the lifecycle of fine-tuned or imported weights. |
 
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's [Guardrail implementation](/blog/bedrock-guardrails-local/) actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
 ```bash
 # Create a guardrail via CLI
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the [fakecloud SDK](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock).

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
-Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
+Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. [fakecloud](https://github.com/faiscadev/fakecloud) eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 214 Bedrock operations across 4 APIs locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
@@ -21,7 +21,7 @@ In a modern CI/CD pipeline, a single feature branch might undergo fifty test run
 
 fakecloud operates on a different philosophy. It requires no account, no auth token, and no internet connection. You run the binary, point your SDK at the local endpoint, and execute your logic against a 100% API-conformant environment.
 
-## Bedrock Locally: Support for 111 Operations
+## Bedrock Locally: Support for 214 Operations Across 4 APIs
 
 fakecloud provides comprehensive coverage for the Bedrock API surface, spanning both the control plane (management) and the data plane (runtime). While other emulators might only support basic model invocation via a proxy to Ollama, fakecloud implements the full Smithy-modeled API shape. This ensures that your code, which uses the official AWS SDK, behaves exactly as it would in production.
 
@@ -38,7 +38,7 @@ Because fakecloud is built for testing, it doesn't just proxy these calls. It al
 
 ### Control Plane: Infrastructure Management
 
-Building AI applications often involves more than just calling an LLM. You need to manage the surrounding infrastructure. fakecloud supports 111 operations, including:
+Building AI applications often involves more than just calling an LLM. You need to manage the surrounding infrastructure. fakecloud supports 214 operations across 4 APIs, including:
 
 | Category | Operations Supported | Key Features |
 | :--- | :--- | :--- |
@@ -121,7 +121,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
-Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
+Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 86,327 generated test variants. These variants cover:
 
 *   **Field Presence**: Ensuring that optional fields are handled correctly and required fields trigger the appropriate 400-series errors when missing.
 *   **Boundary Values**: Testing the limits of string lengths, integer ranges, and collection sizes as defined by the AWS specification.
@@ -166,7 +166,7 @@ This entire flow happens locally, with zero latency from the public internet and
 | **Startup Time** | ~500ms | ~15-30s | N/A |
 | **Account Required** | No | Yes (as of March 2026) | Yes |
 | **Auth Token** | No | Yes | Yes |
-| **Bedrock Ops** | 111 | 4 (Ultimate Tier) | All |
+| **Bedrock Ops** | 214 (4 APIs) | 4 (Ultimate Tier) | All |
 | **Cost** | Free (AGPL-3.0) | Paid Subscription | Pay-per-token |
 | **Offline Mode** | Yes | Limited | No |
 

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Reduce costs and eliminate network dependencies by implementing 111 AWS Bedrock operations locally with fakecloud's zero-friction emulator."
+description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to eliminate costs and reduce latency."
 
 [extra]
 author = "Lucas Vieira"
@@ -44,7 +44,7 @@ Building AI applications often involves more than just calling an LLM. You need 
 | :--- | :--- | :--- |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `CreateAgentAlias` | Full agentic loop emulation with action group triggers. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `IngestContent`, `Retrieve` | Local RAG workflows using integrated vector storage. |
-| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails` | Policy-based content filtering and sensitive information masking. |
+| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails" | Policy-based content filtering and sensitive information masking. |
 | **Provisioned Throughput** | `CreateProvisionedModelThroughput` | Testing code that relies on dedicated capacity identifiers. |
 | **Custom Models** | `CreateModelImportJob`, `ListCustomModels` | Simulating the lifecycle of fine-tuned or imported weights. |
 
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. [fakecloud](https://github.com/faiscadev/fakecloud) mitigates this through a rigorous conformance pipeline. 
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics. For more details on this specific workflow, see our post on [Bedrock Guardrails locally](/blog/bedrock-guardrails-local/).
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
 ```sh
 # Create a guardrail via CLI
@@ -175,11 +175,11 @@ This entire flow happens locally, with zero latency from the public internet and
 To maximize the utility of fakecloud in your organization, follow these three steps:
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
-2.  **CI Integration**: Add [fakecloud](https://github.com/faiscadev/fakecloud) to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
+2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
 3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view our guide on [Bedrock local testing](/blog/bedrock-local-testing/) or browse the detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation. You can also read about [Bedrock guardrails local](/blog/bedrock-guardrails-local/) for more specific use cases.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,7 +1,7 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to reduce costs and latency while maintaining full API conformance."
+description = "Discover how fakecloud enables high-fidelity local emulation of 111 AWS Bedrock operations, allowing developers to test GenAI workflows without AWS costs or latency."
 
 [extra]
 author = "Lucas Vieira"
@@ -44,7 +44,7 @@ Building AI applications often involves more than just calling an LLM. You need 
 | :--- | :--- | :--- |
 | **Agents** | `CreateAgent`, `InvokeAgent`, `CreateAgentAlias` | Full agentic loop emulation with action group triggers. |
 | **Knowledge Bases** | `CreateKnowledgeBase`, `IngestContent`, `Retrieve` | Local RAG workflows using integrated vector storage. |
-| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails"` | Policy-based content filtering and sensitive information masking. |
+| **Guardrails** | `CreateGuardrail`, `UpdateGuardrail`, `ListGuardrails` | Policy-based content filtering and sensitive information masking. |
 | **Provisioned Throughput** | `CreateProvisionedModelThroughput` | Testing code that relies on dedicated capacity identifiers. |
 | **Custom Models** | `CreateModelImportJob`, `ListCustomModels` | Simulating the lifecycle of fine-tuned or imported weights. |
 
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a [Guardrail](/blog/bedrock-guardrails-local/) locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
 
 ```bash
 # Create a guardrail via CLI
@@ -160,7 +160,7 @@ This entire flow happens locally, with zero latency from the public internet and
 
 ## Comparison: fakecloud vs. Alternatives
 
-| Feature | fakecloud | LocalStack (2026) | Live AWS |
+| Feature | fakecloud | [LocalStack Alternatives](/blog/localstack-alternative/) | Live AWS |
 | :--- | :--- | :--- | :--- |
 | **Binary Size** | ~19MB | ~1.2GB (Docker Image) | N/A |
 | **Startup Time** | ~500ms | ~15-30s | N/A |
@@ -176,10 +176,10 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 1.  **Standardize the Endpoint**: Use an environment variable like `AWS_ENDPOINT_URL` in your application's configuration layer. Default it to `None` for production and `http://localhost:4566` for local development.
 2.  **CI Integration**: Add fakecloud to your GitHub Actions or GitLab CI pipeline as a service container. Because it is a single binary, it starts instantly, adding negligible time to your build.
-3.  **Deterministic Seeding**: Use the [fakecloud SDK](https://github.com/faiscadev/fakecloud) to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
+3.  **Deterministic Seeding**: Use the fakecloud SDK to seed your local environment with the necessary Bedrock Agents and Knowledge Bases before your tests run. This ensures every developer starts with a clean, known state.
 
 ## Next Steps
 
 fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock).
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at fakecloud.dev/docs/services/bedrock.

--- a/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
+++ b/website/content/blog/local-generative-ai-implementing-bedrock-with-fakecloud.md
@@ -1,19 +1,19 @@
 +++
 title = "Local Generative AI: Implementing Bedrock with fakecloud"
 date = 2026-05-17
-description = "Learn how to implement and test 111 AWS Bedrock operations locally using fakecloud to reduce costs, eliminate network latency, and ensure deterministic AI application testing."
+description = "Generative AI development on AWS Bedrock is governed by the cost of the feedback loop. fakecloud eliminates this friction by providing a high-fidelity local AWS environment for testing 111 Bedrock operations."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity.
+Generative AI development on AWS Bedrock is governed by a single, inescapable metric: the cost of the feedback loop. As of May 2026, frontier models like Claude 4.7 Opus command $15 per million input tokens and $75 per million output tokens. Even the workhorse models, such as Claude 4.6 Sonnet, maintain a price point of $3 per million input tokens. When your integration tests run on every commit, and your local development environment calls live APIs for every prompt tweak, these costs scale linearly with your engineering velocity. 
 
 Testing generative AI on live infrastructure is inefficient. It introduces network latency, consumes production quotas, and generates line items on your AWS bill for code that hasn't even reached a staging environment. fakecloud eliminates this friction by providing a high-fidelity, zero-friction local AWS environment. It allows you to implement and test 111 Bedrock operations locally with a ~19MB binary that starts in ~500ms.
 
 ## The Cost of Iteration: Why Live Infrastructure Fails Developers
 
-In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial.
+In a modern CI/CD pipeline, a single feature branch might undergo fifty test runs before merging. If those tests involve Bedrock Agents, Knowledge Bases, or complex Guardrail configurations, the overhead is not just financial. 
 
 1.  **Latency**: A round-trip to `us-east-1` for a model invocation adds hundreds of milliseconds of overhead. In a suite of 200 integration tests, this turns a sub-minute test run into a coffee break.
 2.  **State Management**: Cleaning up Bedrock Agents or Knowledge Bases in a live account is slow and prone to leaving orphaned resources that continue to accrue costs (like the $345/month minimum for OpenSearch Serverless backends).
@@ -34,7 +34,7 @@ The runtime operations are where your application spends most of its time. fakec
 *   **Converse / ConverseStream**: The unified conversation API for multi-turn dialogues.
 *   **ApplyGuardrail**: Real-time content filtering and PII detection logic.
 
-Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses. You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
+Because fakecloud is built for testing, it doesn't just proxy these calls. It allows you to configure deterministic responses (see our guide on [Bedrock local testing](/blog/bedrock-local-testing/)). You can simulate model hallucinations, specific JSON structures, or Guardrail violations to ensure your application's error-handling logic is robust.
 
 ### Control Plane: Infrastructure Management
 
@@ -93,7 +93,7 @@ This code is identical to what you would run in production, minus the `endpoint_
 
 ## Verifying Outputs: Using the fakecloud SDK
 
-Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**.
+Testing generative AI is notoriously difficult because of the non-deterministic nature of LLMs. fakecloud solves this by separating the **Application Client** from the **Test Client**. 
 
 While your application uses the standard `boto3` client to call `InvokeModel`, your test suite uses the `fakecloud-sdk` to assert what happened inside the emulator. This allows you to verify that the correct prompt was sent, the correct parameters (like `temperature` or `top_p`) were used, and that the model was called the expected number of times.
 
@@ -119,7 +119,7 @@ This approach eliminates the need for complex monkey-patching or manual mocking 
 
 ## Reliability Through Conformance
 
-One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline.
+One of the primary risks of using a local emulator is "drift"—the possibility that the emulator behaves differently than the real AWS API. fakecloud mitigates this through a rigorous conformance pipeline. 
 
 Every implemented service is validated against AWS's own Smithy models. On every commit, the fakecloud engine runs through 59,000+ generated test variants. These variants cover:
 
@@ -135,7 +135,7 @@ As of 2026, AI applications are moving beyond simple chat interfaces into comple
 
 ### Local Guardrail Testing
 
-You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics.
+You can create a Guardrail locally to test how your application handles blocked content. fakecloud's implementation of `ApplyGuardrail` actually evaluates the input against the configured sensitive information filters and denied topics (see more on [local guardrail testing](/blog/bedrock-guardrails-local/)).
 
 ```sh
 # Create a guardrail via CLI
@@ -180,6 +180,6 @@ To maximize the utility of fakecloud in your organization, follow these three st
 
 ## Next Steps
 
-fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop.
+fakecloud provides the most comprehensive local emulation of AWS Bedrock available today. By moving your generative AI testing to a local environment, you reduce costs, eliminate network dependencies, and tighten your development loop. 
 
-To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud).
+To begin implementing local Bedrock workflows, view the supported model list and detailed operation mapping in our documentation at [fakecloud.dev/docs/services/bedrock](https://fakecloud.dev/docs/services/bedrock). Check out the repository at [https://github.com/faiscadev/fakecloud](https://github.com/faiscadev/fakecloud).


### PR DESCRIPTION
This PR adds a new blog post detailing how to implement and test AWS Bedrock operations locally using fakecloud. 

Key coverage:
- Benefits of local emulation vs live infrastructure
- Support for 111 Bedrock operations across data and control planes
- Python code examples for SDK configuration and testing with the fakecloud SDK
- Advanced scenarios including Guardrails and Agentic loops
- Comparison with alternatives

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a blog post on running AWS Bedrock locally with `fakecloud` to speed feedback loops and cut costs (offline, single ~19MB binary, ~500ms startup, no account/auth).

Covers 214 Bedrock operations across 4 APIs with deterministic responses; streaming (`Converse`/`ConverseStream`/`InvokeModelWithResponseStream`) and `ApplyGuardrail`; Python `boto3` setup via `endpoint_url` (default `http://localhost:4566`) with dummy creds; assertions with `fakecloud-sdk`; Knowledge Bases (local RAG), Guardrails (CLI example), Agents with local Lambda action groups; Provisioned Throughput and Custom Models; Smithy-model conformance (86,327 tests); a comparison vs alternatives; plus install/CI and deterministic seeding steps.

<sup>Written for commit 648e46e50ffbeaa863f3f6daa58faf82e02fa71d. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1429?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

