### PR TITLE
fix(apigatewayv1): bring conformance to 100% (3373/3373)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 84872,
+  "variants_passed": 85076,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -51,7 +51,7 @@
       "total": 5970
     },
     "apigatewayv1": {
-      "passed": 3169,
+      "passed": 3373,
       "total": 3373
     },
     "elasticloadbalancing": {


### PR DESCRIPTION
## Summary
- Fresh probe (`cargo run -p fakecloud-conformance --release -- run --services apigatewayv1`) reports 124/124 ops and 3373/3373 variants passing.
- Baseline was stale at 3169/3373 (94.0%); bump to 3373/3373 to match real behavior.

## Test plan
- [x] Local probe: `Operations: 124/124 implemented (100.0%), 124/124 fully passing (100.0%)` and `Variants: 3373/3373 passed (100.0%)`
- [ ] CI conformance check stays green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update conformance baseline to match current probe results: apigatewayv1 is now 100% (124/124 ops, 3373/3373 variants).
Adjusted `conformance-baseline.json` counts: apigatewayv1 3169 → 3373; total variants 84872 → 85076.

<sup>Written for commit 98f0f8975374477c96dddd5c77c560ea6ab951e5. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1436?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

