### PR TITLE
fix(bedrock): bring conformance to 100% (3834/3834)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 85628,
+  "variants_passed": 85944,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -127,7 +127,7 @@
       "total": 1292
     },
     "bedrock": {
-      "passed": 3518,
+      "passed": 3834,
       "total": 3834
     },
     "scheduler": {


### PR DESCRIPTION
## Summary

Fresh conformance probe shows bedrock at 100% (3834/3834 variants, 101/101 operations). Bumps baseline from 3518/3834 (91.8%) to match reality.

## Test plan

- [x] `cargo run -p fakecloud-conformance --release -- run --services bedrock` -> 3834/3834 passed
- [x] Baseline file updated for bedrock only; totals recomputed
- [x] Unrelated services unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Bedrock conformance baseline to 100%: 3834/3834 variants and 101/101 operations pass. Updated conformance-baseline.json totals (variants_passed 85628 → 85944; bedrock passed 3518 → 3834); other services unchanged.

<sup>Written for commit 14510fa70416df2b2a58a30b4e717c503215a36a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

