### PR TITLE
fix(events): bring conformance to 100% (2112/2112)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 84787,
+  "variants_passed": 84837,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -91,7 +91,7 @@
       "total": 2310
     },
     "events": {
-      "passed": 2062,
+      "passed": 2112,
       "total": 2112
     },
     "sqs": {

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -141,17 +141,18 @@ fn default_value_for_shape_def(model: &ServiceModel, shape: &Shape, depth: usize
             Value::Object(obj)
         }
         ShapeType::List { member_target } => {
-            // Populate at least one element when the list carries a
-            // `@length` min>=1 trait so that services which honour the
-            // bound do not reject auto-built positive variants as a
-            // ValidationException. Lists with min=0 (or no length trait)
-            // still default to empty.
+            // Populate `@length` min elements when the list carries a non-zero
+            // lower bound so positive variants don't trip services that honour
+            // the bound. Lists with min=0 (or no length trait) still default
+            // to empty. Capped at 10 elements to avoid blowing up tests on
+            // pathological models.
             let min = shape.traits.length_min.unwrap_or(0) as usize;
             if min == 0 {
                 Value::Array(vec![])
             } else {
+                let n = min.min(10);
                 let elem = default_value_for_shape(model, member_target, depth + 1);
-                Value::Array(vec![elem])
+                Value::Array(vec![elem; n])
             }
         }
         ShapeType::Map { .. } => Value::Object(serde_json::Map::new()),

--- a/crates/fakecloud-conformance/src/generators/mod.rs
+++ b/crates/fakecloud-conformance/src/generators/mod.rs
@@ -140,7 +140,20 @@ fn default_value_for_shape_def(model: &ServiceModel, shape: &Shape, depth: usize
             }
             Value::Object(obj)
         }
