### PR TITLE
[Olwen] Add AWS Service Coverage & API Conformance Directory

### DIFF
--- a/website/content/supported-services.md
+++ b/website/content/supported-services.md
@@ -1,0 +1,42 @@
++++
+title = "AWS Service Coverage & API Conformance"
+description = "fakecloud provides 100% API conformance across 2,422 operations. Explore our supported AWS services for local development."
+template = "page.html"
++++
+
+fakecloud provides 100% API conformance across 2,422 operations. Unlike mocks, fakecloud is built against official AWS Smithy models to ensure wire-protocol compatibility and deterministic behavior for local development.
+
+## Coverage Summary
+- **Total Services**: 33+
+- **Total Operations**: 2,422
+- **Conformance Engine**: 59,000+ Smithy-based test cases
+- **Startup Time**: ~500ms
+
+## Supported Services
+
+### Compute & Containers
+- **Lambda**: Full execution environment, cross-service triggers (S3, SNS, SQS, EventBridge).
+- **ECR**: 58 operations. Full OCI v2 Distribution protocol support for `docker push` and `docker pull`.
+
+### Storage & Databases
+- **S3**: 100% coverage including Bucket lifecycle, Object tagging, and Multipart uploads.
+- **DynamoDB**: Support for TTL, GSI/LSI, and DynamoDB Streams.
+
+### AI & Machine Learning
+- **Bedrock**: 111 operations supported including Guardrails, Model Customization, and Provisioned Throughput.
+- **Bedrock Runtime**: Deterministic `InvokeModel`, `InvokeModelWithResponseStream`, and `Converse` APIs.
+
+### Messaging & Integration
+- **SQS**: Standard and FIFO queues, Dead Letter Queues (DLQ).
+- **SNS**: Topic management and fan-out to SQS/Lambda.
+- **EventBridge**: Rules, Targets, and EventBridge Scheduler support.
+
+### Security & Management
+- **IAM**: Policy evaluation and role simulation.
+- **STS**: Local token generation and session management.
+- **SSM**: Parameter Store and Secrets Manager integration.
+
+## Technical Conformance Data
+fakecloud is validated against the same Smithy models used by the official AWS SDKs. This ensures that every request and response matches the expected wire format exactly, eliminating 'works on my machine' bugs caused by shallow mocks.
+
+[View the full machine-readable API manifest on GitHub](https://github.com/faiscadev/fakecloud)

--- a/website/content/supported-services.md
+++ b/website/content/supported-services.md
@@ -1,40 +1,43 @@
 +++
 title = "AWS Service Coverage & API Conformance"
-description = "fakecloud provides 100% API conformance across 2,422 operations. Explore our supported AWS services for local development."
+description = "fakecloud provides 100% API conformance across 2,592 operations. Explore our supported AWS services for local development."
 template = "page.html"
 +++
 
-fakecloud provides 100% API conformance across 2,422 operations. Unlike mocks, fakecloud is built against official AWS Smithy models to ensure wire-protocol compatibility and deterministic behavior for local development.
+fakecloud provides 100% API conformance across 2,592 operations. Unlike mocks, fakecloud is built against official AWS Smithy models to ensure wire-protocol compatibility and deterministic behavior for local development.
 
 ## Coverage Summary
-- **Total Services**: 33+
-- **Total Operations**: 2,422
-- **Conformance Engine**: 59,000+ Smithy-based test cases
+- **Total Services**: 39
+- **Total Operations**: 2,592
+- **Conformance Engine**: 86,327 Smithy-based test variants
 - **Startup Time**: ~500ms
 
 ## Supported Services
 
 ### Compute & Containers
-- **Lambda**: Full execution environment, cross-service triggers (S3, SNS, SQS, EventBridge).
+- **Lambda**: 70 operations. Full execution environment in real Docker containers across 23 runtimes, cross-service triggers (S3, SNS, SQS, EventBridge).
 - **ECR**: 58 operations. Full OCI v2 Distribution protocol support for `docker push` and `docker pull`.
+- **ECS**: 76 operations. Real Fargate-style task execution via Docker, services with rolling deployments, ECS Exec.
 
 ### Storage & Databases
-- **S3**: 100% coverage including Bucket lifecycle, Object tagging, and Multipart uploads.
-- **DynamoDB**: Support for TTL, GSI/LSI, and DynamoDB Streams.
+- **S3**: 107 operations. Bucket lifecycle, Object tagging, Multipart uploads, real `SelectObjectContent` EventStream.
+- **DynamoDB**: 57 operations. TTL, GSI/LSI, and DynamoDB Streams.
+- **RDS**: 163 operations. Real Postgres, MySQL, MariaDB, Oracle, SQL Server, and Db2 via Docker.
+- **ElastiCache**: 75 operations. Real Redis, Valkey, and Memcached via Docker.
 
 ### AI & Machine Learning
-- **Bedrock**: 111 operations supported including Guardrails, Model Customization, and Provisioned Throughput.
-- **Bedrock Runtime**: Deterministic `InvokeModel`, `InvokeModelWithResponseStream`, and `Converse` APIs.
+- **Bedrock**: 214 operations across 4 APIs (Bedrock 101, Bedrock Runtime 10, Bedrock Agent 72, Bedrock Agent Runtime 31). Guardrails, Model Customization, Provisioned Throughput, Agents, Knowledge Bases.
+- **Bedrock Runtime**: Deterministic `InvokeModel`, `InvokeModelWithResponseStream`, and `Converse` APIs (echo / configurable-response mode; no real inference).
 
 ### Messaging & Integration
-- **SQS**: Standard and FIFO queues, Dead Letter Queues (DLQ).
-- **SNS**: Topic management and fan-out to SQS/Lambda.
-- **EventBridge**: Rules, Targets, and EventBridge Scheduler support.
+- **SQS**: 23 operations. Standard and FIFO queues, Dead Letter Queues (DLQ).
+- **SNS**: 42 operations. Topic management and fan-out to SQS/Lambda.
+- **EventBridge**: 57 operations. Rules, Targets; EventBridge Scheduler (12 operations) is a separate service.
 
 ### Security & Management
-- **IAM**: Policy evaluation and role simulation.
-- **STS**: Local token generation and session management.
-- **SSM**: Parameter Store and Secrets Manager integration.
+- **IAM**: 176 operations. Policy evaluation including permission boundaries, session policies, ABAC, NotPrincipal, and KMS key policies.
+- **STS**: 11 operations. Local token generation and session management.
+- **SSM**: 146 operations. Parameter Store; Secrets Manager (23 operations) is a separate service.
 
 ## Technical Conformance Data
 fakecloud is validated against the same Smithy models used by the official AWS SDKs. This ensures that every request and response matches the expected wire format exactly, eliminating 'works on my machine' bugs caused by shallow mocks.


### PR DESCRIPTION
This PR adds a high-density technical page listing supported AWS services and their API conformance metrics. This establishes technical authority and provides a clear directory for users to understand what fakecloud supports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “AWS Service Coverage & API Conformance” docs page that lists supported AWS services and shows our API conformance metrics. This gives users a single place to validate `fakecloud` coverage and parity for local development.

- **New Features**
  - Updated coverage summary: 39 services, 2,592 operations, 86,327 Smithy test variants, ~500ms startup.
  - Expanded details with per-service op counts (Lambda, ECR, ECS, S3, DynamoDB, RDS, ElastiCache, Bedrock across 4 APIs, SQS/SNS/EventBridge, IAM/STS/SSM).
  - Technical notes on Smithy-based conformance, plus a link to the machine-readable API manifest.

<sup>Written for commit a125b6f55f2aef881c649a312ef094e9d4c19b52. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1433?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

