### PR TITLE
chore(conformance): bump cloudformation baseline to 3426/3426

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 85172,
+  "variants_passed": 85628,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -11,7 +11,7 @@
       "total": 1793
     },
     "cloudformation": {
-      "passed": 2970,
+      "passed": 3426,
       "total": 3426
     },
     "dynamodb": {


### PR DESCRIPTION
## Summary
- CloudFormation conformance probe reports 3426/3426 variants passing (verified locally against running server).
- Baseline was stuck at 2970/3426 from before the recent cfn fixes landed.
- Bumps `per_service.cloudformation.passed` 2970 -> 3426 and recomputes top-level `variants_passed` (+456 -> 85588). `total_variants` unchanged.

## Test plan
- [x] `fakecloud-conformance run --services cloudformation` locally: 3426/3426
- [x] `fakecloud-conformance check` against the new baseline: PASSED, current 86045/86327
- [ ] CI conformance job green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CloudFormation conformance baseline to 3426/3426 (up from 2970); recompute `variants_passed` to 85628 (`total_variants` unchanged). Verified locally with `fakecloud-conformance`.

<sup>Written for commit 6c7e3bc940cf939625ee3d7f7be362eb09b3e487. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

