### PR TITLE
fix(cognito-idp): rebump baseline to 100% (4469/4469)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 86286,
+  "variants_passed": 86297,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -103,7 +103,7 @@
       "total": 447
     },
     "cognito-idp": {
-      "passed": 4458,
+      "passed": 4469,
       "total": 4469
     },
     "cloudfront": {


### PR DESCRIPTION
## Summary
- Cognito IDP conformance is fully passing on main; baseline had drifted to 4458/4469.
- Re-ran probe: 122/122 ops, 4469/4469 variants pass.
- Bumps baseline only; no source changes.

## Test plan
- [x] `cargo run -p fakecloud-conformance --release -- run --services cognito-idp` -> 4469/4469

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebump conformance baseline to reflect 100% Cognito IDP coverage (4469/4469 across 122 ops). No source changes; updated `conformance-baseline.json` to set `cognito-idp.passed` to 4469 and bump top-level `variants_passed` to 86297.

<sup>Written for commit 4d6eee8d088442865dbb66b4ce96326b30e416d4. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

