### PR TITLE
release(v0.15.0): bump workspace + SDK versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies]
 serde_json = "1"
@@ -101,164 +101,164 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.14.0"
+version = "0.15.0"

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.14.0"
+version = "0.15.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.14.0"
+version = "0.15.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/python/src/fakecloud/types.py
+++ b/sdks/python/src/fakecloud/types.py
@@ -3169,6 +3169,30 @@ class EcsTaskCredentials:
 
 
 @dataclass
+class InjectSsmSessionRequest:
+    target: str
+    account_id: Optional[str] = None
+    status: Optional[str] = None
+    owner: Optional[str] = None
+    reason: Optional[str] = None
+    session_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"target": self.target}
+        if self.account_id is not None:
+            d["accountId"] = self.account_id
+        if self.status is not None:
+            d["status"] = self.status
+        if self.owner is not None:
+            d["owner"] = self.owner
+        if self.reason is not None:
+            d["reason"] = self.reason
+        if self.session_id is not None:
+            d["sessionId"] = self.session_id
+        return d
+
+
+@dataclass
 class InjectSsmSessionResponse:
     session_id: str
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release v0.15.0. Bumps workspace and all SDK manifest versions from 0.14.0 to 0.15.0.

## Release contents

- 4 SDK-drift PRs (#1461 #1462 #1463 #1464) — all 6 SDKs reach 111/111 introspection-route coverage
- new server route: `GET /_fakecloud/lambda/function-code/{account}/{name}/{file}`
- conformance ratchet to 100% (86,327/86,327 Smithy variants) across all reconciled services since v0.14.0
- doc-counts CI guard preventing service/op/variant drift on evergreen surfaces

## Publish-crates pipeline audit

No new publishable crates since v0.14.0 — still 42 crates. Internal dep order in `.github/workflows/release.yml` verified by topo-sort against the actual `Cargo.toml` dep graph; no reordering needed. Only new external dep additions:
- `regex` in `fakecloud-bedrock-agent-runtime`
- `percent-encoding` in `fakecloud-sdk`

Both are workspace-level deps already declared in root `Cargo.toml`.

## Test plan

- [x] `cargo check --workspace` clean
- [x] all 4 SDK toolchains green pre-merge on contributing PRs
- [ ] tag `v0.15.0` after merge to trigger publish workflows (crates.io / npm / PyPI / Maven / Packagist / Go)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.15.0: bump all workspace crates and SDK manifests to 0.15.0. This release completes conformance, aligns SDK coverage, adds a new Lambda function-code route, and fixes a missing Python SDK dataclass.

- **New Features**
  - 100% conformance across reconciled services; CI doc-count guard prevents drift.
  - All 6 SDKs now have 111/111 introspection-route coverage; 110+ universal-gap endpoints added.
  - New route: `GET /_fakecloud/lambda/function-code/{account}/{name}/{file}`.

- **Dependencies**
  - No new publishable crates (still 42); release workflow topo order verified.
  - New external deps: `regex` in `fakecloud-bedrock-agent-runtime`, `percent-encoding` in `fakecloud-sdk` (both at workspace root).

<sup>Written for commit f93b7de64b34d8c043f92f0c87997517d9a63713. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1465?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

