### PR TITLE
fix(logs): bring conformance to 100% (3897/3897)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,9 +1,9 @@
 {
-  "variants_passed": 86028,
+  "variants_passed": 86098,
   "total_variants": 86327,
   "per_service": {
     "logs": {
-      "passed": 3827,
+      "passed": 3897,
       "total": 3897
     },
     "ecr": {

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -4,6 +4,7 @@ pub mod query;
 pub(crate) mod service;
 pub(crate) mod state;
 pub mod transformer;
+pub(crate) mod validation;
 
 pub use service::LogsService;
 pub use state::{

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::LogsService;
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::LogsService;
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::dd_config_json;
 use super::{require_str, LogsService};

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::dd_config_json;
 use super::{require_str, LogsService};

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::LogsService;
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::LogsService;
 use chrono::Utc;
@@ -197,10 +197,13 @@ impl LogsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // `PutDestinationPolicy` does not declare `ResourceNotFoundException`
+        // in its Smithy error union — AWS surfaces unknown-destination errors
+        // as `InvalidParameterException`.
         let dest = state.destinations.get_mut(name).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
+                "InvalidParameterException",
                 format!("The specified destination does not exist: {name}"),
             )
         })?;
@@ -283,6 +286,11 @@ mod tests {
                 "accessPolicy": "{}",
             }),
         );
-        assert!(svc.put_destination_policy(&req).is_err());
+        // CloudWatch Logs declares `InvalidParameterException` (not
+        // `ResourceNotFoundException`) for unknown destinations on this op.
+        match svc.put_destination_policy(&req) {
+            Err(e) => assert_eq!(e.code(), "InvalidParameterException"),
+            Ok(_) => panic!("expected error for unknown destination"),
+        }
     }
 }

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -230,16 +230,10 @@ impl LogsService {
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
-        if let Some(task_id) = task_id_filter {
-            let task = state.export_tasks.iter().find(|t| t.task_id == task_id);
-            if task.is_none() {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ResourceNotFoundException",
-                    "The specified export task does not exist.",
-                ));
-            }
-        }
+        // Real CloudWatch Logs returns an empty `exportTasks` array for an
+        // unknown taskId — `DescribeExportTasks` doesn't declare
+        // `ResourceNotFoundException` in its Smithy error union. The filter
+        // below narrows by taskId.
 
         let tasks: Vec<Value> = state
             .export_tasks
@@ -879,5 +873,17 @@ mod tests {
         let data = entries[0]["data"].as_str().unwrap();
         assert!(data.contains("web event"));
         assert!(!data.contains("api event"));
+    }
+
+    #[test]
+    fn describe_export_tasks_unknown_id_returns_empty_list() {
+        // Real CloudWatch Logs returns an empty `exportTasks` array for an
+        // unknown taskId; `DescribeExportTasks` doesn't declare
+        // `ResourceNotFoundException` in its Smithy model.
+        let svc = make_service();
+        let req = make_request("DescribeExportTasks", json!({ "taskId": "does-not-exist" }));
+        let resp = svc.describe_export_tasks(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["exportTasks"].as_array().unwrap().len(), 0);
     }
 }

--- a/crates/fakecloud-logs/src/service/exports.rs
+++ b/crates/fakecloud-logs/src/service/exports.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use flate2::write::GzEncoder;
 use flate2::Compression;

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::{matches_filter_pattern, validation_error, LogsService};
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::{matches_filter_pattern, validation_error, LogsService};
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use chrono::Utc;
 

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use chrono::Utc;
 

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::{require_str, LogsService};
 use chrono::Utc;
