### PR TITLE
fix(docker): patch HIGH CVEs in runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin fakecloud
 
-FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/fakecloud /usr/local/bin/
 EXPOSE 4566
 ENTRYPOINT ["fakecloud"]


### PR DESCRIPTION
## Summary
- Trivy scan in `Docker` workflow failing on every push since base image fell behind upstream patches
- 5 HIGH CVEs in `debian:bookworm-slim` runtime layer, all with fixed versions in debian 12 repos:
  - `CVE-2026-0861` glibc heap corruption (libc-bin, libc6)
  - `CVE-2026-4878` libcap TOCTOU privesc (libcap2)
  - `CVE-2026-29111` systemd RCE/DoS via IPC (libsystemd0, libudev1)
- Bumped pinned digest to current `debian:bookworm-slim` (2026-05-08) and added `apt-get upgrade -y` so future security patches land at build time without digest bumps

## Test plan
- [ ] Docker workflow green on this PR (build + trivy scan)
- [ ] Scan summary shows 0 HIGH/CRITICAL fixed vulns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches HIGH CVEs in the runtime Docker image so the Trivy scan passes. Bumps the `debian:bookworm-slim` base digest and upgrades packages at build time.

- **Bug Fixes**
  - Update base to `debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3`.
  - Add `apt-get upgrade -y`, install `ca-certificates` with `--no-install-recommends`, and clean APT cache.
  - Resolves HIGH CVEs in `glibc`, `libcap`, and `systemd`, and ensures future builds pull security patches.

<sup>Written for commit c39d1ac56bd48b75e00ce4edcccace0e6bff372c. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1446?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