-        ShapeType::List { .. } => Value::Array(vec![]),
+        ShapeType::List { member_target } => {
+            // Populate at least one element when the list carries a
+            // `@length` min>=1 trait so that services which honour the
+            // bound do not reject auto-built positive variants as a
+            // ValidationException. Lists with min=0 (or no length trait)
+            // still default to empty.
+            let min = shape.traits.length_min.unwrap_or(0) as usize;
+            if min == 0 {
+                Value::Array(vec![])
+            } else {
+                let elem = default_value_for_shape(model, member_target, depth + 1);
+                Value::Array(vec![elem])
+            }
+        }
         ShapeType::Map { .. } => Value::Object(serde_json::Map::new()),
         ShapeType::Union { members } => {
             // Use first member

--- a/crates/fakecloud-conformance/src/generators/proptest_gen.rs
+++ b/crates/fakecloud-conformance/src/generators/proptest_gen.rs
@@ -170,7 +170,14 @@ fn random_value_for_shape_def(
             Value::Object(obj)
         }
         ShapeType::List { member_target } => {
-            let len = rng.next_usize(6); // 0..5
+            // Respect the list's `@length` bounds when generating random
+            // values so positive-success variants don't accidentally hit
+            // services that enforce min>=1 list lengths. `range` is
+            // [min, max+1) over `next_usize`.
+            let min = shape.traits.length_min.unwrap_or(0) as usize;
+            let max = shape.traits.length_max.map(|m| m as usize).unwrap_or(5);
+            let span = max.saturating_sub(min).saturating_add(1).min(6);
+            let len = min + rng.next_usize(span);
             let items: Vec<Value> = (0..len)
                 .map(|_| random_value_for_shape(model, member_target, overrides, rng, depth + 1))
                 .collect();

--- a/crates/fakecloud-core/src/validation.rs
+++ b/crates/fakecloud-core/src/validation.rs
@@ -91,6 +91,31 @@ pub fn validate_optional_string_length(
     Ok(())
 }
 
+/// Validate an optional string length from a JSON value, rejecting non-string types.
+///
+/// Unlike [`validate_optional_string_length`], this takes a raw [`serde_json::Value`]
+/// so non-string inputs (numbers, arrays, objects) surface as a
+/// `SerializationException` instead of silently being treated as missing via
+/// `Value::as_str() -> None`.
+pub fn validate_optional_string_length_value(
+    field: &str,
+    value: &serde_json::Value,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let s = value.as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "SerializationException",
+            format!("Value for '{}' must be a string", field),
+        )
+    })?;
+    validate_string_length(field, s, min, max)
+}
+
 /// Validate an optional integer range if present.
 pub fn validate_optional_range_i64(
     field: &str,

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -347,10 +347,16 @@ impl EventBridgeService {
 
     fn list_event_buses(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // ListEventBuses' Smithy model only declares InternalException — no
-        // ValidationException or InvalidNextTokenException. Length and shape
-        // constraints are client-side; unrecognised pagination tokens fall
-        // back to the start of the list rather than erroring out.
+        // Smithy ListEventBusesRequest constraints:
+        //   NamePrefix: EventBusName length 1..=256
+        //   NextToken: length 1..=2048
+        //   Limit: LimitMax100 range 1..=100
+        // Unrecognised pagination tokens still fall back to the start of the
+        // list — `InvalidNextTokenException` only fires when the token shape
+        // itself is wrong, not when it points at a vanished cursor.
+        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 256)?;
+        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100).clamp(1, 100) as usize;
 
@@ -422,9 +428,16 @@ impl EventBridgeService {
 
     fn put_permission(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // PutPermission's Smithy model does not declare ValidationException —
-        // string-length constraints are client-side. We only emit the
-        // declared errors (ResourceNotFoundException for an unknown bus, etc.).
+        // Smithy PutPermissionRequest constraints (optional members but each
+        // carries a `@length` trait that must be honoured when present):
+        //   EventBusName: NonPartnerEventBusName length 1..=256
+        //   Action: length 1..=64
+        //   Principal: length 1..=12 (12-digit AWS account or `*`)
+        //   StatementId: length 1..=64
+        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 256)?;
+        validate_optional_string_length("Action", body["Action"].as_str(), 1, 64)?;
+        validate_optional_string_length("Principal", body["Principal"].as_str(), 1, 12)?;
+        validate_optional_string_length("StatementId", body["StatementId"].as_str(), 1, 64)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
         let mut accounts = self.state.write();
@@ -532,13 +545,41 @@ impl EventBridgeService {
 
     fn put_rule(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // PutRule's Smithy model does not declare ValidationException — string
-        // length, enum, and `@required` checks are client-side. We surface
-        // only declared errors (ResourceNotFound for unknown bus,
-        // InvalidEventPattern for malformed patterns). Missing-Name and
-        // similar inputs are accepted with an empty default; SDKs never let
-        // them reach the wire.
-        let name = body["Name"].as_str().unwrap_or("").to_string();
+        // Smithy PutRuleRequest constraints:
+        //   Name: RuleName length 1..=64, @required
+        //   ScheduleExpression: length 0..=256
+        //   EventPattern: length 0..=4096 (raw JSON, separate
+        //     InvalidEventPatternException still applies to syntax)
+        //   State: RuleState enum {ENABLED, DISABLED,
+        //          ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS}
+        //   Description: RuleDescription length 0..=512
+        //   RoleArn: length 1..=1600
+        //   EventBusName: EventBusNameOrArn length 1..=1600
+        validate_required("Name", &body["Name"])?;
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        validate_string_length("Name", &name, 1, 64)?;
+        validate_optional_string_length(
+            "ScheduleExpression",
+            body["ScheduleExpression"].as_str(),
+            0,
+            256,
+        )?;
+        validate_optional_string_length("EventPattern", body["EventPattern"].as_str(), 0, 4096)?;
+        validate_optional_enum(
+            "State",
+            body["State"].as_str(),
+            &[
+                "ENABLED",
+                "DISABLED",
+                "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS",
+            ],
+        )?;
+        validate_optional_string_length("Description", body["Description"].as_str(), 0, 512)?;
+        validate_optional_string_length("RoleArn", body["RoleArn"].as_str(), 1, 1600)?;
+        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
 
         let raw_bus = body["EventBusName"]
             .as_str()
@@ -838,12 +879,16 @@ impl EventBridgeService {
 
     fn put_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // PutTargets' Smithy model only declares ConcurrentModification,
-        // Internal, LimitExceeded, ManagedRule, and ResourceNotFound. Bad
-        // per-target input is surfaced through FailedEntries (matching
-        // AWS), not a top-level ValidationException. Top-level fields
-        // (Rule name, EventBusName) are validated client-side by SDKs.
-        let rule_name = body["Rule"].as_str().unwrap_or("");
+        // Smithy PutTargetsRequest constraints (top-level shape):
+        //   Rule: RuleName @required length 1..=64
+        //   EventBusName: EventBusNameOrArn length 1..=1600
+        //   Targets: TargetList @required length 1..=100
+        // Per-target validation still flows through `FailedEntries` (matching
+        // AWS); only the top-level shape produces ValidationException.
+        validate_required("Rule", &body["Rule"])?;
+        let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
+        validate_string_length("Rule", rule_name, 1, 64)?;
+        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
         let targets: Vec<Value> = body["Targets"].as_array().cloned().unwrap_or_default();
 
@@ -1147,10 +1192,11 @@ impl EventBridgeService {
 
     fn put_events(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // PutEvents' Smithy model declares only InternalException — no
-        // ValidationException. SDKs enforce the Entries length [1, 10]
-        // constraint and the EndpointId 1..=50 range client-side. We accept
-        // whatever reaches the wire and process up to 10 entries.
+        // Smithy PutEventsRequest constraints:
+        //   EndpointId: length 1..=50
+        //   Entries: length 1..=10 — we silently truncate to 10 for legacy
+        //     SDK behaviour; min is enforced by `validate_put_events_entry`.
+        validate_optional_string_length("EndpointId", body["EndpointId"].as_str(), 1, 50)?;
         let entries: Vec<Value> = body["Entries"]
             .as_array()
             .cloned()

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -459,7 +459,12 @@ impl EventBridgeService {
             }
         }
 
-        // Old-style: Action, Principal, StatementId
+        // Old-style: Action, Principal, StatementId. All are @optional in the
+        // Smithy model; non-string values were already rejected above with
+        // SerializationException, so reaching here means each is either a
+        // valid string or absent. Fall back to "" to preserve current behavior
+        // — recording an empty-statement policy entry is harmless since it can
+        // never match a real action/principal pair.
         let action = body["Action"].as_str().unwrap_or("");
         let principal = body["Principal"].as_str().unwrap_or("");
         let statement_id = body["StatementId"].as_str().unwrap_or("");

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -354,8 +354,8 @@ impl EventBridgeService {
         // Unrecognised pagination tokens still fall back to the start of the
         // list — `InvalidNextTokenException` only fires when the token shape
         // itself is wrong, not when it points at a vanished cursor.
-        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 256)?;
-        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_string_length_value("NamePrefix", &body["NamePrefix"], 1, 256)?;
+        validate_optional_string_length_value("NextToken", &body["NextToken"], 1, 2048)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         let name_prefix = body["NamePrefix"].as_str();
         let limit = body["Limit"].as_i64().unwrap_or(100).clamp(1, 100) as usize;
@@ -434,10 +434,10 @@ impl EventBridgeService {
         //   Action: length 1..=64
         //   Principal: length 1..=12 (12-digit AWS account or `*`)
         //   StatementId: length 1..=64
-        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 256)?;
-        validate_optional_string_length("Action", body["Action"].as_str(), 1, 64)?;
-        validate_optional_string_length("Principal", body["Principal"].as_str(), 1, 12)?;
-        validate_optional_string_length("StatementId", body["StatementId"].as_str(), 1, 64)?;
+        validate_optional_string_length_value("EventBusName", &body["EventBusName"], 1, 256)?;
+        validate_optional_string_length_value("Action", &body["Action"], 1, 64)?;
+        validate_optional_string_length_value("Principal", &body["Principal"], 1, 12)?;
+        validate_optional_string_length_value("StatementId", &body["StatementId"], 1, 64)?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
 
         let mut accounts = self.state.write();
@@ -561,13 +561,13 @@ impl EventBridgeService {
             .ok_or_else(|| missing("Name"))?
             .to_string();
         validate_string_length("Name", &name, 1, 64)?;
-        validate_optional_string_length(
+        validate_optional_string_length_value(
             "ScheduleExpression",
-            body["ScheduleExpression"].as_str(),
+            &body["ScheduleExpression"],
             0,
             256,
         )?;
-        validate_optional_string_length("EventPattern", body["EventPattern"].as_str(), 0, 4096)?;
+        validate_optional_string_length_value("EventPattern", &body["EventPattern"], 0, 4096)?;
         validate_optional_enum_value(
             "State",
             &body["State"],
@@ -577,9 +577,9 @@ impl EventBridgeService {
                 "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS",
             ],
         )?;
-        validate_optional_string_length("Description", body["Description"].as_str(), 0, 512)?;
-        validate_optional_string_length("RoleArn", body["RoleArn"].as_str(), 1, 1600)?;
-        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
+        validate_optional_string_length_value("Description", &body["Description"], 0, 512)?;
+        validate_optional_string_length_value("RoleArn", &body["RoleArn"], 1, 1600)?;
+        validate_optional_string_length_value("EventBusName", &body["EventBusName"], 1, 1600)?;
 
         let raw_bus = body["EventBusName"]
             .as_str()
@@ -888,7 +888,7 @@ impl EventBridgeService {
         validate_required("Rule", &body["Rule"])?;
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("Rule", rule_name, 1, 64)?;
-        validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
+        validate_optional_string_length_value("EventBusName", &body["EventBusName"], 1, 1600)?;
         // Targets is @required with TargetList length 1..=100 in the Smithy
         // model. Real AWS rejects empty / oversized lists with a
         // ValidationException; per-target validation continues to flow
@@ -1215,7 +1215,7 @@ impl EventBridgeService {
         // Smithy PutEventsRequest constraints:
         //   EndpointId: length 1..=50
         //   Entries: @required, length 1..=10
-        validate_optional_string_length("EndpointId", body["EndpointId"].as_str(), 1, 50)?;
+        validate_optional_string_length_value("EndpointId", &body["EndpointId"], 1, 50)?;
         validate_required("Entries", &body["Entries"])?;
         let entries_array = body["Entries"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -568,9 +568,9 @@ impl EventBridgeService {
             256,
         )?;
         validate_optional_string_length("EventPattern", body["EventPattern"].as_str(), 0, 4096)?;
-        validate_optional_enum(
+        validate_optional_enum_value(
             "State",
-            body["State"].as_str(),
+            &body["State"],
             &[
                 "ENABLED",
                 "DISABLED",
@@ -889,8 +889,20 @@ impl EventBridgeService {
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("Rule", rule_name, 1, 64)?;
         validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
+        // Targets is @required in the Smithy model. We enforce the
+        // null/missing check (matching the real-AWS ValidationException) but
+        // accept empty lists as a no-op — real AWS responds with
+        // FailedEntryCount=0 for an empty Targets list rather than erroring.
+        validate_required("Targets", &body["Targets"])?;
+        let targets_array = body["Targets"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Targets must be a list",
+            )
+        })?;
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
-        let targets: Vec<Value> = body["Targets"].as_array().cloned().unwrap_or_default();
+        let targets: Vec<Value> = targets_array.clone();
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -1194,16 +1206,21 @@ impl EventBridgeService {
         let body = req.json_body();
         // Smithy PutEventsRequest constraints:
         //   EndpointId: length 1..=50
-        //   Entries: length 1..=10 — we silently truncate to 10 for legacy
-        //     SDK behaviour; min is enforced by `validate_put_events_entry`.
+        //   Entries: @required (null/missing -> ValidationException), max 10
+        //     entries silently truncated for legacy SDK behaviour. The
+        //     min=1 list-length bound is not enforced server-side because
+        //     real AWS routes an empty list through to a 0-entry success
+        //     response (verified against live EventBridge as of 2026-05).
         validate_optional_string_length("EndpointId", body["EndpointId"].as_str(), 1, 50)?;
-        let entries: Vec<Value> = body["Entries"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .take(10)
-            .collect();
+        validate_required("Entries", &body["Entries"])?;
+        let entries_array = body["Entries"].as_array().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Entries must be a list",
+            )
+        })?;
+        let entries: Vec<Value> = entries_array.iter().take(10).cloned().collect();
         let entries = &entries;
 
         let mut accounts = self.state.write();

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -889,10 +889,10 @@ impl EventBridgeService {
         let rule_name = body["Rule"].as_str().ok_or_else(|| missing("Rule"))?;
         validate_string_length("Rule", rule_name, 1, 64)?;
         validate_optional_string_length("EventBusName", body["EventBusName"].as_str(), 1, 1600)?;
-        // Targets is @required in the Smithy model. We enforce the
-        // null/missing check (matching the real-AWS ValidationException) but
-        // accept empty lists as a no-op — real AWS responds with
-        // FailedEntryCount=0 for an empty Targets list rather than erroring.
+        // Targets is @required with TargetList length 1..=100 in the Smithy
+        // model. Real AWS rejects empty / oversized lists with a
+        // ValidationException; per-target validation continues to flow
+        // through FailedEntries (matching AWS).
         validate_required("Targets", &body["Targets"])?;
         let targets_array = body["Targets"].as_array().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -901,6 +901,14 @@ impl EventBridgeService {
                 "Targets must be a list",
             )
         })?;
+        if targets_array.is_empty() || targets_array.len() > 100 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Value at 'Targets' failed to satisfy constraint: \
+                 Member must have length between 1 and 100",
+            ));
+        }
         let event_bus_name = body["EventBusName"].as_str().unwrap_or("default");
         let targets: Vec<Value> = targets_array.clone();
 
@@ -1206,11 +1214,7 @@ impl EventBridgeService {
         let body = req.json_body();
         // Smithy PutEventsRequest constraints:
         //   EndpointId: length 1..=50
-        //   Entries: @required (null/missing -> ValidationException), max 10
-        //     entries silently truncated for legacy SDK behaviour. The
-        //     min=1 list-length bound is not enforced server-side because
-        //     real AWS routes an empty list through to a 0-entry success
-        //     response (verified against live EventBridge as of 2026-05).
+        //   Entries: @required, length 1..=10
         validate_optional_string_length("EndpointId", body["EndpointId"].as_str(), 1, 50)?;
         validate_required("Entries", &body["Entries"])?;
         let entries_array = body["Entries"].as_array().ok_or_else(|| {
@@ -1220,7 +1224,15 @@ impl EventBridgeService {
                 "Entries must be a list",
             )
         })?;
-        let entries: Vec<Value> = entries_array.iter().take(10).cloned().collect();
+        if entries_array.is_empty() || entries_array.len() > 10 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "Value at 'Entries' failed to satisfy constraint: \
+                 Member must have length between 1 and 10",
+            ));
+        }
+        let entries: Vec<Value> = entries_array.clone();
         let entries = &entries;
 
         let mut accounts = self.state.write();

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -199,11 +199,34 @@ impl EventBridgeService {
 
     pub(super) fn list_archives(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // ListArchives' Smithy model declares only InternalException and
-        // ResourceNotFoundException — string-length, enum, and exclusive-
-        // filter constraints are client-side. We treat invalid combinations
-        // as best-effort filters rather than emitting an undeclared
-        // ValidationException.
+        // Smithy ListArchivesRequest constraints:
+        //   NamePrefix: ArchiveName length 1..=48
+        //   EventSourceArn: EventBusArn length 1..=1600
+        //   NextToken: length 1..=2048
+        //   Limit: LimitMax100 range 1..=100
+        //   State: ArchiveState enum {ENABLED, DISABLED, CREATING, UPDATING,
+        //          CREATE_FAILED, UPDATE_FAILED}
+        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 48)?;
+        validate_optional_string_length(
+            "EventSourceArn",
+            body["EventSourceArn"].as_str(),
+            1,
+            1600,
+        )?;
+        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
+        validate_optional_enum(
+            "State",
+            body["State"].as_str(),
+            &[
+                "ENABLED",
+                "DISABLED",
+                "CREATING",
+                "UPDATING",
+                "CREATE_FAILED",
+                "UPDATE_FAILED",
+            ],
+        )?;
         let name_prefix = body["NamePrefix"].as_str();
         let source_arn = body["EventSourceArn"].as_str();
         let archive_state = body["State"].as_str();
@@ -597,9 +620,34 @@ impl EventBridgeService {
 
     pub(super) fn list_replays(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // ListReplays' Smithy model declares only InternalException —
-        // string-length, enum, and mutually-exclusive-filter constraints are
-        // client-side. Treat invalid combinations as best-effort filters.
+        // Smithy ListReplaysRequest constraints:
+        //   NamePrefix: ReplayName length 1..=64
+        //   EventSourceArn: ArchiveArn length 1..=1600
+        //   NextToken: length 1..=2048
+        //   Limit: LimitMax100 range 1..=100
+        //   State: ReplayState enum {STARTING, RUNNING, CANCELLING, COMPLETED,
+        //          CANCELLED, FAILED}
+        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 64)?;
+        validate_optional_string_length(
+            "EventSourceArn",
+            body["EventSourceArn"].as_str(),
+            1,
+            1600,
+        )?;
+        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
+        validate_optional_enum(
+            "State",
+            body["State"].as_str(),
+            &[
+                "STARTING",
+                "RUNNING",
+                "CANCELLING",
+                "COMPLETED",
+                "CANCELLED",
+                "FAILED",
+            ],
+        )?;
         let name_prefix = body["NamePrefix"].as_str();
         let source_arn = body["EventSourceArn"].as_str();
         let replay_state = body["State"].as_str();

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -206,14 +206,9 @@ impl EventBridgeService {
         //   Limit: LimitMax100 range 1..=100
         //   State: ArchiveState enum {ENABLED, DISABLED, CREATING, UPDATING,
         //          CREATE_FAILED, UPDATE_FAILED}
-        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 48)?;
-        validate_optional_string_length(
-            "EventSourceArn",
-            body["EventSourceArn"].as_str(),
-            1,
-            1600,
-        )?;
-        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_string_length_value("NamePrefix", &body["NamePrefix"], 1, 48)?;
+        validate_optional_string_length_value("EventSourceArn", &body["EventSourceArn"], 1, 1600)?;
+        validate_optional_string_length_value("NextToken", &body["NextToken"], 1, 2048)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         validate_optional_enum_value(
             "State",
@@ -627,14 +622,9 @@ impl EventBridgeService {
         //   Limit: LimitMax100 range 1..=100
         //   State: ReplayState enum {STARTING, RUNNING, CANCELLING, COMPLETED,
         //          CANCELLED, FAILED}
-        validate_optional_string_length("NamePrefix", body["NamePrefix"].as_str(), 1, 64)?;
-        validate_optional_string_length(
-            "EventSourceArn",
-            body["EventSourceArn"].as_str(),
-            1,
-            1600,
-        )?;
-        validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
+        validate_optional_string_length_value("NamePrefix", &body["NamePrefix"], 1, 64)?;
+        validate_optional_string_length_value("EventSourceArn", &body["EventSourceArn"], 1, 1600)?;
+        validate_optional_string_length_value("NextToken", &body["NextToken"], 1, 2048)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
         validate_optional_enum_value(
             "State",

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -215,9 +215,9 @@ impl EventBridgeService {
         )?;
         validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
-        validate_optional_enum(
+        validate_optional_enum_value(
             "State",
-            body["State"].as_str(),
+            &body["State"],
             &[
                 "ENABLED",
                 "DISABLED",
@@ -636,9 +636,9 @@ impl EventBridgeService {
         )?;
         validate_optional_string_length("NextToken", body["NextToken"].as_str(), 1, 2048)?;
         validate_optional_json_range("Limit", &body["Limit"], 1, 100)?;
-        validate_optional_enum(
+        validate_optional_enum_value(
             "State",
-            body["State"].as_str(),
+            &body["State"],
             &[
                 "STARTING",
                 "RUNNING",

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -62,14 +62,22 @@ impl EventBridgeService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        // DeletePartnerEventSource's Smithy model declares only
-        // ConcurrentModification, Internal, and OperationDisabled — neither
-        // ValidationException nor ResourceNotFoundException. Treat unknown
-        // sources as a no-op success, matching the idempotent
-        // delete-partner-* semantics on the customer side. SDKs enforce
-        // required-name/account client-side.
-        let name = body["Name"].as_str().unwrap_or("").to_string();
-        let account = body["Account"].as_str().unwrap_or("").to_string();
+        // Smithy declares Name (length 1..=256) and Account (length 12..=12)
+        // as @required. Constraint violations surface as ValidationException
+        // — the same wire shape AWS uses for malformed input even on
+        // operations whose `errors:` set doesn't list it explicitly.
+        validate_required("Name", &body["Name"])?;
+        validate_required("Account", &body["Account"])?;
+        let name = body["Name"]
+            .as_str()
+            .ok_or_else(|| missing("Name"))?
+            .to_string();
+        validate_string_length("Name", &name, 1, 256)?;
+        let account = body["Account"]
+            .as_str()
+            .ok_or_else(|| missing("Account"))?
+            .to_string();
+        validate_string_length("Account", &account, 12, 12)?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2764,16 +2764,12 @@ fn cancel_replay_not_found() {
 // ── put_events empty ──
 
 #[test]
-fn put_events_empty_entries_returns_zero_failures() {
-    // PutEvents' Smithy model declares only InternalException — the [1, 10]
-    // Entries length constraint is enforced client-side, so an empty batch
-    // is a no-op success on the wire.
+fn put_events_empty_entries_rejected() {
+    // Smithy PutEventsRequestEntryList carries `@length min=1`. AWS rejects
+    // an empty batch with ValidationException; we enforce the same bound.
     let svc = make_service();
     let req = make_request("PutEvents", json!({"Entries": []}));
-    let resp = svc.put_events(&req).expect("empty entries is accepted");
-    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    assert_eq!(body["FailedEntryCount"], 0);
-    assert_eq!(body["Entries"].as_array().unwrap().len(), 0);
+    assert!(svc.put_events(&req).is_err());
 }
 
 #[test]

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2460,9 +2460,10 @@ fn put_permission_with_policy_json() {
 }
 
 #[test]
-fn put_permission_accepts_any_action() {
-    // PutPermission's Smithy model has no ValidationException — bad Action
-    // values are accepted at the wire and never reach the policy evaluator.
+fn put_permission_accepts_any_action_string_within_length_bounds() {
+    // PutPermission validates Action length (1..=64) per the Smithy
+    // @length trait but does not gate against an allow-list — any string
+    // that fits is recorded verbatim.
     let svc = make_service();
     let req = make_request(
         "PutPermission",
@@ -2473,7 +2474,38 @@ fn put_permission_accepts_any_action() {
         }),
     );
     svc.put_permission(&req)
-        .expect("unknown action is accepted");
+        .expect("in-bounds action string is accepted");
+}
+
+#[test]
+fn put_permission_rejects_action_over_length_bound() {
+    // Smithy declares Action length 1..=64; anything longer is a
+    // ValidationException at the wire.
+    let svc = make_service();
+    let req = make_request(
+        "PutPermission",
+        json!({
+            "Action": "a".repeat(65),
+            "Principal": "123456789012",
+            "StatementId": "s1"
+        }),
+    );
+    assert!(svc.put_permission(&req).is_err());
+}
+
+#[test]
+fn put_permission_rejects_principal_over_length_bound() {
+    // Smithy declares Principal length 1..=12 (12-digit account or `*`).
+    let svc = make_service();
+    let req = make_request(
+        "PutPermission",
+        json!({
+            "Action": "events:PutEvents",
+            "Principal": "1".repeat(13),
+            "StatementId": "s1"
+        }),
+    );
+    assert!(svc.put_permission(&req).is_err());
 }
 
 #[test]
@@ -2562,28 +2594,27 @@ fn remove_permission_unknown_statement_errors() {
 // ── put_rule invalid schedule expression ──
 
 #[test]
-fn put_rule_accepts_missing_name() {
-    // PutRule has no declared ValidationException in its Smithy model —
-    // missing/invalid input fields are accepted server-side; AWS SDKs
-    // enforce them client-side.
+fn put_rule_rejects_missing_name() {
+    // Smithy marks Name @required (RuleName length 1..=64).
     let svc = make_service();
     let req = make_request("PutRule", json!({}));
-    svc.put_rule(&req).expect("missing Name is accepted");
+    assert!(svc.put_rule(&req).is_err());
 }
 
 #[test]
-fn put_rule_accepts_long_name() {
+fn put_rule_rejects_long_name() {
     let svc = make_service();
     let name = "x".repeat(65);
     let req = make_request("PutRule", json!({"Name": name}));
-    svc.put_rule(&req).expect("long Name is accepted");
+    assert!(svc.put_rule(&req).is_err());
 }
 
 #[test]
-fn put_rule_accepts_unknown_state() {
+fn put_rule_rejects_unknown_state() {
+    // RuleState enum: ENABLED, DISABLED, ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS.
     let svc = make_service();
     let req = make_request("PutRule", json!({"Name": "r1", "State": "BOGUS"}));
-    svc.put_rule(&req).expect("unknown State is accepted");
+    assert!(svc.put_rule(&req).is_err());
 }
 
 // ── create_connection variants ──


### PR DESCRIPTION
## Summary

- Eight EventBridge handlers (`DeletePartnerEventSource`, `ListArchives`, `ListEventBuses`, `ListReplays`, `PutEvents`, `PutPermission`, `PutRule`, `PutTargets`) were intentionally skipping Smithy `@length`, `@range`, `@required`, and `@enum` validation. The strict probe surfaced 50 variant failures across those ops.
- Each handler now validates inputs against the bounds vendored in `aws-models/eventbridge.json`. Existing tests that asserted the old lenient behaviour were inverted; new tests added for the Action / Principal length bounds.
- `conformance-baseline.json` bumped: `events` 2062/2112 -> 2112/2112; overall +50 variants.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services events` -> 2112/2112 (100%)
- [x] `cargo test -p fakecloud-eventbridge` -> 210 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforced Smithy validation across EventBridge handlers to match AWS, bringing `events` conformance to 100% (2112/2112). Invalid inputs now return ValidationException; non-string values in string or enum fields return SerializationException.

- Bug Fixes
  - Applied model checks to: DeletePartnerEventSource, ListArchives, ListEventBuses, ListReplays, PutEvents, PutPermission, PutRule, PutTargets.
  - Core rules: PutRule requires Name (1–64) and validates ScheduleExpression (0–256), EventPattern (0–4096), Description (0–512), RoleArn (1–1600), EventBusName (1–1600), and State enum; PutEvents requires Entries list 1–10 and EndpointId 1–50; PutTargets requires Rule 1–64, Targets list 1–100, EventBusName 1–1600; DeletePartnerEventSource requires Name 1–256 and Account 12; List* validate NamePrefix/NextToken/EventSourceArn lengths, Limit 1–100, and State enums.
  - PutPermission enforces lengths for EventBusName (1–256), Action (1–64), Principal (1–12), StatementId (1–64); fields are optional and any in-bounds action string is accepted.
  - Preserved idempotent partner-source deletes; unknown pagination tokens restart listing; PutTargets still reports per-target issues via FailedEntries.
  - Conformance generators honor list @length min for defaults and random values; tests updated for strict bounds and type errors (including empty Entries rejection and PutPermission length limits).

<sup>Written for commit b0638eda8c342368609201170e083070a6f6a241. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1431?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

