### PR TITLE
[Olwen] Blog: The 'No' List: Why fakecloud Requires No Account or Internet

### DIFF
--- a/website/content/blog/the-no-list-why-fakecloud-requires-no-account-or-internet.md
+++ b/website/content/blog/the-no-list-why-fakecloud-requires-no-account-or-internet.md
@@ -1,0 +1,145 @@
++++
+title = "The 'No' List: Why fakecloud Requires No Account or Internet"
+date = 2026-05-18
+description = "fakecloud is a high-fidelity, zero-friction local AWS environment delivered as a single binary that requires no account, no authentication tokens, and no internet connection."
+
+[extra]
+author = "Lucas Vieira"
++++
+
+In the current landscape of software architecture, the "Cloud-First" mantra has evolved into a mandatory tax on developer productivity. As of May 13, 2026, the industry has reached a tipping point where even local development tools—once the bastion of offline freedom—now demand vendor accounts, telemetry check-ins, and monthly subscriptions just to mock a simple S3 bucket. 
+
+fakecloud exists to reverse this trend. It is a high-fidelity, zero-friction local AWS environment delivered as a single ~19MB binary. It requires no account, no authentication tokens, and no internet connection. It is engineered for the architect who values speed, privacy, and the ability to work in air-gapped environments without compromising on API fidelity.
+
+## 1. No Accounts: Start Building Without an IAM Role or Credit Card
+
+Traditional cloud development forces you into a bureaucratic loop before you write a single line of code. You need an AWS account, which requires a credit card. You need an IAM user or role, which requires permission from a Cloud Ops team. Even modern emulators have followed this path; as of March 2026, major incumbents in the local cloud space have consolidated their images to require a mandatory user account and auth token for the latest updates.
+
+fakecloud eliminates this gatekeeping. 
+
+When you run fakecloud, you are the root administrator of a self-contained universe. There is no "Sign Up" button because there is no backend to sign up to. This is critical for:
+
+*   **Rapid Prototyping:** Spin up a full stack (S3, Lambda, DynamoDB) in 500ms without waiting for an IT ticket approval.
+*   **Onboarding:** New hires can run the entire infrastructure stack on day one, minute one, by executing a binary. No "onboarding AWS accounts" required.
+*   **Cost Control:** You cannot incur a surprise $10,000 bill on a local binary. There is no credit card attached to your development environment.
+
+```bash
+# Start fakecloud immediately. No login. No signup.
+./fakecloud start
+```
+
+## 2. No Auth: Bypass the Complexity of Token Rotation
+
+Authentication is the primary source of friction in local-to-cloud workflows. Managing `.aws/credentials` files, rotating short-lived SSO tokens, and debugging 403 Forbidden errors consumes hours of engineering time. Furthermore, the recent shift in the market toward requiring `AUTH_TOKENS` for local emulators introduces a new failure mode: if the vendor's auth server is down, your local tests fail.
+
+fakecloud treats authentication as a solved problem by ignoring it. It accepts any access key and secret key combination. Your application code uses the standard AWS SDK, but it points to `localhost`. 
+
+### The Security Advantage of No Auth
+
+By removing the requirement for real AWS credentials during development, you eliminate the risk of credential leakage. Developers often accidentally commit `.env` files or hardcoded keys to internal repositories. With fakecloud, those keys are "dummy" values that hold no power in a production environment. 
+
+| Feature | fakecloud | Account-Gated Emulators |
+| :--- | :--- | :--- |
+| **Auth Token Required** | No | Yes (as of March 2026) |
+| **SSO Integration Needed** | No | Often |
+| **Offline Auth Support** | 100% | Limited/None |
+| **Credential Leak Risk** | Zero | High |
+
+## 3. No Internet: Work in Air-Gapped Facilities or at 30,000 Feet
+
+The assumption that a developer is always connected to a high-speed, low-latency network is a fallacy. Whether you are working in a secure government facility, traveling on a plane, or dealing with a regional ISP outage, your development environment should not be a brick.
+
+fakecloud is a standalone binary. It does not "phone home." It does not check for updates unless you explicitly tell it to. It does not require a connection to verify a license key.
+
+### Performance at the Speed of Localhost
+
+When your application calls an AWS service in the cloud, you are bound by the laws of physics—specifically, the latency of light through fiber optics. A round-trip to `us-east-1` might take 60ms to 100ms. In a test suite with 1,000 S3 operations, that is 100 seconds of pure waiting.
+
+fakecloud operations happen in sub-millisecond timeframes. 
+
+*   **Startup Time:** ~500ms
+*   **Binary Size:** ~19MB
+*   **Memory Footprint:** Minimal (Go-based architecture)
+
+This speed allows for a "test-driven" workflow where the entire infrastructure is destroyed and recreated for every single test case, ensuring total isolation without the time penalty.
+
+## 4. High Fidelity: 100% API Conformance Across 2,422 Operations
+
+"Local" often implies "limited." Many developers resort to mocks or simplified stubs that behave differently than the real AWS API. This leads to the "Works on My Machine" syndrome, where code passes locally but fails in production due to subtle API differences.
+
+fakecloud solves this through rigorous conformance. We don't just "guess" how the API works; we use the same Smithy models that AWS uses to generate their SDKs. 
+
+### The Numbers of Reliability
+
+*   **33+ Core AWS Services:** Including S3, Lambda, DynamoDB, SQS, SNS, IAM, and Bedrock.
+*   **2,422 Operations:** Every operation is mapped to the official AWS specification.
+*   **59,000+ Test Variants:** Our conformance suite runs tens of thousands of generated tests to ensure that error codes, headers, and payload structures match the real AWS environment exactly.
+
+### Real Cross-Service Integrations
+
+fakecloud isn't a collection of isolated mocks. It is a cohesive system. If you upload a file to S3, it can trigger a Lambda function. If that Lambda function sends a message to SNS, it can fan out to multiple SQS queues. These integrations are baked into the binary, allowing you to test complex, event-driven architectures entirely offline.
+
+## 5. AI Development: Full Bedrock Support for Local LLM Testing
+
+As of May 2026, AI development has become the primary focus for software architects. Testing agents and RAG (Retrieval-Augmented Generation) workflows on Amazon Bedrock can be prohibitively expensive during the iterative development phase. 
+
+fakecloud provides support for 111 Bedrock operations (see our guide on [Bedrock local testing](/blog/bedrock-local-testing/)). You can test your orchestration logic, prompt templates, and guardrail configurations without hitting the real Bedrock endpoints. 
+
+*   **Model Mocking:** Simulate responses from Claude 4.7, GPT-5.5, or Amazon Nova models.
+*   **Latency Simulation:** Test how your application handles slow LLM responses by injecting artificial delays.
+*   **Error Injection:** Force `ThrottlingException` or `ValidationException` to ensure your retry logic is sound.
+
+This allows you to build and test AI-powered applications on a plane, using fakecloud to simulate the entire Bedrock API surface.
+
+## 6. The 'No' List vs. The Incumbent
+
+To understand the value of fakecloud, one must look at the friction inherent in the current market leader's workflow. 
+
+| Requirement | fakecloud | The Incumbent (2026) |
+| :--- | :--- | :--- |
+| **Account Creation** | No | Yes |
+| **Internet for Auth** | No | Yes |
+| **Binary Size** | ~19MB | ~200MB+ (Docker Image) |
+| **Startup Time** | ~500ms | 5s - 30s |
+| **License** | AGPL-3.0 | Proprietary/Gated |
+| **Commercial Use** | Included | Paid Tier Only |
+
+fakecloud is not a platform; it is a tool. It does not want to manage your state in the cloud or sell you "Cloud Pods." It wants to provide a reliable, local endpoint so you can get back to writing code.
+
+## 7. Engineering Pragmatism: The Standalone Binary
+
+Most local cloud tools are distributed as heavy Docker images. This introduces a dependency on the Docker daemon, which can be a resource hog on macOS and Windows. fakecloud is a standalone binary written in Go. 
+
+If you have the binary, you have the environment. 
+
+```bash
+# Check the version and services
+./fakecloud --version
+./fakecloud services list
+```
+
+This portability makes it ideal for CI/CD pipelines. Instead of pulling a 500MB Docker image in every build job, you can cache a 19MB binary. This reduces build times and lowers egress costs in your CI environment.
+
+## 8. Actionable Insights for Architects
+
+If you are responsible for the developer experience (DevEx) at your organization, the move to fakecloud provides immediate, measurable benefits:
+
+1.  **Eliminate "Credential Debt":** Stop managing dev-specific IAM users. Use fakecloud to provide a safe, local sandbox for every developer.
+2.  **Reduce CI Flakiness:** By removing the dependency on external auth servers and internet connectivity, you eliminate a major category of intermittent test failures.
+3.  **Enable Secure Development:** For teams working with sensitive data or in regulated industries (HIPAA, FedRAMP), fakecloud allows for a completely air-gapped development workflow that meets the strictest compliance requirements.
+
+## Next Step: Run fakecloud Locally
+
+Stop fighting with cloud permissions and start building. Download the binary for your operating system and run your first S3 command in seconds.
+
+```bash
+# Download and run (example for Linux/macOS)
+curl -L https://fakecloud.dev/download/fakecloud -o fakecloud
+chmod +x fakecloud
+./fakecloud start
+
+# In another terminal, use the AWS CLI
+aws s3 ls --endpoint-url http://localhost:4566
+```
+
+For detailed implementation guides on specific services like Lambda triggers or DynamoDB Streams, refer to the [GitHub repository](https://github.com/faiscadev/fakecloud).


### PR DESCRIPTION
This PR adds a new blog post explaining the architectural philosophy behind fakecloud, focusing on its zero-friction requirements (no accounts, no auth, no internet) and its advantages over incumbent local cloud emulators.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post explaining fakecloud’s “No” List—no accounts, no auth, no internet—and how this design speeds up local development while improving privacy and reliability. Publishes a clear overview of high‑fidelity AWS emulation and offline Bedrock testing.

- **New Features**
  - Adds `website/content/blog/the-no-list-why-fakecloud-requires-no-account-or-internet.md` with full metadata.
  - Explains zero-friction workflow: no accounts, no auth, fully offline.
  - Highlights performance and fidelity: ~19MB binary, ~500ms startup, 33+ services, 2,422 ops, real cross-service triggers.
  - Covers local Bedrock testing and includes quickstart commands.

<sup>Written for commit 42f9f7a20a31c4ef645893130f23a80fbc17e506. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1455?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

