### PR TITLE
fix(bedrock-agent): bring conformance to 100% (2509/2509)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 85944,
+  "variants_passed": 86028,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -31,7 +31,7 @@
       "total": 949
     },
     "bedrock-agent": {
-      "passed": 2425,
+      "passed": 2509,
       "total": 2509
     },
     "bedrock-agent-runtime": {


### PR DESCRIPTION
## Summary
- Fresh conformance probe shows bedrock-agent already passing all 2509/2509 variants.
- Baseline was stale at 2425/2509 (96.7%); bump to match actual state.
- No code changes needed; honest 100% confirmed via `cargo run -p fakecloud-conformance --release -- run --services bedrock-agent`.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services bedrock-agent` -> 2509/2509 (100.0%)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update conformance baseline: `bedrock-agent` now 100% (2509/2509).
Bump `conformance-baseline.json`: set `bedrock-agent.passed` 2425 → 2509 and `variants_passed` 85944 → 86028.

<sup>Written for commit 6df1be59a1f5a406e3ba677f85e6f3bff58d4000. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

