### PR TITLE
fix(sns): bring conformance to 100% (1018/1018)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 86282,
+  "variants_passed": 86286,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -39,7 +39,7 @@
       "total": 1166
     },
     "sns": {
-      "passed": 1014,
+      "passed": 1018,
       "total": 1018
     },
     "bedrock-runtime": {

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -86,6 +86,36 @@ pub(crate) fn required(req: &AwsRequest, name: &str) -> Result<String, AwsServic
     })
 }
 
+/// Validate MaxResults is in [min, max] per Smithy `@range` traits.
+///
+/// AWS SNS rejects out-of-range MaxResults with `InvalidParameter` (HTTP 400)
+/// rather than silently clamping. Different list ops use different ranges
+/// (e.g. ListOriginationNumbers 1..=30, ListSMSSandboxPhoneNumbers 1..=100).
+pub(crate) fn validate_max_results(
+    req: &AwsRequest,
+    min: i64,
+    max: i64,
+) -> Result<(), AwsServiceError> {
+    let Some(raw) = param(req, "MaxResults") else {
+        return Ok(());
+    };
+    let n: i64 = raw.trim().parse().map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            format!("Invalid parameter: MaxResults must be an integer, got {raw}"),
+        )
+    })?;
+    if n < min || n > max {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameter",
+            format!("Invalid parameter: MaxResults must be between {min} and {max}, got {n}"),
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_message_structure_json(message: &str) -> Result<(), AwsServiceError> {
     let parsed: Value = serde_json::from_str(message).map_err(|_| {
         AwsServiceError::aws_error(

--- a/crates/fakecloud-sns/src/service_sms.rs
+++ b/crates/fakecloud-sns/src/service_sms.rs
@@ -305,6 +305,7 @@ impl SnsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        validate_max_results(req, 1, 100)?;
         let _accts = self.state.read();
         let _empty = crate::state::SnsState::new(&req.account_id, &req.region, "");
         let state = _accts.get(&req.account_id).unwrap_or(&_empty);
@@ -366,6 +367,7 @@ impl SnsService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        validate_max_results(req, 1, 30)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         state.seed_default_origination_numbers();

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -2796,6 +2796,41 @@ fn list_origination_numbers_seeds_default() {
 }
 
 #[test]
+fn list_origination_numbers_rejects_max_results_below_min() {
+    let (svc, _) = make_sns();
+    let req = sns_request("ListOriginationNumbers", vec![("MaxResults", "0")]);
+    let err = match svc.list_origination_numbers(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected MaxResults validation error"),
+    };
+    assert_eq!(err.code(), "InvalidParameter");
+}
+
+#[test]
+fn list_origination_numbers_rejects_max_results_above_max() {
+    let (svc, _) = make_sns();
+    // Smithy @range max for ListOriginationNumbers is 30.
+    let req = sns_request("ListOriginationNumbers", vec![("MaxResults", "31")]);
+    let err = match svc.list_origination_numbers(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected MaxResults validation error"),
+    };
+    assert_eq!(err.code(), "InvalidParameter");
+}
+
+#[test]
+fn list_sms_sandbox_phone_numbers_rejects_max_results_above_max() {
+    let (svc, _) = make_sns();
+    // Smithy @range max for MaxItems is 100.
+    let req = sns_request("ListSMSSandboxPhoneNumbers", vec![("MaxResults", "101")]);
+    let err = match svc.list_sms_sandbox_phone_numbers(&req) {
+        Err(e) => e,
+        Ok(_) => panic!("expected MaxResults validation error"),
+    };
+    assert_eq!(err.code(), "InvalidParameter");
+}
+
+#[test]
 fn put_data_protection_policy_requires_topic() {
     let (svc, _) = make_sns();
     let req = sns_request(


### PR DESCRIPTION
## Summary
- `ListOriginationNumbers` and `ListSMSSandboxPhoneNumbers` were silently accepting out-of-range `MaxResults`. The Smithy models declare `@range` (1..=30 and 1..=100 respectively) which AWS enforces with `InvalidParameter`.
- Add `validate_max_results()` helper and call it from both endpoints with the per-op range.
- Bump baseline 1014 -> 1018.

## Test plan
- [x] 3 new unit tests in `service_tests.rs` covering below-min and above-max rejection
- [x] `cargo run -p fakecloud-conformance --release -- run --services sns` -> 1018/1018

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `MaxResults` validation for SNS `ListOriginationNumbers` and `ListSMSSandboxPhoneNumbers`, returning `InvalidParameter` for non-integer or out-of-range values to match AWS. Brings SNS conformance to 100% (1018/1018).

- **Bug Fixes**
  - Added `validate_max_results()` and applied it to both endpoints; enforces integer and per-op ranges (1..=30, 1..=100).
  - Added 3 unit tests covering below-min and above-max cases.
  - Updated baseline: SNS 1018/1018; `variants_passed` 86286.

<sup>Written for commit 78b9d2e8eebe33fd1f0452c424ea146fe5095ad7. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1448?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

