### PR TITLE
fix(sdks/python tests): catch ReadTimeout in _wait_for_ready

### DIFF
--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -42,7 +42,7 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-def _wait_for_ready(url: str, timeout: float = 15.0) -> None:
+def _wait_for_ready(url: str, timeout: float = 30.0) -> None:
     """Poll the health endpoint until fakecloud is ready."""
     import httpx
 
@@ -52,7 +52,9 @@ def _wait_for_ready(url: str, timeout: float = 15.0) -> None:
             r = httpx.get(f"{url}/_fakecloud/health", timeout=2.0)
             if r.status_code == 200:
                 return
-        except httpx.ConnectError:
+        except httpx.HTTPError:
+            # ConnectError, ReadTimeout, ConnectTimeout — server still
+            # warming up. Retry until deadline.
             pass
         time.sleep(0.1)
     raise RuntimeError(f"fakecloud did not become ready at {url} within {timeout}s")


### PR DESCRIPTION
Server may accept TCP connection before route handlers ready, causing httpx.ReadTimeout (not ConnectError) during boot. Previous except clause only caught ConnectError, so any timeout aborted setup instead of retrying. Caught the broader httpx.HTTPError + bumped timeout 15->30s.

Fixes flaky failure on SDK Python workflow ([example](https://github.com/faiscadev/fakecloud/actions/runs/26069951989/job/76649031797)).

## Test plan
- [x] py_compile clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Python test boot wait more robust by catching `httpx.HTTPError` (covers `ReadTimeout`) and increasing the readiness timeout from 15s to 30s. This prevents flaky failures when the server accepts TCP before routes are ready.

- **Bug Fixes**
  - Retry on `ReadTimeout`/`ConnectTimeout` during health check instead of aborting.
  - Bump default wait time to 30s to handle slower CI runners.

<sup>Written for commit db3c5fb461709de8f824b4c5fc7005e10c1ed5f8. Summary will update on new commits. <a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/1466?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

