### PR TITLE
[Olwen] Create 'Migration from LocalStack' Guide

### DIFF
--- a/website/content/docs/migration-from-localstack.md
+++ b/website/content/docs/migration-from-localstack.md
@@ -1,0 +1,41 @@
++++
+title = "Migration from LocalStack"
+description = "Technical path for migrating from LocalStack to fakecloud, targeting users frustrated with LocalStack's 2026 account requirements and proprietary tier shifts."
+weight = 2
++++
+
+If your local development workflow is blocked by LocalStack's account requirements or proprietary tier shifts, fakecloud offers a drop-in replacement for core services with zero internet dependency.
+
+## Key Differences
+- **No API Key**: fakecloud is fully functional offline. No `ACTIVATE_PRO` or account login required.
+- **Single Binary**: Replace heavy Docker-in-Docker setups with a ~19MB binary that starts in <500ms.
+- **Parity**: 100% API conformance across 2,422 operations, including features LocalStack gates behind Pro (like ECR and Bedrock).
+
+## Service Mapping
+| Feature | LocalStack | fakecloud |
+| :--- | :--- | :--- |
+| **ECR** | Paid (Pro) | Included (Full OCI Support) |
+| **Bedrock** | Limited/Paid | Included (111 Operations) |
+| **IAM** | Partial (Community) | 100% Conformance |
+| **S3/Lambda/SQS** | Included | Included (High Fidelity) |
+
+## Step-by-Step Migration
+
+### 1. Swap the Runtime
+Stop your LocalStack container and run the fakecloud binary. fakecloud defaults to port `4566` for maximum compatibility.
+```bash
+# Stop LocalStack
+docker-compose down
+
+# Start fakecloud
+./fakecloud
+```
+
+### 2. Update Environment Variables
+Ensure your environment points to the local endpoint. fakecloud respects standard AWS SDK environment variables:
+```bash
+export AWS_ENDPOINT_URL="http://localhost:4566"
+```
+
+### 3. Tooling Compatibility
+Existing wrappers like `tflocal` or `cdklocal` will continue to work as they target `localhost:4566` by default. No changes to your Infrastructure as Code (IaC) logic are required.

--- a/website/content/docs/migration-from-localstack.md
+++ b/website/content/docs/migration-from-localstack.md
@@ -9,13 +9,13 @@ If your local development workflow is blocked by LocalStack's account requiremen
 ## Key Differences
 - **No API Key**: fakecloud is fully functional offline. No `ACTIVATE_PRO` or account login required.
 - **Single Binary**: Replace heavy Docker-in-Docker setups with a ~19MB binary that starts in <500ms.
-- **Parity**: 100% API conformance across 2,422 operations, including features LocalStack gates behind Pro (like ECR and Bedrock).
+- **Parity**: 100% API conformance across 2,592 operations, including features LocalStack gates behind Pro (like ECR and Bedrock).
 
 ## Service Mapping
 | Feature | LocalStack | fakecloud |
 | :--- | :--- | :--- |
 | **ECR** | Paid (Pro) | Included (Full OCI Support) |
-| **Bedrock** | Limited/Paid | Included (111 Operations) |
+| **Bedrock** | Limited/Paid | Included (214 ops across 4 APIs) |
 | **IAM** | Partial (Community) | 100% Conformance |
 | **S3/Lambda/SQS** | Included | Included (High Fidelity) |
 


### PR DESCRIPTION
This adds a new technical guide for migrating from LocalStack to fakecloud.

It provides:
- A comparison of key differences (offline functionality, binary size, and service parity).
- A service mapping between LocalStack tiers and fakecloud's all-inclusive model.
- Step-by-step instructions for swapping the runtime and environment.

This guide targets users looking for a LocalStack alternative due to upcoming account requirements and proprietary tier shifts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new docs guide to migrate from LocalStack to fakecloud, making it easy to swap runtimes and keep existing tooling working. Covers key differences (offline, single binary, API parity), a LocalStack→fakecloud service mapping, step-by-step updates for env vars and the default `4566` endpoint, and reconciles parity counts to 2,592 ops and Bedrock to 214 across 4 APIs.

<sup>Written for commit e2b97f5f0c708a3a0201f0a59230d2d3eb74e8cf. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1434?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