@@ -603,52 +603,20 @@ impl LogsService {
             .filter(|s| !s.is_empty())
             .map(String::from);
 
-        // Real CWL StartLiveTail returns vnd.amazon.eventstream over HTTP/2.
-        // fakecloud emulates the same logical session by returning a single
-        // JSON envelope containing a sessionStart followed by a sessionUpdate
-        // populated with the most recent ~500 events from the targeted log
-        // groups that match the filter pattern. SDKs treating the response as
-        // a complete envelope can read both, mirroring what `aws logs
-        // start-live-tail --start-time=now-30s` would surface.
+        // Real CWL StartLiveTail returns vnd.amazon.eventstream over HTTP/2:
+        // each event-stream message carries exactly one `StartLiveTailResponseStream`
+        // union variant (e.g. one `sessionStart`, then a sequence of
+        // `sessionUpdate`s). fakecloud emulates the initial framed response by
+        // returning the first variant (`sessionStart`) inside the JSON envelope.
+        // Subsequent `sessionUpdate`s would be additional event-stream messages
+        // in the real wire format. Returning both variants in one envelope
+        // breaks the union contract (`responseStream` must hold exactly one
+        // member), so SDKs that strictly decode the union would reject it.
+        // Consume the unused state read + filter args so they don't show up
+        // as dead-code warnings; live-tail history is exposed through
+        // FilterLogEvents / GetLogEvents instead.
         let session_id = uuid::Uuid::new_v4().to_string();
-        let mut session_results: Vec<Value> = Vec::new();
-        let accounts = self.state.read();
-        if let Some(state) = accounts.get(&req.account_id) {
-            for ident in &identifiers {
-                let group_name = log_group_name_from_identifier(ident);
-                let Some(group) = state.log_groups.get(&group_name) else {
-                    continue;
-                };
-                for (stream_name, stream) in &group.log_streams {
-                    if !stream_filter.is_empty() && !stream_filter.iter().any(|s| s == stream_name)
-                    {
-                        continue;
-                    }
-                    for ev in stream
-                        .events
-                        .iter()
-                        .rev()
-                        .take(500)
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev()
-                    {
-                        if let Some(p) = &pattern {
-                            if !ev.message.contains(p) {
-                                continue;
-                            }
-                        }
-                        session_results.push(json!({
-                            "logGroupIdentifier": group.arn,
-                            "logStreamName": stream_name,
-                            "message": ev.message,
-                            "timestamp": ev.timestamp,
-                            "ingestionTime": ev.ingestion_time,
-                        }));
-                    }
-                }
-            }
-        }
+        let _ = (&self.state, &stream_filter, &pattern);
         Ok(AwsResponse::json(
             StatusCode::OK,
             serde_json::to_string(&json!({
@@ -659,10 +627,6 @@ impl LogsService {
                         "logGroupIdentifiers": identifiers,
                         "logEventFilterPattern": pattern,
                         "logStreamNames": stream_filter,
-                    },
-                    "sessionUpdate": {
-                        "sessionResults": session_results,
-                        "sessionMetadata": {"sampled": false},
                     },
                 }
             }))
@@ -1295,6 +1259,11 @@ mod tests {
         assert!(body["responseStream"]["sessionStart"]["sessionId"]
             .as_str()
             .is_some());
+        // `StartLiveTailResponseStream` is a Smithy union — the initial
+        // framed response carries exactly one variant (sessionStart).
+        let stream = body["responseStream"].as_object().unwrap();
+        assert_eq!(stream.len(), 1);
+        assert!(stream.contains_key("sessionStart"));
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -1,9 +1,9 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
+use crate::validation::*;
 use fakecloud_aws::arn::Arn;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use crate::validation::*;
 
 use super::{require_str, LogsService};
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::LogsService;
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::LogsService;
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::{require_str, LogsService};
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::{require_str, LogsService};
 use chrono::Utc;

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::{json, Value};
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::{validation_error, LogsService};
 use base64::Engine;

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::{validation_error, LogsService};
 use base64::Engine;

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 use serde_json::json;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
-use fakecloud_core::validation::*;
+use crate::validation::*;
 
 use super::LogsService;
 

--- a/crates/fakecloud-logs/src/service/tags.rs
+++ b/crates/fakecloud-logs/src/service/tags.rs
@@ -1,8 +1,8 @@
 use http::StatusCode;
 use serde_json::json;
 
-use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use crate::validation::*;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use super::LogsService;
 

--- a/crates/fakecloud-logs/src/validation.rs
+++ b/crates/fakecloud-logs/src/validation.rs
@@ -1,0 +1,157 @@
+//! CloudWatch Logs-specific input validators.
+//!
+//! These mirror the generic helpers in [`fakecloud_core::validation`] but emit
+//! `InvalidParameterException` instead of `ValidationException`, matching the
+//! errors declared in the `com.amazonaws.cloudwatchlogs` Smithy model. The
+//! distinction matters for conformance: clients using `aws-sdk-cloudwatchlogs`
+//! expect to deserialize `InvalidParameterException`, and `ValidationException`
+//! is not part of the service's error union.
+
+use fakecloud_core::service::AwsServiceError;
+use http::StatusCode;
+
+fn invalid_parameter(message: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidParameterException",
+        message.into(),
+    )
+}
+
+/// Validate a string's length is within [min, max].
+pub fn validate_string_length(
+    field: &str,
+    value: &str,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    let len = value.len();
+    if len < min || len > max {
+        return Err(invalid_parameter(format!(
+            "Value at '{}' failed to satisfy constraint: \
+             Member must have length between {} and {}",
+            field, min, max,
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an integer is within [min, max].
+pub fn validate_range_i64(
+    field: &str,
+    value: i64,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    if value < min || value > max {
+        return Err(invalid_parameter(format!(
+            "Value '{}' at '{}' failed to satisfy constraint: \
+             Member must have value between {} and {}",
+            value, field, min, max,
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a string is one of the allowed enum values.
+pub fn validate_enum(field: &str, value: &str, allowed: &[&str]) -> Result<(), AwsServiceError> {
+    if !allowed.contains(&value) {
+        return Err(invalid_parameter(format!(
+            "Value '{}' at '{}' failed to satisfy constraint: \
+             Member must satisfy enum value set: [{}]",
+            value,
+            field,
+            allowed.join(", "),
+        )));
+    }
+    Ok(())
+}
+
+/// Validate that a required field is present (not null/missing).
+pub fn validate_required(field: &str, value: &serde_json::Value) -> Result<(), AwsServiceError> {
+    if value.is_null() {
+        return Err(invalid_parameter(format!("{} is required", field)));
+    }
+    Ok(())
+}
+
+/// Validate an optional string's length if present.
+pub fn validate_optional_string_length(
+    field: &str,
+    value: Option<&str>,
+    min: usize,
+    max: usize,
+) -> Result<(), AwsServiceError> {
+    if let Some(v) = value {
+        validate_string_length(field, v, min, max)?;
+    }
+    Ok(())
+}
+
+/// Validate an optional integer range if present.
+pub fn validate_optional_range_i64(
+    field: &str,
+    value: Option<i64>,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    if let Some(v) = value {
+        validate_range_i64(field, v, min, max)?;
+    }
+    Ok(())
+}
+
+/// Validate an optional enum value if present.
+pub fn validate_optional_enum_value(
+    field: &str,
+    value: &serde_json::Value,
+    allowed: &[&str],
+) -> Result<(), AwsServiceError> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let s = value.as_str().ok_or_else(|| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "SerializationException",
+            format!("Value for '{}' must be a string", field),
+        )
+    })?;
+    validate_enum(field, s, allowed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_use_invalid_parameter_exception() {
+        let err = validate_string_length("kmsKeyId", "", 1, 256).unwrap_err();
+        assert_eq!(err.code(), "InvalidParameterException");
+
+        let err = validate_range_i64("limit", 0, 1, 50).unwrap_err();
+        assert_eq!(err.code(), "InvalidParameterException");
+
+        let err = validate_enum("kind", "bad", &["good"]).unwrap_err();
+        assert_eq!(err.code(), "InvalidParameterException");
+
+        let err = validate_required("logGroupName", &serde_json::Value::Null).unwrap_err();
+        assert_eq!(err.code(), "InvalidParameterException");
+    }
+
+    #[test]
+    fn optional_helpers_passthrough_on_none() {
+        assert!(validate_optional_string_length("x", None, 1, 5).is_ok());
+        assert!(validate_optional_range_i64("y", None, 1, 5).is_ok());
+        assert!(
+            validate_optional_enum_value("z", &serde_json::Value::Null, &["a", "b"]).is_ok()
+        );
+    }
+
+    #[test]
+    fn enum_value_rejects_non_string() {
+        let err = validate_optional_enum_value("kind", &serde_json::json!(123), &["a"])
+            .unwrap_err();
+        assert_eq!(err.code(), "SerializationException");
+    }
+}

--- a/crates/fakecloud-logs/src/validation.rs
+++ b/crates/fakecloud-logs/src/validation.rs
@@ -143,15 +143,13 @@ mod tests {
     fn optional_helpers_passthrough_on_none() {
         assert!(validate_optional_string_length("x", None, 1, 5).is_ok());
         assert!(validate_optional_range_i64("y", None, 1, 5).is_ok());
-        assert!(
-            validate_optional_enum_value("z", &serde_json::Value::Null, &["a", "b"]).is_ok()
-        );
+        assert!(validate_optional_enum_value("z", &serde_json::Value::Null, &["a", "b"]).is_ok());
     }
 
     #[test]
     fn enum_value_rejects_non_string() {
-        let err = validate_optional_enum_value("kind", &serde_json::json!(123), &["a"])
-            .unwrap_err();
+        let err =
+            validate_optional_enum_value("kind", &serde_json::json!(123), &["a"]).unwrap_err();
         assert_eq!(err.code(), "SerializationException");
     }
 }


### PR DESCRIPTION
## Summary

- Routes CloudWatch Logs validation through a new logs-local `validation` module that emits `InvalidParameterException` instead of the generic `ValidationException` not declared in the Smithy error union.
- `PutDestinationPolicy` for unknown destinations: `InvalidParameterException` (the op doesn't list `ResourceNotFoundException` in its errors).
- `DescribeExportTasks` with unknown taskId: empty `exportTasks` list (no error declared for this case).
- `StartLiveTail`: response envelope now carries exactly one `StartLiveTailResponseStream` union variant (`sessionStart`), satisfying the Smithy union contract.
- Baseline bumped to 3897/3897 (+70 variants); other services restored from main snapshot.

## Test plan

- [x] `cargo test -p fakecloud-logs --lib` (299 passed; new tests for validator error codes, empty `DescribeExportTasks` list, `PutDestinationPolicy` error code, single-variant `StartLiveTail` union)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Conformance probe: `logs: 3897/3897 (100.00%)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings CloudWatch Logs conformance to 100% by aligning error codes and response shapes with AWS. `fakecloud-logs` now passes 3897/3897 variants and updates the conformance baseline.

- **Bug Fixes**
  - `PutDestinationPolicy` unknown destination now returns `InvalidParameterException`.
  - `DescribeExportTasks` with an unknown `taskId` returns an empty `exportTasks` array.
  - `StartLiveTail` response now carries exactly one `StartLiveTailResponseStream` variant (`sessionStart`).

- **Refactors**
  - Added a logs-specific `validation` module that emits `InvalidParameterException` and rewired Logs ops to use it (e.g., AssociateKmsKey, CreateLogGroup, PutQueryDefinition, UpdateAnomaly).
  - Ran `cargo fmt` on logs code (no functional changes).

<sup>Written for commit fe9cf94ed1d15739f3f29d21a5daa13f22fb2712. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

