### PR TITLE
fix(ecr): bring conformance to 100% (1793/1793)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 85132,
+  "variants_passed": 85172,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -7,7 +7,7 @@
       "total": 3897
     },
     "ecr": {
-      "passed": 1753,
+      "passed": 1793,
       "total": 1793
     },
     "cloudformation": {


### PR DESCRIPTION
## Summary

- Fresh probe shows ECR at 58/58 ops, 1793/1793 variants passing
- Baseline was stale at 1753/1793 (97.8%); bump to honest 1793/1793 (100%)
- No implementation changes needed; ECR already passes every probe variant

## Test plan

- [x] `cargo run --release -p fakecloud-conformance -- run --services ecr` reports 1793/1793
- [x] `cargo run --release -p fakecloud-conformance -- check` passes against new baseline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update conformance baseline to reflect ECR at 100%: 58/58 ops and 1793/1793 variants passing. Updates conformance-baseline.json (ECR 1753 → 1793; variants_passed 85132 → 85172); no implementation changes.

<sup>Written for commit 92bc589d4f1a6aec11e3bdf421027a12555736f1. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1440?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

