### PR TITLE
fix(dynamodb): ratchet baseline to 100% (2110/2110)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 86286,
+  "variants_passed": 86297,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -15,7 +15,7 @@
       "total": 3426
     },
     "dynamodb": {
-      "passed": 2099,
+      "passed": 2110,
       "total": 2110
     },
     "ecs": {


### PR DESCRIPTION
## Summary

The schema-driven conformance probe already reports 2110/2110 passing across all DynamoDB operations on a fresh build of `main`; the 2099/2110 figure in `conformance-baseline.json` reflected an earlier transient probe ordering quirk that has since stabilized.

3 consecutive `--services dynamodb` probe runs return 2110/2110 with no source changes required. Updating the baseline so the CI ratchet locks the new floor.

## Test plan

- [x] `fakecloud-conformance run --services dynamodb` x3 = 2110/2110

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ratchets DynamoDB conformance to 100% (2110/2110) and updates `variants_passed` to 86297. Aligns the CI ratchet with current probe results to prevent false regressions from the old 2099/2110 baseline.

<sup>Written for commit c641f17926c2d12bc8ebf9633c5d3bbb0e979e2e. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

