### PR TITLE
fix(lambda): bring conformance to 100% (3178/3178)

### DIFF
--- a/conformance-baseline.json
+++ b/conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "variants_passed": 86297,
+  "variants_passed": 86304,
   "total_variants": 86327,
   "per_service": {
     "logs": {
@@ -143,7 +143,7 @@
       "total": 2398
     },
     "lambda": {
-      "passed": 3171,
+      "passed": 3178,
       "total": 3178
     }
   }

--- a/crates/fakecloud-lambda/src/extras.rs
+++ b/crates/fakecloud-lambda/src/extras.rs
@@ -1983,7 +1983,7 @@ impl LambdaService {
             function_arn: function_arn.clone(),
             maximum_event_age: event_age,
             maximum_retry_attempts: retries,
-            destination_config: body.get("DestinationConfig").cloned().unwrap_or(json!({})),
+            destination_config: body.get("DestinationConfig").cloned(),
             last_modified: Utc::now(),
         };
         let mut accounts = self.state.write();
@@ -2725,18 +2725,28 @@ fn code_signing_json(c: &CodeSigningConfig) -> Value {
 }
 
 fn event_invoke_json(c: &EventInvokeConfig) -> Value {
-    // AWS always emits `DestinationConfig` with both `OnSuccess` and
-    // `OnFailure` populated (possibly empty objects). Backfill missing
-    // halves so strict shape validators and SDK destructuring don't
-    // trip on absent fields.
-    let mut destination = c.destination_config.clone();
-    if !destination.is_object() {
-        destination = json!({});
-    }
-    if let Some(map) = destination.as_object_mut() {
-        map.entry("OnSuccess".to_string()).or_insert(json!({}));
-        map.entry("OnFailure".to_string()).or_insert(json!({}));
-    }
+    // `DestinationConfig` serialization mirrors the three AWS behaviours
+    // documented in the Smithy `@examples` for Put/UpdateFunctionEventInvokeConfig
+    // and asserted by the conformance round-trip strategy:
+    //
+    //   stored `None`          (input omitted entirely)
+    //       -> emit `{OnSuccess:{}, OnFailure:{}}`  (Put example)
+    //   stored `Some({})`      (caller sent `{}`)
+    //       -> echo `{}` verbatim                    (round-trip strategy)
+    //   stored `Some({half})`  (one side configured)
+    //       -> backfill the other half as `{}`       (Update example)
+    let destination = match &c.destination_config {
+        None => json!({"OnSuccess": {}, "OnFailure": {}}),
+        Some(v) if !v.is_object() => json!({}),
+        Some(v) => {
+            let mut map = v.as_object().cloned().unwrap_or_default();
+            if !map.is_empty() {
+                map.entry("OnSuccess".to_string()).or_insert(json!({}));
+                map.entry("OnFailure".to_string()).or_insert(json!({}));
+            }
+            Value::Object(map)
+        }
+    };
     json!({
         "FunctionArn": c.function_arn,
         "MaximumEventAgeInSeconds": c.maximum_event_age,

--- a/crates/fakecloud-lambda/src/service.rs
+++ b/crates/fakecloud-lambda/src/service.rs
@@ -1758,7 +1758,7 @@ impl LambdaService {
         state
             .event_invoke_configs
             .get(&key)
-            .map(|cfg| cfg.destination_config.clone())
+            .and_then(|cfg| cfg.destination_config.clone())
             .filter(|v| !v.is_null() && !v.as_object().map(|o| o.is_empty()).unwrap_or(false))
     }
 

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -2772,3 +2772,65 @@ async fn invoke_publishes_invocations_metric_when_runtime_missing() {
     assert!(names.contains(&"Duration"), "missing Duration: {names:?}");
     assert!(names.contains(&"Errors"), "missing Errors: {names:?}");
 }
+
+/// Pin the three `DestinationConfig` echo behaviours documented in the
+/// Lambda Smithy `@examples` and asserted by the conformance round-trip
+/// strategy. See `event_invoke_json` in `extras.rs`.
+#[tokio::test]
+async fn put_function_event_invoke_destination_config_echo_variants() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "ei-fn").await;
+
+    // 1. Input omits DestinationConfig -> response synthesizes both halves
+    //    (matches @examples for PutFunctionEventInvokeConfig).
+    let req = make_request(
+        Method::PUT,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({"MaximumRetryAttempts": 0, "MaximumEventAgeInSeconds": 3600}).to_string(),
+    );
+    let v: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(
+        v["DestinationConfig"],
+        json!({"OnSuccess": {}, "OnFailure": {}}),
+        "omitted DestinationConfig should synthesize empty halves"
+    );
+
+    // 2. Input is explicit empty object -> echo verbatim (round-trip strategy).
+    let req = make_request(
+        Method::PUT,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({"DestinationConfig": {}}).to_string(),
+    );
+    let v: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(
+        v["DestinationConfig"],
+        json!({}),
+        "explicit empty DestinationConfig should echo verbatim"
+    );
+
+    // 3. Half-populated -> backfill missing half (matches @examples for
+    //    UpdateFunctionEventInvokeConfig).
+    let req = make_request(
+        Method::PUT,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({
+            "DestinationConfig": {
+                "OnFailure": {"Destination": "arn:aws:sqs:us-east-1:123456789012:dlq"}
+            }
+        })
+        .to_string(),
+    );
+    let v: Value =
+        serde_json::from_slice(svc.handle(req).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(
+        v["DestinationConfig"]["OnFailure"]["Destination"],
+        "arn:aws:sqs:us-east-1:123456789012:dlq"
+    );
+    assert_eq!(
+        v["DestinationConfig"]["OnSuccess"],
+        json!({}),
+        "missing OnSuccess half should be backfilled as empty object"
+    );
+}

--- a/crates/fakecloud-lambda/src/state.rs
+++ b/crates/fakecloud-lambda/src/state.rs
@@ -343,7 +343,17 @@ pub struct EventInvokeConfig {
     pub function_arn: String,
     pub maximum_event_age: i64,
     pub maximum_retry_attempts: i64,
-    pub destination_config: serde_json::Value,
+    /// `None` -> input omitted `DestinationConfig` entirely; AWS responds
+    /// with `{OnSuccess:{}, OnFailure:{}}` (per `@examples` for
+    /// `PutFunctionEventInvokeConfig`).
+    ///
+    /// `Some({})` -> caller explicitly sent `{}`; AWS echoes `{}` verbatim
+    /// (round-trip semantics).
+    ///
+    /// `Some({...})` -> half-populated; AWS backfills the missing half as
+    /// `{}` (per `@examples` for `UpdateFunctionEventInvokeConfig`).
+    #[serde(default)]
+    pub destination_config: Option<serde_json::Value>,
     pub last_modified: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Summary
- `PutFunctionEventInvokeConfig` / `UpdateFunctionEventInvokeConfig` were unconditionally back-filling `DestinationConfig` with empty `OnSuccess` / `OnFailure` halves, breaking the round-trip echo: caller sent `{}`, got back `{OnSuccess:{}, OnFailure:{}}`.
- AWS's actual behaviour (Smithy `@examples`):
  - omitted -> synthesize both empty halves
  - explicit `{}` -> echo verbatim
  - half-populated -> backfill the other half
- Store `destination_config` as `Option<Value>` to keep "omitted" vs "explicit empty" distinct, then serialize per the three cases above.
- Bump baseline 3171 -> 3178.

## Test plan
- [x] New unit test `put_function_event_invoke_destination_config_echo_variants` pins all three branches
- [x] `cargo run -p fakecloud-conformance --release -- run --services lambda` -> 3178/3178

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DestinationConfig` handling in Lambda event-invoke config APIs to match AWS for omitted, empty, and half-populated inputs. Restores round-trip behavior and brings Lambda conformance to 3178/3178 (overall 86304/86327).

- **Bug Fixes**
  - Store `destination_config` as `Option<Value>` and serialize per AWS rules: omitted -> synthesize both halves; `{}` -> echo; half-populated -> backfill the other half.
  - Add a unit test covering all three echo variants.

<sup>Written for commit f044005e12b4c4201d4e316298d8e7b3e04924be. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

