### PR TITLE
fix(application-autoscaling): bring conformance to 100% (949/949)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 86128,
+  "variants_passed": 86212,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -27,7 +27,7 @@
       "total": 2864
     },
     "application-autoscaling": {
-      "passed": 933,
+      "passed": 949,
       "total": 949
     },
     "bedrock-agent": {

--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -94,8 +94,11 @@ impl ApplicationAutoScalingService {
     fn register_scalable_target(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let service_namespace = require_str(&body, "ServiceNamespace")?;
+        validate_service_namespace(&service_namespace)?;
         let resource_id = require_str(&body, "ResourceId")?;
+        validate_resource_id_len("resourceId", &resource_id)?;
         let scalable_dimension = require_str(&body, "ScalableDimension")?;
+        validate_scalable_dimension(&scalable_dimension)?;
         let min_capacity = body
             .get("MinCapacity")
             .and_then(Value::as_i64)
@@ -108,6 +111,9 @@ impl ApplicationAutoScalingService {
             .get("RoleARN")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(role) = role_arn.as_deref() {
+            validate_resource_id_len("roleARN", role)?;
+        }
         let suspended_state = body.get("SuspendedState").map(parse_suspended_state);
 
         let key = (
@@ -208,6 +214,7 @@ impl ApplicationAutoScalingService {
     fn describe_scalable_targets(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let namespace = require_str(&body, "ServiceNamespace")?;
+        validate_service_namespace(&namespace)?;
         let resource_ids: Vec<String> = body
             .get("ResourceIds")
             .and_then(Value::as_array)
@@ -217,10 +224,16 @@ impl ApplicationAutoScalingService {
                     .collect()
             })
             .unwrap_or_default();
+        for rid in &resource_ids {
+            validate_resource_id_len("resourceIds", rid)?;
+        }
         let dimension = body
             .get("ScalableDimension")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(d) = dimension.as_deref() {
+            validate_scalable_dimension(d)?;
+        }
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
@@ -362,6 +375,7 @@ impl ApplicationAutoScalingService {
     fn describe_scaling_policies(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let namespace = require_str(&body, "ServiceNamespace")?;
+        validate_service_namespace(&namespace)?;
         let policy_names: Vec<String> = body
             .get("PolicyNames")
             .and_then(Value::as_array)
@@ -375,10 +389,16 @@ impl ApplicationAutoScalingService {
             .get("ResourceId")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(r) = resource_id.as_deref() {
+            validate_resource_id_len("resourceId", r)?;
+        }
         let dimension = body
             .get("ScalableDimension")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(d) = dimension.as_deref() {
+            validate_scalable_dimension(d)?;
+        }
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
@@ -525,6 +545,7 @@ impl ApplicationAutoScalingService {
     fn describe_scheduled_actions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let namespace = require_str(&body, "ServiceNamespace")?;
+        validate_service_namespace(&namespace)?;
         let names: Vec<String> = body
             .get("ScheduledActionNames")
             .and_then(Value::as_array)
@@ -538,10 +559,16 @@ impl ApplicationAutoScalingService {
             .get("ResourceId")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(r) = resource_id.as_deref() {
+            validate_resource_id_len("resourceId", r)?;
+        }
         let dimension = body
             .get("ScalableDimension")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(d) = dimension.as_deref() {
+            validate_scalable_dimension(d)?;
+        }
         let max_results = body
             .get("MaxResults")
             .and_then(Value::as_u64)
@@ -610,14 +637,21 @@ impl ApplicationAutoScalingService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let namespace = require_str(&body, "ServiceNamespace")?;
+        validate_service_namespace(&namespace)?;
         let resource_id = body
             .get("ResourceId")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(r) = resource_id.as_deref() {
+            validate_resource_id_len("resourceId", r)?;
+        }
         let dimension = body
             .get("ScalableDimension")
             .and_then(Value::as_str)
             .map(|s| s.to_string());
+        if let Some(d) = dimension.as_deref() {
+            validate_scalable_dimension(d)?;
+        }
         let include_not_scaled = body
             .get("IncludeNotScaledActivities")
             .and_then(Value::as_bool)
@@ -812,6 +846,85 @@ fn require_str(body: &Value, field: &str) -> Result<String, AwsServiceError> {
 
 fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg)
+}
+
+// Smithy: com.amazonaws.applicationautoscaling#ServiceNamespace
+const VALID_SERVICE_NAMESPACES: &[&str] = &[
+    "ecs",
+    "elasticmapreduce",
+    "ec2",
+    "appstream",
+    "dynamodb",
+    "rds",
+    "sagemaker",
+    "custom-resource",
+    "comprehend",
+    "lambda",
+    "cassandra",
+    "kafka",
+    "elasticache",
+    "neptune",
+    "workspaces",
+];
+
+// Smithy: com.amazonaws.applicationautoscaling#ScalableDimension
+const VALID_SCALABLE_DIMENSIONS: &[&str] = &[
+    "ecs:service:DesiredCount",
+    "ec2:spot-fleet-request:TargetCapacity",
+    "elasticmapreduce:instancegroup:InstanceCount",
+    "appstream:fleet:DesiredCapacity",
+    "dynamodb:table:ReadCapacityUnits",
+    "dynamodb:table:WriteCapacityUnits",
+    "dynamodb:index:ReadCapacityUnits",
+    "dynamodb:index:WriteCapacityUnits",
+    "rds:cluster:ReadReplicaCount",
+    "sagemaker:variant:DesiredInstanceCount",
+    "custom-resource:ResourceType:Property",
+    "comprehend:document-classifier-endpoint:DesiredInferenceUnits",
+    "comprehend:entity-recognizer-endpoint:DesiredInferenceUnits",
+    "lambda:function:ProvisionedConcurrency",
+    "cassandra:table:ReadCapacityUnits",
+    "cassandra:table:WriteCapacityUnits",
+    "kafka:broker-storage:VolumeSize",
+    "elasticache:cache-cluster:Nodes",
+    "elasticache:replication-group:NodeGroups",
+    "elasticache:replication-group:Replicas",
+    "neptune:cluster:ReadReplicaCount",
+    "sagemaker:variant:DesiredProvisionedConcurrency",
+    "sagemaker:inference-component:DesiredCopyCount",
+    "workspaces:workspacespool:DesiredUserSessions",
+];
+
+fn validate_service_namespace(value: &str) -> Result<(), AwsServiceError> {
+    if VALID_SERVICE_NAMESPACES.contains(&value) {
+        Ok(())
+    } else {
+        Err(invalid_param(format!(
+            "Value '{value}' at 'serviceNamespace' failed to satisfy constraint: Member must satisfy enum value set: {VALID_SERVICE_NAMESPACES:?}"
+        )))
+    }
+}
+
+fn validate_scalable_dimension(value: &str) -> Result<(), AwsServiceError> {
+    if VALID_SCALABLE_DIMENSIONS.contains(&value) {
+        Ok(())
+    } else {
+        Err(invalid_param(format!(
+            "Value '{value}' at 'scalableDimension' failed to satisfy constraint: Member must satisfy enum value set: {VALID_SCALABLE_DIMENSIONS:?}"
+        )))
+    }
+}
+
+// Smithy: com.amazonaws.applicationautoscaling#ResourceIdMaxLen1600 (length 1..=1600).
+// Same shape is also used for RoleARN, so we validate both via the same range.
+fn validate_resource_id_len(field: &str, value: &str) -> Result<(), AwsServiceError> {
+    let len = value.chars().count();
+    if !(1..=1600).contains(&len) {
+        return Err(invalid_param(format!(
+            "Value at '{field}' failed to satisfy constraint: Member must have length between 1 and 1600, inclusive"
+        )));
+    }
+    Ok(())
 }
 
 fn object_not_found(msg: impl Into<String>) -> AwsServiceError {


### PR DESCRIPTION
## Summary

The schema-driven conformance probe surfaced 16 silent input-drop gaps across 5 application-autoscaling operations:

- `DescribeScalableTargets` accepted any string for `ServiceNamespace`/`ScalableDimension` and returned 200 with empty results instead of `ValidationException`.
- `DescribeScalingActivities`, `DescribeScalingPolicies`, `DescribeScheduledActions`: same enum gap, plus `ResourceId` `@length(1, 1600)` was not enforced (empty + 1601-char strings passed).
- `RegisterScalableTarget`: `RoleARN` `@length(1, 1600)` was not enforced.

Added Smithy-grounded validators (`validate_service_namespace`, `validate_scalable_dimension`, `validate_resource_id_len`) and wired them through each affected op. Enum value lists come verbatim from `aws-models/application-autoscaling.json`.

3 consecutive `--services application-autoscaling` probe runs return 949/949. Existing 13 lib tests + 17 e2e tests still pass.

## Test plan

- [x] `cargo test --release -p fakecloud-application-autoscaling`
- [x] `cargo test --release -p fakecloud-e2e --test application_autoscaling`
- [x] `cargo clippy --release -p fakecloud-application-autoscaling --all-targets -- -D warnings`
- [x] `fakecloud-conformance run --services application-autoscaling` x3 = 949/949

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Smithy enum and length validation in Application Auto Scaling to stop silently accepting invalid inputs, bringing conformance to 100% (949/949). Baseline updated; all existing tests still pass.

- **Bug Fixes**
  - Added validators for `ServiceNamespace`/`ScalableDimension` enums and 1–1600 length checks for `ResourceId`/`RoleARN`.
  - Applied to: RegisterScalableTarget, DescribeScalableTargets, DescribeScalingActivities, DescribeScalingPolicies, DescribeScheduledActions. Invalid values now return ValidationException.
  - Updated conformance baseline (application-autoscaling: 949/949; overall +84 variants passed). No changes for valid requests.

<sup>Written for commit 1a0a1cf399821cb4ca4ab7dd8fc3f25a89935368. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

