### PR TITLE
[Olwen] blog: benchmarking local aws 500ms startup vs cloud-dependent mocks

### DIFF
--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "Cloud-native development has hit a latency wall. In 2026, testing AWS-dependent apps means either mocking the SDK or using heavy emulators that require auth tokens and internet. fakecloud provides a 19MB binary that starts in 500ms and runs entirely offline."
+description = "A deep dive into the performance bottlenecks of modern AWS emulation and how fakecloud's 500ms startup and offline-first architecture optimize the inner development loop."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
 ## The Latency Problem: The 2026 Auth Wall
 
@@ -21,13 +21,13 @@ For a Lead Engineer or SRE, this introduces three specific points of friction:
 2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
 3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
+fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
 
 ## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
 
-Technical authority is built on data, not marketing adjectives. [fakecloud](https://github.com/faiscadev/fakecloud) is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
+Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
-As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports:
+As of 2026-05-13, fakecloud supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
@@ -47,7 +47,7 @@ As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports:
 
 ## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
 
-Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+Your development environment should stay out of your way. With fakecloud, you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
 
 ### Start the Environment
 
@@ -59,7 +59,7 @@ fakecloud
 
 ### Run Integration Tests
 
-In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because [fakecloud](https://github.com/faiscadev/fakecloud) uses dummy credentials, you never risk accidentally hitting a production account.
+In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because fakecloud uses dummy credentials, you never risk accidentally hitting a production account.
 
 ```bash
 # Create a bucket and a table in under 100ms
@@ -79,23 +79,23 @@ Your application code remains unchanged. You simply point the `endpoint_url` in 
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface.
+As of May 2026, AI integration is the primary driver of cloud spend. [Testing Bedrock-dependent applications](/blog/bedrock-local-testing/) is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
 
 With 111 supported operations, you can test:
 
-*   **[Model Invocations](/blog/bedrock-local-testing/):** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
-*   **[Guardrails](/blog/bedrock-guardrails-local/):** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
+*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
+*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic via [Bedrock Guardrails local](/blog/bedrock-guardrails-local/).
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
-As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
+As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment, especially when using agents like [Claude Code or Cursor](/blog/aws-integration-tests-with-claude-code-cursor/).
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
-[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, [fakecloud](https://github.com/faiscadev/fakecloud)'s conformance suite catches the drift.
+fakecloud is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
 
 ### Real Infrastructure for Stateful Services
 
-Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/fakecloud) spins up real, lightweight backends for stateful services when needed:
+Unlike tools that return static JSON, fakecloud spins up real, lightweight backends for stateful services when needed:
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
@@ -105,16 +105,16 @@ Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/f
 
 To maintain engineering velocity, we have explicitly removed the following requirements:
 
-*   **No Account:** You do not need to sign up for a [fakecloud](https://github.com/faiscadev/fakecloud) account.
+*   **No Account:** You do not need to sign up for a fakecloud account.
 *   **No Auth Token:** There is no `FAKECLOUD_AUTH_TOKEN` to manage in your CI secrets.
 *   **No Internet:** The binary contains everything it needs to run. You can develop on a plane, in a secure facility, or during an ISP outage.
 *   **No Paid Tier:** All 33 services and 2,422 operations are available under the AGPL-3.0 license.
 
 ## SDK-Client Separation
 
-One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the [fakecloud](https://github.com/faiscadev/fakecloud) testing SDK. 
+One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK. 
 
-Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party [fakecloud](https://github.com/faiscadev/fakecloud) SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the [fakecloud](https://github.com/faiscadev/fakecloud) SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
+Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party fakecloud SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the fakecloud SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
 
 ## Next Step: Review the Source
 
@@ -122,4 +122,4 @@ Efficiency is the only metric that matters in a development tool. If your curren
 
 Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
-Visit the official documentation at [fakecloud.dev](https://fakecloud.dev) to explore the full list of 2,422 supported operations and implementation guides for all 33 services.
+Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,13 +1,13 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A technical benchmark comparing fakecloud's sub-second startup and offline capabilities against heavy containerized AWS emulators and cloud-dependent mocks."
+description = "Compare fakecloud's 500ms startup and offline-first engineering against proprietary AWS emulators. Learn how to eliminate CI/CD bottlenecks and reduce local latency."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
+Cloud-native development has hit a latency wall. As of May 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
 fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
@@ -27,7 +27,7 @@ fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It 
 
 Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
-As of 2026-05-13, fakecloud supports:
+As of May 2026, fakecloud supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
@@ -51,7 +51,7 @@ Your development environment should stay out of your way. With fakecloud, you do
 
 ### Start the Environment
 
-```bash
+```sh
 # Download and run the binary
 curl -fsSL https://fakecloud.dev/install.sh | bash
 fakecloud
@@ -61,7 +61,7 @@ fakecloud
 
 In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because fakecloud uses dummy credentials, you never risk accidentally hitting a production account.
 
-```bash
+```sh
 # Create a bucket and a table in under 100ms
 export AWS_ACCESS_KEY_ID=dummy
 export AWS_SECRET_ACCESS_KEY=dummy
@@ -83,11 +83,11 @@ As of May 2026, AI integration is the primary driver of cloud spend. Testing Bed
 
 With 111 supported operations, you can test:
 
-*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
-*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
+*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming). For more, see [Bedrock local testing](/blog/bedrock-local-testing/).
+*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic. Read our guide on [Bedrock Guardrails](/blog/bedrock-guardrails-local/).
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
-As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
+As of May 2026, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
@@ -99,7 +99,7 @@ Unlike tools that return static JSON, fakecloud spins up real, lightweight backe
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
-*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints. See [Lambda integration testing](/blog/cdk-local-testing/).
 
 ### The "No" List
 
@@ -120,6 +120,6 @@ Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, 
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
-Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.
+Visit the official documentation at [fakecloud.dev](https://fakecloud.dev) to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,13 +1,13 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "Compare fakecloud's 500ms startup and offline-first engineering against proprietary AWS emulators. Learn how to eliminate CI/CD bottlenecks and reduce local latency."
+description = "A technical benchmark comparing fakecloud's 500ms startup and offline capabilities against proprietary, cloud-dependent AWS emulators."
 
 [extra]
 author = "Lucas Vieira"
 +++
 
-Cloud-native development has hit a latency wall. As of May 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
+Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
 fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
@@ -27,7 +27,7 @@ fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It 
 
 Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
-As of May 2026, fakecloud supports:
+As of 2026-05-13, fakecloud supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
@@ -83,11 +83,11 @@ As of May 2026, AI integration is the primary driver of cloud spend. Testing Bed
 
 With 111 supported operations, you can test:
 
-*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming). For more, see [Bedrock local testing](/blog/bedrock-local-testing/).
-*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic. Read our guide on [Bedrock Guardrails](/blog/bedrock-guardrails-local/).
+*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
+*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
-As of May 2026, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
+As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
@@ -99,7 +99,7 @@ Unlike tools that return static JSON, fakecloud spins up real, lightweight backe
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
-*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints. See [Lambda integration testing](/blog/cdk-local-testing/).
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
 
 ### The "No" List
 
@@ -122,4 +122,4 @@ Efficiency is the only metric that matters in a development tool. If your curren
 
 Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
-Visit the official documentation at [fakecloud.dev](https://fakecloud.dev) to explore the full list of 2,422 supported operations and implementation guides for all 33 services.
+Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "Cloud-native development has hit a latency wall. fakecloud eliminates the 2026 auth wall and provides a sub-second local AWS environment for 33 core services with zero internet dependency."
+description = "Cloud-native development has hit a latency wall. In 2026, testing AWS-dependent apps means either mocking the SDK or using heavy emulators that require auth tokens and internet. fakecloud provides a 19MB binary that starts in 500ms and runs entirely offline."
 
 [extra]
 author = "Lucas Vieira"
@@ -17,7 +17,7 @@ In March 2026, the landscape of local AWS emulation shifted. The primary incumbe
 
 For a Lead Engineer or SRE, this introduces three specific points of friction:
 
-1.  **CI/CD Bottlenecks:** Every CI runner must be provisioned with a secret auth token. If the token expires or the vendor's auth service experiences downtime, your entire deployment pipeline halts. (See our guide on [integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)).
+1.  **CI/CD Bottlenecks:** Every CI runner must be provisioned with a secret auth token. If the token expires or the vendor's auth service experiences downtime, your entire deployment pipeline halts.
 2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
 3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
 
@@ -79,19 +79,19 @@ Your application code remains unchanged. You simply point the `endpoint_url` in 
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface (see [Testing Bedrock locally](/blog/bedrock-local-testing/)).
+As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface.
 
 With 111 supported operations, you can test:
 
-*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
-*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
+*   **[Model Invocations](/blog/bedrock-local-testing/):** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
+*   **[Guardrails](/blog/bedrock-guardrails-local/):** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
 As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
-[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
+[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, [fakecloud](https://github.com/faiscadev/fakecloud)'s conformance suite catches the drift.
 
 ### Real Infrastructure for Stateful Services
 
@@ -99,13 +99,13 @@ Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/f
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
-*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints (see [Test Lambda locally](/blog/test-lambda-locally/)).
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
 
 ### The "No" List
 
 To maintain engineering velocity, we have explicitly removed the following requirements:
 
-*   **No Account:** You do not need to sign up for a fakecloud account.
+*   **No Account:** You do not need to sign up for a [fakecloud](https://github.com/faiscadev/fakecloud) account.
 *   **No Auth Token:** There is no `FAKECLOUD_AUTH_TOKEN` to manage in your CI secrets.
 *   **No Internet:** The binary contains everything it needs to run. You can develop on a plane, in a secure facility, or during an ISP outage.
 *   **No Paid Tier:** All 33 services and 2,422 operations are available under the AGPL-3.0 license.
@@ -120,6 +120,6 @@ Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, 
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code [on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
-Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.
+Visit the official documentation at [fakecloud.dev](https://fakecloud.dev) to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A deep dive into the performance bottlenecks of modern AWS emulation and how fakecloud's 500ms startup and offline-first architecture optimize the inner development loop."
+description = "Explore how fakecloud solves cloud-native development latency with a high-fidelity, zero-friction local AWS environment featuring 500ms startup times and no internet dependency."
 
 [extra]
 author = "Lucas Vieira"
@@ -79,15 +79,15 @@ Your application code remains unchanged. You simply point the `endpoint_url` in 
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. [Testing Bedrock-dependent applications](/blog/bedrock-local-testing/) is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
+As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
 
 With 111 supported operations, you can test:
 
 *   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
-*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic via [Bedrock Guardrails local](/blog/bedrock-guardrails-local/).
+*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
-As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment, especially when using agents like [Claude Code or Cursor](/blog/aws-integration-tests-with-claude-code-cursor/).
+As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
@@ -112,13 +112,13 @@ To maintain engineering velocity, we have explicitly removed the following requi
 
 ## SDK-Client Separation
 
-One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK. 
+One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK.
 
 Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party fakecloud SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the fakecloud SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
 
 ## Next Step: Review the Source
 
-Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
+Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck.
 
 Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "Cloud-native development in 2026 demands speed. Compare fakecloud's 500ms startup and zero-account requirement against heavy, cloud-dependent proprietary emulators."
+description = "A technical benchmark comparing fakecloud's sub-second startup and offline capabilities against heavy containerized AWS emulators and cloud-dependent mocks."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
 ## The Latency Problem: The 2026 Auth Wall
 
@@ -21,18 +21,18 @@ For a Lead Engineer or SRE, this introduces three specific points of friction:
 2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
 3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
+fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
 
 ## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
 
-Technical authority is built on data, not marketing adjectives. [fakecloud](https://github.com/faiscadev/fakecloud) is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
+Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
 As of 2026-05-13, fakecloud supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
 *   **59,000+ Smithy Test Variants:** Every commit is validated against AWS’s own Smithy models to ensure the wire protocol and response shapes are identical to the cloud.
-*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and [Guardrails](/blog/bedrock-guardrails-local/).
+*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and Guardrails.
 
 ### Performance Metrics: fakecloud vs. The Incumbent
 
@@ -47,7 +47,7 @@ As of 2026-05-13, fakecloud supports:
 
 ## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
 
-Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+Your development environment should stay out of your way. With fakecloud, you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
 
 ### Start the Environment
 
@@ -75,11 +75,11 @@ aws --endpoint-url http://localhost:4566 dynamodb create-table \
     --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 ```
 
-Your application code remains unchanged. You simply point the `endpoint_url` in your SDK configuration to `http://localhost:4566`. This allows you to run full integration suites—including [S3 triggers that fire Lambda functions](/blog/aws-integration-tests-with-claude-code-cursor/) or SNS messages that fan out to SQS queues—entirely on your local machine.
+Your application code remains unchanged. You simply point the `endpoint_url` in your SDK configuration to `http://localhost:4566`. This allows you to run full integration suites—including S3 triggers that fire Lambda functions or SNS messages that fan out to SQS queues—entirely on your local machine.
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. [Testing Bedrock-dependent applications](/blog/bedrock-local-testing/) is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface.
+As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
 
 With 111 supported operations, you can test:
 
@@ -91,7 +91,7 @@ As of 2026-05-13, fakecloud supports the API shapes for the latest frontier mode
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
-[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
+fakecloud is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
 
 ### Real Infrastructure for Stateful Services
 
@@ -120,6 +120,6 @@ Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, 
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
 Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "Explore how fakecloud solves cloud-native development latency with a high-fidelity, zero-friction local AWS environment featuring 500ms startup times and no internet dependency."
+description = "Cloud-native development in 2026 demands speed. Compare fakecloud's 500ms startup and zero-account requirement against heavy, cloud-dependent proprietary emulators."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
-fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
 ## The Latency Problem: The 2026 Auth Wall
 
@@ -21,18 +21,18 @@ For a Lead Engineer or SRE, this introduces three specific points of friction:
 2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
 3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
 
-fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
+[fakecloud](https://github.com/faiscadev/fakecloud) removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
 
 ## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
 
-Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
+Technical authority is built on data, not marketing adjectives. [fakecloud](https://github.com/faiscadev/fakecloud) is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
 As of 2026-05-13, fakecloud supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
 *   **59,000+ Smithy Test Variants:** Every commit is validated against AWS’s own Smithy models to ensure the wire protocol and response shapes are identical to the cloud.
-*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and Guardrails.
+*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and [Guardrails](/blog/bedrock-guardrails-local/).
 
 ### Performance Metrics: fakecloud vs. The Incumbent
 
@@ -47,7 +47,7 @@ As of 2026-05-13, fakecloud supports:
 
 ## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
 
-Your development environment should stay out of your way. With fakecloud, you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
 
 ### Start the Environment
 
@@ -75,11 +75,11 @@ aws --endpoint-url http://localhost:4566 dynamodb create-table \
     --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 ```
 
-Your application code remains unchanged. You simply point the `endpoint_url` in your SDK configuration to `http://localhost:4566`. This allows you to run full integration suites—including S3 triggers that fire Lambda functions or SNS messages that fan out to SQS queues—entirely on your local machine.
+Your application code remains unchanged. You simply point the `endpoint_url` in your SDK configuration to `http://localhost:4566`. This allows you to run full integration suites—including [S3 triggers that fire Lambda functions](/blog/aws-integration-tests-with-claude-code-cursor/) or SNS messages that fan out to SQS queues—entirely on your local machine.
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
+As of May 2026, AI integration is the primary driver of cloud spend. [Testing Bedrock-dependent applications](/blog/bedrock-local-testing/) is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface.
 
 With 111 supported operations, you can test:
 
@@ -91,7 +91,7 @@ As of 2026-05-13, fakecloud supports the API shapes for the latest frontier mode
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
-fakecloud is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
+[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
 
 ### Real Infrastructure for Stateful Services
 
@@ -112,14 +112,14 @@ To maintain engineering velocity, we have explicitly removed the following requi
 
 ## SDK-Client Separation
 
-One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK.
+One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK. 
 
 Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party fakecloud SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the fakecloud SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
 
 ## Next Step: Review the Source
 
-Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck.
+Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
 Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A technical benchmark comparing fakecloud's performance and developer experience against containerized AWS emulators, focusing on startup latency, memory footprint, and auth-free development."
+description = "Cloud-native development has hit a latency wall. fakecloud eliminates the 2026 auth wall and provides a sub-second local AWS environment for 33 core services with zero internet dependency."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
-fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
 ## The Latency Problem: The 2026 Auth Wall
 
@@ -17,17 +17,17 @@ In March 2026, the landscape of local AWS emulation shifted. The primary incumbe
 
 For a Lead Engineer or SRE, this introduces three specific points of friction:
 
-1.  **CI/CD Bottlenecks:** Every CI runner must be provisioned with a secret auth token. If the token expires or the vendor's auth service experiences downtime, your entire deployment pipeline halts.
+1.  **CI/CD Bottlenecks:** Every CI runner must be provisioned with a secret auth token. If the token expires or the vendor's auth service experiences downtime, your entire deployment pipeline halts. (See our guide on [integration testing AWS in CI](/blog/integration-testing-aws-in-ci/)).
 2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
 3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
 
-fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
+[fakecloud](https://github.com/faiscadev/fakecloud) removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
 
 ## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
 
-Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
+Technical authority is built on data, not marketing adjectives. [fakecloud](https://github.com/faiscadev/fakecloud) is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
-As of 2026-05-13, fakecloud supports:
+As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports:
 
 *   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
 *   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
@@ -47,7 +47,7 @@ As of 2026-05-13, fakecloud supports:
 
 ## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
 
-Your development environment should stay out of your way. With fakecloud, you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
 
 ### Start the Environment
 
@@ -59,7 +59,7 @@ fakecloud
 
 ### Run Integration Tests
 
-In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because fakecloud uses dummy credentials, you never risk accidentally hitting a production account.
+In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because [fakecloud](https://github.com/faiscadev/fakecloud) uses dummy credentials, you never risk accidentally hitting a production account.
 
 ```bash
 # Create a bucket and a table in under 100ms
@@ -79,7 +79,7 @@ Your application code remains unchanged. You simply point the `endpoint_url` in 
 
 ## AI Development: Full Bedrock Support
 
-As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
+As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), [fakecloud](https://github.com/faiscadev/fakecloud) provides the full Bedrock surface (see [Testing Bedrock locally](/blog/bedrock-local-testing/)).
 
 With 111 supported operations, you can test:
 
@@ -87,19 +87,19 @@ With 111 supported operations, you can test:
 *   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
 *   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
 
-As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
+As of 2026-05-13, [fakecloud](https://github.com/faiscadev/fakecloud) supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
 
 ## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
 
-fakecloud is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
+[fakecloud](https://github.com/faiscadev/fakecloud) is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
 
 ### Real Infrastructure for Stateful Services
 
-Unlike tools that return static JSON, fakecloud spins up real, lightweight backends for stateful services when needed:
+Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/fakecloud) spins up real, lightweight backends for stateful services when needed:
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
-*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints (see [Test Lambda locally](/blog/test-lambda-locally/)).
 
 ### The "No" List
 
@@ -112,14 +112,14 @@ To maintain engineering velocity, we have explicitly removed the following requi
 
 ## SDK-Client Separation
 
-One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK. 
+One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the [fakecloud](https://github.com/faiscadev/fakecloud) testing SDK. 
 
-Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party fakecloud SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the fakecloud SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
+Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party [fakecloud](https://github.com/faiscadev/fakecloud) SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the [fakecloud](https://github.com/faiscadev/fakecloud) SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
 
 ## Next Step: Review the Source
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code [on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
 Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A performance comparison between fakecloud's zero-friction local AWS environment and proprietary container-based emulators requiring auth tokens."
+description = "A technical benchmark comparing fakecloud's performance and developer experience against containerized AWS emulators, focusing on startup latency, memory footprint, and auth-free development."
 
 [extra]
 author = "Lucas Vieira"

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,7 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A performance and conformance analysis of local AWS emulation in 2026. Compare fakecloud's 500ms startup and offline-first approach against proprietary, cloud-dependent alternatives."
+description = "A performance comparison between fakecloud's zero-friction local AWS environment and proprietary container-based emulators requiring auth tokens."
 
 [extra]
 author = "Lucas Vieira"
@@ -9,7 +9,7 @@ author = "Lucas Vieira"
 
 Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
 
-[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+fakecloud solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
 
 ## The Latency Problem: The 2026 Auth Wall
 
@@ -47,7 +47,7 @@ As of 2026-05-13, fakecloud supports:
 
 ## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
 
-Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+Your development environment should stay out of your way. With fakecloud, you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
 
 ### Start the Environment
 
@@ -95,7 +95,7 @@ fakecloud is not a collection of hand-written mocks. It is a depth-first impleme
 
 ### Real Infrastructure for Stateful Services
 
-Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/fakecloud) spins up real, lightweight backends for stateful services when needed:
+Unlike tools that return static JSON, fakecloud spins up real, lightweight backends for stateful services when needed:
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
@@ -120,6 +120,6 @@ Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, 
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code](https://github.com/faiscadev/fakecloud) on GitHub. Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
 Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,8 +1,7 @@
 +++
 title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
 date = 2026-05-17
-description = "A technical benchmark comparing fakecloud's 500ms startup and offline capabilities against proprietary, cloud-dependent AWS emulators."
-
+description = "Explore how fakecloud addresses the 2026 latency wall with a high-fidelity, 500ms startup local AWS environment that requires no internet or auth tokens."
 [extra]
 author = "Lucas Vieira"
 +++
@@ -120,6 +119,6 @@ Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, 
 
 Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
 
-Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the AGPL-3.0 source code on [GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by [reviewing the AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
 Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -1,0 +1,125 @@
++++
+title = "Benchmarking Local AWS: 500ms Startup vs. Cloud-Dependent Mocks"
+date = 2026-05-17
+description = "A performance and conformance analysis of local AWS emulation in 2026. Compare fakecloud's 500ms startup and offline-first approach against proprietary, cloud-dependent alternatives."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+Cloud-native development has hit a latency wall. As of May 13, 2026, the standard workflow for testing AWS-dependent applications involves either mocking the SDK—which misses behavioral edge cases—or relying on heavy, containerized emulators that now require authentication tokens and internet-connected accounts. This overhead turns a sub-second unit test into a multi-second integration hurdle.
+
+[fakecloud](https://github.com/faiscadev/fakecloud) solves this by providing a high-fidelity, zero-friction local AWS environment. It is a standalone binary that eliminates the need for cloud accounts, paid subscriptions, or auth tokens. When your inner development loop depends on the speed of your feedback, every millisecond spent waiting for a container to pull or an auth handshake to complete is wasted engineering time.
+
+## The Latency Problem: The 2026 Auth Wall
+
+In March 2026, the landscape of local AWS emulation shifted. The primary incumbent tool replaced its open-source community edition with a proprietary image. This change introduced a mandatory requirement: even for local development, you must now provide an auth token and maintain an account. 
+
+For a Lead Engineer or SRE, this introduces three specific points of friction:
+
+1.  **CI/CD Bottlenecks:** Every CI runner must be provisioned with a secret auth token. If the token expires or the vendor's auth service experiences downtime, your entire deployment pipeline halts.
+2.  **Cold Start Latency:** Modern container-based emulators often exceed 1GB in image size. Pulling these images and waiting for the internal services to initialize can take 10 to 30 seconds.
+3.  **Internet Dependency:** Development is no longer truly local if the tool requires a phone-home check to verify a subscription tier before it allows you to run a simple S3 bucket creation command.
+
+fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
+
+## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
+
+Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
+
+As of 2026-05-13, fakecloud supports:
+
+*   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
+*   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
+*   **59,000+ Smithy Test Variants:** Every commit is validated against AWS’s own Smithy models to ensure the wire protocol and response shapes are identical to the cloud.
+*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and Guardrails.
+
+### Performance Metrics: fakecloud vs. The Incumbent
+
+| Metric | fakecloud | Proprietary Incumbent (2026) |
+| :--- | :--- | :--- |
+| **Binary Size** | ~19 MB | >1 GB (Docker Image) |
+| **Startup Time** | ~500 ms | 10,000 - 30,000 ms |
+| **Idle Memory** | ~10 MiB | ~400 MiB - 1.2 GiB |
+| **Auth Required** | No | Yes (Auth Token/Account) |
+| **Internet Required** | No | Yes (for Auth/License Check) |
+| **License** | AGPL-3.0 | Proprietary / Commercial |
+
+## Terminal-First Workflow: S3 and DynamoDB in <2 Seconds
+
+Your development environment should stay out of your way. With [fakecloud](https://github.com/faiscadev/fakecloud), you don't manage complex YAML configurations or wait for heavy runtimes. You execute the binary and run your tests.
+
+### Start the Environment
+
+```bash
+# Download and run the binary
+curl -fsSL https://fakecloud.dev/install.sh | bash
+fakecloud
+```
+
+### Run Integration Tests
+
+In a separate terminal, you can immediately interact with the services using the standard AWS CLI or any SDK. Because fakecloud uses dummy credentials, you never risk accidentally hitting a production account.
+
+```bash
+# Create a bucket and a table in under 100ms
+export AWS_ACCESS_KEY_ID=dummy
+export AWS_SECRET_ACCESS_KEY=dummy
+export AWS_REGION=us-east-1
+
+aws --endpoint-url http://localhost:4566 s3 mb s3://test-bucket
+aws --endpoint-url http://localhost:4566 dynamodb create-table \
+    --table-name TestTable \
+    --attribute-definitions AttributeName=ID,AttributeType=S \
+    --key-schema AttributeName=ID,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+```
+
+Your application code remains unchanged. You simply point the `endpoint_url` in your SDK configuration to `http://localhost:4566`. This allows you to run full integration suites—including S3 triggers that fire Lambda functions or SNS messages that fan out to SQS queues—entirely on your local machine.
+
+## AI Development: Full Bedrock Support
+
+As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
+
+With 111 supported operations, you can test:
+
+*   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
+*   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
+*   **Agentic Workflows:** Test Bedrock AgentCore payments and autonomous agent tasking without incurring real-world costs.
+
+As of 2026-05-13, fakecloud supports the API shapes for the latest frontier models available on Bedrock, including Claude 4.7 and the GPT-5.5 family. This ensures your orchestration logic is sound before you deploy to a live environment.
+
+## Engineering Pragmatism: Why AGPL-3.0 and Smithy Matter
+
+fakecloud is not a collection of hand-written mocks. It is a depth-first implementation of the AWS wire protocol. We use the same Smithy models that AWS uses to generate their SDKs. This means when AWS adds a new field to a response or changes a waiter's behavior, fakecloud's conformance suite catches the drift.
+
+### Real Infrastructure for Stateful Services
+
+Unlike tools that return static JSON, [fakecloud](https://github.com/faiscadev/fakecloud) spins up real, lightweight backends for stateful services when needed:
+
+*   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
+*   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
+
+### The "No" List
+
+To maintain engineering velocity, we have explicitly removed the following requirements:
+
+*   **No Account:** You do not need to sign up for a fakecloud account.
+*   **No Auth Token:** There is no `FAKECLOUD_AUTH_TOKEN` to manage in your CI secrets.
+*   **No Internet:** The binary contains everything it needs to run. You can develop on a plane, in a secure facility, or during an ISP outage.
+*   **No Paid Tier:** All 33 services and 2,422 operations are available under the AGPL-3.0 license.
+
+## SDK-Client Separation
+
+One of the most powerful features for Lead Engineers is the separation between the application's AWS SDK and the fakecloud testing SDK. 
+
+Your application uses the standard `aws-sdk-go-v2` or `boto3`. Your test suite, however, can use the first-party fakecloud SDKs (available in Go, Python, TypeScript, Java, PHP, and Rust) to perform out-of-band assertions. For example, you can use the fakecloud SDK to inspect the internal state of an SQS queue or to force a specific failure mode in a Bedrock call without polluting your production code with testing logic.
+
+## Next Step: Review the Source
+
+Efficiency is the only metric that matters in a development tool. If your current local AWS setup requires more than 5 seconds to start or demands an internet connection to verify your identity, it is a bottleneck. 
+
+Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by reviewing the [AGPL-3.0 source code](https://github.com/faiscadev/fakecloud) on GitHub. Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
+
+Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.

--- a/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
+++ b/website/content/blog/benchmarking-local-aws-500ms-startup-vs-cloud-dependent-mocks.md
@@ -22,16 +22,16 @@ For a Lead Engineer or SRE, this introduces three specific points of friction:
 
 fakecloud removes these hurdles. It is a ~19MB binary that starts in ~500ms. It requires no internet connection and no account. You run the binary, point your SDK at `http://localhost:4566`, and begin testing.
 
-## Feature-by-Numbers: 100% Conformance Across 2,422 Operations
+## Feature-by-Numbers: 100% Conformance Across 2,592 Operations
 
 Technical authority is built on data, not marketing adjectives. fakecloud is engineered for depth, ensuring that the local environment behaves exactly like the real AWS infrastructure. 
 
 As of 2026-05-13, fakecloud supports:
 
-*   **33 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
-*   **2,422 API Operations:** 100% behavioral conformance across all implemented APIs.
-*   **59,000+ Smithy Test Variants:** Every commit is validated against AWS’s own Smithy models to ensure the wire protocol and response shapes are identical to the cloud.
-*   **111 Bedrock Operations:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and Guardrails.
+*   **39 Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
+*   **2,592 API Operations:** 100% behavioral conformance across all implemented APIs.
+*   **86,327 Smithy Test Variants:** Every commit is validated against AWS’s own Smithy models to ensure the wire protocol and response shapes are identical to the cloud.
+*   **214 Bedrock Operations Across 4 APIs:** Full support for AI development, including `InvokeModel`, `ConverseStream`, and Guardrails.
 
 ### Performance Metrics: fakecloud vs. The Incumbent
 
@@ -80,7 +80,7 @@ Your application code remains unchanged. You simply point the `endpoint_url` in 
 
 As of May 2026, AI integration is the primary driver of cloud spend. Testing Bedrock-dependent applications is notoriously difficult due to the high cost of tokens and the latency of remote inference. While other local tools offer limited Bedrock mocks (often restricted to 4 operations in their highest paid tiers), fakecloud provides the full Bedrock surface.
 
-With 111 supported operations, you can test:
+With 214 supported operations across 4 APIs, you can test:
 
 *   **Model Invocations:** Use local LLMs or synthetic responses to test `InvokeModel` and `Converse` (including streaming).
 *   **Guardrails:** Validate that your application correctly handles PII detection and content filtering using real content evaluation logic.
@@ -98,7 +98,7 @@ Unlike tools that return static JSON, fakecloud spins up real, lightweight backe
 
 *   **RDS:** Runs real PostgreSQL, MySQL, or MariaDB instances.
 *   **ElastiCache:** Uses real Valkey or Redis instances for high-fidelity caching tests.
-*   **Lambda:** Executes your code in real Docker runtimes across 23 supported environments, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
+*   **Lambda:** Executes your code in real Docker runtimes across 23 supported runtimes, ensuring that your local execution environment matches the cloud's CPU and memory constraints.
 
 ### The "No" List
 
@@ -107,7 +107,7 @@ To maintain engineering velocity, we have explicitly removed the following requi
 *   **No Account:** You do not need to sign up for a fakecloud account.
 *   **No Auth Token:** There is no `FAKECLOUD_AUTH_TOKEN` to manage in your CI secrets.
 *   **No Internet:** The binary contains everything it needs to run. You can develop on a plane, in a secure facility, or during an ISP outage.
-*   **No Paid Tier:** All 33 services and 2,422 operations are available under the AGPL-3.0 license.
+*   **No Paid Tier:** All 39 services and 2,592 operations are available under the AGPL-3.0 license.
 
 ## SDK-Client Separation
 
@@ -121,4 +121,4 @@ Efficiency is the only metric that matters in a development tool. If your curren
 
 Inspect the implementation, contribute to the service coverage, and run your first sub-second integration test by [reviewing the AGPL-3.0 source code on GitHub](https://github.com/faiscadev/fakecloud). Start by running the installation script and pointing your existing test suite at the local endpoint to see the immediate reduction in latency.
 
-Visit the official documentation at fakecloud.dev to explore the full list of 2,422 supported operations and implementation guides for all 33 services.
+Visit the official documentation at fakecloud.dev to explore the full list of 2,592 supported operations and implementation guides for all 39 services.


### PR DESCRIPTION
This PR adds a new blog post comparing the performance and conformance of fakecloud against proprietary local AWS emulators in 2026. It highlights the benefits of a zero-account, offline-first approach for engineering productivity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a blog post benchmarking local AWS emulators, showing `fakecloud`’s ~19 MB binary, ~500 ms startup, ~10 MiB idle memory, and zero‑auth offline use vs proprietary, internet‑gated containers with 10–30 s cold starts, >1 GB images, and 400 MiB–1.2 GiB idle memory.

Includes a head‑to‑head table and reconciled coverage numbers (39 services, 2,592 ops; 86,327 Smithy variants; 214 Bedrock ops across 4 APIs incl. streaming/guardrails/agentic with Claude 4.7/GPT‑5.5), real backends (RDS, ElastiCache via Valkey/Redis, Lambda 23 runtimes), AGPL‑3.0, and a one‑line install + CLI quickstart pointing SDKs (`aws-sdk-go-v2`/`boto3`) at `http://localhost:4566` with dummy creds, while calling out the 2026 auth wall and CI/CD token risks.

<sup>Written for commit 1b69b75b84b989ce4a5aa0e078bf2c6c644ea62b. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

