### PR TITLE
feat(sdks): stepfunctions sync-executions + execution-tree parity (TS/Py/Go/PHP/Java)

### DIFF
--- a/sdks/go/logs.go
+++ b/sdks/go/logs.go
@@ -61,15 +61,15 @@ func (c *LogsClient) GetFieldIndexes(ctx context.Context, logGroupName string) (
 // LogsDeliveryConfiguration mirrors one entry of the delivery-config
 // introspection response.
 type LogsDeliveryConfiguration struct {
-	ID                       string                 `json:"id"`
-	Name                     string                 `json:"name"`
-	DeliveryDestinationARN   string                 `json:"deliveryDestinationArn"`
-	DeliverySourceName       string                 `json:"deliverySourceName"`
-	LogType                  string                 `json:"logType"`
-	RecordFields             []string               `json:"recordFields,omitempty"`
-	FieldDelimiter           *string                `json:"fieldDelimiter,omitempty"`
-	S3DeliveryConfiguration  map[string]interface{} `json:"s3DeliveryConfiguration,omitempty"`
-	CreatedAt                int64                  `json:"createdAt"`
+	ID                      string                 `json:"id"`
+	Name                    string                 `json:"name"`
+	DeliveryDestinationARN  string                 `json:"deliveryDestinationArn"`
+	DeliverySourceName      string                 `json:"deliverySourceName"`
+	LogType                 string                 `json:"logType"`
+	RecordFields            []string               `json:"recordFields,omitempty"`
+	FieldDelimiter          *string                `json:"fieldDelimiter,omitempty"`
+	S3DeliveryConfiguration map[string]interface{} `json:"s3DeliveryConfiguration,omitempty"`
+	CreatedAt               int64                  `json:"createdAt"`
 }
 
 // LogsDeliveryConfigResponse is returned by GetDeliveryConfig.

--- a/sdks/go/stepfunctions.go
+++ b/sdks/go/stepfunctions.go
@@ -2,6 +2,7 @@ package fakecloud
 
 import (
 	"context"
+	"net/url"
 )
 
 // StepFunctionsClient provides access to Step Functions introspection endpoints.
@@ -13,6 +14,25 @@ type StepFunctionsClient struct {
 func (c *StepFunctionsClient) GetExecutions(ctx context.Context) (*StepFunctionsExecutionsResponse, error) {
 	var out StepFunctionsExecutionsResponse
 	if err := c.fc.doGet(ctx, "/_fakecloud/stepfunctions/executions", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetSyncExecutions lists all recorded EXPRESS sync executions, with billing detail.
+func (c *StepFunctionsClient) GetSyncExecutions(ctx context.Context) (*StepFunctionsSyncExecutionsResponse, error) {
+	var out StepFunctionsSyncExecutionsResponse
+	if err := c.fc.doGet(ctx, "/_fakecloud/stepfunctions/sync-executions", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetExecutionTree returns the parent/child execution tree rooted at the given execution ARN.
+func (c *StepFunctionsClient) GetExecutionTree(ctx context.Context, arn string) (*StepFunctionsExecutionTreeResponse, error) {
+	var out StepFunctionsExecutionTreeResponse
+	path := "/_fakecloud/stepfunctions/execution-tree/" + url.PathEscape(arn)
+	if err := c.fc.doGet(ctx, path, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -222,10 +222,10 @@ type SESMailFromStatusResponse struct {
 
 // SESDkimPublicKey describes the DKIM signing material for an identity.
 type SESDkimPublicKey struct {
-	Identity       string `json:"identity"`
-	Selector       string `json:"selector"`
+	Identity        string `json:"identity"`
+	Selector        string `json:"selector"`
 	PublicKeyBase64 string `json:"publicKeyBase64"`
-	SigningEnabled bool   `json:"signingEnabled"`
+	SigningEnabled  bool   `json:"signingEnabled"`
 }
 
 // SESSandboxRequest toggles sandbox / production access for the account.
@@ -235,8 +235,8 @@ type SESSandboxRequest struct {
 
 // SESSandboxResponse echoes the new sandbox state.
 type SESSandboxResponse struct {
-	Sandbox                  bool `json:"sandbox"`
-	ProductionAccessEnabled  bool `json:"productionAccessEnabled"`
+	Sandbox                 bool `json:"sandbox"`
+	ProductionAccessEnabled bool `json:"productionAccessEnabled"`
 }
 
 // SESBouncedRecipientInfo describes one recipient inside a queued bounce.
@@ -250,14 +250,14 @@ type SESBouncedRecipientInfo struct {
 
 // SESBounce is one bounce queued via SES SendBounce.
 type SESBounce struct {
-	MessageID             string                    `json:"messageId"`
-	BounceType            string                    `json:"bounceType"`
-	BounceSubType         string                    `json:"bounceSubType"`
-	BouncedRecipientInfo  []SESBouncedRecipientInfo `json:"bouncedRecipientInfo"`
-	Explanation           *string                   `json:"explanation,omitempty"`
-	Timestamp             string                    `json:"timestamp"`
-	OriginalMessageID     string                    `json:"originalMessageId"`
-	BounceSender          string                    `json:"bounceSender"`
+	MessageID            string                    `json:"messageId"`
+	BounceType           string                    `json:"bounceType"`
+	BounceSubType        string                    `json:"bounceSubType"`
+	BouncedRecipientInfo []SESBouncedRecipientInfo `json:"bouncedRecipientInfo"`
+	Explanation          *string                   `json:"explanation,omitempty"`
+	Timestamp            string                    `json:"timestamp"`
+	OriginalMessageID    string                    `json:"originalMessageId"`
+	BounceSender         string                    `json:"bounceSender"`
 }
 
 // SESBouncesResponse contains all queued bounces.
@@ -268,12 +268,12 @@ type SESBouncesResponse struct {
 // SESMessageInsightEvent is one delivery / bounce / complaint observation
 // recorded against a sent SES message.
 type SESMessageInsightEvent struct {
-	Destination            string  `json:"destination"`
-	Timestamp              string  `json:"timestamp"`
-	BounceType             *string `json:"bounceType,omitempty"`
-	BounceSubType          *string `json:"bounceSubType,omitempty"`
-	DiagnosticCode         *string `json:"diagnosticCode,omitempty"`
-	ComplaintFeedbackType  *string `json:"complaintFeedbackType,omitempty"`
+	Destination           string  `json:"destination"`
+	Timestamp             string  `json:"timestamp"`
+	BounceType            *string `json:"bounceType,omitempty"`
+	BounceSubType         *string `json:"bounceSubType,omitempty"`
+	DiagnosticCode        *string `json:"diagnosticCode,omitempty"`
+	ComplaintFeedbackType *string `json:"complaintFeedbackType,omitempty"`
 }
 
 // SESMessageInsightsResponse is the per-message MessageInsights shape.
@@ -290,13 +290,13 @@ type SESMessageInsightsResponse struct {
 
 // SESSmtpSubmission is one message accepted via the SES SMTP listener.
 type SESSmtpSubmission struct {
-	MessageID     string   `json:"messageId"`
-	From          string   `json:"from"`
-	To            []string `json:"to"`
-	Subject       *string  `json:"subject,omitempty"`
-	RawSizeBytes  int      `json:"rawSizeBytes"`
-	ReceivedAt    string   `json:"receivedAt"`
-	AuthUser      string   `json:"authUser"`
+	MessageID    string   `json:"messageId"`
+	From         string   `json:"from"`
+	To           []string `json:"to"`
+	Subject      *string  `json:"subject,omitempty"`
+	RawSizeBytes int      `json:"rawSizeBytes"`
+	ReceivedAt   string   `json:"receivedAt"`
+	AuthUser     string   `json:"authUser"`
 }
 
 // SESSmtpSubmissionsResponse contains all SMTP submissions.
@@ -510,14 +510,14 @@ type LifecycleTickResponse struct {
 
 // S3AccessPointEntry describes a single S3 access point.
 type S3AccessPointEntry struct {
-	Name               string  `json:"name"`
-	Alias              string  `json:"alias"`
-	Bucket             string  `json:"bucket"`
-	AccountID          string  `json:"accountId"`
-	NetworkOrigin      string  `json:"networkOrigin"`
-	VpcConfiguration   *string `json:"vpcConfiguration,omitempty"`
-	PublicAccessBlock  *string `json:"publicAccessBlock,omitempty"`
-	CreatedAt          string  `json:"createdAt"`
+	Name              string  `json:"name"`
+	Alias             string  `json:"alias"`
+	Bucket            string  `json:"bucket"`
+	AccountID         string  `json:"accountId"`
+	NetworkOrigin     string  `json:"networkOrigin"`
+	VpcConfiguration  *string `json:"vpcConfiguration,omitempty"`
+	PublicAccessBlock *string `json:"publicAccessBlock,omitempty"`
+	CreatedAt         string  `json:"createdAt"`
 }
 
 // S3AccessPointsResponse holds the S3 access point registry.
@@ -727,6 +727,47 @@ type StepFunctionsExecutionsResponse struct {
 	Executions []StepFunctionsExecution `json:"executions"`
 }
 
+// StepFunctionsSyncBillingDetails captures billed compute for a sync execution.
+type StepFunctionsSyncBillingDetails struct {
+	BilledDurationInMilliseconds int64 `json:"billedDurationInMilliseconds"`
+	BilledMemoryUsedInMb         int64 `json:"billedMemoryUsedInMb"`
+}
+
+// StepFunctionsSyncExecution represents a recorded EXPRESS sync execution.
+type StepFunctionsSyncExecution struct {
+	ExecutionARN    string                          `json:"executionArn"`
+	StateMachineARN string                          `json:"stateMachineArn"`
+	Name            string                          `json:"name"`
+	Status          string                          `json:"status"`
+	Input           *string                         `json:"input,omitempty"`
+	Output          *string                         `json:"output,omitempty"`
+	StartedAt       string                          `json:"startedAt"`
+	StoppedAt       *string                         `json:"stoppedAt,omitempty"`
+	DurationMs      int64                           `json:"durationMs"`
+	BillingDetails  StepFunctionsSyncBillingDetails `json:"billingDetails"`
+}
+
+// StepFunctionsSyncExecutionsResponse contains all recorded sync executions.
+type StepFunctionsSyncExecutionsResponse struct {
+	Executions []StepFunctionsSyncExecution `json:"executions"`
+}
+
+// StepFunctionsExecutionTreeNode is a node in a parent/child execution tree.
+type StepFunctionsExecutionTreeNode struct {
+	ARN             string                           `json:"arn"`
+	StateMachineARN string                           `json:"stateMachineArn"`
+	Status          string                           `json:"status"`
+	StartedAt       string                           `json:"startedAt"`
+	StoppedAt       *string                          `json:"stoppedAt,omitempty"`
+	Children        []StepFunctionsExecutionTreeNode `json:"children"`
+}
+
+// StepFunctionsExecutionTreeResponse is the rooted parent/child tree for an execution.
+type StepFunctionsExecutionTreeResponse struct {
+	RootARN string                         `json:"rootArn"`
+	Tree    StepFunctionsExecutionTreeNode `json:"tree"`
+}
+
 // SfnEnqueueActivityTaskRequest queues a task for an activity worker without
 // running an ASL execution.
 type SfnEnqueueActivityTaskRequest struct {
@@ -840,20 +881,20 @@ type BedrockAgentCollaboratorSummary struct {
 
 // BedrockAgentRow is one Bedrock Agent flattened for introspection.
 type BedrockAgentRow struct {
-	AgentID          string                             `json:"agentId"`
-	AgentName        string                             `json:"agentName"`
-	AgentArn         string                             `json:"agentArn"`
-	AgentStatus      string                             `json:"agentStatus"`
-	FoundationModel  *string                            `json:"foundationModel"`
-	Instruction      *string                            `json:"instruction"`
-	KnowledgeBases   []BedrockAgentKnowledgeBaseSummary `json:"knowledgeBases"`
-	ActionGroups     []any                              `json:"actionGroups"`
-	Collaborators    []BedrockAgentCollaboratorSummary  `json:"collaborators"`
-	Aliases          []BedrockAgentAliasSummary         `json:"aliases"`
-	Versions         []BedrockAgentVersionSummary       `json:"versions"`
-	PromptOverrides  any                                `json:"promptOverrides"`
-	CreatedAt        string                             `json:"createdAt"`
-	UpdatedAt        string                             `json:"updatedAt"`
+	AgentID         string                             `json:"agentId"`
+	AgentName       string                             `json:"agentName"`
+	AgentArn        string                             `json:"agentArn"`
+	AgentStatus     string                             `json:"agentStatus"`
+	FoundationModel *string                            `json:"foundationModel"`
+	Instruction     *string                            `json:"instruction"`
+	KnowledgeBases  []BedrockAgentKnowledgeBaseSummary `json:"knowledgeBases"`
+	ActionGroups    []any                              `json:"actionGroups"`
+	Collaborators   []BedrockAgentCollaboratorSummary  `json:"collaborators"`
+	Aliases         []BedrockAgentAliasSummary         `json:"aliases"`
+	Versions        []BedrockAgentVersionSummary       `json:"versions"`
+	PromptOverrides any                                `json:"promptOverrides"`
+	CreatedAt       string                             `json:"createdAt"`
+	UpdatedAt       string                             `json:"updatedAt"`
 }
 
 // BedrockAgentAgentsResponse is the list-agents response body.
@@ -1226,19 +1267,19 @@ type Elbv2RulesResponse struct {
 // GlueJob describes one Glue Job recorded by CreateJob. Returned by the
 // /_fakecloud/glue/jobs endpoint.
 type GlueJob struct {
-	AccountID         string            `json:"accountId"`
-	Name              string            `json:"name"`
-	Role              string            `json:"role"`
-	Command           json.RawMessage   `json:"command"`
-	DefaultArguments  map[string]string `json:"defaultArguments"`
-	MaxCapacity       *float64          `json:"maxCapacity,omitempty"`
-	MaxRetries        int64             `json:"maxRetries"`
-	Timeout           *int64            `json:"timeout,omitempty"`
-	GlueVersion       *string           `json:"glueVersion,omitempty"`
-	WorkerType        *string           `json:"workerType,omitempty"`
-	NumberOfWorkers   *int64            `json:"numberOfWorkers,omitempty"`
-	CreatedOn         string            `json:"createdOn"`
-	LastModifiedOn    string            `json:"lastModifiedOn"`
+	AccountID        string            `json:"accountId"`
+	Name             string            `json:"name"`
+	Role             string            `json:"role"`
+	Command          json.RawMessage   `json:"command"`
+	DefaultArguments map[string]string `json:"defaultArguments"`
+	MaxCapacity      *float64          `json:"maxCapacity,omitempty"`
+	MaxRetries       int64             `json:"maxRetries"`
+	Timeout          *int64            `json:"timeout,omitempty"`
+	GlueVersion      *string           `json:"glueVersion,omitempty"`
+	WorkerType       *string           `json:"workerType,omitempty"`
+	NumberOfWorkers  *int64            `json:"numberOfWorkers,omitempty"`
+	CreatedOn        string            `json:"createdOn"`
+	LastModifiedOn   string            `json:"lastModifiedOn"`
 }
 
 // GlueJobsResponse contains every Glue Job registered on the server.

--- a/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
+++ b/sdks/java/src/main/java/dev/fakecloud/FakeCloud.java
@@ -84,6 +84,8 @@ import dev.fakecloud.Types.SetHealthCheckStatusRequest;
 import dev.fakecloud.Types.SnsMessagesResponse;
 import dev.fakecloud.Types.SqsMessagesResponse;
 import dev.fakecloud.Types.StepFunctionsExecutionsResponse;
+import dev.fakecloud.Types.StepFunctionsSyncExecutionsResponse;
+import dev.fakecloud.Types.StepFunctionsExecutionTreeResponse;
 import dev.fakecloud.Types.TokensResponse;
 import dev.fakecloud.Types.TtlTickResponse;
 import dev.fakecloud.Types.UserConfirmationCodes;
@@ -690,6 +692,18 @@ public final class FakeCloud {
             return http.get(
                     "/_fakecloud/stepfunctions/executions",
                     StepFunctionsExecutionsResponse.class);
+        }
+
+        public StepFunctionsSyncExecutionsResponse getSyncExecutions() {
+            return http.get(
+                    "/_fakecloud/stepfunctions/sync-executions",
+                    StepFunctionsSyncExecutionsResponse.class);
+        }
+
+        public StepFunctionsExecutionTreeResponse getExecutionTree(String arn) {
+            return http.get(
+                    "/_fakecloud/stepfunctions/execution-tree/" + encodePath(arn),
+                    StepFunctionsExecutionTreeResponse.class);
         }
 
         public Types.SfnEnqueueActivityTaskResponse enqueueActivityTask(

--- a/sdks/java/src/main/java/dev/fakecloud/Types.java
+++ b/sdks/java/src/main/java/dev/fakecloud/Types.java
@@ -605,6 +605,41 @@ public final class Types {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record StepFunctionsExecutionsResponse(List<StepFunctionsExecution> executions) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record StepFunctionsSyncBillingDetails(
+            long billedDurationInMilliseconds,
+            long billedMemoryUsedInMb) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record StepFunctionsSyncExecution(
+            String executionArn,
+            String stateMachineArn,
+            String name,
+            String status,
+            String input,
+            String output,
+            String startedAt,
+            String stoppedAt,
+            long durationMs,
+            StepFunctionsSyncBillingDetails billingDetails) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record StepFunctionsSyncExecutionsResponse(List<StepFunctionsSyncExecution> executions) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record StepFunctionsExecutionTreeNode(
+            String arn,
+            String stateMachineArn,
+            String status,
+            String startedAt,
+            String stoppedAt,
+            List<StepFunctionsExecutionTreeNode> children) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record StepFunctionsExecutionTreeResponse(
+            String rootArn,
+            StepFunctionsExecutionTreeNode tree) {}
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record SfnEnqueueActivityTaskRequest(
             String activityArn,

--- a/sdks/php/src/FakeCloud.php
+++ b/sdks/php/src/FakeCloud.php
@@ -693,6 +693,20 @@ final class StepFunctionsClient
         );
     }
 
+    public function getSyncExecutions(): StepFunctionsSyncExecutionsResponse
+    {
+        return StepFunctionsSyncExecutionsResponse::fromArray(
+            $this->http->get('/_fakecloud/stepfunctions/sync-executions')
+        );
+    }
+
+    public function getExecutionTree(string $arn): StepFunctionsExecutionTreeResponse
+    {
+        return StepFunctionsExecutionTreeResponse::fromArray(
+            $this->http->get('/_fakecloud/stepfunctions/execution-tree/' . rawurlencode($arn))
+        );
+    }
+
     public function enqueueActivityTask(SfnEnqueueActivityTaskRequest $req): SfnEnqueueActivityTaskResponse
     {
         return SfnEnqueueActivityTaskResponse::fromArray(

--- a/sdks/php/src/Types.php
+++ b/sdks/php/src/Types.php
@@ -1800,6 +1800,108 @@ final class StepFunctionsExecutionsResponse
     }
 }
 
+final class StepFunctionsSyncBillingDetails
+{
+    public function __construct(
+        public readonly int $billedDurationInMilliseconds,
+        public readonly int $billedMemoryUsedInMb,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) $data['billedDurationInMilliseconds'],
+            (int) $data['billedMemoryUsedInMb'],
+        );
+    }
+}
+
+final class StepFunctionsSyncExecution
+{
+    public function __construct(
+        public readonly string $executionArn,
+        public readonly string $stateMachineArn,
+        public readonly string $name,
+        public readonly string $status,
+        public readonly ?string $input,
+        public readonly ?string $output,
+        public readonly string $startedAt,
+        public readonly ?string $stoppedAt,
+        public readonly int $durationMs,
+        public readonly StepFunctionsSyncBillingDetails $billingDetails,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['executionArn'],
+            $data['stateMachineArn'],
+            $data['name'],
+            $data['status'],
+            $data['input'] ?? null,
+            $data['output'] ?? null,
+            $data['startedAt'],
+            $data['stoppedAt'] ?? null,
+            (int) $data['durationMs'],
+            StepFunctionsSyncBillingDetails::fromArray($data['billingDetails']),
+        );
+    }
+}
+
+final class StepFunctionsSyncExecutionsResponse
+{
+    public function __construct(
+        /** @var StepFunctionsSyncExecution[] */
+        public readonly array $executions,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(array_map(StepFunctionsSyncExecution::fromArray(...), $data['executions']));
+    }
+}
+
+final class StepFunctionsExecutionTreeNode
+{
+    public function __construct(
+        public readonly string $arn,
+        public readonly string $stateMachineArn,
+        public readonly string $status,
+        public readonly string $startedAt,
+        public readonly ?string $stoppedAt,
+        /** @var StepFunctionsExecutionTreeNode[] */
+        public readonly array $children,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['arn'],
+            $data['stateMachineArn'],
+            $data['status'],
+            $data['startedAt'],
+            $data['stoppedAt'] ?? null,
+            array_map(self::fromArray(...), $data['children'] ?? []),
+        );
+    }
+}
+
+final class StepFunctionsExecutionTreeResponse
+{
+    public function __construct(
+        public readonly string $rootArn,
+        public readonly StepFunctionsExecutionTreeNode $tree,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['rootArn'],
+            StepFunctionsExecutionTreeNode::fromArray($data['tree']),
+        );
+    }
+}
+
 final class SfnEnqueueActivityTaskRequest
 {
     public function __construct(

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -95,8 +95,8 @@ from fakecloud.types import (
     SnsMessagesResponse,
     SqsMessagesResponse,
     StepFunctionsExecutionsResponse,
-    StepFunctionsSyncExecutionsResponse,
     StepFunctionsExecutionTreeResponse,
+    StepFunctionsSyncExecutionsResponse,
     TokensResponse,
     TtlTickResponse,
     UserConfirmationCodes,
@@ -1091,9 +1091,7 @@ class StepFunctionsClient:
         _check(resp)
         return StepFunctionsSyncExecutionsResponse.from_dict(resp.json())
 
-    async def get_execution_tree(
-        self, arn: str
-    ) -> StepFunctionsExecutionTreeResponse:
+    async def get_execution_tree(self, arn: str) -> StepFunctionsExecutionTreeResponse:
         encoded = _urlquote(arn, safe="")
         resp = await self._client.get(
             f"{self._base}/_fakecloud/stepfunctions/execution-tree/{encoded}"

--- a/sdks/python/src/fakecloud/client.py
+++ b/sdks/python/src/fakecloud/client.py
@@ -95,6 +95,8 @@ from fakecloud.types import (
     SnsMessagesResponse,
     SqsMessagesResponse,
     StepFunctionsExecutionsResponse,
+    StepFunctionsSyncExecutionsResponse,
+    StepFunctionsExecutionTreeResponse,
     TokensResponse,
     TtlTickResponse,
     UserConfirmationCodes,
@@ -1082,6 +1084,23 @@ class StepFunctionsClient:
         _check(resp)
         return StepFunctionsExecutionsResponse.from_dict(resp.json())
 
+    async def get_sync_executions(self) -> StepFunctionsSyncExecutionsResponse:
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/stepfunctions/sync-executions"
+        )
+        _check(resp)
+        return StepFunctionsSyncExecutionsResponse.from_dict(resp.json())
+
+    async def get_execution_tree(
+        self, arn: str
+    ) -> StepFunctionsExecutionTreeResponse:
+        encoded = _urlquote(arn, safe="")
+        resp = await self._client.get(
+            f"{self._base}/_fakecloud/stepfunctions/execution-tree/{encoded}"
+        )
+        _check(resp)
+        return StepFunctionsExecutionTreeResponse.from_dict(resp.json())
+
     async def enqueue_activity_task(
         self, req: SfnEnqueueActivityTaskRequest
     ) -> SfnEnqueueActivityTaskResponse:
@@ -1640,6 +1659,21 @@ class _SyncStepFunctionsClient:
         resp = self._client.get(f"{self._base}/_fakecloud/stepfunctions/executions")
         _check(resp)
         return StepFunctionsExecutionsResponse.from_dict(resp.json())
+
+    def get_sync_executions(self) -> StepFunctionsSyncExecutionsResponse:
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/stepfunctions/sync-executions"
+        )
+        _check(resp)
+        return StepFunctionsSyncExecutionsResponse.from_dict(resp.json())
+
+    def get_execution_tree(self, arn: str) -> StepFunctionsExecutionTreeResponse:
+        encoded = _urlquote(arn, safe="")
+        resp = self._client.get(
+            f"{self._base}/_fakecloud/stepfunctions/execution-tree/{encoded}"
+        )
+        _check(resp)
+        return StepFunctionsExecutionTreeResponse.from_dict(resp.json())
 
     def enqueue_activity_task(
         self, req: SfnEnqueueActivityTaskRequest

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1561,6 +1561,103 @@ class StepFunctionsExecutionsResponse:
 
 
 @dataclass
+class StepFunctionsSyncBillingDetails:
+    billed_duration_in_milliseconds: int
+    billed_memory_used_in_mb: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> StepFunctionsSyncBillingDetails:
+        d = _convert_keys(data)
+        return cls(**d)
+
+
+@dataclass
+class StepFunctionsSyncExecution:
+    execution_arn: str
+    state_machine_arn: str
+    name: str
+    status: str
+    started_at: str
+    duration_ms: int
+    billing_details: StepFunctionsSyncBillingDetails
+    input: Optional[str] = None
+    output: Optional[str] = None
+    stopped_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> StepFunctionsSyncExecution:
+        return cls(
+            execution_arn=data["executionArn"],
+            state_machine_arn=data["stateMachineArn"],
+            name=data["name"],
+            status=data["status"],
+            started_at=data["startedAt"],
+            duration_ms=data["durationMs"],
+            billing_details=StepFunctionsSyncBillingDetails.from_dict(
+                data["billingDetails"]
+            ),
+            input=data.get("input"),
+            output=data.get("output"),
+            stopped_at=data.get("stoppedAt"),
+        )
+
+
+@dataclass
+class StepFunctionsSyncExecutionsResponse:
+    executions: List[StepFunctionsSyncExecution]
+
+    @classmethod
+    def from_dict(
+        cls, data: Dict[str, Any]
+    ) -> StepFunctionsSyncExecutionsResponse:
+        return cls(
+            executions=[
+                StepFunctionsSyncExecution.from_dict(e)
+                for e in data.get("executions", [])
+            ],
+        )
+
+
+@dataclass
+class StepFunctionsExecutionTreeNode:
+    arn: str
+    state_machine_arn: str
+    status: str
+    started_at: str
+    children: List[StepFunctionsExecutionTreeNode]
+    stopped_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> StepFunctionsExecutionTreeNode:
+        return cls(
+            arn=data["arn"],
+            state_machine_arn=data["stateMachineArn"],
+            status=data["status"],
+            started_at=data["startedAt"],
+            stopped_at=data.get("stoppedAt"),
+            children=[
+                StepFunctionsExecutionTreeNode.from_dict(c)
+                for c in data.get("children", [])
+            ],
+        )
+
+
+@dataclass
+class StepFunctionsExecutionTreeResponse:
+    root_arn: str
+    tree: StepFunctionsExecutionTreeNode
+
+    @classmethod
+    def from_dict(
+        cls, data: Dict[str, Any]
+    ) -> StepFunctionsExecutionTreeResponse:
+        return cls(
+            root_arn=data["rootArn"],
+            tree=StepFunctionsExecutionTreeNode.from_dict(data["tree"]),
+        )
+
+
+@dataclass
 class SfnEnqueueActivityTaskRequest:
     activity_arn: str
     input: Optional[str] = None

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -1607,9 +1607,7 @@ class StepFunctionsSyncExecutionsResponse:
     executions: List[StepFunctionsSyncExecution]
 
     @classmethod
-    def from_dict(
-        cls, data: Dict[str, Any]
-    ) -> StepFunctionsSyncExecutionsResponse:
+    def from_dict(cls, data: Dict[str, Any]) -> StepFunctionsSyncExecutionsResponse:
         return cls(
             executions=[
                 StepFunctionsSyncExecution.from_dict(e)
@@ -1648,9 +1646,7 @@ class StepFunctionsExecutionTreeResponse:
     tree: StepFunctionsExecutionTreeNode
 
     @classmethod
-    def from_dict(
-        cls, data: Dict[str, Any]
-    ) -> StepFunctionsExecutionTreeResponse:
+    def from_dict(cls, data: Dict[str, Any]) -> StepFunctionsExecutionTreeResponse:
         return cls(
             root_arn=data["rootArn"],
             tree=StepFunctionsExecutionTreeNode.from_dict(data["tree"]),

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakecloud",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakecloud",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.750.0",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -77,6 +77,8 @@ import type {
   CompromisedPasswordsResponse,
   WebAuthnCredentialsResponse,
   StepFunctionsExecutionsResponse,
+  StepFunctionsSyncExecutionsResponse,
+  StepFunctionsExecutionTreeResponse,
   SfnEnqueueActivityTaskRequest,
   SfnEnqueueActivityTaskResponse,
   EcsClustersResponse,
@@ -629,6 +631,22 @@ export class StepFunctionsClient {
   async getExecutions(): Promise<StepFunctionsExecutionsResponse> {
     const resp = await fetch(
       `${this.baseUrl}/_fakecloud/stepfunctions/executions`,
+    );
+    return parse(resp);
+  }
+
+  async getSyncExecutions(): Promise<StepFunctionsSyncExecutionsResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/stepfunctions/sync-executions`,
+    );
+    return parse(resp);
+  }
+
+  async getExecutionTree(
+    arn: string,
+  ): Promise<StepFunctionsExecutionTreeResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/_fakecloud/stepfunctions/execution-tree/${encodeURIComponent(arn)}`,
     );
     return parse(resp);
   }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -631,6 +631,42 @@ export interface StepFunctionsExecutionsResponse {
   executions: StepFunctionsExecution[];
 }
 
+export interface StepFunctionsSyncBillingDetails {
+  billedDurationInMilliseconds: number;
+  billedMemoryUsedInMb: number;
+}
+
+export interface StepFunctionsSyncExecution {
+  executionArn: string;
+  stateMachineArn: string;
+  name: string;
+  status: string;
+  input?: string | null;
+  output?: string | null;
+  startedAt: string;
+  stoppedAt?: string | null;
+  durationMs: number;
+  billingDetails: StepFunctionsSyncBillingDetails;
+}
+
+export interface StepFunctionsSyncExecutionsResponse {
+  executions: StepFunctionsSyncExecution[];
+}
+
+export interface StepFunctionsExecutionTreeNode {
+  arn: string;
+  stateMachineArn: string;
+  status: string;
+  startedAt: string;
+  stoppedAt?: string | null;
+  children: StepFunctionsExecutionTreeNode[];
+}
+
+export interface StepFunctionsExecutionTreeResponse {
+  rootArn: string;
+  tree: StepFunctionsExecutionTreeNode;
+}
+
 export interface SfnEnqueueActivityTaskRequest {
   activityArn: string;
   input?: string;


### PR DESCRIPTION
## Summary

Brings 5 language SDKs (TS/Py/Go/PHP/Java) to parity with Rust SDK on two StepFunctions introspection routes:

- GET /_fakecloud/stepfunctions/sync-executions
- GET /_fakecloud/stepfunctions/execution-tree/{arn}

Rust SDK untouched (already had both). ARN segments URL-encoded.

## Test plan

- [x] tsc --noEmit
- [x] python -m py_compile
- [x] go build + vet
- [x] gradle compileJava
- [ ] PHP — structural review (no local toolchain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Step Functions sync-execution and execution-tree introspection to the TypeScript, Python, Go, PHP, and Java SDKs, matching the Rust SDK. You can now list EXPRESS sync executions (with billing) and fetch parent/child execution trees; a follow-up commit applies formatter-only changes.

- **New Features**
  - Added `getSyncExecutions` and `getExecutionTree(arn)` to StepFunctions clients in TypeScript, Python, Go, PHP, and Java.
  - Introduced types: `StepFunctionsSyncBillingDetails`, `StepFunctionsSyncExecution`, `StepFunctionsSyncExecutionsResponse`, `StepFunctionsExecutionTreeNode`, `StepFunctionsExecutionTreeResponse` (camelCase to match the wire format).
  - ARN path segments are URL-encoded in all SDKs.

- **Dependencies**
  - Bumped TypeScript package `fakecloud` to `0.14.0`.

<sup>Written for commit 88b1274dc3335aa3f8361b1a7008b20fca48745d. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1463?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

