### PR TITLE
[Olwen] Blog: Eliminating AWS Auth Friction: The 'No' List for Local Development

### DIFF
--- a/website/content/blog/eliminating-aws-auth-friction-the-no-list-for-local-development.md
+++ b/website/content/blog/eliminating-aws-auth-friction-the-no-list-for-local-development.md
@@ -1,0 +1,132 @@
++++
+title = "Eliminating AWS Auth Friction: The 'No' List for Local Development"
+date = 2026-05-18
+description = "Discover why local development shouldn't require cloud accounts or auth tokens, and how fakecloud provides a high-fidelity AWS environment that works offline."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+As of May 13, 2026, the landscape of local AWS development has shifted from open utility to account-gated platforms. For security architects and engineering managers, this transition introduces a non-trivial risk: the proliferation of authentication tokens and the requirement for persistent internet connectivity just to run a local integration test. When your local development environment requires a login to a third-party SaaS provider, you haven't eliminated cloud friction; you've simply moved the gatekeeper.
+
+Security-first engineering requires a "No" List. This list defines the barriers that should not exist between a developer and their code. [fakecloud](https://github.com/faiscadev/fakecloud) was engineered to satisfy this list, providing a high-fidelity AWS environment that operates as a standalone binary without external dependencies.
+
+## The Security Hurdle: Secret Sprawl and Token Fatigue
+
+In late 2025, reports from security firms like Sysdig highlighted a disturbing trend: attackers using AI-driven automation to exploit compromised AWS credentials in under ten minutes. The "Codefinger" ransomware campaign of early 2025 specifically targeted S3 buckets by leveraging leaked developer keys. 
+
+When local development tools require real AWS credentials or proprietary auth tokens to function, the blast radius of a single developer's machine increases. If a developer's `.aws/credentials` file or a tool-specific `AUTH_TOKEN` is committed to a repository or leaked via a misconfigured CI pipeline, the security team is forced into an immediate rotation and audit cycle.
+
+fakecloud eliminates this risk by design. It does not know your real AWS account exists. It does not want your tokens. It treats all incoming requests as authorized by default, allowing you to use dummy credentials that have zero value to an attacker.
+
+```bash
+# Standard AWS CLI configuration for fakecloud
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+# No real keys required. No risk of leakage.
+aws --endpoint-url http://localhost:4566 s3 ls
+```
+
+## The 'No' List: Zero-Friction Local Development
+
+To maintain a secure and high-velocity development cycle, your local environment must adhere to three strict negatives. As of 2026-05-13, fakecloud is the only major AWS emulator that satisfies all three without a paid tier.
+
+### 1. No Account Required
+You do not need to sign up for a fakecloud account. There is no "Hobby" tier to outgrow and no "Enterprise" sales call required to unlock core services. You download the binary and run it. Your identity is irrelevant to the tool's utility.
+
+### 2. No Auth Token Required
+In March 2026, the industry's incumbent local AWS emulator transitioned its community edition to a proprietary image requiring an authentication token. This change broke thousands of air-gapped CI pipelines and forced developers to manage yet another secret. fakecloud requires zero tokens. It is a standalone utility, not a SaaS-tethered agent.
+
+### 3. No Internet Connection Required
+True local development should work on a plane, in a secure bunker, or during a regional ISP outage. fakecloud does not "phone home" to verify a license or pull service definitions. The entire API surface—all 2,422 operations—is contained within the local binary.
+
+## How It Works: High-Fidelity Emulation via Smithy
+
+Engineering managers often worry that "fake" services lead to "fake" passes in CI. A mock that returns a hardcoded JSON string is not an infrastructure emulator. fakecloud achieves 100% API conformance across its 33 supported services by using AWS's own Smithy models.
+
+Every commit to the [fakecloud repository](https://github.com/faiscadev/fakecloud) is validated against 59,000+ generated test variants. This ensures that when your application calls `DynamoDB.PutItem` or `Lambda.Invoke`, the response format, headers, and error codes exactly match the behavior of the real AWS production environment.
+
+### Performance Metrics (Verified 2026-05-13)
+- **Binary Size:** ~19MB (Rust-based, statically linked)
+- **Startup Time:** ~500ms
+- **Idle Memory Usage:** ~10MiB
+- **API Conformance:** 100% across 2,422 operations
+
+Because fakecloud is a single binary, it eliminates the overhead of managing multiple Docker containers for basic services like SQS or S3. While it can spin up Docker containers for complex runtimes (like the 23 supported Lambda runtimes), the core engine remains lightweight and fast.
+
+## Side-by-Side: The Auth Workflow Delta
+
+As of May 2026, the difference between a "SaaS-first" emulator and a "Local-first" emulator like fakecloud is stark. The following table compares the workflow requirements for a standard team setup.
+
+| Feature | Incumbent (as of 2026) | fakecloud (2026-05-13) |
+| :--- | :--- | :--- |
+| **Initial Setup** | Account creation + API Key | `curl` + `chmod +x` |
+| **CI/CD Integration** | Secret management for Auth Token | Zero configuration |
+| **Offline Usage** | Limited/Requires Enterprise | Native / Default |
+| **Bedrock Support** | 4 operations (Ultimate Tier) | 111 operations (Free/AGPL) |
+| **License** | Proprietary / Tiered | Open-source (AGPL-3.0) |
+| **Binary Size** | ~150MB+ (Docker Image) | ~19MB (Standalone Binary) |
+| **Startup Latency** | 5 - 15 seconds | ~500ms |
+
+## AI Development: Full Bedrock Support Locally
+
+Generative AI development has introduced a new set of expensive AWS dependencies. Testing agents that use Amazon Bedrock can quickly consume thousands of dollars in token costs during the debugging phase. 
+
+As of 2026-05-13, fakecloud provides the most comprehensive local Bedrock emulator available, covering 111 operations across the runtime and control plane. This includes:
+- **InvokeModel / Converse:** Full support for streaming responses.
+- **Guardrails:** Real content evaluation and PII detection logic.
+- **Async Batch:** Simulation of S3-based batch inference jobs.
+- **Prompt Management:** Local versioning and testing of prompt templates.
+
+By pointing your AI SDK to a local fakecloud endpoint, you can iterate on agentic workflows without incurring costs or sending sensitive prompt data to the public cloud.
+
+## Cross-Service Integration: Beyond Simple Mocks
+
+One of the primary failures of local development is the "silo effect," where S3 works and Lambda works, but S3 cannot trigger a Lambda. fakecloud implements real cross-service wiring for over 30 service-to-service integrations.
+
+When you run fakecloud, you are running a miniature cloud fabric. An SNS message can fan out to multiple SQS queues with active filter policies. An EventBridge rule can trigger a Step Functions state machine. These are not simulated effects; they are real operations executed within the local environment.
+
+### Supported Integration Examples:
+- **S3 Notifications:** Trigger Lambda, SQS, or SNS on object creation.
+- **SNS Fanout:** Deliver messages to SQS, Lambda, or HTTPS endpoints.
+- **DynamoDB Streams:** Capture item-level changes and trigger downstream consumers.
+- **Cognito Triggers:** Execute custom logic during the authentication lifecycle.
+
+## The Engineering Manager's Perspective: ROI of Local-First
+
+For an engineering manager, the decision to adopt fakecloud is a matter of operational efficiency. Every second a developer waits for a cloud deployment or a slow container startup is a second of lost productivity. 
+
+Consider a team of 50 developers. If each developer runs 20 integration tests per day, and a cloud-based test takes 60 seconds while a fakecloud test takes 2 seconds, the time savings is significant:
+- **Cloud-based:** 50 devs * 20 tests * 60s = 1,000 minutes/day (~16.6 hours)
+- **fakecloud:** 50 devs * 20 tests * 2s = 33.3 minutes/day (~0.5 hours)
+
+By reclaiming 16 hours of engineering time per day, the team can accelerate feature delivery without increasing headcount. Furthermore, the elimination of "sandbox account" costs and the reduction in security overhead (no more credential rotation for local leaks) provides a direct impact on the bottom line.
+
+## Implementation: Using the fakecloud SDKs
+
+While your application code should always use the standard AWS SDKs (to ensure what you test is what you ship), your test suite can benefit from the fakecloud-specific SDKs. These first-party clients for TypeScript, Python, Go, PHP, Java, and Rust allow your tests to "reach inside" the emulator to verify state or force behavior.
+
+```ts
+import { FakecloudClient } from '@fakecloud/sdk-typescript';
+
+const fc = new FakecloudClient('http://localhost:4566');
+
+// In your test:
+await fc.sns.waitForDelivery(); // Ensure all async fanouts are complete
+const emails = await fc.ses.getSentEmails(); // Inspect sent emails without a real inbox
+expect(emails[0].subject).toBe('Welcome!');
+```
+
+This separation of concerns—app uses AWS SDK, test uses fakecloud SDK—is the key to high-fidelity testing. You aren't changing your production code to make it "testable"; you are using a more powerful lens to inspect the infrastructure it runs on.
+
+## Conclusion: Start Local, Stay Local
+
+The era of requiring a cloud account to build cloud software is over. Security architects can now enforce a "no-real-keys" policy for local development, and engineering managers can stop worrying about the monthly bill for developer sandboxes. fakecloud provides the performance of a local binary with the conformance of a global cloud.
+
+Stop managing auth tokens and start building. Run the following command to launch your local AWS environment in under a second.
+
+```bash
+fakecloud start
+```


### PR DESCRIPTION
This PR adds a new blog post titled "Eliminating AWS Auth Friction: The 'No' List for Local Development".

Summary:
- Discusses the security risks of token proliferation in local development.
- Outlines the "No List" for local AWS development: No Account, No Auth Token, and No Internet required.
- Highlights fakecloud's high-fidelity emulation via Smithy models.
- Provides a side-by-side comparison with traditional cloud emulators.
- Explains the ROI of a local-first approach for engineering managers.

Slug: `eliminating-aws-auth-friction-the-no-list-for-local-development`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post, “Eliminating AWS Auth Friction: The 'No' List for Local Development,” showing how `fakecloud` enables local AWS dev with no account, no tokens, and no internet. It highlights the security, fidelity, and ROI benefits of a local-first workflow.

- **New Features**
  - Explains token sprawl risks and the “No” List (No account, No auth token, No internet).
  - Details `fakecloud`’s Smithy-based emulation, performance, Bedrock coverage, and cross-service integrations.
  - Compares with incumbents and outlines ROI for engineering managers.
  - Slug: `eliminating-aws-auth-friction-the-no-list-for-local-development`

<sup>Written for commit 7db216712648562350b628866c5d0b7aefe1efd5. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

