### PR TITLE
fix(logs): rebump baseline to 100% (3897/3897)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,9 +1,9 @@
 {
-  "variants_passed": 86212,
+  "variants_passed": 86282,
   "total_variants": 86327,
   "per_service": {
     "logs": {
-      "passed": 3827,
+      "passed": 3897,
       "total": 3897
     },
     "ecr": {


### PR DESCRIPTION
## Summary
- CloudWatch Logs conformance is fully passing on main; baseline had drifted to 3827/3897 after a prior revert (see #1442).
- Re-ran probe: 113/113 ops implemented, 3897/3897 variants pass.
- Bumps baseline only; no source changes.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services logs` -> 3897/3897

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-sync conformance baseline for CloudWatch Logs to 100% (3897/3897); overall totals now 86282/86327. Updates `conformance-baseline.json` only; no source changes.

<sup>Written for commit aaec6da47faba010192cee19d1480fec8faa063a. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1447?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

